### PR TITLE
Fix an error when importing an object with a location when global lock is enabled on it

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1365,7 +1365,7 @@ class CommonDBTM extends CommonGLPI
                     ($key[0] !== '_')
                     && isset($table_fields[$key])
                 ) {
-                    $this->fields[$key] = $this->input['_raw' . $key] ?? $this->input[$key];
+                    $this->fields[$key] = $this->input[$key];
                 }
             }
 

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -284,14 +284,16 @@ abstract class InventoryAsset
                             getItemtypeForForeignKeyField($key),
                             $value->$key,
                             $entities_id,
-                            ['manufacturer' => $manufacturer_name]
+                            ['manufacturer' => $manufacturer_name],
+                            '',
+                            !isset($is_locked[$key])
                         );
                         if ($new_id < 0) { //importExternal can return -1
                             $new_id = 0;
                         }
                         $this->known_links[$known_key] = $new_id;
                     } elseif (isset($foreignkey_itemtype[$key])) {
-                        $new_id = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id);
+                        $new_id = Dropdown::importExternal($foreignkey_itemtype[$key], $value->$key, $entities_id, [], '', !isset($is_locked[$key]));
                         if ($new_id < 0) { //importExternal can return -1
                             $new_id = 0;
                         }
@@ -302,7 +304,10 @@ abstract class InventoryAsset
                         $new_id = Dropdown::importExternal(
                             $foreignkey_itemtype[$key],
                             $value->$key,
-                            $entities_id
+                            $entities_id,
+                            [],
+                            '',
+                            !isset($is_locked[$key])
                         );
                         if ($new_id < 0) { //importExternal can return -1
                             $new_id = 0;

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -244,9 +244,11 @@ abstract class InventoryAsset
                 $this->raw_links[$known_key] = $val;
 
                 //do not process field if it's locked
-                if ($this->item->isNewItem()) {
-                    foreach ($locks as $lock) {
-                        if ($key == $lock) {
+                foreach ($locks as $lock) {
+                    if ($key == $lock) {
+                        if ($this->item->isNewItem()) {
+                            $is_locked[$key] = true;
+                        } else {
                             continue 2;
                         }
                     }
@@ -270,7 +272,7 @@ abstract class InventoryAsset
                 if (!isset($this->known_links[$known_key]) && $value->$key !== 0) {
                     $entities_id = $this->entities_id;
                     if ($key == "locations_id") {
-                        $new_id = Dropdown::importExternal('Location', $value->$key, $entities_id);
+                        $new_id = Dropdown::importExternal('Location', $value->$key, $entities_id, [], '', !isset($is_locked[$key]));
                         if ($new_id < 0) { //importExternal can return -1
                             $new_id = 0;
                         }
@@ -523,6 +525,7 @@ abstract class InventoryAsset
                 if (isset($this->raw_links[$known_key])) {
                     if (isset($this->known_links[$known_key])) {
                         $input[$key] = $this->known_links[$known_key];
+                        $input['_raw' . $key] = $this->raw_links[$known_key];
                     } elseif (!$item->isNewItem()) {
                         // If $item is new and the input key is locked, we do not want to set it using the raw value.
                         // This is because locked fields are no longer processed or sanitized during the addition process.

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -244,9 +244,11 @@ abstract class InventoryAsset
                 $this->raw_links[$known_key] = $val;
 
                 //do not process field if it's locked
-                foreach ($locks as $lock) {
-                    if ($key == $lock) {
-                        continue 2;
+                if ($this->item->isNewItem()) {
+                    foreach ($locks as $lock) {
+                        if ($key == $lock) {
+                            continue 2;
+                        }
                     }
                 }
 
@@ -521,7 +523,6 @@ abstract class InventoryAsset
                 if (isset($this->raw_links[$known_key])) {
                     if (isset($this->known_links[$known_key])) {
                         $input[$key] = $this->known_links[$known_key];
-                        $input['_raw' . $key] = $this->raw_links[$known_key];
                     } elseif (!$item->isNewItem()) {
                         // If $item is new and the input key is locked, we do not want to set it using the raw value.
                         // This is because locked fields are no longer processed or sanitized during the addition process.


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41876 and #23065
- Here is a brief description of what this PR does
Fixed an error when importing the location of an object when global locking is enabled on it. The problem only occurred when adding a new item, particularly because it did not yet have a value.

## Screenshots (if appropriate):
<img width="1346" height="121" alt="image" src="https://github.com/user-attachments/assets/b2737080-1e79-410f-9fe9-6aad1f6b510d" />


