### PR TITLE
make project sub-entities non interactive when creating from template

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3922,13 +3922,13 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$with_private of method CommonITILObject\\:\\:numberOfFollowups\\(\\) expects bool, bool\\|int given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$with_private of method CommonITILObject\\:\\:numberOfTasks\\(\\) expects bool, bool\\|int given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7094,8 +7094,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         $name . '<br>',
                         sprintf(
                             __s('%1$s - %2$s'),
-                            $item->numberOfFollowups($showprivate_fup),
-                            $item->numberOfTasks($showprivate_task[$itemtype])
+                            $item->numberOfFollowups((bool)$showprivate_fup),
+                            $item->numberOfTasks((bool)$showprivate_task[$itemtype])
                         )
                     );
                 } else {
@@ -7104,8 +7104,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         '<a id="' . htmlescape($name_link_id) . '" href="' . htmlescape($item->getLinkURL()) . '">' . $name . '</a><br>',
                         sprintf(
                             __s('%1$s - %2$s'),
-                            $item->numberOfFollowups($showprivate_fup),
-                            $item->numberOfTasks($showprivate_task[$itemtype])
+                            $item->numberOfFollowups((bool)$showprivate_fup),
+                            $item->numberOfTasks((bool)$showprivate_task[$itemtype])
                         )
                     );
                 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7094,8 +7094,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         $name . '<br>',
                         sprintf(
                             __s('%1$s - %2$s'),
-                            $item->numberOfFollowups((bool)$showprivate_fup),
-                            $item->numberOfTasks((bool)$showprivate_task[$itemtype])
+                            $item->numberOfFollowups((bool) $showprivate_fup),
+                            $item->numberOfTasks((bool) $showprivate_task[$itemtype])
                         )
                     );
                 } else {
@@ -7104,8 +7104,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         '<a id="' . htmlescape($name_link_id) . '" href="' . htmlescape($item->getLinkURL()) . '">' . $name . '</a><br>',
                         sprintf(
                             __s('%1$s - %2$s'),
-                            $item->numberOfFollowups((bool)$showprivate_fup),
-                            $item->numberOfTasks((bool)$showprivate_task[$itemtype])
+                            $item->numberOfFollowups((bool) $showprivate_fup),
+                            $item->numberOfTasks((bool) $showprivate_task[$itemtype])
                         )
                     );
                 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7051,6 +7051,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     {
         $params = array_replace([
             'ticket_stats' => false,
+            'disable_links' => false,
         ], $params);
 
         $showprivate_fup = Session::haveRight('followup', ITILFollowup::SEEPRIVATE);
@@ -7087,15 +7088,27 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
             $name = '<span class="fw-bold">' . htmlescape($item->getName()) . '</span>';
             if ($item->canViewItem()) {
-                $name  = sprintf(
-                    __s('%1$s (%2$s)'),
-                    '<a id="' . htmlescape($name_link_id) . '" href="' . htmlescape($item->getLinkURL()) . '">' . $name . '</a><br>',
-                    sprintf(
-                        __s('%1$s - %2$s'),
-                        $item->numberOfFollowups($showprivate_fup),
-                        $item->numberOfTasks($showprivate_task[$itemtype])
-                    )
-                );
+                if (!empty($params['disable_links'])) {
+                    $name  = sprintf(
+                        __s('%1$s (%2$s)'),
+                        $name . '<br>',
+                        sprintf(
+                            __s('%1$s - %2$s'),
+                            $item->numberOfFollowups($showprivate_fup),
+                            $item->numberOfTasks($showprivate_task[$itemtype])
+                        )
+                    );
+                } else {
+                    $name  = sprintf(
+                        __s('%1$s (%2$s)'),
+                        '<a id="' . htmlescape($name_link_id) . '" href="' . htmlescape($item->getLinkURL()) . '">' . $name . '</a><br>',
+                        sprintf(
+                            __s('%1$s - %2$s'),
+                            $item->numberOfFollowups($showprivate_fup),
+                            $item->numberOfTasks($showprivate_task[$itemtype])
+                        )
+                    );
+                }
                 $name = sprintf(
                     __s('%1$s %2$s'),
                     $name,

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -220,7 +220,12 @@ TWIG, $twig_params);
         $entries = [];
         /** @var class-string<CommonITILObject> $itemtype */
         foreach ($entries_by_itemtype as $itemtype => $v) {
-            $entries = [...$entries, ...$itemtype::getDatatableEntries($v)];
+            // If withtemplate == 2, pass a special parameter to disable links in the datatable
+            $datatable_params = [];
+            if ($withtemplate == 2) {
+                $datatable_params['disable_links'] = true;
+            }
+            $entries = [...$entries, ...$itemtype::getDatatableEntries($v, $datatable_params)];
         }
         // add itemtype for MA
         foreach ($entries as &$entry) {
@@ -235,12 +240,13 @@ TWIG, $twig_params);
             'entries' => $entries,
             'total_number' => count($entries),
             'filtered_number' => count($entries),
-            'showmassiveactions' => $canedit,
+            'showmassiveactions' => ($withtemplate != 2) ? $canedit : false,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . self::class . mt_rand(),
-                'specific_actions' => ['purge' => _x('button', 'Delete permanently')],
+                'specific_actions' => ($withtemplate != 2) ? ['purge' => _x('button', 'Delete permanently')] : [],
             ],
+            'disable_checkbox' => ($withtemplate == 2),
         ]);
 
         return true;

--- a/src/Project.php
+++ b/src/Project.php
@@ -1459,7 +1459,7 @@ TWIG, $twig_params);
                             'itemtype' => ProjectTeam::class,
                             'id' => $data['id'],
                             'type' => $item::getTypeName(1),
-                            'member' => $item->getLink(),
+                            'member' => ($withtemplate == 2) ? $item->fields['name'] : $item->getLink(),
                         ];
                     }
                 }
@@ -1480,7 +1480,7 @@ TWIG, $twig_params);
             'entries' => $entries,
             'total_number' => count($entries),
             'filtered_number' => count($entries),
-            'showmassiveactions' => $canedit,
+            'showmassiveactions' => ($withtemplate == 2) ? false : $canedit,
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . mt_rand(),

--- a/src/Project.php
+++ b/src/Project.php
@@ -1485,6 +1485,7 @@ TWIG, $twig_params);
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . mt_rand(),
             ],
+            'disable_checkbox' => ($withtemplate == 2),
         ]);
 
         return true;

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1344,7 +1344,9 @@ TWIG, $twig_params);
                 'itemtype' => static::class,
                 'id' => $data['id'],
                 'row_class' => $data['is_deleted'] ? 'table-danger' : '',
-                'name' => $task->getLink(['comments' => true]),
+                'name' => ($withtemplate == 2)
+                    ? htmlescape($data['name'])
+                    : $task->getLink(['comments' => true]),
                 'tname' => $data['transname2'] ?? $data['tname'],
                 'sname' => [
                     'content' => $data['transname3'] ?? $data['sname'],

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1408,6 +1408,7 @@ TWIG, $twig_params);
                     'purge' => _x('button', 'Delete permanently'),
                 ],
             ],
+            'disable_checkbox' => ($withtemplate == 2),
         ]);
     }
 

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -105,7 +105,8 @@
                                 <div>
                                     <input class="form-check-input massive_action_checkbox" type="checkbox" id="checkall_{{ massiveactionparams['container'] }}"
                                         value="" aria-label="{{ __('Check all') }}"
-                                        onclick="checkAsCheckboxes(this, '{{ massiveactionparams['container']|e('js') }}', '.massive_action_checkbox');" />
+                                        onclick="checkAsCheckboxes(this, '{{ massiveactionparams['container']|e('js') }}', '.massive_action_checkbox');"
+                                        {% if disable_checkbox %}disabled{% endif %} />
                                 </div>
                             </th>
                         {% endif %}
@@ -240,7 +241,7 @@
                                     {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}
                                         <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
                                                value="1" aria-label="{{ __("Select item") }}"
-                                               name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                               name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" {% if disable_checkbox %}disabled{% endif %}/>
                                     {% endif %}
                                 </td>
                             {% endif %}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41602 (follows !40258 - #22293)
- This PR ensures that all project sub-entities (tasks, team members, etc.) are non-interactive when creating a project from a template. It disables clickable links, removes massive action checkboxes and buttons, and prevents user interaction with related entities until the project is saved.




