### PR TITLE
Fix incorrect custom icons size

### DIFF
--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -108,3 +108,7 @@
 .min-width-200 {
     min-width: 200px;
 }
+
+.max-width-unset {
+    max-width: unset !important;
+}

--- a/templates/components/illustration/custom_icon.html.twig
+++ b/templates/components/illustration/custom_icon.html.twig
@@ -36,5 +36,5 @@
     {% endif %}
     width="{{ width }}"
     height="{{ height }}"
-    class="align-self-start"
+    class="align-self-start max-width-unset"
 />


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

Before:

<img width="1369" height="418" alt="image" src="https://github.com/user-attachments/assets/4abc3920-86d7-46c7-b246-0d3ce3f29998" />

After:
<img width="1318" height="383" alt="image" src="https://github.com/user-attachments/assets/dbe0c7bf-a943-4624-9e5d-2b0601796cb2" />



