### PR TITLE
[UX] Fix missing icon in Reservation view

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -426,7 +426,7 @@ TWIG, $twig_params);
             {% if not reserve %}
                 <div id="makesearch" class="text-center mb-3">
                     <a class="btn btn-secondary" href="{{ path('front/reservation.php?reservationitems_id=0') }}">
-                        <i class="{{ 'Planning'|itemtype_icon }} me-2"></i>{{ view_calendar_label }}
+                        <i class="{{ 'Reservation'|itemtype_icon }} me-2"></i>{{ view_calendar_label }}
                     </a>
                     <button type="button" class="btn btn-secondary mw-100 d-inline-block text-truncate" onClick="$('#viewresasearch').toggleClass('d-none');$('#makesearch').toggleClass('d-none')">
                         <i class="ti ti-search me-2"></i>{{ find_free_item_label }}
@@ -639,7 +639,7 @@ TWIG, $twig_params);
                 }
                 $cal_href = htmlescape(Reservation::getSearchURL() . "?reservationitems_id=" . $row['id']);
                 $entry['calendar'] = "<a href='$cal_href'>";
-                $entry['calendar'] .= "<i class='" . htmlescape(Planning::getIcon()) . " fa-2x cursor-pointer' title=\"" . __s("Reserve this item") . "\"></i>";
+                $entry['calendar'] .= "<i class='" . htmlescape(Reservation::getIcon()) . " fa-2x cursor-pointer' title=\"" . __s("Reserve this item") . "\"></i>";
 
                 $ok = true;
                 $entries[] = $entry;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does: 

This PR fixes a display issue where the icon for the "View calendar" button was missing in the Reservation view (``front/reservation.php``).

Previously, the template used ``{{ 'Planning'|itemtype_icon }}``, which resulted in an empty class string (``<i class=" me-2"></i>``) because the Planning class does not register an icon via the standard ``itemtype_icon`` filter.

In GLPI, the ``|itemtype_icon`` filter is designed for **Assets** (Computers, Monitors) and **ITIL Objects** (Tickets, Changes). The "Planning" screen is a **View** (a UI concept), not an object stored in the database. Therefore, the ``Planning`` class does not register an icon in the way the filter expects.

Current Twig code:

https://github.com/glpi-project/glpi/blob/dbc387ab4abce37da2e73397f5ae0b9ac0bf93b6/src/ReservationItem.php#L425-L437

Current HTML output:

```html
                <div id="makesearch" class="text-center mb-3">
                    <a class="btn btn-secondary" href="/front/reservation.php?reservationitems_id=0">
                        <i class=" me-2"></i>View the calendar to see all items
                    </a>
                    <button type="button" class="btn btn-secondary mw-100 d-inline-block text-truncate" onclick="$('#viewresasearch').toggleClass('d-none');$('#makesearch').toggleClass('d-none')">
                        <i class="ti ti-search me-2"></i>Find a free item in a specific period
                    </button>
                </div>
```

Switched the ItemType to Reservation to correctly pull the associated system icon.

How to test:

1. Navigate to **Tools > Reservations**.
2. Observe the button "View the calendar to see all items" (or similar label depending on translation).
3. Verify that the Calendar icon is now visible next to the text.

## Screenshots (if appropriate):

Before this PR:

<img width="1075" height="167" alt="image" src="https://github.com/user-attachments/assets/f863a3d5-350e-4635-a633-d338de83ee2b" />

After this PR:

<img width="1081" height="182" alt="image" src="https://github.com/user-attachments/assets/484319f3-1e10-4bfa-a0b1-3cb0cc4fd0a5" />
