### PR TITLE
Comments threads

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -8762,12 +8762,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Controller/ItemType/Form/SavedSearchFormController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$input of method CommonDBTM\\:\\:add\\(\\) expects array\\<string, mixed\\>, array\\<string, mixed\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Controller/Knowbase/AddCommentController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\$status of class Symfony\\\\Component\\\\HttpFoundation\\\\Response constructor expects int, bool\\|int given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ bash: ## Start a shell inside the php container
 .PHONY: bash
 
 sql: ## Enter the database cli
-	@$(DB) sh -c 'mariadb --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE'
+	@$(DB) sh -c 'mariadb --user=root --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE'
 .PHONY: sql
 
 ## —— GLPI commands ————————————————————————————————————————————————————————————

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ bash: ## Start a shell inside the php container
 .PHONY: bash
 
 sql: ## Enter the database cli
-	@$(DB) sh -c 'mariadb --user=root --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE'
+	@$(DB) sh -c 'mariadb --user=$$MARIADB_USER --password=$$MARIADB_PASSWORD $$MARIADB_DATABASE'
 .PHONY: sql
 
 ## —— GLPI commands ————————————————————————————————————————————————————————————

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -86,3 +86,49 @@
         background-color: transparent;
     }
 }
+
+// KB comment thread reply trigger
+.kb-comment-thread {
+    .kb-reply-trigger {
+        transition: opacity 0.15s ease-in-out;
+    }
+
+    &:hover .kb-reply-trigger {
+        opacity: 1 !important;
+    }
+}
+
+// Handle shared borders for comments in the same thread.
+.kb-comment-card {
+    border-radius: 0 !important;
+    border-bottom-width: 0 !important;
+}
+
+// Re-add top border radius for first comment of a thread
+.kb-comment:first-child {
+    .kb-comment-card {
+        border-top-left-radius: var(--tblr-border-radius) !important;
+        border-top-right-radius: var(--tblr-border-radius) !important;
+    }
+}
+
+// Re-add bottom border radius + border bottom for last comment of a thread.
+// This must only be done if the "reply form" is not displayed.
+.kb-comment-thread:not(.reply-shown) {
+    .kb-comment:nth-last-child(-n + 3) {
+        .kb-comment-card {
+            border-bottom-left-radius: var(--tblr-border-radius) !important;
+            border-bottom-right-radius: var(--tblr-border-radius) !important;
+            border-bottom-width: 1px !important;
+        }
+    }
+}
+
+// Re-add bottom border radius + border bottom for the "reply form".
+.kb-reply-form {
+    .kb-comment-card {
+        border-bottom-left-radius: var(--tblr-border-radius) !important;
+        border-bottom-right-radius: var(--tblr-border-radius) !important;
+        border-bottom-width: 1px !important;
+    }
+}

--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -116,3 +116,13 @@
     // if it is still unsuported when we are ready to release the 12.0 version.
     field-sizing: content;
 }
+
+@media (hover: hover) {
+    .opacity-0-hoverable {
+        opacity: 0 !important;
+    }
+
+    .opacity-100-hoverable {
+        opacity: 100 !important;
+    }
+}

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitem_comments.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitem_comments.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+$table = 'glpi_knowbaseitems_comments';
+
+$migration->displayMessage("Flatten knowbase item comments to max 2 levels");
+
+$all_comments = [];
+foreach ($DB->request([
+    'SELECT' => ['id', 'parent_comment_id'],
+    'FROM'   => $table,
+]) as $row) {
+    $all_comments[$row['id']] = $row['parent_comment_id'];
+}
+
+$root_comments = [];
+$level_2_plus_comments = [];
+
+$updates = [];
+foreach ($all_comments as $id => $parent_id) {
+    // Root comment (level 0): keep track of it
+    if ($parent_id === null) {
+        $root_comments[] = $id;
+        continue;
+    }
+
+    // Level 1 comment (parent has no parent itself): nothing to do
+    $grand_parent_id = $all_comments[$parent_id] ?? null;
+    if ($grand_parent_id === null) {
+        continue;
+    }
+
+    // Level 2+: keep track so we can find its first root ancestor
+    $level_2_plus_comments[] = $id;
+}
+
+foreach ($level_2_plus_comments as $comment_id) {
+    // Find the first root ancestor
+    $previous = $comment_id;
+    do {
+        $parent = $all_comments[$previous] ?? null;
+        $previous = $parent;
+    } while ($parent !== null && !in_array($parent, $root_comments));
+
+    if ($parent === null) {
+        // This comment is an orphan, ignore it.
+        continue;
+    }
+
+    $updates[$comment_id] = $parent;
+}
+
+foreach ($updates as $id => $new_parent_id) {
+    $DB->update($table, ['parent_comment_id' => $new_parent_id], ['id' => $id]);
+}

--- a/js/modules/Knowbase/CommentsPanelController.js
+++ b/js/modules/Knowbase/CommentsPanelController.js
@@ -133,8 +133,8 @@ export class GlpiKnowbaseCommentsPanelController
             if (thread) {
                 const trigger = thread.querySelector(reply_trigger_selector);
                 if (trigger) {
-                    trigger.classList.remove('opacity-0');
-                    trigger.classList.add('opacity-100');
+                    trigger.classList.remove('opacity-0-hoverable');
+                    trigger.classList.add('opacity-100-hoverable');
                 }
             }
         }, true);
@@ -144,8 +144,8 @@ export class GlpiKnowbaseCommentsPanelController
             if (thread) {
                 const trigger = thread.querySelector(reply_trigger_selector);
                 if (trigger) {
-                    trigger.classList.add('opacity-0');
-                    trigger.classList.remove('opacity-100');
+                    trigger.classList.add('opacity-0-hoverable');
+                    trigger.classList.remove('opacity-100-hoverable');
                 }
             }
         }, true);

--- a/js/modules/Knowbase/CommentsPanelController.js
+++ b/js/modules/Knowbase/CommentsPanelController.js
@@ -32,6 +32,8 @@
 
 /* global glpi_toast_error, glpi_confirm_danger, getAjaxCsrfToken */
 
+import { post } from "/js/modules/Ajax.js";
+
 const content_selector  = "[data-glpi-add-comments-content]";
 const submit_selector   = "[data-glpi-add-comments-submit]";
 const kb_id_selector    = "[data-glpi-kb-id]";
@@ -44,6 +46,13 @@ const comment_edit_textarea_selector = "[data-glpi-comment-edit-textarea]";
 const comment_edit_cancel_selector = "[data-glpi-comment-edit-cancel]";
 const comment_edit_submit_selector = "[data-glpi-comment-edit-submit]";
 const comments_empty_selector = "[data-glpi-comments-empty]";
+const reply_trigger_selector = "[data-glpi-reply-trigger]";
+const reply_btn_selector = "[data-glpi-reply-btn]";
+const reply_form_selector = "[data-glpi-reply-form]";
+const reply_textarea_selector = "[data-glpi-reply-textarea]";
+const reply_cancel_selector = "[data-glpi-reply-cancel]";
+const reply_submit_selector = "[data-glpi-reply-submit]";
+const comment_thread_selector = "[data-glpi-comment-thread]";
 
 export class GlpiKnowbaseCommentsPanelController
 {
@@ -98,7 +107,48 @@ export class GlpiKnowbaseCommentsPanelController
             if (delete_btn) {
                 this.#deleteComment(delete_btn);
             }
+
+            // Reply button
+            const reply_btn = e.target.closest(reply_btn_selector);
+            if (reply_btn) {
+                this.#showReplyForm(reply_btn);
+            }
+
+            // Cancel reply button
+            const reply_cancel_btn = e.target.closest(reply_cancel_selector);
+            if (reply_cancel_btn) {
+                this.#hideReplyForm(reply_cancel_btn);
+            }
+
+            // Submit reply button
+            const reply_submit_btn = e.target.closest(reply_submit_selector);
+            if (reply_submit_btn) {
+                this.#submitReply(reply_submit_btn);
+            }
         });
+
+        // Show/hide reply trigger on thread hover
+        this.#container.addEventListener('mouseenter', (e) => {
+            const thread = e.target.closest(comment_thread_selector);
+            if (thread) {
+                const trigger = thread.querySelector(reply_trigger_selector);
+                if (trigger) {
+                    trigger.classList.remove('opacity-0');
+                    trigger.classList.add('opacity-100');
+                }
+            }
+        }, true);
+
+        this.#container.addEventListener('mouseleave', (e) => {
+            const thread = e.target.closest(comment_thread_selector);
+            if (thread) {
+                const trigger = thread.querySelector(reply_trigger_selector);
+                if (trigger) {
+                    trigger.classList.add('opacity-0');
+                    trigger.classList.remove('opacity-100');
+                }
+            }
+        }, true);
     }
 
     #showEditForm(edit_btn)
@@ -137,31 +187,15 @@ export class GlpiKnowbaseCommentsPanelController
         submit_btn.querySelector('[data-glpi-loading]').classList.remove('d-none');
         submit_btn.querySelector('[data-glpi-icon]').classList.add('d-none');
 
-        const data = new FormData();
-        data.append('content', textarea.value);
-
-        const base_url = CFG_GLPI.root_doc;
-        const url = `${base_url}/Knowbase/UpdateComment/${comment_id}`;
-        const response = await fetch(url, {
-            method: "POST",
-            body: data,
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-            }
+        const response = await post(`Knowbase/UpdateComment/${comment_id}`, {
+            'content': textarea.value,
         });
+        const result = await response.json();
 
         // Reset loading state
         submit_btn.classList.remove('pointer-events-none');
         submit_btn.querySelector('[data-glpi-icon]').classList.remove('d-none');
         submit_btn.querySelector('[data-glpi-loading]').classList.add('d-none');
-
-        if (!response.ok) {
-            glpi_toast_error(__("An unexpected error occurred."));
-            return;
-        }
-
-        const result = await response.json();
 
         // Update content and hide form
         content.innerHTML = result.comment.replace(/\n/g, '<br>');
@@ -185,22 +219,20 @@ export class GlpiKnowbaseCommentsPanelController
         }
 
         // Delete comment on the backend
-        const base_url = CFG_GLPI.root_doc;
-        const url = `${base_url}/Knowbase/PurgeComment/${comment_id}`;
-        const response = await fetch(url, {
-            method: "POST",
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-            }
-        });
-        if (!response.ok) {
-            glpi_toast_error(__("An unexpected error occurred."));
-            return;
+        await post(`Knowbase/PurgeComment/${comment_id}`);
+
+        // Get the others comments from this thread
+        const parent_thread = comment_card.closest('[data-glpi-comment-thread]');
+        const comments = parent_thread.querySelectorAll('[data-glpi-comment-id]');
+
+        if (comments.length === 1) {
+            // This is the only comment in this thread, delete the whole thread
+            parent_thread.remove();
+        } else {
+            // Delete the comment
+            comment_card.remove();
         }
 
-        // Delete comment on the client
-        comment_card.remove();
         this.#updateCounter(-1);
         this.#showEmptyStateIfNoComments();
     }
@@ -229,30 +261,9 @@ export class GlpiKnowbaseCommentsPanelController
             .add('d-none')
         ;
 
-        const data = new FormData();
-        data.append('content', this.#getContentTextarea().value);
-
-        const base_url = CFG_GLPI.root_doc;
-        const url = `${base_url}/Knowbase/${this.#getKbId()}/AddComment`;
-        const response = await fetch(url, {
-            method: "POST",
-            body: data,
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-            }
+        const response = await post(`Knowbase/${this.#getKbId()}/AddComment`, {
+            'content': this.#getContentTextarea().value,
         });
-
-        if (!response.ok) {
-            glpi_toast_error(__("An unexpected error occurred."));
-            return;
-        }
-
-        // Insert new comment
-        const html = await response.text();
-        this.#getCommentsDiv().insertAdjacentHTML('beforeend', html);
-        this.#updateCounter(1);
-        this.#hideEmptyState();
 
         // Clear input/UI
         this.#getContentTextarea().value = "";
@@ -268,6 +279,12 @@ export class GlpiKnowbaseCommentsPanelController
             .classList
             .add('d-none')
         ;
+
+        // Insert new comment
+        const html = await response.text();
+        this.#getCommentsDiv().insertAdjacentHTML('beforeend', html);
+        this.#updateCounter(1);
+        this.#hideEmptyState();
         this.#getCommentsDiv().lastElementChild.scrollIntoView();
     }
 
@@ -317,5 +334,75 @@ export class GlpiKnowbaseCommentsPanelController
         const comments = this.#getCommentsDiv();
         const has_comments = comments.querySelectorAll('[data-testid="comment"]').length > 0;
         empty.classList.toggle('d-none', has_comments);
+    }
+
+    #showReplyForm(reply_btn)
+    {
+        const thread = reply_btn.closest(comment_thread_selector);
+        const form = thread.querySelector(reply_form_selector);
+        const trigger = thread.querySelector(reply_trigger_selector);
+
+        trigger.classList.add('d-none');
+        form.classList.remove('d-none');
+        form.querySelector(reply_textarea_selector).focus();
+
+        // Add a special class so we can merge the borders with the reply form.
+        thread.classList.add('reply-shown');
+    }
+
+    #hideReplyForm(cancel_btn)
+    {
+        const thread = cancel_btn.closest(comment_thread_selector);
+        const form = thread.querySelector(reply_form_selector);
+        const trigger = thread.querySelector(reply_trigger_selector);
+
+        form.classList.add('d-none');
+        form.querySelector(reply_textarea_selector).value = '';
+        trigger.classList.remove('d-none');
+
+        // Remove the special temporary class to deal with borders
+        thread.classList.remove('reply-shown');
+    }
+
+    async #submitReply(submit_btn)
+    {
+        const thread            = submit_btn.closest(comment_thread_selector);
+        const form              = thread.querySelector(reply_form_selector);
+        const textarea          = form.querySelector(reply_textarea_selector);
+        const parent_comment_id = form.dataset.parentCommentId;
+
+        const content = textarea.value.trim();
+        if (!content) {
+            return;
+        }
+
+        // Show loading state
+        submit_btn.classList.add('pointer-events-none');
+        submit_btn.querySelector('[data-glpi-loading]').classList.remove('d-none');
+        submit_btn.querySelector('[data-glpi-icon]').classList.add('d-none');
+
+        const response = await post(`Knowbase/${this.#getKbId()}/AddComment`, {
+            content : content,
+            parent_comment_id : parent_comment_id,
+        });
+
+        // Reset loading state
+        submit_btn.classList.remove('pointer-events-none');
+        submit_btn.querySelector('[data-glpi-icon]').classList.remove('d-none');
+        submit_btn.querySelector('[data-glpi-loading]').classList.add('d-none');
+
+        // Insert new comment before the reply button
+        const trigger = thread.querySelector(reply_trigger_selector);
+        const html = await response.text();
+        trigger.insertAdjacentHTML('beforebegin', html);
+        this.#updateCounter(1);
+
+        // Hide reply form and clear textarea
+        textarea.value = '';
+        form.classList.add('d-none');
+        thread.querySelector(reply_trigger_selector).classList.remove('d-none');
+
+        // Remove the special temporary class to deal with borders
+        thread.classList.remove('reply-shown');
     }
 }

--- a/src/Glpi/Controller/CrudControllerTrait.php
+++ b/src/Glpi/Controller/CrudControllerTrait.php
@@ -41,7 +41,36 @@ use RuntimeException;
 
 trait CrudControllerTrait
 {
-    /** @param array<mixed> $input */
+    /**
+     * @template T of CommonDBTM
+     * @param class-string<T> $class
+     * @param array<mixed> $input
+     * @return T
+     */
+    private function add(string $class, array $input): CommonDBTM
+    {
+        $item = getItemForItemtype($class);
+        if (!$item) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$item->can(-1, CREATE, $input)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        if ($input === null || !$item->add($input)) {
+            throw new RuntimeException("Failed to create item");
+        }
+
+        return $item;
+    }
+
+    /**
+     * @template T of CommonDBTM
+     * @param class-string<T> $class
+     * @param array<mixed> $input
+     * @return T
+     */
     private function update(string $class, int $id, array $input): CommonDBTM
     {
         $item = getItemForItemtype($class);
@@ -61,6 +90,9 @@ trait CrudControllerTrait
         return $item;
     }
 
+    /**
+     * @param class-string<CommonDBTM> $class
+     */
     private function delete(string $class, int $id): void
     {
         $item = getItemForItemtype($class);

--- a/src/Glpi/Controller/Knowbase/AddCommentController.php
+++ b/src/Glpi/Controller/Knowbase/AddCommentController.php
@@ -35,18 +35,22 @@
 namespace Glpi\Controller\Knowbase;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Controller\CrudControllerTrait;
 use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Knowbase\CommentsThread;
 use KnowbaseItem;
 use KnowbaseItem_Comment;
-use RuntimeException;
 use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+use function Safe\json_decode;
+
 final class AddCommentController extends AbstractController
 {
+    use CrudControllerTrait;
+
     #[Route(
         "/Knowbase/{id}/AddComment",
         name: "knowbase_article_add_comment",
@@ -56,6 +60,8 @@ final class AddCommentController extends AbstractController
     )]
     public function __invoke(int $id, Request $request): Response
     {
+        $data = json_decode($request->getContent(), true);
+
         // Parse kb id
         $kb = KnowbaseItem::getById($id);
         if (!$kb) {
@@ -63,33 +69,36 @@ final class AddCommentController extends AbstractController
         }
 
         // Parse content
-        $content = $request->request->getString('content');
+        $content = $data['content'] ?? '';
         if (empty($content)) {
             throw new BadRequestHttpException();
         }
 
-        $comment = new KnowbaseItem_Comment();
-        $input = [
-            'knowbaseitems_id' => $id,
-            'comment' => $content,
-        ];
-        if (!$comment->can(-1, CREATE, $input)) {
-            throw new AccessDeniedHttpException();
-        }
+        // Parse optional parent comment id
+        $parent_comment_id = $data['parent_comment_id'] ?? null;
 
-        // Try to add comment
-        if (!$comment->add($input)) {
-            throw new RuntimeException("Failed to create comment");
-        }
-
-        // Render new comment
-        return $this->render('pages/tools/kb/sidepanel/comment.html.twig', [
-            'comment_id'    => $comment->getID(),
-            'user'          => Session::getCurrentUser(),
-            'date_creation' => $comment->fields['date_creation'],
-            'comment'       => $comment->fields['comment'],
-            'can_edit'      => true,
-            'can_purge'     => true,
+        $comment = $this->add(KnowbaseItem_Comment::class, [
+            'knowbaseitems_id'  => $id,
+            'comment'           => $content,
+            'parent_comment_id' => $parent_comment_id,
         ]);
+
+        if ($parent_comment_id === null) {
+            // Comment has no parent, render a new thread
+            return $this->render('pages/tools/kb/sidepanel/comments_thread.html.twig', [
+                'thread' => new CommentsThread([$comment]),
+                'users'  => [Session::getLoginUserID() => Session::getCurrentUser()],
+            ]);
+        } else {
+            // Render new comment
+            return $this->render('pages/tools/kb/sidepanel/comment.html.twig', [
+                'comment_id'    => $comment->getID(),
+                'user'          => Session::getCurrentUser(),
+                'date_creation' => $comment->fields['date_creation'],
+                'comment'       => $comment->fields['comment'],
+                'can_edit'      => true,
+                'can_purge'     => true,
+            ]);
+        }
     }
 }

--- a/src/Glpi/Controller/Knowbase/UpdateCommentController.php
+++ b/src/Glpi/Controller/Knowbase/UpdateCommentController.php
@@ -43,6 +43,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+use function Safe\json_decode;
+
 final class UpdateCommentController extends AbstractController
 {
     use CrudControllerTrait;
@@ -57,8 +59,10 @@ final class UpdateCommentController extends AbstractController
     )]
     public function __invoke(int $id, Request $request): Response
     {
+        $data = json_decode($request->getContent(), true);
+
         // Get submitted comment
-        $content = $request->request->getString('content');
+        $content = $data['content'] ?? '';
         if (empty($content)) {
             throw new BadRequestHttpException();
         }

--- a/src/Glpi/Knowbase/CommentsThread.php
+++ b/src/Glpi/Knowbase/CommentsThread.php
@@ -1,3 +1,5 @@
+<?php
+
 /**
  * ---------------------------------------------------------------------
  *
@@ -30,40 +32,36 @@
  * ---------------------------------------------------------------------
  */
 
-/* global getAjaxCsrfToken, glpi_toast_error */
+namespace Glpi\Knowbase;
 
-/**
- * Perform a POST request to a GLPI endpoint.
- *
- * @param {string} url - The relative URL path (without root_doc prefix).
- * @param {Object | null} values - The data to send as JSON in the request body or null if the request doens't send any data.
- * @returns {Promise<Response>} The fetch Response object.
- * @throws {Error} If the request fails or returns a non-ok status.
- */
-export async function post(url, values = null)
+use KnowbaseItem_Comment;
+use RuntimeException;
+
+final class CommentsThread
 {
-    try {
-        const params = {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-            },
-        };
+    public function __construct(
+        /** @var KnowbaseItem_Comment[] $comments */
+        private array $comments = [],
+    ) {}
 
-        if (values !== null) {
-            params.body = JSON.stringify(values);
+    public function addComment(KnowbaseItem_Comment $comment): void
+    {
+        $this->comments[] = $comment;
+    }
+
+    /** @return KnowbaseItem_Comment[] */
+    public function getComments(): array
+    {
+        return $this->comments;
+    }
+
+    public function getRootComment(): KnowbaseItem_Comment
+    {
+        $key = array_key_first($this->comments);
+        if ($key === null) {
+            throw new RuntimeException("Thread is empty");
         }
 
-        const response = await fetch(`${CFG_GLPI.root_doc}/${url}`, params);
-        if (!response.ok) {
-            throw new Error("POST request failed");
-        }
-
-        return response;
-    } catch (e) {
-        glpi_toast_error(__("An unexpected error occurred."));
-        throw e;
+        return $this->comments[$key];
     }
 }

--- a/templates/pages/tools/kb/sidepanel/comment.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment.html.twig
@@ -31,7 +31,7 @@
  #}
 
 
-<div class="d-flex w-100" data-testid="comment" data-glpi-comment-id="{{ comment_id }}">
+<div class="d-flex w-100 kb-comment" data-testid="comment" data-glpi-comment-id="{{ comment_id }}">
     {{ include('components/user/picture.html.twig', {
         'user_object': user,
         'avatar_size': 'avatar-sm',
@@ -39,7 +39,7 @@
         'circle': true,
     }, with_context = false) }}
 
-    <div class="card rounded w-100">
+    <div class="kb-comment-card card rounded w-100">
         <div class="card-body px-3 py-2">
             <div class="card-title fs-4 d-flex align-items-start">
                 <div class="flex-grow-1" data-testid="comment-header">

--- a/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
@@ -31,7 +31,7 @@
  #}
 
 {# Reply button - visible on hover #}
-<div class="kb-reply-trigger ms-5 mt-1 opacity-0" data-glpi-reply-trigger>
+<div class="kb-reply-trigger ms-5 mt-1 opacity-0-hoverable" data-glpi-reply-trigger>
     <span
         role="button"
         class="text-muted px-2 py-1"

--- a/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
@@ -1,0 +1,89 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# Reply button - visible on hover #}
+<div class="kb-reply-trigger ms-5 mt-1 opacity-0" data-glpi-reply-trigger>
+    <span
+        role="button"
+        class="text-muted px-2 py-1"
+        data-glpi-reply-btn
+        data-parent-comment-id="{{ comment.id }}"
+    >
+        {{ __('Reply...') }}
+    </span>
+</div>
+
+{# Reply form - hidden by default #}
+<div
+    class="kb-reply-form d-none mb-4"
+    data-glpi-reply-form data-parent-comment-id="{{ comment.id }}"
+>
+    <div class="d-flex w-100">
+        {{ include('components/user/picture.html.twig', {
+            'user_object': get_current_user(),
+            'avatar_size': 'avatar-sm',
+            'extra_class': 'me-2 align-self-start mt-1',
+            'circle': true,
+            'with_link' : false,
+        }, with_context = false) }}
+
+        <div class="kb-comment-card card rounded w-100 last-comment">
+            <div class="card-body px-3 py-2">
+                <textarea
+                    class="w-100 form-control auto-resize mb-2"
+                    rows="2"
+                    placeholder="{{ __('Write a reply...') }}"
+                    data-glpi-reply-textarea
+                ></textarea>
+                <div class="d-flex justify-content-end gap-2">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-ghost-secondary"
+                        data-glpi-reply-cancel
+                    >
+                        {{ __('Cancel') }}
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-primary"
+                        data-glpi-reply-submit
+                        aria-label="{{ __('Reply') }}"
+                    >
+                        <i class="ti ti-arrow-back-up" data-glpi-icon></i>
+                        <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+                        <span>{{ __('Reply') }}</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/pages/tools/kb/sidepanel/comments.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments.html.twig
@@ -36,21 +36,20 @@
 {% block title %}{{ __("Comments") }}{% endblock %}
 
 {% block content %}
-    <div class="d-flex flex-column row-gap-4 overflow-auto flex-grow-1 mx-n4 my-n4 px-4 py-4" data-glpi-comments>
+    <div
+        class="d-flex flex-column row-gap-2 overflow-auto flex-grow-1 mx-n4 my-n4 px-4 py-4"
+        data-glpi-comments
+    >
         <p
-            class="text-muted fs-3 mt-auto mb-auto align-self-center {{ comments|length > 0 ? 'd-none' : '' }}"
+            class="text-muted fs-3 mt-auto mb-auto align-self-center {{ threads|length > 0 ? 'd-none' : '' }}"
             data-glpi-comments-empty
         >
             {{ __('No comments yet.') }}
         </p>
-        {% for comment in comments %}
-            {{ include('pages/tools/kb/sidepanel/comment.html.twig', {
-                comment_id   : comment.fields.id,
-                date_creation: comment.fields.date_creation,
-                comment      : comment.fields.comment,
-                can_edit     : comment.canUpdateItem(),
-                can_purge   : comment.canPurgeItem(),
-                user         : users[comment.fields.users_id] ?? null,
+        {% for thread in threads %}
+            {{ include('pages/tools/kb/sidepanel/comments_thread.html.twig', {
+                thread: thread,
+                users: users,
             }, with_context = false) }}
         {% endfor %}
     </div>
@@ -59,11 +58,11 @@
 
     <div class="d-flex w-100 mt-2">
         {{ include('components/user/picture.html.twig', {
-            'user_object': get_current_user(),
-            'avatar_size': 'avatar-sm',
-            'extra_class': 'me-2 align-self-start mt-1',
-            'circle': true,
-            'with_link' : false,
+            user_object: get_current_user(),
+            avatar_size: 'avatar-sm',
+            extra_class: 'me-2 align-self-start mt-1',
+            circle: true,
+            with_link : false,
         }, with_context = false) }}
 
         <textarea

--- a/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
@@ -1,0 +1,104 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set root = thread.getRootComment().fields.id %}
+
+<div class="kb-comment-thread" data-glpi-comment-thread="{{ root }}">
+    {% for comment in thread.getComments() %}
+        {{ include('pages/tools/kb/sidepanel/comment.html.twig', {
+            comment_id   : comment.fields.id,
+            date_creation: comment.fields.date_creation,
+            comment      : comment.fields.comment,
+            can_edit     : comment.canUpdateItem(),
+            can_purge    : comment.canPurgeItem(),
+            user         : users[comment.fields.users_id] ?? null,
+        }, with_context = false) }}
+    {% endfor %}
+
+    {# Reply button - visible on hover #}
+    <div class="kb-reply-trigger ms-5 mt-1 opacity-0" data-glpi-reply-trigger>
+        <span
+            role="button"
+            class="text-muted px-2 py-1"
+            data-glpi-reply-btn
+            data-parent-comment-id="{{ root }}"
+        >
+            {{ __('Reply...') }}
+        </span>
+    </div>
+
+    {# Reply form - hidden by default #}
+    <div
+        class="kb-reply-form d-none mb-4"
+        data-glpi-reply-form data-parent-comment-id="{{ root }}"
+    >
+        <div class="d-flex w-100">
+            {{ include('components/user/picture.html.twig', {
+                'user_object': get_current_user(),
+                'avatar_size': 'avatar-sm',
+                'extra_class': 'me-2 align-self-start mt-1',
+                'circle': true,
+                'with_link' : false,
+            }, with_context = false) }}
+
+            <div class="kb-comment-card card rounded w-100 last-comment">
+                <div class="card-body px-3 py-2">
+                    <textarea
+                        class="w-100 form-control auto-resize mb-2"
+                        rows="2"
+                        placeholder="{{ __('Write a reply...') }}"
+                        data-glpi-reply-textarea
+                    ></textarea>
+                    <div class="d-flex justify-content-end gap-2">
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-ghost-secondary"
+                            data-glpi-reply-cancel
+                        >
+                            {{ __('Cancel') }}
+                        </button>
+                        <button
+                            type="button"
+                            class="btn btn-sm btn-primary"
+                            data-glpi-reply-submit
+                            aria-label="{{ __('Reply') }}"
+                        >
+                            <i class="ti ti-arrow-back-up" data-glpi-icon></i>
+                            <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+                            <span>{{ __('Reply') }}</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
@@ -38,8 +38,8 @@
             comment_id   : comment.fields.id,
             date_creation: comment.fields.date_creation,
             comment      : comment.fields.comment,
-            can_edit     : comment.canUpdateItem(),
-            can_purge    : comment.canPurgeItem(),
+            can_edit     : comment.can(comment.fields.id, constant('UPDATE')),
+            can_purge    : comment.can(comment.fields.id, constant('PURGE')),
             user         : users[comment.fields.users_id] ?? null,
         }, with_context = false) }}
     {% endfor %}

--- a/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
@@ -45,7 +45,7 @@
     {% endfor %}
 
     {# Reply button - visible on hover #}
-    <div class="kb-reply-trigger ms-5 mt-1 opacity-0" data-glpi-reply-trigger>
+    <div class="kb-reply-trigger ms-5 mt-1 opacity-0-hoverable" data-glpi-reply-trigger>
         <span
             role="button"
             class="text-muted px-2 py-1"

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -57,10 +57,38 @@ export class KnowbaseItemPage extends GlpiPage
         await response_promise;
     }
 
+    public async doOpenCommentsPanel(): Promise<void>
+    {
+        await this.page.getByTitle('More actions').click();
+        await this.getButton('Comments').click();
+    }
+
     public getCommentByContent(content: string): Locator
     {
         return this.page.getByText(content).filter({
             'visible': true,
         });
+    }
+
+    public getCommentsCounter(): Locator
+    {
+        return this.page.getByTestId('comments-counter');
+    }
+
+    public getNoCommentsMessage(): Locator
+    {
+        return this.page.getByText('No comments yet.');
+    }
+
+    public getComment(content: string): Locator
+    {
+        return this.page.getByTestId('comment').filter({
+            hasText: content
+        });
+    }
+
+    public getNewCommentTextarea(): Locator
+    {
+        return this.page.getByPlaceholder("Add a comment...");
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Thread are grouped visually:

<img width="468" height="811" alt="image" src="https://github.com/user-attachments/assets/ae2db5df-d2e2-44c8-8d13-9947e818f0ec" />

Reply form:
<img width="459" height="557" alt="image" src="https://github.com/user-attachments/assets/6b19b54d-b6d7-4b8a-ad8e-7845bda3f59c" />

As validated with Alexandre's, comments threads are now limited to a maximum of one parent (compared to GLPI 11 where thread had unlimited depth).

