### PR TITLE
[HLAPI] Add missing type in team member response

### DIFF
--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -2044,7 +2044,7 @@ EOT,
 
     /**
      * @param CommonITILObject $item
-     * @return array{role: string|int, name?: string, realname?: string, firstname?: string, display_name?: string, href: string}[]
+     * @return array{role: string|int, name?: string, realname?: string, firstname?: string, display_name?: string, href: string, type: string}[]
      */
     private static function getCleanTeam(CommonITILObject $item): array
     {
@@ -2063,6 +2063,7 @@ EOT,
             // Add a link to the full resource represented by the team member (User, Group, etc)
             $member['id'] = $member_items_id;
             $member['href'] = $member_itemtype::getFormURLWithID($member_items_id);
+            $member['type'] = $member_itemtype;
             // Replace role with non-localized textual representation
             try {
                 $member['role'] = self::getRoleName($member['role']);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Still needs reworked at some point, but a short-term fix is to add the "type" property to the team member response which exists in the official schema but was never set.
The only way previously to differentiate the team member types was by the href/form URL (also not very useful for API consumers).
