### PR TITLE
Knowbase UI tweaks 1

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -30,6 +30,10 @@
  * ---------------------------------------------------------------------
  */
 
+.article-container {
+    max-width: 1320px !important;
+}
+
 .kb-sidepanel {
     background-color: var(--tblr-card-cap-bg);
     border-left: 1px solid #e1e4e8;
@@ -43,6 +47,12 @@
         padding-right: 0.5rem;
         border-left: none;
     }
+
+    &.closed {
+        width: 0;
+        overflow: hidden;
+        padding: 0 !important;
+    }
 }
 
 .kb-article {
@@ -54,6 +64,12 @@
         overflow: visible;
         max-height: none;
     }
+
+    transition: width 0.35s ease-in-out;
+}
+
+[data-glpi-knowbase-side-panel-offcanvas] {
+    width: min(400px, 85vw);
 }
 
 // KB Documents footer section

--- a/css/standalone/kb.scss
+++ b/css/standalone/kb.scss
@@ -375,23 +375,3 @@ input[type="checkbox"].toggle_comments {
         margin: 0 0.25rem;
     }
 }
-
-.article-container {
-    max-width: 1320px !important;
-}
-
-.kb-article {
-    transition: width 0.35s ease-in-out;
-}
-
-.kb-sidepanel {
-    &.closed {
-        width: 0;
-        overflow: hidden;
-        padding: 0 !important;
-    }
-}
-
-[data-glpi-knowbase-side-panel-offcanvas] {
-    width: min(400px, 85vw);
-}

--- a/css/standalone/kb.scss
+++ b/css/standalone/kb.scss
@@ -375,3 +375,19 @@ input[type="checkbox"].toggle_comments {
         margin: 0 0.25rem;
     }
 }
+
+.article-container {
+    max-width: 1320px !important;
+}
+
+.kb-article {
+    transition: width 0.35s ease-in-out, width 0.35s ease-in-out;
+}
+
+.kb-sidepanel {
+    &.closed {
+        width: 0;
+        overflow: hidden;
+        padding: 0 !important;
+    }
+}

--- a/css/standalone/kb.scss
+++ b/css/standalone/kb.scss
@@ -381,7 +381,7 @@ input[type="checkbox"].toggle_comments {
 }
 
 .kb-article {
-    transition: width 0.35s ease-in-out, width 0.35s ease-in-out;
+    transition: width 0.35s ease-in-out;
 }
 
 .kb-sidepanel {
@@ -390,4 +390,8 @@ input[type="checkbox"].toggle_comments {
         overflow: hidden;
         padding: 0 !important;
     }
+}
+
+[data-glpi-knowbase-side-panel-offcanvas] {
+    width: min(400px, 85vw);
 }

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -71,6 +71,7 @@ export class GlpiKnowbaseArticleController
         this.#container = container;
         this.#side_panel = new GlpiKnowbaseArticleSidePanelController(
             side_panel_container,
+            this.#container.querySelector('[data-glpi-knowbase-article-content]'),
         );
         this.#item_id = parseInt(container.dataset.glpiKbItemId, 10) || null;
 

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -65,12 +65,14 @@ export class GlpiKnowbaseArticleController
     /**
      * @param {HTMLElement} container
      * @param {HTMLElement} side_panel_container
+     * @param {HTMLElement} offcanvas_container
      */
-    constructor(container, side_panel_container)
+    constructor(container, side_panel_container, offcanvas_container)
     {
         this.#container = container;
         this.#side_panel = new GlpiKnowbaseArticleSidePanelController(
             side_panel_container,
+            offcanvas_container,
             this.#container.querySelector('[data-glpi-knowbase-article-content]'),
         );
         this.#item_id = parseInt(container.dataset.glpiKbItemId, 10) || null;

--- a/js/modules/Knowbase/ArticleSidePanelController.js
+++ b/js/modules/Knowbase/ArticleSidePanelController.js
@@ -39,6 +39,11 @@ import { GlpiKnowbaseRevisionsPanelController } from "/js/modules/Knowbase/Revis
 export class GlpiKnowbaseArticleSidePanelController
 {
     /**
+     * @type {number}
+     */
+    static #OFFCANVAS_BREAKPOINT = 1500;
+
+    /**
      * @type {HTMLElement}
      */
     #container;
@@ -46,17 +51,36 @@ export class GlpiKnowbaseArticleSidePanelController
     /**
      * @type {HTMLElement}
      */
+    #offcanvas_container;
+
+    /**
+     * @type {HTMLElement}
+     */
     #article;
 
-    constructor(container, article)
+    /**
+     * @param {HTMLElement} container
+     * @param {HTMLElement} offcanvas_container
+     * @param {HTMLElement} article
+     */
+    constructor(container, offcanvas_container, article)
     {
         this.#container = container;
+        this.#offcanvas_container = offcanvas_container;
         this.#article = article;
         this.#initEventListeners();
 
         new GlpiKnowbaseCommentsPanelController(this.#container);
         new GlpiKnowbaseServiceCatalogPanelController(this.#container);
         new GlpiKnowbaseRevisionsPanelController(this.#container);
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    #isSmallScreen()
+    {
+        return window.innerWidth < GlpiKnowbaseArticleSidePanelController.#OFFCANVAS_BREAKPOINT;
     }
 
     #initEventListeners()
@@ -66,20 +90,38 @@ export class GlpiKnowbaseArticleSidePanelController
                 this.#close();
             }
         });
+
+        this.#offcanvas_container.addEventListener('click', (e) => {
+            if (e.target.closest('[data-glpi-knowbase-side-panel-close]')) {
+                this.#close();
+            }
+        });
     }
 
     #open()
     {
-        this.#container.classList.remove('closed');
-        this.#article.classList.remove('col-12');
-        this.#article.classList.add('col-9');
+        if (this.#isSmallScreen()) {
+            const offcanvas = bootstrap.Offcanvas.getOrCreateInstance(this.#offcanvas_container);
+            offcanvas.show();
+        } else {
+            this.#container.classList.remove('closed');
+            this.#article.classList.remove('col-12');
+            this.#article.classList.add('col-9');
+        }
     }
 
     #close()
     {
-        this.#container.classList.add('closed');
-        this.#article.classList.remove('col-9');
-        this.#article.classList.add('col-12');
+        if (this.#isSmallScreen()) {
+            const offcanvas = bootstrap.Offcanvas.getInstance(this.#offcanvas_container);
+            if (offcanvas) {
+                offcanvas.hide();
+            }
+        } else {
+            this.#container.classList.add('closed');
+            this.#article.classList.remove('col-9');
+            this.#article.classList.add('col-12');
+        }
     }
 
     /**
@@ -96,12 +138,17 @@ export class GlpiKnowbaseArticleSidePanelController
             throw new Error("Failed to load side panel content.");
         }
 
+        const html = await response.text();
+        const target = this.#isSmallScreen()
+            ? this.#offcanvas_container.querySelector('.offcanvas-body')
+            : this.#container;
+
         // jQuery's .html() trigger scripts execution, which is needed for select2 and tinymce
-        $(this.#container).html(await response.text());
+        $(target).html(html);
         this.#open();
 
         // Trigger bootstrap tooltips
-        new bootstrap.Tooltip(this.#container, {
+        new bootstrap.Tooltip(target, {
             selector: "[data-bs-toggle='tooltip']"
         });
     }

--- a/js/modules/Knowbase/ArticleSidePanelController.js
+++ b/js/modules/Knowbase/ArticleSidePanelController.js
@@ -43,9 +43,15 @@ export class GlpiKnowbaseArticleSidePanelController
      */
     #container;
 
-    constructor(container)
+    /**
+     * @type {HTMLElement}
+     */
+    #article;
+
+    constructor(container, article)
     {
         this.#container = container;
+        this.#article = article;
         this.#initEventListeners();
 
         new GlpiKnowbaseCommentsPanelController(this.#container);
@@ -57,9 +63,23 @@ export class GlpiKnowbaseArticleSidePanelController
     {
         this.#container.addEventListener('click', (e) => {
             if (e.target.closest('[data-glpi-knowbase-side-panel-close]')) {
-                this.#container.classList.add('d-none');
+                this.#close();
             }
         });
+    }
+
+    #open()
+    {
+        this.#container.classList.remove('closed');
+        this.#article.classList.remove('col-12');
+        this.#article.classList.add('col-9');
+    }
+
+    #close()
+    {
+        this.#container.classList.add('closed');
+        this.#article.classList.remove('col-9');
+        this.#article.classList.add('col-12');
     }
 
     /**
@@ -78,7 +98,7 @@ export class GlpiKnowbaseArticleSidePanelController
 
         // jQuery's .html() trigger scripts execution, which is needed for select2 and tinymce
         $(this.#container).html(await response.text());
-        this.#container.classList.remove('d-none');
+        this.#open();
 
         // Trigger bootstrap tooltips
         new bootstrap.Tooltip(this.#container, {

--- a/src/Glpi/Knowbase/EditorActionSeparator.php
+++ b/src/Glpi/Knowbase/EditorActionSeparator.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Knowbase;
+
+final readonly class EditorActionSeparator {}

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -42,6 +42,7 @@ use Glpi\Features\TreeBrowse;
 use Glpi\Features\TreeBrowseInterface;
 use Glpi\Form\ServiceCatalog\ServiceCatalogLeafInterface;
 use Glpi\Knowbase\EditorAction;
+use Glpi\Knowbase\EditorActionSeparator;
 use Glpi\Knowbase\EditorActionType;
 use Glpi\Knowbase\History\HistoryBuilder;
 use Glpi\Knowbase\LastUpdateInfo;
@@ -969,53 +970,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
         $last_update_info = $this->getLastUpdateInfo();
         $actions = [];
-        if ($this->canComment()) {
-            $actions[] = new EditorAction(
-                label: "Comments",
-                icon: "ti ti-message-circle",
-                type: EditorActionType::LOAD_SIDE_PANEL,
-                params: [
-                    'id' => $this->fields['id'],
-                    'key' => 'comments',
-                ],
-                counter: countElementsInTable(KnowbaseItem_Comment::getTable(), [
-                    'knowbaseitems_id' => $this->fields['id'],
-                ]),
-            );
-        }
-        if ($this->canUpdateItem()) {
-            $actions[] = new EditorAction(
-                label: "Add to FAQ",
-                icon: "ti ti-bookmark",
-                type: EditorActionType::TOGGLE_VALUE,
-                params: [
-                    'id' => $this->fields['id'],
-                    'field' => 'is_faq',
-                    'checked' => $this->fields['is_faq'],
-                ],
-            );
-            $actions[] = new EditorAction(
-                label: "Service catalog",
-                icon: "ti ti-library",
-                type: EditorActionType::LOAD_SIDE_PANEL,
-                params: [
-                    'id' => $this->fields['id'],
-                    'key' => 'service-catalog',
-                ],
-            );
-        }
-        if ($this->canDeleteItem()) {
-            $actions[] = new EditorAction(
-                label: __("Delete article"),
-                icon: "ti ti-trash",
-                type: EditorActionType::DELETE_ARTICLE,
-                params: [
-                    'id' => $this->fields['id'],
-                ],
-                is_danger: true,
-            );
-        }
-        if ($this->canUpdateItem()) {
+        $can_update_item = $this->can($this->fields['id'], UPDATE);
+        if ($can_update_item) {
             $actions[] = new EditorAction(
                 label: __("History"),
                 icon: "ti ti-history",
@@ -1029,6 +985,56 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                     'knowbaseitems_id' => $this->fields['id'],
                     'language' => '',
                 ]),
+            );
+
+            if ($this->canComment()) {
+                $actions[] = new EditorAction(
+                    label: "Comments",
+                    icon: "ti ti-message-circle",
+                    type: EditorActionType::LOAD_SIDE_PANEL,
+                    params: [
+                        'id' => $this->fields['id'],
+                        'key' => 'comments',
+                    ],
+                    counter: countElementsInTable(KnowbaseItem_Comment::getTable(), [
+                        'knowbaseitems_id' => $this->fields['id'],
+                    ]),
+                );
+            }
+
+            $actions[] = new EditorAction(
+                label: "Service catalog",
+                icon: "ti ti-library",
+                type: EditorActionType::LOAD_SIDE_PANEL,
+                params: [
+                    'id' => $this->fields['id'],
+                    'key' => 'service-catalog',
+                ],
+            );
+
+            $actions[] = new EditorActionSeparator();
+            $actions[] = new EditorAction(
+                label: "Add to FAQ",
+                icon: "ti ti-bookmark",
+                type: EditorActionType::TOGGLE_VALUE,
+                params: [
+                    'id' => $this->fields['id'],
+                    'field' => 'is_faq',
+                    'checked' => $this->fields['is_faq'],
+                ],
+            );
+        }
+
+        if ($this->canDeleteItem()) {
+            $actions[] = new EditorActionSeparator();
+            $actions[] = new EditorAction(
+                label: __("Delete article"),
+                icon: "ti ti-trash",
+                type: EditorActionType::DELETE_ARTICLE,
+                params: [
+                    'id' => $this->fields['id'],
+                ],
+                is_danger: true,
             );
         }
         $actions[] = new EditorAction(
@@ -1053,8 +1059,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             'last_update_can_view_author' => $last_update_info->canViewAuthor(),
             'documents' => $documents,
             'documents_count' => count($documents),
-            'can_add_documents' => $this->can($this->fields['id'], UPDATE),
             'can_edit' => $this->can($this->fields['id'], UPDATE),
+            'can_add_documents' => $can_update_item,
             'edit_mode' => $options['edit_mode'],
             'actions' => $actions,
         ]);

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -77,39 +77,46 @@
                             title="{{ __('More actions') }}"
                         ></i>
                         <ul class="dropdown-menu" data-bs-popper="none">
+                            {% set add_separator = false %}
                             {% for action in actions %}
-                                <li>
-                                    <button
-                                        type="button"
-                                        class="dropdown-item {{ action.is_danger ? "text-danger" : "" }}"
-                                        aria-label="{{ action.label }}"
-                                        data-glpi-kb-action="{{ action.type.value }}"
-                                        {% for key, param in action.params %}
-                                            data-glpi-kb-action-param-{{ key }}="{{ param }}"
-                                        {% endfor %}
-                                    >
-                                        <i class="{{ action.icon }}"></i>
-                                        <span>{{ action.label }}</span>
+                                {% if action is instanceof('\\Glpi\\Knowbase\\EditorActionSeparator') %}
+                                    {# Will add an extra border on the next iteration #}
+                                    {% set add_separator = true %}
+                                {% else %}
+                                    <li class="{{ add_separator ? 'border-top' : '' }}">
+                                        <button
+                                            type="button"
+                                            class="dropdown-item {{ action.is_danger ? "text-danger" : "" }}"
+                                            aria-label="{{ action.label }}"
+                                            data-glpi-kb-action="{{ action.type.value }}"
+                                            {% for key, param in action.params %}
+                                                data-glpi-kb-action-param-{{ key }}="{{ param }}"
+                                            {% endfor %}
+                                        >
+                                            <i class="{{ action.icon }}"></i>
+                                            <span>{{ action.label }}</span>
 
-                                        {% if action.counter is not null %}
-                                            <span
-                                                class="badge glpi-badge ms-auto"
-                                                data-testid="{{ action.params.key }}-counter"
-                                                data-glpi-kb-action-counter="{{ action.params.key }}"
-                                            >{{ action.counter }}</span>
-                                        {% endif %}
+                                            {% if action.counter is not null %}
+                                                <span
+                                                    class="badge glpi-badge ms-auto"
+                                                    data-testid="{{ action.params.key }}-counter"
+                                                    data-glpi-kb-action-counter="{{ action.params.key }}"
+                                                >{{ action.counter }}</span>
+                                            {% endif %}
 
-                                        {% if action.type.value == "TOGGLE_VALUE" %}
-                                            <label class="form-check form-switch ms-auto mb-0">
-                                                <input
-                                                    type="checkbox"
-                                                    class="form-check-input ms-0"
-                                                    {{ action.params.checked ? 'checked' : '' }}
-                                                >
-                                            </label>
-                                        {% endif %}
-                                    </button>
-                                </li>
+                                            {% if action.type.value == "TOGGLE_VALUE" %}
+                                                <label class="form-check form-switch ms-auto mb-0">
+                                                    <input
+                                                        type="checkbox"
+                                                        class="form-check-input ms-0"
+                                                        {{ action.params.checked ? 'checked' : '' }}
+                                                    >
+                                                </label>
+                                            {% endif %}
+                                        </button>
+                                    </li>
+                                    {% set add_separator = false %}
+                                {% endif %}
                             {% endfor %}
                         </ul>
                     {% endif %}
@@ -172,14 +179,12 @@
 
         <hr class="mt-4 mb-4">
 
-<<<<<<< HEAD
         {# Tiptap editor container #}
-        <div id="kb-tiptap-editor"
-             class="rich_text_container"
-             data-testid="content">
-=======
-        <div class="rich_text_container article-container" data-testid="content">
->>>>>>> 8aea1fe262 (Expand KB article container until side panel is opened)
+        <div
+            id="kb-tiptap-editor"
+            class="rich_text_container article-container"
+            data-testid="content"
+        >
             {{ answer|safe_html }}
         </div>
 

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -288,7 +288,18 @@
     <div
         class="col-3 kb-sidepanel px-4 py-3 closed d-flex flex-column"
         data-glpi-knowbase-side-panel
+        data-testid="side-panel"
     >
+    </div>
+</div>
+
+<div
+    class="offcanvas offcanvas-end"
+    tabindex="-1"
+    data-glpi-knowbase-side-panel-offcanvas
+    data-testid="offcanvas"
+>
+    <div class="offcanvas-body px-4 py-3 d-flex flex-column">
     </div>
 </div>
 
@@ -300,6 +311,7 @@
         new module.GlpiKnowbaseArticleController(
             document.querySelector('[data-glpi-knowbase-article]'),
             document.querySelector('[data-glpi-knowbase-side-panel]'),
+            document.querySelector('[data-glpi-knowbase-side-panel-offcanvas]'),
         );
     })();
 </script>

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -34,7 +34,10 @@
      data-glpi-knowbase-article
      data-glpi-kb-item-id="{{ item_id }}"
      data-glpi-kb-can-edit="{{ can_edit ? 'true' : 'false' }}">
-    <article class="col-9 container ms-0 px-4 py-3 kb-article">
+    <article
+        class="col-12 container ms-0 px-4 py-3 kb-article"
+        data-glpi-knowbase-article-content
+    >
         <div class="d-flex align-items-center mb-3">
             <h1 class="fw-bold mb-0" data-testid="subject">{{ subject }}</h1>
             <div class="ms-auto d-flex align-items-center gap-2">
@@ -169,10 +172,14 @@
 
         <hr class="mt-4 mb-4">
 
+<<<<<<< HEAD
         {# Tiptap editor container #}
         <div id="kb-tiptap-editor"
              class="rich_text_container"
              data-testid="content">
+=======
+        <div class="rich_text_container article-container" data-testid="content">
+>>>>>>> 8aea1fe262 (Expand KB article container until side panel is opened)
             {{ answer|safe_html }}
         </div>
 
@@ -274,7 +281,7 @@
         {% endif %}
     </article>
     <div
-        class="col-3 kb-sidepanel px-4 py-3 d-none d-flex flex-column"
+        class="col-3 kb-sidepanel px-4 py-3 closed d-flex flex-column"
         data-glpi-knowbase-side-panel
     >
     </div>

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -35,7 +35,7 @@
      data-glpi-kb-item-id="{{ item_id }}"
      data-glpi-kb-can-edit="{{ can_edit ? 'true' : 'false' }}">
     <article
-        class="col-12 container ms-0 px-4 py-3 kb-article"
+        class="col-12 ms-0 px-4 py-3 kb-article"
         data-glpi-knowbase-article-content
     >
         <div class="d-flex align-items-center mb-3">

--- a/templates/pages/tools/kb/sidepanel/base.html.twig
+++ b/templates/pages/tools/kb/sidepanel/base.html.twig
@@ -35,7 +35,9 @@
     <h2 class="mb-0 fs-3">{% block title %}{% endblock %}</h2>
     <i
         class="ti ti-x ms-auto pointer"
+        role="button"
         data-glpi-knowbase-side-panel-close
+        data-testid="side-panel-close"
         title="{{ __("Close") }}"
         data-bs-toggle="tooltip"
         data-bs-placement="bottom"

--- a/templates/pages/tools/kb/sidepanel/revisions.html.twig
+++ b/templates/pages/tools/kb/sidepanel/revisions.html.twig
@@ -36,7 +36,7 @@
 {% block title %}{{ __("History") }}{% endblock %}
 
 {% block content %}
-    <ul class="steps steps-vertical overflow-auto flex-grow-1 my-n3 py-3" data-glpi-revisions>
+    <ul class="steps steps-vertical border-start-0 overflow-auto my-n3 py-3" data-glpi-revisions>
         {% for event in history.getEvents() %}
             {% set is_revision = event is instanceof("\\Glpi\\Knowbase\\History\\RevisionEvent") %}
 

--- a/tests/e2e/specs/Knowbase/comments.spec.ts
+++ b/tests/e2e/specs/Knowbase/comments.spec.ts
@@ -196,7 +196,7 @@ test('Can reply to a comment thread', async ({ page, profile, api }) => {
     const thread = page.getByText('Root comment for thread').filter({
         visible: true
     });
-    await thread.hover();
+    await thread.hover({ position: {x: 5, y: 5}});
 
     // Click the reply button
     await kb.getButton('Reply...').click();

--- a/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
+++ b/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from "../../fixtures/glpi_fixture";
+import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
+import { Profiles } from "../../utils/Profiles";
+import { getWorkerEntityId } from "../../utils/WorkerEntities";
+
+test('Side panel displays as offcanvas on small screens', async ({
+    page,
+    profile,
+    api
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create a KB item with a comment
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'Responsive KB entry',
+        entities_id: getWorkerEntityId(),
+        answer: "Responsive test answer",
+    });
+    await api.createItem('KnowbaseItem_Comment', {
+        knowbaseitems_id: id,
+        comment: "Test comment for responsive view",
+    });
+
+    // Set viewport to mobile size (< 768px)
+    await page.setViewportSize({ width: 600, height: 800 });
+
+    // Go to article
+    await kb.goto(id);
+    await expect(page.getByText('Responsive test answer')).toBeVisible();
+
+    // Open comments panel
+    await page.getByTitle('More actions').click();
+    await kb.getButton('Comments').click();
+
+    // On small screens, an offcanvas should be disabled
+    const offcanvas = page.getByTestId('offcanvas');
+    const side_panel = page.getByTestId('side-panel');
+    await expect(offcanvas).not.toBeEmpty();
+    await expect(side_panel).toBeEmpty();
+
+    // Comments should be visible within the offcanvas
+    await expect(offcanvas.getByText('Test comment for responsive view').filter({
+        'visible': true,
+    })).toBeAttached();
+
+    // Close the offcanvas
+    const close_button = offcanvas.getByTestId('side-panel-close');
+    await close_button.click();
+
+    // Offcanvas should be hidden after close
+    await expect(offcanvas).toBeHidden();
+});
+
+test('Side panel displays normally on large screens', async ({
+    page,
+    profile,
+    api
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create a KB item with a comment
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'Responsive KB entry',
+        entities_id: getWorkerEntityId(),
+        answer: "Responsive test answer",
+    });
+    await api.createItem('KnowbaseItem_Comment', {
+        knowbaseitems_id: id,
+        comment: "Test comment for responsive view",
+    });
+
+    // Go to article
+    await kb.goto(id);
+    await expect(page.getByText('Responsive test answer')).toBeVisible();
+
+    // Open comments panel and verify it uses the side panel
+    await page.getByTitle('More actions').click();
+    await kb.getButton('Comments').click();
+
+    // On default sized screens, a side panel should be disabled
+    const offcanvas = page.getByTestId('offcanvas');
+    const side_panel = page.getByTestId('side-panel');
+    await expect(offcanvas).toBeEmpty();
+    await expect(side_panel).not.toBeEmpty();
+
+    // Comments should be visible within the side panel
+    await expect(side_panel.getByText('Test comment for responsive view').filter({
+        'visible': true,
+    })).toBeAttached();
+
+    // Close the side panel
+    const close_button = side_panel.getByTestId('side-panel-close');
+    await close_button.click();
+
+    // Side panel should be reduced after close
+    await expect(side_panel).toHaveCSS('width', '1px');
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Multiple small UI improvements for the new KB.

### 1\) Expand KB article container until side panel is opened

The container now take the full space when the sidebar is closed (with a small animation when opening/closing).

Before:
<img width="1948" height="399" alt="image" src="https://github.com/user-attachments/assets/03c8df0c-ac28-4d6c-8823-69bd2c350a62" />

After:
<img width="1928" height="403" alt="image" src="https://github.com/user-attachments/assets/581f3f5b-7e7a-48d5-a124-0fbf1d2d8973" />

### 2\) Don't expand history when they are very few entries

There was too much spacing when the history didn't contains enough entries to fill the vertical space.

Before:
<img width="393" height="692" alt="image" src="https://github.com/user-attachments/assets/810f1466-3431-424a-9192-527f6c58b90c" />

After:
<img width="454" height="273" alt="image" src="https://github.com/user-attachments/assets/f6eb461f-4a65-4a3d-b243-64d2aabd4f45" />

### 3\) Reorder actions and add separator
 
The actions order didn't look like what was built on Alexandre's mock.  
I've reordered them and added section separators like in the mock.

Before:
<img width="278" height="261" alt="image" src="https://github.com/user-attachments/assets/d76090cc-c18a-4855-a576-d801b996e764" />

After:
<img width="274" height="274" alt="image" src="https://github.com/user-attachments/assets/0d266f70-c6c6-4032-ba92-ff1ffb358113" />

###  4\) Use an off-canvas for smaller screens

When we detect a smallish screen, the side panel is now transformed into an off-canvas to prevent the content from being too thin to read.

<img width="1217" height="337" alt="image" src="https://github.com/user-attachments/assets/2705e93d-e251-4d98-8ed9-3365108371e4" />

