### PR TITLE
Fix - Preserve original image quality for email attachments

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -504,12 +504,6 @@ class NotificationEventMailing extends NotificationEventAbstract
                 continue;
             }
             $path = GLPI_DOC_DIR . "/" . $document->fields['filepath'];
-            if (Document::isImage($path)) {
-                $path = Document::getImage(
-                    $path,
-                    'mail'
-                );
-            }
 
             $encoding = PHPMailer::ENCODING_BASE64;
             $mime = mime_content_type($path);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41933
- Here is a brief description of what this PR does

When images are attached to ticket notifications (via "Add documents into ticket notifications" option), they are resized to 400x300px, resulting in blurry images for email recipients.

### Changes
- Remove automatic image resizing for email attachments in `NotificationEventMailing::attachDocuments()`
- Images attached to emails now preserve their original quality
- Inline/embedded images remain resized to avoid bloating email body size