### PR TITLE
Update CommonDBTM.php

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4595,7 +4595,10 @@ class CommonDBTM extends CommonGLPI
                         if ($tmp->maybeTemplate()) {
                             $where['is_template'] = 0;
                         }
-
+                        // GLPI Custom Assets support - filter by asset definition ID
+                        if ($this instanceof \Glpi\Asset\Asset) {
+                            $where['assets_assetdefinitions_id'] = static::getDefinition()->getID();
+                        }
                         //If update, exclude ID of the current object
                         if (!$add) {
                             $where['NOT'] = [static::getTable() . '.id' => $this->input['id']];


### PR DESCRIPTION
fix: Add Custom Assets support in CommonDBTM::checkUnicity()`
- **Extended description:** 
```
  Filter duplicate checks by assets_assetdefinitions_id when the item
  is a Custom Asset, ensuring unicity rules only apply within the same
  asset definition type.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


