### PR TITLE
fix Certificate management throws an error

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -553,7 +553,7 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
             if ($before = Entity::getUsedConfig('send_certificates_alert_before_delay', $_SESSION['glpiactive_entity'])) {
                 if ($this->fields['date_expiration'] < date('Y-m-d')) {
                     $class = 'expired';
-                } elseif ($this->fields['date_expiration'] < date('Y-m-d', strtotime("+ $before days"))) {
+                } elseif ($this->fields['date_expiration'] < date('Y-m-d', strtotime("+$before days"))) {
                     $class = 'soon_expired';
                 } else {
                     $class = "not_expired";

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6402,7 +6402,7 @@ final class SQLProvider implements SearchProviderInterface
                         $before = Entity::getUsedConfig('send_certificates_alert_before_delay', $_SESSION['glpiactive_entity']);
                         $color = ($date < $_SESSION['glpi_currenttime']) ? '#cf9b9b' : null;
                         if ($before) {
-                            $before = date('Y-m-d', strtotime($_SESSION['glpi_currenttime'] . " + $before days"));
+                            $before = date('Y-m-d', strtotime($_SESSION['glpi_currenttime'] . "+$before days"));
                             $color = match (true) {
                                 $date < $_SESSION['glpi_currenttime'] => '#d63939',
                                 $date < $before => '#de5d06',


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #21916 
- After installing GLPI 11, our certificate management no longer works. When opening the page (front/certificate.php), I get the following error:

An unexpected error occurred
Return to previous page
An exception has been thrown during the rendering of a template ("An error occurred") in "pages/generic_list.html.twig" at line 37.
In ./templates/pages/generic_list.html.twig(37)
0 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
1 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
2 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
3 ./src/Glpi/Application/View/TemplateRenderer.php(170): Twig\TemplateWrapper->render()
4 ./src/Glpi/Controller/AbstractController.php(68): Glpi\Application\View\TemplateRenderer->render()
5 ./src/Glpi/Controller/GenericListController.php(51): Glpi\Controller\AbstractController->render()
6 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\GenericListController->__invoke()
7 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
8 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
9 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle()
10 {main}

Previous: An error occurred
In ./vendor/thecodingmachine/safe/generated/Exceptions/DatetimeException.php(9)
0 ./vendor/thecodingmachine/safe/generated/8.3/datetime.php(1215): Safe\Exceptions\DatetimeException::createFromPhpError()
1 ./src/Glpi/Search/Provider/SQLProvider.php(6386): Safe\strtotime()
2 ./src/Glpi/Search/Provider/SQLProvider.php(5219): Glpi\Search\Provider\SQLProvider::giveItem()
3 ./src/Glpi/Search/SearchEngine.php(655): Glpi\Search\Provider\SQLProvider::constructData()
4 ./src/Glpi/Search/SearchEngine.php(670): Glpi\Search\SearchEngine::getData()
5 ./src/Glpi/Search/SearchEngine.php(627): Glpi\Search\SearchEngine::showOutput()
6 [internal function]: Glpi\Search\SearchEngine::show()
7 ./src/Glpi/Application/View/Extension/PhpExtension.php(93): call_user_func_array()
8 /var/lib/glpi/_cache/11.0.2-52505ef9-production/templates/fe/fe46d70ce53b72576e15cbf75684b04a.php(55): Glpi\Application\View\Extension\PhpExtension->call()
9 ./vendor/twig/twig/src/Template.php(402): __TwigTemplate_bc928cfd99306e9547d49a1826a7b368->doDisplay()
10 ./vendor/twig/twig/src/Template.php(358): Twig\Template->yield()
11 ./vendor/twig/twig/src/Template.php(373): Twig\Template->display()
12 ./vendor/twig/twig/src/TemplateWrapper.php(51): Twig\Template->render()
13 ./src/Glpi/Application/View/TemplateRenderer.php(170): Twig\TemplateWrapper->render()
14 ./src/Glpi/Controller/AbstractController.php(68): Glpi\Application\View\TemplateRenderer->render()
15 ./src/Glpi/Controller/GenericListController.php(51): Glpi\Controller\AbstractController->render()
16 ./vendor/symfony/http-kernel/HttpKernel.php(181): Glpi\Controller\GenericListController->__invoke()
17 ./vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
18 ./vendor/symfony/http-kernel/Kernel.php(197): Symfony\Component\HttpKernel\HttpKernel->handle()
19 ./public/index.php(70): Symfony\Component\HttpKernel\Kernel->handle()
20 {main}

this error may occur in certificate page due to the use of spaces in strtotime() function in Certificate.php