### PR TITLE
Fix vertical tabs styling (double borders)

### DIFF
--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -68,20 +68,23 @@
 
     &.vertical {
         .nav:not(.nav-underline) {
-            .nav-link {
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-                border-top-right-radius: 0;
-    
-                /* Remove bottom border only from last visible link */
-                &:last-of-type {
-                    border-bottom: 0;
+            .nav-item {
+                .nav-link {
+                    border-bottom: 1px solid var(--glpi-tabs-border-color);
+                    border-top-right-radius: 0;
                 }
     
-                &.active {
-                    border-left-width: 5px;
-                    border-right-color: transparent !important;
-                    margin-right: -1px;
+                &:last-child {
+                    .nav-link {
+                        border-bottom: 0;
+                    }
                 }
+            }
+    
+            .nav-link.active {
+                border-left-width: 5px;
+                border-right-color: transparent !important;
+                margin-right: -1px; // keep overlap hack
             }
         }
     }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -69,20 +69,27 @@
     &.vertical {
             #tabspanel.nav-tabs {
                 .nav-link {
-                    /* 1. FORCE the bottom border to be visible on all items */
+                    /* 1. VISIBILITY: Force borders to show and prevent overlapping */
                     border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                    margin-bottom: 0 !important; /* Replaces your commented-out line safely */
     
-                    /* 2. REMOVE the top border to prevent the "double line" issue */
+                    /* 2. LAYOUT: Remove top border to prevent double-thickness */
                     border-top: 0 !important;
     
-                    /* 3. Do NOT touch border-left or border-right. 
-                       This preserves your blue active indicator and default box layout. */
+                    /* 3. CORNER FIX: Remove the strange radius you see on the right */
+                    border-top-right-radius: 0 !important;
+                    border-bottom-right-radius: 0 !important;
                 }
     
-                /* 4. EXCEPTION: The first tab needs a top border to close the container */
+                /* 4. FIRST ITEM: Needs a top border to close the list */
                 .nav-item:first-child .nav-link {
                     border-top: 1px solid var(--glpi-tabs-border-color) !important;
-                    border-top-left-radius: 4px; /* Matches default bootstrap radius */
+                    border-top-left-radius: 4px; /* Optional: Keep top-left rounded */
+                }
+                
+                /* 5. LAST ITEM: Ensure the very bottom-right corner is square (optional safety) */
+                 .nav-item:last-child .nav-link {
+                    border-bottom-right-radius: 0 !important;
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -36,57 +36,23 @@
 }
 
 .card-tabs {
-    /* 1. Main Container Border */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
-    /* 2. Vertical Tabs Layout */
     #tabspanel.nav-tabs {
-        border-bottom: 0; 
-        gap: 0; 
-
-        /* Kill all spacing on the list items */
-        .nav-item {
-            border: 0 !important;
-            margin: 0 !important;
-            padding: 0 !important;
-        }
-
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-
-            /* FIX: Strictly set Top/Left/Right borders to 0 width */
-            border-top: 0 !important;
-            border-left: 0 !important;
-            border-right: 0 !important;
-            
-            /* Add the ONE true separator line */
-            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-            
-            /* Remove negative margin - let them stack naturally */
-            margin-bottom: 0 !important;
-            border-radius: 0 !important;
+            border: 1px solid var(--glpi-tabs-border-color);
+            border-right-width: 0;
+            border-radius: 0;
 
             &.active {
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
+                border-color: var(--glpi-tabs-active-border-color);
                 font-weight: bold;
-
-                /* Active Borders */
-                /* 1. Left Accent */
-                border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
-                
-                /* 2. Bottom Separator (Matches the list) */
-                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                
-                /* 3. Open to the right */
-                border-right: 1px solid transparent !important;
-                margin-right: -1px !important; 
-
-                /* 4. Ensure no Top border leaks in */
-                border-top: 0 !important;
 
                 .badge {
                     font-weight: bold;
@@ -97,28 +63,41 @@
                 margin-left: 5px;
             }
         }
+    }
 
-        /* Cleanup: Remove border from the very last tab */
-        .nav-item:last-child .nav-link {
-            border-bottom: 0 !important;
+    &.vertical {
+        .nav:not(.nav-underline) {
+            .nav-link {
+                border-bottom: 0;
+                border-top-right-radius: 0;
+
+                & + .nav-link {
+                    border-top: 1px solid var(--glpi-tabs-border-color);
+                }
+
+                &.active {
+                    border-left-width: 5px;
+                    border-right-color: transparent !important;
+                }
+            }
         }
     }
 
-    /* 3. Horizontal View Specifics (Legacy/Desktop) */
     &.horizontal {
         #tabspanel.nav-tabs {
-            border-bottom: 1px solid var(--glpi-tabs-border-color);
-
             .nav-link {
-                margin-bottom: -1px;
-                border: 1px solid transparent;
-                border-bottom: 0;
-                border-left: 1px solid var(--glpi-tabs-border-color);
+                border-bottom-width: 1px;
+                border-bottom-style: solid;
+
+                &:last-of-type {
+                    border-right-width: 1px;
+
+                    &.active {
+                        border-right-color: var(--glpi-tabs-border-color) !important;
+                    }
+                }
 
                 &.active {
-                    background: #fff;
-                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff;
-                    border-left-width: 1px;
                     border-bottom-color: transparent !important;
                 }
             }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -36,83 +36,79 @@
 }
 
 .card-tabs {
-    /* 1. Main Divider: Keep the right border on the UL container */
+    /* 1. APPLY THE FULL FRAME TO THE CONTAINER */
+    /* This fixes the "missing top and left border" issue */
     #tabspanel {
-        border-right: 1px solid var(--glpi-tabs-border-color);
+        border: 1px solid var(--glpi-tabs-border-color);
+        border-radius: var(--tblr-border-radius, 4px);
     }
 
-    /* 2. Reset Default Bootstrap Tabs styles */
+    /* Reset Bootstrap defaults */
     #tabspanel.nav-tabs {
-        border-bottom: 0; 
-        
+        border-bottom: 0;
         .nav-link {
             border-right-width: 0;
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-
-            /* Badge alignment */
             .badge { margin-left: 5px; }
         }
     }
 
-    /* 3. VERTICAL LAYOUT FIXES */
     &.vertical {
         .nav:not(.nav-underline) {
             
-            /* Ensure items don't have extra padding disrupting the flow */
             .nav-item {
                 margin: 0;
+
+                /* 2. ROUNDED CORNERS MANAGEMENT */
+                /* Force the first item to fit the container's top-left radius */
+                &:first-child .nav-link {
+                    border-top-left-radius: var(--tblr-border-radius, 4px);
+                }
+                /* Force the last item to fit the container's bottom-left radius */
+                &:last-child .nav-link {
+                    border-bottom-left-radius: var(--tblr-border-radius, 4px);
+                    /* 3. REMOVE LAST SEPARATOR */
+                    /* Prevent double border at the bottom of the list */
+                    border-bottom: 0;
+                }
             }
 
             .nav-link {
-                /* A. RESTORE SEPARATORS: Give every link a bottom border */
-                border: 1px solid transparent; /* Reset everything first */
+                /* 4. DEFINE THE SEPARATORS */
+                /* Give every item a bottom border by default (fixes "missing border") */
+                border: 0; 
                 border-bottom: 1px solid var(--glpi-tabs-border-color);
-                
-                /* Reset radius for the list look */
-                border-radius: 0;
+                border-radius: 0; /* Square by default */
                 
                 /* Standard spacing */
                 margin-right: 0;
-                
-                /* Interactive state for non-active items */
+
+                /* Hover State - ensure border persists */
                 &:hover {
                     background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
+                    border-bottom-color: var(--glpi-tabs-border-color);
                 }
 
-                /* B. ACTIVE STATE CONFIGURATION */
+                /* 5. ACTIVE STATE "FUSION" */
                 &.active {
-                    /* Colors */
                     background: var(--glpi-tabs-active-bg);
                     color: var(--glpi-tabs-active-fg);
                     font-weight: bold;
 
-                    /* Borders: Full box except right side */
-                    border-color: var(--glpi-tabs-active-border-color);
-                    border-left-width: 5px; 
-                    border-right-color: transparent !important;
+                    /* LEFT ACCENT */
+                    border-left: 5px solid var(--glpi-tabs-active-border-color);
                     
-                    /* C. THE DOUBLE-BORDER FIX */
-                    /* Pull the active tab UP by 1px so its top border overlaps the previous item's bottom border */
-                    margin-top: -1px;
-                    /* Pull it RIGHT by 1px to overlap the main panel line */
+                    /* CONNECTION TO CONTENT */
+                    /* Shift right by 1px to cover the container's right border */
                     margin-right: -1px;
-                    
-                    /* Ensure it sits on top of neighbors so the borders merge cleanly */
+                    border-right: 1px solid transparent;
+
+                    /* Bring to front so it covers the line */
                     position: relative;
                     z-index: 10; 
-                    
-                    .badge { font-weight: bold; }
-                }
-            }
 
-            /* D. CORNER FIX: Restore rounded corner ONLY on the very first item */
-            .nav-item:first-child .nav-link {
-                border-top-left-radius: var(--tblr-border-radius, 4px);
-                
-                /* If the active tab is first, prevent it from shifting up (optional, keeps alignment tidy) */
-                &.active {
-                    margin-top: 0;
+                    .badge { font-weight: bold; }
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,6 +1,33 @@
 /*!
  * ---------------------------------------------------------------------
- * GLPI - Card Tabs Fix (Final)
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  * ---------------------------------------------------------------------
  */
 
@@ -9,36 +36,52 @@
 }
 
 .card-tabs {
+    /* 1. Main container border (Vertical Line) */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
+    /* 2. Vertical Tabs Layout */
     #tabspanel.nav-tabs {
+        border-bottom: 0; /* Remove container bottom border */
+        gap: 0; /* Prevent flex gaps from creating double lines */
+
+        /* CLEANUP: Remove all styles from the list item wrapper */
+        .nav-item {
+            border: 0 !important;
+            margin: 0 !important;
+            padding: 0 !important;
+        }
+
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
 
-            /* 1. FORCE REMOVAL OF ALL BORDERS BY DEFAULT */
-            /* This kills the "second border" on inactive tabs */
-            border: 0 !important;
+            /* OVERRIDE _cards.scss: Set all borders to transparent first */
+            border: 1px solid transparent; 
+            
+            /* FORCE: Add a clean single line at the bottom */
+            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+            
+            /* STRATEGY: Pull the next item up by 1px to merge overlapping borders */
+            margin-bottom: -1px;
             border-radius: 0;
+            position: relative; /* Needed for z-index */
 
             &.active {
-                /* 2. RESTORE BORDERS ONLY FOR ACTIVE TAB */
+                /* Active State: Bring to front so it covers the overlap */
+                z-index: 10;
+                
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 font-weight: bold;
 
-                /* Left accent (thick line) */
+                /* Active Borders */
+                border-color: var(--glpi-tabs-active-border-color);
                 border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
-                
-                /* Bottom separator (thin line) */
                 border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                border-right: 1px solid transparent !important; /* Open to content */
                 
-                /* Ensure right side is open/transparent */
-                border-right: 1px solid transparent !important;
-                margin-right: -1px; 
-
                 .badge {
                     font-weight: bold;
                 }
@@ -48,23 +91,30 @@
                 margin-left: 5px;
             }
         }
-        
-        /* Optional: clean up the list item container */
-        .nav-item {
-            border: 0 !important;
+
+        /* CLEANUP: Remove border from the very last tab so it doesn't double with container edge */
+        .nav-item:last-child .nav-link {
+            border-bottom: 0 !important;
         }
     }
 
-    /* Horizontal Mode (Legacy) - Restore borders if needed */
+    /* 3. Horizontal View Specifics (Legacy/Desktop) */
     &.horizontal {
         #tabspanel.nav-tabs {
+            border-bottom: 1px solid var(--glpi-tabs-border-color);
+
             .nav-link {
-                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                border-left: 1px solid var(--glpi-tabs-border-color) !important;
+                margin-bottom: -1px; /* Overlap bottom container border */
+                border: 1px solid transparent;
+                border-bottom: 0; /* Let container handle the line */
+                border-left: 1px solid var(--glpi-tabs-border-color);
 
                 &.active {
+                    z-index: 2;
+                    background: #fff;
+                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff;
+                    border-left-width: 1px; /* Reset the 5px accent */
                     border-bottom-color: transparent !important;
-                    border-left-width: 1px !important;
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,84 +1,122 @@
-/* ---------------------------------------------------------------------
- * GLPI - Card Tabs Fix (Nuclear Option)
- * --------------------------------------------------------------------- */
+/*!
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
 
 .tab-content {
     border-top-left-radius: 0;
 }
 
 .card-tabs {
-    /* Target the container specifically */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
-        
-        /* NUCLEAR FIX 1: Kill any flex-gap that separates items */
-        gap: 0 !important; 
     }
 
-    /* Target the tabs container */
     #tabspanel.nav-tabs {
-        border-bottom: 0 !important; /* Remove Bootstrap container border */
-
-        /* NUCLEAR FIX 2: Ensure list items have ZERO influence on spacing */
-        .nav-item {
-            border: 0 !important;
-            margin: 0 !important;
-            padding: 0 !important;
-        }
-
-        /* Target the links (the actual visible tabs) */
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            
-            /* NUCLEAR FIX 3: Reset ALL borders and margins first */
-            border: 0 !important;
-            margin: 0 !important;
-            border-radius: 0 !important;
-            
-            /* NUCLEAR FIX 4: Apply ONLY a bottom border */
-            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+
+            /* FIXED: Kill Top/Left/Right borders explicitly */
+            border-top: 0;
+            border-left: 0;
+            border-right: 0;
+
+            /* FIXED: Make the bottom separator TRANSPARENT by default 
+               so inactive tabs don't show lines (prevents double borders) */
+            border-bottom: 1px solid transparent;
 
             &.active {
+                /* Active Tab Background & Text */
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
+                font-weight: bold;
 
-                /* Active state specifics */
+                /* FIXED: Active borders specifics */
+                border-right: 1px solid transparent !important;
+                margin-right: -1px; // Hack for border overlap
+
+                /* The Left Accent Border (Primary Color) */
                 border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
+                
+                /* The Bottom Border (Visible only on Active tab) */
                 border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
                 
-                /* Ensure active tab font is bold */
-                font-weight: bold;
-                .badge { font-weight: bold; }
+                .badge {
+                    font-weight: bold;
+                }
             }
 
             .badge {
                 margin-left: 5px;
             }
         }
+    }
 
-        /* NUCLEAR FIX 5: Remove border from the very last tab so it doesn't duplicate the container edge */
-        .nav-item:last-child .nav-link {
-            border-bottom: 0 !important;
+    /* Vertical Specifics (Legacy/Backup) */
+    &.vertical {
+        #tabspanel.nav-tabs .nav-link {
+             /* Ensure vertical tabs follow the main rule */
+             border-bottom: 1px solid transparent;
+             border-top-right-radius: 0;
+             border-top-left-radius: 0;
+
+             &.active {
+                 border-left: 5px solid var(--glpi-tabs-active-border-color);
+                 border-right-color: transparent !important;
+                 border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+             }
         }
     }
 
-    /* Horizontal View (Legacy/Desktop) */
+    /* Horizontal View Specifics */
     &.horizontal {
         #tabspanel.nav-tabs {
-            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-
             .nav-link {
-                /* In horizontal, we need the bottom border to be transparent to blend with content */
-                border: 1px solid transparent !important;
-                border-bottom: 0 !important; 
-                border-left: 1px solid var(--glpi-tabs-border-color) !important;
+                /* Restore borders for horizontal mode */
+                border-bottom-width: 1px;
+                border-bottom-style: solid;
+                border-left: 1px solid var(--glpi-tabs-border-color);
+
+                &:last-of-type {
+                    border-right-width: 1px;
+
+                    &.active {
+                        border-right-color: var(--glpi-tabs-border-color) !important;
+                    }
+                }
 
                 &.active {
-                    background: #fff;
-                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff !important;
-                    border-left-width: 1px !important; 
-                    margin-bottom: -1px !important; /* Push active tab down over the line */
+                    border-bottom-color: transparent !important;
+                    border-left-width: 1px; /* Reset the 5px vertical accent */
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,112 +1,84 @@
-/*!
- * ---------------------------------------------------------------------
- *
- * GLPI - Gestionnaire Libre de Parc Informatique
- *
- * http://glpi-project.org
- *
- * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
- * @licence   https://www.gnu.org/licenses/gpl-3.0.html
- *
- * ---------------------------------------------------------------------
- *
- * LICENSE
- *
- * This file is part of GLPI.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * ---------------------------------------------------------------------
- */
-
-/*!
- * ---------------------------------------------------------------------
- * GLPI - Custom Tab Fix
- * ---------------------------------------------------------------------
- */
+/* ---------------------------------------------------------------------
+ * GLPI - Card Tabs Fix (Nuclear Option)
+ * --------------------------------------------------------------------- */
 
 .tab-content {
     border-top-left-radius: 0;
 }
 
 .card-tabs {
-    /* 1. Main Container Border */
+    /* Target the container specifically */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
+        
+        /* NUCLEAR FIX 1: Kill any flex-gap that separates items */
+        gap: 0 !important; 
     }
 
-    /* 2. Global Reset for this tab panel */
+    /* Target the tabs container */
     #tabspanel.nav-tabs {
-        border-bottom: 0; /* Remove Bootstrap's default bottom border on the container */
+        border-bottom: 0 !important; /* Remove Bootstrap container border */
 
-        /* KILL THE GHOST: Remove any potential border from the list item wrapper */
+        /* NUCLEAR FIX 2: Ensure list items have ZERO influence on spacing */
         .nav-item {
             border: 0 !important;
-            margin-bottom: 0 !important;
+            margin: 0 !important;
+            padding: 0 !important;
         }
 
+        /* Target the links (the actual visible tabs) */
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
             
-            /* RESET: Ensure no rogue borders appear */
-            border: 0;
-            border-radius: 0; /* Sharp corners for vertical stacking */
-
-            /* STRATEGY: Add bottom border, then pull the next item up by 1px to overlap */
-            border-bottom: 1px solid var(--glpi-tabs-border-color);
-            margin-bottom: -1px; 
+            /* NUCLEAR FIX 3: Reset ALL borders and margins first */
+            border: 0 !important;
+            margin: 0 !important;
+            border-radius: 0 !important;
+            
+            /* NUCLEAR FIX 4: Apply ONLY a bottom border */
+            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
 
             &.active {
-                /* Active State: Bring to front (z-index) so its border sits on top */
-                z-index: 2; 
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
 
-                /* Active Borders */
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-                border-left: 5px solid var(--glpi-tabs-active-border-color);
-                border-right: 1px solid transparent; // Blend with content area
+                /* Active state specifics */
+                border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
+                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
                 
+                /* Ensure active tab font is bold */
                 font-weight: bold;
-
-                .badge {
-                    font-weight: bold;
-                }
+                .badge { font-weight: bold; }
             }
 
             .badge {
                 margin-left: 5px;
             }
         }
+
+        /* NUCLEAR FIX 5: Remove border from the very last tab so it doesn't duplicate the container edge */
+        .nav-item:last-child .nav-link {
+            border-bottom: 0 !important;
+        }
     }
 
-    /* 3. Horizontal View (Legacy/Desktop) */
+    /* Horizontal View (Legacy/Desktop) */
     &.horizontal {
         #tabspanel.nav-tabs {
-            border-bottom: 1px solid var(--glpi-tabs-border-color); /* Restore container border */
+            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
 
             .nav-link {
-                margin-bottom: -1px; /* Overlap bottom container border */
-                border: 1px solid transparent;
-                border-bottom: 0; /* Let container handle the line */
-                border-left: 1px solid var(--glpi-tabs-border-color);
+                /* In horizontal, we need the bottom border to be transparent to blend with content */
+                border: 1px solid transparent !important;
+                border-bottom: 0 !important; 
+                border-left: 1px solid var(--glpi-tabs-border-color) !important;
 
                 &.active {
-                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff;
-                    border-left-width: 1px; /* Reset the 5px accent */
+                    background: #fff;
+                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff !important;
+                    border-left-width: 1px !important; 
+                    margin-bottom: -1px !important; /* Push active tab down over the line */
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -36,17 +36,17 @@
 }
 
 .card-tabs {
-    /* 1. Main container border (Vertical Line) */
+    /* 1. Main Container Border */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
     /* 2. Vertical Tabs Layout */
     #tabspanel.nav-tabs {
-        border-bottom: 0; /* Remove container bottom border */
-        gap: 0; /* Prevent flex gaps from creating double lines */
+        border-bottom: 0; 
+        gap: 0; 
 
-        /* CLEANUP: Remove all styles from the list item wrapper */
+        /* Kill all spacing on the list items */
         .nav-item {
             border: 0 !important;
             margin: 0 !important;
@@ -57,31 +57,37 @@
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
 
-            /* OVERRIDE _cards.scss: Set all borders to transparent first */
-            border: 1px solid transparent; 
+            /* FIX: Strictly set Top/Left/Right borders to 0 width */
+            border-top: 0 !important;
+            border-left: 0 !important;
+            border-right: 0 !important;
             
-            /* FORCE: Add a clean single line at the bottom */
+            /* Add the ONE true separator line */
             border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
             
-            /* STRATEGY: Pull the next item up by 1px to merge overlapping borders */
-            margin-bottom: -1px;
-            border-radius: 0;
-            position: relative; /* Needed for z-index */
+            /* Remove negative margin - let them stack naturally */
+            margin-bottom: 0 !important;
+            border-radius: 0 !important;
 
             &.active {
-                /* Active State: Bring to front so it covers the overlap */
-                z-index: 10;
-                
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 font-weight: bold;
 
                 /* Active Borders */
-                border-color: var(--glpi-tabs-active-border-color);
+                /* 1. Left Accent */
                 border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
-                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                border-right: 1px solid transparent !important; /* Open to content */
                 
+                /* 2. Bottom Separator (Matches the list) */
+                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                
+                /* 3. Open to the right */
+                border-right: 1px solid transparent !important;
+                margin-right: -1px !important; 
+
+                /* 4. Ensure no Top border leaks in */
+                border-top: 0 !important;
+
                 .badge {
                     font-weight: bold;
                 }
@@ -92,7 +98,7 @@
             }
         }
 
-        /* CLEANUP: Remove border from the very last tab so it doesn't double with container edge */
+        /* Cleanup: Remove border from the very last tab */
         .nav-item:last-child .nav-link {
             border-bottom: 0 !important;
         }
@@ -104,16 +110,15 @@
             border-bottom: 1px solid var(--glpi-tabs-border-color);
 
             .nav-link {
-                margin-bottom: -1px; /* Overlap bottom container border */
+                margin-bottom: -1px;
                 border: 1px solid transparent;
-                border-bottom: 0; /* Let container handle the line */
+                border-bottom: 0;
                 border-left: 1px solid var(--glpi-tabs-border-color);
 
                 &.active {
-                    z-index: 2;
                     background: #fff;
                     border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff;
-                    border-left-width: 1px; /* Reset the 5px accent */
+                    border-left-width: 1px;
                     border-bottom-color: transparent !important;
                 }
             }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -44,11 +44,12 @@
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            border: 1px solid var(--glpi-tabs-border-color);
+            border-color: var(--glpi-tabs-border-color);
             border-right-width: 0;
-            border-radius: 0;
 
             &.active {
+                border-right: 1px solid transparent !important;
+                margin-right: -1px; // Keep original overlap hack
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 border-color: var(--glpi-tabs-active-border-color);
@@ -68,11 +69,12 @@
     &.vertical {
         .nav:not(.nav-underline) {
             .nav-link {
-                border-bottom: 0;
+                border-bottom: 0; // reset first
                 border-top-right-radius: 0;
 
-                & + .nav-link {
-                    border-top: 1px solid var(--glpi-tabs-border-color);
+                /* Apply separator only between items */
+                .nav-link:not(:last-child) {
+                    border-bottom: 1px solid var(--glpi-tabs-border-color);
                 }
 
                 &.active {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,136 +1,105 @@
-/*!
- * ---------------------------------------------------------------------
- *
- * GLPI - Gestionnaire Libre de Parc Informatique
- *
- * http://glpi-project.org
- *
- * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
- * @licence   https://www.gnu.org/licenses/gpl-3.0.html
- *
- * ---------------------------------------------------------------------
- *
- * LICENSE
- *
- * This file is part of GLPI.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * ---------------------------------------------------------------------
- */
-
 .tab-content {
     border-top-left-radius: 0;
 }
 
-/* Main Container Styling */
 .card-tabs {
-    
-    /* 1. Reset default Bootstrap nav-tabs styles so they don't interfere */
+    /* 1. CONTAINER BORDER (The "Red Line" Fix) */
+    /* We apply the full border to the UL container to create the frame */
+    #tabspanel {
+        border: 1px solid var(--glpi-tabs-border-color);
+        /* Round the left corners of the container */
+        border-radius: var(--tblr-border-radius, 4px) 0 0 var(--tblr-border-radius, 4px);
+    }
+
+    /* Reset Bootstrap defaults */
     #tabspanel.nav-tabs {
         border-bottom: 0;
         .nav-link {
-            border: 0; /* Wipe out all default link borders */
-            margin-right: 0;
+            border-right-width: 0;
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            border-radius: 0; /* Ensure they are square by default */
-            
             .badge { margin-left: 5px; }
         }
     }
 
-    /* ==================================================
-       VERTICAL ORIENTATION (The fix)
-    ================================================== */
+    /* VERTICAL LAYOUT */
     &.vertical {
-        /* A. THE CONTAINER FRAME */
-        #tabspanel {
-            /* Give the UL the main border and rounded corners */
-            border: 1px solid var(--glpi-tabs-border-color);
-            /* IMPORTANT: Don't put a right border here, the content pane has the matching left border */
-            border-right: 0; 
-            /* Apply rounding only to the left side corners */
-            border-radius: var(--tblr-border-radius, 4px) 0 0 var(--tblr-border-radius, 4px);
-            /* CRITICAL: Clip inner items so they don't overflow the rounded corners */
-            overflow: hidden; 
-        }
-
         .nav:not(.nav-underline) {
             
-            /* B. THE SEPARATORS (Apply to the list item LI, not the anchor A) */
             .nav-item {
                 margin: 0;
-                /* Add bottom border to create separators between items */
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
+                /* 2. LINK BORDERS (Restoring "Missing Borders") */
+                /* We apply borders to the link, not the item, to ensure they are visible */
+                .nav-link {
+                    /* Reset defaults */
+                    border: 0;
+                    border-radius: 0;
+                    
+                    /* The Separator Line */
+                    border-bottom: 1px solid var(--glpi-tabs-border-color);
+                    
+                    /* Interactive states */
+                    &:hover {
+                        background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
+                    }
 
-                /* Remove the separator from the very last item to avoid a double-bottom-border */
-                &:last-child {
-                    border-bottom: 0;
+                    /* 3. ACTIVE STATE "MERGE" */
+                    &.active {
+                        background: var(--glpi-tabs-active-bg);
+                        color: var(--glpi-tabs-active-fg);
+                        font-weight: bold;
+
+                        /* Thick Accent on Left */
+                        border-left: 5px solid var(--glpi-tabs-active-border-color);
+                        
+                        /* Borders to match the separators */
+                        border-top: 1px solid var(--glpi-tabs-border-color);
+                        border-bottom: 1px solid var(--glpi-tabs-border-color);
+                        
+                        /* Open connection to the right (Content) */
+                        border-right: 1px solid transparent; 
+                        margin-right: -1px; /* Overlaps the container's right border */
+
+                        /* Slight overlap vertically to merge cleanly with neighbors */
+                        margin-top: -1px;
+                        margin-bottom: -1px;
+                        
+                        position: relative;
+                        z-index: 10;
+                    }
                 }
-            }
 
-            /* C. THE LINKS */
-            .nav-link {
-                /* Ensure hover state exists */
-                &:hover {
-                    background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
+                /* 4. CORNER & BORDER CLEANUP */
+                
+                /* Top Item: Round the top-left corner */
+                &:first-child .nav-link {
+                    border-top-left-radius: var(--tblr-border-radius, 4px);
+                    /* Prevent active tab from shifting up out of the box */
+                    &.active { margin-top: 0; }
                 }
 
-                /* D. ACTIVE STATE "FUSION" */
-                &.active {
-                    background: var(--glpi-tabs-active-bg);
-                    color: var(--glpi-tabs-active-fg);
-                    font-weight: bold;
-
-                    /* Re-apply borders specifically for the active tab definition */
-                    border: 1px solid var(--glpi-tabs-active-border-color);
-                    border-left-width: 5px; /* Thick accent */
-                    border-right-color: transparent; /* Open connection to content */
-
-                    /* MAGIC MARGINS: Pull the tab outward to overlap surrounding borders */
-                    margin-top: -1px;    /* Covers the separator above it */
-                    /* Important: margin-bottom needs to be handled carefully if it's the last item, 
-                       but usually -1px works fine so it covers the separator below it */
-                    margin-bottom: -1px; 
-                    margin-right: -1px;  /* Covers the content pane's border */
-
-                    /* Z-Index ensures it sits on top of the separators */
-                    position: relative;
-                    z-index: 10;
-
-                    .badge { font-weight: bold; }
+                /* Bottom Item: Round the bottom-left corner and REMOVE double border */
+                &:last-child .nav-link {
+                    border-bottom-left-radius: var(--tblr-border-radius, 4px);
+                    border-bottom: 0; /* The container already has the bottom border */
+                    
+                    /* Prevent active tab from shifting down out of the box */
+                    &.active { margin-bottom: 0; }
                 }
             }
         }
     }
 
-    /* Horizontal fallback (Unchanged from original) */
+    /* Horizontal fallback (Unchanged) */
     &.horizontal {
-        #tabspanel { border-right: 1px solid var(--glpi-tabs-border-color); }
         #tabspanel.nav-tabs .nav-link {
-            border: 1px solid transparent;
-            border-bottom-color: var(--glpi-tabs-border-color);
+            border-bottom-width: 1px;
+            border-bottom-style: solid;
             &:last-of-type {
-                border-right: 1px solid transparent;
+                border-right-width: 1px;
                 &.active { border-right-color: var(--glpi-tabs-border-color) !important; }
             }
-            &.active {
-                border-color: var(--glpi-tabs-border-color);
-                border-bottom-color: transparent !important;
-            }
+            &.active { border-bottom-color: transparent !important; }
         }
     }
 }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,27 +67,33 @@
     }
 
     &.vertical {
-        /* Remove Bootstrap nav-tabs bottom border */
+        /* Remove Bootstrap nav-tabs borders completely */
         #tabspanel.nav-tabs {
-            border-bottom: 0 !important;
+            border: 0 !important;
         }
 
-        /* Remove Bootstrap negative margin */
+        /* Remove Bootstrap negative margin behavior */
         #tabspanel.nav-tabs .nav-link {
-            margin-bottom: 0;
+            margin: 0;
         }
 
-        /* Add top border for full frame */
+        /* Panel frame (top + right side) */
         #tabspanel {
             border-top: 1px solid var(--glpi-tabs-border-color);
+            border-right: 1px solid var(--glpi-tabs-border-color);
             border-top-left-radius: var(--tblr-border-radius);
+            overflow: hidden; // ensures radius is visible
         }
 
         .nav:not(.nav-underline) {
-            .nav-item {
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
+            /* Remove inherited borders from other rules */
+            border: 0;
 
-                &:last-child {
+            .nav-item {
+                border: 0; // prevent double stacking
+
+                /* separator line */
+                &:not(:last-child) {
                     border-bottom: 1px solid var(--glpi-tabs-border-color);
                 }
             }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,105 +1,104 @@
+/*!
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 .tab-content {
     border-top-left-radius: 0;
 }
 
 .card-tabs {
-    /* 1. CONTAINER BORDER (The "Red Line" Fix) */
-    /* We apply the full border to the UL container to create the frame */
     #tabspanel {
-        border: 1px solid var(--glpi-tabs-border-color);
-        /* Round the left corners of the container */
-        border-radius: var(--tblr-border-radius, 4px) 0 0 var(--tblr-border-radius, 4px);
+        border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
-    /* Reset Bootstrap defaults */
     #tabspanel.nav-tabs {
-        border-bottom: 0;
         .nav-link {
-            border-right-width: 0;
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            .badge { margin-left: 5px; }
+            border-color: var(--glpi-tabs-border-color);
+            border-right-width: 0;
+
+            &.active {
+                border-right: 1px solid transparent !important;
+                margin-right : -1px; // Hack for border overlap
+                background: var(--glpi-tabs-active-bg);
+                color: var(--glpi-tabs-active-fg);
+                border-color: var(--glpi-tabs-active-border-color);
+                font-weight: bold;
+
+                .badge {
+                    font-weight: bold;
+                }
+            }
+
+            .badge {
+                margin-left: 5px;
+            }
         }
     }
 
-    /* VERTICAL LAYOUT */
     &.vertical {
-        .nav:not(.nav-underline) {
-            
-            .nav-item {
-                margin: 0;
-                /* 2. LINK BORDERS (Restoring "Missing Borders") */
-                /* We apply borders to the link, not the item, to ensure they are visible */
-                .nav-link {
-                    /* Reset defaults */
-                    border: 0;
-                    border-radius: 0;
-                    
-                    /* The Separator Line */
-                    border-bottom: 1px solid var(--glpi-tabs-border-color);
-                    
-                    /* Interactive states */
-                    &:hover {
-                        background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
-                    }
+        .nav:not(.nav-underline)
+            .nav-link {
+                /* FIX: Remove top border to prevent doubling with the bottom border of the previous item */
+                border-top: 0;
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
+                border-top-right-radius: 0;
 
-                    /* 3. ACTIVE STATE "MERGE" */
-                    &.active {
-                        background: var(--glpi-tabs-active-bg);
-                        color: var(--glpi-tabs-active-fg);
-                        font-weight: bold;
-
-                        /* Thick Accent on Left */
-                        border-left: 5px solid var(--glpi-tabs-active-border-color);
-                        
-                        /* Borders to match the separators */
-                        border-top: 1px solid var(--glpi-tabs-border-color);
-                        border-bottom: 1px solid var(--glpi-tabs-border-color);
-                        
-                        /* Open connection to the right (Content) */
-                        border-right: 1px solid transparent; 
-                        margin-right: -1px; /* Overlaps the container's right border */
-
-                        /* Slight overlap vertically to merge cleanly with neighbors */
-                        margin-top: -1px;
-                        margin-bottom: -1px;
-                        
-                        position: relative;
-                        z-index: 10;
-                    }
-                }
-
-                /* 4. CORNER & BORDER CLEANUP */
-                
-                /* Top Item: Round the top-left corner */
-                &:first-child .nav-link {
-                    border-top-left-radius: var(--tblr-border-radius, 4px);
-                    /* Prevent active tab from shifting up out of the box */
-                    &.active { margin-top: 0; }
-                }
-
-                /* Bottom Item: Round the bottom-left corner and REMOVE double border */
-                &:last-child .nav-link {
-                    border-bottom-left-radius: var(--tblr-border-radius, 4px);
-                    border-bottom: 0; /* The container already has the bottom border */
-                    
-                    /* Prevent active tab from shifting down out of the box */
-                    &.active { margin-bottom: 0; }
+                &.active {
+                    border-left-width: 5px;
+                    border-right-color: transparent !important;
                 }
             }
-        }
     }
 
-    /* Horizontal fallback (Unchanged) */
     &.horizontal {
-        #tabspanel.nav-tabs .nav-link {
-            border-bottom-width: 1px;
-            border-bottom-style: solid;
-            &:last-of-type {
-                border-right-width: 1px;
-                &.active { border-right-color: var(--glpi-tabs-border-color) !important; }
+        #tabspanel.nav-tabs {
+            .nav-link {
+                border-bottom-width: 1px;
+                border-bottom-style: solid;
+
+                &:last-of-type {
+                    border-right-width: 1px;
+
+                    &.active {
+                        border-right-color: var(--glpi-tabs-border-color) !important;
+                    }
+                }
+
+                &.active {
+                    border-bottom-color: transparent !important;
+                }
             }
-            &.active { border-bottom-color: transparent !important; }
         }
     }
 }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -35,78 +35,81 @@
     border-top-left-radius: 0;
 }
 
+/* Main Container Styling */
 .card-tabs {
-    /* 1. APPLY THE FULL FRAME TO THE CONTAINER */
-    /* This fixes the "missing top and left border" issue */
-    #tabspanel {
-        border: 1px solid var(--glpi-tabs-border-color);
-        border-radius: var(--tblr-border-radius, 4px);
-    }
-
-    /* Reset Bootstrap defaults */
+    
+    /* 1. Reset default Bootstrap nav-tabs styles so they don't interfere */
     #tabspanel.nav-tabs {
         border-bottom: 0;
         .nav-link {
-            border-right-width: 0;
+            border: 0; /* Wipe out all default link borders */
+            margin-right: 0;
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
+            border-radius: 0; /* Ensure they are square by default */
+            
             .badge { margin-left: 5px; }
         }
     }
 
+    /* ==================================================
+       VERTICAL ORIENTATION (The fix)
+    ================================================== */
     &.vertical {
+        /* A. THE CONTAINER FRAME */
+        #tabspanel {
+            /* Give the UL the main border and rounded corners */
+            border: 1px solid var(--glpi-tabs-border-color);
+            /* IMPORTANT: Don't put a right border here, the content pane has the matching left border */
+            border-right: 0; 
+            /* Apply rounding only to the left side corners */
+            border-radius: var(--tblr-border-radius, 4px) 0 0 var(--tblr-border-radius, 4px);
+            /* CRITICAL: Clip inner items so they don't overflow the rounded corners */
+            overflow: hidden; 
+        }
+
         .nav:not(.nav-underline) {
             
+            /* B. THE SEPARATORS (Apply to the list item LI, not the anchor A) */
             .nav-item {
                 margin: 0;
+                /* Add bottom border to create separators between items */
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
 
-                /* 2. ROUNDED CORNERS MANAGEMENT */
-                /* Force the first item to fit the container's top-left radius */
-                &:first-child .nav-link {
-                    border-top-left-radius: var(--tblr-border-radius, 4px);
-                }
-                /* Force the last item to fit the container's bottom-left radius */
-                &:last-child .nav-link {
-                    border-bottom-left-radius: var(--tblr-border-radius, 4px);
-                    /* 3. REMOVE LAST SEPARATOR */
-                    /* Prevent double border at the bottom of the list */
+                /* Remove the separator from the very last item to avoid a double-bottom-border */
+                &:last-child {
                     border-bottom: 0;
                 }
             }
 
+            /* C. THE LINKS */
             .nav-link {
-                /* 4. DEFINE THE SEPARATORS */
-                /* Give every item a bottom border by default (fixes "missing border") */
-                border: 0; 
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-                border-radius: 0; /* Square by default */
-                
-                /* Standard spacing */
-                margin-right: 0;
-
-                /* Hover State - ensure border persists */
+                /* Ensure hover state exists */
                 &:hover {
                     background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
-                    border-bottom-color: var(--glpi-tabs-border-color);
                 }
 
-                /* 5. ACTIVE STATE "FUSION" */
+                /* D. ACTIVE STATE "FUSION" */
                 &.active {
                     background: var(--glpi-tabs-active-bg);
                     color: var(--glpi-tabs-active-fg);
                     font-weight: bold;
 
-                    /* LEFT ACCENT */
-                    border-left: 5px solid var(--glpi-tabs-active-border-color);
-                    
-                    /* CONNECTION TO CONTENT */
-                    /* Shift right by 1px to cover the container's right border */
-                    margin-right: -1px;
-                    border-right: 1px solid transparent;
+                    /* Re-apply borders specifically for the active tab definition */
+                    border: 1px solid var(--glpi-tabs-active-border-color);
+                    border-left-width: 5px; /* Thick accent */
+                    border-right-color: transparent; /* Open connection to content */
 
-                    /* Bring to front so it covers the line */
+                    /* MAGIC MARGINS: Pull the tab outward to overlap surrounding borders */
+                    margin-top: -1px;    /* Covers the separator above it */
+                    /* Important: margin-bottom needs to be handled carefully if it's the last item, 
+                       but usually -1px works fine so it covers the separator below it */
+                    margin-bottom: -1px; 
+                    margin-right: -1px;  /* Covers the content pane's border */
+
+                    /* Z-Index ensures it sits on top of the separators */
                     position: relative;
-                    z-index: 10; 
+                    z-index: 10;
 
                     .badge { font-weight: bold; }
                 }
@@ -114,16 +117,20 @@
         }
     }
 
-    /* Horizontal fallback (Unchanged) */
+    /* Horizontal fallback (Unchanged from original) */
     &.horizontal {
+        #tabspanel { border-right: 1px solid var(--glpi-tabs-border-color); }
         #tabspanel.nav-tabs .nav-link {
-            border-bottom-width: 1px;
-            border-bottom-style: solid;
+            border: 1px solid transparent;
+            border-bottom-color: var(--glpi-tabs-border-color);
             &:last-of-type {
-                border-right-width: 1px;
+                border-right: 1px solid transparent;
                 &.active { border-right-color: var(--glpi-tabs-border-color) !important; }
             }
-            &.active { border-bottom-color: transparent !important; }
+            &.active {
+                border-color: var(--glpi-tabs-border-color);
+                border-bottom-color: transparent !important;
+            }
         }
     }
 }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -69,35 +69,20 @@
     &.vertical {
             #tabspanel.nav-tabs {
                 .nav-link {
-                    /* FORCE the borders to be visible (Solid and Correct Color) */
-                    border-left: 1px solid var(--glpi-tabs-border-color) !important;
+                    /* 1. FORCE the bottom border to be visible on all items */
                     border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                    
-                    /* Remove top border from ALL items by default to prevent "double lines" */
-                    border-top: 0 !important;
-                    
-                    /* Keep right side open (handled by the main container border) */
-                    border-right: 0 !important;
-                    
-                    /* Reset radius for clean stacking */
-                    border-radius: 0; 
     
-                    &.active {
-                        /* Active State: Thick left border, white background */
-                        border-left: 5px solid var(--glpi-active-color, #0d6efd) !important;
-                        background: var(--glpi-tabs-active-bg) !important;
-                        /* Ensure text is dark/visible */
-                        color: var(--glpi-tabs-active-fg, #000) !important;
-                        
-                        /* Overlap the container's right border */
-                        margin-right: -1px;
-                    }
+                    /* 2. REMOVE the top border to prevent the "double line" issue */
+                    border-top: 0 !important;
+    
+                    /* 3. Do NOT touch border-left or border-right. 
+                       This preserves your blue active indicator and default box layout. */
                 }
     
-                /* EXCEPTION: The very first tab needs a Top Border to close the box */
+                /* 4. EXCEPTION: The first tab needs a top border to close the container */
                 .nav-item:first-child .nav-link {
                     border-top: 1px solid var(--glpi-tabs-border-color) !important;
-                    border-top-left-radius: 4px; /* Optional: adds a nice curve to the top-left */
+                    border-top-left-radius: 4px; /* Matches default bootstrap radius */
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -36,101 +36,98 @@
 }
 
 .card-tabs {
-    /* 1. Keep the main separation line on the UL (the right side) */
+    /* 1. Main Divider: Keep the right border on the UL container */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
-    /* 2. Style the tabs within the panel */
+    /* 2. Reset Default Bootstrap Tabs styles */
     #tabspanel.nav-tabs {
-        border-bottom: 0; /* Remove default bootstrap nav-tabs bottom border */
-
+        border-bottom: 0; 
+        
         .nav-link {
-            /* 3. RESET: clear all default borders first to prevent "double border" */
-            border: 1px solid transparent; 
-            border-right-width: 0; /* We handle the right side via the panel or margin hack */
-            
+            border-right-width: 0;
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
 
-            /* 4. ACTIVE STATE: The "Fusion" effect */
-            &.active {
-                background: var(--glpi-tabs-active-bg);
-                color: var(--glpi-tabs-active-fg);
-                
-                /* Overlap the panel's right border */
-                margin-right: -1px; 
-                border: 1px solid var(--glpi-tabs-active-border-color);
-                border-right-color: transparent !important; 
-                
-                font-weight: bold;
-
-                .badge {
-                    font-weight: bold;
-                }
-            }
-
-            .badge {
-                margin-left: 5px;
-            }
+            /* Badge alignment */
+            .badge { margin-left: 5px; }
         }
     }
 
-    /* 5. VERTICAL SPECIFIC STYLES */
+    /* 3. VERTICAL LAYOUT FIXES */
     &.vertical {
         .nav:not(.nav-underline) {
+            
+            /* Ensure items don't have extra padding disrupting the flow */
             .nav-item {
-                /* Ensure no extra spacing interferes with borders */
-                margin: 0; 
-
-                /* 6. Restore Rounded Corner on FIRST item only */
-                &:first-child .nav-link {
-                    border-top-left-radius: var(--tblr-border-radius, 4px);
-                }
-                
-                /* Ensure other items are square */
-                &:not(:first-child) .nav-link {
-                    border-radius: 0;
-                }
+                margin: 0;
             }
 
             .nav-link {
-                /* 7. The clean separator line */
+                /* A. RESTORE SEPARATORS: Give every link a bottom border */
+                border: 1px solid transparent; /* Reset everything first */
                 border-bottom: 1px solid var(--glpi-tabs-border-color);
                 
-                /* Ensure no left border by default (unless active) */
-                border-left: 1px solid transparent; 
-                border-top: 0; /* Clean top to avoid double lines with previous bottom */
+                /* Reset radius for the list look */
+                border-radius: 0;
+                
+                /* Standard spacing */
+                margin-right: 0;
+                
+                /* Interactive state for non-active items */
+                &:hover {
+                    background: var(--glpi-tabs-hover-bg, rgba(0,0,0,0.02));
+                }
 
+                /* B. ACTIVE STATE CONFIGURATION */
                 &.active {
-                    /* The thick accent on the left */
-                    border-left: 5px solid var(--glpi-tabs-active-border-color);
+                    /* Colors */
+                    background: var(--glpi-tabs-active-bg);
+                    color: var(--glpi-tabs-active-fg);
+                    font-weight: bold;
+
+                    /* Borders: Full box except right side */
+                    border-color: var(--glpi-tabs-active-border-color);
+                    border-left-width: 5px; 
                     border-right-color: transparent !important;
-                    border-bottom-color: var(--glpi-tabs-border-color);
+                    
+                    /* C. THE DOUBLE-BORDER FIX */
+                    /* Pull the active tab UP by 1px so its top border overlaps the previous item's bottom border */
+                    margin-top: -1px;
+                    /* Pull it RIGHT by 1px to overlap the main panel line */
+                    margin-right: -1px;
+                    
+                    /* Ensure it sits on top of neighbors so the borders merge cleanly */
+                    position: relative;
+                    z-index: 10; 
+                    
+                    .badge { font-weight: bold; }
+                }
+            }
+
+            /* D. CORNER FIX: Restore rounded corner ONLY on the very first item */
+            .nav-item:first-child .nav-link {
+                border-top-left-radius: var(--tblr-border-radius, 4px);
+                
+                /* If the active tab is first, prevent it from shifting up (optional, keeps alignment tidy) */
+                &.active {
+                    margin-top: 0;
                 }
             }
         }
     }
 
-    /* Horizontal fallback (kept from your original) */
+    /* Horizontal fallback (Unchanged) */
     &.horizontal {
-        #tabspanel.nav-tabs {
-            .nav-link {
-                border-bottom-width: 1px;
-                border-bottom-style: solid;
-
-                &:last-of-type {
-                    border-right-width: 1px;
-
-                    &.active {
-                        border-right-color: var(--glpi-tabs-border-color) !important;
-                    }
-                }
-
-                &.active {
-                    border-bottom-color: transparent !important;
-                }
+        #tabspanel.nav-tabs .nav-link {
+            border-bottom-width: 1px;
+            border-bottom-style: solid;
+            &:last-of-type {
+                border-right-width: 1px;
+                &.active { border-right-color: var(--glpi-tabs-border-color) !important; }
             }
+            &.active { border-bottom-color: transparent !important; }
         }
     }
 }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -41,33 +41,26 @@
     }
 
     #tabspanel.nav-tabs {
-        /* Ensure the list item wrapper has no border (prevents double-border issue) */
-        .nav-item {
-            border: 0 !important;
-        }
-
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            
-            /* RESET: Remove default borders */
-            border: 0;
-            border-right-width: 0;
-            
-            /* FORCE: Add a clean single line at the bottom */
-            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+
+            /* FIXED: Explicitly reset side/top borders but FORCE the bottom one */
+            border-top: 0;
+            border-left: 0;
+            border-right: 0;
+            border-bottom: 1px solid var(--glpi-tabs-border-color);
 
             &.active {
-                border-right: 1px solid transparent !important;
-                margin-right : -1px;
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
+
+                /* FIXED: Vertical active state borders */
+                border-left: 5px solid var(--glpi-tabs-active-border-color);
+                border-right: 1px solid transparent !important;
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
                 
-                /* Specific borders for active state */
-                border-color: var(--glpi-tabs-active-border-color);
-                border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
-                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                
+                margin-right : -1px; // Hack for border overlap
                 font-weight: bold;
 
                 .badge {
@@ -80,30 +73,20 @@
             }
         }
 
-        /* CLEANUP: Remove the border from the very last tab */
+        /* FIXED: Remove the border from the very last tab so it doesn't double with container edge */
         .nav-item:last-child .nav-link {
             border-bottom: 0 !important;
         }
     }
 
-    &.vertical {
-        .nav:not(.nav-underline)
-            .nav-link {
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-                border-top-right-radius: 0;
-
-                &.active {
-                    border-left-width: 5px;
-                    border-right-color: transparent !important;
-                }
-            }
-    }
-
+    /* Horizontal View Specifics */
     &.horizontal {
         #tabspanel.nav-tabs {
             .nav-link {
+                /* Restore borders for horizontal mode */
                 border-bottom-width: 1px;
                 border-bottom-style: solid;
+                border-left: 1px solid var(--glpi-tabs-border-color);
 
                 &:last-of-type {
                     border-right-width: 1px;
@@ -115,6 +98,7 @@
 
                 &.active {
                     border-bottom-color: transparent !important;
+                    border-left-width: 1px; /* Reset the 5px vertical accent */
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,24 +67,36 @@
     }
 
     &.vertical {
+        #tabspanel.nav-tabs {
+            border-bottom: 0; // kill Bootstrap bottom border
+        }
+    
+        .nav-tabs .nav-link {
+            border: 0; // remove ALL Bootstrap borders
+        }
+    
         .nav:not(.nav-underline) {
             .nav-item {
-                .nav-link {
-                    border-bottom: 1px solid var(--glpi-tabs-border-color);
-                    border-top-right-radius: 0;
-                }
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
     
                 &:last-child {
-                    .nav-link {
-                        border-bottom: 0;
-                    }
+                    border-bottom: 0;
                 }
             }
     
-            .nav-link.active {
-                border-left-width: 5px;
-                border-right-color: transparent !important;
-                margin-right: -1px; // keep overlap hack
+            .nav-link {
+                background: var(--glpi-tabs-bg);
+                color: var(--glpi-tabs-fg);
+                border-top-right-radius: 0;
+    
+                &.active {
+                    border-left: 5px solid var(--glpi-tabs-active-border-color);
+                    border-right: 1px solid transparent !important;
+                    margin-right: -1px; // keep overlap
+                    background: var(--glpi-tabs-active-bg);
+                    color: var(--glpi-tabs-active-fg);
+                    font-weight: bold;
+                }
             }
         }
     }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,32 +67,37 @@
     }
 
     &.vertical {
-            /* We add #tabspanel here to ensure we win the 'specificity war' against the generic rules */
             #tabspanel.nav-tabs {
                 .nav-link {
-                    /* 1. Ensure borders are solid and visible on all sides first */
-                    border: 1px solid var(--glpi-tabs-border-color);
+                    /* FORCE the borders to be visible (Solid and Correct Color) */
+                    border-left: 1px solid var(--glpi-tabs-border-color) !important;
+                    border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
                     
-                    /* 2. Remove the top border from ALL items to stop the "double border" thickness */
-                    border-top: 0;
+                    /* Remove top border from ALL items by default to prevent "double lines" */
+                    border-top: 0 !important;
                     
-                    /* 3. Keep the right side square (standard for vertical tabs) */
-                    border-top-right-radius: 0;
-                    border-bottom-right-radius: 0;
+                    /* Keep right side open (handled by the main container border) */
+                    border-right: 0 !important;
+                    
+                    /* Reset radius for clean stacking */
+                    border-radius: 0; 
     
                     &.active {
-                        /* Restore the active indicator */
-                        border-left-width: 5px;
-                        border-right-color: transparent !important;
+                        /* Active State: Thick left border, white background */
+                        border-left: 5px solid var(--glpi-active-color, #0d6efd) !important;
+                        background: var(--glpi-tabs-active-bg) !important;
+                        /* Ensure text is dark/visible */
+                        color: var(--glpi-tabs-active-fg, #000) !important;
+                        
+                        /* Overlap the container's right border */
                         margin-right: -1px;
                     }
                 }
     
-                /* 4. EXCEPTION: The very first item MUST have a top border to close the list */
+                /* EXCEPTION: The very first tab needs a Top Border to close the box */
                 .nav-item:first-child .nav-link {
-                    border-top: 1px solid var(--glpi-tabs-border-color);
-                    /* Optional: Ensure the top-left corner is rounded if you prefer */
-                    border-top-left-radius: var(--bs-border-radius, 4px); 
+                    border-top: 1px solid var(--glpi-tabs-border-color) !important;
+                    border-top-left-radius: 4px; /* Optional: adds a nice curve to the top-left */
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -105,7 +105,7 @@
                     border-bottom-right-radius: 0 !important;
                 }
             }
-        }
+    }
 
     &.horizontal {
         #tabspanel.nav-tabs {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -77,6 +77,11 @@
             margin-bottom: 0;
         }
 
+        /* Add top border for full frame */
+        #tabspanel {
+            border-top: 1px solid var(--glpi-tabs-border-color);
+        }
+
         .nav:not(.nav-underline) {
             .nav-item {
                 border-bottom: 1px solid var(--glpi-tabs-border-color);

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -49,7 +49,7 @@
 
             &.active {
                 border-right: 1px solid transparent !important;
-                margin-right: -1px; // Keep original overlap hack
+                margin-right: -1px; // Hack for border overlap
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 border-color: var(--glpi-tabs-active-border-color);
@@ -68,14 +68,17 @@
 
     &.vertical {
         .nav:not(.nav-underline) {
-            .nav-link {
-                border-bottom: 0; // reset first
-                border-top-right-radius: 0;
-
-                /* Apply separator only between items */
-                .nav-link:not(:last-child) {
-                    border-bottom: 1px solid var(--glpi-tabs-border-color);
+            .nav-item {
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
+    
+                &:last-child {
+                    border-bottom: 0;
                 }
+            }
+    
+            .nav-link {
+                border-bottom: 0; // prevent double border
+                border-top-right-radius: 0;
 
                 &.active {
                     border-left-width: 5px;

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -1,33 +1,6 @@
 /*!
  * ---------------------------------------------------------------------
- *
- * GLPI - Gestionnaire Libre de Parc Informatique
- *
- * http://glpi-project.org
- *
- * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
- * @licence   https://www.gnu.org/licenses/gpl-3.0.html
- *
- * ---------------------------------------------------------------------
- *
- * LICENSE
- *
- * This file is part of GLPI.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
+ * GLPI - Card Tabs Fix (Final)
  * ---------------------------------------------------------------------
  */
 
@@ -45,31 +18,27 @@
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
 
-            /* FIXED: Kill Top/Left/Right borders explicitly */
-            border-top: 0;
-            border-left: 0;
-            border-right: 0;
-
-            /* FIXED: Make the bottom separator TRANSPARENT by default 
-               so inactive tabs don't show lines (prevents double borders) */
-            border-bottom: 1px solid transparent;
+            /* 1. FORCE REMOVAL OF ALL BORDERS BY DEFAULT */
+            /* This kills the "second border" on inactive tabs */
+            border: 0 !important;
+            border-radius: 0;
 
             &.active {
-                /* Active Tab Background & Text */
+                /* 2. RESTORE BORDERS ONLY FOR ACTIVE TAB */
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 font-weight: bold;
 
-                /* FIXED: Active borders specifics */
-                border-right: 1px solid transparent !important;
-                margin-right: -1px; // Hack for border overlap
-
-                /* The Left Accent Border (Primary Color) */
+                /* Left accent (thick line) */
                 border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
                 
-                /* The Bottom Border (Visible only on Active tab) */
+                /* Bottom separator (thin line) */
                 border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
                 
+                /* Ensure right side is open/transparent */
+                border-right: 1px solid transparent !important;
+                margin-right: -1px; 
+
                 .badge {
                     font-weight: bold;
                 }
@@ -79,44 +48,23 @@
                 margin-left: 5px;
             }
         }
-    }
-
-    /* Vertical Specifics (Legacy/Backup) */
-    &.vertical {
-        #tabspanel.nav-tabs .nav-link {
-             /* Ensure vertical tabs follow the main rule */
-             border-bottom: 1px solid transparent;
-             border-top-right-radius: 0;
-             border-top-left-radius: 0;
-
-             &.active {
-                 border-left: 5px solid var(--glpi-tabs-active-border-color);
-                 border-right-color: transparent !important;
-                 border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-             }
+        
+        /* Optional: clean up the list item container */
+        .nav-item {
+            border: 0 !important;
         }
     }
 
-    /* Horizontal View Specifics */
+    /* Horizontal Mode (Legacy) - Restore borders if needed */
     &.horizontal {
         #tabspanel.nav-tabs {
             .nav-link {
-                /* Restore borders for horizontal mode */
-                border-bottom-width: 1px;
-                border-bottom-style: solid;
-                border-left: 1px solid var(--glpi-tabs-border-color);
-
-                &:last-of-type {
-                    border-right-width: 1px;
-
-                    &.active {
-                        border-right-color: var(--glpi-tabs-border-color) !important;
-                    }
-                }
+                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                border-left: 1px solid var(--glpi-tabs-border-color) !important;
 
                 &.active {
                     border-bottom-color: transparent !important;
-                    border-left-width: 1px; /* Reset the 5px vertical accent */
+                    border-left-width: 1px !important;
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,14 +67,14 @@
     }
 
     &.vertical {
+        /* Remove Bootstrap nav-tabs bottom border */
         #tabspanel.nav-tabs {
-            border: 0;
+            border-bottom: 0 !important;
         }
 
+        /* Remove Bootstrap negative margin */
         #tabspanel.nav-tabs .nav-link {
-            border: 0;
-            margin: 0;
-            border-radius: 0;
+            margin-bottom: 0;
         }
 
         .nav:not(.nav-underline) {
@@ -87,20 +87,13 @@
             }
 
             .nav-link {
-                background: var(--glpi-tabs-bg);
-                color: var(--glpi-tabs-fg);
+                border: 0;
                 border-left: 3px solid transparent;
-                border-top-right-radius: 0;
+                border-radius: 0;
 
                 &.active {
-                    background: var(--glpi-tabs-active-bg);
-                    color: var(--glpi-tabs-active-fg);
                     border-left: 5px solid var(--glpi-tabs-active-border-color);
                     font-weight: bold;
-                }
-
-                .badge {
-                    margin-left: 5px;
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,37 +67,23 @@
     }
 
     &.vertical {
-        #tabspanel.nav-tabs {
-            border-bottom: 0; // kill Bootstrap bottom border
+        #tabspanel.nav-tabs .nav-link {
+            margin-bottom: 0;
         }
     
-        .nav-tabs .nav-link {
-            border: 0; // remove ALL Bootstrap borders
+        .nav:not(.nav-underline) .nav-link {
+            border-bottom: 1px solid var(--glpi-tabs-border-color);
+            border-top-right-radius: 0;
+    
+            &.active {
+                border-left-width: 5px;
+                border-right-color: transparent !important;
+                margin-right: -1px; // keep this
+            }
         }
     
-        .nav:not(.nav-underline) {
-            .nav-item {
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-    
-                &:last-child {
-                    border-bottom: 0;
-                }
-            }
-    
-            .nav-link {
-                background: var(--glpi-tabs-bg);
-                color: var(--glpi-tabs-fg);
-                border-top-right-radius: 0;
-    
-                &.active {
-                    border-left: 5px solid var(--glpi-tabs-active-border-color);
-                    border-right: 1px solid transparent !important;
-                    margin-right: -1px; // keep overlap
-                    background: var(--glpi-tabs-active-bg);
-                    color: var(--glpi-tabs-active-fg);
-                    font-weight: bold;
-                }
-            }
+        .nav:not(.nav-underline) .nav-item:last-child .nav-link {
+            border-bottom: 0;
         }
     }
 

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -72,34 +72,34 @@
                     /* 1. VISIBILITY: Fix bottom border and remove overlap gap */
                     border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
                     margin-bottom: 0 !important;
-    
+
                     /* 2. LAYOUT: Remove top border (prevents double lines) */
                     border-top: 0 !important;
-    
+
                     /* 3. CORNER FIX: Flatten the right side to attach to the panel */
                     border-top-right-radius: 0 !important;
                     border-bottom-right-radius: 0 !important;
-    
+
                     /* 4. ACTIVE STATE: Restore the thick left border */
                     &.active {
                         /* We force the width and style to ensure it appears */
                         border-left-width: 5px !important;
                         border-left-style: solid !important;
-                        
+
                         /* We explicitly inherit the color to ensure it stays Blue (or your theme color) */
                         border-left-color: var(--glpi-tabs-active-border-color) !important;
-                        
+
                         /* Ensure the right side remains open */
                         border-right-color: transparent !important;
                     }
                 }
-    
+
                 /* 5. FIRST ITEM: Restore top border to close the list */
                 .nav-item:first-child .nav-link {
                     border-top: 1px solid var(--glpi-tabs-border-color) !important;
                     border-top-left-radius: 4px;
                 }
-    
+
                 /* 6. LAST ITEM: Flatten bottom-right corner */
                 .nav-item:last-child .nav-link {
                     border-bottom-right-radius: 0 !important;

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -68,21 +68,19 @@
 
     &.vertical {
         .nav:not(.nav-underline) {
-            .nav-item {
+            .nav-link {
                 border-bottom: 1px solid var(--glpi-tabs-border-color);
+                border-top-right-radius: 0;
     
-                &:last-child {
+                /* Remove bottom border only from last visible link */
+                &:last-of-type {
                     border-bottom: 0;
                 }
-            }
     
-            .nav-link {
-                border-bottom: 0; // prevent double border
-                border-top-right-radius: 0;
-
                 &.active {
                     border-left-width: 5px;
                     border-right-color: transparent !important;
+                    margin-right: -1px;
                 }
             }
         }

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,19 +67,35 @@
     }
 
     &.vertical {
-        .nav:not(.nav-underline)
-            .nav-link {
-                /* FIX: Remove top border to prevent doubling with the bottom border of the previous item */
-                border-top: 0;
-                border-bottom: 1px solid var(--glpi-tabs-border-color);
-                border-top-right-radius: 0;
-
-                &.active {
-                    border-left-width: 5px;
-                    border-right-color: transparent !important;
+            /* We add #tabspanel here to ensure we win the 'specificity war' against the generic rules */
+            #tabspanel.nav-tabs {
+                .nav-link {
+                    /* 1. Ensure borders are solid and visible on all sides first */
+                    border: 1px solid var(--glpi-tabs-border-color);
+                    
+                    /* 2. Remove the top border from ALL items to stop the "double border" thickness */
+                    border-top: 0;
+                    
+                    /* 3. Keep the right side square (standard for vertical tabs) */
+                    border-top-right-radius: 0;
+                    border-bottom-right-radius: 0;
+    
+                    &.active {
+                        /* Restore the active indicator */
+                        border-left-width: 5px;
+                        border-right-color: transparent !important;
+                        margin-right: -1px;
+                    }
+                }
+    
+                /* 4. EXCEPTION: The very first item MUST have a top border to close the list */
+                .nav-item:first-child .nav-link {
+                    border-top: 1px solid var(--glpi-tabs-border-color);
+                    /* Optional: Ensure the top-left corner is rounded if you prefer */
+                    border-top-left-radius: var(--bs-border-radius, 4px); 
                 }
             }
-    }
+        }
 
     &.horizontal {
         #tabspanel.nav-tabs {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -36,23 +36,33 @@
 }
 
 .card-tabs {
+    /* 1. Keep the main separation line on the UL (the right side) */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
+    /* 2. Style the tabs within the panel */
     #tabspanel.nav-tabs {
+        border-bottom: 0; /* Remove default bootstrap nav-tabs bottom border */
+
         .nav-link {
+            /* 3. RESET: clear all default borders first to prevent "double border" */
+            border: 1px solid transparent; 
+            border-right-width: 0; /* We handle the right side via the panel or margin hack */
+            
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            border-color: var(--glpi-tabs-border-color);
-            border-right-width: 0;
 
+            /* 4. ACTIVE STATE: The "Fusion" effect */
             &.active {
-                border-right: 1px solid transparent !important;
-                margin-right: -1px; // required for horizontal merge
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
-                border-color: var(--glpi-tabs-active-border-color);
+                
+                /* Overlap the panel's right border */
+                margin-right: -1px; 
+                border: 1px solid var(--glpi-tabs-active-border-color);
+                border-right-color: transparent !important; 
+                
                 font-weight: bold;
 
                 .badge {
@@ -66,50 +76,43 @@
         }
     }
 
+    /* 5. VERTICAL SPECIFIC STYLES */
     &.vertical {
-        /* The real visual frame belongs to the container */
-        border: 1px solid var(--glpi-tabs-border-color);
-        border-radius: var(--tblr-border-radius);
-        overflow: hidden;
-
-        /* Remove Bootstrap nav-tabs borders */
-        #tabspanel.nav-tabs {
-            border: 0 !important;
-        }
-
-        /* Remove Bootstrap negative margin behavior */
-        #tabspanel.nav-tabs .nav-link {
-            margin: 0;
-        }
-
-        /* Remove right border from previous rule */
-        #tabspanel {
-            border: 0;
-        }
-
         .nav:not(.nav-underline) {
             .nav-item {
-                border: 0; // prevent double stacking
+                /* Ensure no extra spacing interferes with borders */
+                margin: 0; 
 
-                /* separator line */
-                &:not(:last-child) {
-                    border-bottom: 1px solid var(--glpi-tabs-border-color);
+                /* 6. Restore Rounded Corner on FIRST item only */
+                &:first-child .nav-link {
+                    border-top-left-radius: var(--tblr-border-radius, 4px);
+                }
+                
+                /* Ensure other items are square */
+                &:not(:first-child) .nav-link {
+                    border-radius: 0;
                 }
             }
 
             .nav-link {
-                border: 0;
-                border-left: 3px solid transparent;
-                border-radius: 0;
+                /* 7. The clean separator line */
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
+                
+                /* Ensure no left border by default (unless active) */
+                border-left: 1px solid transparent; 
+                border-top: 0; /* Clean top to avoid double lines with previous bottom */
 
                 &.active {
+                    /* The thick accent on the left */
                     border-left: 5px solid var(--glpi-tabs-active-border-color);
-                    font-weight: bold;
+                    border-right-color: transparent !important;
+                    border-bottom-color: var(--glpi-tabs-border-color);
                 }
             }
         }
     }
 
+    /* Horizontal fallback (kept from your original) */
     &.horizontal {
         #tabspanel.nav-tabs {
             .nav-link {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -66,33 +66,46 @@
         }
     }
 
-    &.vertical {
-            #tabspanel.nav-tabs {
-                .nav-link {
-                    /* 1. VISIBILITY: Force borders to show and prevent overlapping */
-                    border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                    margin-bottom: 0 !important; /* Replaces your commented-out line safely */
-    
-                    /* 2. LAYOUT: Remove top border to prevent double-thickness */
-                    border-top: 0 !important;
-    
-                    /* 3. CORNER FIX: Remove the strange radius you see on the right */
-                    border-top-right-radius: 0 !important;
-                    border-bottom-right-radius: 0 !important;
-                }
-    
-                /* 4. FIRST ITEM: Needs a top border to close the list */
-                .nav-item:first-child .nav-link {
-                    border-top: 1px solid var(--glpi-tabs-border-color) !important;
-                    border-top-left-radius: 4px; /* Optional: Keep top-left rounded */
-                }
-                
-                /* 5. LAST ITEM: Ensure the very bottom-right corner is square (optional safety) */
-                 .nav-item:last-child .nav-link {
-                    border-bottom-right-radius: 0 !important;
+&.vertical {
+        #tabspanel.nav-tabs {
+            .nav-link {
+                /* 1. VISIBILITY: Fix bottom border and remove overlap gap */
+                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                margin-bottom: 0 !important;
+
+                /* 2. LAYOUT: Remove top border (prevents double lines) */
+                border-top: 0 !important;
+
+                /* 3. CORNER FIX: Flatten the right side to attach to the panel */
+                border-top-right-radius: 0 !important;
+                border-bottom-right-radius: 0 !important;
+
+                /* 4. ACTIVE STATE: Restore the thick left border */
+                &.active {
+                    /* We force the width and style to ensure it appears */
+                    border-left-width: 5px !important;
+                    border-left-style: solid !important;
+                    
+                    /* We explicitly inherit the color to ensure it stays Blue (or your theme color) */
+                    border-left-color: var(--glpi-tabs-active-border-color) !important;
+                    
+                    /* Ensure the right side remains open */
+                    border-right-color: transparent !important;
                 }
             }
+
+            /* 5. FIRST ITEM: Restore top border to close the list */
+            .nav-item:first-child .nav-link {
+                border-top: 1px solid var(--glpi-tabs-border-color) !important;
+                border-top-left-radius: 4px;
+            }
+
+            /* 6. LAST ITEM: Flatten bottom-right corner */
+            .nav-item:last-child .nav-link {
+                border-bottom-right-radius: 0 !important;
+            }
         }
+    }
 
     &.horizontal {
         #tabspanel.nav-tabs {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -66,46 +66,46 @@
         }
     }
 
-&.vertical {
-        #tabspanel.nav-tabs {
-            .nav-link {
-                /* 1. VISIBILITY: Fix bottom border and remove overlap gap */
-                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
-                margin-bottom: 0 !important;
-
-                /* 2. LAYOUT: Remove top border (prevents double lines) */
-                border-top: 0 !important;
-
-                /* 3. CORNER FIX: Flatten the right side to attach to the panel */
-                border-top-right-radius: 0 !important;
-                border-bottom-right-radius: 0 !important;
-
-                /* 4. ACTIVE STATE: Restore the thick left border */
-                &.active {
-                    /* We force the width and style to ensure it appears */
-                    border-left-width: 5px !important;
-                    border-left-style: solid !important;
-                    
-                    /* We explicitly inherit the color to ensure it stays Blue (or your theme color) */
-                    border-left-color: var(--glpi-tabs-active-border-color) !important;
-                    
-                    /* Ensure the right side remains open */
-                    border-right-color: transparent !important;
+    &.vertical {
+            #tabspanel.nav-tabs {
+                .nav-link {
+                    /* 1. VISIBILITY: Fix bottom border and remove overlap gap */
+                    border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                    margin-bottom: 0 !important;
+    
+                    /* 2. LAYOUT: Remove top border (prevents double lines) */
+                    border-top: 0 !important;
+    
+                    /* 3. CORNER FIX: Flatten the right side to attach to the panel */
+                    border-top-right-radius: 0 !important;
+                    border-bottom-right-radius: 0 !important;
+    
+                    /* 4. ACTIVE STATE: Restore the thick left border */
+                    &.active {
+                        /* We force the width and style to ensure it appears */
+                        border-left-width: 5px !important;
+                        border-left-style: solid !important;
+                        
+                        /* We explicitly inherit the color to ensure it stays Blue (or your theme color) */
+                        border-left-color: var(--glpi-tabs-active-border-color) !important;
+                        
+                        /* Ensure the right side remains open */
+                        border-right-color: transparent !important;
+                    }
+                }
+    
+                /* 5. FIRST ITEM: Restore top border to close the list */
+                .nav-item:first-child .nav-link {
+                    border-top: 1px solid var(--glpi-tabs-border-color) !important;
+                    border-top-left-radius: 4px;
+                }
+    
+                /* 6. LAST ITEM: Flatten bottom-right corner */
+                .nav-item:last-child .nav-link {
+                    border-bottom-right-radius: 0 !important;
                 }
             }
-
-            /* 5. FIRST ITEM: Restore top border to close the list */
-            .nav-item:first-child .nav-link {
-                border-top: 1px solid var(--glpi-tabs-border-color) !important;
-                border-top-left-radius: 4px;
-            }
-
-            /* 6. LAST ITEM: Flatten bottom-right corner */
-            .nav-item:last-child .nav-link {
-                border-bottom-right-radius: 0 !important;
-            }
         }
-    }
 
     &.horizontal {
         #tabspanel.nav-tabs {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -41,18 +41,33 @@
     }
 
     #tabspanel.nav-tabs {
+        /* Ensure the list item wrapper has no border (prevents double-border issue) */
+        .nav-item {
+            border: 0 !important;
+        }
+
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
-            border-color: var(--glpi-tabs-border-color);
+            
+            /* RESET: Remove default borders */
+            border: 0;
             border-right-width: 0;
+            
+            /* FORCE: Add a clean single line at the bottom */
+            border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
 
             &.active {
                 border-right: 1px solid transparent !important;
-                margin-right : -1px; // Hack for border overlap
+                margin-right : -1px;
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
+                
+                /* Specific borders for active state */
                 border-color: var(--glpi-tabs-active-border-color);
+                border-left: 5px solid var(--glpi-tabs-active-border-color) !important;
+                border-bottom: 1px solid var(--glpi-tabs-border-color) !important;
+                
                 font-weight: bold;
 
                 .badge {
@@ -63,6 +78,11 @@
             .badge {
                 margin-left: 5px;
             }
+        }
+
+        /* CLEANUP: Remove the border from the very last tab */
+        .nav-item:last-child .nav-link {
+            border-bottom: 0 !important;
         }
     }
 

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -49,7 +49,7 @@
 
             &.active {
                 border-right: 1px solid transparent !important;
-                margin-right: -1px; // Hack for border overlap
+                margin-right: -1px; // required for horizontal merge
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
                 border-color: var(--glpi-tabs-active-border-color);
@@ -67,23 +67,42 @@
     }
 
     &.vertical {
+        #tabspanel.nav-tabs {
+            border: 0;
+        }
+
         #tabspanel.nav-tabs .nav-link {
-            margin-bottom: 0;
+            border: 0;
+            margin: 0;
+            border-radius: 0;
         }
-    
-        .nav:not(.nav-underline) .nav-link {
-            border-bottom: 1px solid var(--glpi-tabs-border-color);
-            border-top-right-radius: 0;
-    
-            &.active {
-                border-left-width: 5px;
-                border-right-color: transparent !important;
-                margin-right: -1px; // keep this
+
+        .nav:not(.nav-underline) {
+            .nav-item {
+                border-bottom: 1px solid var(--glpi-tabs-border-color);
+
+                &:last-child {
+                    border-bottom: 1px solid var(--glpi-tabs-border-color);
+                }
             }
-        }
-    
-        .nav:not(.nav-underline) .nav-item:last-child .nav-link {
-            border-bottom: 0;
+
+            .nav-link {
+                background: var(--glpi-tabs-bg);
+                color: var(--glpi-tabs-fg);
+                border-left: 3px solid transparent;
+                border-top-right-radius: 0;
+
+                &.active {
+                    background: var(--glpi-tabs-active-bg);
+                    color: var(--glpi-tabs-active-fg);
+                    border-left: 5px solid var(--glpi-tabs-active-border-color);
+                    font-weight: bold;
+                }
+
+                .badge {
+                    margin-left: 5px;
+                }
+            }
         }
     }
 

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -67,7 +67,12 @@
     }
 
     &.vertical {
-        /* Remove Bootstrap nav-tabs borders completely */
+        /* The real visual frame belongs to the container */
+        border: 1px solid var(--glpi-tabs-border-color);
+        border-radius: var(--tblr-border-radius);
+        overflow: hidden;
+
+        /* Remove Bootstrap nav-tabs borders */
         #tabspanel.nav-tabs {
             border: 0 !important;
         }
@@ -77,18 +82,12 @@
             margin: 0;
         }
 
-        /* Panel frame (top + right side) */
+        /* Remove right border from previous rule */
         #tabspanel {
-            border-top: 1px solid var(--glpi-tabs-border-color);
-            border-right: 1px solid var(--glpi-tabs-border-color);
-            border-top-left-radius: var(--tblr-border-radius);
-            overflow: hidden; // ensures radius is visible
+            border: 0;
         }
 
         .nav:not(.nav-underline) {
-            /* Remove inherited borders from other rules */
-            border: 0;
-
             .nav-item {
                 border: 0; // prevent double stacking
 

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -80,6 +80,7 @@
         /* Add top border for full frame */
         #tabspanel {
             border-top: 1px solid var(--glpi-tabs-border-color);
+            border-top-left-radius: var(--tblr-border-radius);
         }
 
         .nav:not(.nav-underline) {

--- a/css/includes/components/_tabs.scss
+++ b/css/includes/components/_tabs.scss
@@ -31,36 +31,55 @@
  * ---------------------------------------------------------------------
  */
 
+/*!
+ * ---------------------------------------------------------------------
+ * GLPI - Custom Tab Fix
+ * ---------------------------------------------------------------------
+ */
+
 .tab-content {
     border-top-left-radius: 0;
 }
 
 .card-tabs {
+    /* 1. Main Container Border */
     #tabspanel {
         border-right: 1px solid var(--glpi-tabs-border-color);
     }
 
+    /* 2. Global Reset for this tab panel */
     #tabspanel.nav-tabs {
+        border-bottom: 0; /* Remove Bootstrap's default bottom border on the container */
+
+        /* KILL THE GHOST: Remove any potential border from the list item wrapper */
+        .nav-item {
+            border: 0 !important;
+            margin-bottom: 0 !important;
+        }
+
         .nav-link {
             background: var(--glpi-tabs-bg);
             color: var(--glpi-tabs-fg);
+            
+            /* RESET: Ensure no rogue borders appear */
+            border: 0;
+            border-radius: 0; /* Sharp corners for vertical stacking */
 
-            /* FIXED: Explicitly reset side/top borders but FORCE the bottom one */
-            border-top: 0;
-            border-left: 0;
-            border-right: 0;
+            /* STRATEGY: Add bottom border, then pull the next item up by 1px to overlap */
             border-bottom: 1px solid var(--glpi-tabs-border-color);
+            margin-bottom: -1px; 
 
             &.active {
+                /* Active State: Bring to front (z-index) so its border sits on top */
+                z-index: 2; 
                 background: var(--glpi-tabs-active-bg);
                 color: var(--glpi-tabs-active-fg);
 
-                /* FIXED: Vertical active state borders */
-                border-left: 5px solid var(--glpi-tabs-active-border-color);
-                border-right: 1px solid transparent !important;
+                /* Active Borders */
                 border-bottom: 1px solid var(--glpi-tabs-border-color);
+                border-left: 5px solid var(--glpi-tabs-active-border-color);
+                border-right: 1px solid transparent; // Blend with content area
                 
-                margin-right : -1px; // Hack for border overlap
                 font-weight: bold;
 
                 .badge {
@@ -72,33 +91,22 @@
                 margin-left: 5px;
             }
         }
-
-        /* FIXED: Remove the border from the very last tab so it doesn't double with container edge */
-        .nav-item:last-child .nav-link {
-            border-bottom: 0 !important;
-        }
     }
 
-    /* Horizontal View Specifics */
+    /* 3. Horizontal View (Legacy/Desktop) */
     &.horizontal {
         #tabspanel.nav-tabs {
+            border-bottom: 1px solid var(--glpi-tabs-border-color); /* Restore container border */
+
             .nav-link {
-                /* Restore borders for horizontal mode */
-                border-bottom-width: 1px;
-                border-bottom-style: solid;
+                margin-bottom: -1px; /* Overlap bottom container border */
+                border: 1px solid transparent;
+                border-bottom: 0; /* Let container handle the line */
                 border-left: 1px solid var(--glpi-tabs-border-color);
 
-                &:last-of-type {
-                    border-right-width: 1px;
-
-                    &.active {
-                        border-right-color: var(--glpi-tabs-border-color) !important;
-                    }
-                }
-
                 &.active {
-                    border-bottom-color: transparent !important;
-                    border-left-width: 1px; /* Reset the 5px vertical accent */
+                    border-color: var(--glpi-tabs-border-color) var(--glpi-tabs-border-color) #fff;
+                    border-left-width: 1px; /* Reset the 5px accent */
                 }
             }
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR fixes several visual regressions in the styling of vertical tabs (e.g., **Administration > Forms** or any object's tab) in GLPI 11.0.5.

Previously, tabs rendered both a ``border-bottom`` (from the item above) and a ``border-top`` (from the item below), creating a "double-thick" line between items.

Due to specificity conflicts with generic Bootstrap/Tabler styles, the bottom border on inactive tabs was often invisible or only appeared on hover.

I have updated the ``.card-tabs.vertical`` SCSS block to:

- Remove ``border-top`` from all tab items to prevent border doubling (stacking).
- Restore ``border-top`` only on the first child to ensure the list is visually closed at the top.
- Force ``border-bottom`` visibility and remove the negative ``margin-bottom`` that was hiding borders.
- Flatten right-side corners (``border-top-right-radius: 0``) so tabs attach flush to the content panel.
- Explicitly define Active State properties (width, style, color) to ensure the active indicator remains consistent regardless of theme or specificity.

## Screenshots (if appropriate):

Before this PR:

<img width="191" height="261" alt="2026-02-10 18_44_23-Greenshot" src="https://github.com/user-attachments/assets/61cb2182-04c1-42af-b5dd-41e119f0abe6" />

After this PR:

<img width="191" height="248" alt="image" src="https://github.com/user-attachments/assets/93c2d661-efc0-49aa-b8b2-2833713b4ddc" />
