### PR TITLE
fix(FuzzyMatcher): Add substring validation to prevent false positive matches

### DIFF
--- a/src/Glpi/FuzzyMatcher/FuzzyMatcher.php
+++ b/src/Glpi/FuzzyMatcher/FuzzyMatcher.php
@@ -157,4 +157,3 @@ final class FuzzyMatcher
         return true;
     }
 }
-

--- a/src/Glpi/FuzzyMatcher/FuzzyMatcher.php
+++ b/src/Glpi/FuzzyMatcher/FuzzyMatcher.php
@@ -130,6 +130,31 @@ final class FuzzyMatcher
 
         $max_cost = $this->strategy->maxCostForSuccess(strlen($word));
 
-        return $cost <= $max_cost;
+        // If the cost is above the maximum cost allowed by the strategy, it's not a match
+        if ($cost > $max_cost) {
+            return false;
+        }
+
+        // Additional check: Ensure that the word contains at least one substring
+        // of consecutive characters from the filter to avoid false positives.
+        // For example, "laptop" should not match "calculation" because none of
+        // the 3-character substrings from "laptop" (lap, apt, pto, top) are
+        // present in "calculation", even though the Levenshtein distance might
+        // be acceptable.
+        if (strlen($filter) >= $this->strategy->minimumFilterLenghtForFuzzySearch()) {
+            $min_substring_length = $this->strategy->minimumFilterLenghtForFuzzySearch();
+
+            for ($offset = 0; $offset <= strlen($filter) - $min_substring_length; $offset++) {
+                $substring = substr($filter, $offset, $min_substring_length);
+                if (str_contains($word, $substring)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return true;
     }
 }
+

--- a/src/Glpi/FuzzyMatcher/PartialMatchStrategy.php
+++ b/src/Glpi/FuzzyMatcher/PartialMatchStrategy.php
@@ -49,7 +49,7 @@ final class PartialMatchStrategy implements FuzzyMatcherStrategyInterface
 
     public function minimumFilterLenghtForFuzzySearch(): int
     {
-        return 5;
+        return 3;
     }
 
     public function insertionCost(): int

--- a/tests/functional/Glpi/FuzzyMatcher/FuzzyMatcherTest.php
+++ b/tests/functional/Glpi/FuzzyMatcher/FuzzyMatcherTest.php
@@ -72,6 +72,10 @@ final class FuzzyMatcherTest extends GLPITestCase
         yield [$subject, "メール", true];
         yield [$subject, "サーバー", true];
         yield [$subject, "メサバー", false];
+
+        $subject = "Calculation";
+        yield [$subject, "laptop", false];
+        yield [$subject, "latop", true];
     }
 
     #[DataProvider('partialMatchStrategyProvider')]


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42043
- The use of Levenshtein distance can generate false positives depending on the cost configuration.

In our case, the deletion cost is deliberately set to 0 so that the user does not have to enter the entire word to obtain a relevant result. This allows superfluous characters in the compared string to be ignored free of charge and makes the search more tolerant.

However, this configuration introduces a side effect:
words may be considered similar when they are not.

For example:

**Word**: calculation
**Filter**: laptop

With a deletion cost of zero, the algorithm can:

1. delete “calcu,” “i,” and “n” at no cost
2. keep the substring “lato”
3. insert two “p”s

(total cost = 2)

The distance returned is therefore low (2), resulting in a false positive, even though the two words are not semantically close.

To limit these false positives, an additional check is added. The word and the filter must share at least one common substring of 3 consecutive characters.

This constraint ensures that there is a genuine structural overlap between the two strings, while maintaining the flexibility offered by the zero deletion cost.

## Screenshots (if appropriate):

Before:
<img width="1344" height="220" alt="image" src="https://github.com/user-attachments/assets/7c29e705-87fc-424b-923a-1a1bae3a57c4" />

After:
<img width="1344" height="220" alt="image" src="https://github.com/user-attachments/assets/c2d20c65-5b47-4d87-94a3-84df8c6bd9ee" />
