### PR TITLE
Use the `glpi-project/rector-glpi` Rector extension

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -224,12 +224,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/ajax/impact.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/ajax/itilfollowup.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Part \\$parents_itemtype \\(class\\-string\\<CommonITILObject\\>\\|CommonITILObject\\) of encapsed string cannot be cast to string\\.$#',
 	'identifier' => 'encapsedStringPart.nonString',
 	'count' => 1,
@@ -416,34 +410,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/ajax/ruleaction.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$sub_type of method RuleAction\\:\\:getAlreadyUsedForRuleID\\(\\) expects class\\-string\\<Rule\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/ajax/ruleaction.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$input of method CommonDBTM\\:\\:add\\(\\) expects array\\<string, mixed\\>, array\\<string, mixed\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/ajax/savedsearch.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/ajax/solution.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Part \\$parents_itemtype \\(class\\-string\\<CommonITILObject\\>\\|CommonITILObject\\) of encapsed string cannot be cast to string\\.$#',
 	'identifier' => 'encapsedStringPart.nonString',
 	'count' => 1,
 	'path' => __DIR__ . '/ajax/solution.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/ajax/task.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Part \\$parents_itemtype \\(class\\-string\\<CommonITILObject\\>\\|CommonITILObject\\) of encapsed string cannot be cast to string\\.$#',
@@ -2168,12 +2144,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Appliance.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Appliance.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -2201,18 +2171,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method Appliance_Item\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Appliance_Item.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Appliance_Item.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Appliance_Item.php',
 ];
 $ignoreErrors[] = [
@@ -2498,20 +2456,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Blacklist.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Blacklist.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method BlacklistedMailContent\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/BlacklistedMailContent.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/BlacklistedMailContent.php',
 ];
@@ -2540,19 +2486,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Budget.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Budget.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getItemForItemtype expects string, string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Budget.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Budget.php',
@@ -2566,12 +2500,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Cable\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Cable.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Cable.php',
 ];
@@ -2591,12 +2519,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method getLink\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 2,
-	'path' => __DIR__ . '/src/CableStrand.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/CableStrand.php',
 ];
 $ignoreErrors[] = [
@@ -2624,32 +2546,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Calendar.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Calendar.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CalendarSegment.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Calendar_Holiday.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Cartridge\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Cartridge.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Cartridge.php',
 ];
@@ -2666,22 +2564,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CartridgeItem.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CartridgeItem.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CartridgeItem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CartridgeItem_PrinterModel.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$ID of method CommonDBTM\\:\\:getFromDB\\(\\) expects int\\|string, int\\|string\\|false given\\.$#',
@@ -2708,22 +2594,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Certificate.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Certificate.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Certificate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Certificate_Item.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$itemtype of method Certificate_Item\\:\\:getFromDBbyCertificatesAndItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
@@ -2750,12 +2624,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Change.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Change.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method ChangeTask\\:\\:displayPlanningItem\\(\\) should return string but returns string\\|false\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -2770,12 +2638,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method ChangeTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ChangeTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ChangeTemplate.php',
 ];
@@ -2798,12 +2660,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Cluster.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Cluster.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -2816,15 +2672,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBChild.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/CommonDBChild.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CommonDBConnexity\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
+	'path' => __DIR__ . '/src/CommonDBConnexity.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Offset mixed might not exist on array\\|null\\.$#',
+	'identifier' => 'offsetAccess.notFound',
+	'count' => 3,
 	'path' => __DIR__ . '/src/CommonDBConnexity.php',
 ];
 $ignoreErrors[] = [
@@ -2840,10 +2696,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBConnexity.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBConnexity.php',
+	'message' => '#^Cannot access constant class on CommonDBTM\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 5,
+	'path' => __DIR__ . '/src/CommonDBRelation.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on CommonDBTM\\|false\\.$#',
@@ -2861,12 +2717,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method getTable\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 6,
-	'path' => __DIR__ . '/src/CommonDBRelation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 5,
 	'path' => __DIR__ . '/src/CommonDBRelation.php',
 ];
 $ignoreErrors[] = [
@@ -3026,12 +2876,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBRelation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 8,
-	'path' => __DIR__ . '/src/CommonDBRelation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$subject of function Safe\\\\preg_match expects string, string\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 22,
@@ -3170,6 +3014,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc tag @var with type class\\-string\\<CommonDBTM\\> is not subtype of native type class\\-string\\<static\\(CommonDBTM\\)\\>\\.$#',
+	'identifier' => 'varTag.nativeType',
+	'count' => 2,
+	'path' => __DIR__ . '/src/CommonDBTM.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$ID of function getUserName expects int, float\\|int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -3195,24 +3045,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$integer of static method Toolbox\\:\\:cleanInteger\\(\\) expects string, int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of method Lockedfield\\:\\:getLockedValues\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of method Lockedfield\\:\\:setLastValue\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
@@ -3256,12 +3088,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method CommonDCModelDropdown\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDCModelDropdown.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDCModelDropdown.php',
 ];
@@ -3332,12 +3158,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDeviceModel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonDeviceModel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type list\\<list\\<string\\>\\|string\\>\\|string supplied for foreach, only iterables are supported\\.$#',
 	'identifier' => 'foreach.nonIterable',
 	'count' => 1,
@@ -3374,14 +3194,14 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonGLPI.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access offset \'path\' on array\\|int\\|string\\|null\\.$#',
-	'identifier' => 'offsetAccess.nonOffsetAccessible',
+	'message' => '#^Call to function method_exists\\(\\) with class\\-string\\<static\\(CommonGLPI\\)\\> and \'canView\' will always evaluate to true\\.$#',
+	'identifier' => 'function.alreadyNarrowedType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonGLPI.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$typeform of static method CommonGLPI\\:\\:getOtherTabs\\(\\) expects class\\-string\\<CommonGLPI\\>, string given\\.$#',
-	'identifier' => 'argument.type',
+	'message' => '#^Cannot access offset \'path\' on array\\|int\\|string\\|null\\.$#',
+	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonGLPI.php',
 ];
@@ -3494,10 +3314,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILCost.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
+	'message' => '#^Cannot access constant class on CommonITILTask\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
 	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILCost.php',
+	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access constant class on CommonITILValidation\\|null\\.$#',
@@ -3586,12 +3406,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method update\\(\\) on ITIL_ValidationStep\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call static method getType\\(\\) on CommonITILTask\\|false\\.$#',
-	'identifier' => 'staticMethod.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
@@ -3686,6 +3500,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^PHPDoc tag @var with type CommonITILObject is not subtype of native type class\\-string\\<static\\(CommonITILObject\\)\\>\\.$#',
+	'identifier' => 'varTag.nativeType',
+	'count' => 1,
+	'path' => __DIR__ . '/src/CommonITILObject.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$haystack of function str_contains expects string, bool\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -3748,7 +3568,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
@@ -3765,18 +3585,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method CommonITILObject\\:\\:getKanbanPluginFilters\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method CommonITILObject_CommonITILObject\\:\\:countLinksByStatus\\(\\) expects class\\-string\\<CommonITILObject\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
@@ -3872,12 +3680,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property CommonDBTM\\:\\:\\$updates \\(list\\<string\\>\\) does not accept array\\<int\\<0, max\\>, string\\>\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 14,
@@ -3945,12 +3747,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$datetime of function Safe\\\\strtotime expects string, string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILRecurrent.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILRecurrent.php',
@@ -4148,12 +3944,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILTask.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILTask.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$users_id of method PlanningRecall\\:\\:getFromDBForItemAndUser\\(\\) expects int, int\\|string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
@@ -4269,12 +4059,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$item of static method NotificationEvent\\:\\:raiseEvent\\(\\) expects CommonGLPI, CommonDBTM\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILValidation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILValidation.php',
@@ -4472,25 +4256,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonItilObject_Item.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/CommonTreeDropdown.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Dropdown\\:\\:show\\(\\) expects string, bool\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonTreeDropdown.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/CommonTreeDropdown.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonTreeDropdown.php',
@@ -4498,12 +4264,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method CommonType\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonType.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonType.php',
 ];
@@ -4546,12 +4306,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Computer\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Computer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Computer.php',
 ];
@@ -4616,12 +4370,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Config.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 10,
-	'path' => __DIR__ . '/src/Config.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -4670,20 +4418,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Consumable.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Consumable.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method ConsumableItem\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ConsumableItem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ConsumableItem.php',
 ];
@@ -4706,18 +4442,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Contact.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Contact.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Contact_Supplier.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Contract\\:\\:getSpecificValueToSelect\\(\\) should return string but returns int\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 2,
@@ -4726,12 +4450,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Contract\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Contract.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Contract.php',
 ];
@@ -4836,12 +4554,6 @@ $ignoreErrors[] = [
 	'identifier' => 'assign.propertyType',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CronTask.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/CronTaskLog.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$dbhost on DBmysql\\|null\\.$#',
@@ -4988,12 +4700,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DCRoom.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DCRoom.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on Agent\\|null\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 4,
@@ -5012,19 +4718,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DatabaseInstance.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DatabaseInstance.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DatabaseInstance.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DatabaseInstance.php',
@@ -5156,12 +4850,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DefaultFilter.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method addCell\\(\\) on HTMLTableRow\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 3,
@@ -5186,8 +4874,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DeviceCamera.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|null\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DeviceCase.php',
 ];
@@ -5270,6 +4958,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DeviceGraphicCard.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/DeviceHardDrive.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot call method addCell\\(\\) on HTMLTableRow\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 3,
@@ -5282,10 +4976,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DeviceHardDrive.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|null\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
 	'count' => 1,
-	'path' => __DIR__ . '/src/DeviceHardDrive.php',
+	'path' => __DIR__ . '/src/DeviceMemory.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method addCell\\(\\) on HTMLTableRow\\|null\\.$#',
@@ -5297,12 +4991,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method getHeaderByName\\(\\) on HTMLTableRow\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 2,
-	'path' => __DIR__ . '/src/DeviceMemory.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
 	'path' => __DIR__ . '/src/DeviceMemory.php',
 ];
 $ignoreErrors[] = [
@@ -5330,6 +5018,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DeviceNetworkCard.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/DevicePowerSupply.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot call method addCell\\(\\) on HTMLTableRow\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -5337,12 +5031,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getHeaderByName\\(\\) on HTMLTableRow\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DevicePowerSupply.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DevicePowerSupply.php',
@@ -5570,12 +5258,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Domain.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Domain.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -5592,12 +5274,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 2,
 	'path' => __DIR__ . '/src/DomainRecordType.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Domain_Item.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'count\' on array\\|string\\|false\\.$#',
@@ -5720,12 +5396,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Enclosure.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Enclosure.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -5799,12 +5469,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$items_id of static method Glpi\\\\Event\\:\\:log\\(\\) expects int\\|string, int\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Entity.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Entity.php',
@@ -6068,6 +5732,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 4,
+	'path' => __DIR__ . '/src/Glpi/Api/API.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'endpoint\' on array\\{api_version\\: string, version\\: string, description\\?\\: string, endpoint\\: string\\}\\|false\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
@@ -6119,12 +5789,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 4,
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
@@ -6338,9 +6002,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:getItemtype\\(\\) should return class\\-string\\<CommonDBTM\\>\\|false but returns \'AllAssets\'\\.$#',
+	'identifier' => 'return.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\APIRest\\:\\:getItemtype\\(\\) should return class\\-string\\<CommonDBTM\\>\\|false but returns string\\.$#',
 	'identifier' => 'return.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/APIRest.php',
 ];
 $ignoreErrors[] = [
@@ -7757,12 +7427,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$input of method Glpi\\\\Asset\\\\Asset\\:\\:handleReadonlyFieldUpdate\\(\\) expects array, array\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Asset/Asset.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Asset/Asset.php',
 ];
 $ignoreErrors[] = [
@@ -9368,6 +9032,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Dashboard/Provider.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot call method getSystemSQLCriteria\\(\\) on CommonDBTM\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -9446,12 +9116,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Provider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call static method getType\\(\\) on CommonDBTM\\|null\\.$#',
-	'identifier' => 'staticMethod.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Dashboard/Provider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call static method getTypeName\\(\\) on CommonDBTM\\|null\\.$#',
 	'identifier' => 'staticMethod.nonObject',
 	'count' => 2,
@@ -9476,7 +9140,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Provider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
+	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Provider.php',
@@ -9755,12 +9419,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$input of method CommonDBTM\\:\\:addFiles\\(\\) expects array\\<string, mixed\\>, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Form/Comment.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Glpi/Form/Comment.php',
 ];
 $ignoreErrors[] = [
@@ -10226,12 +9884,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Form.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Form.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on Glpi\\\\ItemTranslation\\\\ItemTranslation\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 1,
@@ -10355,12 +10007,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$type of method Glpi\\\\Form\\\\QuestionType\\\\QuestionTypesManager\\:\\:isValidQuestionType\\(\\) expects string, class\\-string\\<Glpi\\\\Form\\\\QuestionType\\\\QuestionTypeInterface\\>\\|Glpi\\\\Form\\\\QuestionType\\\\QuestionTypeInterface given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Question.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Glpi/Form/Question.php',
 ];
 $ignoreErrors[] = [
@@ -11122,7 +10768,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of method Lockedfield\\:\\:getLockedNames\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/InventoryAsset.php',
 ];
 $ignoreErrors[] = [
@@ -12146,12 +11792,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Software.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/Software.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:\\$known_links \\(array\\<string, int\\>\\) does not accept array\\<string, bool\\|int\\>\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 3,
@@ -12518,12 +12158,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Inventory/Conf.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 38,
-	'path' => __DIR__ . '/src/Glpi/Inventory/Conf.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Access to an undefined property object\\:\\:\\$properties\\.$#',
 	'identifier' => 'property.notFound',
 	'count' => 1,
@@ -12869,12 +12503,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$value of method Glpi\\\\Inventory\\\\Asset\\\\InventoryAsset\\:\\:handleInput\\(\\) expects stdClass, object given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of method Glpi\\\\Inventory\\\\MainAsset\\\\MainAsset\\:\\:rulepassed\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/MainAsset/MainAsset.php',
 ];
 $ignoreErrors[] = [
@@ -13742,12 +13370,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/CriteriaFilter.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/CriteriaFilter.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'defaultfilter\' on array\\|true\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
@@ -14270,18 +13892,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Socket.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Socket.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Socket.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$array of function array_keys expects array, array\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -14570,12 +14180,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Group.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Group.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on Group\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 1,
@@ -14628,12 +14232,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/HTMLTableGroup.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of method HTMLTableMain\\:\\:addItemType\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/HTMLTableHeader.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$content of class HTMLTableCell constructor expects string, array\\|string given\\.$#',
@@ -14804,6 +14402,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Html.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/IPAddress.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot access offset 1\\|2\\|3 on array\\<int\\>\\|string\\|false\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
@@ -14831,12 +14435,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method getLink\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 3,
-	'path' => __DIR__ . '/src/IPAddress.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
 	'path' => __DIR__ . '/src/IPAddress.php',
 ];
 $ignoreErrors[] = [
@@ -14883,12 +14481,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$nb of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects int, int\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/IPAddress.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/IPAddress.php',
@@ -15032,20 +14624,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/IPNetwork_Vlan.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/IPNetwork_Vlan.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'code\' on array\\<string, mixed\\>\\|false\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILCategory.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ITILCategory.php',
 ];
@@ -15152,12 +14732,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ITILFollowupTemplate.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILFollowupTemplate.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'_job\' on array\\<string, mixed\\>\\|false\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
@@ -15182,12 +14756,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ITILSolution.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILSolution.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method ITILTemplate\\:\\:getITILObjectClass\\(\\) should return class\\-string\\<CommonITILObject\\> but returns string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -15206,30 +14774,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ITILTemplateField.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILTemplateHiddenField.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILTemplateMandatoryField.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILTemplatePredefinedField.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILTemplateReadonlyField.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method ITILValidationTemplate\\:\\:displayValidatorField\\(\\) should return string but returns int\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -15238,12 +14782,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method ITILValidationTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ITILValidationTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ITILValidationTemplate.php',
 ];
@@ -15344,12 +14882,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Impact.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Impact.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Binary operation "\\+" between float\\|int\\|string and float\\|int results in an error\\.$#',
 	'identifier' => 'binaryOp.invalid',
 	'count' => 2,
@@ -15419,12 +14951,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$fiscaldate of static method Infocom\\:\\:linearAmortise\\(\\) expects string, string\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Infocom.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Infocom.php',
 ];
 $ignoreErrors[] = [
@@ -15518,12 +15044,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ItemAntivirus.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ItemAntivirus.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method can\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -15560,12 +15080,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ItemVirtualMachine.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ItemVirtualMachine.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -15574,12 +15088,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getLink\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Cluster.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Item_Cluster.php',
 ];
@@ -15686,12 +15194,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_Devices.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Item_Devices.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#4 \\$item of method HTMLTableRow\\:\\:addCell\\(\\) expects CommonDBTM\\|null, CommonDBTM\\|false\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -15716,12 +15218,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_Disk.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Disk.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -15738,18 +15234,6 @@ $ignoreErrors[] = [
 	'identifier' => 'staticMethod.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Item_Enclosure.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Enclosure.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Environment.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#',
@@ -15830,12 +15314,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_Line.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Item_Line.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CommonDBTM\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 2,
@@ -15866,18 +15344,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_OperatingSystem.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_OperatingSystem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Process.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -15887,12 +15353,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$item of static method CommonDBRelation\\:\\:countForItem\\(\\) expects CommonDBTM, CommonDBTM\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Project.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Item_Project.php',
 ];
 $ignoreErrors[] = [
@@ -16010,12 +15470,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_SoftwareVersion.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Itil_Project.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Binary operation "\\." between non\\-falsy\\-string and array\\<string\\>\\|string results in an error\\.$#',
 	'identifier' => 'binaryOp.invalid',
 	'count' => 2,
@@ -16070,12 +15524,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/KnowbaseItem.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/KnowbaseItem.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method KnowbaseItem\\:\\:getTreeCategoryList\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -16094,22 +15542,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/KnowbaseItem.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/KnowbaseItem.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'parent\' might not exist on array\\<string, mixed\\>\\|null\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/KnowbaseItemTranslation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/KnowbaseItem_Comment.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CommonDBTM\\|false\\.$#',
@@ -16120,7 +15556,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/KnowbaseItem_Item.php',
 ];
 $ignoreErrors[] = [
@@ -16262,12 +15698,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/LevelAgreement.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/LevelAgreement.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Static property LevelAgreement\\:\\:\\$itemtype \\(string\\) does not accept class\\-string\\|false\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 1,
@@ -16298,12 +15728,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/LevelAgreementLevel.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/LevelAgreementLevel.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -16317,12 +15741,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$get_ip of static method Link\\:\\:getIPAndMACForItem\\(\\) expects bool, string\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Link.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Link.php',
@@ -16400,27 +15818,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Location.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Location.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CommonDBTM\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Lock.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getErrorMessage\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Lock.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Lock.php',
 ];
 $ignoreErrors[] = [
@@ -16479,18 +15885,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$specific_itemtype of method Lockedfield\\:\\:getFieldsToLock\\(\\) expects string\\|null, bool\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Lock.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$baseitemtype of static method Lock\\:\\:getLocksQueryInfosByItemType\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Lock.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Lock.php',
@@ -16556,19 +15950,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Log.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Log.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$params of method DBmysql\\:\\:buildInsert\\(\\) expects array\\<string, mixed\\>\\|Glpi\\\\DBAL\\\\QuerySubQuery, array\\<int\\|string, Glpi\\\\DBAL\\\\QueryParam\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Log.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Log.php',
@@ -16718,12 +16100,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/MailCollector.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ManualLink.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method addCell\\(\\) on HTMLTableRow\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -16738,12 +16114,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Manufacturer\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Manufacturer.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Manufacturer.php',
 ];
@@ -16803,12 +16173,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, class\\-string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/MassiveAction.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/MassiveAction.php',
@@ -16904,12 +16268,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Monitor.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Monitor.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -16946,25 +16304,19 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NetworkEquipment.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NetworkEquipment.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NetworkEquipment.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getID\\(\\) on CommonDBTM\\|null\\.$#',
-	'identifier' => 'method.nonObject',
+	'message' => '#^Cannot access constant class on CommonDBTM\\|null\\.$#',
+	'identifier' => 'classConstant.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NetworkEquipmentModelStencil.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|null\\.$#',
+	'message' => '#^Cannot call method getID\\(\\) on CommonDBTM\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NetworkEquipmentModelStencil.php',
@@ -17043,12 +16395,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$input of method CommonDBChild\\:\\:prepareInputForAdd\\(\\) expects array\\<string, mixed\\>, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NetworkPort.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of method NetworkPort\\:\\:getIpsForPort\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NetworkPort.php',
@@ -17282,20 +16628,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Notepad.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Notepad.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Notification\\:\\:getSpecificValueToSelect\\(\\) should return string but returns int\\|string\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Notification.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Notification.php',
 ];
@@ -17474,12 +16808,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTarget.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/NotificationTarget.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property NotificationTarget\\<T of CommonGLPI\\>\\:\\:\\$mode \\(\'ajax\'\\|\'irc\'\\|\'mailing\'\\|\'sms\'\\|\'websocket\'\\|\'xmpp\'\\|null\\) does not accept string\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 1,
@@ -17572,7 +16900,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access constant class on \\(T of CommonITILObject\\)\\|null\\.$#',
 	'identifier' => 'classConstant.nonObject',
-	'count' => 1,
+	'count' => 7,
 	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
 ];
 $ignoreErrors[] = [
@@ -17660,12 +16988,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on \\(T of CommonITILObject\\)\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 6,
-	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getTypeName\\(\\) on \\(T of CommonITILObject\\)\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -17728,7 +17050,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$string of function strtolower expects string, class\\-string\\<T of CommonITILObject\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/src/NotificationTargetCommonITILObject.php',
 ];
 $ignoreErrors[] = [
@@ -17870,6 +17192,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetInfocom.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on Entity\\|Group\\|Profile\\|User\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/NotificationTargetKnowbaseItem.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on Entity\\|Group\\|Profile\\|User\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 1,
@@ -17901,12 +17229,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getLink\\(\\) on KnowbaseItem\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTargetKnowbaseItem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on Entity\\|Group\\|Profile\\|User\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetKnowbaseItem.php',
@@ -17978,6 +17300,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetPlanningRecall.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on CommonDBTM\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/NotificationTargetPlanningRecall.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CommonITILTask\\|null\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 6,
@@ -17985,12 +17313,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getID\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTargetPlanningRecall.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetPlanningRecall.php',
@@ -18272,12 +17594,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTemplate.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTemplate.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$object of function get_class expects object, CommonGLPI\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -18386,12 +17702,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/PDU.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/PDU.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -18406,12 +17716,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method PassiveDCEquipment\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/PassiveDCEquipment.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/PassiveDCEquipment.php',
 ];
@@ -18542,12 +17846,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Peripheral.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Peripheral.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -18568,12 +17866,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Phone\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Phone.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Phone.php',
 ];
@@ -18932,12 +18224,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Printer.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Printer.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -18962,12 +18248,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/PrinterLog.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/PrinterLog.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Problem\\:\\:displayTabContentForItem\\(\\) should return bool but returns false\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -18977,12 +18257,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$users_id of method CommonITILObject\\:\\:isUser\\(\\) expects int, int\\|string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 4,
-	'path' => __DIR__ . '/src/Problem.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Problem.php',
 ];
 $ignoreErrors[] = [
@@ -19000,12 +18274,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method ProblemTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ProblemTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ProblemTemplate.php',
 ];
@@ -19064,12 +18332,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Profile.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Profile.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Profile\\:\\:getRightsFor\\(\\) expects class\\-string\\<CommonDBTM\\>, string\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -19092,6 +18354,24 @@ $ignoreErrors[] = [
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ProfileRight.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on Entity\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Profile_User.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on Profile\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 2,
+	'path' => __DIR__ . '/src/Profile_User.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Cannot access constant class on User\\|false\\.$#',
+	'identifier' => 'classConstant.nonObject',
+	'count' => 3,
+	'path' => __DIR__ . '/src/Profile_User.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$dohistory on Entity\\|false\\.$#',
@@ -19148,36 +18428,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Profile_User.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on Entity\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Profile_User.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on Profile\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Profile_User.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getType\\(\\) on User\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Profile_User.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$itemtype of static method Log\\:\\:history\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Profile_User.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Profile_User.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on static\\(Project\\)\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 3,
@@ -19205,18 +18455,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$input of method CommonDBTM\\:\\:addFiles\\(\\) expects array\\<string, mixed\\>, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Project.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Project.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Project\\:\\:getKanbanPluginFilters\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Project.php',
 ];
 $ignoreErrors[] = [
@@ -19370,22 +18608,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ProjectTask.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ProjectTaskTeam.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Part \\$sort \\(\'_effect_duration\'\\|\'fname\'\\|\'name\'\\|\'percent_done\'\\|\'plan_end_date\'\\|\'plan_start_date\'\\|\'planned_duration\'\\|\'projectname\'\\|\'sname\'\\|\'tname\'\\|array\\{\'plan_start_date ASC\'\\|\'plan_start_date DESC\', \'name\'\\}\\) of encapsed string cannot be cast to string\\.$#',
 	'identifier' => 'encapsedStringPart.nonString',
 	'count' => 1,
 	'path' => __DIR__ . '/src/ProjectTask_Ticket.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ProjectTeam.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CronTask\\|null\\.$#',
@@ -19442,12 +18668,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/RSSFeed.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/RSSFeed.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on CommonDBTM\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 2,
@@ -19473,12 +18693,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Rack.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Rack.php',
@@ -19570,7 +18784,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Reminder.php',
 ];
 $ignoreErrors[] = [
@@ -19586,22 +18800,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Reminder.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Reminder.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$users_id of method PlanningRecall\\:\\:getFromDBForItemAndUser\\(\\) expects int, int\\|string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Reminder.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/ReminderTranslation.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
@@ -19731,18 +18933,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$datetime of function Safe\\\\strtotime expects string, string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Reservation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of method ReservationItem\\:\\:getFromDBbyItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Reservation.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Reservation.php',
@@ -19892,12 +19082,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Rule.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Rule.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getItemForItemtype expects string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -20009,12 +19193,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$type of method Rule\\:\\:getActionValue\\(\\) expects string, array\\<int\\|string\\>\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Rule.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Rule.php',
 ];
 $ignoreErrors[] = [
@@ -20666,20 +19844,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/SavedSearch.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SavedSearch.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset \'savedsearches_id\' might not exist on array\\<string, mixed\\>\\|null\\.$#',
 	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SavedSearch_Alert.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/SavedSearch_Alert.php',
 ];
@@ -20912,12 +20078,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Software.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Software.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Search\\:\\:getDatas\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -20954,12 +20114,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/SoftwareLicense.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SoftwareLicense.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\<string, mixed\\>\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -20974,12 +20128,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method SolutionTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SolutionTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/SolutionTemplate.php',
 ];
@@ -21062,12 +20210,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/State.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/State.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -21075,12 +20217,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$item of static method Stencil\\:\\:getStencilFromItem\\(\\) expects CommonDBTM, CommonDBTM\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Stencil.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Stencil.php',
@@ -21104,20 +20240,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Supplier.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Supplier.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method TaskCategory\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/TaskCategory.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/TaskCategory.php',
 ];
@@ -21130,12 +20254,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method TaskTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/TaskTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/TaskTemplate.php',
 ];
@@ -21254,12 +20372,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Ticket.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Ticket.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$specifictime of static method Html\\:\\:computeGenericDateTimeSearch\\(\\) expects int\\|string, int\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -21280,12 +20392,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method TicketTemplate\\:\\:prepareInputForClone\\(\\) should return array but returns array\\|false\\.$#',
 	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/TicketTemplate.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/TicketTemplate.php',
 ];
@@ -21764,12 +20870,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/User.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/User.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Search\\:\\:getDatas\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -21806,12 +20906,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/User.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/User.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$value of function getEntitiesRestrictCriteria expects \'\'\\|array\\<int\\>\\|int, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -21833,12 +20927,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$id of static method CommonDBTM\\:\\:getById\\(\\) expects int\\|null, int\\|string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
-	'path' => __DIR__ . '/src/ValidatorSubstitute.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/ValidatorSubstitute.php',
 ];
 $ignoreErrors[] = [
@@ -21938,18 +21026,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Webhook.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Webhook.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Webhook.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Webhook\\:\\:getAPISchemaBySupportedItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -21964,19 +21040,13 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$itemtype of method Webhook\\:\\:addParentItemData\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Webhook.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$ong of method CommonGLPI\\:\\:addStandardTab\\(\\) expects array\\<string, bool\\|string\\>, array\\<string, bool\\|string\\|null\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Webhook.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
 	'path' => __DIR__ . '/src/Webhook.php',
 ];
 $ignoreErrors[] = [

--- a/ajax/comments.php
+++ b/ajax/comments.php
@@ -51,7 +51,7 @@ if (
     }
 
     switch ($_POST["itemtype"]) {
-        case User::getType():
+        case User::class:
             $link = null;
             $comments = [];
             if ($_POST['value'] == 0) {
@@ -86,7 +86,7 @@ if (
             }
             break;
 
-        case Group::getType():
+        case Group::class:
             if ($_POST['value'] != 0) {
                 $group = new Group();
                 if (!is_array($_POST["value"]) && $group->getFromDB($_POST['value']) && $group->canView()) {
@@ -102,7 +102,7 @@ if (
             }
             break;
 
-        case Supplier::getType():
+        case Supplier::class:
             $tmpname = [
                 'comment' => "",
             ];

--- a/ajax/debug.php
+++ b/ajax/debug.php
@@ -106,7 +106,7 @@ if (isset($_GET['action'])) {
         try {
             /** @var CommonGLPI $item */
             $item = getItemForItemtype($_GET['itemtype']);
-            $options = Search::getOptions($item::getType());
+            $options = Search::getOptions($item::class);
         } catch (Throwable $e) {
             $options = [];
         }

--- a/ajax/dropdownProjectTaskTicket.php
+++ b/ajax/dropdownProjectTaskTicket.php
@@ -73,7 +73,7 @@ if (isset($_POST["projects_id"])) {
         }
 
         $dropdown_params = [
-            'itemtype'        => ProjectTask::getType(),
+            'itemtype'        => ProjectTask::class,
             'entity_restrict' => Session::getMatchingActiveEntities($_POST['entity_restrict']),
             'myname'          => $_POST["myname"],
             'condition'       => $condition,

--- a/ajax/getMapPoint.php
+++ b/ajax/getMapPoint.php
@@ -48,11 +48,11 @@ if (!isset($_POST['itemtype']) || !isset($_POST['items_id']) || (int) $_POST['it
     $itemtype = $_POST['itemtype'];
     $items_id = $_POST['items_id'];
 
-    if ($itemtype != Location::getType()) {
+    if ($itemtype != Location::class) {
         $item = getItemForItemtype($itemtype);
         $found = $item->getFromDB($items_id);
         if ($found && isset($item->fields['locations_id']) && (int) $item->fields['locations_id'] > 0) {
-            $itemtype = Location::getType();
+            $itemtype = Location::class;
             $items_id = $item->fields['locations_id'];
         } else {
             $result = [

--- a/ajax/itilfollowup.php
+++ b/ajax/itilfollowup.php
@@ -94,7 +94,7 @@ if ($template->fields['requesttypes_id']) {
         ])
     ) {
         $template->fields['requesttypes_name'] = Dropdown::getDropdownName(
-            getTableForItemType(RequestType::getType()),
+            getTableForItemType(RequestType::class),
             $template->fields['requesttypes_id'],
             false,
             true,

--- a/ajax/map.php
+++ b/ajax/map.php
@@ -94,7 +94,7 @@ if (!isset($_POST['itemtype']) || !isset($_POST['params'])) {
             }
         }
 
-        if ($itemtype == AllAssets::getType()) {
+        if ($itemtype == AllAssets::class) {
             $curtype = $row['TYPE'];
             if (isset($points[$idx]['types'][$curtype])) {
                 $points[$idx]['types'][$curtype]['count']++;

--- a/ajax/projecttask.php
+++ b/ajax/projecttask.php
@@ -48,7 +48,7 @@ if (isset($_POST['projecttasktemplates_id']) && ($_POST['projecttasktemplates_id
 
     $template->fields['description'] = DropdownTranslation::getTranslatedValue(
         $template->getID(),
-        $template->getType(),
+        $template::class,
         'description',
         $_SESSION['glpilanguage'],
         $template->fields['description']

--- a/ajax/ruleaction.php
+++ b/ajax/ruleaction.php
@@ -58,7 +58,7 @@ if (isset($_POST["sub_type"]) && class_exists($_POST["sub_type"])) {
         $ra           = getItemForItemtype($item->getRuleActionClass());
         $used         = $ra->getAlreadyUsedForRuleID(
             $_POST[$item->getRuleIdField()],
-            $item->getType()
+            $item::class
         );
         $already_used = in_array($_POST["field"], $used);
     }

--- a/ajax/solution.php
+++ b/ajax/solution.php
@@ -78,7 +78,7 @@ if ($parents_id > 0 && !empty($parents_itemtype) && is_a($parents_itemtype, Comm
 
     $content = DropdownTranslation::getTranslatedValue(
         $template->getID(),
-        $template->getType(),
+        $template::class,
         'content',
         $_SESSION['glpilanguage'],
         $template->fields['content']
@@ -92,7 +92,7 @@ if ($parents_id > 0 && !empty($parents_itemtype) && is_a($parents_itemtype, Comm
 $template->fields['solutiontypes_name'] = "";
 if ($template->fields['solutiontypes_id']) {
     $entityRestrict = getEntitiesRestrictCriteria(
-        getTableForItemType(SolutionType::getType()),
+        getTableForItemType(SolutionType::class),
         "",
         $parent->fields['entities_id'] ?? 0,
         true
@@ -105,7 +105,7 @@ if ($template->fields['solutiontypes_id']) {
         ] + $entityRestrict)
     ) {
         $template->fields['solutiontypes_name'] = Dropdown::getDropdownName(
-            getTableForItemType(SolutionType::getType()),
+            getTableForItemType(SolutionType::class),
             $template->fields['solutiontypes_id'],
             false,
             true,

--- a/ajax/task.php
+++ b/ajax/task.php
@@ -87,7 +87,7 @@ $template->fields['content'] = $template->getRenderedContent($parent);
 //need when template is used and when GLPI preselected type if defined
 $template->fields['taskcategories_name'] = "";
 if ($template->fields['taskcategories_id']) {
-    $entityRestrict = getEntitiesRestrictCriteria(getTableForItemType(TaskCategory::getType()), "", $parent->fields['entities_id'], true);
+    $entityRestrict = getEntitiesRestrictCriteria(getTableForItemType(TaskCategory::class), "", $parent->fields['entities_id'], true);
 
     $taskcategory = new TaskCategory();
     if (
@@ -96,7 +96,7 @@ if ($template->fields['taskcategories_id']) {
         ] + $entityRestrict)
     ) {
         $template->fields['taskcategories_name'] = Dropdown::getDropdownName(
-            getTableForItemType(TaskCategory::getType()),
+            getTableForItemType(TaskCategory::class),
             $template->fields['taskcategories_id'],
             false,
             true,

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
         "friendsofphp/php-cs-fixer": "^3.93",
         "friendsoftwig/twigcs": "^6.6",
         "glpi-project/phpstan-glpi": "^1.1",
+        "glpi-project/rector-glpi": "^1.0",
         "mikey179/vfsstream": "^1.6",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/phpstan": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3bd4cbd639c8e2766fa8cffb087b65c",
+    "content-hash": "d4c539079b386f2a732965f1002b3c12",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -11138,6 +11138,45 @@
                 "source": "https://github.com/glpi-project/phpstan-glpi/tree/1.1.1"
             },
             "time": "2025-08-11T13:48:13+00:00"
+        },
+        {
+            "name": "glpi-project/rector-glpi",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/glpi-project/rector-glpi.git",
+                "reference": "c62f7192a0bd4b30c7900f9b69429bc5dc74c991"
+            },
+            "require": {
+                "php": ">=8.2",
+                "rector/rector": "^2.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.93",
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "rector-extension",
+            "autoload": {
+                "psr-4": {
+                    "RectorGlpi\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "classmap": [
+                    "tests/"
+                ],
+                "psr-4": {
+                    "RectorGlpi\\Tests\\": "tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Rector rules for GLPI.",
+            "time": "2026-02-05T13:10:30+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/front/commonitilobject_item.form.php
+++ b/front/commonitilobject_item.form.php
@@ -72,7 +72,7 @@ if (isset($_POST["add"])) {
     if ($item_obj->add($_POST)) {
         Event::log(
             $_POST[$obj_fkey],
-            strtolower($obj->getType()),
+            strtolower($obj::class),
             4,
             "tracking",
             //TRANS: %s is the user login

--- a/front/form/answersset.form.php
+++ b/front/form/answersset.form.php
@@ -49,5 +49,5 @@ if (isset($_POST["purge"])) {
     $answers_set->redirectToList();
 } else {
     Session::checkRight(Form::$rightname, READ);
-    AnswersSet::displayFullPageForItem($id, ['admin', Form::getType()], []);
+    AnswersSet::displayFullPageForItem($id, ['admin', Form::class], []);
 }

--- a/front/form/form.form.php
+++ b/front/form/form.form.php
@@ -67,5 +67,5 @@ if (($_REQUEST['id'] ?? 0) == 0) {
 } else {
     // Show requested form
     Session::checkRight(Form::$rightname, READ);
-    Form::displayFullPageForItem($id, ['admin', Form::getType()], []);
+    Form::displayFullPageForItem($id, ['admin', Form::class], []);
 }

--- a/front/item_device.common.form.php
+++ b/front/item_device.common.form.php
@@ -110,10 +110,10 @@ if (isset($_POST["add"])) {
     );
     Html::back();
 } else {
-    if (in_array($item_device->getType(), $CFG_GLPI['devices_in_menu'])) {
-        $menus = ["assets", strtolower($item_device->getType())];
+    if (in_array($item_device::class, $CFG_GLPI['devices_in_menu'])) {
+        $menus = ["assets", strtolower($item_device::class)];
     } else {
-        $menus = ["config", "commondevice", $item_device->getType()];
+        $menus = ["config", "commondevice", $item_device::class];
     }
 
     $item_device::displayFullPageForItem($_GET["id"], $menus, $options ?? []);

--- a/front/item_device.php
+++ b/front/item_device.php
@@ -50,12 +50,12 @@ if (!$itemDevice->canView()) {
     throw new AccessDeniedHttpException();
 }
 
-if (in_array($itemDevice->getType(), $CFG_GLPI['devices_in_menu'])) {
-    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "assets", strtolower($itemDevice->getType()));
+if (in_array($itemDevice::class, $CFG_GLPI['devices_in_menu'])) {
+    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "assets", strtolower($itemDevice::class));
 } else {
-    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $itemDevice->getType());
+    Html::header($itemDevice->getTypeName(Session::getPluralNumber()), '', "config", "commondevice", $itemDevice::class);
 }
 
-Search::show($itemDevice->getType());
+Search::show($itemDevice::class);
 
 Html::footer();

--- a/front/itilsolution.form.php
+++ b/front/itilsolution.form.php
@@ -92,7 +92,7 @@ if ($handled) {
         //if solution should be linked to selected KB entry
         $params = [
             'knowbaseitems_id' => $_POST['kb_linked_id'],
-            'itemtype'         => $track->getType(),
+            'itemtype'         => $track::class,
             'items_id'         => $track->getID(),
         ];
         $existing = $DB->request([

--- a/front/networkalias.form.php
+++ b/front/networkalias.form.php
@@ -54,7 +54,7 @@ if (isset($_POST["add"])) {
     if ($newID = $alias->add($_POST)) {
         Event::log(
             $newID,
-            $alias->getType(),
+            $alias::class,
             4,
             "setup",
             sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"])
@@ -87,7 +87,7 @@ if (isset($_POST["add"])) {
 
     Event::log(
         $_POST["id"],
-        $alias->getType(),
+        $alias::class,
         4,
         "setup",
         //TRANS: %s is the user login

--- a/front/notificationtemplatetranslation.form.php
+++ b/front/notificationtemplatetranslation.form.php
@@ -89,7 +89,7 @@ if (isset($_POST["add"])) {
         $_GET["notificationtemplates_id"] = $language->fields["notificationtemplates_id"];
     }
     $template->getFromDB($_GET["notificationtemplates_id"]);
-    $_SESSION['glpilisturl'][NotificationTemplateTranslation::getType()] = $template->getLinkURL();
+    $_SESSION['glpilisturl'][NotificationTemplateTranslation::class] = $template->getLinkURL();
 
     if ($_GET["id"] == '') {
         $options = [

--- a/front/pdu_rack.form.php
+++ b/front/pdu_rack.form.php
@@ -70,7 +70,7 @@ if (isset($_GET['id'])) {
     ];
 }
 
-$_SESSION['glpilisturl'][PDU_Rack::getType()] = $rack->getSearchURL();
+$_SESSION['glpilisturl'][PDU_Rack::class] = $rack->getSearchURL();
 
 $ajax = isset($_REQUEST['ajax']);
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -93,7 +93,7 @@ if (isset($_POST["add"])) {
         //if solution should be linked to selected KB entry
         $params = [
             'knowbaseitems_id' => $_POST['kb_linked_id'],
-            'itemtype'         => $track->getType(),
+            'itemtype'         => $track::class,
             'items_id'         => $track->getID(),
         ];
         $existing = $DB->request([

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -856,7 +856,7 @@ $empty_data_builder = new class {
                 'hourmax' => 6,
             ], [
                 'id' => 38,
-                'itemtype' => CleanSoftwareCron::getType(),
+                'itemtype' => CleanSoftwareCron::class,
                 'name' => CleanSoftwareCron::TASK_NAME,
                 'frequency' => MONTH_TIMESTAMP,
                 'param' => 1000,
@@ -904,7 +904,7 @@ $empty_data_builder = new class {
                 'hourmax' => 6,
             ], [
                 'id' => 42,
-                'itemtype' => PendingReasonCron::getType(),
+                'itemtype' => PendingReasonCron::class,
                 'name' => PendingReasonCron::TASK_NAME,
                 'frequency' => 30 * MINUTE_TIMESTAMP,
                 'param' => null,

--- a/install/migrations/update_10.0.5_to_10.0.6/unmanaged.php
+++ b/install/migrations/update_10.0.5_to_10.0.6/unmanaged.php
@@ -50,7 +50,7 @@ if (countElementsInTable(Rule::getTable(), ['sub_type' => 'RuleImportAsset']) > 
             'name'      => 'Unmanaged update (by name)',
             'uuid'      => 'glpi_rule_import_asset_unmanaged_update_name',
             'match'     => 'AND',
-            'sub_type'  => RuleImportAsset::getType(),
+            'sub_type'  => RuleImportAsset::class,
             'is_active' => 1,
         ],
         [
@@ -84,7 +84,7 @@ if (countElementsInTable(Rule::getTable(), ['sub_type' => 'RuleImportAsset']) > 
             'name'      => 'Unmanaged import (by name)',
             'uuid'      => 'glpi_rule_import_asset_unmanaged_import_name',
             'match'     => 'AND',
-            'sub_type'  => RuleImportAsset::getType(),
+            'sub_type'  => RuleImportAsset::class,
             'is_active' => 1,
         ],
         [
@@ -113,7 +113,7 @@ if (countElementsInTable(Rule::getTable(), ['sub_type' => 'RuleImportAsset']) > 
             'name'      => 'Unmanaged import denied',
             'uuid'      => 'glpi_rule_import_asset_unmanaged_import_denied',
             'match'     => 'AND',
-            'sub_type'  => RuleImportAsset::getType(),
+            'sub_type'  => RuleImportAsset::class,
             'is_active' => 1,
         ],
         [

--- a/rector.php
+++ b/rector.php
@@ -38,8 +38,12 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector as DeadCode;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\ValueObject\PhpVersion;
+use RectorGlpi\Set\GlpiSetList;
 
 return RectorConfig::configure()
+    ->withSets([
+        GlpiSetList::GLPI_DEFAULT_SET,
+    ])
     ->withPaths([
         __DIR__ . '/ajax',
         __DIR__ . '/dependency_injection',

--- a/src/AbstractITILChildTemplate.php
+++ b/src/AbstractITILChildTemplate.php
@@ -130,7 +130,7 @@ abstract class AbstractITILChildTemplate extends CommonDropdown
         $content = $this->fields['content'];
         $content = DropdownTranslation::getTranslatedValue(
             $this->getID(),
-            $this->getType(),
+            static::class,
             'content',
             $_SESSION['glpilanguage'],
             $content

--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -131,33 +131,33 @@ abstract class AbstractRightsDropdown
         $possible_rights = [];
 
         // Add profiles if enabled
-        if (self::isTypeEnabled(Profile::getType())) {
-            $possible_rights[Profile::getType()] = self::getProfiles($text);
+        if (self::isTypeEnabled(Profile::class)) {
+            $possible_rights[Profile::class] = self::getProfiles($text);
         }
 
         // Add entities if enabled
-        if (self::isTypeEnabled(Entity::getType())) {
-            $possible_rights[Entity::getType()] = self::getEntities($text);
+        if (self::isTypeEnabled(Entity::class)) {
+            $possible_rights[Entity::class] = self::getEntities($text);
         }
 
         // Add users if enabled
-        if (self::isTypeEnabled(User::getType(), $options)) {
-            $possible_rights[User::getType()] = self::getUsers($text, $options);
+        if (self::isTypeEnabled(User::class, $options)) {
+            $possible_rights[User::class] = self::getUsers($text, $options);
         }
 
         // Add groups if enabled
-        if (self::isTypeEnabled(Group::getType(), $options)) {
-            $possible_rights[Group::getType()] = self::getGroups($text, $options);
+        if (self::isTypeEnabled(Group::class, $options)) {
+            $possible_rights[Group::class] = self::getGroups($text, $options);
         }
 
         // Add contacts if enabled
-        if (self::isTypeEnabled(Contact::getType())) {
-            $possible_rights[Contact::getType()] = self::getContacts($text);
+        if (self::isTypeEnabled(Contact::class)) {
+            $possible_rights[Contact::class] = self::getContacts($text);
         }
 
         // Add suppliers if enabled
-        if (self::isTypeEnabled(Supplier::getType())) {
-            $possible_rights[Supplier::getType()] = self::getSuppliers($text, $options);
+        if (self::isTypeEnabled(Supplier::class)) {
+            $possible_rights[Supplier::class] = self::getSuppliers($text, $options);
         }
 
         $results = [];

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -580,7 +580,7 @@ class Agent extends CommonDBTM
                 'SELECT' => ['ips.name', 'ips.version'],
                 'FROM'   => NetworkPort::getTable() . ' AS netports',
                 'WHERE'  => [
-                    'netports.itemtype'  => $item->getType(),
+                    'netports.itemtype'  => $item::class,
                     'netports.items_id'  => $item->getID(),
                     'NOT'       => [
                         'OR'  => [
@@ -600,7 +600,7 @@ class Agent extends CommonDBTM
                             'netnames'  => 'items_id',
                             'netports'  => 'id', [
                                 'AND' => [
-                                    'netnames.itemtype'  => NetworkPort::getType(),
+                                    'netnames.itemtype'  => NetworkPort::class,
                                 ],
                             ],
                         ],
@@ -610,7 +610,7 @@ class Agent extends CommonDBTM
                             'ips'       => 'items_id',
                             'netnames'  => 'id', [
                                 'AND' => [
-                                    'ips.itemtype' => NetworkName::getType(),
+                                    'ips.itemtype' => NetworkName::class,
                                 ],
                             ],
                         ],
@@ -633,7 +633,7 @@ class Agent extends CommonDBTM
                 'SELECT' => ['d.name'],
                 'FROM'   => Domain_Item::getTable(),
                 'WHERE'  => [
-                    'itemtype'  => $item->getType(),
+                    'itemtype'  => $item::class,
                     'items_id'  => $item->getID(),
                 ],
                 'INNER JOIN'   => [

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -548,16 +548,16 @@ class Appliance extends CommonDBTM implements AssignableItemInterface, StateInte
                     $input = [
                         'appliances_id'   => $input['appliances_id'],
                         'items_id'        => $id,
-                        'itemtype'        => $item->getType(),
+                        'itemtype'        => $item::class,
                     ];
                     if ($appli_item->can(-1, UPDATE, $input)) {
                         if ($appli_item->add($input)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                     }
                 }
 

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -76,12 +76,12 @@ class Appliance_Item extends CommonDBRelation
                     $nb = self::countForMainItem($item);
                 }
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
-        } elseif (in_array($item->getType(), Appliance::getTypes(true))) {
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
+        } elseif (in_array($item::class, Appliance::getTypes(true))) {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(Appliance::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
 
         return '';
@@ -98,7 +98,7 @@ class Appliance_Item extends CommonDBRelation
                 self::showItems($item);
                 break;
             default:
-                if (in_array($item->getType(), Appliance::getTypes())) {
+                if (in_array($item::class, Appliance::getTypes())) {
                     self::showForItem($item, $withtemplate);
                 }
         }
@@ -135,7 +135,7 @@ class Appliance_Item extends CommonDBRelation
         ]);
 
         Session::initNavigateListItems(
-            self::getType(),
+            static::class,
             //TRANS : %1$s is the itemtype name,
             //        %2$s is the name of the item (used for headings of a list)
             sprintf(

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -370,7 +370,7 @@ class AuthLDAP extends CommonDBTM
                     !Session::haveRight("user", User::UPDATEAUTHENT)
                     || !$group->canGlobal(UPDATE)
                 ) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     return;
                 }
@@ -392,9 +392,9 @@ class AuthLDAP extends CommonDBTM
                             'type'         => $input['ldap_import_type'][$id],
                         ];
                         if (self::ldapImportGroup($group_dn, $options)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION, htmlescape($group_dn)));
                         }
                     }
@@ -406,7 +406,7 @@ class AuthLDAP extends CommonDBTM
             case 'import':
             case 'sync':
                 if (!Session::haveRight("user", User::IMPORTEXTAUTHUSERS)) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     return;
                 }
@@ -421,9 +421,9 @@ class AuthLDAP extends CommonDBTM
                             true
                         )
                     ) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION, htmlescape($id)));
                     }
                 }

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -99,10 +99,10 @@ class Budget extends CommonDropdown
     {
 
         if (!$withtemplate) {
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case self::class:
                     return [1 => self::createTabEntry(__('Main')),
-                        2 => self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package'),
+                        2 => self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), 0, $item::class, 'ti ti-package'),
                     ];
             }
         }

--- a/src/CableStrand.php
+++ b/src/CableStrand.php
@@ -71,7 +71,7 @@ class CableStrand extends CommonDropdown
 
         if (!$withtemplate) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case self::class:
                     /** @var CableStrand $item */
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -80,7 +80,7 @@ class CableStrand extends CommonDropdown
                             ['cablestrands_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';
@@ -155,7 +155,7 @@ class CableStrand extends CommonDropdown
 
             foreach ($iterator as $data) {
                 if (!$cable->getFromDB($data['id'])) {
-                    trigger_error(sprintf('Unable to load item %s (%s).', $cable->getType(), $data['id']), E_USER_WARNING);
+                    trigger_error(sprintf('Unable to load item %s (%s).', $cable::class, $data['id']), E_USER_WARNING);
                     continue;
                 }
 
@@ -177,7 +177,7 @@ class CableStrand extends CommonDropdown
                 if ($cable->fields["sockets_id_endpoint_b"] > 0) {
                     $sockets_endpoint_b = new Socket();
                     if (!$sockets_endpoint_b->getFromDB($cable->fields["sockets_id_endpoint_b"])) {
-                        trigger_error(sprintf('Unable to load item %s (%s).', Socket::getType(), $cable->fields["sockets_id_endpoint_b"]), E_USER_WARNING);
+                        trigger_error(sprintf('Unable to load item %s (%s).', Socket::class, $cable->fields["sockets_id_endpoint_b"]), E_USER_WARNING);
                     } else {
                         echo $sockets_endpoint_b->getLink();
                     }
@@ -197,7 +197,7 @@ class CableStrand extends CommonDropdown
                 if ($cable->fields["sockets_id_endpoint_a"] > 0) {
                     $sockets_endpoint_a = new Socket();
                     if (!$sockets_endpoint_a->getFromDB($cable->fields["sockets_id_endpoint_a"])) {
-                        trigger_error(sprintf('Unable to load item %s (%s).', Socket::getType(), $cable->fields["sockets_id_endpoint_a"]), E_USER_WARNING);
+                        trigger_error(sprintf('Unable to load item %s (%s).', Socket::class, $cable->fields["sockets_id_endpoint_a"]), E_USER_WARNING);
                     } else {
                         echo $sockets_endpoint_a->getLink();
                     }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -149,26 +149,26 @@ class Calendar extends CommonDropdown
                             ) {
                                 if ($item->can(-1, CREATE, $options)) {
                                     if (method_exists($item, 'clone') && $item->clone($options)) {
-                                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                     } else {
-                                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                     }
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
 
@@ -191,18 +191,18 @@ class Calendar extends CommonDropdown
                                 'holidays_id'  => $input['holidays_id'],
                             ];
                             if ($calendar_holiday->add($input)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
         }

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -448,7 +448,7 @@ class CalendarSegment extends CommonDBChild
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = countElementsInTable(static::getTable(), ['calendars_id' => $item->getID()]);
                 }
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';

--- a/src/Calendar_Holiday.php
+++ b/src/Calendar_Holiday.php
@@ -166,7 +166,7 @@ class Calendar_Holiday extends CommonDBRelation
                 return self::createTabEntry(
                     _n('Close time', 'Close times', Session::getPluralNumber()),
                     $nb,
-                    $item::getType()
+                    $item::class
                 );
             }
         }

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -77,12 +77,12 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
 
         if (!$withtemplate && Printer::canView()) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'CartridgeItem':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(PrinterModel::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(PrinterModel::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';

--- a/src/Central.php
+++ b/src/Central.php
@@ -339,7 +339,7 @@ class Central extends CommonGLPI
                 'itemtype'  => Project::class,
                 'widget'    => 'central_list',
                 'params'    => $card_params + [
-                    'itemtype'      => User::getType(),
+                    'itemtype'      => User::class,
                     '_idor_token'  => $idor,
                 ],
             ];
@@ -350,7 +350,7 @@ class Central extends CommonGLPI
                 'itemtype'  => ProjectTask::class,
                 'widget'    => 'central_list',
                 'params'    => $card_params + [
-                    'itemtype'      => User::getType(),
+                    'itemtype'      => User::class,
                     '_idor_token'  => $idor,
                 ],
             ];
@@ -501,7 +501,7 @@ class Central extends CommonGLPI
                 'itemtype'  => Project::class,
                 'widget'    => 'central_list',
                 'params'    => [
-                    'itemtype'    => Group::getType(),
+                    'itemtype'    => Group::class,
                     '_idor_token' => $idor,
                 ],
             ];
@@ -512,7 +512,7 @@ class Central extends CommonGLPI
                 'itemtype'  => ProjectTask::class,
                 'widget'    => 'central_list',
                 'params'    => [
-                    'itemtype'    => Group::getType(),
+                    'itemtype'    => Group::class,
                     '_idor_token' => $idor,
                 ],
             ];

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -631,16 +631,16 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
                 foreach ($ids as $id) {
                     $input = ['certificates_id' => $input['certificates_id'],
                         'items_id'        => $id,
-                        'itemtype'        => $item->getType(),
+                        'itemtype'        => $item::class,
                     ];
                     if ($certif_item->can(-1, UPDATE, $input)) {
                         if ($certif_item->add($input)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                     }
                 }
 
@@ -655,12 +655,12 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
                             'itemtype' => $input['typeitem'],
                         ];
                         if ($certif_item->add($values)) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -670,9 +670,9 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
                 $input = $ma->getInput();
                 foreach ($ids as $key) {
                     if ($certif_item->deleteItemByCertificatesAndItem($key, $input['item_item'], $input['typeitem'])) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                     }
                 }
                 return;

--- a/src/Certificate_Item.php
+++ b/src/Certificate_Item.php
@@ -69,7 +69,7 @@ class Certificate_Item extends CommonDBRelation
     public static function cleanForItem(CommonDBTM $item)
     {
         $temp = new self();
-        $temp->deleteByCriteria(['itemtype' => $item->getType(),
+        $temp->deleteByCriteria(['itemtype' => $item::class,
             'items_id' => $item->getField('id'),
         ]);
     }
@@ -89,9 +89,9 @@ class Certificate_Item extends CommonDBRelation
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = self::countForMainItem($item);
                 }
-                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+                return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
             } elseif (
-                in_array($item->getType(), Certificate::getTypes(true))
+                in_array($item::class, Certificate::getTypes(true))
                 && Certificate::canView()
             ) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
@@ -115,7 +115,7 @@ class Certificate_Item extends CommonDBRelation
 
         if ($item instanceof Certificate) {
             self::showForCertificate($item);
-        } elseif (in_array($item->getType(), Certificate::getTypes(true))) {
+        } elseif (in_array($item::class, Certificate::getTypes(true))) {
             self::showForItem($item);
         }
         return true;

--- a/src/Change.php
+++ b/src/Change.php
@@ -234,7 +234,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                         $satisfaction->getFromDB($item->getID())
                         && in_array($item->fields['status'], self::getClosedStatusArray())
                     ) {
-                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
+                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), 0, static::class);
                     }
 
                     return $ong;
@@ -252,7 +252,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                             ] + getEntitiesRestrictCriteria(self::getTable())
                         );
                     }
-                    return self::createTabEntry(__('Created changes'), $nb, $item::getType());
+                    return self::createTabEntry(__('Created changes'), $nb, $item::class);
 
                 case Group::class:
                     $nb = 0;
@@ -267,7 +267,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                             ] + getEntitiesRestrictCriteria(self::getTable())
                         );
                     }
-                    return self::createTabEntry(__('Created changes'), $nb, $item::getType());
+                    return self::createTabEntry(__('Created changes'), $nb, $item::class);
             }
         }
         return '';
@@ -883,7 +883,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
 
             default:
                 $restrict['glpi_changes_items.items_id'] = $item->getID();
-                $restrict['glpi_changes_items.itemtype'] = $item->getType();
+                $restrict['glpi_changes_items.itemtype'] = $item::class;
                 // you can only see your tickets
                 if (!Session::haveRight(self::$rightname, self::READALL)) {
                     $or = [

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -225,7 +225,7 @@ class Cluster extends CommonDBTM implements AssignableItemInterface, StateInterf
         $cluster = new self();
         $item_cluster = new Item_Cluster();
         if (
-            $item_cluster->getFromDBByCrit(['itemtype' => $item->getType(), 'items_id' => $item->getID()])
+            $item_cluster->getFromDBByCrit(['itemtype' => $item::class, 'items_id' => $item->getID()])
             && $item_cluster->fields['clusters_id'] != 0
             && $cluster->getFromDB($item_cluster->fields['clusters_id'])
         ) {

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -546,9 +546,9 @@ abstract class CommonDBChild extends CommonDBConnexity
             ];
             Log::history(
                 $item->getID(),
-                $item->getType(),
+                $item::class,
                 $changes,
-                $this->getType(),
+                static::class,
                 static::$log_history_add
             );
         }
@@ -596,7 +596,7 @@ abstract class CommonDBChild extends CommonDBConnexity
                         $item->getID(),
                         $item->getType(),
                         $changes,
-                        $this->getType(),
+                        static::class,
                         static::$log_history_update
                     );
                 }
@@ -619,7 +619,7 @@ abstract class CommonDBChild extends CommonDBConnexity
                         $prevItem->getID(),
                         $prevItem->getType(),
                         $changes,
-                        $this->getType(),
+                        static::class,
                         static::$log_history_delete
                     );
                 }
@@ -635,7 +635,7 @@ abstract class CommonDBChild extends CommonDBConnexity
                         $newItem->getID(),
                         $newItem->getType(),
                         $changes,
-                        $this->getType(),
+                        static::class,
                         static::$log_history_add
                     );
                 }
@@ -679,9 +679,9 @@ abstract class CommonDBChild extends CommonDBConnexity
             }
             Log::history(
                 $item->getID(),
-                $item->getType(),
+                $item::class,
                 $changes,
-                $this->getType(),
+                static::class,
                 static::$log_history_delete
             );
         }
@@ -722,9 +722,9 @@ abstract class CommonDBChild extends CommonDBConnexity
                 ];
                 Log::history(
                     $item->getID(),
-                    $item->getType(),
+                    $item::class,
                     $changes,
-                    $this->getType(),
+                    static::class,
                     static::$log_history_lock
                 );
             }
@@ -766,9 +766,9 @@ abstract class CommonDBChild extends CommonDBConnexity
                 ];
                 Log::history(
                     $item->getID(),
-                    $item->getType(),
+                    $item::class,
                     $changes,
-                    $this->getType(),
+                    static::class,
                     static::$log_history_unlock
                 );
             }
@@ -956,7 +956,7 @@ abstract class CommonDBChild extends CommonDBConnexity
         ];
 
         if (preg_match('/^itemtype/', static::$itemtype)) {
-            $query['WHERE']['itemtype'] = $item->getType();
+            $query['WHERE']['itemtype'] = $item::class;
         }
 
         $current_item = new static();

--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -748,7 +748,7 @@ abstract class CommonDBConnexity extends CommonDBTM
             return;
         }
 
-        $itemtype      = $item->getType();
+        $itemtype      = $item::class;
         $specificities = $itemtype::getConnexityMassiveActionsSpecificities();
 
         $action        = $ma->getAction();
@@ -770,27 +770,27 @@ abstract class CommonDBConnexity extends CommonDBTM
                 foreach ($ids as $key) {
                     if ($item->can($key, UPDATE)) {
                         if ($item instanceof CommonDBRelation) {
-                            if (isset($input['peer'][$item->getType()])) {
-                                if ($item->affectRelation($key, $input['peer'][$item->getType()])) {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            if (isset($input['peer'][$item::class])) {
+                                if ($item->affectRelation($key, $input['peer'][$item::class])) {
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } elseif ($item instanceof CommonDBChild) {
                             if ($item->affectChild($key)) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -798,7 +798,7 @@ abstract class CommonDBConnexity extends CommonDBTM
 
             case 'affect':
                 if (!$specificities['reaffect']) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     return;
                 }
@@ -823,21 +823,21 @@ abstract class CommonDBConnexity extends CommonDBTM
                 $input2[$peers_id] = $input['peers_id'];
                 if (preg_match('/^itemtype/', $peertype)) {
                     if (!in_array($input['peertype'], $specificities['itemtypes'])) {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         return;
                     }
                     $input2[$peertype] = $input['peertype'];
                 } else {
                     if ($peertype != $input['peertype']) {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         return;
                     }
                 }
                 foreach ($ids as $key) {
                     if (!$item->getFromDB($key)) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         continue;
                     }
@@ -846,13 +846,13 @@ abstract class CommonDBConnexity extends CommonDBTM
                             ($input2[$peertype] == $item->fields[$peertype])
                             && ($input2[$peers_id] == $item->fields[$peers_id])
                         ) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ALREADY_DEFINED));
                             continue;
                         }
                     } else {
                         if ($input2[$peers_id] == $item->fields[$peers_id]) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ALREADY_DEFINED));
                             continue;
                         }
@@ -860,13 +860,13 @@ abstract class CommonDBConnexity extends CommonDBTM
                     $input2[$item->getIndexName()] = $item->getID();
                     if ($item->can($item->getID(), UPDATE, $input2)) {
                         if ($item->update($input2)) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -203,7 +203,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
      **/
     public static function getOpposite(CommonDBTM $item, &$relations_id = null)
     {
-        return static::getOppositeByTypeAndID($item->getType(), $item->getID(), $relations_id);
+        return static::getOppositeByTypeAndID($item::class, $item->getID(), $relations_id);
     }
 
 
@@ -321,14 +321,14 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
         // Check item 1 type
         if (preg_match('/^itemtype/', static::$itemtype_1)) {
-            $wheres[static::$itemtype_1] = $item1->getType();
+            $wheres[static::$itemtype_1] = $item1::class;
         } elseif (!is_a($item1, static::$itemtype_1)) {
             return false;
         }
 
         // Check item 1 type
         if (preg_match('/^itemtype/', static::$itemtype_2)) {
-            $wheres[static::$itemtype_2] = $item2->getType();
+            $wheres[static::$itemtype_2] = $item2::class;
         } elseif (!is_a($item2, static::$itemtype_2)) {
             return false;
         }
@@ -845,9 +845,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 ];
                 Log::history(
                     $item1->getID(),
-                    $item1->getType(),
+                    $item1::class,
                     $changes,
-                    $item2->getType(),
+                    $item2::class,
                     static::$log_history_1_add
                 );
             }
@@ -860,9 +860,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 ];
                 Log::history(
                     $item2->getID(),
-                    $item2->getType(),
+                    $item2::class,
                     $changes,
-                    $item1->getType(),
+                    $item1::class,
                     static::$log_history_2_add
                 );
             }
@@ -1043,9 +1043,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
                     Log::history(
                         $item1->getID(),
-                        $item1->getType(),
+                        $item1::class,
                         $changes,
-                        $item2->getType(),
+                        $item2::class,
                         static::$log_history_1_lock
                     );
                 }
@@ -1061,9 +1061,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                     ];
                     Log::history(
                         $item2->getID(),
-                        $item2->getType(),
+                        $item2::class,
                         $changes,
-                        $item1->getType(),
+                        $item1::class,
                         static::$log_history_2_lock
                     );
                 }
@@ -1101,9 +1101,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                     ];
                     Log::history(
                         $item1->getID(),
-                        $item1->getType(),
+                        $item1::class,
                         $changes,
-                        $item2->getType(),
+                        $item2::class,
                         static::$log_history_1_unlock
                     );
                 }
@@ -1119,9 +1119,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                     ];
                     Log::history(
                         $item2->getID(),
-                        $item2->getType(),
+                        $item2::class,
                         $changes,
-                        $item1->getType(),
+                        $item1::class,
                         static::$log_history_2_unlock
                     );
                 }
@@ -1155,9 +1155,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 ];
                 Log::history(
                     $item1->getID(),
-                    $item1->getType(),
+                    $item1::class,
                     $changes,
-                    $item2->getType(),
+                    $item2::class,
                     static::$log_history_1_delete
                 );
             }
@@ -1173,9 +1173,9 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 ];
                 Log::history(
                     $item2->getID(),
-                    $item2->getType(),
+                    $item2::class,
                     $changes,
-                    $item1->getType(),
+                    $item1::class,
                     static::$log_history_2_delete
                 );
             }
@@ -1252,7 +1252,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
             $item = $father->getItem();
         }
 
-        $criteria = self::getSQLCriteriaToSearchForItem($item->getType(), $item->getID());
+        $criteria = self::getSQLCriteriaToSearchForItem($item::class, $item->getID());
         if ($criteria !== null) {
             $relation = new static();
             $iterator = $DB->request($criteria);
@@ -1561,7 +1561,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
         // If the fields provided by showMassiveActionsSubForm are not valid then quit !
         if (!isset($item_number)) {
-            $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+            $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
             $ma->addMessage($link->getErrorMessage(ERROR_NOT_FOUND));
             return;
         }
@@ -1579,7 +1579,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         }
 
         if (preg_match('/^itemtype/', $itemtype)) {
-            $input2[$itemtype] = $item->getType();
+            $input2[$itemtype] = $item::class;
         }
 
         // Get the peer from the $input2 and the name of its fields
@@ -1588,7 +1588,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         // $peer not valid => not in DB or try to remove all at once !
         if (!($peer instanceof CommonDBTM) || $peer->isNewItem()) {
             if ((isset($input2[$peers_id])) && ($input2[$peers_id] > 0)) {
-                $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 if ($peer instanceof CommonDBTM) {
                     $ma->addMessage($peer->getErrorMessage(ERROR_NOT_FOUND));
                 } else {
@@ -1619,13 +1619,13 @@ abstract class CommonDBRelation extends CommonDBConnexity
             case 'add':
                 // remove all at once only available for remove !
                 if (!$peer) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($link->getErrorMessage(ERROR_ON_ACTION));
                     return;
                 }
                 foreach ($ids as $key) {
                     if (!$item->getFromDB($key)) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         continue;
                     }
@@ -1634,13 +1634,13 @@ abstract class CommonDBRelation extends CommonDBConnexity
                     if ($specificities['can_link_several_times']) {
                         if ($link->can(-1, CREATE, $input2)) {
                             if ($link->add($input2)) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($link->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($link->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
@@ -1655,20 +1655,20 @@ abstract class CommonDBRelation extends CommonDBConnexity
                         }
                         if (!$link->isNewItem()) {
                             if (!$specificities['update_if_different']) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($link->getErrorMessage(ERROR_ALREADY_DEFINED));
                                 continue;
                             }
                             $input2[static::getIndexName()] = $link->getID();
                             if ($link->can($link->getID(), UPDATE, $input2)) {
                                 if ($link->update($input2)) {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($link->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($link->getErrorMessage(ERROR_RIGHT));
                             }
                             // if index defined, then cannot not add any other link due to index unicity
@@ -1676,13 +1676,13 @@ abstract class CommonDBRelation extends CommonDBConnexity
                         } else {
                             if ($link->can(-1, CREATE, $input2)) {
                                 if ($link->add($input2)) {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($link->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($link->getErrorMessage(ERROR_RIGHT));
                             }
                         }
@@ -1694,10 +1694,10 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 foreach ($ids as $key) {
                     // First, get the query to find all occurences of the link item<=>key
                     if (!$peer) {
-                        $criteria = static::getSQLCriteriaToSearchForItem($item->getType(), $key);
+                        $criteria = static::getSQLCriteriaToSearchForItem($item::class, $key);
                     } else {
                         if (!$item->getFromDB($key)) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                             continue;
                         }
@@ -1707,10 +1707,10 @@ abstract class CommonDBRelation extends CommonDBConnexity
                             static::$items_id_2  => $item_2->getID(),
                         ];
                         if (preg_match('/^itemtype/', static::$itemtype_1)) {
-                            $WHERE[static::$itemtype_1] = $item_1->getType();
+                            $WHERE[static::$itemtype_1] = $item_1::class;
                         }
                         if (preg_match('/^itemtype/', static::$itemtype_2)) {
-                            $WHERE[static::$itemtype_2] = $item_2->getType();
+                            $WHERE[static::$itemtype_2] = $item_2::class;
                         }
 
                         if (
@@ -1722,10 +1722,10 @@ abstract class CommonDBRelation extends CommonDBConnexity
                                 static::$items_id_2 => $item_2->getID(),
                             ];
                             if (preg_match('/^itemtype/', static::$itemtype_1)) {
-                                $ORWHERE[static::$itemtype_1] = $item_2->getType();
+                                $ORWHERE[static::$itemtype_1] = $item_2::class;
                             }
                             if (preg_match('/^itemtype/', static::$itemtype_2)) {
-                                $ORWHERE[static::$itemtype_2] = $item_2->getType();
+                                $ORWHERE[static::$itemtype_2] = $item_2::class;
                             }
                             $WHERE = [
                                 'OR' => [
@@ -1744,7 +1744,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
                     $request        = $DB->request($criteria);
                     $number_results = count($request);
                     if ($number_results == 0) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         $ma->addMessage($link->getErrorMessage(ERROR_NOT_FOUND));
                         continue;
                     }
@@ -1765,12 +1765,12 @@ abstract class CommonDBRelation extends CommonDBConnexity
                         }
                     }
                     if ($ok == $number_results) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                     } else {
                         if ($noright > 0) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         } elseif ($ko > 0) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         }
                     }
                 }
@@ -1811,7 +1811,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 throw new RuntimeException(
                     sprintf(
                         'Cannot use getListForItemParams() for a %s',
-                        $item->getType()
+                        $item::class
                     )
                 );
             }
@@ -1850,10 +1850,10 @@ abstract class CommonDBRelation extends CommonDBConnexity
         }
 
         if ($DB->fieldExists(static::getTable(), 'itemtype')) {
-            $params['WHERE'][static::getTable() . '.itemtype'] = $item->getType();
+            $params['WHERE'][static::getTable() . '.itemtype'] = $item::class;
         }
 
-        if ($noent === false && $link->isEntityAssign() && $link_type != Entity::getType()) {
+        if ($noent === false && $link->isEntityAssign() && $link_type != Entity::class) {
             $params['SELECT'][] = 'glpi_entities.id AS entity';
             $params['INNER JOIN']['glpi_entities'] = [
                 'FKEY'   => [
@@ -2013,7 +2013,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
             $params['WHERE'][$item->getTable() . '.is_template'] = 0;
         }
 
-        if ($noent === false && $item->isEntityAssign() && $itemtype != Entity::getType()) {
+        if ($noent === false && $item->isEntityAssign() && $itemtype != Entity::class) {
             $params['SELECT'][] = 'glpi_entities.id AS entity';
             $params['LEFT JOIN']['glpi_entities'] = [
                 'FKEY'   => [

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -568,7 +568,7 @@ class CommonDBTM extends CommonGLPI
             && !$this->isNewItem()
             && $lockedfield->isHandled($this)
         ) {
-            $locks = $lockedfield->getLockedValues(static::getType(), $this->fields['id']);
+            $locks = $lockedfield->getLockedValues(static::class, $this->fields['id']);
         }
 
         return $locks;
@@ -692,7 +692,7 @@ class CommonDBTM extends CommonGLPI
      **/
     public function getLogTypeID()
     {
-        return [static::getType(), $this->fields['id']];
+        return [static::class, $this->fields['id']];
     }
 
     /**
@@ -886,7 +886,7 @@ class CommonDBTM extends CommonGLPI
             $DB->delete(
                 'glpi_logs',
                 [
-                    'itemtype'  => static::getType(),
+                    'itemtype'  => static::class,
                     'items_id'  => $this->fields['id'],
                 ]
             );
@@ -1080,7 +1080,7 @@ class CommonDBTM extends CommonGLPI
         if (in_array(static::class, $CFG_GLPI['databaseinstance_types'], true)) {
             // DatabaseInstance does not extends CommonDBConnexity
             $dbinstance = new DatabaseInstance();
-            $dbinstance->deleteByCriteria(['itemtype' => $this->getType(), 'items_id' => $this->getID()], true);
+            $dbinstance->deleteByCriteria(['itemtype' => static::class, 'items_id' => $this->getID()], true);
         }
 
         if (in_array(static::class, $CFG_GLPI['itemdevices_types'], true)) {
@@ -1762,8 +1762,8 @@ class CommonDBTM extends CommonGLPI
                             Plugin::doHook(Hooks::ITEM_UPDATE, $this);
 
                             //Fill forward_entity_to array with itemtypes coming from plugins
-                            if (isset(self::$plugins_forward_entity[$this->getType()])) {
-                                foreach (self::$plugins_forward_entity[$this->getType()] as $itemtype) {
+                            if (isset(self::$plugins_forward_entity[static::class])) {
+                                foreach (self::$plugins_forward_entity[static::class] as $itemtype) {
                                     static::$forward_entity_to[] = $itemtype;
                                 }
                             }
@@ -1836,7 +1836,7 @@ class CommonDBTM extends CommonGLPI
             && $this->input['is_dynamic'] == true)
         ) {
             $lockedfield = new Lockedfield();
-            $locks = $lockedfield->getFullLockedFields($this->getType(), $this->fields['id']);
+            $locks = $lockedfield->getFullLockedFields(static::class, $this->fields['id']);
             foreach ($locks as $lock) {
                 $lock_field = $lock['field'];
                 $idx = array_search($lock_field, $this->updates);
@@ -1844,7 +1844,7 @@ class CommonDBTM extends CommonGLPI
                     //do not update global lock value
                     if (!$lock['is_global']) {
                         $lockedfield->setLastValue(
-                            $this->getType(),
+                            static::class,
                             $this->fields['id'],
                             $lock_field,
                             $this->input['_raw' . $lock_field] ?? $this->input[$lock_field]
@@ -1888,7 +1888,7 @@ class CommonDBTM extends CommonGLPI
                 $DB->buildInsert(
                     $lockedfield->getTable(),
                     [
-                        'itemtype'        => $this->getType(),
+                        'itemtype'        => static::class,
                         'items_id'        => $this->fields['id'],
                         'date_creation'   => $_SESSION["glpi_currenttime"],
                         'field'           => new QueryParam(),
@@ -1931,7 +1931,7 @@ class CommonDBTM extends CommonGLPI
                 $OR = [];
                 if ($item->isField('itemtype')) {
                     $OR[] = [
-                        'itemtype'  => $this->getType(),
+                        'itemtype'  => static::class,
                         'items_id'  => $this->getID(),
                     ];
                 }
@@ -2522,7 +2522,7 @@ class CommonDBTM extends CommonGLPI
         if (Infocom::canApplyOn($this)) {
             $infocom = new Infocom();
 
-            if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
+            if ($infocom->getFromDBforDevice(static::class, $this->fields['id'])) {
                 return $infocom->canPurge();
             }
         }
@@ -2649,7 +2649,7 @@ class CommonDBTM extends CommonGLPI
                                 $items_id_field = reset($items_id_matches);
                             }
                             $or_criteria[] = [
-                                $tablename . "." . $itemtype_field => $this->getType(),
+                                $tablename . "." . $itemtype_field => static::class,
                                 $tablename . "." . $items_id_field => $this->getID(),
                             ];
                         } else {
@@ -2700,7 +2700,7 @@ class CommonDBTM extends CommonGLPI
                                                 $tablename  => $otheritems_id_field,
                                                 $othertable => 'id',
                                                 [
-                                                    'AND' => [$tablename . '.' . $otheritemtype_field => $this->getType()],
+                                                    'AND' => [$tablename . '.' . $otheritemtype_field => static::class],
                                                 ],
                                             ];
                                         } else {
@@ -2736,7 +2736,7 @@ class CommonDBTM extends CommonGLPI
             countElementsInTable(
                 ['glpi_documents_items', 'glpi_documents'],
                 ['glpi_documents_items.items_id' => $ID,
-                    'glpi_documents_items.itemtype' => $this->getType(),
+                    'glpi_documents_items.itemtype' => static::class,
                     'FKEY' => ['glpi_documents_items' => 'documents_id','glpi_documents' => 'id'],
                     'NOT'  => ['glpi_documents.entities_id' => $entities],
                 ]
@@ -2748,8 +2748,8 @@ class CommonDBTM extends CommonGLPI
 
         // check connections between assets
         if (
-            in_array($this->getType(), Asset_PeripheralAsset::getPeripheralHostItemtypes(), true)
-            || in_array($this->getType(), $CFG_GLPI["directconnect_types"])
+            in_array(static::class, Asset_PeripheralAsset::getPeripheralHostItemtypes(), true)
+            || in_array(static::class, $CFG_GLPI["directconnect_types"])
         ) {
             return Asset_PeripheralAsset::canUnrecursSpecif($this, $entities);
         }
@@ -3080,7 +3080,7 @@ class CommonDBTM extends CommonGLPI
         } else {
             if (!$this->can($ID, $right, $input)) {
                 /** @var class-string<CommonDBTM> $itemtype */
-                $itemtype = static::getType();
+                $itemtype = static::class;
                 $right_name = Session::getRightNameForError($itemtype::$rightname, $right);
                 $info = "User failed a can* method check for right $right ($right_name) on item Type: $itemtype ID: $ID";
                 throw new AccessDeniedHttpException($info);
@@ -3154,7 +3154,7 @@ class CommonDBTM extends CommonGLPI
     {
         if (!$this->canGlobal($right)) {
             /** @var class-string<CommonDBTM> $itemtype */
-            $itemtype = static::getType();
+            $itemtype = static::class;
             $right_name = Session::getRightNameForError($itemtype::$rightname, $right);
             $info = "User failed a global can* method check for right $right ($right_name) on item Type: $itemtype";
             throw new AccessDeniedHttpException($info);
@@ -3596,7 +3596,7 @@ class CommonDBTM extends CommonGLPI
 
         if (Infocom::canApplyOn($this)) {
             $infocom = new Infocom();
-            if ($infocom->getFromDBforDevice($this->getType(), $this->fields['id'])) {
+            if ($infocom->getFromDBforDevice(static::class, $this->fields['id'])) {
                 $toadd[] = [
                     'name'  => __s('Warranty expiration date'),
                     'value' => Infocom::getWarrantyExpir(
@@ -4077,7 +4077,7 @@ class CommonDBTM extends CommonGLPI
 
         if (Infocom::canApplyOn($this)) {
             $ic = new Infocom();
-            if ($ic->getFromDBforDevice($this->getType(), $this->fields['id'])) {
+            if ($ic->getFromDBforDevice(static::class, $this->fields['id'])) {
                 $excluded[] = 'Infocom:activate';
             }
         }
@@ -4116,7 +4116,7 @@ class CommonDBTM extends CommonGLPI
 
         $actions = ['MassiveAction:add_transfer_list'];
 
-        if (in_array(static::getType(), $CFG_GLPI['rackable_types'])) {
+        if (in_array(static::class, $CFG_GLPI['rackable_types'])) {
             $actions[] = 'Item_Rack:delete';
         }
 
@@ -4152,12 +4152,12 @@ class CommonDBTM extends CommonGLPI
                 MassiveAction::getAddTransferList($actions);
             }
 
-            if (in_array(static::getType(), Appliance::getTypes(true))) {
+            if (in_array(static::class, Appliance::getTypes(true))) {
                 $actions['Appliance' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item']
                 = "<i class='" . htmlescape(Appliance::getIcon()) . "'></i>" . _sx('button', 'Associate to an appliance');
             }
 
-            if (in_array(static::getType(), $CFG_GLPI['rackable_types'])) {
+            if (in_array(static::class, $CFG_GLPI['rackable_types'])) {
                 $actions['Item_Rack' . MassiveAction::CLASS_ACTION_SEPARATOR . 'delete']
                 = "<i class='ti ti-server-off'></i>" . _sx('button', 'Remove from a rack');
             }
@@ -4226,7 +4226,7 @@ class CommonDBTM extends CommonGLPI
     {
 
         if (!$this->searchopt) {
-            $this->searchopt = SearchOption::getOptionsForItemtype(static::getType());
+            $this->searchopt = SearchOption::getOptionsForItemtype(static::class);
         }
 
         return $this->searchopt;
@@ -5390,7 +5390,7 @@ class CommonDBTM extends CommonGLPI
         }
         // Fill forward_entity_to array with itemtypes coming from plugins
         if (
-            isset(static::$plugins_forward_entity[static::getType()])
+            isset(static::$plugins_forward_entity[static::class])
             && in_array($itemtype, static::$plugins_forward_entity[static::class], true)
         ) {
             return true;
@@ -6244,7 +6244,7 @@ class CommonDBTM extends CommonGLPI
                         '_is_model_img'   => isset($model),
                     ] + $p;
                 } else {
-                    $owner_type = isset($model) ? $model::getType() : $itemtype;
+                    $owner_type = isset($model) ? $model::class : $itemtype;
                     $owner_id = isset($model) ? $model->getID() : $this->getID();
 
                     trigger_error(
@@ -6641,7 +6641,7 @@ class CommonDBTM extends CommonGLPI
         if (in_array('date_expiration', $this->updates)) {
             $input = [
                 'type'     => $types,
-                'itemtype' => $this->getType(),
+                'itemtype' => static::class,
                 'items_id' => $this->fields['id'],
             ];
             $alert = new Alert();
@@ -6655,7 +6655,7 @@ class CommonDBTM extends CommonGLPI
             return false;
         }
 
-        $confname = strtolower($this->gettype()) . 's_management_restrict';
+        $confname = strtolower(static::class) . 's_management_restrict';
         if (Config::getConfigurationValue('core', $confname) == Config::GLOBAL_MANAGEMENT) {
             $is_global = true;
         } elseif (Config::getConfigurationValue('core', $confname) == Config::UNIT_MANAGEMENT) {

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -331,7 +331,7 @@ abstract class CommonDBVisible extends CommonDBTM
     {
         $params = [
             'type'          => '__VALUE__',
-            'right'         => strtolower($this::getType()) . '_public',
+            'right'         => strtolower(static::class) . '_public',
         ];
         if (isset($this->fields['entities_id'])) {
             $params['entity'] = $this->fields['entities_id'];

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -597,7 +597,7 @@ abstract class CommonDevice extends CommonDropdown
             (isset($this->input['_registeredID']))
             && (is_array($this->input['_registeredID']))
         ) {
-            $input = ['itemtype' => $this->getType(),
+            $input = ['itemtype' => static::class,
                 'items_id' => $this->getID(),
             ];
 

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -225,7 +225,7 @@ abstract class CommonDropdown extends CommonDBTM
         $this->addDefaultFormTab($ong);
 
         if (
-            in_array($this->getType(), $CFG_GLPI['document_types'])
+            in_array(static::class, $CFG_GLPI['document_types'])
         ) {
             $this->addStandardTab(Document_Item::class, $ong, $options);
         }
@@ -586,7 +586,7 @@ abstract class CommonDropdown extends CommonDBTM
                         $items_id_field = reset($items_id_matches);
                     }
                     $or_criteria[] = [
-                        $itemtype_field => $this->getType(),
+                        $itemtype_field => static::class,
                         $items_id_field => $this->getID(),
                     ];
                 } else {
@@ -659,7 +659,7 @@ abstract class CommonDropdown extends CommonDBTM
             echo "<form action='" . $target . "' method='post'>";
             echo "<table class='tab_cadre'><tr>";
             echo "<td><input type='hidden' name='id' value='$ID'>";
-            echo "<input type='hidden' name='itemtype' value='" . htmlescape($this->getType()) . "' />";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape(static::class) . "' />";
             echo "<input type='hidden' name='forcepurge' value='1'>";
             echo "<input class='btn btn-primary' type='submit' name='purge'
                 value=\"" . _sx('button', 'Confirm') . "\">";
@@ -696,7 +696,7 @@ abstract class CommonDropdown extends CommonDBTM
             $replacement_options
         );
         echo "<input type='hidden' name='id' value='$ID' />";
-        echo "<input type='hidden' name='itemtype' value='" . htmlescape($this->getType()) . "' />";
+        echo "<input type='hidden' name='itemtype' value='" . htmlescape(static::class) . "' />";
         echo "</td><td>";
         echo "<input class='btn btn-primary' type='submit' name='replace' value=\"" . _sx('button', 'Replace') . "\">";
         echo "</td><td>";
@@ -810,7 +810,7 @@ abstract class CommonDropdown extends CommonDBTM
         }
 
         $ruleinput      = ["name" => $value];
-        $rulecollection = RuleCollection::getClassByType($this->getType(), true);
+        $rulecollection = RuleCollection::getClassByType(static::class, true);
 
         foreach ($this->additional_fields_for_dictionnary as $field) {
             if (isset($external_params[$field])) {
@@ -900,9 +900,9 @@ abstract class CommonDropdown extends CommonDBTM
                                     'is_recursive' => 1,
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
@@ -928,14 +928,14 @@ abstract class CommonDropdown extends CommonDBTM
                                     $input2['id'] = $newid;
                                     $item->update($input2);
                                 }
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -344,7 +344,7 @@ class CommonGLPI implements CommonGLPIInterface
 
         // Object with class with 'addtabon' attribute
         if (!$this->isNewItem()) {
-            $othertabs = self::getOtherTabs(static::getType());
+            $othertabs = self::getOtherTabs(static::class);
             foreach ($othertabs as $typetab) {
                 $this->addStandardTab($typetab, $onglets, $options);
             }
@@ -429,7 +429,7 @@ class CommonGLPI implements CommonGLPIInterface
             $icon = static::getIcon();
         }
         $icon = $icon ? "<i class='" . htmlescape($icon) . " me-2'></i>" : '';
-        $ong[static::getType() . '$main'] = '<span>' . $icon . htmlescape(static::getTypeName(1)) . '</span>';
+        $ong[static::class . '$main'] = '<span>' . $icon . htmlescape(static::getTypeName(1)) . '</span>';
         return $this;
     }
 
@@ -444,7 +444,7 @@ class CommonGLPI implements CommonGLPIInterface
     {
         $menu       = [];
 
-        $type       = static::getType();
+        $type       = static::class;
         $item       = new static();
         $forbidden  = $item->getForbiddenActionsForMenu();
 
@@ -455,7 +455,7 @@ class CommonGLPI implements CommonGLPIInterface
                 $menu['page']            = $item->getSearchURL(false);
                 $menu['links']['search'] = $item->getSearchURL(false);
                 $menu['links']['lists']  = "";
-                $menu['lists_itemtype']  = $item->getType();
+                $menu['lists_itemtype']  = $item::class;
                 $menu['icon']            = $item->getIcon();
 
                 if (
@@ -837,14 +837,14 @@ class CommonGLPI implements CommonGLPIInterface
         global $CFG_GLPI;
 
         if (!empty($_GET['withtemplate'])) {
-            return $CFG_GLPI["root_doc"] . "/front/setup.templates.php?add=0&itemtype=" . static::getType();
+            return $CFG_GLPI["root_doc"] . "/front/setup.templates.php?add=0&itemtype=" . static::class;
         }
 
         if (
-            isset($_SESSION['glpilisturl'][static::getType()])
-            && !empty($_SESSION['glpilisturl'][static::getType()])
+            isset($_SESSION['glpilisturl'][static::class])
+            && !empty($_SESSION['glpilisturl'][static::class])
         ) {
-            return $_SESSION['glpilisturl'][static::getType()];
+            return $_SESSION['glpilisturl'][static::class];
         }
 
         return static::getSearchURL();
@@ -1007,7 +1007,7 @@ class CommonGLPI implements CommonGLPIInterface
                 $tab_params,
                 [
                     '_target' => $target,
-                    '_itemtype' => static::getType(),
+                    '_itemtype' => static::class,
                     'id' => $ID,
                 ]
             );
@@ -1040,7 +1040,7 @@ class CommonGLPI implements CommonGLPIInterface
                 'tabspanel',
                 'tabcontent',
                 $tabs,
-                static::getType(),
+                static::class,
                 $ID,
                 $this->taborientation,
                 $options
@@ -1091,12 +1091,12 @@ class CommonGLPI implements CommonGLPIInterface
 
         if (
             !static::isNewID($ID)
-            && static::getType()
+            && static::class
             && $this->displaylist
         ) {
-            $glpilistitems = & $_SESSION['glpilistitems'][static::getType()];
-            $glpilisttitle = & $_SESSION['glpilisttitle'][static::getType()];
-            $glpilisturl   = & $_SESSION['glpilisturl'][static::getType()];
+            $glpilistitems = & $_SESSION['glpilistitems'][static::class];
+            $glpilisttitle = & $_SESSION['glpilisttitle'][static::class];
+            $glpilisturl   = & $_SESSION['glpilisturl'][static::class];
             if ($this instanceof CommonDBChild && $parent = $this->getItem(true, false)) {
                 $glpilisturl = $parent::getFormURLWithID($parent->fields['id'], true);
             }
@@ -1314,7 +1314,7 @@ class CommonGLPI implements CommonGLPIInterface
         echo "<div class='row'>";
         if ($this instanceof CommonDBTM) {
             TemplateRenderer::getInstance()->display('layout/parts/saved_searches.html.twig', [
-                'itemtype' => static::getType(),
+                'itemtype' => static::class,
             ]);
         }
         echo "<div class='col'>";
@@ -1379,7 +1379,7 @@ class CommonGLPI implements CommonGLPIInterface
             'FROM'   => KnowbaseItem::getTable(),
             'WHERE'  => [
                 KnowbaseItem_Item::getTable() . '.items_id'  => $this->fields['id'],
-                KnowbaseItem_Item::getTable() . '.itemtype'  => static::getType(),
+                KnowbaseItem_Item::getTable() . '.itemtype'  => static::class,
             ],
             'INNER JOIN'   => [
                 KnowbaseItem_Item::getTable() => [

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -80,7 +80,7 @@ abstract class CommonITILCost extends CommonDBChild
                     [$item::getForeignKeyField() => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -502,7 +502,7 @@ abstract class CommonITILCost extends CommonDBChild
             $twig_params = [
                 'id'        => $ID,
                 'rand'      => $rand,
-                'type'      => static::getType(),
+                'type'      => static::class,
                 'parenttype' => static::$itemtype,
                 'items_id'  => static::$items_id,
             ];
@@ -571,7 +571,7 @@ TWIG, $twig_params);
                 $budget_links[$data['budgets_id']] = $budget->getLink();
             }
             $entry = [
-                'itemtype' => static::getType(),
+                'itemtype' => static::class,
                 'id'       => $data['id'],
                 'name'     => sprintf(__s('%1$s %2$s'), htmlescape($name), Html::showToolTip($data['comment'], ['display' => false])),
                 'begin_date' => $data['begin_date'],

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -722,7 +722,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $tickets_id = $options['tickets_id'] ?? $options['_tickets_id'] ?? null;
         $ticket = new Ticket();
         $ticket->getEmpty();
-        if (in_array($this->getType(), [Change::class, Problem::class]) && $tickets_id) {
+        if (in_array(static::class, [Change::class, Problem::class]) && $tickets_id) {
             $ticket->getFromDB($tickets_id);
 
             // copy fields from original ticket, only when fields are not already set by the user (contained in _saved array)
@@ -1830,7 +1830,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     $allowed_fields[] = 'status';
                     $allowed_fields[] = '_accepted';
                 }
-                $validation_class = static::getType() . 'Validation';
+                $validation_class = static::class . 'Validation';
                 if (
                     class_exists($validation_class)
                     && (
@@ -1845,7 +1845,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     $allowed_fields[] = 'global_validation';
                 }
                 // Manage assign and steal right
-                if (static::getType() === Ticket::getType() && Session::haveRightsOr(static::$rightname, [Ticket::ASSIGN, Ticket::STEAL])) {
+                if (static::class === Ticket::class && Session::haveRightsOr(static::$rightname, [Ticket::ASSIGN, Ticket::STEAL])) {
                     $allowed_fields[] = '_itil_assign';
                     $allowed_fields[] = '_users_id_assign';
                     $allowed_fields[] = '_groups_id_assign';
@@ -1961,7 +1961,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 return;
             }
 
-            if ($link['itemtype_1'] == $this->getType() && $link['items_id_1'] == 0) {
+            if ($link['itemtype_1'] == static::class && $link['items_id_1'] == 0) {
                 // Link was added in creation form, ID was not available yet
                 $link['items_id_1'] = $this->getID();
             }
@@ -2033,7 +2033,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $docitem = new Document_Item();
                 if (
                     $docitem->add(['documents_id' => $input["document"],
-                        'itemtype'     => $this->getType(),
+                        'itemtype'     => static::class,
                         'items_id'     => $input["id"],
                     ])
                 ) {
@@ -2344,7 +2344,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             $soltype = new SolutionType();
             $soltype->getFromDB($input['solutiontypes_id']);
             $solution->add([
-                'itemtype'           => $this->getType(),
+                'itemtype'           => static::class,
                 'items_id'           => $this->getID(),
                 'solutiontypes_id'   => $input['solutiontypes_id'],
                 'content'            => 'Solved using type ' . $soltype->getName(),
@@ -2822,7 +2822,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 ],
                 [
                     'WHERE'  => [
-                        'itemtype'  => static::getType(),
+                        'itemtype'  => static::class,
                         'items_id'  => $this->getID(),
                     ],
                     'ORDER'  => [
@@ -2849,7 +2849,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 ],
                 [
                     'WHERE'  => [
-                        'itemtype'  => static::getType(),
+                        'itemtype'  => static::class,
                         'items_id'  => $this->getID(),
                     ],
                     'ORDER'  => [
@@ -3046,7 +3046,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                                 unset($mandatory_missing['_add_validation']);
                             }
 
-                            if (static::getType() === Ticket::getType()) {
+                            if (static::class === Ticket::class) {
                                 // For time_to_resolve and time_to_own : check also slas
                                 // For internal_time_to_resolve and internal_time_to_own : check also olas
                                 foreach ([SLM::TTR, SLM::TTO] as $slmType) {
@@ -3217,7 +3217,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             foreach ($this->input['_documents_id'] as $docID) {
                 $docitem->add(['documents_id' => $docID,
                     '_do_notif'    => false,
-                    'itemtype'     => $this->getType(),
+                    'itemtype'     => static::class,
                     'items_id'     => $this->fields['id'],
                 ]);
             }
@@ -4269,13 +4269,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     }
                     if ($item->can($id, UPDATE)) {
                         if ($item->update($input2)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -4300,9 +4300,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                             }
                         }
 
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -4310,7 +4310,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
             case 'add_task':
                 if (!($task = $item->getTaskClassInstance())) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     break;
                 }
 
@@ -4337,17 +4337,17 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                             )
                         ) {
                             if ($task->add($input)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -4655,7 +4655,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     'joinparams'         => [
                         'jointype'           => 'child',
                         'linkfield'          => 'items_id',
-                        'condition'          => ['NEWTABLE.itemtype' => self::getType()],
+                        'condition'          => ['NEWTABLE.itemtype' => static::class],
                     ],
                 ],
             ],
@@ -4733,7 +4733,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'FROM'   => ITILSolution::getTable(),
             'WHERE'  => [
                 ITILSolution::getTable() . '.items_id' => new QueryExpression($DB::quoteName('REFTABLE.id')),
-                ITILSolution::getTable() . '.itemtype' => static::getType(),
+                ITILSolution::getTable() . '.itemtype' => static::class,
             ],
             'ORDER'  => ITILSolution::getTable() . '.id DESC',
             'LIMIT'  => 1,
@@ -5379,7 +5379,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         );
         $params = ['type'            => '__VALUE__',
             'actortype'       => $typename,
-            'itemtype'        => $this->getType(),
+            'itemtype'        => static::class,
             'allow_email'     => (($type == CommonITILActor::OBSERVER)
                                             || $type == CommonITILActor::REQUESTER),
             'entity_restrict' => $entities_id,
@@ -6249,7 +6249,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 ],
             ],
             'WHERE'           => [
-                ITILSolution::getTable() . ".itemtype" => $this->getType(),
+                ITILSolution::getTable() . ".itemtype" => static::class,
                 "$ctable.is_deleted"                   => 0,
             ] + getEntitiesRestrictCriteria($ctable),
             'ORDERBY'         => 'solutiontypes_id',
@@ -6662,7 +6662,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         RichText::getEnhancedHtml($item->fields['content']),
                         [
                             'display' => false,
-                            'applyto' => $item->getType() . $item->fields["id"] . $rand,
+                            'applyto' => $item::class . $item->fields["id"] . $rand,
                         ]
                     )
                 );
@@ -6884,7 +6884,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                             implode('<br>', $planned_info),
                             [
                                 'display' => false,
-                                'applyto' => $item->getType() . $item->fields["id"] . "planning" . $rand,
+                                'applyto' => $item::class . $item->fields["id"] . "planning" . $rand,
                             ]
                         )
                     );
@@ -7398,7 +7398,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     {
         global $PLUGIN_HOOKS;
 
-        $obj_type = static::getType();
+        $obj_type = static::class;
         $foreign_key = static::getForeignKeyField();
 
         //check sub-items rights
@@ -7470,7 +7470,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         if ($validation !== null) {
             $itemtypes['validation'] = [
                 'type'          => 'ITILValidation',
-                'class'         => $validation::getType(),
+                'class'         => $validation::class,
                 'icon'          => CommonITILValidation::getIcon(),
                 'label'         => _x('button', 'Ask for approval'),
                 'short_label'   => CommonITILValidation::getTypeName(1),
@@ -7603,7 +7603,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         /** @var CommonITILObject $objType */
-        $objType    = static::getType();
+        $objType    = static::class;
         $foreignKey = static::getForeignKeyField();
         $timeline = [];
 
@@ -7630,7 +7630,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             }
         }
 
-        $restrict_fup['itemtype'] = static::getType();
+        $restrict_fup['itemtype'] = static::class;
         $restrict_fup['items_id'] = $this->getID();
 
         $taskClass = static::getTaskClass();
@@ -7722,7 +7722,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         && $this instanceof Ticket
                         && Ticket::canCreate()
                     ;
-                    $timeline[$tltask::getType() . "_" . $tasks_id] = [
+                    $timeline[$tltask::class . "_" . $tasks_id] = [
                         'type'     => $taskClass,
                         'item'     => $task_row,
                         'object'   => $tltask,
@@ -7735,7 +7735,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         // Add solutions to timeline
         $solution_obj   = new ITILSolution();
         $solution_items = $solution_obj->find([
-            'itemtype'  => static::getType(),
+            'itemtype'  => static::class,
             'items_id'  => $this->getID(),
         ]);
 
@@ -7794,7 +7794,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $user = new User();
                 $user->getFromDB($validation_row['users_id_validate']);
 
-                $request_key = $validation_obj::getType() . '_' . $validations_id
+                $request_key = $validation_obj::class . '_' . $validations_id
                     . (empty($validation_row['validation_date']) ? '' : '_request'); // If no answer, no suffix to see attached documents on request
 
                 $content = __s('Approval request');
@@ -7831,7 +7831,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 ];
 
                 if (!empty($validation_row['validation_date'])) {
-                    $timeline[$validation_obj::getType() . "_" . $validations_id] = [
+                    $timeline[$validation_obj::class . "_" . $validations_id] = [
                         'type' => $validation_class,
                         'item' => [
                             'id'        => $validations_id,
@@ -7892,7 +7892,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     $doc_entry['_is_image'] = true;
                     $doc_entry['_size'] = getimagesize($docpath);
                 }
-                if ($document_item['itemtype'] == static::getType()) {
+                if ($document_item['itemtype'] == static::class) {
                     // document associated directly to itilobject
                     $doc_entry['object'] = $document_obj;
                     $timeline["Document_" . $document_item['documents_id']] = $doc_entry;
@@ -8148,7 +8148,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'COUNT'  => 'cpt',
             'FROM'   => 'glpi_itilfollowups',
             'WHERE'  => [
-                'itemtype'  => $this->getType(),
+                'itemtype'  => static::class,
                 'items_id'  => $this->fields['id'],
             ] + $RESTRICT,
         ])->current();
@@ -8167,7 +8167,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     {
         global $DB;
 
-        $table = 'glpi_' . strtolower($this->getType()) . 'tasks';
+        $table = 'glpi_' . strtolower(static::class) . 'tasks';
 
         $RESTRICT = [];
         if ($with_private !== true && $this instanceof Ticket) {
@@ -8221,7 +8221,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $nb_elements = count($timeline);
         $label = static::getTypeName(1);
 
-        $ong[static::getType() . '$main'] = static::createTabEntry($label, $nb_elements, static::getType());
+        $ong[static::class . '$main'] = static::createTabEntry($label, $nb_elements, static::class);
         return $this;
     }
 
@@ -8348,9 +8348,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         ) {
             // load default entity one if not already loaded
             $template_id = Entity::getUsedConfig(
-                strtolower($this->getType()) . 'templates_strategy',
+                strtolower(static::class) . 'templates_strategy',
                 $entities_id,
-                strtolower($this->getType()) . 'templates_id',
+                strtolower(static::class) . 'templates_id',
                 0
             );
             if ($template_id > 0 && $tt->getFromDBWithData($template_id, true)) {
@@ -8431,8 +8431,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function getTemplateFieldName($type = null): string
     {
-        $field = strtolower(static::getType()) . 'templates_id';
-        if (static::getType() === Ticket::getType()) {
+        $field = strtolower(static::class) . 'templates_id';
+        if (static::class === Ticket::class) {
             switch ($type) {
                 case Ticket::INCIDENT_TYPE:
                     $field .= '_incident';
@@ -8473,7 +8473,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public static function getTemplateClass()
     {
-        return static::getType() . 'Template';
+        return static::class . 'Template';
     }
 
     /**
@@ -8485,7 +8485,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public static function getTemplateFormFieldName()
     {
-        return '_' . strtolower(static::getType()) . 'template';
+        return '_' . strtolower(static::class) . 'template';
     }
 
     /**
@@ -8619,7 +8619,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $or_crits = [
             // documents associated to ITIL item directly
             [
-                Document_Item::getTableField('itemtype') => $this->getType(),
+                Document_Item::getTableField('itemtype') => static::class,
                 Document_Item::getTableField('items_id') => $this->getID(),
             ],
         ];
@@ -8630,12 +8630,12 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             || ITILFollowup::canView()
             || (
                 $user !== null
-                && $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                && $user->hasRightsOr(static::$rightname, $can_view_itilobject[static::class], $this->fields['entities_id'])
                 && $user->hasRight(ITILFollowup::$rightname, ITILFollowup::SEEPUBLIC, $this->fields['entities_id'])
             )
         ) {
             $fup_crits = [
-                ITILFollowup::getTableField('itemtype') => $this->getType(),
+                ITILFollowup::getTableField('itemtype') => static::class,
                 ITILFollowup::getTableField('items_id') => $this->getID(),
             ];
             if (!$bypass_rights) {
@@ -8659,7 +8659,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             $arr_values = array_column(iterator_to_array($iterator_tmp, false), 'id');
             if (count($arr_values) > 0) {
                 $or_crits[] = [
-                    Document_Item::getTableField('itemtype') => ITILFollowup::getType(),
+                    Document_Item::getTableField('itemtype') => ITILFollowup::class,
                     Document_Item::getTableField('items_id') => $arr_values,
                 ];
             }
@@ -8671,7 +8671,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             || ITILSolution::canView()
             || (
                 $user !== null
-                && $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                && $user->hasRightsOr(static::$rightname, $can_view_itilobject[static::class], $this->fields['entities_id'])
             )
         ) {
             // Run the subquery separately. It's better for huge databases
@@ -8679,21 +8679,21 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 'SELECT' => 'id',
                 'FROM'   => ITILSolution::getTable(),
                 'WHERE'  => [
-                    ITILSolution::getTableField('itemtype') => $this->getType(),
+                    ITILSolution::getTableField('itemtype') => static::class,
                     ITILSolution::getTableField('items_id') => $this->getID(),
                 ],
             ]);
             $arr_values = array_column(iterator_to_array($iterator_tmp, false), 'id');
             if (count($arr_values) > 0) {
                 $or_crits[] = [
-                    Document_Item::getTableField('itemtype') => ITILSolution::getType(),
+                    Document_Item::getTableField('itemtype') => ITILSolution::class,
                     Document_Item::getTableField('items_id') => $arr_values,
                 ];
             }
         }
 
         // documents associated to ticketvalidation
-        $validation_class = static::getType() . 'Validation';
+        $validation_class = static::class . 'Validation';
         if (
             class_exists($validation_class)
             && (
@@ -8701,7 +8701,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 || $validation_class::canView()
                 || (
                     $user !== null
-                    && $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                    && $user->hasRightsOr(static::$rightname, $can_view_itilobject[static::class], $this->fields['entities_id'])
                     && $user->hasRightsOr(
                         $validation_class::$rightname,
                         array_merge(
@@ -8739,7 +8739,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 || $task_class::canView()
                 || (
                     $user !== null
-                    && $user->hasRightsOr(static::$rightname, $can_view_itilobject[$this->getType()], $this->fields['entities_id'])
+                    && $user->hasRightsOr(static::$rightname, $can_view_itilobject[static::class], $this->fields['entities_id'])
                     && $user->hasRight($task_class::$rightname, $task_class::SEEPUBLIC, $this->fields['entities_id'])
                 )
             )
@@ -8954,7 +8954,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         foreach ($this->input['_itilfollowuptemplates_id'] as $fup_templates_id) {
             $values = [
                 '_itilfollowuptemplates_id' => $fup_templates_id,
-                'itemtype'                  => $this->getType(),
+                'itemtype'                  => static::class,
                 'items_id'                  => $this->getID(),
                 '_do_not_compute_status'    => $this->input['_do_not_compute_status'] ?? 0,
                 '_do_not_compute_takeintoaccount' => $this->input['_do_not_compute_takeintoaccount'] ?? 0,
@@ -8978,7 +8978,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $solution = new ITILSolution();
         $input = [
             '_solutiontemplates_id' => $this->input['_solutiontemplates_id'],
-            'itemtype'              => $this->getType(),
+            'itemtype'              => static::class,
             'items_id'              => $this->getID(),
         ];
         if (isset($this->input['_do_not_compute_status'])) {
@@ -9307,7 +9307,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     if ($add_done) {
                         Event::log(
                             $this->fields['id'],
-                            strtolower($this->getType()),
+                            strtolower(static::class),
                             4,
                             "tracking",
                             sprintf(
@@ -9936,7 +9936,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
                 // Push users
                 $linked_actors[$common_itil_id][] = [
-                    'itemtype'  => User::getType(),
+                    'itemtype'  => User::class,
                     'id'        => $linked_user_row['users_id'],
                     'firstname' => $linked_user_row['firstname'],
                     'realname'  => $linked_user_row['realname'],
@@ -9984,7 +9984,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
                 // Push groups
                 $linked_actors[$common_itil_id][] = [
-                    'itemtype' => Group::getType(),
+                    'itemtype' => Group::class,
                     'id'       => $linked_group_row['groups_id'],
                     'name'     => $linked_group_row['name'],
                 ];
@@ -10025,7 +10025,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
                 // Push groups
                 $linked_actors[$common_itil_id][] = [
-                    'itemtype' => Supplier::getType(),
+                    'itemtype' => Supplier::class,
                     'id'       => $linked_supplier_row['suppliers_id'],
                     'name'     => $linked_supplier_row['name'],
                 ];
@@ -10261,7 +10261,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                             $cat_table => 'id',
                             [
                                 'AND' => [
-                                    $trans_table . '.itemtype' => ITILCategory::getType(),
+                                    $trans_table . '.itemtype' => ITILCategory::class,
                                     $trans_table . '.field' => 'name',
                                     $trans_table . '.language' => $_SESSION['glpilanguage'],
                                 ],
@@ -10386,7 +10386,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     'description' => _x('filters', 'A supplier in the team of the item'),
                     'supported_prefixes' => ['!'],
                 ],
-            ] + self::getKanbanPluginFilters(static::getType()),
+            ] + self::getKanbanPluginFilters(static::class),
         ]);
     }
 
@@ -10557,7 +10557,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         ];
 
         // compute itilobject duration
-        $task_class  = $this->getType() . "Task";
+        $task_class  = static::class . "Task";
         $task_table  = getTableForItemType($task_class);
         $foreign_key = $this->getForeignKeyField();
 
@@ -10659,7 +10659,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function countOpenChildrenOfSameType()
     {
-        $itemtype = $this->getType();
+        $itemtype = static::class;
         $link_class = CommonITILObject_CommonITILObject::getLinkClass($itemtype, $itemtype);
 
         if ($link_class === null || $this->isNewItem()) {
@@ -10676,7 +10676,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         );
 
         return $link_class::countLinksByStatus(
-            $this->getType(),
+            static::class,
             $this->getID(),
             $open_statuses,
             [CommonITILObject_CommonITILObject::SON_OF]
@@ -10819,7 +10819,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     {
         global $DB;
 
-        $inquest_class = static::getType() . 'Satisfaction';
+        $inquest_class = static::class . 'Satisfaction';
 
         if (!class_exists($inquest_class) || !is_a($inquest_class, CommonITILSatisfaction::class, true)) {
             return 0;
@@ -11014,7 +11014,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         // Get suffix for entity config fields. For backwards compatibility, ticket values have no suffix.
-        $config_suffix = $this instanceof Ticket ? '' : ('_' . strtolower($this->getType()));
+        $config_suffix = $this instanceof Ticket ? '' : ('_' . strtolower(static::class));
         $rate          = Entity::getUsedConfig(
             'inquest_config' . $config_suffix,
             $this->fields['entities_id'],
@@ -11231,7 +11231,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
     public static function getRuleCollectionClassInstance(int $entity_id): RuleCommonITILObjectCollection
     {
-        $expected = 'Rule' . static::getType() . 'Collection';
+        $expected = 'Rule' . static::class . 'Collection';
         if (is_a($expected, RuleCommonITILObjectCollection::class, true)) {
             return new $expected($entity_id);
         }
@@ -11239,7 +11239,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             sprintf(
                 'Collection class %s does not exists for rule type %s',
                 $expected,
-                static::getType()
+                static::class
             )
         );
     }

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -165,7 +165,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
                 'url' => $url,
             ]);
         } else { // for internal inquest => form
-            $config_suffix = $item instanceof Ticket ? '' : ('_' . strtolower($item->getType()));
+            $config_suffix = $item instanceof Ticket ? '' : ('_' . strtolower($item::class));
 
             if ($add_form_header) {
                 $this->showFormHeader($options);

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -361,7 +361,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
     {
         /** @var CommonDBTM $item */
         if (
-            ($item->getType() == static::getItilObjectItemType())
+            ($item::class == static::getItilObjectItemType())
             && static::canView()
         ) {
             $nb = 0;
@@ -379,7 +379,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 }
                 $nb = countElementsInTable($this->getTable(), $restrict);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -540,7 +540,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 $input["users_id_tech"],
                 $input["begin"],
                 $input["end"],
-                [$this->getType() => [$input["id"]]]
+                [static::class => [$input["id"]]]
             );
 
             $calendars_id = Entity::getUsedConfig(
@@ -585,7 +585,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         if (in_array("begin", $this->updates)) {
             PlanningRecall::managePlanningUpdates(
-                $this->getType(),
+                static::class,
                 $this->getID(),
                 $this->fields["begin"]
             );
@@ -651,7 +651,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 $this->getField($item->getForeignKeyField()),
                 $item::class,
                 $changes,
-                $this->getType(),
+                static::class,
                 Log::HISTORY_UPDATE_SUBITEM
             );
         }
@@ -761,7 +761,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         $input['timeline_position'] = CommonITILObject::TIMELINE_LEFT;
         if (isset($input["users_id"])) {
-            $input['timeline_position'] = $parent::getTimelinePosition($input["_job"]->getID(), $this->getType(), $input["users_id"]);
+            $input['timeline_position'] = $parent::getTimelinePosition($input["_job"]->getID(), static::class, $input["users_id"]);
         }
 
         return $input;
@@ -787,7 +787,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 $this->fields["users_id_tech"],
                 $this->fields["begin"],
                 $this->fields["end"],
-                [$this->getType() => [$this->fields["id"]]]
+                [static::class => [$this->fields["id"]]]
             );
 
             $calendars_id = Entity::getUsedConfig(
@@ -847,7 +847,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $this->getField($this->input["_job"]->getForeignKeyField()),
             $this->input["_job"]->getTYpe(),
             $changes,
-            $this->getType(),
+            static::class,
             Log::HISTORY_ADD_SUBITEM
         );
 
@@ -1728,7 +1728,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         $prep_req = ['SELECT' => self::getTable() . '.id', 'FROM' => self::getTable()];
 
-        $itemtype = str_replace('Task', '', self::getType());
+        $itemtype = str_replace('Task', '', static::class);
         $fk_table = getTableForItemType($itemtype);
         $fk_field = Toolbox::strtolower(getPlural($itemtype)) . '_id';
 
@@ -1975,7 +1975,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             echo "</td>";
 
             echo "<td>";
-            $link = "<a id='" . htmlescape(strtolower($item_link->getType())) . "ticket" . htmlescape($item_link->fields["id"] . $rand) . "' href='"
+            $link = "<a id='" . htmlescape(strtolower($item_link::class)) . "ticket" . htmlescape($item_link->fields["id"] . $rand) . "' href='"
                    . htmlescape($item_link->getFormURLWithID($item_link->fields["id"]));
             $link .= "&amp;forcetab=" . htmlescape($tab_name) . "$1";
             $link   .= "'>";

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -305,7 +305,7 @@ abstract class CommonITILValidation extends CommonDBChild
                 }
                 $nb = countElementsInTable(static::getTable(), $restrict);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -997,17 +997,17 @@ abstract class CommonITILValidation extends CommonDBChild
                                 }
                             }
                             if ($ok) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -698,7 +698,7 @@ TWIG, $twig_params);
         $params['criteria'][0]['value']      = 'all';
         $params['criteria'][0]['link']       = 'AND';
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case User::class:
                 $params['criteria'][] = [
                     'link'       => 'AND',
@@ -738,7 +738,7 @@ TWIG, $twig_params);
         if (
             $item->getID()
             && !$item->isDeleted()
-            && CommonITILObject::isPossibleToAssignType($item->getType())
+            && CommonITILObject::isPossibleToAssignType($item::class)
             && static::canCreate()
             && !(!empty($withtemplate) && ($withtemplate == 2))
             && (!isset($item->fields['is_template']) || ($item->fields['is_template'] == 0))
@@ -1419,17 +1419,17 @@ TWIG, $twig_params);
                             }
 
                             if ($ok) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -1456,21 +1456,21 @@ TWIG, $twig_params);
                                 }
 
                                 if ($ok) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -1796,7 +1796,7 @@ TWIG, $twig_params);
         return countElementsInTable(
             static::getTable(),
             [
-                'itemtype' => $asset::getType(),
+                'itemtype' => $asset::class,
                 'items_id' => $asset->getId(),
             ]
         ) > 0;

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -106,7 +106,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     [$this->getForeignKeyField() => $item->getID()]
                 );
             }
-            return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry($this->getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -276,8 +276,8 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 'FROM'   => $this->getTable(),
                 'WHERE'  => [$this->getForeignKeyField() => $ID],
             ];
-            if (Session::haveTranslations($this->getType(), 'completename')) {
-                DropdownTranslation::regenerateAllCompletenameTranslationsFor($this->getType(), $ID);
+            if (Session::haveTranslations(static::class, 'completename')) {
+                DropdownTranslation::regenerateAllCompletenameTranslationsFor(static::class, $ID);
             }
 
             foreach ($DB->request($query) as $data) {
@@ -306,8 +306,8 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     ['id' => $data['id']]
                 );
                 // Translations :
-                if (Session::haveTranslations($this->getType(), 'completename')) {
-                    DropdownTranslation::regenerateAllCompletenameTranslationsFor($this->getType(), $data['id']);
+                if (Session::haveTranslations(static::class, 'completename')) {
+                    DropdownTranslation::regenerateAllCompletenameTranslationsFor(static::class, $data['id']);
                 }
 
                 $this->regenerateTreeUnderID($data["id"], $updateName, $changeParent);
@@ -391,9 +391,9 @@ abstract class CommonTreeDropdown extends CommonDropdown
             ];
             Log::history(
                 $parent,
-                $this->getType(),
+                static::class,
                 $changes,
-                $this->getType(),
+                static::class,
                 Log::HISTORY_ADD_SUBITEM
             );
         }
@@ -425,9 +425,9 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     ];
                     Log::history(
                         $oldParentID,
-                        $this->getType(),
+                        static::class,
                         $changes,
-                        $this->getType(),
+                        static::class,
                         Log::HISTORY_DELETE_SUBITEM
                     );
                 }
@@ -444,9 +444,9 @@ abstract class CommonTreeDropdown extends CommonDropdown
                     ];
                     Log::history(
                         $newParentID,
-                        $this->getType(),
+                        static::class,
                         $changes,
-                        $this->getType(),
+                        static::class,
                         Log::HISTORY_ADD_SUBITEM
                     );
                 }
@@ -460,16 +460,16 @@ abstract class CommonTreeDropdown extends CommonDropdown
                 ];
                 Log::history(
                     $ID,
-                    $this->getType(),
+                    static::class,
                     $changes,
-                    $this->getType(),
+                    static::class,
                     Log::HISTORY_UPDATE_SUBITEM
                 );
             }
 
             // Force DB cache refresh
-            getAncestorsOf(getTableForItemType($this->getType()), $ID);
-            getSonsOf(getTableForItemType($this->getType()), $ID);
+            getAncestorsOf(getTableForItemType(static::class), $ID);
+            getSonsOf(getTableForItemType(static::class), $ID);
         }
     }
 
@@ -486,9 +486,9 @@ abstract class CommonTreeDropdown extends CommonDropdown
             ];
             Log::history(
                 $parent,
-                $this->getType(),
+                static::class,
                 $changes,
-                $this->getType(),
+                static::class,
                 Log::HISTORY_DELETE_SUBITEM
             );
         }
@@ -725,7 +725,7 @@ TWIG, $twig_params);
                     $fk     = $item->getForeignKeyField();
                     $parent = clone $item;
                     if (!$parent->getFromDB($input['parent'])) {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                         $ma->addMessage($parent->getErrorMessage(ERROR_NOT_FOUND));
                         return;
                     }
@@ -743,22 +743,22 @@ TWIG, $twig_params);
                                         $fk  => $parent->getID(),
                                     ])
                                 ) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                 }
                 return;

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -249,7 +249,7 @@ class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcru
                         'FROM'   => Asset_PeripheralAsset::getTable(),
                         'WHERE'  => [
                             'itemtype_peripheral' => $type,
-                            'itemtype_asset'      => self::getType(),
+                            'itemtype_asset'      => static::class,
                             'items_id_asset'      => $this->fields["id"],
                             'is_deleted'          => 0,
                         ],
@@ -291,7 +291,7 @@ class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcru
                             'SELECT' => ['id'],
                             'FROM'   => $item::getTable(),
                             'WHERE'  => [
-                                'itemtype'     => self::getType(),
+                                'itemtype'     => static::class,
                                 'items_id'     => $this->fields["id"],
                                 'is_deleted'   => 0,
                             ],
@@ -381,7 +381,7 @@ class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcru
             ],
             'FROM'   => Asset_PeripheralAsset::getTable(),
             'WHERE'  => [
-                'itemtype_asset' => self::getType(),
+                'itemtype_asset' => static::class,
                 'items_id_asset' => $this->getID(),
             ],
         ]);

--- a/src/Config.php
+++ b/src/Config.php
@@ -1016,31 +1016,31 @@ class Config extends CommonDBTM
                 $tabs = [
                     1 => self::createTabEntry(__('General setup')),  // Display
                     2 => self::createTabEntry(__('Default values')), // Prefs
-                    3 => self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-package'),
-                    4 => self::createTabEntry(__('Assistance'), 0, $item::getType(), 'ti ti-headset'),
-                    12 => self::createTabEntry(__('Management'), 0, $item::getType(), 'ti ti-wallet'),
+                    3 => self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::class, 'ti ti-package'),
+                    4 => self::createTabEntry(__('Assistance'), 0, $item::class, 'ti ti-headset'),
+                    12 => self::createTabEntry(__('Management'), 0, $item::class, 'ti ti-wallet'),
                 ];
                 if (Config::canUpdate()) {
-                    $tabs[9]  = self::createTabEntry(__('Logs purge'), 0, $item::getType(), Event::getIcon());
+                    $tabs[9]  = self::createTabEntry(__('Logs purge'), 0, $item::class, Event::getIcon());
                     $tabs[5]  = self::createTabEntry(__('System'));
-                    $tabs[10] = self::createTabEntry(__('Security'), 0, $item::getType(), 'ti ti-shield-lock');
-                    $tabs[7]  = self::createTabEntry(__('Performance'), 0, $item::getType(), 'ti ti-dashboard');
-                    $tabs[8]  = self::createTabEntry(__('API'), 0, $item::getType(), 'ti ti-api-app');
-                    $tabs[11] = self::createTabEntry(Impact::getTypeName(), 0, $item::getType(), Impact::getIcon());
+                    $tabs[10] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                    $tabs[7]  = self::createTabEntry(__('Performance'), 0, $item::class, 'ti ti-dashboard');
+                    $tabs[8]  = self::createTabEntry(__('API'), 0, $item::class, 'ti ti-api-app');
+                    $tabs[11] = self::createTabEntry(Impact::getTypeName(), 0, $item::class, Impact::getIcon());
                 }
 
                 if (
                     DBConnection::isDBSlaveActive()
                     && Config::canUpdate()
                 ) {
-                    $tabs[6]  = self::createTabEntry(_n('SQL replica', 'SQL replicas', Session::getPluralNumber()), 0, $item::getType(), 'ti ti-database');  // Slave
+                    $tabs[6]  = self::createTabEntry(_n('SQL replica', 'SQL replicas', Session::getPluralNumber()), 0, $item::class, 'ti ti-database');  // Slave
                 }
                 return $tabs;
 
             case 'GLPINetwork':
-                return self::createTabEntry(GLPINetwork::getTypeName(), 0, $item::getType(), GLPINetwork::getIcon());
+                return self::createTabEntry(GLPINetwork::getTypeName(), 0, $item::class, GLPINetwork::getIcon());
 
-            case Impact::getType():
+            case Impact::class:
                 return self::createTabEntry(Impact::getTypeName());
         }
         return '';
@@ -1734,7 +1734,7 @@ class Config extends CommonDBTM
 
     public function getLogTypeID()
     {
-        return [$this->getType(), 1];
+        return [static::class, 1];
     }
 
     public function post_addItem()

--- a/src/Consumable.php
+++ b/src/Consumable.php
@@ -111,11 +111,11 @@ class Consumable extends CommonDBChild
     public function post_addItem()
     {
         // inherit infocom
-        $infocoms = Infocom::getItemsAssociatedTo(ConsumableItem::getType(), $this->fields[ConsumableItem::getForeignKeyField()]);
+        $infocoms = Infocom::getItemsAssociatedTo(ConsumableItem::class, $this->fields[ConsumableItem::getForeignKeyField()]);
         if (count($infocoms)) {
             $infocom = reset($infocoms);
             $infocom->clone([
-                'itemtype'  => self::getType(),
+                'itemtype'  => static::class,
                 'items_id'  => $this->getID(),
             ]);
         }
@@ -207,7 +207,7 @@ class Consumable extends CommonDBChild
             return;
         }
 
-        $action_prefix = self::getType() . MassiveAction::CLASS_ACTION_SEPARATOR;
+        $action_prefix = static::class . MassiveAction::CLASS_ACTION_SEPARATOR;
         $actions[$action_prefix . 'backtostock'] = __s('Back to stock');
         $actions[$action_prefix . 'give'] = _sx('button', 'Give');
     }
@@ -220,7 +220,7 @@ class Consumable extends CommonDBChild
         switch ($ma->getAction()) {
             case 'give':
                 // Retrieve entity restrict from consumable item
-                $consumable_id = current($input['items'][self::getType()]);
+                $consumable_id = current($input['items'][static::class]);
                 $consumable = new self();
                 if (
                     $consumable_id === false
@@ -641,7 +641,7 @@ class Consumable extends CommonDBChild
 
         $envs = [];
         foreach ($filtered_data as $env) {
-            $env['itemtype'] = self::getType();
+            $env['itemtype'] = static::class;
             $envs[$env['id']] = $env;
         }
 

--- a/src/Contact_Supplier.php
+++ b/src/Contact_Supplier.php
@@ -68,18 +68,18 @@ class Contact_Supplier extends CommonDBRelation
 
         if (!$withtemplate && Session::haveRight("contact_enterprise", READ)) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'Supplier':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb =  self::countForItem($item);
                     }
-                    return self::createTabEntry(Contact::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(Contact::getTypeName(Session::getPluralNumber()), $nb, $item::class);
 
                 case 'Contact':
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForItem($item);
                     }
-                    return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(Supplier::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1348,17 +1348,17 @@ TWIG, ['msg' => __('Last run list')]);
                     if (Config::canUpdate()) {
                         if ($item->getFromDB($key)) {
                             if ($item->resetDate()) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }

--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -87,7 +87,7 @@ class CronTaskLog extends CommonDBChild
             $nb = 0;
             if ($item instanceof CronTask) {
                 $ong    = [];
-                $ong[1] = self::createTabEntry(__('Statistics'), 0, $item::getType(), 'ti ti-report-analytics');
+                $ong[1] = self::createTabEntry(__('Statistics'), 0, $item::class, 'ti ti-report-analytics');
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb =  countElementsInTable(
                         $this->getTable(),
@@ -96,7 +96,7 @@ class CronTaskLog extends CommonDBChild
                         ]
                     );
                 }
-                $ong[2] = self::createTabEntry(_n('Log', 'Logs', Session::getPluralNumber()), $nb, $item::getType());
+                $ong[2] = self::createTabEntry(_n('Log', 'Logs', Session::getPluralNumber()), $nb, $item::class);
                 return $ong;
             }
         }

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -318,7 +318,7 @@ class DCRoom extends CommonDBTM implements DCBreadcrumbInterface
                 return self::createTabEntry(
                     self::getTypeName(Session::getPluralNumber()),
                     $nb,
-                    $item::getType()
+                    $item::class
                 );
         }
 

--- a/src/DatabaseInstance.php
+++ b/src/DatabaseInstance.php
@@ -412,13 +412,13 @@ class DatabaseInstance extends CommonDBTM implements AssignableItemInterface, St
         if (
             ($item instanceof CommonDBTM)
             && self::canView()
-            && in_array($item->getType(), self::getTypes(true))
+            && in_array($item::class, self::getTypes(true))
         ) {
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = countElementsInTable(self::getTable(), ['itemtype' => $item->getType(), 'items_id' => $item->fields['id']]);
+                $nb = countElementsInTable(self::getTable(), ['itemtype' => $item::class, 'items_id' => $item->fields['id']]);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -429,9 +429,9 @@ class DatabaseInstance extends CommonDBTM implements AssignableItemInterface, St
             return false;
         }
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             default:
-                if (in_array($item->getType(), self::getTypes())) {
+                if (in_array($item::class, self::getTypes())) {
                     self::showInstances($item, $withtemplate);
                 }
         }
@@ -452,7 +452,7 @@ class DatabaseInstance extends CommonDBTM implements AssignableItemInterface, St
             'SELECT' => 'id',
             'FROM'   => self::getTable(),
             'WHERE'  => [
-                'itemtype' => $item->getType(),
+                'itemtype' => $item::class,
                 'items_id' => $item->fields['id'],
             ],
         ]);

--- a/src/Datacenter.php
+++ b/src/Datacenter.php
@@ -167,7 +167,7 @@ class Datacenter extends CommonDBTM
             'massiveaction'      => false,
         ];
 
-        if (($itemtype != Rack::getType()) && ($itemtype != DCRoom::getType())) {
+        if (($itemtype != Rack::class) && ($itemtype != DCRoom::class)) {
             $tab[] = [
                 'id'            => '1451',
                 'table'         => Datacenter::getTable(),

--- a/src/DeviceCase.php
+++ b/src/DeviceCase.php
@@ -116,7 +116,7 @@ class DeviceCase extends CommonDevice
             return $father;
         }
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Computer':
                 Manufacturer::getHTMLTableCellsForItem($row, $this, null, $options);
                 break;

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -204,7 +204,7 @@ class DeviceHardDrive extends CommonDevice
             return $father;
         }
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Computer':
                 Manufacturer::getHTMLTableCellsForItem($row, $this, null, $options);
                 if ($this->fields["rpm"]) {

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -178,7 +178,7 @@ class DeviceMemory extends CommonDevice
             return $father;
         }
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Computer':
                 Manufacturer::getHTMLTableCellsForItem($row, $this, null, $options);
                 if ($this->fields["devicememorytypes_id"]) {

--- a/src/DevicePowerSupply.php
+++ b/src/DevicePowerSupply.php
@@ -128,7 +128,7 @@ class DevicePowerSupply extends CommonDevice
             return $father;
         }
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Computer':
                 Manufacturer::getHTMLTableCellsForItem($row, $this, null, $options);
                 if ($this->fields["power"]) {

--- a/src/DisplayPreference.php
+++ b/src/DisplayPreference.php
@@ -179,18 +179,18 @@ class DisplayPreference extends CommonDBTM
                                     'itemtype' => $id,
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($user->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($user->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
             case 'reset_to_default':
@@ -198,13 +198,13 @@ class DisplayPreference extends CommonDBTM
                 if (!isset($input['users_id']) || $input['users_id'] <= 0) {
                     foreach ($ids as $itemtype) {
                         if (self::resetToDefaultOptions($itemtype)) {
-                            $ma->itemDone($item->getType(), $itemtype, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $itemtype, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $itemtype, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $itemtype, MassiveAction::ACTION_KO);
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
         }
@@ -650,7 +650,7 @@ class DisplayPreference extends CommonDBTM
 
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Preference':
                 if (Session::haveRight(self::$rightname, self::PERSONAL)) {
                     return self::createTabEntry(text: __('Personal View'), icon: 'ti ti-columns-3');
@@ -686,7 +686,7 @@ class DisplayPreference extends CommonDBTM
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'Preference':
                 self::showForUser(Session::getLoginUserID());
                 return true;

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -124,7 +124,7 @@ class Domain extends CommonDBTM implements AssignableItemInterface
             'field'              => 'name',
             'name'               => __('Name'),
             'datatype'           => 'itemlink',
-            'itemlink_type'      => $this->getType(),
+            'itemlink_type'      => static::class,
         ];
 
         $tab[] = [
@@ -515,23 +515,23 @@ class Domain extends CommonDBTM implements AssignableItemInterface
             case 'add_item':
                 $input = $ma->getInput();
                 if (!isset($input['domains_id'])) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::NO_ACTION);
+                    $ma->itemDone($item::class, $ids, MassiveAction::NO_ACTION);
                     return;
                 }
                 foreach ($ids as $id) {
                     $input = ['domains_id' => $input['domains_id'],
                         'items_id'                  => $id,
-                        'itemtype'                  => $item->getType(),
+                        'itemtype'                  => $item::class,
                         'domainrelations_id'        => $input['domainrelations_id'],
                     ];
                     if ($domain_item->can(-1, UPDATE, $input)) {
                         if ($domain_item->getFromDBByCrit($input)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                            $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                         } else {
                             if ($domain_item->add($input)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             }
                         }
                     }
@@ -546,19 +546,19 @@ class Domain extends CommonDBTM implements AssignableItemInterface
                         $domain_item->find([
                             'domains_id' => $input['domains_id'],
                             'items_id'   => $id,
-                            'itemtype'   => $item->getType(),
+                            'itemtype'   => $item::class,
                         ]) as $data
                     ) {
                         $purge = !$data['is_dynamic']; // dynamic relations should be preserved for inventory lock feature (dynamic + deleted = locked)
                         if ($domain_item->delete($data, $purge)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                         $nolink = false;
                     }
                     if ($nolink) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;
@@ -571,12 +571,12 @@ class Domain extends CommonDBTM implements AssignableItemInterface
                             'itemtype'                  => $input['typeitem'],
                         ];
                         if ($domain_item->add($values)) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -586,9 +586,9 @@ class Domain extends CommonDBTM implements AssignableItemInterface
                 $input = $ma->getInput();
                 foreach ($ids as $key) {
                     if ($domain_item->deleteItemByDomainsAndItem($key, $input['item_item'], $input['typeitem'])) {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                     }
                 }
                 return;
@@ -603,9 +603,9 @@ class Domain extends CommonDBTM implements AssignableItemInterface
                         $item->fields["comment"] = $item->fields["comment"];
                         $item->fields["entities_id"] = $input['entities_id'];
                         if ($item->add($item->fields)) {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                         }
                     }
                 }

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -59,7 +59,7 @@ class Domain_Item extends CommonDBRelation
     {
         $temp = new self();
         $temp->deleteByCriteria(
-            ['itemtype' => $item->getType(),
+            ['itemtype' => $item::class,
                 'items_id' => $item->getField('id'),
             ]
         );
@@ -76,7 +76,7 @@ class Domain_Item extends CommonDBRelation
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForDomain($item);
             }
-            return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+            return self::createTabEntry(_n('Associated item', 'Associated items', Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
         }
 
         if (
@@ -87,7 +87,7 @@ class Domain_Item extends CommonDBRelation
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(Domain::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3551,7 +3551,7 @@ HTML;
                     ];
                     break;
 
-                case KnowbaseItem::getType():
+                case KnowbaseItem::class:
                     $criteria = [
                         'SELECT' => array_merge(["$table.*"], $addselect),
                         'DISTINCT'        => true,
@@ -3592,7 +3592,7 @@ HTML;
                     }
                     break;
 
-                case Project::getType():
+                case Project::class:
                     $visibility = Project::getVisibilityCriteria();
                     if (count($visibility['LEFT JOIN'])) {
                         $ljoin = array_merge($ljoin, $visibility['LEFT JOIN']);

--- a/src/DropdownTranslation.php
+++ b/src/DropdownTranslation.php
@@ -201,7 +201,7 @@ class DropdownTranslation extends CommonDBChild
         return countElementsInTable(
             getTableForItemType(self::class),
             [
-                'itemtype' => $item->getType(),
+                'itemtype' => $item::class,
                 'items_id' => $item->getID(),
                 'NOT'      => ['field' => 'completename' ],
             ]
@@ -385,7 +385,7 @@ TWIG, $twig_params);
         $iterator = $DB->request([
             'FROM'   => getTableForItemType(self::class),
             'WHERE'  => [
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'items_id'  => $item->getID(),
                 'field'     => ['<>', 'completename'],
             ],

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2278,13 +2278,13 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
      **/
     public static function generateLinkSatisfaction($item)
     {
-        $config_suffix = $item instanceof Ticket ? '' : ('_' . strtolower($item::getType()));
+        $config_suffix = $item instanceof Ticket ? '' : ('_' . strtolower($item::class));
         $url = self::getUsedConfig('inquest_config' . $config_suffix, $item->fields['entities_id'], 'inquest_URL' . $config_suffix);
 
-        $tag_prefix = strtoupper($item::getType());
+        $tag_prefix = strtoupper($item::class);
 
         if (strstr($url, "[ITEMTYPE]")) {
-            $url = str_replace("[ITEMTYPE]", $item::getType(), $url);
+            $url = str_replace("[ITEMTYPE]", $item::class, $url);
         }
         if (strstr($url, "[ITEMTYPE_NAME]")) {
             $url = str_replace("[ITEMTYPE_NAME]", $item::getTypeName(1), $url);
@@ -3442,7 +3442,7 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
     public function listTranslationsHandlers(): array
     {
         $handlers = [];
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', static::class, $this->getID());
         $category_name = sprintf('%s: %s', self::getTypeName(), $this->getName());
         if ($this->fields['custom_helpdesk_home_title'] != self::CONFIG_PARENT) {
             $handlers[$key][] = new TranslationHandler(

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -654,12 +654,12 @@ abstract class API
             && in_array($itemtype, Item_Devices::getConcernedItems())
         ) {
             $all_devices = [];
-            foreach (Item_Devices::getItemAffinities($item->getType()) as $device_type) {
+            foreach (Item_Devices::getItemAffinities($item::class) as $device_type) {
                 $found_devices = getAllDataFromTable(
                     $device_type::getTable(),
                     [
                         'items_id'     => $item->getID(),
-                        'itemtype'     => $item->getType(),
+                        'itemtype'     => $item::class,
                         'is_deleted'   => 0,
                     ],
                     true
@@ -1018,7 +1018,7 @@ abstract class API
                     "glpi_logs",
                     [
                         'items_id'  => $item->getID(),
-                        'itemtype'  => $item->getType(),
+                        'itemtype'  => $item::class,
                     ]
                 );
             }
@@ -1265,7 +1265,7 @@ abstract class API
             foreach ($search_values as $filter_field => $filter_value) {
                 if (!$DB->fieldExists($table, $filter_field)) {
                     $this->returnError(
-                        sprintf(__('Field %s is not valid for %s item.'), $filter_field, $item->getType()),
+                        sprintf(__('Field %s is not valid for %s item.'), $filter_field, $item::class),
                         400,
                         "ERROR_FIELD_NOT_FOUND"
                     );
@@ -1796,7 +1796,7 @@ abstract class API
             }
 
             // if all asset, provide type in returned data
-            if ($itemtype == AllAssets::getType()) {
+            if ($itemtype == AllAssets::class) {
                 $current_line['id']       = $raw['id'];
                 $current_line['itemtype'] = $raw['TYPE'];
             }
@@ -3279,7 +3279,7 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
     {
         // Return massive actions for a given item
         $actions = MassiveAction::getAllMassiveActions(
-            $item::getType(),
+            $item::class,
             $item->isDeleted(),
             $item,
             $item->getID()

--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -409,7 +409,7 @@ class APIRest extends API
     {
 
         if (isset($this->url_elements[$index])) {
-            $all_assets = $all_assets && $this->url_elements[$index] == AllAssets::getType();
+            $all_assets = $all_assets && $this->url_elements[$index] == AllAssets::class;
             $valid_class = Toolbox::isCommonDBTM($this->url_elements[$index])
             || Toolbox::isAPIDeprecated($this->url_elements[$index]);
 
@@ -426,7 +426,7 @@ class APIRest extends API
 
                 // AllAssets
                 if ($all_assets) {
-                    return AllAssets::getType();
+                    return AllAssets::class;
                 }
 
                 // Load namespace for deprecated

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -835,7 +835,7 @@ final class ITILController extends AbstractController
                 'requested_approver_type' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'x-field' => 'itemtype_target',
-                    'enum' => [User::getType(), Group::getType()],
+                    'enum' => [User::class, Group::class],
                 ],
                 'requested_approver_id' => [
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -1449,7 +1449,7 @@ EOT,
     private function getRequiredTimelineItemFields(CommonITILObject $item, Request $request, string $subitem_type): array
     {
         $fields = [
-            'itemtype' => $item::getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ];
         if ($subitem_type === 'Task' || $subitem_type === 'Validation') {
@@ -1477,8 +1477,8 @@ EOT,
             $schema = (new ManagementController())->getKnownSchema('Document_Item', $api_version);
         } elseif ($subitem_type === 'Task') {
             $schema = $this->getKnownSchema($item::getTaskClass(), $api_version);
-        } elseif ($subitem_type === 'Validation' && class_exists($item::getType() . 'Validation')) {
-            $schema = $this->getKnownSchema($item::getType() . 'Validation', $api_version);
+        } elseif ($subitem_type === 'Validation' && class_exists($item::class . 'Validation')) {
+            $schema = $this->getKnownSchema($item::class . 'Validation', $api_version);
         } else {
             $schema = $this->getKnownSchema($subitem_type, $api_version);
         }
@@ -1715,7 +1715,7 @@ EOT,
         $schema = $this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request));
         return ResourceAccessor::createBySchema($schema, $parameters, [self::class, 'getTimelineItem'], [
             'mapped' => [
-                'itemtype' => $item::getType(),
+                'itemtype' => $item::class,
                 'subitem_type' => $subitem_type,
                 'id' => $item->getID(),
             ],
@@ -1739,7 +1739,7 @@ EOT,
         $schema = $this->getKnownSubitemSchema($item, 'Task', $this->getAPIVersion($request));
         return ResourceAccessor::createBySchema($schema, $parameters, [self::class, 'getTimelineTask'], [
             'mapped' => [
-                'itemtype' => $item::getType(),
+                'itemtype' => $item::class,
                 'subitem_type' => 'Task',
                 'id' => $item->getID(),
             ],
@@ -1765,7 +1765,7 @@ EOT,
         $schema = $this->getKnownSubitemSchema($item, 'Validation', $this->getAPIVersion($request));
         return ResourceAccessor::createBySchema($schema, $parameters, [self::class, 'getTimelineValidation'], [
             'mapped' => [
-                'itemtype' => $item::getType(),
+                'itemtype' => $item::class,
                 'subitem_type' => 'Validation',
                 'id' => $item->getID(),
             ],

--- a/src/Glpi/Api/HL/Controller/ReportController.php
+++ b/src/Glpi/Api/HL/Controller/ReportController.php
@@ -867,13 +867,13 @@ class ReportController extends AbstractController
             $result = [];
             if (isset($item['itemtype'])) {
                 $result['item'] = [
-                    'itemtype' => $param_item::getType(),
+                    'itemtype' => $param_item::class,
                     'id' => $item['id'],
                     'name' => Dropdown::getDropdownName($item['itemtype']::getTable(), $item['id'], false, true, true, ''),
                 ];
             } else {
                 $result['item'] = [
-                    'itemtype' => $param_item::getType(),
+                    'itemtype' => $param_item::class,
                     'id' => $item['id'],
                     'name' => $item['link'],
                 ];

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -599,7 +599,7 @@ TWIG, $twig_params);
             'FROM'   => self::getTable(),
             'WHERE'  => [
                 'items_id_peripheral' => $item->getID(),
-                'itemtype_peripheral' => $item->getType(),
+                'itemtype_peripheral' => $item::class,
             ],
         ]);
 
@@ -744,7 +744,7 @@ TWIG, $twig_params);
                 ],
                 'FROM' => self::getTable(),
                 'WHERE' => [
-                    'itemtype_asset' => $item->getType(),
+                    'itemtype_asset' => $item::class,
                     'items_id_asset' => $item->getID(),
                 ],
                 'GROUP' => 'itemtype_peripheral',
@@ -781,7 +781,7 @@ TWIG, $twig_params);
                 ],
                 'FROM'   => self::getTable(),
                 'WHERE'  => [
-                    'itemtype_peripheral' => $item->getType(),
+                    'itemtype_peripheral' => $item::class,
                     'items_id_peripheral' => $item->fields['id'],
                 ],
                 'GROUP'  => 'itemtype_peripheral',

--- a/src/Glpi/Asset/Capacity/HasContractsCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasContractsCapacity.php
@@ -110,7 +110,7 @@ class HasContractsCapacity extends AbstractCapacity
         );
 
         // Clean history related to contracts (both sides of the relation)
-        $this->deleteRelationLogs($classname, Contract::getType());
+        $this->deleteRelationLogs($classname, Contract::class);
 
         // Clean display preferences
         $this->deleteDisplayPreferences(

--- a/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasOperatingSystemCapacity.php
@@ -115,8 +115,8 @@ class HasOperatingSystemCapacity extends AbstractCapacity
         );
 
         // Clean history related to operating systems
-        $this->deleteRelationLogs($classname, OperatingSystem::getType());
-        $this->deleteRelationLogs($classname, Item_OperatingSystem::getType());
+        $this->deleteRelationLogs($classname, OperatingSystem::class);
+        $this->deleteRelationLogs($classname, Item_OperatingSystem::class);
 
         // Clean display preferences
         $this->deleteDisplayPreferences(

--- a/src/Glpi/CalDAV/Backend/Calendar.php
+++ b/src/Glpi/CalDAV/Backend/Calendar.php
@@ -89,7 +89,7 @@ class Calendar extends AbstractBackend
         }
 
         $principal_calendar_key = Planning::getPlanningKeyForActor(
-            $principal_item->getType(),
+            $principal_item::class,
             $principal_item->fields['id']
         );
 
@@ -383,7 +383,7 @@ class Calendar extends AbstractBackend
             if (false === $items_id) {
                 return false;
             }
-            return $this->storeVCalendarData($calendarData, $items_id, $item->getType());
+            return $this->storeVCalendarData($calendarData, $items_id, $item::class);
         }
 
         $input['id'] = $item->fields['id'];
@@ -397,7 +397,7 @@ class Calendar extends AbstractBackend
         if (false === $update) {
             return false;
         }
-        return $this->storeVCalendarData($calendarData, $item->fields['id'], $item->getType());
+        return $this->storeVCalendarData($calendarData, $item->fields['id'], $item::class);
     }
 
     /**

--- a/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
+++ b/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
@@ -86,7 +86,7 @@ trait VobjectConverterTrait
         $vobject = new VObject();
         $vobject_crit = [
             'items_id' => $item->fields['id'],
-            'itemtype' => $item->getType(),
+            'itemtype' => $item::class,
         ];
 
         // Restore previously saved VCalendar if available

--- a/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
+++ b/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
@@ -260,7 +260,7 @@ final class CheckHtmlEncodingCommand extends AbstractCommand
     {
         global $DB;
 
-        $itemtype = $item::getType();
+        $itemtype = $item::class;
 
         // update the item
         $update = [];
@@ -294,7 +294,7 @@ final class CheckHtmlEncodingCommand extends AbstractCommand
     {
         $new_value = $item->fields[$field];
 
-        if (in_array($item::getType(), [Ticket::getType(), ITILFollowup::getType()]) && $field == 'content') {
+        if (in_array($item::class, [Ticket::class, ITILFollowup::class]) && $field == 'content') {
             $new_value = $this->fixEmailHeadersEncoding($new_value);
         }
 
@@ -419,7 +419,7 @@ final class CheckHtmlEncodingCommand extends AbstractCommand
             [$field => ['LIKE', '%&quot(?!;)/%']],
         ];
 
-        if (in_array($itemtype, [Ticket::getType(), ITILFollowup::getType()]) && $field == 'content') {
+        if (in_array($itemtype, [Ticket::class, ITILFollowup::class]) && $field == 'content') {
             $searches[] = [
                 $field => ['REGEXP', '(&#38;amp;lt;)(?<email>[^@]*?@[a-zA-Z0-9\-.]*?)(&#38;amp;gt;)'],
             ];

--- a/src/Glpi/Console/Migration/AbstractPluginToCoreCommand.php
+++ b/src/Glpi/Console/Migration/AbstractPluginToCoreCommand.php
@@ -380,7 +380,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
 
         $exists = $infocom->getFromDBByCrit(
             [
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'items_id'  => $item->getID(),
             ]
         );
@@ -391,7 +391,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
             $success = $infocom->update($infocom_input);
         } else {
             $infocom_input += [
-                'itemtype'     => $item->getType(),
+                'itemtype'     => $item::class,
                 'items_id'     => $item->getID(),
                 'entities_id'  => $item->fields['entities_id'] ?? 0,
                 'is_recursive' => $item->fields['is_recursive'] ?? 0,
@@ -403,7 +403,7 @@ abstract class AbstractPluginToCoreCommand extends AbstractCommand
             $this->handleImportError(
                 sprintf(
                     __('Unable to financial and administrative information for %s "%s" (%d).'),
-                    $item->getType(),
+                    $item::class,
                     $item->getName(),
                     $item->getID()
                 ),

--- a/src/Glpi/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Glpi/Console/Migration/RacksPluginToCoreCommand.php
@@ -1285,7 +1285,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
                 }
 
                 $item_input = [
-                    'itemtype' => $item->getType(),
+                    'itemtype' => $item::class,
                     'items_id' => $item->fields['id'],
                 ];
 
@@ -1305,7 +1305,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
                 }
 
                 $required_units = 1;
-                $modeltype = $item->getType() . 'Model';
+                $modeltype = $item::class . 'Model';
                 if (class_exists($modeltype)) {
                     $model_fkey = getForeignKeyFieldForTable($modeltype::getTable());
                     if (

--- a/src/Glpi/ContentTemplates/Parameters/AssetParameters.php
+++ b/src/Glpi/ContentTemplates/Parameters/AssetParameters.php
@@ -86,7 +86,7 @@ class AssetParameters extends AbstractParameters
         $values = [
             'id'       => $fields['id'],
             'name'     => $fields['name'],
-            'itemtype' => $asset->getType(),
+            'itemtype' => $asset::class,
             'serial'   => $fields['serial'],
             'model'    => '',
             'type'     => '',

--- a/src/Glpi/ContentTemplates/Parameters/TicketParameters.php
+++ b/src/Glpi/ContentTemplates/Parameters/TicketParameters.php
@@ -144,7 +144,7 @@ class TicketParameters extends CommonITILObjectParameters
 
         // Add assets
         $values['assets'] = [];
-        $items_ticket = Item_Ticket::getItemsAssociatedTo($ticket::getType(), $fields['id']);
+        $items_ticket = Item_Ticket::getItemsAssociatedTo($ticket::class, $fields['id']);
         foreach ($items_ticket as $item_ticket) {
             $itemtype = $item_ticket->fields['itemtype'];
             if (!in_array($itemtype, $CFG_GLPI["asset_types"])) {

--- a/src/Glpi/ContentTemplates/TemplateManager.php
+++ b/src/Glpi/ContentTemplates/TemplateManager.php
@@ -113,7 +113,7 @@ class TemplateManager
             $html = TemplateManager::render(
                 $template,
                 [
-                    'itemtype' => $itil_item->getType(),
+                    'itemtype' => $itil_item::class,
                     $parameters->getDefaultNodeName() => $parameters->getValues($itil_item),
                 ]
             );

--- a/src/Glpi/Controller/Form/Import/Step1IndexController.php
+++ b/src/Glpi/Controller/Form/Import/Step1IndexController.php
@@ -55,7 +55,7 @@ final class Step1IndexController extends AbstractController
 
         return $this->render("pages/admin/form/import/step1_index.html.twig", [
             'title' => __("Import form"),
-            'menu'  => ['admin', Form::getType()],
+            'menu'  => ['admin', Form::class],
         ]);
     }
 }

--- a/src/Glpi/Controller/Form/Import/Step2PreviewController.php
+++ b/src/Glpi/Controller/Form/Import/Step2PreviewController.php
@@ -89,7 +89,7 @@ final class Step2PreviewController extends AbstractController
 
         return $this->render("pages/admin/form/import/step2_preview.html.twig", [
             'title'        => __("Preview import"),
-            'menu'         => ['admin', Form::getType()],
+            'menu'         => ['admin', Form::class],
             'preview'      => $previewResult,
             'json'         => $json,
             'replacements' => $replacements,

--- a/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
+++ b/src/Glpi/Controller/Form/Import/Step3ResolveIssuesController.php
@@ -73,7 +73,7 @@ final class Step3ResolveIssuesController extends AbstractController
         $issues = $serializer->listIssues($mapper, $json)->getIssues()[$form_id];
         return $this->render("pages/admin/form/import/step3_resolve_issues.html.twig", [
             'title'        => __("Resolve issues"),
-            'menu'         => ['admin', Form::getType()],
+            'menu'         => ['admin', Form::class],
             'issues'       => $issues,
             'json'         => $json,
             'replacements' => $replacements,

--- a/src/Glpi/Controller/Form/Import/Step4ExecuteController.php
+++ b/src/Glpi/Controller/Form/Import/Step4ExecuteController.php
@@ -71,7 +71,7 @@ final class Step4ExecuteController extends AbstractController
 
         return $this->render("pages/admin/form/import/step4_execute.html.twig", [
             'title'   => __("Import results"),
-            'menu'    => ['admin', Form::getType()],
+            'menu'    => ['admin', Form::class],
             'results' => $serializer->importFormsFromJson($json, $mapper, $skipped_forms),
         ]);
     }

--- a/src/Glpi/Controller/Form/RendererController.php
+++ b/src/Glpi/Controller/Form/RendererController.php
@@ -105,7 +105,7 @@ final class RendererController extends AbstractController
 
         return $this->render('pages/form_renderer.html.twig', [
             'title' => $form->fields['name'],
-            'menu' => ['helpdesk', ServiceCatalog::getType()],
+            'menu' => ['helpdesk', ServiceCatalog::class],
             'form' => $form,
             'unauthenticated_user' => $is_unauthenticated_user,
             'my_tickets_url_param' => http_build_query($my_tickets_criteria),

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -829,7 +829,7 @@ class Provider
 
         $c_table     = $item::getTable();
         $fk_table    = $fk_item::getTable();
-        $fk_itemtype = $fk_item::getType();
+        $fk_itemtype = $fk_item::class;
 
         // try to autodetect searchoption id
         $searchoptions = $item->rawSearchOptions();

--- a/src/Glpi/Features/Clonable.php
+++ b/src/Glpi/Features/Clonable.php
@@ -136,7 +136,7 @@ trait Clonable
                     $override_input['name'] = $relation_item->fields['name'];
                 }
                 $origin_id = $relation_item->getID();
-                $itemtype = $relation_item->getType();
+                $itemtype = $relation_item::class;
                 if (method_exists($relation_item, 'clone')) {
                     $method = new ReflectionMethod($relation_item, 'clone');
 
@@ -170,7 +170,7 @@ trait Clonable
             }
             // Update relations between cloned items
             foreach ($relation_newitems as $relation_newitem) {
-                $itemtype = $relation_newitem->getType();
+                $itemtype = $relation_newitem::class;
                 $foreignkey = getForeignKeyFieldForItemType($itemtype);
                 if ($relation_newitem->isField($foreignkey) && isset($cloned[$itemtype][$relation_newitem->fields[$foreignkey]])) {
                     $relation_newitem->update([

--- a/src/Glpi/Features/DCBreadcrumb.php
+++ b/src/Glpi/Features/DCBreadcrumb.php
@@ -72,7 +72,7 @@ trait DCBreadcrumb
                     && $rack->getFromDB($pdu_rack->fields['racks_id'])
                 ) {
                     $location = Location::getFromItem($rack) ?: null;
-                    $breadcrumb[Rack::getType()] = [
+                    $breadcrumb[Rack::class] = [
                         'link'     => $rack->getLink(
                             [
                                 'class' => $rack->isDeleted() ? 'target-deleted' : '',
@@ -93,7 +93,7 @@ trait DCBreadcrumb
             unset($enclosure_types[array_search('Enclosure', $enclosure_types)]);
             if (in_array($item->getType(), $enclosure_types) && $enclosure = $item->getParentEnclosure()) {
                 $location = Location::getFromItem($enclosure) ?: null;
-                $breadcrumb[Enclosure::getType()] = [
+                $breadcrumb[Enclosure::class] = [
                     'link'     => $enclosure->getLink(
                         [
                             'class' => $enclosure->isDeleted() ? 'target-deleted' : '',
@@ -110,7 +110,7 @@ trait DCBreadcrumb
             // Add Rack part of breadcrumb
             if (in_array($item->getType(), $types) && $rack = $item->getParentRack()) {
                 $location = Location::getFromItem($rack) ?: null;
-                $breadcrumb[Rack::getType()] = [
+                $breadcrumb[Rack::class] = [
                     'link'     => $rack->getLink(
                         [
                             'class' => $rack->isDeleted() ? 'target-deleted' : '',
@@ -132,7 +132,7 @@ trait DCBreadcrumb
                 && $dcroom->getFromDB($item->fields['dcrooms_id'])
             ) {
                 $location = Location::getFromItem($dcroom) ?: null;
-                $breadcrumb[DCRoom::getType()] = [
+                $breadcrumb[DCRoom::class] = [
                     'link'     => $dcroom->getLink(
                         [
                             'class' => $dcroom->isDeleted() ? 'target-deleted' : '',
@@ -153,7 +153,7 @@ trait DCBreadcrumb
                 && $datacenter->getFromDB($item->fields['datacenters_id'])
             ) {
                 $location = Location::getFromItem($datacenter) ?: null;
-                $breadcrumb[Datacenter::getType()] = [
+                $breadcrumb[Datacenter::class] = [
                     'link'     => $datacenter->getLink(
                         [
                             'class' => $datacenter->isDeleted() ? 'target-deleted' : '',
@@ -181,7 +181,7 @@ trait DCBreadcrumb
         $ien = new Item_Enclosure();
         if (
             !($this instanceof CommonDBTM)
-            || !$ien->getFromDBByCrit(['itemtype' => $this->getType(), 'items_id' => $this->getID()])
+            || !$ien->getFromDBByCrit(['itemtype' => static::class, 'items_id' => $this->getID()])
         ) {
             return null;
         }
@@ -196,7 +196,7 @@ trait DCBreadcrumb
         $ien = new Item_Enclosure();
         if (
             !($this instanceof CommonDBTM)
-            || !$ien->getFromDBByCrit(['itemtype' => $this->getType(), 'items_id' => $this->getID()])
+            || !$ien->getFromDBByCrit(['itemtype' => static::class, 'items_id' => $this->getID()])
         ) {
             return null;
         }
@@ -210,7 +210,7 @@ trait DCBreadcrumb
         $ira = new Item_Rack();
         if (
             !($this instanceof CommonDBTM)
-            || !$ira->getFromDBByCrit(['itemtype' => $this->getType(), 'items_id' => $this->getID()])
+            || !$ira->getFromDBByCrit(['itemtype' => static::class, 'items_id' => $this->getID()])
         ) {
             return null;
         }
@@ -225,7 +225,7 @@ trait DCBreadcrumb
         $ira = new Item_Rack();
         if (
             !($this instanceof CommonDBTM)
-            || !$ira->getFromDBByCrit(['itemtype' => $this->getType(), 'items_id' => $this->getID()])
+            || !$ira->getFromDBByCrit(['itemtype' => static::class, 'items_id' => $this->getID()])
         ) {
             return null;
         }

--- a/src/Glpi/Features/State.php
+++ b/src/Glpi/Features/State.php
@@ -67,7 +67,7 @@ trait State
         $this->checkSetup();
         $dropdownVisibility = new DropdownVisibility();
         return $dropdownVisibility->getFromDBByCrit([
-            'itemtype' => \State::getType(),
+            'itemtype' => \State::class,
             'items_id' => $id,
             'visible_itemtype' => static::class,
             'is_visible' => 1,
@@ -87,14 +87,14 @@ trait State
                         DropdownVisibility::getTable() => 'items_id',
                         \State::getTable() => 'id', [
                             'AND' => [
-                                DropdownVisibility::getTable() . '.itemtype' => \State::getType(),
+                                DropdownVisibility::getTable() . '.itemtype' => \State::class,
                             ],
                         ],
                     ],
                 ],
             ],
             'WHERE' => [
-                DropdownVisibility::getTable() . '.itemtype' => \State::getType(),
+                DropdownVisibility::getTable() . '.itemtype' => \State::class,
                 DropdownVisibility::getTable() . '.visible_itemtype' => static::class,
                 DropdownVisibility::getTable() . '.is_visible' => 1,
             ],

--- a/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowListDropdown.php
@@ -83,9 +83,9 @@ final class AllowListDropdown extends AbstractRightsDropdown
     protected static function getTypes(array $options = []): array
     {
         return [
-            User::getType(),
-            Profile::getType(),
-            Group::getType(),
+            User::class,
+            Profile::class,
+            Group::class,
         ];
     }
 

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -442,7 +442,7 @@ final class AnswersHandler
                 $form_item = new AnswersSet_FormDestinationItem();
                 $input = [
                     AnswersSet::getForeignKeyField() => $answers_set->getID(),
-                    'itemtype'                       => $item::getType(),
+                    'itemtype'                       => $item::class,
                     'items_id'                       => $item->getID(),
                 ];
                 if (!$form_item->add($input)) {

--- a/src/Glpi/Form/Comment.php
+++ b/src/Glpi/Form/Comment.php
@@ -195,7 +195,7 @@ final class Comment extends CommonDBChild implements
     #[Override]
     public function listTranslationsHandlers(): array
     {
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = sprintf('%s: %s', self::getTypeName(), $this->getName());
         $handlers = [];
 
@@ -314,9 +314,9 @@ final class Comment extends CommonDBChild implements
         // Report logs to the parent form
         Log::history(
             $form->getID(),
-            $form->getType(),
+            $form::class,
             $changes,
-            $this->getType(),
+            self::class,
             static::$log_history_add
         );
 
@@ -353,9 +353,9 @@ final class Comment extends CommonDBChild implements
 
             Log::history(
                 $form->getID(),
-                $form->getType(),
+                $form::class,
                 $changes,
-                $this->getType(),
+                self::class,
                 static::$log_history_update
             );
         }
@@ -383,9 +383,9 @@ final class Comment extends CommonDBChild implements
 
         Log::history(
             $form->getID(),
-            $form->getType(),
+            $form::class,
             $changes,
-            $this->getType(),
+            self::class,
             static::$log_history_delete
         );
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityField.php
@@ -140,7 +140,7 @@ final class EntityField extends AbstractConfigField implements DestinationFieldC
             $form->getQuestionsByType(
                 QuestionTypeItem::class
             ),
-            fn($question) => (new QuestionTypeItem())->getDefaultValueItemtype($question) === Entity::getType()
+            fn($question) => (new QuestionTypeItem())->getDefaultValueItemtype($question) === Entity::class
         );
 
         if (count($valid_answers) == 0) {
@@ -170,7 +170,7 @@ final class EntityField extends AbstractConfigField implements DestinationFieldC
 
         foreach ($questions as $question) {
             // Only keep questions that are Entity
-            if ((new QuestionTypeItem())->getDefaultValueItemtype($question) !== Entity::getType()) {
+            if ((new QuestionTypeItem())->getDefaultValueItemtype($question) !== Entity::class) {
                 continue;
             }
 

--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
@@ -107,7 +107,7 @@ enum EntityFieldStrategy: string
         }
 
         $value = $answer->getRawAnswer();
-        if ($value['itemtype'] !== Entity::getType() || !is_numeric($value['items_id'])) {
+        if ($value['itemtype'] !== Entity::class || !is_numeric($value['items_id'])) {
             return $this->getFormFillerEntityID();
         }
 
@@ -122,7 +122,7 @@ enum EntityFieldStrategy: string
                 QuestionTypeItem::class
             ),
             fn($answer)
-                => $answer->getRawAnswer()['itemtype'] === Entity::getType()
+                => $answer->getRawAnswer()['itemtype'] === Entity::class
                 && $answer->getRawAnswer()['items_id'] > -1
         );
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryField.php
@@ -186,7 +186,7 @@ final class ITILCategoryField extends AbstractConfigField implements Destination
 
         foreach ($questions as $question) {
             // Only keep questions that are ITIL categories
-            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== ITILCategory::getType()) {
+            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== ITILCategory::class) {
                 continue;
             }
 

--- a/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILCategoryFieldStrategy.php
@@ -83,7 +83,7 @@ enum ITILCategoryFieldStrategy: string
         }
 
         $value = $answer->getRawAnswer();
-        if ($value['itemtype'] !== ITILCategory::getType() || !is_numeric($value['items_id'])) {
+        if ($value['itemtype'] !== ITILCategory::class || !is_numeric($value['items_id'])) {
             return null;
         }
 
@@ -101,7 +101,7 @@ enum ITILCategoryFieldStrategy: string
         $valid_answers = array_filter($valid_answers, function (Answer $answer) {
             $value = $answer->getRawAnswer();
             if (
-                $value['itemtype'] !== ITILCategory::getType()
+                $value['itemtype'] !== ITILCategory::class
                 || !is_numeric($value['items_id'])
             ) {
                 return false;

--- a/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LinkedITILObjectsFieldStrategy.php
@@ -105,7 +105,7 @@ enum LinkedITILObjectsFieldStrategy: string
             foreach ($created_objects[$destination_id] as $item) {
                 if ($item instanceof CommonITILObject) {
                     $linked_itil_objects[] = [
-                        'itemtype' => $item::getType(),
+                        'itemtype' => $item::class,
                         'items_id' => $item->getID(),
                         'linktype' => $linktype,
                     ];

--- a/src/Glpi/Form/Destination/CommonITILField/LocationField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationField.php
@@ -154,7 +154,7 @@ final class LocationField extends AbstractConfigField implements DestinationFiel
 
         foreach ($questions as $question) {
             // Only keep questions that are Location
-            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== Location::getType()) {
+            if ((new QuestionTypeItemDropdown())->getDefaultValueItemtype($question) !== Location::class) {
                 continue;
             }
 

--- a/src/Glpi/Form/Destination/CommonITILField/LocationFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/LocationFieldStrategy.php
@@ -86,7 +86,7 @@ enum LocationFieldStrategy: string
         }
 
         $value = $answer->getRawAnswer();
-        if ($value['itemtype'] !== Location::getType() || !is_numeric($value['items_id'])) {
+        if ($value['itemtype'] !== Location::class || !is_numeric($value['items_id'])) {
             return null;
         }
 

--- a/src/Glpi/Form/Dropdown/FormActorsDropdown.php
+++ b/src/Glpi/Form/Dropdown/FormActorsDropdown.php
@@ -56,9 +56,9 @@ final class FormActorsDropdown extends AbstractRightsDropdown
     protected static function getTypes(array $options = []): array
     {
         $allowed_types = [
-            User::getType(),
-            Group::getType(),
-            Supplier::getType(),
+            User::class,
+            Group::class,
+            Supplier::class,
         ];
 
         if (isset($options['allowed_types'])) {
@@ -149,18 +149,18 @@ final class FormActorsDropdown extends AbstractRightsDropdown
         $possible_rights = [];
 
         // Add users if enabled
-        if (self::isTypeEnabled(User::getType(), $options)) {
-            $possible_rights[User::getType()] = self::getUsers($text, $options);
+        if (self::isTypeEnabled(User::class, $options)) {
+            $possible_rights[User::class] = self::getUsers($text, $options);
         }
 
         // Add groups if enabled
-        if (self::isTypeEnabled(Group::getType(), $options)) {
-            $possible_rights[Group::getType()] = self::getGroups($text, $options);
+        if (self::isTypeEnabled(Group::class, $options)) {
+            $possible_rights[Group::class] = self::getGroups($text, $options);
         }
 
         // Add suppliers if enabled
-        if (self::isTypeEnabled(Supplier::getType(), $options)) {
-            $possible_rights[Supplier::getType()] = self::getSuppliers($text, $options);
+        if (self::isTypeEnabled(Supplier::class, $options)) {
+            $possible_rights[Supplier::class] = self::getSuppliers($text, $options);
         }
 
         $results = [];

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -459,7 +459,7 @@ final class Form extends CommonDBTM implements
     #[Override]
     public function listTranslationsHandlers(): array
     {
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = __('Form properties');
         $handlers = [];
         $handlers[$key][] = new TranslationHandler(

--- a/src/Glpi/Form/FormTranslation.php
+++ b/src/Glpi/Form/FormTranslation.php
@@ -82,7 +82,7 @@ final class FormTranslation extends ItemTranslation
                 $count = countDistinctElementsInTable(
                     static::getTable(),
                     'language',
-                    ['items_id' => $item->getID(), 'itemtype' => $item->getType()]
+                    ['items_id' => $item->getID(), 'itemtype' => $item::class]
                 );
             }
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1330,14 +1330,14 @@ class FormMigration extends AbstractPluginMigration
                             FormTranslation::class,
                             [
                                 FormTranslation::$items_id => $handler->getItem()->getID(),
-                                FormTranslation::$itemtype => $handler->getItem()->getType(),
+                                FormTranslation::$itemtype => $handler->getItem()::class,
                                 'key'                      => $handler->getKey(),
                                 'language'                 => $raw_language['name'],
                                 'translations'             => [$plural_key => $translations[$handler->getValue()]],
                             ],
                             [
                                 FormTranslation::$items_id => $handler->getItem()->getID(),
-                                FormTranslation::$itemtype => $handler->getItem()->getType(),
+                                FormTranslation::$itemtype => $handler->getItem()::class,
                                 'key'                      => $handler->getKey(),
                                 'language'                 => $raw_language['name'],
                             ]

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -150,7 +150,7 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
     #[Override]
     public function listTranslationsHandlers(): array
     {
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = sprintf('%s: %s', self::getTypeName(), $this->getName());
         $handlers = [];
         $handlers[$key][] = new TranslationHandler(
@@ -451,9 +451,9 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
         // Report logs to the parent form
         Log::history(
             $form->getID(),
-            $form->getType(),
+            $form::class,
             $changes,
-            $this->getType(),
+            self::class,
             static::$log_history_add
         );
 
@@ -490,9 +490,9 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
 
             Log::history(
                 $form->getID(),
-                $form->getType(),
+                $form::class,
                 $changes,
-                $this->getType(),
+                self::class,
                 static::$log_history_update
             );
         }
@@ -520,9 +520,9 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
 
         Log::history(
             $form->getID(),
-            $form->getType(),
+            $form::class,
             $changes,
-            $this->getType(),
+            self::class,
             static::$log_history_delete
         );
 

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -190,7 +190,7 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
         }
 
         $handlers = [];
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = sprintf('%s: %s', self::getTypeName(), $this->getName());
         if (count($form->getSections()) > 1) {
             $handlers[$key][] = new TranslationHandler(

--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -135,7 +135,7 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface, Provid
     public function listTranslationsHandlers(): array
     {
         $handlers = [];
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = sprintf('%s: %s', $this->getLabel(), $this->fields['title'] ?? NOT_AVAILABLE);
         if (!empty($this->fields['title'])) {
             $handlers[$key][] = new TranslationHandler(

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -238,7 +238,7 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     public function listTranslationsHandlers(): array
     {
         $handlers = [];
-        $key = sprintf('%s_%d', self::getType(), $this->getID());
+        $key = sprintf('%s_%d', self::class, $this->getID());
         $category_name = sprintf('%s: %s', $this->getLabel(), $this->fields['title'] ?? NOT_AVAILABLE);
         if (!empty($this->fields['title'])) {
             $handlers[$key][] = new TranslationHandler(

--- a/src/Glpi/Inventory/Asset/Antivirus.php
+++ b/src/Glpi/Inventory/Asset/Antivirus.php
@@ -45,8 +45,8 @@ class Antivirus extends InventoryAsset
     {
         global $CFG_GLPI;
 
-        if (!in_array($this->item->getType(), $CFG_GLPI['itemantivirus_types'])) {
-            throw new RuntimeException('Antivirus are not handled for ' . $this->item->getType());
+        if (!in_array($this->item::class, $CFG_GLPI['itemantivirus_types'])) {
+            throw new RuntimeException('Antivirus are not handled for ' . $this->item::class);
         }
         $mapping = [
             'company'      => 'manufacturers_id',
@@ -99,7 +99,7 @@ class Antivirus extends InventoryAsset
             'SELECT' => ['id', 'name', 'antivirus_version', 'is_dynamic'],
             'FROM'   => ItemAntivirus::getTable(),
             'WHERE'  => [
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
                 'items_id' => $this->item->fields['id'],
             ],
         ]);
@@ -149,7 +149,7 @@ class Antivirus extends InventoryAsset
 
         if (count($value) != 0) {
             foreach ($value as $val) {
-                $val->itemtype = $this->item->getType();
+                $val->itemtype = $this->item::class;
                 $val->items_id = $this->item->fields['id'];
                 $val->is_dynamic = 1;
                 $input = $this->handleInput($val, $itemAntivirus);

--- a/src/Glpi/Inventory/Asset/DatabaseInstance.php
+++ b/src/Glpi/Inventory/Asset/DatabaseInstance.php
@@ -89,7 +89,7 @@ class DatabaseInstance extends InventoryAsset
             ],
             'FROM'   => GDatabaseInstance::getTable(),
             'WHERE'  => [
-                'itemtype'     => $this->item->getType(),
+                'itemtype'     => $this->item::class,
                 'items_id'     => $this->item->fields['id'],
             ],
         ]);
@@ -118,7 +118,7 @@ class DatabaseInstance extends InventoryAsset
                 'name'         => $val->name ?? '',
                 'entities_id'  => $this->item->fields['entities_id'],
                 'linked_item' => [
-                    'itemtype' => $this->item->getType(),
+                    'itemtype' => $this->item::class,
                     'items_id' => $this->item->fields['id'],
                 ],
             ];
@@ -134,7 +134,7 @@ class DatabaseInstance extends InventoryAsset
                     // add instance
                     $input += [
                         'entities_id'  => $this->entities_id,
-                        'itemtype'     => $this->item->getType(),
+                        'itemtype'     => $this->item::class,
                         'items_id'     => $this->item->fields['id'],
                     ];
                     $items_id = $instance->add($input);

--- a/src/Glpi/Inventory/Asset/Device.php
+++ b/src/Glpi/Inventory/Asset/Device.php
@@ -61,7 +61,7 @@ abstract class Device extends InventoryAsset
             'FROM'      => $itemdevicetable,
             'WHERE'     => [
                 "$itemdevicetable.items_id"     => $this->item->fields['id'],
-                "$itemdevicetable.itemtype"     => $this->item->getType(),
+                "$itemdevicetable.itemtype"     => $this->item::class,
             ],
         ]);
 
@@ -76,7 +76,7 @@ abstract class Device extends InventoryAsset
     {
         global $DB;
 
-        $devicetypes = Item_Devices::getItemAffinities($this->item->getType());
+        $devicetypes = Item_Devices::getItemAffinities($this->item::class);
 
         $itemdevicetype = $this->getItemtype();
         if (in_array($itemdevicetype, $devicetypes)) {
@@ -117,7 +117,7 @@ abstract class Device extends InventoryAsset
                 $i_criteria = $itemdevice->getImportCriteria();
                 $fk_input = [
                     $fk                  => $device_id,
-                    'itemtype'           => $this->item->getType(),
+                    'itemtype'           => $this->item::class,
                     'items_id'           => $this->item->fields['id'],
                     'is_dynamic'         => 1,
                 ];
@@ -167,7 +167,7 @@ abstract class Device extends InventoryAsset
                         $itemdevice_data = [
                             'id'                 => $existing_item['id'],
                             $fk                  => $device_id,
-                            'itemtype'           => $this->item->getType(),
+                            'itemtype'           => $this->item::class,
                             'items_id'           => $this->item->fields['id'],
                             'is_dynamic'         => 1,
                         ] + $this->handleInput($val, $itemdevice);
@@ -181,7 +181,7 @@ abstract class Device extends InventoryAsset
                     $itemdevice->getEmpty();
                     $itemdevice_data = [
                         $fk => $device_id,
-                        'itemtype' => $this->item->getType(),
+                        'itemtype' => $this->item::class,
                         'items_id' => $this->item->fields['id'],
                         'is_dynamic' => 1,
                     ] + $this->handleInput($val, $itemdevice);
@@ -222,6 +222,6 @@ abstract class Device extends InventoryAsset
         /** @var class-string<Item_Devices> $item_device */
         $item_device = $this->getItemtype();
         $affinities = $item_device::itemAffinity();
-        return in_array('*', $affinities) || in_array($this->item->getType(), $item_device::itemAffinity());
+        return in_array('*', $affinities) || in_array($this->item::class, $item_device::itemAffinity());
     }
 }

--- a/src/Glpi/Inventory/Asset/Environment.php
+++ b/src/Glpi/Inventory/Asset/Environment.php
@@ -65,7 +65,7 @@ final class Environment extends InventoryAsset
             'FROM'   => Item_Environment::getTable(),
             'WHERE'  => [
                 'items_id' => $this->item->fields['id'],
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
             ],
         ]);
         foreach ($iterator as $data) {
@@ -119,7 +119,7 @@ final class Environment extends InventoryAsset
             foreach ($value as $val) {
                 $input = (array) $val + [
                     'items_id'     => $this->item->fields['id'],
-                    'itemtype'     => $this->item->getType(),
+                    'itemtype'     => $this->item::class,
                 ];
 
                 $itemEnv->add($input);

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -461,7 +461,7 @@ abstract class InventoryAsset
             $relation = new Asset_PeripheralAsset();
             $relation->deleteByCriteria(
                 [
-                    'itemtype_asset' => Computer::getType(),
+                    'itemtype_asset' => Computer::class,
                     'itemtype_peripheral' => $input['itemtype_peripheral'],
                     'items_id_peripheral' => $input['items_id_peripheral'],
                 ],
@@ -500,7 +500,7 @@ abstract class InventoryAsset
 
         if ($item !== null) {
             $lockeds = new Lockedfield();
-            $locks = $lockeds->getLockedNames($item->getType(), $item->isNewItem() ? 0 : $item->fields['id']);
+            $locks = $lockeds->getLockedNames($item::class, $item->isNewItem() ? 0 : $item->fields['id']);
         }
 
         foreach ($value as $key => $val) { // @phpstan-ignore foreach.nonIterable

--- a/src/Glpi/Inventory/Asset/InventoryNetworkPort.php
+++ b/src/Glpi/Inventory/Asset/InventoryNetworkPort.php
@@ -679,7 +679,7 @@ trait InventoryNetworkPort
                 $networkport->deleteByCriteria([
                     "itemtype"           => $this->port_itemtype,
                     "items_id"           => $this->port_items_id,
-                    "instantiation_type" => NetworkPortAggregate::getType(),
+                    "instantiation_type" => NetworkPortAggregate::class,
                     "name"               => "Management",
                 ], true);
             }

--- a/src/Glpi/Inventory/Asset/NetworkPort.php
+++ b/src/Glpi/Inventory/Asset/NetworkPort.php
@@ -841,9 +841,9 @@ class NetworkPort extends InventoryAsset
                 //remove all port management ports
                 $networkport = new GlobalNetworkPort();
                 $networkport->deleteByCriteria([
-                    "itemtype"           => $this->item->getType(),
+                    "itemtype"           => $this->item::class,
                     "items_id"           => $this->item->getID(),
-                    "instantiation_type" => NetworkPortAggregate::getType(),
+                    "instantiation_type" => NetworkPortAggregate::class,
                     "name"               => "Management",
                 ], true);
             }
@@ -911,7 +911,7 @@ class NetworkPort extends InventoryAsset
         $id = $link->getOppositeContact($netports_id);
         $netport->getFromDB($id);
 
-        if ($id && $netport->fields['itemtype'] == Unmanaged::getType()) {
+        if ($id && $netport->fields['itemtype'] == Unmanaged::class) {
             $unmanaged = new Unmanaged();
             $unmanaged->getFromDB($netport->fields['items_id']);
             if ($unmanaged->fields['hub'] == 1) {
@@ -935,7 +935,7 @@ class NetworkPort extends InventoryAsset
         $glpi_ports = [];
         $dbports = $netport->find([
             'items_id' => $hubs_id,
-            'itemtype' => Unmanaged::getType(),
+            'itemtype' => Unmanaged::class,
         ]);
         foreach ($dbports as $dbport) {
             $id = $link->getOppositeContact($dbport['id']);

--- a/src/Glpi/Inventory/Asset/OperatingSystem.php
+++ b/src/Glpi/Inventory/Asset/OperatingSystem.php
@@ -152,12 +152,12 @@ class OperatingSystem extends InventoryAsset
         $val = $this->data[0];
 
         $ios->getFromDBByCrit([
-            'itemtype'  => $this->item->getType(),
+            'itemtype'  => $this->item::class,
             'items_id'  => $this->item->fields['id'],
         ]);
 
         $input_os = $this->handleInput($val, $ios) + [
-            'itemtype'                          => $this->item->getType(),
+            'itemtype'                          => $this->item::class,
             'items_id'                          => $this->item->fields['id'],
             'is_dynamic'                        => 1,
             'entities_id'                       => $this->item->fields['entities_id'],
@@ -188,7 +188,7 @@ class OperatingSystem extends InventoryAsset
             $iterator = $DB->request([
                 'FROM' => $ios->getTable(),
                 'WHERE' => [
-                    'itemtype'  => $this->item->getType(),
+                    'itemtype'  => $this->item::class,
                     'items_id'  => $this->item->fields['id'],
                     'NOT'       => ['id' => $ios->fields['id']],
                 ],

--- a/src/Glpi/Inventory/Asset/Printer.php
+++ b/src/Glpi/Inventory/Asset/Printer.php
@@ -106,16 +106,16 @@ class Printer extends InventoryAsset
         $entities_id = $this->entities_id;
 
         $lclass = null;
-        if (class_exists($this->item->getType() . '_Item')) {
-            $lclass = $this->item->getType() . '_Item';
-        } elseif (class_exists('Item_' . $this->item->getType())) {
-            $lclass = 'Item_' . $this->item->getType();
-        } elseif (in_array($this->item->getType(), Asset_PeripheralAsset::getPeripheralHostItemtypes(), true)) {
+        if (class_exists($this->item::class . '_Item')) {
+            $lclass = $this->item::class . '_Item';
+        } elseif (class_exists('Item_' . $this->item::class)) {
+            $lclass = 'Item_' . $this->item::class;
+        } elseif (in_array($this->item::class, Asset_PeripheralAsset::getPeripheralHostItemtypes(), true)) {
             $lclass = Asset_PeripheralAsset::class;
         }
 
         if (!\is_a($lclass, CommonDBTM::class, true)) {
-            throw new RuntimeException('Unable to find linked item object name for ' . $this->item->getType());
+            throw new RuntimeException('Unable to find linked item object name for ' . $this->item::class);
         }
 
         foreach ($this->data as $key => $val) {

--- a/src/Glpi/Inventory/Asset/Process.php
+++ b/src/Glpi/Inventory/Asset/Process.php
@@ -88,7 +88,7 @@ class Process extends InventoryAsset
             'FROM'   => Item_Process::getTable(),
             'WHERE'  => [
                 'items_id' => $this->item->fields['id'],
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
             ],
         ]);
         foreach ($iterator as $data) {
@@ -142,7 +142,7 @@ class Process extends InventoryAsset
             foreach ($value as $val) {
                 $input = (array) $val + [
                     'items_id'     => $this->item->fields['id'],
-                    'itemtype'     => $this->item->getType(),
+                    'itemtype'     => $this->item::class,
                 ];
 
                 $itemProcess->add($input);

--- a/src/Glpi/Inventory/Asset/RemoteManagement.php
+++ b/src/Glpi/Inventory/Asset/RemoteManagement.php
@@ -45,7 +45,7 @@ class RemoteManagement extends InventoryAsset
     {
         global $CFG_GLPI;
 
-        if (!in_array($this->item->getType(), $CFG_GLPI['remote_management_types'])) {
+        if (!in_array($this->item::class, $CFG_GLPI['remote_management_types'])) {
             throw new RuntimeException(
                 'Remote Management are handled for following types only: '
                 . implode(', ', $CFG_GLPI['remote_management_types'])
@@ -85,7 +85,7 @@ class RemoteManagement extends InventoryAsset
             'SELECT' => ['id', 'remoteid', 'type', 'is_dynamic'],
             'FROM'   => Item_RemoteManagement::getTable(),
             'WHERE'  => [
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
                 'items_id' => $this->item->fields['id'],
             ],
         ]);
@@ -131,7 +131,7 @@ class RemoteManagement extends InventoryAsset
         }
 
         foreach ($value as $val) {
-            $val->itemtype = $this->item->getType();
+            $val->itemtype = $this->item::class;
             $val->items_id = $this->item->fields['id'];
             $val->is_dynamic = 1;
             $mgmt->add((array) $val);

--- a/src/Glpi/Inventory/Asset/Software.php
+++ b/src/Glpi/Inventory/Asset/Software.php
@@ -317,7 +317,7 @@ class Software extends InventoryAsset
                 $item_os = new Item_OperatingSystem();
                 $os_list = $item_os->find([
                     'items_id' => $this->main_asset->item->fields['id'],
-                    'itemtype' => $this->main_asset->item->getType(),
+                    'itemtype' => $this->main_asset->item::class,
                 ]);
                 if (count($os_list) == 1) {
                     $operatingsystems_id = current($os_list)['operatingsystems_id'];
@@ -375,7 +375,7 @@ class Software extends InventoryAsset
             ],
             'WHERE'     => [
                 'glpi_items_softwareversions.items_id' => $this->item->fields['id'],
-                'glpi_items_softwareversions.itemtype'    => $this->item->getType(),
+                'glpi_items_softwareversions.itemtype'    => $this->item::class,
                 'glpi_items_softwareversions.is_dynamic'  => 1,
             ],
         ]);
@@ -928,7 +928,7 @@ class Software extends InventoryAsset
                 'date_install'          => $val->date_install ?? null,
             ];
 
-            $itemtype = $this->item->getType();
+            $itemtype = $this->item::class;
             $DB->executeStatement(
                 $stmt,
                 [
@@ -976,7 +976,7 @@ class Software extends InventoryAsset
         foreach ($this->added_versions as $software_data) {
             Log::history(
                 $this->item->fields['id'],
-                $this->item->getType(),
+                $this->item::class,
                 [0, '', sprintf(__('%1$s - %2$s'), $software_data['name'], $software_data['version'])],
                 'Software',
                 Log::HISTORY_ADD_SUBITEM
@@ -986,7 +986,7 @@ class Software extends InventoryAsset
         foreach ($this->updated_versions as $software_data) {
             Log::history(
                 $this->item->fields['id'],
-                $this->item->getType(),
+                $this->item::class,
                 [
                     0,
                     '',
@@ -1007,7 +1007,7 @@ class Software extends InventoryAsset
             // log into asset
             Log::history(
                 $this->item->fields['id'],
-                $this->item->getType(),
+                $this->item::class,
                 [0, sprintf(__('%1$s - %2$s'), $software_name, $version_name), ''],
                 'Software',
                 Log::HISTORY_DELETE_SUBITEM

--- a/src/Glpi/Inventory/Asset/VirtualMachine.php
+++ b/src/Glpi/Inventory/Asset/VirtualMachine.php
@@ -84,11 +84,11 @@ class VirtualMachine extends InventoryAsset
             'macaddr'     => 'mac',
         ];
 
-        if (!in_array($this->item->getType(), $CFG_GLPI['itemvirtualmachines_types'])) {
+        if (!in_array($this->item::class, $CFG_GLPI['itemvirtualmachines_types'])) {
             throw new RuntimeException(
                 sprintf(
                     'Virtual machines are not handled for %s.',
-                    $this->item->getType()
+                    $this->item::class
                 )
             );
         }
@@ -212,7 +212,7 @@ class VirtualMachine extends InventoryAsset
             'SELECT' => ['id', 'name', 'uuid', 'virtualmachinesystems_id'],
             'FROM'   => ItemVirtualMachine::getTable(),
             'WHERE'  => [
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
                 'items_id' => $this->item->fields['id'],
                 'is_dynamic'   => 1,
             ],
@@ -282,7 +282,7 @@ class VirtualMachine extends InventoryAsset
         if (count($value) != 0) {
             foreach ($value as $val) {
                 $input = $this->handleInput($val, $itemVirtualmachine);
-                $input['itemtype'] = $this->item->getType();
+                $input['itemtype'] = $this->item::class;
                 $input['items_id'] = $this->item->fields['id'];
                 $input['is_dynamic']  = 1;
                 $itemVirtualmachine->add($input);

--- a/src/Glpi/Inventory/Asset/Volume.php
+++ b/src/Glpi/Inventory/Asset/Volume.php
@@ -128,7 +128,7 @@ class Volume extends InventoryAsset
             'FROM'   => Item_Disk::getTable(),
             'WHERE'  => [
                 'items_id' => $this->item->fields['id'],
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
             ],
         ]);
         foreach ($iterator as $data) {
@@ -183,7 +183,7 @@ class Volume extends InventoryAsset
             foreach ($value as $val) {
                 $input = $this->handleInput($val, $itemDisk) + [
                     'items_id'     => $this->item->fields['id'],
-                    'itemtype'     => $this->item->getType(),
+                    'itemtype'     => $this->item::class,
                 ];
 
                 $itemDisk->add($input);

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -315,7 +315,7 @@ class Conf extends CommonGLPI
         if ($item instanceof self) {
             $tabs = [];
             if (Session::haveRight(self::$rightname, self::UPDATECONFIG)) {
-                $tabs[1] = self::createTabEntry(__('Configuration'), 0, $item::getType());
+                $tabs[1] = self::createTabEntry(__('Configuration'), 0, $item::class);
             }
             if ($item->enabled_inventory && Session::haveRight(self::$rightname, self::IMPORTFROMFILE)) {
                 $tabs[2] = self::createTabEntry(__('Import from file'), icon: 'ti ti-upload');
@@ -461,7 +461,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_volume'>";
-            echo Item_Disk::createTabEntry(Item_Disk::getTypeName(Session::getPluralNumber()), 0, Item_Disk::getType());
+            echo Item_Disk::createTabEntry(Item_Disk::getTypeName(Session::getPluralNumber()), 0, Item_Disk::class);
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -474,7 +474,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_networkdrive'>";
-            echo DeviceDrive::createTabEntry(__('Network drives'), 0, DeviceDrive::getType());
+            echo DeviceDrive::createTabEntry(__('Network drives'), 0, DeviceDrive::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -489,7 +489,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_drive'>";
-            echo DeviceDrive::createTabEntry(__('Removable drives'), 0, DeviceDrive::getType());
+            echo DeviceDrive::createTabEntry(__('Removable drives'), 0, DeviceDrive::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -502,7 +502,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='import_software'>";
-            echo Software::createTabEntry(Software::getTypeName(Session::getPluralNumber()), 0, Software::getType());
+            echo Software::createTabEntry(Software::getTypeName(Session::getPluralNumber()), 0, Software::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -517,7 +517,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_monitor'>";
-            echo Monitor::createTabEntry(Monitor::getTypeName(Session::getPluralNumber()), 0, Monitor::getType());
+            echo Monitor::createTabEntry(Monitor::getTypeName(Session::getPluralNumber()), 0, Monitor::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -531,7 +531,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_printer'>";
-            echo Printer::createTabEntry(Printer::getTypeName(Session::getPluralNumber()), 0, Printer::getType());
+            echo Printer::createTabEntry(Printer::getTypeName(Session::getPluralNumber()), 0, Printer::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -546,7 +546,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_peripheral'>";
-            echo Peripheral::createTabEntry(Peripheral::getTypeName(Session::getPluralNumber()), 0, Peripheral::getType());
+            echo Peripheral::createTabEntry(Peripheral::getTypeName(Session::getPluralNumber()), 0, Peripheral::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -560,7 +560,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_antivirus'>";
-            echo ItemAntivirus::createTabEntry(ItemAntivirus::getTypeName(Session::getPluralNumber()), 0, ItemAntivirus::getType());
+            echo ItemAntivirus::createTabEntry(ItemAntivirus::getTypeName(Session::getPluralNumber()), 0, ItemAntivirus::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -575,7 +575,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_process'>";
-            echo Item_Process::createTabEntry(Item_Process::getTypeName(Session::getPluralNumber()), 0, Item_Process::getType());
+            echo Item_Process::createTabEntry(Item_Process::getTypeName(Session::getPluralNumber()), 0, Item_Process::class);
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -587,7 +587,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='import_env'>";
-            echo Item_Environment::createTabEntry(Item_Environment::getTypeName(Session::getPluralNumber()), 0, Item_Environment::getType());
+            echo Item_Environment::createTabEntry(Item_Environment::getTypeName(Session::getPluralNumber()), 0, Item_Environment::class);
             echo "</label>";
             echo "</td>";
             echo "<td width='360'>";
@@ -602,7 +602,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_unmanaged'>";
-            echo Unmanaged::createTabEntry(Unmanaged::getTypeName(Session::getPluralNumber()), 0, Unmanaged::getType());
+            echo Unmanaged::createTabEntry(Unmanaged::getTypeName(Session::getPluralNumber()), 0, Unmanaged::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -621,7 +621,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='dropdown_states_id_default$rand'>";
-            echo State::createTabEntry(__('Default status'), 0, State::getType());
+            echo State::createTabEntry(__('Default status'), 0, State::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -639,7 +639,7 @@ class Conf extends CommonGLPI
             echo "</td>";
 
             echo "<td><label for='dropdown_inventory_frequency$rand'>";
-            echo self::createTabEntry(__('Inventory frequency (in hours)'), 0, self::getType());
+            echo self::createTabEntry(__('Inventory frequency (in hours)'), 0, static::class);
             echo "</label></td><td>";
             Dropdown::showNumber(
                 "inventory_frequency",
@@ -658,7 +658,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='dropdown_entities_id_default$rand'>";
-            echo Entity::createTabEntry(__('Default entity'), 0, Entity::getType());
+            echo Entity::createTabEntry(__('Default entity'), 0, Entity::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -676,7 +676,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='import_monitor_on_partial_sn'>";
-            echo Monitor::createTabEntry(__('Import monitor on serial partial match'), 0, Monitor::getType());
+            echo Monitor::createTabEntry(__('Import monitor on serial partial match'), 0, Monitor::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -700,7 +700,7 @@ class Conf extends CommonGLPI
             echo sprintf(
                 '<a href="%s">%s</a>',
                 htmlescape(Rule::getSearchURL()),
-                Rule::createTabEntry(Rule::getTypeName(Session::getPluralNumber()), 0, Rule::getType())
+                Rule::createTabEntry(Rule::getTypeName(Session::getPluralNumber()), 0, Rule::class)
             );
             echo "</td>";
             echo "<td colspan='2'>";
@@ -708,7 +708,7 @@ class Conf extends CommonGLPI
             echo sprintf(
                 '<a href="%s">%s</a>',
                 htmlescape(NetworkPortType::getSearchURL()),
-                NetworkPort::createTabEntry(NetworkPortType::getTypeName(), 0, NetworkPort::getType())
+                NetworkPort::createTabEntry(NetworkPortType::getTypeName(), 0, NetworkPort::class)
             );
             echo "</td>";
             echo "</tr>";
@@ -722,7 +722,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='import_vm'>";
-            echo ItemVirtualMachine::createTabEntry(__('Import virtual machines'), 0, ItemVirtualMachine::getType());
+            echo ItemVirtualMachine::createTabEntry(__('Import virtual machines'), 0, ItemVirtualMachine::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -734,7 +734,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='dropdown_vm_type$rand'>";
-            echo ComputerType::createTabEntry(ComputerType::getTypeName(1), 0, ComputerType::getType());
+            echo ComputerType::createTabEntry(ComputerType::getTypeName(1), 0, ComputerType::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -753,7 +753,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='vm_as_computer'>";
-            echo Computer::createTabEntry(__('Create computer for virtual machines'), 0, Computer::getType());
+            echo Computer::createTabEntry(__('Create computer for virtual machines'), 0, Computer::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -765,7 +765,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='vm_components'>";
-            echo ItemVirtualMachine::createTabEntry(__('Create components for virtual machines'), 0, ItemVirtualMachine::getType());
+            echo ItemVirtualMachine::createTabEntry(__('Create components for virtual machines'), 0, ItemVirtualMachine::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -792,7 +792,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_processor'>";
-            echo DeviceProcessor::createTabEntry(DeviceProcessor::getTypeName(Session::getPluralNumber()), 0, DeviceProcessor::getType());
+            echo DeviceProcessor::createTabEntry(DeviceProcessor::getTypeName(Session::getPluralNumber()), 0, DeviceProcessor::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -805,7 +805,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_harddrive'>";
-            echo DeviceHardDrive::createTabEntry(DeviceHardDrive::getTypeName(Session::getPluralNumber()), 0, DeviceHardDrive::getType());
+            echo DeviceHardDrive::createTabEntry(DeviceHardDrive::getTypeName(Session::getPluralNumber()), 0, DeviceHardDrive::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -820,7 +820,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_memory'>";
-            echo DeviceMemory::createTabEntry(DeviceMemory::getTypeName(Session::getPluralNumber()), 0, DeviceMemory::getType());
+            echo DeviceMemory::createTabEntry(DeviceMemory::getTypeName(Session::getPluralNumber()), 0, DeviceMemory::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -833,7 +833,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_soundcard'>";
-            echo DeviceSoundCard::createTabEntry(DeviceSoundCard::getTypeName(Session::getPluralNumber()), 0, DeviceSoundCard::getType());
+            echo DeviceSoundCard::createTabEntry(DeviceSoundCard::getTypeName(Session::getPluralNumber()), 0, DeviceSoundCard::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -849,7 +849,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_networkcard'>";
-            echo DeviceNetworkCard::createTabEntry(DeviceNetworkCard::getTypeName(Session::getPluralNumber()), 0, DeviceNetworkCard::getType());
+            echo DeviceNetworkCard::createTabEntry(DeviceNetworkCard::getTypeName(Session::getPluralNumber()), 0, DeviceNetworkCard::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -862,7 +862,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_networkcardvirtual'>";
-            echo DeviceNetworkCard::createTabEntry(__('Virtual network cards'), 0, DeviceNetworkCard::getType());
+            echo DeviceNetworkCard::createTabEntry(__('Virtual network cards'), 0, DeviceNetworkCard::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -878,7 +878,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_graphiccard'>";
-            echo DeviceGraphicCard::createTabEntry(DeviceGraphicCard::getTypeName(Session::getPluralNumber()), 0, DeviceGraphicCard::getType());
+            echo DeviceGraphicCard::createTabEntry(DeviceGraphicCard::getTypeName(Session::getPluralNumber()), 0, DeviceGraphicCard::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -891,7 +891,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_simcard'>";
-            echo DeviceSimcard::createTabEntry(DeviceSimcard::getTypeName(Session::getPluralNumber()), 0, DeviceSimcard::getType());
+            echo DeviceSimcard::createTabEntry(DeviceSimcard::getTypeName(Session::getPluralNumber()), 0, DeviceSimcard::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -907,7 +907,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_drive'>";
-            echo DeviceDrive::createTabEntry(DeviceDrive::getTypeName(Session::getPluralNumber()), 0, DeviceDrive::getType());
+            echo DeviceDrive::createTabEntry(DeviceDrive::getTypeName(Session::getPluralNumber()), 0, DeviceDrive::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -920,7 +920,7 @@ class Conf extends CommonGLPI
 
             echo "<td>";
             echo "<label for='component_powersupply'>";
-            echo DevicePowerSupply::createTabEntry(DevicePowerSupply::getTypeName(Session::getPluralNumber()), 0, DevicePowerSupply::getType());
+            echo DevicePowerSupply::createTabEntry(DevicePowerSupply::getTypeName(Session::getPluralNumber()), 0, DevicePowerSupply::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -936,7 +936,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<td>";
             echo "<label for='component_control'>";
-            echo DeviceControl::createTabEntry(DeviceControl::getTypeName(Session::getPluralNumber()), 0, DeviceControl::getType());
+            echo DeviceControl::createTabEntry(DeviceControl::getTypeName(Session::getPluralNumber()), 0, DeviceControl::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -950,7 +950,7 @@ class Conf extends CommonGLPI
             echo "</td>";
             echo "<td>";
             echo "<label for='component_battery'>";
-            echo DeviceBattery::createTabEntry(DeviceBattery::getTypeName(Session::getPluralNumber()), 0, DeviceBattery::getType());
+            echo DeviceBattery::createTabEntry(DeviceBattery::getTypeName(Session::getPluralNumber()), 0, DeviceBattery::class);
             echo "</label>";
             echo "</td>";
             echo "<td>";
@@ -965,7 +965,7 @@ class Conf extends CommonGLPI
             echo "<tr class='tab_bg_1'>";
             echo "<th colspan=4 >" . __s('Agent cleanup') . "</th></tr>";
             echo "<tr class='tab_bg_1'><td><label for='dropdown_stale_agents_delay$rand'>";
-            echo Agent::createTabEntry(__('Update agents who have not contacted the server for (in days)'), 0, Agent::getType());
+            echo Agent::createTabEntry(__('Update agents who have not contacted the server for (in days)'), 0, Agent::class);
             echo "</label></td><td width='20%'>";
             Dropdown::showNumber(
                 'stale_agents_delay',
@@ -978,7 +978,7 @@ class Conf extends CommonGLPI
                 ]
             );
             echo "</td><td><label for='dropdown_stale_agents_action$rand'>";
-            echo Agent::createTabEntry(_n('Action', 'Actions', 1), 0, Agent::getType());
+            echo Agent::createTabEntry(_n('Action', 'Actions', 1), 0, Agent::class);
             echo "</label></td><td width='20%'>";
             //action
             $action = self::getDefaults()['stale_agents_action'];
@@ -1009,7 +1009,7 @@ class Conf extends CommonGLPI
             //blocaction with status
             echo "<tr class='tab_bg_1' style='display:none' id='bloc_status_action1'><td colspan=2></td>";
             echo "<td>";
-            echo State::createTabEntry(__('If the asset status is'), 0, State::getType());
+            echo State::createTabEntry(__('If the asset status is'), 0, State::class);
             echo "</td>";
             echo "<td width='20%'>";
             $condition = [];
@@ -1034,7 +1034,7 @@ class Conf extends CommonGLPI
 
             echo "<tr class='tab_bg_1' style='display:none' id='bloc_status_action2'><td colspan=2></td>";
             echo "<td>";
-            echo State::createTabEntry(__('Status to apply'), 0, State::getType());
+            echo State::createTabEntry(__('Status to apply'), 0, State::class);
             echo "</td>";
             echo "<td width='20%'>";
             State::dropdown(

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -435,7 +435,7 @@ class Inventory
 
             $item_start = microtime(true);
             $main->prepare();
-            $this->addBench($this->item->getType(), 'prepare', $item_start);
+            $this->addBench($this->item::class, 'prepare', $item_start);
 
             $this->mainasset = $main;
             if (isset($this->data['hardware'])) {
@@ -473,11 +473,11 @@ class Inventory
                 if (count($items)) {
                     $extra = 'Inventoried assets: ';
                     foreach ($items as $item) {
-                        $extra .= $item->getType() . ' #' . $item->getId() . ', ';
+                        $extra .= $item::class . ' #' . $item->getId() . ', ';
                     }
                     $extra = rtrim($extra, ', ') . "\n";
                 }
-                $this->addBench($this->item->getType(), 'full', $main_start, $extra);
+                $this->addBench($this->item::class, 'full', $main_start, $extra);
                 $this->printBenchResults();
             }
         }
@@ -527,7 +527,7 @@ class Inventory
             $items = $this->getItems();
 
             foreach ($items as $item) {
-                $itemtype = $item->getType();
+                $itemtype = $item::class;
                 if (!isset($item->fields['id']) || empty($item->fields['id'])) {
                     throw new RuntimeException('Item ID is missing :(');
                 }
@@ -840,7 +840,7 @@ class Inventory
             $item_start = microtime(true);
             $this->mainasset->handle();
             $this->item = $this->mainasset->getItem();
-            $this->addBench($this->item->getType(), 'handle', $item_start);
+            $this->addBench($this->item::class, 'handle', $item_start);
         }
         return;
     }
@@ -1043,7 +1043,7 @@ class Inventory
             /** @var class-string<CommonDBTM> $itemtype */
             $itemtype = str_replace(GLPI_INVENTORY_DIR . '/', '', $existing_type);
             // use `getItemForItemtype` to fix classname case (i.e. `refusedequipement` -> `RefusedEquipement`)
-            $itemtype = getItemForItemtype($itemtype)::getType();
+            $itemtype = getItemForItemtype($itemtype)::class;
             $inventory_files = new RegexIterator(
                 new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($existing_type)

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -513,7 +513,7 @@ abstract class MainAsset extends InventoryAsset
         }
 
         if (isset($this->item)) {
-            $input['itemtype'] = $this->item->getType();
+            $input['itemtype'] = $this->item::class;
         }
 
         if (property_exists($val, 'comment')) {
@@ -621,7 +621,7 @@ abstract class MainAsset extends InventoryAsset
 
             if (isset($datarules['_no_rule_matches']) && $datarules['_no_rule_matches'] == '1') {
                 //no rule matched, this is a new one
-                $this->rulepassed(0, $this->item->getType(), null);
+                $this->rulepassed(0, $this->item::class, null);
             } elseif (!isset($datarules['found_inventories'])) {
                 if ($this->isAccessPoint($data)) {
                     //Only main item is stored as refused, not all APs
@@ -886,7 +886,7 @@ abstract class MainAsset extends InventoryAsset
         //check for any old agent to remove
         $agent = new Agent();
         $agent->deleteByCriteria([
-            'itemtype' => $this->item->getType(),
+            'itemtype' => $this->item::class,
             'items_id' => $items_id,
             'NOT' => [
                 'id' => $this->agent->fields['id'],

--- a/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
+++ b/src/Glpi/Inventory/MainAsset/NetworkEquipment.php
@@ -489,7 +489,7 @@ class NetworkEquipment extends MainAsset
                     $ipaddress = new IPAddress($ip);
                     $criteria = [
                         'mainitems_id' => $item->fields['id'],
-                        'mainitemtype' => $item::getType(),
+                        'mainitemtype' => $item::class,
                         'is_dynamic'   => 1,
                         'name'         => $ipaddress->getTextual(),
                     ];

--- a/src/Glpi/Inventory/MainAsset/Unmanaged.php
+++ b/src/Glpi/Inventory/MainAsset/Unmanaged.php
@@ -239,7 +239,7 @@ class Unmanaged extends MainAsset
         if ($need_to_add) {
             $agent = new Agent();
             $agent->deleteByCriteria([
-                'itemtype' => $this->item->getType(),
+                'itemtype' => $this->item::class,
                 'items_id' => $items_id,
                 'NOT' => [
                     'id' => $this->agent->fields['id'],

--- a/src/Glpi/Inventory/Request.php
+++ b/src/Glpi/Inventory/Request.php
@@ -547,7 +547,7 @@ class Request extends AbstractRequest
         if (count($items) == 1) {
             $item = $items[0];
             $status += [
-                'itemtype' => $item->getType(),
+                'itemtype' => $item::class,
                 'items_id' => $item->fields['id'],
             ];
         } elseif (count($items)) {
@@ -555,8 +555,8 @@ class Request extends AbstractRequest
             $itemtype = null;
             foreach ($items as $item) {
                 if ($itemtype === null && !$item instanceof Unmanaged) {
-                    $itemtype = $item->getType();
-                } elseif ($itemtype !== $item->getType()) {
+                    $itemtype = $item::class;
+                } elseif ($itemtype !== $item::class) {
                     $itemtype = false;
                     break;
                 }

--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -206,7 +206,7 @@ abstract class ItemTranslation extends CommonDBChild
     {
         $translations = (new static())->find([
             static::$items_id => $item->getID(),
-            static::$itemtype => $item->getType(),
+            static::$itemtype => $item::class,
         ]);
 
         return array_map(fn($id) => static::getById($id), array_keys($translations));
@@ -219,7 +219,7 @@ abstract class ItemTranslation extends CommonDBChild
     {
         $translation = (new static())->find([
             static::$items_id => $item->getID(),
-            static::$itemtype => $item->getType(),
+            static::$itemtype => $item::class,
             'key'             => $key,
             'language'        => $language,
         ]);

--- a/src/Glpi/Rules/RulesManager.php
+++ b/src/Glpi/Rules/RulesManager.php
@@ -86,7 +86,7 @@ final class RulesManager
                 continue;
             }
 
-            if (countElementsInTable(Rule::getTable(), ['sub_type' => $ruleclass->getType()]) === 0) {
+            if (countElementsInTable(Rule::getTable(), ['sub_type' => $ruleclass::class]) === 0) {
                 $ruleclass->initRules(false);
                 $has_initialized_rules = true;
             }

--- a/src/Glpi/Search/CriteriaFilter.php
+++ b/src/Glpi/Search/CriteriaFilter.php
@@ -78,7 +78,7 @@ final class CriteriaFilter extends CommonDBChild
         return self::createTabEntry(
             self::getTypeName($nb),
             $nb,
-            $item::getType(),
+            $item::class,
             'ti ti-adjustments-horizontal'
         );
     }
@@ -117,7 +117,7 @@ final class CriteriaFilter extends CommonDBChild
             'actionvalue'             => __("Preview results"),
             'extra_actions_templates' => [
                 "components/search/criteria_filter_actions.html.twig" => [
-                    'itemtype'    => $item->getType(),
+                    'itemtype'    => $item::class,
                     'items_id'    => $item->getID(),
                     'show_save'   => $can_edit,
                     'show_delete' => $can_edit && !is_null($filter),
@@ -169,7 +169,7 @@ final class CriteriaFilter extends CommonDBChild
     {
         $filter = new self();
         $filter_exist = $filter->getFromDBByCrit([
-            'itemtype' => $item->getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ]);
 

--- a/src/Glpi/Search/FilterableTrait.php
+++ b/src/Glpi/Search/FilterableTrait.php
@@ -54,7 +54,7 @@ trait FilterableTrait
         }
 
         // The ID is not always search option 2
-        $opts = SearchOption::getOptionsForItemtype($item::getType());
+        $opts = SearchOption::getOptionsForItemtype($item::class);
         $item_table = $item::getTable();
         $id_field = $item::getIndexName();
         $id_opt_num = null;
@@ -88,7 +88,7 @@ trait FilterableTrait
         ];
 
         // Execute search
-        $data = SearchEngine::getData($item::getType(), [
+        $data = SearchEngine::getData($item::class, [
             'criteria' => $criteria,
         ]);
 

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -674,7 +674,7 @@ final class QueryBuilder implements SearchInputInterface
             )
             && ( // Is an asset
                 in_array($itemtype, $CFG_GLPI['asset_types'])
-                || $itemtype == AllAssets::getType()
+                || $itemtype == AllAssets::class
             )
         ) {
             // Disable sort on assets default search request
@@ -717,7 +717,7 @@ final class QueryBuilder implements SearchInputInterface
         //                                  searchtype =>
         //                                  value =>   (contains)
 
-        if ($itemtype != AllAssets::getType() && class_exists($itemtype)) {
+        if ($itemtype != AllAssets::class && class_exists($itemtype)) {
             // retrieve default values for current itemtype
             $itemtype_default_values = [];
             $item = getItemForItemtype($itemtype);

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -234,7 +234,7 @@ class HTMLSearchOutput extends AbstractSearchOutput
             'showmassiveactions'  => ($params['showmassiveactions'] ?? $search['showmassiveactions'] ?? true)
                 && $data['display_type'] != Search::GLOBAL_SEARCH
                 && (
-                    $itemtype == AllAssets::getType()
+                    $itemtype == AllAssets::class
                     || count(MassiveAction::getAllMassiveActions($item, $is_deleted))
                 ),
             'massiveactionparams' => $data['search']['massiveactionparams'] + [

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -157,7 +157,7 @@ final class SQLProvider implements SearchProviderInterface
         $itemtable = SearchEngine::getOrigTableName($itemtype);
         $item      = null;
         $mayberecursive = false;
-        if ($itemtype != AllAssets::getType()) {
+        if ($itemtype != AllAssets::class) {
             $item           = getItemForItemtype($itemtype);
             $mayberecursive = $item->maybeRecursive();
         }
@@ -1046,15 +1046,15 @@ final class SQLProvider implements SearchProviderInterface
                 $criteria = [
                     'glpi_itilfollowups.is_private' => $allowed_is_private,
                     'OR' => [
-                        new QueryExpression(ITILFollowup::buildParentCondition(Ticket::getType())),
+                        new QueryExpression(ITILFollowup::buildParentCondition(Ticket::class)),
                         new QueryExpression(ITILFollowup::buildParentCondition(
-                            Change::getType(),
+                            Change::class,
                             'changes_id',
                             "glpi_changes_users",
                             "glpi_changes_groups"
                         )),
                         new QueryExpression(ITILFollowup::buildParentCondition(
-                            Problem::getType(),
+                            Problem::class,
                             'problems_id',
                             "glpi_problems_users",
                             "glpi_groups_problems"
@@ -2293,7 +2293,7 @@ final class SQLProvider implements SearchProviderInterface
             if (
                 (!isset($opt['searchequalsonfield'])
                     || !$opt['searchequalsonfield'])
-                && ($itemtype == AllAssets::getType()
+                && ($itemtype == AllAssets::class
                     || $table != $itemtype::getTable())
             ) {
                 $append_criterion_with_search($criteria['OR'], "$table.id");
@@ -4502,7 +4502,7 @@ final class SQLProvider implements SearchProviderInterface
                         && $citem->canView()
                     ) {
                         // State case
-                        if ($data['itemtype'] == AllAssets::getType()) {
+                        if ($data['itemtype'] == AllAssets::class) {
                             $query_num  = str_replace(
                                 $CFG_GLPI["union_search_type"][$data['itemtype']],
                                 $ctable,
@@ -4617,7 +4617,7 @@ final class SQLProvider implements SearchProviderInterface
                     }
                     $tmpquery = "";
                     // AllAssets case
-                    if ($data['itemtype'] == AllAssets::getType()) {
+                    if ($data['itemtype'] == AllAssets::class) {
                         $tmpquery = $SELECT . ", '{$DB->escape($ctype)}' AS TYPE "
                             . $FROM
                             . $WHERE;
@@ -4651,7 +4651,7 @@ final class SQLProvider implements SearchProviderInterface
                         // Replace 'AllAssets' by itemtype
                         // Use quoted value to prevent replacement of AllAssets in column identifiers
                         $tmpquery = str_replace(
-                            $DB->quoteValue(AllAssets::getType()),
+                            $DB->quoteValue(AllAssets::class),
                             $DB->quoteValue($ctype),
                             $tmpquery
                         );

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -187,7 +187,7 @@ final class SearchEngine
 
         // Add entity meta if needed
         if ($item->isField('entities_id') && !($item instanceof Entity)) {
-            $linked[] = Entity::getType();
+            $linked[] = Entity::class;
         }
 
         return array_unique($linked);
@@ -399,7 +399,7 @@ final class SearchEngine
         // Instanciate an object to access method
         $data['item'] = null;
 
-        if ($itemtype != AllAssets::getType()) {
+        if ($itemtype != AllAssets::class) {
             $data['item'] = getItemForItemtype($itemtype);
         }
 

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -202,7 +202,7 @@ final class SearchOption implements ArrayAccess
                 $fn_append_options(NetworkPort::getSearchOptionsToAdd('networkport_types'));
                 break;
 
-            case AllAssets::getType():
+            case AllAssets::class:
                 $search[$itemtype]['common']            = __('Characteristics');
 
                 $search[$itemtype][1]['table']          = 'asset_types';
@@ -312,42 +312,42 @@ final class SearchOption implements ArrayAccess
 
         if (
             in_array($itemtype, $CFG_GLPI["networkport_types"])
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(NetworkPort::getSearchOptionsToAdd($itemtype));
         }
 
         if (
             in_array($itemtype, $CFG_GLPI["contract_types"])
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(Contract::getSearchOptionsToAdd());
         }
 
         if (
             Document::canApplyOn($itemtype)
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(Document::getSearchOptionsToAdd());
         }
 
         if (
             Infocom::canApplyOn($itemtype)
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(Infocom::getSearchOptionsToAdd($itemtype));
         }
 
         if (
             in_array($itemtype, $CFG_GLPI["domain_types"])
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(Domain::getSearchOptionsToAdd($itemtype));
         }
 
         if (
             in_array($itemtype, $CFG_GLPI["appliance_types"])
-            || ($itemtype == AllAssets::getType())
+            || ($itemtype == AllAssets::class)
         ) {
             $fn_append_options(Appliance::getSearchOptionsToAdd($itemtype));
         }
@@ -730,7 +730,7 @@ final class SearchOption implements ArrayAccess
         $item   = null;
         $entity_check = true;
 
-        if ($itemtype !== AllAssets::getType()) {
+        if ($itemtype !== AllAssets::class) {
             $item = getItemForItemtype($itemtype);
             $entity_check = $item->isEntityAssign();
 
@@ -766,7 +766,7 @@ final class SearchOption implements ArrayAccess
         }
 
         if (isset($params['as_map']) && (int) $params['as_map'] === 1) {
-            if ($itemtype !== AllAssets::getType()) {
+            if ($itemtype !== AllAssets::class) {
                 // Add location name when map mode
                 $loc_opt = self::getOptionNumber($itemtype, 'completename', 'Location');
                 if ($loc_opt > 0) {
@@ -785,7 +785,7 @@ final class SearchOption implements ArrayAccess
                 || ($item && $item->maybeRecursive())
                 || isset($_SESSION['glpiactiveentities']) && (count($_SESSION["glpiactiveentities"]) > 1))
         ) {
-            if ($itemtype !== AllAssets::getType()) {
+            if ($itemtype !== AllAssets::class) {
                 $entity_opt = self::getOptionNumber($itemtype, 'completename', 'Entity');
                 if ($entity_opt > 0) {
                     $toview[] = $entity_opt;

--- a/src/Glpi/Socket.php
+++ b/src/Glpi/Socket.php
@@ -532,7 +532,7 @@ class Socket extends CommonDBChild
             $changes[0] = '0';
             $changes[1] = '';
             $changes[2] = $this->getNameID(['forceid' => true]);
-            Log::history($parent, 'Location', $changes, $this->getType(), Log::HISTORY_ADD_SUBITEM);
+            Log::history($parent, 'Location', $changes, static::class, Log::HISTORY_ADD_SUBITEM);
         }
 
         $this->cleanIfStealNetworkPort();
@@ -553,7 +553,7 @@ class Socket extends CommonDBChild
         if ($this->fields['networkports_id'] > 0) {
             $iter = $DB->request([
                 'SELECT' => 'id',
-                'FROM'  => getTableForItemType(self::getType()),
+                'FROM'  => getTableForItemType(static::class),
                 'WHERE' => [
                     'networkports_id' => $this->fields['networkports_id'],
                     ['NOT' => ['id' => $this->fields['id']]],
@@ -574,7 +574,7 @@ class Socket extends CommonDBChild
             $changes[0] = '0';
             $changes[1] = $this->getNameID(['forceid' => true]);
             $changes[2] = '';
-            Log::history($parent, 'Location', $changes, $this->getType(), Log::HISTORY_DELETE_SUBITEM);
+            Log::history($parent, 'Location', $changes, static::class, Log::HISTORY_DELETE_SUBITEM);
         }
     }
 
@@ -591,19 +591,19 @@ class Socket extends CommonDBChild
                             ['locations_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                 default:
                     /** @var CommonDBTM $item */
-                    if (in_array($item->getType(), $CFG_GLPI['socket_types'])) {
+                    if (in_array($item::class, $CFG_GLPI['socket_types'])) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $nb =  countElementsInTable(
                                 $this->getTable(),
-                                ['itemtype' => $item->getType(),
+                                ['itemtype' => $item::class,
                                     'items_id' => $item->getID(),
                                 ]
                             );
                         }
-                        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                     }
             }
         }
@@ -661,7 +661,7 @@ class Socket extends CommonDBChild
             'SELECT' => 'id',
             'FROM'   => self::getTable(),
             'WHERE'  => [
-                'itemtype'   => $item->getType(),
+                'itemtype'   => $item::class,
                 'items_id'   => $item->getID(),
             ],
         ]);
@@ -706,7 +706,7 @@ class Socket extends CommonDBChild
             $item_id = '';
             if ($has_cable) {
                 if (
-                    $cable->fields['itemtype_endpoint_a'] === $item->getType()
+                    $cable->fields['itemtype_endpoint_a'] === $item::class
                     && $cable->fields['items_id_endpoint_a'] === $item->getID()
                 ) {
                     $itemtype = $cable->fields['itemtype_endpoint_b'];
@@ -718,7 +718,7 @@ class Socket extends CommonDBChild
             }
             $endpoint = getItemForItemtype($itemtype);
             if ($endpoint !== false && $item_id !== 0 && $endpoint->getFromDB($item_id)) {
-                $itemtype_label = $endpoint::getType();
+                $itemtype_label = $endpoint::class;
                 $item_label = sprintf(
                     '<a href="%s">%s</a>',
                     htmlescape($endpoint->getLinkURL()),

--- a/src/Group.php
+++ b/src/Group.php
@@ -315,18 +315,18 @@ class Group extends CommonTreeDropdown
                                     $input["field"] => $input["groups_id"],
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                 }
                 return;

--- a/src/HTMLTableHeader.php
+++ b/src/HTMLTableHeader.php
@@ -108,12 +108,12 @@ abstract class HTMLTableHeader extends HTMLTableEntity
             throw new Exception('Implementation error: header requires an item');
         }
         if ($item !== null) {
-            if (!isset($this->itemtypes[$item->getType()])) {
+            if (!isset($this->itemtypes[$item::class])) {
                 throw new Exception('Implementation error: type mismatch between header and cell');
             }
             $table = $this->getTable();
             if ($table instanceof HTMLTableMain) {
-                $table->addItemType($item->getType(), $this->itemtypes[$item->getType()]);
+                $table->addItemType($item::class, $this->itemtypes[$item::class]);
             }
         }
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -2034,7 +2034,7 @@ TWIG,
             $p['extraparams']['add_actions'] = $p['add_actions'];
         }
         if ($p['item'] instanceof CommonDBTM) {
-            $p['extraparams']['item_itemtype'] = $p['item']->getType();
+            $p['extraparams']['item_itemtype'] = $p['item']::class;
             $p['extraparams']['item_items_id'] = $p['item']->getID();
         }
 

--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -207,7 +207,7 @@ class IPAddress extends CommonDBChild
             || (isset($this->oldvalues['entities_id']))
         ) {
             $link = new IPAddress_IPNetwork();
-            $link->cleanDBonItemDelete($this->getType(), $this->getID());
+            $link->cleanDBonItemDelete(static::class, $this->getID());
             $link->addIPAddress($this);
         }
 
@@ -331,7 +331,7 @@ class IPAddress extends CommonDBChild
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'IPNetwork':
                 self::showForItem($item, $withtemplate);
                 break;
@@ -348,7 +348,7 @@ class IPAddress extends CommonDBChild
     {
         global $DB;
 
-        switch ($item->getType()) {
+        switch ($item::class) {
             case 'IPNetwork':
                 $result = $DB->request([
                     'COUNT'  => 'cpt',
@@ -373,7 +373,7 @@ class IPAddress extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -1410,7 +1410,7 @@ class IPAddress extends CommonDBChild
                 'FROM'   => self::getTable(),
                 'WHERE'  => [
                     'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
+                    'itemtype'     => $item::class,
                     'is_deleted'   => 0,
                 ],
             ]);

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -244,7 +244,7 @@ class IPNetwork_Vlan extends CommonDBRelation
                             ['ipnetworks_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::getType());
+                    return self::createTabEntry(Vlan::getTypeName(), $nb, $item::class);
             }
         }
         return '';

--- a/src/ITILCategory.php
+++ b/src/ITILCategory.php
@@ -476,7 +476,7 @@ class ITILCategory extends CommonTreeDropdown
 
         echo "<table class='tab_cadre_fixe'>";
         echo "<tr><th colspan='5'>";
-        $itilcategory_type = $itilcategory->getType();
+        $itilcategory_type = $itilcategory::class;
         echo "<a href='" . htmlescape($itilcategory_type::getSearchURL()) . "'>";
         echo htmlescape(self::getTypeName(count($iterator)));
         echo "</a>";

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -64,7 +64,7 @@ class ITILFollowup extends CommonDBChild
      */
     public function getItilObjectItemType()
     {
-        return str_replace('Followup', '', $this->getType());
+        return str_replace('Followup', '', static::class);
     }
 
 
@@ -298,7 +298,7 @@ class ITILFollowup extends CommonDBChild
             $this->getField('items_id'),
             get_class($parentitem),
             $changes,
-            $this->getType(),
+            static::class,
             Log::HISTORY_ADD_SUBITEM
         );
 
@@ -363,7 +363,7 @@ class ITILFollowup extends CommonDBChild
             $this->getField(self::$items_id),
             $this->fields['itemtype'],
             $changes,
-            $this->getType(),
+            static::class,
             Log::HISTORY_DELETE_SUBITEM
         );
 
@@ -485,7 +485,7 @@ class ITILFollowup extends CommonDBChild
 
         // Only calculate timeline_position if not already specified in the input
         if (!isset($input['timeline_position'])) {
-            $input['timeline_position'] = $itemtype::getTimelinePosition($input["items_id"], $this->getType(), $input["users_id"]);
+            $input['timeline_position'] = $itemtype::getTimelinePosition($input["items_id"], static::class, $input["users_id"]);
         }
 
         if (!isset($input['date'])) {
@@ -589,7 +589,7 @@ class ITILFollowup extends CommonDBChild
             $this->getField('items_id'),
             $this->fields['itemtype'],
             $changes,
-            $this->getType(),
+            static::class,
             Log::HISTORY_UPDATE_SUBITEM
         );
 
@@ -999,30 +999,30 @@ class ITILFollowup extends CommonDBChild
                         && $item->getFromDB($id)
                     ) {
                         if (in_array($item->fields['status'], array_merge($item->getSolvedStatusArray(), $item->getClosedStatusArray()))) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         } else {
                             $input2 = [
                                 'items_id'        => $id,
-                                'itemtype'        => $item->getType(),
+                                'itemtype'        => $item::class,
                                 'is_private'      => $input['is_private'],
                                 'requesttypes_id' => $input['requesttypes_id'],
                                 'content'         => $input['content'],
                             ];
                             if ($fup->can(-1, CREATE, $input2)) {
                                 if ($fup->add($input2)) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                             }
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -70,9 +70,9 @@ class ITILSolution extends CommonDBChild
             $nb    = 0;
             $title = self::getTypeName(Session::getPluralNumber());
             if ($_SESSION['glpishow_count_on_tabs']) {
-                $nb = self::countFor($item->getType(), $item->getID());
+                $nb = self::countFor($item::class, $item->getID());
             }
-            return self::createTabEntry($title, $nb, $item::getType());
+            return self::createTabEntry($title, $nb, $item::class);
         }
         return '';
     }
@@ -249,7 +249,7 @@ class ITILSolution extends CommonDBChild
             $status = CommonITILValidation::ACCEPTED;
 
             //handle autoclose, for tickets only
-            if ($input['itemtype'] == Ticket::getType()) {
+            if ($input['itemtype'] == Ticket::class) {
                 $autoclosedelay =  Entity::getUsedConfig(
                     'autoclose_delay',
                     $this->item->getEntityID(),

--- a/src/ITILTemplate.php
+++ b/src/ITILTemplate.php
@@ -467,7 +467,7 @@ abstract class ITILTemplate extends CommonDropdown
     {
 
         if (Session::haveRight(static::$rightname, READ)) {
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'TicketTemplate':
                 case 'ChangeTemplate':
                 case 'ProblemTemplate':
@@ -641,9 +641,9 @@ abstract class ITILTemplate extends CommonDropdown
                                     'is_recursive' => 1,
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
@@ -653,14 +653,14 @@ abstract class ITILTemplate extends CommonDropdown
                             $input2['is_recursive'] = 1;
 
                             if (!$item->import($input2)) {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                             }
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -740,12 +740,12 @@ abstract class ITILTemplate extends CommonDropdown
         global $DB;
 
         $to_merge = [];
-        switch (static::getType()) {
-            case Ticket::getType():
+        switch (static::class) {
+            case Ticket::class:
                 $to_merge = ['tickettemplates_id_incident', 'tickettemplates_id_demand'];
                 break;
             default:
-                $to_merge = [strtolower($this->getType() . 'templates_id')];
+                $to_merge = [strtolower(static::class . 'templates_id')];
                 break;
         }
 
@@ -951,6 +951,6 @@ abstract class ITILTemplate extends CommonDropdown
      */
     public static function getITILObjectClass(): string
     {
-        return preg_replace("/Template$/i", "", static::getType());
+        return preg_replace("/Template$/i", "", static::class);
     }
 }

--- a/src/ITILTemplateHiddenField.php
+++ b/src/ITILTemplateHiddenField.php
@@ -67,7 +67,7 @@ abstract class ITILTemplateHiddenField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/ITILTemplateMandatoryField.php
+++ b/src/ITILTemplateMandatoryField.php
@@ -68,7 +68,7 @@ abstract class ITILTemplateMandatoryField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/ITILTemplatePredefinedField.php
+++ b/src/ITILTemplatePredefinedField.php
@@ -144,7 +144,7 @@ abstract class ITILTemplatePredefinedField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/ITILTemplateReadonlyField.php
+++ b/src/ITILTemplateReadonlyField.php
@@ -67,7 +67,7 @@ abstract class ITILTemplateReadonlyField extends ITILTemplateField
                     [static::$items_id => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -146,7 +146,7 @@ class Impact extends CommonGLPI
             $total = 0;
         }
 
-        return self::createTabEntry(__("Impact analysis"), $total, $item::getType());
+        return self::createTabEntry(__("Impact analysis"), $total, $item::class);
     }
 
     public static function displayTabContentForItem(
@@ -1704,7 +1704,7 @@ TWIG, $twig_params);
         global $DB;
 
         // Skip if not a valid impact type
-        if (!self::isEnabled($item::getType())) {
+        if (!self::isEnabled($item::class)) {
             return;
         }
 
@@ -1824,7 +1824,7 @@ TWIG, $twig_params);
         global $CFG_GLPI;
 
         // Form head
-        $action = htmlescape(Toolbox::getItemTypeFormURL(Config::getType()));
+        $action = htmlescape(Toolbox::getItemTypeFormURL(Config::class));
         echo "<form name='form' action='$action' method='post'>";
 
         // Table head

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -86,7 +86,7 @@ class Infocom extends CommonDBChild
 
         // We also allow direct items to check
         if ($item instanceof CommonGLPI) {
-            $item = $item->getType();
+            $item = $item::class;
         }
 
         if (in_array($item, $CFG_GLPI['infocom_types'])) {
@@ -152,24 +152,24 @@ class Infocom extends CommonDBChild
             && ($item instanceof CommonDBTM)
         ) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'Supplier':
                     /** @var Supplier $item */
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForSupplier($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class);
 
                 default:
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = countElementsInTable(
                             'glpi_infocoms',
-                            ['itemtype' => $item->getType(),
+                            ['itemtype' => $item::class,
                                 'items_id' => $item->getID(),
                             ]
                         );
                     }
-                    return self::createTabEntry(__('Management'), $nb, $item::getType());
+                    return self::createTabEntry(__('Management'), $nb, $item::class);
             }
         }
         return '';
@@ -592,7 +592,7 @@ class Infocom extends CommonDBChild
               && ($this->oldvalues['warranty_duration'] < $this->fields['warranty_duration']))
         ) {
             $alert = new Alert();
-            $alert->clear($this->getType(), $this->fields['id'], Alert::END);
+            $alert->clear(static::class, $this->fields['id'], Alert::END);
         }
         // Check budgets link validity
         if (
@@ -626,7 +626,7 @@ class Infocom extends CommonDBChild
     {
 
         $class = new Alert();
-        $class->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+        $class->cleanDBonItemDelete(static::class, $this->fields['id']);
     }
 
 
@@ -671,7 +671,7 @@ class Infocom extends CommonDBChild
                             'glpi_alerts'  => 'items_id',
                             $table         => 'id', [
                                 'AND' => [
-                                    'glpi_alerts.itemtype'  => self::getType(),
+                                    'glpi_alerts.itemtype'  => static::class,
                                     'glpi_alerts.type'      => Alert::END,
                                 ],
                             ],
@@ -1392,15 +1392,15 @@ HTML;
         $dev_ID   = $item->getField('id');
         $ic       = new self();
 
-        if (in_array($item->getType(), self::getExcludedTypes())) {
+        if (in_array($item::class, self::getExcludedTypes())) {
             echo "<div class='firstbloc center'>"
                 . __s('For this type of item, the financial and administrative information are only a model for the items which you should add.')
                 . "</div>";
         }
 
-        $ic->getFromDBforDevice($item->getType(), $dev_ID);
+        $ic->getFromDBforDevice($item::class, $dev_ID);
         $can_input = [
-            'itemtype'    => $item->getType(),
+            'itemtype'    => $item::class,
             'items_id'    => $dev_ID,
             'entities_id' => $item->getEntityID(),
         ];
@@ -2056,7 +2056,7 @@ HTML;
             case 'activate':
                 $ic = new self();
                 if ($ic->canCreate()) {
-                    $itemtype = $item->getType();
+                    $itemtype = $item::class;
                     foreach ($ids as $key) {
                         if (!$ic->getFromDBforDevice($itemtype, $key)) {
                             $input = ['itemtype' => $itemtype,
@@ -2064,18 +2064,18 @@ HTML;
                             ];
                             if ($ic->can(-1, CREATE, $input)) {
                                 if ($ic->add($input)) {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($ic->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($ic->getErrorMessage(ERROR_RIGHT));
                             }
                         } else {
                             // Infocom already exists for this item, nothing to do.
-                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                         }
                     }
                 }

--- a/src/ItemAntivirus.php
+++ b/src/ItemAntivirus.php
@@ -65,10 +65,10 @@ class ItemAntivirus extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = countElementsInTable(
                     self::getTable(),
-                    ['itemtype' => $item->getType(), 'items_id' => $item->getID(), 'is_deleted' => 0 ]
+                    ['itemtype' => $item::class, 'items_id' => $item->getID(), 'is_deleted' => 0 ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -293,7 +293,7 @@ class ItemAntivirus extends CommonDBChild
         global $DB;
 
         $ID = $asset->fields['id'];
-        $itemtype = $asset->getType();
+        $itemtype = $asset::class;
 
         if (
             !$asset->getFromDB($ID)

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -78,7 +78,7 @@ class ItemVirtualMachine extends CommonDBChild
 
         if (
             !$withtemplate
-            && in_array($item::getType(), $CFG_GLPI['itemvirtualmachines_types'])
+            && in_array($item::class, $CFG_GLPI['itemvirtualmachines_types'])
             && $item::canView()
         ) {
             $nb = 0;
@@ -86,13 +86,13 @@ class ItemVirtualMachine extends CommonDBChild
                 $nb = countElementsInTable(
                     self::getTable(),
                     [
-                        'itemtype' => $item->getType(),
+                        'itemtype' => $item::class,
                         'items_id' => $item->getID(),
                         'is_deleted' => 0,
                     ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(), $nb, $item::class);
         }
         return '';
     }
@@ -181,7 +181,7 @@ class ItemVirtualMachine extends CommonDBChild
 
         $ID = $asset->fields['id'];
 
-        if (!in_array($asset->getType(), $CFG_GLPI['itemvirtualmachines_types']) || !$asset->getFromDB($ID) || !$asset->can($ID, READ)) {
+        if (!in_array($asset::class, $CFG_GLPI['itemvirtualmachines_types']) || !$asset->getFromDB($ID) || !$asset->can($ID, READ)) {
             return;
         }
 
@@ -248,7 +248,7 @@ class ItemVirtualMachine extends CommonDBChild
     {
 
         $ID = $asset->fields['id'];
-        $itemtype = $asset->getType();
+        $itemtype = $asset::class;
 
         if (!$asset->getFromDB($ID) || !$asset->can($ID, READ)) {
             return;

--- a/src/Item_Cluster.php
+++ b/src/Item_Cluster.php
@@ -60,7 +60,7 @@ class Item_Cluster extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::getType(), 'ti ti-package');
+        return self::createTabEntry(_n('Item', 'Items', $nb), $nb, $item::class, 'ti ti-package');
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -601,13 +601,13 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         /** @var CommonDBTM $item */
         if ($item->canView()) {
             $nb = 0;
-            if (in_array($item->getType(), self::getConcernedItems())) {
+            if (in_array($item::class, self::getConcernedItems())) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    foreach (self::getItemAffinities($item->getType()) as $link_type) {
+                    foreach (self::getItemAffinities($item::class) as $link_type) {
                         $nb   += countElementsInTable(
                             $link_type::getTable(),
                             ['items_id'   => $item->getID(),
-                                'itemtype'   => $item->getType(),
+                                'itemtype'   => $item::class,
                                 'is_deleted' => 0,
                             ]
                         );
@@ -616,12 +616,12 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                 return self::createTabEntry(
                     _n('Component', 'Components', Session::getPluralNumber()),
                     $nb,
-                    $item::getType()
+                    $item::class
                 );
             }
             if ($item instanceof CommonDevice) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    $deviceClass     = $item->getType();
+                    $deviceClass     = $item::class;
                     $linkClass       = $deviceClass::getItem_DeviceType();
                     $table           = $linkClass::getTable();
                     $foreignkeyField = $deviceClass::getForeignKeyField();
@@ -632,7 +632,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                         ]
                     );
                 }
-                return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';
@@ -673,7 +673,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             echo "<form id='form_device_add$rand' name='form_device_add$rand'
                   action='" . htmlescape(Toolbox::getItemTypeFormURL(self::class)) . "' method='post'>";
             echo "<input type='hidden' name='items_id' value='$ID'>";
-            echo "<input type='hidden' name='itemtype' value='" . htmlescape($item->getType()) . "'>";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape($item::class) . "'>";
         }
 
         $table = new HTMLTableMain();
@@ -724,7 +724,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
 
         if ($is_device) {
             Session::initNavigateListItems(
-                static::getType(),
+                static::class,
                 sprintf(
                     __('%1$s = %2$s'),
                     $item->getTypeName(1),
@@ -748,7 +748,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             }
         } else {
             $devtypes = [];
-            foreach (self::getItemAffinities($item->getType()) as $link_type) {
+            foreach (self::getItemAffinities($item::class) as $link_type) {
                 $devtypes [] = $link_type::getDeviceType();
                 $link        = getItemForItemtype($link_type);
 
@@ -800,7 +800,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             echo "<form id='form_device_action$rand' name='form_device_action$rand'
                   action='" . htmlescape(Toolbox::getItemTypeFormURL(self::class)) . "' method='post'>";
             echo "<input type='hidden' name='items_id' value='$ID'>";
-            echo "<input type='hidden' name='itemtype' value='" . htmlescape($item->getType()) . "'>";
+            echo "<input type='hidden' name='itemtype' value='" . htmlescape($item::class) . "'>";
         }
 
         $table->display(['display_super_for_each_group' => false,
@@ -876,7 +876,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             $fk = static::getDeviceForeignKey();
 
             $criteria['WHERE'] = [
-                'itemtype'     => $item->getType(),
+                'itemtype'     => $item::class,
                 'items_id'     => $item->getID(),
                 'is_deleted'   => 0,
             ];
@@ -962,7 +962,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             );
 
             $peer_type::getHTMLTableHeader(
-                $item->getType(),
+                $item::class,
                 $table_group,
                 $common_column,
                 null,
@@ -1041,7 +1041,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         /** @var CommonDevice $device */
         $device = getItemForItemtype($device_type);
         foreach ($iterator as $link) {
-            Session::addToNavigateListItems(static::getType(), $link["id"]);
+            Session::addToNavigateListItems(static::class, $link["id"]);
             $this->getFromDB($link['id']);
             $current_row  = $table_group->createRow();
             if ((is_null($peer)) || ($link[$fk] != $peer->getID())) {
@@ -1132,12 +1132,12 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             }
 
             if (
-                countElementsInTable('glpi_infocoms', ['itemtype' => $this->getType(),
+                countElementsInTable('glpi_infocoms', ['itemtype' => static::class,
                     'items_id' => $link['id'],
                 ])
             ) {
                 $content = [['function'   => 'Infocom::showDisplayLink',
-                    'parameters' => [$this->getType(), $link['id']],
+                    'parameters' => [static::class, $link['id']],
                 ],
                 ];
             } else {
@@ -1153,7 +1153,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                 'WHERE'  => [
                     'OR' => [
                         [
-                            'itemtype'  => $this->getType(),
+                            'itemtype'  => static::class,
                             'items_id'  => $link['id'],
                         ],
                         [
@@ -1185,7 +1185,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
 
             if ($options['canedit']) {
                 $cell_value = Html::getMassiveActionCheckBox(
-                    $this->getType(),
+                    static::class,
                     $link['id'],
                     ['massive_tags' => $group_checkbox_tag]
                 );

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -86,12 +86,12 @@ class Item_Disk extends CommonDBChild
                     self::getTable(),
                     [
                         'items_id'     => $item->getID(),
-                        'itemtype'     => $item->getType(),
+                        'itemtype'     => $item::class,
                         'is_deleted'   => 0,
                     ]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -187,7 +187,7 @@ class Item_Disk extends CommonDBChild
                 ],
             ],
             'WHERE'     => [
-                'itemtype'     => $item->getType(),
+                'itemtype'     => $item::class,
                 'items_id'     => $item->fields['id'],
             ],
         ]);

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -61,7 +61,7 @@ class Item_Enclosure extends CommonDBRelation
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = self::countForMainItem($item);
         }
-        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/Item_Environment.php
+++ b/src/Item_Environment.php
@@ -63,7 +63,7 @@ final class Item_Environment extends CommonDBChild
                 self::getTable(),
                 [
                     'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
+                    'itemtype'     => $item::class,
                 ]
             );
             if ($nb == 0) {
@@ -73,7 +73,7 @@ final class Item_Environment extends CommonDBChild
             if (!$_SESSION['glpishow_count_on_tabs']) {
                 $nb = 0;
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
 
         return '';
@@ -100,7 +100,7 @@ final class Item_Environment extends CommonDBChild
     {
         global $DB;
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $start       = intval($_GET["start"] ?? 0);

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -58,12 +58,12 @@ class Item_Line extends CommonDBRelation
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForMainItem($item) + self::countSimcardItemsForLine($item);
             }
-            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+            return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
         } else {
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item) + self::countSimcardLinesForItem($item);
             }
-            return self::createTabEntry(Line::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(Line::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
     }
 
@@ -135,7 +135,7 @@ class Item_Line extends CommonDBRelation
     {
         return countElementsInTable(Item_DeviceSimcard::getTable(), [
             'items_id' => $item->getID(),
-            'itemtype' => $item->getType(),
+            'itemtype' => $item::class,
             'NOT'   => [
                 'lines_id' => 0,
             ],
@@ -306,7 +306,7 @@ class Item_Line extends CommonDBRelation
     {
         global $DB;
 
-        $itemtype = $item::getType();
+        $itemtype = $item::class;
         $ID = $item->fields['id'];
 
         if (

--- a/src/Item_OperatingSystem.php
+++ b/src/Item_OperatingSystem.php
@@ -59,12 +59,12 @@ class Item_OperatingSystem extends CommonDBRelation
         }
 
         $nb = 0;
-        switch ($item->getType()) {
+        switch ($item::class) {
             default:
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     $nb = self::countForItem($item);
                 }
-                return self::createTabEntry(OperatingSystem::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(OperatingSystem::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
     }
 
@@ -133,7 +133,7 @@ class Item_OperatingSystem extends CommonDBRelation
                 ],
             ],
             'WHERE'     => [
-                'glpi_items_operatingsystems.itemtype' => $item->getType(),
+                'glpi_items_operatingsystems.itemtype' => $item::class,
                 'glpi_items_operatingsystems.items_id' => $item->getID(),
             ],
             'ORDERBY'   => "$sort $order",
@@ -202,7 +202,7 @@ class Item_OperatingSystem extends CommonDBRelation
                 $id = array_keys($os)[0];
             } else {
                 //set itemtype and items_id
-                $instance->fields['itemtype']       = $item->getType();
+                $instance->fields['itemtype']       = $item::class;
                 $instance->fields['items_id']       = $item->getID();
                 $instance->fields['install_date']   = $item->fields['install_date'] ?? '';
                 $instance->fields['entities_id']    = $item->fields['entities_id'];
@@ -257,7 +257,7 @@ class Item_OperatingSystem extends CommonDBRelation
             if ($_SESSION["glpiis_ids_visible"] || empty($data["name"])) {
                 $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $data["assocID"]);
             }
-            $link = Toolbox::getItemTypeFormURL(self::getType());
+            $link = Toolbox::getItemTypeFormURL(static::class);
             $name = "<a href=\"" . htmlescape($link) . "?id=" . (int) $data["assocID"] . "\">" . htmlescape($linkname) . "</a>";
 
             echo "<tr class='tab_bg_1'>";
@@ -626,28 +626,28 @@ class Item_OperatingSystem extends CommonDBRelation
                     if ($item->getFromDB($id)) {
                         if ($item->can($id, UPDATE, $input)) {
                             $exists = $ios->getFromDBByCrit([
-                                'itemtype'  => $item->getType(),
+                                'itemtype'  => $item::class,
                                 'items_id'  => $item->getID(),
                             ]);
                             $ok = false;
                             if ($exists) {
                                 $ok = $ios->update(['id'  => $ios->getID()] + $input);
                             } else {
-                                $ok = $ios->add(['itemtype' => $item->getType(), 'items_id' => $item->getID()] + $input);
+                                $ok = $ios->add(['itemtype' => $item::class, 'items_id' => $item->getID()] + $input);
                             }
 
                             if ($ok != false) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }

--- a/src/Item_Process.php
+++ b/src/Item_Process.php
@@ -63,7 +63,7 @@ class Item_Process extends CommonDBChild
                 self::getTable(),
                 [
                     'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
+                    'itemtype'     => $item::class,
                 ]
             );
             if ($nb == 0) {
@@ -73,7 +73,7 @@ class Item_Process extends CommonDBChild
             if (!$_SESSION['glpishow_count_on_tabs']) {
                 $nb = 0;
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
 
         return '';
@@ -99,7 +99,7 @@ class Item_Process extends CommonDBChild
     {
         global $DB;
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $start       = intval($_GET["start"] ?? 0);

--- a/src/Item_Project.php
+++ b/src/Item_Project.php
@@ -206,13 +206,13 @@ class Item_Project extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = self::countForMainItem($item);
                     }
-                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::getType(), 'ti ti-package');
+                    return self::createTabEntry(_n('Item', 'Items', Session::getPluralNumber()), $nb, $item::class, 'ti ti-package');
 
                 default:
                     if (
                         Project::canView()
                         && $item instanceof CommonDBTM
-                        && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
+                        && in_array($item::class, $CFG_GLPI["project_asset_types"])
                     ) {
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             // Direct one
@@ -231,7 +231,7 @@ class Item_Project extends CommonDBRelation
                                 }
                             }
                         }
-                        return self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                     }
             }
         }
@@ -253,7 +253,7 @@ class Item_Project extends CommonDBRelation
 
         if (
             Project::canView()
-            && in_array($item->getType(), $CFG_GLPI["project_asset_types"])
+            && in_array($item::class, $CFG_GLPI["project_asset_types"])
         ) {
             return self::showForAsset($item);
         }

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -103,22 +103,22 @@ class Item_Rack extends CommonDBRelation
                 foreach ($ids as $id) {
                     if ($item->can($id, UPDATE, $input)) {
                         $relation_criteria = [
-                            'itemtype' => $item->getType(),
+                            'itemtype' => $item::class,
                             'items_id' => $item->getID(),
                         ];
                         if (countElementsInTable(Item_Rack::getTable(), $relation_criteria) > 0) {
                             if ($item_rack->deleteByCriteria($relation_criteria)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
                             // Item is not linked to a rack, not an error
-                            $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                            $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -397,7 +397,7 @@ class Item_Rack extends CommonDBRelation
 
         if ($canedit) {
             Session::initNavigateListItems(
-                self::getType(),
+                static::class,
                 //TRANS : %1$s is the itemtype name,
                 //        %2$s is the name of the item (used for headings of a list)
                 sprintf(

--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -65,7 +65,7 @@ class Item_RemoteManagement extends CommonDBChild
                 self::getTable(),
                 [
                     'items_id'     => $item->getID(),
-                    'itemtype'     => $item->getType(),
+                    'itemtype'     => $item::class,
                 ]
             );
         }
@@ -99,7 +99,7 @@ class Item_RemoteManagement extends CommonDBChild
         $iterator = $DB->request([
             'FROM'      => self::getTable(),
             'WHERE'     => [
-                'itemtype'     => $item->getType(),
+                'itemtype'     => $item::class,
                 'items_id'     => $item->fields['id'],
                 'is_deleted'   => 0,
             ],
@@ -118,7 +118,7 @@ class Item_RemoteManagement extends CommonDBChild
     public static function showForItem(CommonDBTM $item, $withtemplate = 0)
     {
         $ID = $item->fields['id'];
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
 
         if (
             !$item->getFromDB($ID)
@@ -135,7 +135,7 @@ class Item_RemoteManagement extends CommonDBChild
             $entries[] = [
                 'id'        => $mgmt->getID(),
                 'items_id'  => $mgmt->fields['items_id'],
-                'itemtype'  => self::getType(),
+                'itemtype'  => static::class,
                 'remoteid'  => $mgmt->getRemoteLink(),
                 'type'      => $mgmt->fields['type'],
                 'comment'   => Dropdown::getYesNo($data['is_dynamic']),

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -247,18 +247,18 @@ class Item_SoftwareLicense extends CommonDBRelation
                                            => $input['softwarelicenses_id'],
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
 
@@ -286,19 +286,19 @@ class Item_SoftwareLicense extends CommonDBRelation
                                 if ($csv->can(-1, CREATE, $params)) {
                                     //Process rules
                                     if ($csv->add($params)) {
-                                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                     } else {
-                                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     }
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                 }
                             } else {
                                 Session::addMessageAfterRedirect(__s('A version is required!'), false, ERROR);
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     }
                 }
@@ -321,7 +321,7 @@ class Item_SoftwareLicense extends CommonDBRelation
                                 && $number >= $license->getField('number')
                                 && !$license->getField('allow_overquota')
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage(sprintf(__s('Maximum number of items reached for license "%s".'), htmlescape($license->getName())));
                                 continue;
                             }
@@ -340,15 +340,15 @@ class Item_SoftwareLicense extends CommonDBRelation
 
                         if ($item_licence->can(-1, UPDATE, $input_data)) {
                             if ($item_licence->add($input_data)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                     }
                 }
                 return;

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -197,18 +197,18 @@ class Item_SoftwareVersion extends CommonDBRelation
                                                   => $input['softwareversions_id'],
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
 
@@ -221,22 +221,22 @@ class Item_SoftwareVersion extends CommonDBRelation
                             if (
                                 $itemtoadd->add([
                                     'items_id'              => $id,
-                                    'itemtype'              => $item::getType(),
+                                    'itemtype'              => $item::class,
                                     'softwareversions_id'   => $_POST['peer_softwareversions_id'],
                                 ])
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($itemtoadd->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($itemtoadd->getErrorMessage(ERROR_RIGHT));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
         }
@@ -936,7 +936,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             ],
             'WHERE'     => [
                 "{$selftable}.items_id" => $item->getField('id'),
-                "{$selftable}.itemtype" => $item->getType(),
+                "{$selftable}.itemtype" => $item::class,
             ] + getEntitiesRestrictCriteria('glpi_softwares', '', '', true),
             'ORDER'     => ['softname', 'version'],
         ];
@@ -1654,7 +1654,7 @@ class Item_SoftwareVersion extends CommonDBRelation
         unset($params['SELECT'], $params['ORDER']);
         $params['WHERE'] = [
             $table . '.items_id'   => $item->getID(),
-            $table . '.itemtype'   => $item::getType(),
+            $table . '.itemtype'   => $item::class,
             $table . '.is_deleted' => 0,
         ];
         if ($noent === false) {

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -76,12 +76,12 @@ class Itil_Project extends CommonDBRelation
                         $nb = countElementsInTable(
                             self::getTable(),
                             [
-                                'itemtype' => $item->getType(),
+                                'itemtype' => $item::class,
                                 'items_id' => $item->getID(),
                             ]
                         );
                     }
-                    $label = self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    $label = self::createTabEntry(Project::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                     break;
 
                 case Project::class:
@@ -92,7 +92,7 @@ class Itil_Project extends CommonDBRelation
                     $label = self::createTabEntry(
                         _n('Itil item', 'Itil items', Session::getPluralNumber()),
                         $nb,
-                        $item::getType(),
+                        $item::class,
                         Ticket::getIcon()
                     );
                     break;
@@ -293,7 +293,7 @@ TWIG, $twig_params);
                 ],
             ],
             'WHERE'           => [
-                "{$selfTable}.itemtype" => $itil->getType(),
+                "{$selfTable}.itemtype" => $itil::class,
                 "{$selfTable}.items_id" => $ID,
                 'NOT'                   => ["{$projectTable}.id" => null],
             ],

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -247,7 +247,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                         $ong[2] = self::createTabEntry(
                             _n('Target', 'Targets', Session::getPluralNumber()),
                             $nb,
-                            $item::getType()
+                            $item::class
                         );
                         $ong[3] = self::createTabEntry(__('Edit'), 0, $item::class, 'ti ti-pencil');
                     }

--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -149,7 +149,7 @@ class KnowbaseItem_Comment extends CommonDBTM
                 $where
             );
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
+        return self::createTabEntry(self::getTypeName($nb), $nb, $item::class);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -140,7 +140,7 @@ class KnowbaseItem_Item extends CommonDBRelation
                 $linked_item = getItemForItemtype($data['itemtype']);
                 $linked_item->getFromDB($data['items_id']);
             } else {
-                $linked_item = getItemForItemtype(KnowbaseItem::getType());
+                $linked_item = getItemForItemtype(KnowbaseItem::class);
                 $linked_item->getFromDB($data['knowbaseitems_id']);
             }
             $type = $linked_item::getTypeName(1);

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -492,7 +492,7 @@ TWIG, $twig_params);
     {
         if (!$withtemplate) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case 'SLM':
                     /** @var SLM $item */
                     if ($_SESSION['glpishow_count_on_tabs']) {
@@ -501,7 +501,7 @@ TWIG, $twig_params);
                             ['slms_id' => $item->getField('id')]
                         );
                     }
-                    return self::createTabEntry(static::getTypeName($nb), $nb, $item::getType());
+                    return self::createTabEntry(static::getTypeName($nb), $nb, $item::class);
             }
         }
         return '';

--- a/src/LevelAgreementLevel.php
+++ b/src/LevelAgreementLevel.php
@@ -367,7 +367,7 @@ abstract class LevelAgreementLevel extends RuleTicket
     {
         if (!$withtemplate) {
             $nb = 0;
-            switch ($item->getType()) {
+            switch ($item::class) {
                 case static::$parentclass:
                     if (
                         $_SESSION['glpishow_count_on_tabs']
@@ -375,7 +375,7 @@ abstract class LevelAgreementLevel extends RuleTicket
                     ) {
                         $nb =  countElementsInTable(static::getTable(), [static::$fkparent => $item->getID()]);
                     }
-                    return self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(static::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';

--- a/src/Link.php
+++ b/src/Link.php
@@ -105,11 +105,11 @@ class Link extends CommonDBTM
                     ['glpi_links_itemtypes','glpi_links'],
                     [
                         'glpi_links_itemtypes.links_id'  => new QueryExpression(DBmysql::quoteName('glpi_links.id')),
-                        'glpi_links_itemtypes.itemtype'  => $item->getType(),
+                        'glpi_links_itemtypes.itemtype'  => $item::class,
                     ] + $entity_criteria
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1090,7 +1090,7 @@ TWIG);
             && $item->isDynamic()
             && $item->can($item->fields['id'], UPDATE)
         ) {
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::class);
         }
         return '';
     }
@@ -1392,7 +1392,7 @@ TWIG);
             case 'unlock_fields':
                 $input = $ma->getInput();
                 if (isset($input['attached_fields'])) {
-                    $base_itemtype = $baseitem->getType();
+                    $base_itemtype = $baseitem::class;
                     foreach ($ids as $id) {
                         $lock_fields_name = [];
                         foreach ($input['attached_fields'] as $fields) {
@@ -1424,7 +1424,7 @@ TWIG);
                     }
                     $links = [];
                     foreach ($attached_items as $attached_item) {
-                        $infos = self::getLocksQueryInfosByItemType($attached_item, $baseitem->getType());
+                        $infos = self::getLocksQueryInfosByItemType($attached_item, $baseitem::class);
                         if ($item = getItemForItemtype($infos['type'])) {
                             $infos['item'] = $item;
                             $links[$attached_item] = $infos;
@@ -1446,7 +1446,7 @@ TWIG);
                             }
                         }
 
-                        $baseItemType = $baseitem->getType();
+                        $baseItemType = $baseitem::class;
                         if ($action_valid) {
                             $ma->itemDone($baseItemType, $id, MassiveAction::ACTION_OK);
                         } else {

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -325,7 +325,7 @@ class Lockedfield extends CommonDBTM
         return $DB->delete(
             $this->getTable(),
             [
-                'itemtype'  => $this->item->getType(),
+                'itemtype'  => $this->item::class,
                 'items_id'  => $this->item->fields['id'],
             ]
         );

--- a/src/Log.php
+++ b/src/Log.php
@@ -106,12 +106,12 @@ class Log extends CommonDBTM
         ) {
             $nb = countElementsInTable(
                 'glpi_logs',
-                ['itemtype' => $item->getType(),
+                ['itemtype' => $item::class,
                     'items_id' => $item->getID(),
                 ]
             );
         }
-        return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
+        return self::createTabEntry(self::getTypeName(1), $nb, $item::class);
     }
 
 
@@ -170,7 +170,7 @@ class Log extends CommonDBTM
                         $changes          =  [$id_search_option, $oldval ?? '', $values[$key] ?? ''];
                     }
                 } elseif (
-                    ($val2['linkfield'] == $key && $real_type === $item->getType())
+                    ($val2['linkfield'] == $key && $real_type === $item::class)
                        || ($key == $val2['field'] && $val2['table'] == $item->getTable())
                        || ($val2['linkfield'] == $key && $item instanceof Infocom)
                 ) {
@@ -318,7 +318,7 @@ class Log extends CommonDBTM
             return;
         }
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $start       = intval(($_GET["start"] ?? 0));
@@ -353,7 +353,7 @@ class Log extends CommonDBTM
             : [],
             'csv_url'           => $CFG_GLPI['root_doc'] . "/front/log/export.php?" . http_build_query([
                 'filter'   => $filters,
-                'itemtype' => $item::getType(),
+                'itemtype' => $item::class,
                 'id'       => $item->getId(),
             ]),
         ]);
@@ -380,7 +380,7 @@ class Log extends CommonDBTM
     {
         $DBread = DBConnection::getReadConnection();
 
-        $itemtype  = $item->getType();
+        $itemtype  = $item::class;
         $items_id  = $item->getField('id');
         $itemtable = $item->getTable();
 
@@ -936,7 +936,7 @@ class Log extends CommonDBTM
     {
         global $DB;
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $iterator = $DB->request([
@@ -977,7 +977,7 @@ class Log extends CommonDBTM
     {
         global $DB;
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $affected_fields = ['linked_action', 'itemtype_link', 'id_search_option'];
@@ -1151,7 +1151,7 @@ class Log extends CommonDBTM
     {
         global $DB;
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $items_id = $item->getField('id');
 
         $iterator = $DB->request([

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2099,7 +2099,7 @@ class MailCollector extends CommonDBTM
 
                 // Handle old format MessageId where itemtype was not in header
                 if (empty($itemtype) && !empty($items_id)) {
-                    $itemtype = Ticket::getType();
+                    $itemtype = Ticket::class;
                 }
 
                 if (empty($itemtype) || !class_exists($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -70,7 +70,7 @@ class ManualLink extends CommonDBChild
             $count += countElementsInTable(
                 'glpi_manuallinks',
                 [
-                    'itemtype'  => $item->getType(),
+                    'itemtype'  => $item::class,
                     'items_id'  => $item->fields[$item->getIndexName()],
                 ]
             );
@@ -79,12 +79,12 @@ class ManualLink extends CommonDBChild
                     ['glpi_links_itemtypes', 'glpi_links'],
                     [
                         'glpi_links_itemtypes.links_id'  => new QueryExpression(DBmysql::quoteName('glpi_links.id')),
-                        'glpi_links_itemtypes.itemtype'  => $item->getType(),
+                        'glpi_links_itemtypes.itemtype'  => $item::class,
                     ] + getEntitiesRestrictCriteria('glpi_links', '', '', false)
                 );
             }
         }
-        return self::createTabEntry(_n('Link', 'Links', Session::getPluralNumber()), $count, $item::getType());
+        return self::createTabEntry(_n('Link', 'Links', Session::getPluralNumber()), $count, $item::class);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
@@ -159,7 +159,7 @@ class ManualLink extends CommonDBChild
         $iterator = $DB->request([
             'FROM'         => 'glpi_manuallinks',
             'WHERE'        => [
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'items_id'  => $item->fields[$item->getIndexName()],
             ],
             'ORDERBY'      => 'name',

--- a/src/Manufacturer.php
+++ b/src/Manufacturer.php
@@ -86,7 +86,7 @@ class Manufacturer extends CommonDropdown
             (isset($this->input['_registeredID']))
             && (is_array($this->input['_registeredID']))
         ) {
-            $input = ['itemtype' => $this->getType(),
+            $input = ['itemtype' => static::class,
                 'items_id' => $this->getID(),
             ];
 

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -608,7 +608,7 @@ class MassiveAction
                 return false;
             }
         } elseif ($item instanceof CommonDBTM) {
-            $itemtype = $item->getType();
+            $itemtype = $item::class;
         } else {
             return false;
         }
@@ -1062,14 +1062,14 @@ class MassiveAction
 
                 $plugdisplay = false;
                 if (
-                    ($plug = isPluginItemType($item->getType()))
+                    ($plug = isPluginItemType($item::class))
                     // Specific for plugin which add link to core object
                     || ($plug = isPluginItemType(getItemTypeForTable($search['table'])))
                 ) {
                     $plugdisplay = Plugin::doOneHook(
                         $plug['plugin'],
                         Hooks::AUTO_MASSIVE_ACTIONS_FIELDS_DISPLAY,
-                        ['itemtype' => $item->getType(),
+                        ['itemtype' => $item::class,
                             'options'  => $search,
                         ]
                     );
@@ -1091,7 +1091,7 @@ class MassiveAction
                     if (isset($ma->POST['options'])) {
                         $options = $ma->POST['options'];
                     }
-                    switch ($item->getType()) {
+                    switch ($item::class) {
                         case Change::class:
                             $search['condition'][] = 'is_change';
                             break;
@@ -1334,14 +1334,14 @@ class MassiveAction
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
                         if ($item->delete(["id" => $id])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             $deleted_ids[] = $id;
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -1355,14 +1355,14 @@ class MassiveAction
                 foreach ($ids as $id) {
                     if ($item->can($id, DELETE)) {
                         if ($item->restore(["id" => $id])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             $restored_ids[] = $id;
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -1394,7 +1394,7 @@ class MassiveAction
                             if ($item->haveChildren()) {
                                 if ($action != 'purge_but_item_linked') {
                                     $force = false;
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage(__s("You can't delete that item by massive actions, because it has sub-items"));
                                     $ma->addMessage(__s("but you can do it by the form of the item"));
                                     continue;
@@ -1403,7 +1403,7 @@ class MassiveAction
                             if ($item->isUsed()) {
                                 if ($action != 'purge_but_item_linked') {
                                     $force = false;
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage(__s("You can't delete that item, because it is used for one or more items"));
                                     $ma->addMessage(__s("but you can do it by the form of the item"));
                                     continue;
@@ -1411,14 +1411,14 @@ class MassiveAction
                             }
                         }
                         if ($item->delete($delete_array, $force)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             $purged_ids[] = $id;
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -1432,16 +1432,16 @@ class MassiveAction
             case 'update':
                 if (
                     (!isset($ma->POST['search_options']))
-                    || (!isset($ma->POST['search_options'][$item->getType()]))
+                    || (!isset($ma->POST['search_options'][$item::class]))
                 ) {
                     return false;
                 }
-                $index     = $ma->POST['search_options'][$item->getType()];
-                $searchopt = Search::getCleanedOptions($item->getType(), UPDATE);
+                $index     = $ma->POST['search_options'][$item::class];
+                $searchopt = Search::getCleanedOptions($item::class, UPDATE);
                 $input     = $ma->POST;
                 if (isset($searchopt[$index])) {
                     // Infocoms case
-                    if (Search::isInfocomOption($item->getType(), $index)) {
+                    if (Search::isInfocomOption($item::class, $index)) {
                         $ic               = new Infocom();
                         $link_entity_type = -1;
                         $is_recursive     = 0;
@@ -1469,17 +1469,17 @@ class MassiveAction
                                 ) {
                                     $input2 = [
                                         'items_id'  => $key,
-                                        'itemtype'  => $item->getType(),
+                                        'itemtype'  => $item::class,
                                     ];
 
                                     if ($ic->can(-1, CREATE, $input2)) {
                                         // Add infocom if not exists
-                                        if (!$ic->getFromDBforDevice($item->getType(), $key)) {
+                                        if (!$ic->getFromDBforDevice($item::class, $key)) {
                                             $input2["items_id"] = $key;
-                                            $input2["itemtype"] = $item->getType();
+                                            $input2["itemtype"] = $item::class;
                                             $ic->fields = [];
                                             $ic->add($input2);
-                                            $ic->getFromDBforDevice($item->getType(), $key);
+                                            $ic->getFromDBforDevice($item::class, $key);
                                         }
                                         $id = $ic->fields["id"];
                                         $ic->fields = [];
@@ -1488,28 +1488,28 @@ class MassiveAction
                                                 $input["field"] => $input[$input["field"]],
                                             ])
                                         ) {
-                                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                         } else {
-                                            $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                            $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                         }
                                     } else {
-                                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                                     }
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                             }
                         }
                     } else { // Not infocoms
                         $link_entity_type = [];
                         // Specific entity item
-                        $itemtable = getTableForItemType($item->getType());
+                        $itemtable = getTableForItemType($item::class);
                         $itemtype2 = getItemTypeForTable($searchopt[$index]["table"]);
 
                         $field_name  = $input["field"];
@@ -1540,7 +1540,7 @@ class MassiveAction
                                         // Case 2: The field is not a foreign key, but the target class supports connexity (relations)
                                         // Use getConnexityItem() to dynamically resolve the related object based on the main itemtype and id (items_id)
                                     } elseif ($item2 instanceof CommonDBConnexity) {
-                                        $related_item = $item2->getConnexityItem($item->getType(), $key);
+                                        $related_item = $item2->getConnexityItem($item::class, $key);
                                     }
 
                                     if (!is_null($related_item)) {
@@ -1582,17 +1582,17 @@ class MassiveAction
                                             $field_name => $field_value,
                                         ])
                                     ) {
-                                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);
+                                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_OK);
                                     } else {
-                                        $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                        $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                     }
                                 } else {
-                                    $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $key, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $key, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                             }
                         }
@@ -1617,21 +1617,21 @@ class MassiveAction
                                 method_exists($item, "cloneMultiple")
                                 && $item->cloneMultiple($input["nb_copy"] ?? 1, $override_input, true, $clone_as_template)
                             ) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
                 break;
 
             case 'add_transfer_list':
-                $itemtype = $item->getType();
+                $itemtype = $item::class;
                 if (!isset($_SESSION['glpitransfer_list'])) {
                     $_SESSION['glpitransfer_list'] = [];
                 }
@@ -1640,7 +1640,7 @@ class MassiveAction
                 }
                 foreach ($ids as $id) {
                     $_SESSION['glpitransfer_list'][$itemtype][$id] = $id;
-                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                 }
                 $ma->setRedirect($CFG_GLPI['root_doc'] . '/front/transfer.action.php');
                 break;
@@ -1663,7 +1663,7 @@ class MassiveAction
 
                     // Check rights
                     if (!$item->canUpdateItem()) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         continue;
                     }
@@ -1685,10 +1685,10 @@ class MassiveAction
                     ]);
 
                     if (!$success) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     }
                 }
                 break;
@@ -1708,7 +1708,7 @@ class MassiveAction
 
                 foreach ($ids as $id) {
                     $success = $em->add([
-                        'itemtype'             => $item::getType(),
+                        'itemtype'             => $item::class,
                         'items_id'             => $id,
                         'content'              => $content,
                         'users_id'             => Session::getLoginUserID(),
@@ -1716,10 +1716,10 @@ class MassiveAction
                     ]);
 
                     if (!$success) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     }
                 }
 
@@ -1860,7 +1860,7 @@ class MassiveAction
             );
             Event::log(
                 $ids[0],
-                strtolower($item->getType()),
+                strtolower($item::class),
                 4,
                 "massiveaction",
                 $message
@@ -1881,7 +1881,7 @@ class MassiveAction
             );
             Event::log(
                 0,
-                strtolower($item->getType()),
+                strtolower($item::class),
                 4,
                 "massiveaction",
                 $message

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -197,7 +197,7 @@ class Monitor extends CommonDBTM implements AssignableItemInterface, DCBreadcrum
             ],
             'FROM'   => Asset_PeripheralAsset::getTable(),
             'WHERE'  => [
-                'itemtype_peripheral' => $this->getType(),
+                'itemtype_peripheral' => static::class,
                 'items_id_peripheral' => $this->fields['id'],
             ],
         ]);

--- a/src/NetworkAlias.php
+++ b/src/NetworkAlias.php
@@ -404,7 +404,7 @@ class NetworkAlias extends FQDNLabel
             echo "</tr>";
 
             Session::initNavigateListItems(
-                $item->getType(),
+                $item::class,
                 //TRANS : %1$s is the itemtype name, %2$s is the name of the item (used for headings of a list)
                 sprintf(
                     __('%1$s = %2$s'),
@@ -436,7 +436,7 @@ class NetworkAlias extends FQDNLabel
             ]);
 
             foreach ($iterator as $data) {
-                Session::addToNavigateListItems($alias->getType(), $data["alias_id"]);
+                Session::addToNavigateListItems($alias::class, $data["alias_id"]);
                 if ($address->getFromDB($data["address_id"])) {
                     echo "<tr class='tab_bg_1'>";
                     echo "<td><a href='" . htmlescape($alias->getFormURLWithID($data['alias_id'])) . "'>"

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -232,7 +232,7 @@ class NetworkEquipment extends CommonDBTM implements AssignableItemInterface, DC
                         'SELECT' => 'id',
                         'FROM'   => 'glpi_networkports',
                         'WHERE'  => [
-                            'itemtype'  => $this->getType(),
+                            'itemtype'  => static::class,
                             'items_id'  => $ID,
                         ],
                     ]),

--- a/src/NetworkEquipmentModelStencil.php
+++ b/src/NetworkEquipmentModelStencil.php
@@ -122,7 +122,7 @@ class NetworkEquipmentModelStencil extends Stencil
             $networkPort->getFromDBByCrit([
                 'logical_number' => $port['number'],
                 'items_id'  => $this->getStencilItem()->getID(),
-                'itemtype'  => $this->getStencilItem()->getType(),
+                'itemtype'  => $this->getStencilItem()::class,
                 'is_deleted' => 0,
             ]) && $networkPort->fields['ifstatus']
         ) {

--- a/src/NetworkName.php
+++ b/src/NetworkName.php
@@ -843,7 +843,7 @@ TWIG, $twig_params);
             case NetworkPort::class:
                 return countElementsInTable(
                     'glpi_networknames',
-                    ['itemtype'   => $item->getType(),
+                    ['itemtype'   => $item::class,
                         'items_id'   => $item->getID(),
                         'is_deleted' => 0,
                     ]
@@ -866,7 +866,7 @@ TWIG, $twig_params);
                         ],
                     ],
                     'WHERE'           => [
-                        'glpi_networkports.itemtype'     => $item->getType(),
+                        'glpi_networkports.itemtype'     => $item::class,
                         'glpi_networkports.items_id'     => $item->getID(),
                         'glpi_networkports.is_deleted'   => 0,
                         'glpi_networknames.is_deleted'   => 0,

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -644,7 +644,7 @@ class NetworkPort extends CommonDBChild
             'FROM'   => $netport_table,
             'WHERE'  => [
                 "$netport_table.items_id"  => $item->getID(),
-                "$netport_table.itemtype"  => $item->getType(), [
+                "$netport_table.itemtype"  => $item::class, [
                     'OR' => [
                         ["$netport_table.name" => ['!=', 'Management']],
                         ["$netport_table.name" => null],
@@ -734,7 +734,7 @@ class NetworkPort extends CommonDBChild
             <span class='sr-only'>" . __s('Select default items to show') . "</span></span>";
 
             $pref_url = $CFG_GLPI["root_doc"] . "/front/displaypreference.form.php?itemtype="
-                     . self::getType();
+                     . static::class;
             $search_config_top .= Ajax::createIframeModalWindow(
                 'search_config_top',
                 $pref_url,
@@ -839,7 +839,7 @@ class NetworkPort extends CommonDBChild
             'FROM'   => $netport::getTable(),
             'WHERE'  => [
                 'items_id'  => $item->getID(),
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'name'      => 'Management',
             ] + $deleted_criteria,
         ];
@@ -1326,7 +1326,7 @@ class NetworkPort extends CommonDBChild
             $link .= '<br/>' . htmlescape($asset->fields['mac']);
         }
 
-        $ips_iterator = $this->getIpsForPort($asset->getType(), $asset->getID());
+        $ips_iterator = $this->getIpsForPort($asset::class, $asset->getID());
         $ips = '';
         foreach ($ips_iterator as $ipa) {
             $ips .= ' ' . htmlescape($ipa['name']);
@@ -1861,7 +1861,7 @@ class NetworkPort extends CommonDBChild
                         $table       => 'items_id',
                         Unmanaged::getTable()   => 'id', [
                             'AND' => [
-                                $table . '.itemtype' => Unmanaged::getType(),
+                                $table . '.itemtype' => Unmanaged::class,
                             ],
                         ],
                     ],

--- a/src/NotImportedEmail.php
+++ b/src/NotImportedEmail.php
@@ -105,7 +105,7 @@ class NotImportedEmail extends CommonDBTM
             case 'delete_email':
             case 'import_email':
                 if (!$item->canUpdate()) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                 } else {
                     $input = $ma->getInput();
                     if (count($ids)) {
@@ -116,7 +116,7 @@ class NotImportedEmail extends CommonDBTM
                             $mailcollector->deleteOrImportSeveralEmails($ids, 1, $input['entities_id']);
                         }
                     }
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_OK);
                 }
                 return;
         }

--- a/src/Notepad.php
+++ b/src/Notepad.php
@@ -122,7 +122,7 @@ class Notepad extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::countForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -148,7 +148,7 @@ class Notepad extends CommonDBChild
 
         return countElementsInTable(
             'glpi_notepads',
-            ['itemtype' => $item->getType(),
+            ['itemtype' => $item::class,
                 'items_id' => $item->getID(),
             ]
         );
@@ -181,7 +181,7 @@ class Notepad extends CommonDBChild
                 ],
             ],
             'WHERE'     => [
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'items_id'  => $item->getID(),
             ],
             'ORDERBY'   => 'date_mod DESC',
@@ -338,7 +338,7 @@ class Notepad extends CommonDBChild
             TemplateRenderer::getInstance()->display('components/notepad/form.html.twig', [
                 'rand'      => $rand,
                 'url'       => Toolbox::getItemTypeFormURL('Notepad'),
-                'itemtype'  => $item->getType(),
+                'itemtype'  => $item::class,
                 'items_id'  => $item->getID(),
                 'notes'     => $notes,
                 'canedit'   => $canedit,

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -200,7 +200,7 @@ class Notification extends CommonDBTM implements FilterableInterface
             $menu['options'][Notification::class]['links']['search'] = Notification::getSearchURL(false);
             //saved search list
             $menu['options'][Notification::class]['links']['lists']  = "";
-            $menu['options'][Notification::class]['lists_itemtype']  = Notification::getType();
+            $menu['options'][Notification::class]['lists_itemtype']  = Notification::class;
 
             $menu['options'][NotificationTemplate::class]['title']
                         = _n('Notification template', 'Notification templates', Session::getPluralNumber());
@@ -212,7 +212,7 @@ class Notification extends CommonDBTM implements FilterableInterface
                         = NotificationTemplate::getSearchURL(false);
             //saved search list
             $menu['options'][NotificationTemplate::class]['links']['lists']  = "";
-            $menu['options'][NotificationTemplate::class]['lists_itemtype']  = NotificationTemplate::getType();
+            $menu['options'][NotificationTemplate::class]['lists_itemtype']  = NotificationTemplate::class;
         }
         if (count($menu)) {
             return $menu;
@@ -499,13 +499,13 @@ class Notification extends CommonDBTM implements FilterableInterface
                             'notifications_id'         => $id,
                         ];
                         if ($notification_notificationtemplate->getFromDBByCrit($data)) {
-                            $ma->itemDone(Notification::getType(), $ma->POST['notificationtemplates_id'], MassiveAction::ACTION_OK);
+                            $ma->itemDone(Notification::class, $ma->POST['notificationtemplates_id'], MassiveAction::ACTION_OK);
                         } else {
                             $notification_notificationtemplate->add($data);
-                            $ma->itemDone(Notification::getType(), $ma->POST['notificationtemplates_id'], MassiveAction::ACTION_OK);
+                            $ma->itemDone(Notification::class, $ma->POST['notificationtemplates_id'], MassiveAction::ACTION_OK);
                         }
                     } else {
-                        $ma->itemDone(Notification::getType(), 0, MassiveAction::ACTION_KO);
+                        $ma->itemDone(Notification::class, 0, MassiveAction::ACTION_KO);
                         $ma->addMessage($notification->getErrorMessage(ERROR_COMPAT) . " (" . $notification_template->getLink() . ")");
                     }
                 }
@@ -519,7 +519,7 @@ class Notification extends CommonDBTM implements FilterableInterface
                     //delete all links between notification and template
                     $notification_notificationtemplate = new Notification_NotificationTemplate();
                     $notification_notificationtemplate->deleteByCriteria(['notifications_id' => $id]);
-                    $ma->itemDone(Notification::getType(), $id, MassiveAction::ACTION_OK);
+                    $ma->itemDone(Notification::class, $id, MassiveAction::ACTION_OK);
                 }
                 return;
         }

--- a/src/NotificationEvent.php
+++ b/src/NotificationEvent.php
@@ -131,7 +131,7 @@ class NotificationEvent extends CommonDBTM
             //Foreach notification
             $notifications = Notification::getNotificationsByEventAndType(
                 $event,
-                $item->getType(),
+                $item::class,
                 $notificationtarget->getEntity()
             );
 

--- a/src/NotificationSetting.php
+++ b/src/NotificationSetting.php
@@ -96,7 +96,7 @@ abstract class NotificationSetting extends CommonDBTM
     #[Override]
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
-        switch ($item->getType()) {
+        switch ($item::class) {
             case static::class:
                 $tabs[1] = self::createTabEntry(__('Setup'));
                 return $tabs;

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -334,7 +334,7 @@ class NotificationTarget extends CommonDBChild
     public function getMessageID()
     {
         return self::getMessageIdForEvent(
-            $this->obj instanceof CommonDBTM ? $this->obj->getType() : null,
+            $this->obj instanceof CommonDBTM ? $this->obj::class : null,
             $this->obj instanceof CommonDBTM ? $this->obj->getID() : null,
             $this->raiseevent
         );
@@ -1743,7 +1743,7 @@ class NotificationTarget extends CommonDBChild
                     return self::createTabEntry(
                         Notification::getTypeName(Session::getPluralNumber()),
                         $nb,
-                        $item::getType()
+                        $item::class
                     );
 
                 case Notification::class:
@@ -1753,7 +1753,7 @@ class NotificationTarget extends CommonDBChild
                             ['notifications_id' => $item->getID()]
                         );
                     }
-                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
         return '';

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -447,7 +447,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         global $DB;
 
         if (isset($options['validation_id'])) {
-            $validationtable = getTableForItemType($this->obj->getType() . 'Validation');
+            $validationtable = getTableForItemType($this->obj::class . 'Validation');
 
             $criteria = ['LEFT JOIN' => [
                 User::getTable() => [
@@ -482,7 +482,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         global $DB;
 
         if (isset($options['validation_id'])) {
-            $validationtable = getTableForItemType($this->obj->getType() . 'Validation');
+            $validationtable = getTableForItemType($this->obj::class . 'Validation');
 
             $criteria = ['LEFT JOIN' => [
                 User::getTable() => [
@@ -677,7 +677,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $this->addToRecipientsList($data);
             }
         } elseif (isset($options['task_id'])) {
-            $tasktable = getTableForItemType($this->obj->getType() . 'Task');
+            $tasktable = getTableForItemType($this->obj::class . 'Task');
 
             $criteria = array_merge_recursive(
                 ['INNER JOIN' => [
@@ -724,7 +724,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $this->addToRecipientsList($data);
             }
         } elseif (isset($options['task_id'])) {
-            $tasktable = getTableForItemType($this->obj->getType() . 'Task');
+            $tasktable = getTableForItemType($this->obj::class . 'Task');
 
             $criteria = array_merge_recursive(
                 ['INNER JOIN' => [
@@ -766,7 +766,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         if (isset($options['task_groups_id_tech'])) {
             $this->addForGroup(0, $options['task_groups_id_tech']);
         } elseif (isset($options['task_id'])) {
-            $tasktable = getTableForItemType($this->obj->getType() . 'Task');
+            $tasktable = getTableForItemType($this->obj::class . 'Task');
             $iterator = $DB->request([
                 'FROM'   => $tasktable,
                 'INNER JOIN'   => [
@@ -1224,7 +1224,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
         $is_self_service = $options['additionnaloption']['is_self_service'] ?? true;
         $are_names_anonymized = $is_self_service
             && Entity::getAnonymizeConfig($item->fields['entities_id']) !== Entity::ANONYMIZE_DISABLED;
-        $objettype = strtolower($item->getType());
+        $objettype = strtolower($item::class);
 
         $data["##$objettype.title##"]        = $item->getField('name');
         $data["##$objettype.content##"]      = $item->getField('content');
@@ -1242,7 +1242,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                            = $this->formatURL(
                                $options['additionnaloption']['usertype'],
                                $objettype . "_" . $item->getField("id") . "_"
-                               . $item->getType() . $tab
+                               . $item::class . $tab
                            );
 
         $entity = new Entity();
@@ -1502,7 +1502,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
 
         // Complex mode
         if (!$simple) {
-            $linked = CommonITILObject_CommonITILObject::getAllLinkedTo($item->getType(), $item->getField('id'));
+            $linked = CommonITILObject_CommonITILObject::getAllLinkedTo($item::class, $item->getField('id'));
             $data['linkedtickets'] = [];
             $data['linkedchanges'] = [];
             $data['linkedproblems'] = [];
@@ -1704,7 +1704,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                         = count($data['documents']);
 
             //costs infos
-            $costtype = $item->getType() . 'Cost';
+            $costtype = $item::class . 'Cost';
             $costs    = $costtype::getCostsSummary($costtype, $item->getField("id"));
 
             $data["##$objettype.costfixed##"]    = $costs['costfixed'];
@@ -1834,7 +1834,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 $itilfup = ITILFollowup::getById($timeline_data['item']['id']);
                 if (
                     $item_users_id > 0
-                    && $timeline_data['type'] == ITILFollowup::getType()
+                    && $timeline_data['type'] == ITILFollowup::class
                     && $are_names_anonymized
                     && $itilfup instanceof ITILFollowup
                     && $itilfup->isFromSupportAgent()
@@ -1864,7 +1864,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     // internal inquest
                     if ($inquest->fields['type'] == 1) {
                         $user_type = $options['additionnaloption']['usertype'];
-                        $redirect = "{$objettype}_" . $item->getField("id") . '_' . $item::getType() . '$3';
+                        $redirect = "{$objettype}_" . $item->getField("id") . '_' . $item::class . '$3';
                         $data["##{$objettype}.urlsatisfaction##"] = $this->formatURL($user_type, $redirect);
                     } elseif ($inquest->fields['type'] == 2) { // external inquest
                         $data["##{$objettype}.urlsatisfaction##"] = Entity::generateLinkSatisfaction($item);
@@ -1979,7 +1979,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
     public function getTags()
     {
 
-        $itemtype  = $this->obj->getType();
+        $itemtype  = $this->obj::class;
         $objettype = strtolower($itemtype);
 
         //Locales

--- a/src/NotificationTargetKnowbaseItem.php
+++ b/src/NotificationTargetKnowbaseItem.php
@@ -142,7 +142,7 @@ class NotificationTargetKnowbaseItem extends NotificationTarget
             $this->data['targets'][] = [
                 '##target.url##'             => $target->getLink(),
                 '##target.name##'            => $target->fields['name'],
-                '##target.itemtype##'        => $target->getType(),
+                '##target.itemtype##'        => $target::class,
             ];
         }
         if ($listofcategories !== []) {

--- a/src/NotificationTargetPlanningRecall.php
+++ b/src/NotificationTargetPlanningRecall.php
@@ -116,7 +116,7 @@ class NotificationTargetPlanningRecall extends NotificationTarget
             if ($item->isField('users_id_tech')) {
                 $field = 'users_id_tech';
             } elseif (
-                in_array($item->getType(), ['PlanningExternalEvent', 'Reminder'])
+                in_array($item::class, ['PlanningExternalEvent', 'Reminder'])
                     && $item->isField('users_id')
             ) {
                 $field = 'users_id';
@@ -177,13 +177,13 @@ class NotificationTargetPlanningRecall extends NotificationTarget
             $this->data['##recall.item.url##']
                   = $this->formatURL(
                       $options['additionnaloption']['usertype'],
-                      $item2->getType() . "_" . $item2->getID()
+                      $item2::class . "_" . $item2->getID()
                   );
         } else {
             $this->data['##recall.item.url##']
                   = $this->formatURL(
                       $options['additionnaloption']['usertype'],
-                      $target_object->getType()
+                      $target_object::class
                       . "_" . $target_object->getID()
                   );
         }

--- a/src/NotificationTargetSavedSearch_Alert.php
+++ b/src/NotificationTargetSavedSearch_Alert.php
@@ -49,7 +49,7 @@ class NotificationTargetSavedSearch_Alert extends NotificationTarget
             'SELECT'          => 'event',
             'DISTINCT'        => true,
             'FROM'            => Notification::getTable(),
-            'WHERE'           => ['itemtype' => SavedSearch_Alert::getType()],
+            'WHERE'           => ['itemtype' => SavedSearch_Alert::class],
         ]);
 
         if ($iterator->numRows()) {

--- a/src/PendingReasonCron.php
+++ b/src/PendingReasonCron.php
@@ -87,9 +87,9 @@ class PendingReasonCron extends CommonDBTM
         }
 
         $targets = [
-            Ticket::getType(),
-            Change::getType(),
-            Problem::getType(),
+            Ticket::class,
+            Change::class,
+            Problem::class,
         ];
 
         $now = $_SESSION['glpi_currenttime'];

--- a/src/PendingReason_Item.php
+++ b/src/PendingReason_Item.php
@@ -62,7 +62,7 @@ class PendingReason_Item extends CommonDBRelation
     {
         $em = new self();
         $find = $em->find([
-            'itemtype' => $item::getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ]);
 
@@ -91,7 +91,7 @@ class PendingReason_Item extends CommonDBRelation
     {
         $em = new self();
         $find = $em->find([
-            'itemtype' => $item::getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ]);
 
@@ -104,7 +104,7 @@ class PendingReason_Item extends CommonDBRelation
             $em = new self();
         }
 
-        $fields['itemtype'] = $item::getType();
+        $fields['itemtype'] = $item::class;
         $fields['items_id'] = $item->getID();
         if (!isset($fields['last_bump_date'])) {
             $fields['last_bump_date'] = $_SESSION['glpi_currenttime'];
@@ -130,7 +130,7 @@ class PendingReason_Item extends CommonDBRelation
     {
         $em = new self();
         $find = $em->find([
-            'itemtype' => $item::getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ]);
 
@@ -159,7 +159,7 @@ class PendingReason_Item extends CommonDBRelation
     {
         $em = new self();
         $find = $em->find([
-            'itemtype' => $item::getType(),
+            'itemtype' => $item::class,
             'items_id' => $item->getID(),
         ]);
 
@@ -275,12 +275,12 @@ class PendingReason_Item extends CommonDBRelation
             'WHERE' => [
                 'OR' => [
                     [
-                        'itemtype' => ITILFollowup::getType(),
+                        'itemtype' => ITILFollowup::class,
                         'items_id' => new QuerySubQuery([
                             'SELECT' => 'id',
                             'FROM'   => ITILFollowup::getTable(),
                             'WHERE'  => [
-                                'itemtype' => $item::getType(),
+                                'itemtype' => $item::class,
                                 'items_id' => $item->getID(),
                             ],
                         ]),
@@ -329,7 +329,7 @@ class PendingReason_Item extends CommonDBRelation
 
         return
             $pending_item->fields['items_id'] == $timeline_item->fields['id']
-            && $pending_item->fields['itemtype'] == $timeline_item::getType()
+            && $pending_item->fields['itemtype'] == $timeline_item::class
         ;
     }
 
@@ -445,7 +445,7 @@ class PendingReason_Item extends CommonDBRelation
         // This mean there was no active pending reason before this timeline item was added
         // Nothing to be done here as we don't have any older active pending reason to update
         if (
-            $last_pending->fields['itemtype'] == $new_timeline_item::getType()
+            $last_pending->fields['itemtype'] == $new_timeline_item::class
             && $last_pending->fields['items_id'] == $new_timeline_item->getID()
         ) {
             self::updateForItem($new_timeline_item->input['_job'], $ticket_pending_updates);
@@ -484,10 +484,10 @@ class PendingReason_Item extends CommonDBRelation
         $pending_updates_timeline_item = $ticket_pending_updates;
 
         $pending_updates_timeline_item['items_id'] = $new_timeline_item->getID();
-        $pending_updates_timeline_item['itemtype'] = $new_timeline_item::getType();
+        $pending_updates_timeline_item['itemtype'] = $new_timeline_item::class;
 
         // Update last pending item and parent
-        if ($ticket_pending_updates['pendingreasons_id'] > 0 || $new_timeline_item::getType() !== $last_pending::getType()) {
+        if ($ticket_pending_updates['pendingreasons_id'] > 0 || $new_timeline_item::class !== $last_pending::class) {
             self::createForItem($new_timeline_item, $pending_updates_timeline_item);
         }
         self::updateForItem($new_timeline_item->input['_job'], $ticket_pending_updates);

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -179,7 +179,7 @@ class Peripheral extends CommonDBTM implements AssignableItemInterface, DCBreadc
             ],
             'FROM'   => Asset_PeripheralAsset::getTable(),
             'WHERE'  => [
-                'itemtype_peripheral' => $this->getType(),
+                'itemtype_peripheral' => static::class,
                 'items_id_peripheral' => $this->fields['id'],
             ],
         ]);

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -220,7 +220,7 @@ class Phone extends CommonDBTM implements AssignableItemInterface, StateInterfac
             ],
             'FROM'   => Asset_PeripheralAsset::getTable(),
             'WHERE'  => [
-                'itemtype_peripheral' => $this->getType(),
+                'itemtype_peripheral' => static::class,
                 'items_id_peripheral' => $this->fields['id'],
             ],
         ]);

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -2434,7 +2434,7 @@ TWIG, ['msg' => __('Your planning')]);
     public static function getActorTypeFromPlanningKey($key)
     {
         if (preg_match('/group_\d+_users/', $key)) {
-            return Group_User::getType();
+            return Group_User::class;
         }
         $itemtype = ucfirst(preg_replace('/^([a-z]+)_\d+$/', '$1', $key));
         return class_exists($itemtype) ? $itemtype : null;

--- a/src/PlanningExternalEventTemplate.php
+++ b/src/PlanningExternalEventTemplate.php
@@ -108,7 +108,7 @@ class PlanningExternalEventTemplate extends CommonDropdown
             case 'plan':
                 Planning::showAddEventClassicForm([
                     'duration'       => $this->fields['duration'],
-                    'itemtype'       => self::getType(),
+                    'itemtype'       => static::class,
                     'items_id'       => $this->fields['id'],
                     '_display_dates' => false,
                 ]);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3200,12 +3200,12 @@ class Plugin extends CommonDBTM
                     if (!$plugin->isInstalled($plugin->fields['directory'])) {
                         $plugin->install($id);
                         if ($plugin->isInstalled($plugin->fields['directory'])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;
@@ -3215,12 +3215,12 @@ class Plugin extends CommonDBTM
                     if ($plugin->isInstalled($plugin->fields['directory'])) {
                         $plugin->uninstall($id);
                         if (!$plugin->isInstalled($plugin->fields['directory'])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;
@@ -3230,12 +3230,12 @@ class Plugin extends CommonDBTM
                     if ($plugin->isInstalled($plugin->fields['directory']) && !$plugin->isActivated($plugin->fields['directory'])) {
                         $plugin->activate($id);
                         if ($plugin->isActivated($plugin->fields['directory'])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;
@@ -3245,12 +3245,12 @@ class Plugin extends CommonDBTM
                     if ($plugin->isActivated($plugin->fields['directory'])) {
                         $plugin->unactivate($id);
                         if (!$plugin->isActivated($plugin->fields['directory'])) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;
@@ -3259,9 +3259,9 @@ class Plugin extends CommonDBTM
                     $plugin->getFromDB($id);
                     if (!$plugin->isLoadable($plugin->fields['directory'])) {
                         $plugin->clean($id);
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                        $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                     }
                 }
                 return;

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -213,7 +213,7 @@ class Printer extends CommonDBTM implements AssignableItemInterface, StateInterf
                         'SELECT' => 'id',
                         'FROM'   => 'glpi_networkports',
                         'WHERE'  => [
-                            'itemtype'  => $this->getType(),
+                            'itemtype'  => static::class,
                             'items_id'  => $ID,
                         ],
                     ]),
@@ -341,7 +341,7 @@ class Printer extends CommonDBTM implements AssignableItemInterface, StateInterf
             ],
             'FROM'   => Asset_PeripheralAsset::getTable(),
             'WHERE'  => [
-                'itemtype_peripheral' => $this->getType(),
+                'itemtype_peripheral' => static::class,
                 'items_id_peripheral' => $this->fields['id'],
             ],
         ]);

--- a/src/PrinterLog.php
+++ b/src/PrinterLog.php
@@ -68,7 +68,7 @@ class PrinterLog extends CommonDBChild
         /** @var Printer|Asset $item */
         if (in_array($item::class, $CFG_GLPI['printer_types'])) {
             $cnt = countElementsInTable([static::getTable()], [static::$items_id => $item->getField('id')]);
-            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::getType());
+            $array_ret[] = self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $cnt, $item::class);
         }
         return $array_ret;
     }

--- a/src/Printer_CartridgeInfo.php
+++ b/src/Printer_CartridgeInfo.php
@@ -166,7 +166,7 @@ HTML;
         $tab = [];
 
         $tab[] = [
-            'id' => strtolower(self::getType()),
+            'id' => strtolower(static::class),
             'name' => self::getTypeName(1),
         ];
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -189,7 +189,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                             ] + getEntitiesRestrictCriteria(self::getTable())
                         );
                     }
-                    return self::createTabEntry(__('Created problems'), $nb, $item::getType());
+                    return self::createTabEntry(__('Created problems'), $nb, $item::class);
 
                 case Group::class:
                     $nb = 0;
@@ -204,7 +204,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                             ] + getEntitiesRestrictCriteria(self::getTable())
                         );
                     }
-                    return self::createTabEntry(__('Created problems'), $nb, $item::getType());
+                    return self::createTabEntry(__('Created problems'), $nb, $item::class);
             }
         }
         return '';
@@ -1414,7 +1414,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
 
             default:
                 $restrict['glpi_items_problems.items_id'] = $item->getID();
-                $restrict['glpi_items_problems.itemtype'] = $item->getType();
+                $restrict['glpi_items_problems.itemtype'] = $item::class;
                 // you can only see your tickets
                 if (!Session::haveRight(self::$rightname, self::READALL)) {
                     $or = [

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -133,17 +133,17 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                             ];
                             if ($task->can(-1, CREATE, $input2)) {
                                 if ($task->add($input2)) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
                     }

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1035,7 +1035,7 @@ TWIG, $avatar_params) . $username;
                             ])->current();
                             $nb        = $count['cpt'];
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType(), User::getIcon());
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::class, User::getIcon());
                     }
                     break;
 
@@ -1044,7 +1044,7 @@ TWIG, $avatar_params) . $username;
                         if ($_SESSION['glpishow_count_on_tabs']) {
                             $nb = self::countForItem($item);
                         }
-                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                        return self::createTabEntry(User::getTypeName(Session::getPluralNumber()), $nb, $item::class);
                     }
                     break;
 
@@ -1056,7 +1056,7 @@ TWIG, $avatar_params) . $username;
                         'Authorization',
                         'Authorizations',
                         Session::getPluralNumber()
-                    ), $nb, $item::getType());
+                    ), $nb, $item::class);
             }
         }
         return '';
@@ -1254,9 +1254,9 @@ TWIG, $avatar_params) . $username;
             ];
             Log::history(
                 $user->getID(),
-                $user->getType(),
+                $user::class,
                 $changes,
-                $profile->getType(),
+                $profile::class,
                 constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
             );
         }
@@ -1274,9 +1274,9 @@ TWIG, $avatar_params) . $username;
             ];
             Log::history(
                 $profile->getID(),
-                $profile->getType(),
+                $profile::class,
                 $changes,
-                $user->getType(),
+                $user::class,
                 constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
             );
         }
@@ -1294,9 +1294,9 @@ TWIG, $avatar_params) . $username;
             ];
             Log::history(
                 $entity->getID(),
-                $entity->getType(),
+                $entity::class,
                 $changes,
-                $user->getType(),
+                $user::class,
                 constant(sprintf('Log::HISTORY_%s_SUBITEM', strtoupper($type)))
             );
         }

--- a/src/Project.php
+++ b/src/Project.php
@@ -1567,14 +1567,14 @@ TWIG, $twig_params);
 
             $addselect = [];
             $ljoin = [];
-            if (Session::haveTranslations(ProjectState::getType(), 'name')) {
+            if (Session::haveTranslations(ProjectState::class, 'name')) {
                 $addselect[] = "namet2.value AS transname";
                 $ljoin['glpi_dropdowntranslations AS namet2'] = [
                     'ON' => [
                         'namet2' => 'items_id',
                         ProjectState::getTable()   => 'id', [
                             'AND' => [
-                                'namet2.itemtype' => ProjectState::getType(),
+                                'namet2.itemtype' => ProjectState::class,
                                 'namet2.language' => $_SESSION['glpilanguage'],
                                 'namet2.field'    => 'name',
                             ],
@@ -2136,7 +2136,7 @@ TWIG, $twig_params);
                     'description' => _x('filters', 'A contact in the team of the item'),
                     'supported_prefixes' => ['!'],
                 ],
-            ] + self::getKanbanPluginFilters(static::getType()),
+            ] + self::getKanbanPluginFilters(static::class),
         ]);
     }
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -255,12 +255,12 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             $users = [];
             foreach ($team as $type => $actors) {
                 switch ($type) {
-                    case User::getType():
+                    case User::class:
                         foreach ($actors as $actor) {
                             $users[$actor['items_id']] = $actor['items_id'];
                         }
                         break;
-                    case Group::getType():
+                    case Group::class:
                         foreach ($actors as $actor) {
                             $group_iterator = $DB->request([
                                 'SELECT' => 'users_id',
@@ -272,8 +272,8 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                             }
                         }
                         break;
-                    case Supplier::getType():
-                    case Contact::getType():
+                    case Supplier::class:
+                    case Contact::class:
                         //only Users can be checked for planning conflicts
                         break;
                     default:

--- a/src/ProjectTaskTeam.php
+++ b/src/ProjectTaskTeam.php
@@ -98,7 +98,7 @@ class ProjectTaskTeam extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = $item->getTeamCount();
                     }
-                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(1), $nb, $item::class);
             }
         }
         return '';
@@ -203,14 +203,14 @@ class ProjectTaskTeam extends CommonDBRelation
         $task = new ProjectTask();
         $task->getFromDB($input['projecttasks_id']);
         switch ($input['itemtype']) {
-            case User::getType():
+            case User::class:
                 Planning::checkAlreadyPlanned(
                     $input['items_id'],
                     $task->fields['plan_start_date'],
                     $task->fields['plan_end_date']
                 );
                 break;
-            case Group::getType():
+            case Group::class:
                 $group_iterator = $DB->request([
                     'SELECT' => 'users_id',
                     'FROM'   => Group_User::getTable(),
@@ -224,8 +224,8 @@ class ProjectTaskTeam extends CommonDBRelation
                     );
                 }
                 break;
-            case Supplier::getType():
-            case Contact::getType():
+            case Supplier::class:
+            case Contact::class:
                 //only Users can be checked for planning conflicts
                 break;
             default:

--- a/src/ProjectTeam.php
+++ b/src/ProjectTeam.php
@@ -99,7 +99,7 @@ class ProjectTeam extends CommonDBRelation
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nb = $item->getTeamCount();
                     }
-                    return self::createTabEntry(self::getTypeName(1), $nb, $item::getType());
+                    return self::createTabEntry(self::getTypeName(1), $nb, $item::class);
             }
         }
         return '';

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -146,17 +146,17 @@ class QueuedNotification extends CommonDBTM
                 foreach ($ids as $id) {
                     if ($item->canEdit($id)) {
                         if ($item->fields['mode'] === Notification_NotificationTemplate::MODE_AJAX) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::NO_ACTION);
+                            $ma->itemDone($item::class, $id, MassiveAction::NO_ACTION);
                         } elseif (
                             ($item instanceof QueuedNotification)
                             && $item->sendById($id)
                         ) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                     }
                 }
                 return;

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -118,12 +118,12 @@ class QueuedWebhook extends CommonDBChild
                 foreach ($ids as $id) {
                     if ($item->canEdit($id)) {
                         if ($item::sendById($id)) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                     }
                 }
                 return;

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -434,7 +434,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb, $item::getType());
+                        ), $nb, $item::class);
                     }
                     return $showtab;
             }

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -387,7 +387,7 @@ class Rack extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbIn
                 return self::createTabEntry(
                     self::getTypeName(Session::getPluralNumber()),
                     $nb,
-                    $item::getType()
+                    $item::class
                 );
         }
         return '';

--- a/src/RefusedEquipment.php
+++ b/src/RefusedEquipment.php
@@ -68,7 +68,7 @@ class RefusedEquipment extends CommonDBTM implements DefaultSearchRequestInterfa
             'id'            => '2',
             'table'         => RuleImportAsset::getTable(),
             'field'         => 'id',
-            'real_type'     => RuleImportAsset::getType(),
+            'real_type'     => RuleImportAsset::class,
             'name'          => Rule::getTypeName(1),
             'datatype'      => 'specific',
             'massiveaction' => false,
@@ -215,7 +215,7 @@ class RefusedEquipment extends CommonDBTM implements DefaultSearchRequestInterfa
         );
         Ajax::createIframeModalWindow(
             'allruletest' . $rand,
-            $CFG_GLPI['root_doc'] . "/front/rulesengine.test.php?" . "sub_type=" . RuleImportAsset::getType() . "&refusedequipments_id=" . $this->fields['id'],
+            $CFG_GLPI['root_doc'] . "/front/rulesengine.test.php?" . "sub_type=" . RuleImportAsset::class . "&refusedequipments_id=" . $this->fields['id'],
             ['title' => __('Test rules engine')]
         );
 

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -486,7 +486,7 @@ class Reminder extends CommonDBVisible implements
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb, $item::getType()),
+                        ), $nb, $item::class),
                         ];
                     }
             }

--- a/src/ReminderTranslation.php
+++ b/src/ReminderTranslation.php
@@ -78,7 +78,7 @@ class ReminderTranslation extends CommonDBChild
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $nb = self::getNumberOfTranslationsForItem($item);
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
 
         return '';

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -62,7 +62,7 @@ class Reservation extends CommonDBChild
             !$withtemplate
             && Session::haveRight("reservation", READ)
         ) {
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), 0, $item::class);
         }
         return '';
     }
@@ -1011,7 +1011,7 @@ class Reservation extends CommonDBChild
         ReservationItem::showActivationFormForItem($item);
 
         $ri = new ReservationItem();
-        if (!$ri->getFromDBbyItem($item->getType(), $item->getID())) {
+        if (!$ri->getFromDBbyItem($item::class, $item->getID())) {
             return;
         }
 
@@ -1333,52 +1333,52 @@ JAVASCRIPT;
         switch ($ma->getAction()) {
             case 'enable':
                 foreach ($ids as $id) {
-                    if ($reservation_item->getFromDBbyItem($item::getType(), $id)) {
+                    if ($reservation_item->getFromDBbyItem($item::class, $id)) {
                         // Treat as OK
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
                         $result = $reservation_item->add([
-                            'itemtype' => $item->getType(),
+                            'itemtype' => $item::class,
                             'items_id' => $id,
                             'is_active' => 1,
                         ]);
-                        $ma->itemDone($item->getType(), $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
                     }
                 }
                 break;
             case 'disable':
                 foreach ($ids as $id) {
-                    if ($reservation_item->getFromDBbyItem($item::getType(), $id)) {
+                    if ($reservation_item->getFromDBbyItem($item::class, $id)) {
                         $result = $reservation_item->delete(['id' => $reservation_item->getID()]);
-                        $ma->itemDone($item->getType(), $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     }
                 }
                 break;
             case 'available':
                 foreach ($ids as $id) {
-                    if ($reservation_item->getFromDBbyItem($item::getType(), $id)) {
+                    if ($reservation_item->getFromDBbyItem($item::class, $id)) {
                         $result = $reservation_item->update([
                             'id' => $reservation_item->getID(),
                             'is_active' => 1,
                         ]);
-                        $ma->itemDone($item->getType(), $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     }
                 }
                 break;
             case 'unavailable':
                 foreach ($ids as $id) {
-                    if ($reservation_item->getFromDBbyItem($item::getType(), $id)) {
+                    if ($reservation_item->getFromDBbyItem($item::class, $id)) {
                         $result = $reservation_item->update([
                             'id' => $reservation_item->getID(),
                             'is_active' => 0,
                         ]);
-                        $ma->itemDone($item->getType(), $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, $result ? MassiveAction::ACTION_OK : MassiveAction::ACTION_KO);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     }
                 }
                 break;

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -694,7 +694,7 @@ class Rule extends CommonDBTM
             case 'export':
                 if (count($ids)) {
                     $_SESSION['exportitems'] = $ids;
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_OK);
                     $ma->setRedirect('rule.backup.php?action=download&itemtype=' . $item::class);
                 }
                 break;
@@ -704,24 +704,24 @@ class Rule extends CommonDBTM
                 $collectionname = $input['rule_class_name'] . 'Collection';
                 $rulecollection = getItemForItemtype($collectionname);
                 if (!($rulecollection instanceof RuleCollection)) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                 } elseif ($rulecollection->canUpdate()) {
                     foreach ($ids as $id) {
                         if ($item->getFromDB($id)) {
                             if ($rulecollection->moveRule($id, $input['ranking'], $input['move_type'])) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_NOT_FOUND));
                         }
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                 }
                 break;
@@ -2911,7 +2911,7 @@ TWIG, $twig_params);
         global $PLUGIN_HOOKS;
 
         if (empty($itemtype)) {
-            $itemtype = static::getType();
+            $itemtype = static::class;
         }
 
         //Aggregate all plugins criteria for this rules engine
@@ -3316,13 +3316,13 @@ TWIG, ['label' => $this->getTitle()]);
                         $ong[1] = self::createTabEntry(
                             RuleCriteria::getTypeName(Session::getPluralNumber()),
                             $nbcriteria,
-                            $item::getType(),
+                            $item::class,
                             RuleCriteria::getIcon()
                         );
                         $ong[2] = self::createTabEntry(
                             RuleAction::getTypeName(Session::getPluralNumber()),
                             $nbaction,
-                            $item::getType(),
+                            $item::class,
                             RuleAction::getIcon()
                         );
                         return $ong;
@@ -3521,7 +3521,7 @@ TWIG, ['label' => $this->getTitle()]);
             );
         }
         foreach ($xml->xpath($xpath) as $rulexml) {
-            if ((string) $rulexml->sub_type !== self::getType()) {
+            if ((string) $rulexml->sub_type !== static::class) {
                 trigger_error(
                     sprintf(
                         'Unexpected rule type %s for rule `%s`.',
@@ -3557,7 +3557,7 @@ TWIG, ['label' => $this->getTitle()]);
 
             $rule_input = [
                 'entities_id'  => 0, // Always add default rules to root entity
-                'sub_type'     => self::getType(),
+                'sub_type'     => static::class,
                 'ranking'      => (int) $rulexml->ranking + $ranking_increment,
                 'name'         => (string) $rulexml->name,
                 'description'  => (string) $rulexml->description,

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -304,7 +304,7 @@ class RuleCollection extends CommonDBTM
 
             if (count($iterator)) {
                 $this->RuleList->list = [];
-                $active_tab = Session::getActiveTab($this->getType());
+                $active_tab = Session::getActiveTab(static::class);
 
                 foreach ($iterator as $rule) {
                     //For each rule, get a Rule object with all the criterias and actions

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -303,7 +303,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                             if (!array_key_exists("items_id", $output) || $output['items_id'] == '0') {
                                 $output["items_id"] = [];
                             }
-                            $output["items_id"][Appliance::getType()][] = $action->fields["value"];
+                            $output["items_id"][Appliance::class][] = $action->fields["value"];
                         }
 
                         // Remove values that may have been added by any "append" rule action on same actor field.
@@ -337,7 +337,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                             if (!array_key_exists("items_id", $output) || $output['items_id'] == '0') {
                                 $output["items_id"] = [];
                             }
-                            $output["items_id"][Appliance::getType()][] = $value;
+                            $output["items_id"][Appliance::class][] = $value;
                         } else {
                             $output[$actions[$action->fields["field"]]["appendto"]][] = $value;
                         }
@@ -606,7 +606,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                                 }
 
                                 foreach ($target_appliances as $value) {
-                                    $output["items_id"][Appliance::getType()][] = $value['id'];
+                                    $output["items_id"][Appliance::class][] = $value['id'];
                                 }
                             }
                         } elseif ($field == "itilcategories_id") {

--- a/src/RuleImportAsset.php
+++ b/src/RuleImportAsset.php
@@ -602,7 +602,7 @@ class RuleImportAsset extends Rule
         $is_ip          = false;
         $is_networkport = false;
         $itemtable      = $item->getTable();
-        $itemtype       = $item->getType();
+        $itemtype       = $item::class;
 
         foreach ($this->complex_criteria as $criteria) {
             if ($criteria->fields['criteria'] == 'ip') {
@@ -661,7 +661,7 @@ class RuleImportAsset extends Rule
     public function handleOneJoinPerCriteria(CommonDBTM $item, array &$it_criteria)
     {
         $itemtable      = $item->getTable();
-        $itemtype       = $item->getType();
+        $itemtype       = $item::class;
 
         foreach ($this->complex_criteria as $criterion) {
             if ($criterion->fields['criteria'] == 'ip') {
@@ -716,7 +716,7 @@ class RuleImportAsset extends Rule
     public function handleFieldsCriteria(CommonDBTM $item, &$it_criteria, $input)
     {
         $itemtable      = $item->getTable();
-        $itemtype       = $item->getType();
+        $itemtype       = $item::class;
 
         foreach ($this->complex_criteria as $criterion) {
             switch ($criterion->fields['criteria']) {

--- a/src/RuleImportAssetCollection.php
+++ b/src/RuleImportAssetCollection.php
@@ -91,7 +91,7 @@ class RuleImportAssetCollection extends RuleCollection
     public function collectionFilter($criteria, $options = [])
     {
         // current tab
-        $active_tab = $options['_glpi_tab'] ?? Session::getActiveTab($this->getType());
+        $active_tab = $options['_glpi_tab'] ?? Session::getActiveTab(static::class);
         $current_tab = str_replace(self::class . '$', '', $active_tab);
         $tabs = $this->getTabNameForItem($this);
 

--- a/src/RuleMatchedLog.php
+++ b/src/RuleMatchedLog.php
@@ -72,7 +72,7 @@ class RuleMatchedLog extends CommonDBTM
         return countElementsInTable(
             self::getTable(),
             [
-                'itemtype' => $item->getType(),
+                'itemtype' => $item::class,
                 'items_id' => $item->getField('id'),
             ]
         );

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -161,17 +161,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                         if ($saved_search->can($id, UPDATE)) {
                             $success = (new SavedSearch_User())->deleteByCriteria(['savedsearches_id' => $id]);
                             if ($success) {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($saved_search->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($saved_search->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($saved_search->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -187,17 +187,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                                 'do_count' => $input['do_count'],
                             ]);
                             if ($success) {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($saved_search->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($saved_search->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($saved_search->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -214,17 +214,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                                 'is_recursive' => $input['is_recursive'],
                             ]);
                             if ($success) {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($saved_search->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($saved_search->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($saved_search->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -240,17 +240,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                                 'is_private' => $input['is_private'],
                             ]);
                             if ($success) {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($saved_search->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($saved_search->getErrorMessage(ERROR_RIGHT));
                         }
                     } else {
-                        $ma->itemDone($saved_search->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($saved_search::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($saved_search->getErrorMessage(ERROR_NOT_FOUND));
                     }
                 }
@@ -1166,7 +1166,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $notif->check(-1, CREATE);
             $notif->add(['name'            => SavedSearch::getTypeName(1) . ' ' . $this->getName(),
                 'entities_id'     => $_SESSION["glpidefault_entity"],
-                'itemtype'        => SavedSearch_Alert::getType(),
+                'itemtype'        => SavedSearch_Alert::class,
                 'event'           => 'alert_' . $this->getID(),
                 'is_active'       => 0,
                 'date_creation' => date('Y-m-d H:i:s'),

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -81,7 +81,7 @@ class SavedSearch_Alert extends CommonDBChild
                     ['savedsearches_id' => $item->getID()]
                 );
             }
-            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+            return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
         }
         return '';
     }
@@ -171,7 +171,7 @@ class SavedSearch_Alert extends CommonDBChild
         $notifications = $DB->request([
             'FROM'   => Notification::getTable(),
             'WHERE'  => [
-                'itemtype'  => self::getType(),
+                'itemtype'  => static::class,
                 'event'     => 'alert' . ($search->getField('is_private') ? '' : '_' . $search->getID()),
             ],
         ]);

--- a/src/ShareDashboardDropdown.php
+++ b/src/ShareDashboardDropdown.php
@@ -45,10 +45,10 @@ class ShareDashboardDropdown extends AbstractRightsDropdown
     protected static function getTypes(array $options = []): array
     {
         return [
-            User::getType(),
-            Entity::getType(),
-            Profile::getType(),
-            Group::getType(),
+            User::class,
+            Entity::class,
+            Profile::class,
+            Group::class,
         ];
     }
 }

--- a/src/Software.php
+++ b/src/Software.php
@@ -284,17 +284,17 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
                     }
                     if ($item->can($input['item_items_id'], UPDATE)) {
                         if ($item->merge($items)) {
-                            $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $ids, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                 }
                 return;
 
@@ -317,13 +317,13 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
                                                   => $output['softwarecategories_id'],
                             ])
                         ) {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -336,14 +336,14 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
                     if ($item->can($id, UPDATE)) {
                         $allowed_ids[] = $id;
                     } else {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
                 if ($softdictionnayrule->replayRulesOnExistingDB(0, 0, $allowed_ids) > 0) {
-                    $ma->itemDone($item->getType(), $allowed_ids, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $allowed_ids, MassiveAction::ACTION_OK);
                 } else {
-                    $ma->itemDone($item->getType(), $allowed_ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $allowed_ids, MassiveAction::ACTION_KO);
                 }
 
                 return;

--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -69,12 +69,12 @@ class Stencil extends CommonDBChild implements ZonableModelPicture
      */
     public static function getStencilFromItem(CommonDBTM $item): ?Stencil
     {
-        $itemtype = $item::getType();
+        $itemtype = $item::class;
         $items_id = $item->getID();
 
-        switch ($item->getType()) {
-            case NetworkEquipment::getType():
-            case NetworkEquipmentModel::getType():
+        switch ($item::class) {
+            case NetworkEquipment::class:
+            case NetworkEquipmentModel::class:
                 $stencil = new NetworkEquipmentModelStencil();
                 break;
             default:
@@ -283,7 +283,7 @@ class Stencil extends CommonDBChild implements ZonableModelPicture
 
         $nb = count(json_decode(static::getStencilFromItem($item)->fields['zones'] ?? '{}', true));
 
-        return self::createTabEntry(static::getTypeName(), $nb, $item::getType());
+        return self::createTabEntry(static::getTypeName(), $nb, $item::class);
     }
 
     public function displayStencil(): void
@@ -347,7 +347,7 @@ class Stencil extends CommonDBChild implements ZonableModelPicture
         TemplateRenderer::getInstance()->display('stencil/editor.html.twig', [
             'item'              => $item,
             'stencil'           => $this,
-            'itemtype'          => $item->gettype(),
+            'itemtype'          => $item::class,
             'items_id'          => $item->getID(),
             'id'                => $self->fields['id'] ?? 0,
             'zones_json'        => $self->fields['zones'] ?? '{}',

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -784,7 +784,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             }
             // Not for Ticket class
             if (!$item instanceof self) {
-                return self::createTabEntry($title, $nb, $item::getType());
+                return self::createTabEntry($title, $nb, $item::class);
             }
         }
 
@@ -798,7 +798,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                 $satisfaction->getFromDB($item->getID())
                 && $item->fields['status'] == self::CLOSED
             ) {
-                $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
+                $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), 0, static::class);
             }
             if ($item->canView()) {
                 $ong[4] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
@@ -2198,7 +2198,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             }
 
             if (self::canUpdate()) {
-                $actions[self::getType() . MassiveAction::CLASS_ACTION_SEPARATOR . 'resolve_tickets']
+                $actions[static::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'resolve_tickets']
                 = "<i class='ti ti-check'></i>"
                 . __s("Resolve selected tickets");
             }
@@ -2406,12 +2406,12 @@ JAVASCRIPT;
                 Ticket::merge($input['_mergeticket'], $ids, $status, $mergeparams);
                 foreach ($status as $id => $status_code) {
                     if ($status_code == 0) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } elseif ($status_code == 2) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
                 }
@@ -2420,7 +2420,7 @@ JAVASCRIPT;
             case 'link_to_problem':
                 Toolbox::deprecated('Ticket "link_to_problem" massive action is deprecated. Use CommonITILObject_CommonITILObject "add" massive action.');
                 // Skip if not tickets
-                if ($item::getType() !== Ticket::getType()) {
+                if ($item::class !== Ticket::class) {
                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                     return;
                 }
@@ -2454,9 +2454,9 @@ JAVASCRIPT;
 
                     // Check if creation was successful
                     if ($res) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
                 }
@@ -2465,7 +2465,7 @@ JAVASCRIPT;
 
             case 'resolve_tickets':
                 // Skip if not tickets
-                if ($item::getType() !== self::getType()) {
+                if ($item::class !== static::class) {
                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                     return;
                 }
@@ -2493,7 +2493,7 @@ JAVASCRIPT;
                 foreach ($ids as $id) {
                     // Try to load ticket
                     if (!$ticket->getFromDB($id)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
 
@@ -2503,12 +2503,12 @@ JAVASCRIPT;
                         CommonITILObject::CLOSED,
                     ];
                     if (in_array($ticket->fields['status'], $invalid_status)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
 
                     // Add reference to ticket in input
-                    $input['itemtype'] = self::getType();
+                    $input['itemtype'] = static::class;
                     $input['items_id'] = $id;
 
                     // Insert new solution
@@ -2516,9 +2516,9 @@ JAVASCRIPT;
 
                     // Check if creation was successful
                     if ($res) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
                 }
@@ -2526,7 +2526,7 @@ JAVASCRIPT;
 
             case 'add_contract':
                 // Skip if wrong itemtype
-                if ($item::getType() !== self::getType()) {
+                if ($item::class !== static::class) {
                     $ma->addMessage($item->getErrorMessage(ERROR_COMPAT));
                     return;
                 }
@@ -2554,7 +2554,7 @@ JAVASCRIPT;
 
                     // Link already exist, skip
                     if (count($links)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                         continue;
                     }
 
@@ -2566,9 +2566,9 @@ JAVASCRIPT;
 
                     // Check if creation was successful
                     if ($res) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                         $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     }
                 }
@@ -6302,7 +6302,7 @@ JAVASCRIPT;
 
             default:
                 $restrict['glpi_items_tickets.items_id'] = $item->getID();
-                $restrict['glpi_items_tickets.itemtype'] = $item->getType();
+                $restrict['glpi_items_tickets.itemtype'] = $item::class;
                 // you can only see your tickets
                 if (!Session::haveRight(self::$rightname, self::READALL)) {
                     $or = [

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -91,13 +91,13 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
                             $input2['_link']['tickets_id_2'] = $input['tickets_id_1'];
                             if ($item->can($input['tickets_id_1'], UPDATE)) {
                                 if ($ticket->update($input2)) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                                 } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                                 }
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                                 $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                             }
                         }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2551,7 +2551,7 @@ class Toolbox
                             $docitem->add(['documents_id'  => $image['id'],
                                 '_do_notif'     => false,
                                 '_disablenotif' => true,
-                                'itemtype'      => $item->getType(),
+                                'itemtype'      => $item::class,
                                 'items_id'      => $item->fields['id'],
                             ]);
                         }

--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -324,7 +324,7 @@ class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInte
                 foreach ($ids as $id) {
                     $itemtype = $_POST['itemtype'];
                     $new_asset_id = $unmanaged->convert($id, $itemtype);
-                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                     if ($ma->isFromSingleItem()) {
                         $ma->setRedirect($itemtype::getFormURLWithID($new_asset_id));
                     } else {
@@ -354,7 +354,7 @@ class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInte
             'SELECT' => ['id'],
             'FROM' => NetworkPort::getTable(),
             'WHERE' => [
-                'itemtype' => self::getType(),
+                'itemtype' => static::class,
                 'items_id' => $items_id,
             ],
         ]);
@@ -363,7 +363,7 @@ class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInte
             'SELECT' => ['id'],
             'FROM' => RuleMatchedLog::getTable(),
             'WHERE' => [
-                'itemtype' => self::getType(),
+                'itemtype' => static::class,
                 'items_id' => $items_id,
             ],
         ]);
@@ -372,7 +372,7 @@ class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInte
             'SELECT' => ['id'],
             'FROM' => Lockedfield::getTable(),
             'WHERE' => [
-                'itemtype' => self::getType(),
+                'itemtype' => static::class,
                 'items_id' => $items_id,
             ],
         ]);

--- a/src/User.php
+++ b/src/User.php
@@ -368,14 +368,14 @@ class User extends CommonDBTM implements TreeBrowseInterface
         switch ($item::class) {
             case self::class:
                 $ong    = [];
-                $ong[1] = self::createTabEntry(__('Used items'), 0, $item::getType(), 'ti ti-package');
-                $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::getType(), 'ti ti-package');
+                $ong[1] = self::createTabEntry(__('Used items'), 0, $item::class, 'ti ti-package');
+                $ong[2] = self::createTabEntry(__('Managed items'), 0, $item::class, 'ti ti-package');
 
                 if (
                     $item->fields['authtype'] === Auth::LDAP
                     && Session::haveRight(self::$rightname, self::READAUTHENT)
                 ) {
-                    $ong[3] = self::createTabEntry(__('LDAP information'), 0, $item::getType(), AuthLDAP::getIcon());
+                    $ong[3] = self::createTabEntry(__('LDAP information'), 0, $item::class, AuthLDAP::getIcon());
                 }
                 $ong[4] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
                 return $ong;
@@ -586,7 +586,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
         // Alert does not extends CommonDBConnexity
         $alert = new Alert();
-        $alert->cleanDBonItemDelete($this->getType(), $this->fields['id']);
+        $alert->cleanDBonItemDelete(static::class, $this->fields['id']);
     }
 
 
@@ -1433,7 +1433,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             $alert = new Alert();
             $alert->deleteByCriteria(
                 [
-                    'itemtype' => $this->getType(),
+                    'itemtype' => static::class,
                     'items_id' => $this->fields['id'],
                 ],
                 true
@@ -3122,17 +3122,17 @@ HTML;
                             )
                         ) {
                             if (AuthLDAP::forceOneUserSynchronization($item, ($ma->getAction() == 'clean_ldap_fields'), false)) {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                                 $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
-                            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
                             $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                         }
                     } else {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
@@ -3144,18 +3144,18 @@ HTML;
                     !isset($input["authtype"])
                     || !isset($input["auths_id"])
                 ) {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                     return;
                 }
                 if (Session::haveRight(self::$rightname, self::UPDATEAUTHENT)) {
                     if (User::changeAuthMethod($ids, $input["authtype"], $input["auths_id"])) {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_OK);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_OK);
                     } else {
-                        $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_KO);
+                        $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     }
                 } else {
-                    $ma->itemDone($item->getType(), $ids, MassiveAction::ACTION_NORIGHT);
+                    $ma->itemDone($item::class, $ids, MassiveAction::ACTION_NORIGHT);
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                 }
                 return;
@@ -3164,7 +3164,7 @@ HTML;
                 foreach ($ids as $id) {
                     // Check rights
                     if (!$item->can($id, UPDATE)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         continue;
                     }
@@ -3178,7 +3178,7 @@ HTML;
                             $status = MassiveAction::ACTION_KO;
                         }
                     }
-                    $ma->itemDone($item->getType(), $id, $status);
+                    $ma->itemDone($item::class, $id, $status);
                 }
                 return;
 
@@ -3187,12 +3187,12 @@ HTML;
                 $totp = new TOTPManager();
                 foreach ($ids as $id) {
                     if (!$can_update_auth || !$item->can($id, UPDATE)) {
-                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                         $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         continue;
                     }
                     $totp->disable2FAForUser($id);
-                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                 }
                 break;
             case 'send_pw_reset':
@@ -4418,7 +4418,7 @@ HTML;
 
             $paramscomment = [
                 'value'    => '__VALUE__',
-                'itemtype' => User::getType(),
+                'itemtype' => User::class,
             ];
 
             if ($view_users) {
@@ -5894,7 +5894,7 @@ HTML;
                             self::getTable()  => 'id',
                             [
                                 'AND' => [
-                                    Alert::getTableField('itemtype') => self::getType(),
+                                    Alert::getTableField('itemtype') => static::class,
                                 ],
                             ],
                         ],

--- a/src/ValidatorSubstitute.php
+++ b/src/ValidatorSubstitute.php
@@ -48,7 +48,7 @@ final class ValidatorSubstitute extends CommonDBTM
             $user = User::getById(Session::getLoginUserID());
             if ($user instanceof User) {
                 $nb = $_SESSION['glpishow_count_on_tabs'] ? count($user->getSubstitutes()) : 0;
-                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
+                return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
             }
         }
 

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -679,7 +679,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     public function getApiPath(CommonDBTM $item): string
     {
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $id = $item->getID();
         $itemtypes = self::getAPIItemtypeData();
 
@@ -809,13 +809,13 @@ class Webhook extends CommonDBTM implements FilterableInterface
         $has_preview = !in_array($item->fields['itemtype'], $no_preview, true);
 
         $tabs = [
-            1 => self::createTabEntry(__('Security'), 0, $item::getType(), 'ti ti-shield-lock'),
-            2 => self::createTabEntry(__('Payload editor'), 0, $item::getType(), 'ti ti-code-dots'),
-            3 => self::createTabEntry(_n('Custom header', 'Custom headers', Session::getPluralNumber()), $headers_count, $item::getType(), 'ti ti-code-plus'),
-            4 => self::createTabEntry(_n('Query log', 'Queries log', Session::getPluralNumber()), $queries_count, $item::getType(), 'ti ti-mail-forward'),
+            1 => self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock'),
+            2 => self::createTabEntry(__('Payload editor'), 0, $item::class, 'ti ti-code-dots'),
+            3 => self::createTabEntry(_n('Custom header', 'Custom headers', Session::getPluralNumber()), $headers_count, $item::class, 'ti ti-code-plus'),
+            4 => self::createTabEntry(_n('Query log', 'Queries log', Session::getPluralNumber()), $queries_count, $item::class, 'ti ti-mail-forward'),
         ];
         if ($has_preview) {
-            $tabs[5] = self::createTabEntry(__('Preview'), 0, $item::getType(), 'ti ti-eye-exclamation');
+            $tabs[5] = self::createTabEntry(__('Preview'), 0, $item::class, 'ti ti-eye-exclamation');
         }
         return $tabs;
     }
@@ -1177,7 +1177,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 'FROM' => self::getTable(),
                 'WHERE' => [
                     'event' => $event,
-                    'itemtype' => $item->getType(),
+                    'itemtype' => $item::class,
                     'is_active' => 1,
                 ],
             ]);
@@ -1194,7 +1194,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
             }
 
             // Ignore raising if the item type is not supported
-            if (!in_array($item->getType(), $supported_types, true)) {
+            if (!in_array($item::class, $supported_types, true)) {
                 return;
             }
 
@@ -1238,7 +1238,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                     'event' => $event,
                     'item' => $api_data,
                 ];
-                $webhook->addParentItemData($api_data, $item::getType(), $item->getID());
+                $webhook->addParentItemData($api_data, $item::class, $item->getID());
 
                 $custom_headers = $webhook->fields['custom_headers'];
                 foreach ($custom_headers as $key => $value) {

--- a/tools/update_registered_ids.php
+++ b/tools/update_registered_ids.php
@@ -77,7 +77,7 @@ foreach (
                     $input = ['name' => $name];
                     $manufacturer->add($input);
                 }
-                $input = ['itemtype'    => $manufacturer->getType(),
+                $input = ['itemtype'    => $manufacturer::class,
                     'items_id'    => $manufacturer->getID(),
                     'device_type' => $type,
                     'name'        => $id,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Related to https://github.com/glpi-project/rector-glpi/pull/1.

This PR permits to validate the ability to ease the refactoring using our own Rector extension.

For the moment, I developed a unique rule that replaces most of the use of `CommonGLPI::getType()` with the `::class` constant. Some occurences remains, but they can be handled later since the `CommonGLPI::getType()` method is not yet deprecated.

It also fixes a lot of PHPStan errors. Some error switched from `Cannot call method getType() on CommonDBTM|false.` to `Cannot access constant class on CommonDBTM|false.`.