### PR TITLE
Fix(Inventory): Do not handle lock on add

### DIFF
--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -1054,30 +1054,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc002</NAME>
     </HARDWARE>
@@ -1114,30 +1090,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc_with_other_name</NAME>
     </HARDWARE>
@@ -1201,30 +1153,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc002</NAME>
     </HARDWARE>
@@ -1275,30 +1203,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc002</NAME>
     </HARDWARE>
@@ -1389,30 +1293,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc002</NAME>
     </HARDWARE>

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -1034,7 +1034,7 @@ class LockedfieldTest extends DbTestCase
         $this->assertTrue($networkEquipment->getFromDB($networkEquipmentId), 'Network equipment item could not be retrieved from the database.');
 
         // Assert that the network equipment type is set to 0 (because of locked field)
-        $this->assertEquals(0, $networkEquipment->fields['networkequipmenttypes_id'], 'Network equipment type should be 0 before applying the global locked field.');
+        $this->assertGreaterThan(0, $networkEquipment->fields['networkequipmenttypes_id'], 'Network equipment type should be greater than 0 on first creation');
     }
 
 

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -1327,7 +1327,7 @@ class LockedfieldTest extends DbTestCase
         $this->assertGreaterThan(0, $computers_id);
 
         $this->assertTrue($computer->getFromDB($computers_id));
-        // check that name is always the one set manually
+        // check that name is the one defined by inventory
         $this->assertEquals('pc002', $computer->fields['name']);
 
     }
@@ -1336,7 +1336,7 @@ class LockedfieldTest extends DbTestCase
     {
         $computer = new Computer();
 
-        //create global lock on Computer Name
+        //create global lock on Computer Manufacturer
         $lockedfield = new \Lockedfield();
         $this->assertGreaterThan(
             0,
@@ -1348,30 +1348,6 @@ class LockedfieldTest extends DbTestCase
         $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
-    <OPERATINGSYSTEM>
-      <ARCH>x86_64</ARCH>
-      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
-      <FQDN>test-pc002</FQDN>
-      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
-      <HOSTID>a8c07701</HOSTID>
-      <KERNEL_NAME>linux</KERNEL_NAME>
-      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
-      <NAME>Fedora</NAME>
-      <TIMEZONE>
-        <NAME>CEST</NAME>
-        <OFFSET>+0200</OFFSET>
-      </TIMEZONE>
-      <VERSION>28 (Workstation Edition)</VERSION>
-    </OPERATINGSYSTEM>
-    <ANTIVIRUS>
-      <COMPANY>Microsoft Corporation</COMPANY>
-      <ENABLED>1</ENABLED>
-      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
-      <NAME>Microsoft Security Essentials</NAME>
-      <UPTODATE>1</UPTODATE>
-      <VERSION>4.3.216.0</VERSION>
-      <EXPIRATION>01/04/2019</EXPIRATION>
-    </ANTIVIRUS>
     <HARDWARE>
       <NAME>pc002</NAME>
     </HARDWARE>
@@ -1410,7 +1386,7 @@ class LockedfieldTest extends DbTestCase
 
 
         // rerun inventory and change Manufacturer
-$xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
     <OPERATINGSYSTEM>

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -1038,10 +1038,8 @@ class LockedfieldTest extends DbTestCase
     }
 
 
-    public function testglobalLockOnAddSaveValue()
+    public function testglobalLockOnAddFromInventory()
     {
-        global $DB;
-
         //create global lock on Computer Name
         $lockedfield = new \Lockedfield();
         $this->assertGreaterThan(
@@ -1107,7 +1105,154 @@ class LockedfieldTest extends DbTestCase
 
         $computer = new \Computer();
         $this->assertTrue($computer->getFromDB($computers_id));
-        $this->assertEquals('>pc002', $computer->fields['name']);
+        // check that name is the one defined in inventory file on create
+        $this->assertEquals('pc002', $computer->fields['name']);
+
+        // rerun inventory with different name
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc_with_other_name</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $computer = new \Computer();
+        $this->assertTrue($computer->getFromDB($computers_id));
+        // check that name is the one defined in inventory file on create
+        $this->assertEquals('pc002', $computer->fields['name']);
+    }
+
+    public function testglobalLockOnAddFromManualthenInventory()
+    {
+        global $DB;
+
+        //create global lock on Computer Name
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'item' => 'Computer - name',
+            ])
+        );
+
+        // create computer manually
+        $computer = new \Computer();
+        $cid = (int) $computer->add([
+            'name'         => 'Computer_create_manually',
+            'serial'       => 'ggheb7ne7',
+            'entities_id'  => 0,
+            'is_dynamic'   => 1,
+        ]);
+
+        $this->assertGreaterThan(0, $cid);
+
+        $this->assertTrue($computer->getFromDB($cid));
+        $this->assertEquals('Computer_create_manually', $computer->fields['name']);
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $this->assertTrue($computer->getFromDB($computers_id));
+        // check that name is always the one set manually
+        $this->assertEquals('Computer_create_manually', $computer->fields['name']);
 
     }
 

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -1037,4 +1037,78 @@ class LockedfieldTest extends DbTestCase
         $this->assertEquals(0, $networkEquipment->fields['networkequipmenttypes_id'], 'Network equipment type should be 0 before applying the global locked field.');
     }
 
+
+    public function testglobalLockOnAddSaveValue()
+    {
+        global $DB;
+
+        //create global lock on Computer Name
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'item' => 'Computer - name',
+            ])
+        );
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $computer = new \Computer();
+        $this->assertTrue($computer->getFromDB($computers_id));
+        $this->assertEquals('>pc002', $computer->fields['name']);
+
+    }
+
 }

--- a/phpunit/functional/LockedfieldTest.php
+++ b/phpunit/functional/LockedfieldTest.php
@@ -34,8 +34,10 @@
 
 namespace tests\units;
 
+use Computer;
 use DbTestCase;
 use Location;
+use Manufacturer;
 
 /* Test for inc/savedsearch.class.php */
 
@@ -1254,6 +1256,221 @@ class LockedfieldTest extends DbTestCase
         // check that name is always the one set manually
         $this->assertEquals('Computer_create_manually', $computer->fields['name']);
 
+    }
+
+
+    public function testglobalLockOnInputTextAddInventory()
+    {
+        $computer = new Computer();
+
+        //create global lock on Computer Name
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'item' => 'Computer - name',
+            ])
+        );
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $this->assertTrue($computer->getFromDB($computers_id));
+        // check that name is always the one set manually
+        $this->assertEquals('pc002', $computer->fields['name']);
+
+    }
+
+    public function testglobalLockOnForeignKeyTextAddInventory()
+    {
+        $computer = new Computer();
+
+        //create global lock on Computer Name
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'item' => 'Computer - manufacturers_id',
+            ])
+        );
+
+        $xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <BMANUFACTURER>Intel</BMANUFACTURER>,
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $this->assertTrue($computer->getFromDB($computers_id));
+
+        $manufacturer = new Manufacturer();
+        $this->assertTrue($manufacturer->getFromDB($computer->fields['manufacturers_id']));
+
+        $this->assertEquals('Intel', $manufacturer->fields['name']);
+
+
+        // rerun inventory and change Manufacturer
+$xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <BOOT_TIME>2018-10-02 08:56:09</BOOT_TIME>
+      <FQDN>test-pc002</FQDN>
+      <FULL_NAME>Fedora 28 (Workstation Edition)</FULL_NAME>
+      <HOSTID>a8c07701</HOSTID>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>4.18.9-200.fc28.x86_64</KERNEL_VERSION>
+      <NAME>Fedora</NAME>
+      <TIMEZONE>
+        <NAME>CEST</NAME>
+        <OFFSET>+0200</OFFSET>
+      </TIMEZONE>
+      <VERSION>28 (Workstation Edition)</VERSION>
+    </OPERATINGSYSTEM>
+    <ANTIVIRUS>
+      <COMPANY>Microsoft Corporation</COMPANY>
+      <ENABLED>1</ENABLED>
+      <GUID>{641105E6-77ED-3F35-A304-765193BCB75F}</GUID>
+      <NAME>Microsoft Security Essentials</NAME>
+      <UPTODATE>1</UPTODATE>
+      <VERSION>4.3.216.0</VERSION>
+      <EXPIRATION>01/04/2019</EXPIRATION>
+    </ANTIVIRUS>
+    <HARDWARE>
+      <NAME>pc002</NAME>
+    </HARDWARE>
+    <BIOS>
+      <BMANUFACTURER>Nvidia</BMANUFACTURER>,
+      <SSN>ggheb7ne7</SSN>
+    </BIOS>
+    <VERSIONCLIENT>FusionInventory-Agent_v2.3.19</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc002</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $converter = new \Glpi\Inventory\Converter();
+        $data = $converter->convert($xml);
+        $json = json_decode($data);
+
+        $inventory = new \Glpi\Inventory\Inventory($json);
+
+        if ($inventory->inError()) {
+            $this->dump($inventory->getErrors());
+        }
+
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $computers_id = $inventory->getItem()->fields['id'];
+        $this->assertGreaterThan(0, $computers_id);
+
+        $this->assertTrue($computer->getFromDB($computers_id));
+
+        $manufacturer = new Manufacturer();
+        $this->assertTrue($manufacturer->getFromDB($computer->fields['manufacturers_id']));
+        $this->assertEquals('Intel', $manufacturer->fields['name']);
     }
 
 }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1327,7 +1327,7 @@ class CommonDBTM extends CommonGLPI
                     ($key[0] != '_')
                     && isset($table_fields[$key])
                 ) {
-                    $this->fields[$key] = $this->input['_raw' . $key] ?? $this->input[$key];
+                    $this->fields[$key] = $this->input[$key];
                 }
             }
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -234,9 +234,9 @@ abstract class InventoryAsset
                 //keep raw values...
                 $this->raw_links[$known_key] = $val;
 
-                //do not process field if it's locked
+                //do not process field if it's locked and from update process
                 foreach ($locks as $lock) {
-                    if ($key == $lock) {
+                    if ($key == $lock && !$this->item->isNewItem()) {
                         continue 2;
                     }
                 }
@@ -477,9 +477,9 @@ abstract class InventoryAsset
         $input = ['_auto' => 1];
         $locks = [];
 
-        if ($item !== null && !$item->isNewItem()) {
+        if ($item !== null) {
             $lockeds = new \Lockedfield();
-            $locks = $lockeds->getLockedNames($item->getType(), $item->fields['id']);
+            $locks = $lockeds->getLockedNames($item->getType(), $item->isNewItem() ? 0 : $item->fields['id']);
         }
 
         foreach ($value as $key => $val) {
@@ -497,15 +497,13 @@ abstract class InventoryAsset
                         // This is because locked fields are no longer processed or sanitized during the addition process.
                         // For more details, see: https://github.com/glpi-project/glpi/pull/19426
                         $input[$key] = $this->raw_links[$known_key];
+                    } else {
+                        $input[$key] = $val;
                     }
                 }
             } elseif (isset($this->known_links[$known_key])) {
                 $input[$key] = $this->known_links[$known_key];
             } else {
-                // if it a foreygn ket field and is not an int
-                if (isForeignKeyField($key) && !is_int($val)) {
-                    continue;
-                }
                 $input[$key] = $val;
             }
         }
@@ -514,7 +512,6 @@ abstract class InventoryAsset
             // Pass the tag that can be used in rules criteria
             $input['_tag'] = $this->agent->fields['tag'];
         }
-
         return $input;
     }
 

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -477,7 +477,7 @@ abstract class InventoryAsset
         $input = ['_auto' => 1];
         $locks = [];
 
-        if ($item !== null) {
+        if ($item !== null && !$item->isNewItem()) {
             $lockeds = new \Lockedfield();
             $locks = $lockeds->getLockedNames($item->getType(), $item->isNewItem() ? 0 : $item->fields['id']);
         }

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -502,6 +502,10 @@ abstract class InventoryAsset
             } elseif (isset($this->known_links[$known_key])) {
                 $input[$key] = $this->known_links[$known_key];
             } else {
+                // if it a foreygn ket field and is not an int
+                if (isForeignKeyField($key) && !is_int($val)) {
+                    continue;
+                }
                 $input[$key] = $val;
             }
         }

--- a/src/Inventory/Asset/InventoryAsset.php
+++ b/src/Inventory/Asset/InventoryAsset.php
@@ -479,7 +479,7 @@ abstract class InventoryAsset
 
         if ($item !== null && !$item->isNewItem()) {
             $lockeds = new \Lockedfield();
-            $locks = $lockeds->getLockedNames($item->getType(), $item->isNewItem() ? 0 : $item->fields['id']);
+            $locks = $lockeds->getLockedNames($item->getType(), $item->fields['id']);
         }
 
         foreach ($value as $key => $val) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This is an additional fix related to [https://github.com/glpi-project/glpi/pull/19426](https://github.com/glpi-project/glpi/pull/19426), as the previous change is not sufficient.

When a PC is created by the dynamic inventory with a global lock on the name field, the name field is empty at creation time.

This should not happen.

At creation, the PC should take the name provided by the inventory and then keep it unchanged during subsequent updates.

## Screenshots (if appropriate):


