### PR TITLE
Fix raw value stored when field is globally locked

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1365,7 +1365,7 @@ class CommonDBTM extends CommonGLPI
                     ($key[0] !== '_')
                     && isset($table_fields[$key])
                 ) {
-                    $this->fields[$key] = $this->input['_raw' . $key] ?? $this->input[$key];
+                    $this->fields[$key] = $this->input[$key];
                 }
             }
 

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -246,6 +246,7 @@ abstract class InventoryAsset
                 //do not process field if it's locked
                 foreach ($locks as $lock) {
                     if ($key == $lock) {
+                        unset($value->$key);
                         continue 2;
                     }
                 }


### PR DESCRIPTION
Alternative to https://github.com/glpi-project/glpi/pull/23085 (and maybe to https://github.com/glpi-project/glpi/pull/23078).

With current system, locks on update seems correct, but we often have issue on add.
When a field is globally locked, its value must never change; and this field must not be imported in the database. But it is on add; we finally have the initial value that is set. I consider it's wrong.

Another alternative would be not to handle locked fields at all on add; rather than trying to deal with incertain data. If we ends with db integration of all values; there is no need to check locks.
