### PR TITLE
Fix(System info): improve readability

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1645,7 +1645,7 @@ class Plugin extends CommonDBTM
         $content = '';
 
         $plug     = new Plugin();
-        $pluglist = $plug->find([], "name, directory");
+        $pluglist = $plug->find([], "state, name, directory");
         foreach ($pluglist as $plugin) {
             $name = Toolbox::stripTags($plugin['name']);
             $version = Toolbox::stripTags($plugin['version']);
@@ -1656,7 +1656,7 @@ class Plugin extends CommonDBTM
 
             $msg  = substr(str_pad($plugin['directory'], 30), 0, 20)
                  . " Name: " . Toolbox::substr(str_pad($name, 40), 0, 30)
-                 . " Version: " . str_pad($version, 10)
+                 . " Version: " . str_pad($version, 12)
                  . " State: " . str_pad($state, 40)
                  . " Install Method: " . $install_method;
             $content .= "\n" . $msg;

--- a/templates/pages/setup/general/systeminfo_table.html.twig
+++ b/templates/pages/setup/general/systeminfo_table.html.twig
@@ -45,7 +45,7 @@
 
 {% macro sysinfo_section(label, content, raw = false, raw_precontent = '') %}
    {% set rand = random() %}
-   {% set cleaned_content = content|trim|u.wordwrap(128) %}
+   {% set cleaned_content = content|trim %}
    <div class="accordion-item">
       <div class="accordion-header section-header" id="sysinfo_header_{{ rand }}">
          <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#sysinfo_section_{{ rand }}">{{ label }}</button>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

Improve the readability of "Information about system installation and configuration" (Setup > General: System)
- Added sorting by status for plugins, to make it easier to see which ones are active
- Removal of word wrap

## Screenshots (if appropriate):

Before:
<img width="1380" height="875" alt="image" src="https://github.com/user-attachments/assets/9f4bb89f-dc79-495a-8779-069e6c99e7b1" />

<img width="1379" height="851" alt="image" src="https://github.com/user-attachments/assets/f6fefc0e-0991-4c53-8140-26d73f14d76e" />


After:
<img width="1380" height="875" alt="image" src="https://github.com/user-attachments/assets/bebe2906-c3d3-4c78-87b4-c016ccef1d71" />

<img width="1379" height="851" alt="image" src="https://github.com/user-attachments/assets/46e32e96-d684-406b-9f0f-a7479d5a5b51" />

