### PR TITLE
fix exclusion notification + tests

### DIFF
--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1497,6 +1497,7 @@ class NotificationTarget extends CommonDBChild
             ],
         ]));
         if ($exclusions === []) {
+            // No exclusion, no need to filter
             return $target_list;
         }
         $user_ids = [];
@@ -1506,6 +1507,7 @@ class NotificationTarget extends CommonDBChild
             }
         }
         if ($user_ids === []) {
+            // Cannot filter targets without a user id
             return $target_list;
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -1488,6 +1488,10 @@ class NotificationTarget extends CommonDBChild
     private function removeExcludedTargets(array $target_list): array
     {
         global $DB;
+
+        if ($target_list === []) {
+            return $target_list;
+        }
         $exclusions = iterator_to_array($DB->request([
             'SELECT' => ['type', 'items_id'],
             'FROM'   => self::getTable(),

--- a/tests/functional/NotificationTargetTest.php
+++ b/tests/functional/NotificationTargetTest.php
@@ -677,4 +677,31 @@ class NotificationTargetTest extends DbTestCase
             $this->assertSame($has_admin_target, array_key_exists('1_1', $notification_target->notification_targets));
         }
     }
+
+    public function testExclusionFieldDoesNotAddRecipient()
+    {
+        $this->login();
+
+        $notification_target = new NotificationTarget();
+
+        // Ensure the notification context is set so getTargets can find exclusions
+        $notification_target->data = [
+            'notifications_id' => 1,
+        ];
+
+        // Add exclusion for "Profil: Technician"
+        $notification_target->add([
+            'notifications_id' => 1, // Assuming notification ID 1 for testing
+            'type'             => Notification::PROFILE_TYPE,
+            'items_id'         => getItemByTypeName('Profile', 'Technician', true),
+            'is_exclusion'     => 1,
+        ]);
+
+        // Ensure the profile is excluded and not added as a recipient
+        $targets = $notification_target->getTargets();
+        foreach ($targets as $target) {
+            $this->assertNotEquals(Notification::PROFILE_TYPE, $target['type']);
+            $this->assertNotEquals(getItemByTypeName('Profile', 'Technician', true), $target['items_id']);
+        }
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41459

When a profile or group was placed in the exclusions for a notification, it was incorrectly included as a recipient; now the exclusion is correctly applied and users linked to the excluded profile/group no longer receive the notification.

A test has been added to verify that a profile marked is_exclusion (in this case, Technician) does not appear in the list of recipients after calling getTargets().


## Screenshots (if appropriate):
<img width="735" height="202" alt="image" src="https://github.com/user-attachments/assets/1b0b5bcc-dba2-40f7-9eff-983f1a325215" />



