### PR TITLE
fix: Generated message id for plugin could trigger an error with RFC 2822

### DIFF
--- a/phpunit/functional/NotificationTargetTest.php
+++ b/phpunit/functional/NotificationTargetTest.php
@@ -489,7 +489,7 @@ class NotificationTargetTest extends DbTestCase
                 "itemtype" => "Glpi\\Socket",
                 "items_id" => 3,
                 "event" => "new",
-                "expected" => "/^GLPI_%UUID%-GlpiSocket-3\/new@%UNAME%$/",
+                "expected" => "/^GLPI_%UUID%-Glpi-Socket-3\/new@%UNAME%$/",
             ],
         ];
     }

--- a/phpunit/functional/NotificationTargetTest.php
+++ b/phpunit/functional/NotificationTargetTest.php
@@ -483,6 +483,14 @@ class NotificationTargetTest extends DbTestCase
                 "event" => null,
                 "expected" => "/^GLPI_%UUID%\/none\.\d+\.\d+@%UNAME%$/",
             ],
+            [
+                // namespaced itemtype (real GLPI class) - validates RFC 2822 fix
+                // backslashes from namespace must be stripped from message ID
+                "itemtype" => "Glpi\\Socket",
+                "items_id" => 3,
+                "event" => "new",
+                "expected" => "/^GLPI_%UUID%-GlpiSocket-3\/new@%UNAME%$/",
+            ],
         ];
     }
 
@@ -513,5 +521,8 @@ class NotificationTargetTest extends DbTestCase
         $instance = new \NotificationTarget();
         $messageid = $instance->getMessageIdForEvent($itemtype, $items_id, $event);
         $this->assertMatchesRegularExpression($expected, $messageid);
+
+        // Ensure the message ID never contains backslashes (RFC 2822 compliance)
+        $this->assertStringNotContainsString('\\', $messageid, 'Message ID must not contain backslashes to comply with RFC 2822 addr-spec');
     }
 }

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -293,7 +293,7 @@ class NotificationTarget extends CommonDBChild
 
         $reference_event = null;
         if ($is_item_related) {
-            $message_id .= sprintf('-%s-%d', str_replace(['\\', '/'], '', $itemtype), $items_id);
+            $message_id .= sprintf('-%s-%d', str_replace(['\\', '/'], '-', $itemtype), $items_id);
             $reference_event = $itemtype::getMessageReferenceEvent($event);
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -293,7 +293,7 @@ class NotificationTarget extends CommonDBChild
 
         $reference_event = null;
         if ($is_item_related) {
-            $message_id .= sprintf('-%s-%d', str_replace('\\', '', $itemtype), $items_id);
+            $message_id .= sprintf('-%s-%d', str_replace(['\\', '/'], '', $itemtype), $items_id);
             $reference_event = $itemtype::getMessageReferenceEvent($event);
         }
 

--- a/src/NotificationTarget.php
+++ b/src/NotificationTarget.php
@@ -293,7 +293,7 @@ class NotificationTarget extends CommonDBChild
 
         $reference_event = null;
         if ($is_item_related) {
-            $message_id .= sprintf('-%s-%d', $itemtype, $items_id);
+            $message_id .= sprintf('-%s-%d', str_replace('\\', '', $itemtype), $items_id);
             $reference_event = $itemtype::getMessageReferenceEvent($event);
         }
 


### PR DESCRIPTION
Generated message id for plugin could trigger an error `does not comply with addr-spec of RFC 2822` caused by itemtype having full-namespace and having so `\`.

This issue was reported on GLPI 11, but his also present on 10.x so fixing it here.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Exception 

```
Attention : un mail n'a pas pu être délivré à xxxxxxxx. 10 tentatives restantes. 
Message : [GLPI] Une ressource a été déclarée partante -  xxxxxxx, 
Erreur : Email "GLPI_oU3H1UJFnYsUSUZKr7erCDcmc1MKSbMTlpio639d-GlpiPlugin\MyPlugin\MyResource/LeavingResource.1770293282.671121134@va-glpi" does not comply with addr-spec of RFC 2822.
```