### PR TITLE
Pass solution as trigger for solved ticket notification

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -387,7 +387,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again change to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
+            $trigger = $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -387,7 +387,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again change to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
+            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 

--- a/src/Change.php
+++ b/src/Change.php
@@ -387,7 +387,8 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again change to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            NotificationEvent::raiseEvent($mailtype, $this);
+            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
+            NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 
         $this->handleSatisfactionSurveyOnUpdate();

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -402,6 +402,7 @@ abstract class CommonITILValidation extends CommonDBChild
             'id' => $itilobject->getID(),
             'global_validation' => static::computeValidationStatus($itilobject),
             '_from_itilvalidation' => true,
+            '_trigger' => $this,
         ];
 
         // to fix lastupdater
@@ -558,6 +559,7 @@ abstract class CommonITILValidation extends CommonDBChild
                 'id'                    => $item->getID(),
                 'global_validation'     => static::computeValidationStatus($item),
                 '_from_itilvalidation'  => true,
+                '_trigger'              => $this,
             ];
 
             if (!$item->update($input)) {
@@ -2149,6 +2151,7 @@ HTML;
                 'id' => $itil_object->getID(),
                 'global_validation' => self::computeValidationStatus($itil_object),
                 '_from_itilvalidation' => true,
+                '_trigger' => $this,
                 '_validationsteps_id' => $validationstep_id ?? null,
             ]
         );

--- a/src/Glpi/Features/ParentStatus.php
+++ b/src/Glpi/Features/ParentStatus.php
@@ -38,6 +38,7 @@ namespace Glpi\Features;
 use CommonITILActor;
 use CommonITILObject;
 use CommonITILTask;
+use ITILFollowup;
 use PendingReason_Item;
 use Session;
 
@@ -88,6 +89,10 @@ trait ParentStatus
                 'closedate' => $_SESSION["glpi_currenttime"],
                 '_accepted' => true,
             ];
+
+            if ($this instanceof ITILFollowup) {
+                $update['_followup'] = $this;
+            }
 
             // Use update method for history
             $parentitem->update($update);
@@ -169,6 +174,10 @@ trait ParentStatus
 
             if ($needupdateparent) {
                 $update['id'] = $parentitem->fields['id'];
+
+                if ($this instanceof ITILFollowup) {
+                    $update['_followup'] = $this;
+                }
 
                 // Use update method for history
                 $parentitem->update($update);

--- a/src/Glpi/Features/ParentStatus.php
+++ b/src/Glpi/Features/ParentStatus.php
@@ -38,7 +38,6 @@ namespace Glpi\Features;
 use CommonITILActor;
 use CommonITILObject;
 use CommonITILTask;
-use ITILFollowup;
 use PendingReason_Item;
 use Session;
 
@@ -90,9 +89,7 @@ trait ParentStatus
                 '_accepted' => true,
             ];
 
-            if ($this instanceof ITILFollowup) {
-                $update['_followup'] = $this;
-            }
+            $update['_trigger'] = $this;
 
             // Use update method for history
             $parentitem->update($update);
@@ -175,9 +172,7 @@ trait ParentStatus
             if ($needupdateparent) {
                 $update['id'] = $parentitem->fields['id'];
 
-                if ($this instanceof ITILFollowup) {
-                    $update['_followup'] = $this;
-                }
+                $update['_trigger'] = $this;
 
                 // Use update method for history
                 $parentitem->update($update);

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -334,7 +334,7 @@ class ITILSolution extends CommonDBChild
             $this->item->update([
                 'id'         => $this->item->getID(),
                 'status'     => $status,
-                '_solution'  => $this,
+                '_trigger'   => $this,
             ]);
         }
 

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -332,8 +332,9 @@ class ITILSolution extends CommonDBChild
             }
 
             $this->item->update([
-                'id'     => $this->item->getID(),
-                'status' => $status,
+                'id'         => $this->item->getID(),
+                'status'     => $status,
+                '_solution'  => $this,
             ]);
         }
 

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -317,7 +317,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again problem to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
+            $trigger = $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
     }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -317,7 +317,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again problem to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
+            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
     }

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -317,7 +317,8 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again problem to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            NotificationEvent::raiseEvent($mailtype, $this);
+            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
+            NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
     }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1501,7 +1501,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? null;
+            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1501,7 +1501,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_followup'] ?? null;
+            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1501,7 +1501,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            $trigger = $this->input['_solution'] ?? $this->input['_trigger'] ?? null;
+            $trigger = $this->input['_trigger'] ?? null;
             NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -1501,7 +1501,8 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
             // Read again ticket to be sure that all data are up to date
             $this->getFromDB($this->fields['id']);
-            NotificationEvent::raiseEvent($mailtype, $this);
+            $trigger = $this->input['_solution'] ?? null;
+            NotificationEvent::raiseEvent($mailtype, $this, [], $trigger);
         }
 
         $this->handleSatisfactionSurveyOnUpdate();

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -535,6 +535,113 @@ HTML,
         }
     }
 
+    public function testSolutionDocumentsAttachedToSolvedNotification(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $solved_notif = new \Notification();
+        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'solved']));
+
+        $CFG_GLPI['use_notifications'] = $CFG_GLPI['notifications_mailing'] = true;
+
+        $deactivated = $DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            ['id' => ['<>', $solved_notif->getID()]]
+        );
+        $this->assertTrue($deactivated);
+        $this->assertTrue($solved_notif->update(['id' => $solved_notif->getID(), 'is_active' => 1]));
+
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+        $this->assertTrue($solved_notif->update(['id' => $solved_notif->getID(), 'attach_documents' => \NotificationSetting::ATTACH_INHERIT]));
+
+        $notification_notificationtemplate_it = $DB->request([
+            'FROM' => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $solved_notif->getID()],
+        ]);
+        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
+            $notificationtemplate_it = $DB->request([
+                'FROM' => 'glpi_notificationtemplates',
+                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
+            ]);
+            foreach ($notificationtemplate_it as $notificationtemplate_data) {
+                $template_updated = $DB->update(
+                    'glpi_notificationtemplatetranslations',
+                    ['content_html' => null],
+                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
+                );
+                $this->assertTrue($template_updated);
+            }
+        }
+
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name'        => __FUNCTION__,
+            'content'     => '<p>Test ticket</p>',
+            'entities_id' => $entity,
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        $solution_doc = $this->createTxtDocument();
+
+        $this->assertEmpty(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
+
+        $solution = new \ITILSolution();
+        $solution_id = $solution->add([
+            'itemtype'   => \Ticket::class,
+            'items_id'   => $ticket_id,
+            'content'    => '<p>Solution with attachment</p>',
+        ]);
+        $this->assertGreaterThan(0, $solution_id);
+
+        $this->createItem(
+            \Document_Item::class,
+            [
+                'documents_id' => $solution_doc->getID(),
+                'itemtype'     => $solution->getType(),
+                'items_id'     => $solution->getID(),
+            ]
+        );
+
+        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+            'is_deleted' => 0,
+            'event'      => 'solved',
+        ]);
+        $this->assertCount(1, $queued_notifications);
+
+        $queued = reset($queued_notifications);
+        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
+        $this->assertEquals($solution_id, $queued['items_id_trigger']);
+
+        $transport = new class extends AbstractTransport {
+            public $sent_email;
+
+            protected function doSend(SentMessage $message): void
+            {
+                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
+                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
+            }
+
+            public function __toString(): string
+            {
+                return 'test://';
+            }
+        };
+
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        $attachments = $transport->sent_email->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(DataPart::class, $attachments[0]);
+        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
+    }
+
     /**
      * Simulates upload of a random PNG image and return its filename.
      */

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -561,26 +561,6 @@ HTML,
             'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
         ]);
 
-        // Set notification template to plain text (no HTML content)
-        $notification_notificationtemplate_it = $DB->request([
-            'FROM' => 'glpi_notifications_notificationtemplates',
-            'WHERE' => ['notifications_id' => $solved_notif->getID()],
-        ]);
-        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
-            $notificationtemplate_it = $DB->request([
-                'FROM' => 'glpi_notificationtemplates',
-                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
-            ]);
-            foreach ($notificationtemplate_it as $notificationtemplate_data) {
-                $template_updated = $DB->update(
-                    'glpi_notificationtemplatetranslations',
-                    ['content_html' => null],
-                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
-                );
-                $this->assertTrue($template_updated);
-            }
-        }
-
         // Arrange - Create ticket with a solution and attach a document to it
         $ticket = $this->createItem(\Ticket::class, [
             'name'        => __FUNCTION__,
@@ -669,25 +649,6 @@ HTML,
             'is_active'        => 1,
             'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
         ]);
-
-        $notification_notificationtemplate_it = $DB->request([
-            'FROM' => 'glpi_notifications_notificationtemplates',
-            'WHERE' => ['notifications_id' => $closed_notif->getID()],
-        ]);
-        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
-            $notificationtemplate_it = $DB->request([
-                'FROM' => 'glpi_notificationtemplates',
-                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
-            ]);
-            foreach ($notificationtemplate_it as $notificationtemplate_data) {
-                $template_updated = $DB->update(
-                    'glpi_notificationtemplatetranslations',
-                    ['content_html' => null],
-                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
-                );
-                $this->assertTrue($template_updated);
-            }
-        }
 
         // Arrange - Create ticket with a solution, then a followup accepting it, and attach a document to the followup
         $ticket = $this->createItem(\Ticket::class, [
@@ -807,25 +768,6 @@ HTML,
             'type'             => \Notification::USER_TYPE,
             'items_id'         => \Notification::GLOBAL_ADMINISTRATOR,
         ]);
-
-        $notification_notificationtemplate_it = $DB->request([
-            'FROM' => 'glpi_notifications_notificationtemplates',
-            'WHERE' => ['notifications_id' => $rejectsolution_notif->getID()],
-        ]);
-        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
-            $notificationtemplate_it = $DB->request([
-                'FROM' => 'glpi_notificationtemplates',
-                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
-            ]);
-            foreach ($notificationtemplate_it as $notificationtemplate_data) {
-                $template_updated = $DB->update(
-                    'glpi_notificationtemplatetranslations',
-                    ['content_html' => null],
-                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
-                );
-                $this->assertTrue($template_updated);
-            }
-        }
 
         // Arrange - Create ticket with a solution, then a followup rejecting it, and attach a document to the followup
         $this->updateItem(\Entity::class, $entity, ['autoclose_delay' => \Entity::CONFIG_NEVER]);

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -543,22 +543,25 @@ HTML,
 
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
+        // Arrange - Configure notifications
+        $CFG_GLPI['use_notifications'] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+
         $solved_notif = new \Notification();
         $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'solved']));
 
-        $CFG_GLPI['use_notifications'] = $CFG_GLPI['notifications_mailing'] = true;
-
-        $deactivated = $DB->update(
+        $DB->update(
             \Notification::getTable(),
             ['is_active' => false],
             ['id' => ['<>', $solved_notif->getID()]]
         );
-        $this->assertTrue($deactivated);
-        $this->assertTrue($solved_notif->update(['id' => $solved_notif->getID(), 'is_active' => 1]));
+        $this->updateItem(\Notification::class, $solved_notif->getID(), [
+            'is_active'        => 1,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
 
-        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
-        $this->assertTrue($solved_notif->update(['id' => $solved_notif->getID(), 'attach_documents' => \NotificationSetting::ATTACH_INHERIT]));
-
+        // Set notification template to plain text (no HTML content)
         $notification_notificationtemplate_it = $DB->request([
             'FROM' => 'glpi_notifications_notificationtemplates',
             'WHERE' => ['notifications_id' => $solved_notif->getID()],
@@ -578,45 +581,43 @@ HTML,
             }
         }
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        // Arrange - Create ticket with a solution and attach a document to it
+        $ticket = $this->createItem(\Ticket::class, [
             'name'        => __FUNCTION__,
             'content'     => '<p>Test ticket</p>',
             'entities_id' => $entity,
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
 
         $solution_doc = $this->createTxtDocument();
 
-        $this->assertEmpty(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
+        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
 
-        $solution = new \ITILSolution();
-        $solution_id = $solution->add([
+        $solution = $this->createItem(\ITILSolution::class, [
             'itemtype'   => \Ticket::class,
-            'items_id'   => $ticket_id,
+            'items_id'   => $ticket->getID(),
             'content'    => '<p>Solution with attachment</p>',
         ]);
-        $this->assertGreaterThan(0, $solution_id);
 
-        $this->createItem(
-            \Document_Item::class,
-            [
-                'documents_id' => $solution_doc->getID(),
-                'itemtype'     => $solution->getType(),
-                'items_id'     => $solution->getID(),
-            ]
-        );
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $solution_doc->getID(),
+            'itemtype'     => $solution->getType(),
+            'items_id'     => $solution->getID(),
+        ]);
 
+        // Act - Retrieve queued notification
         $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
             'is_deleted' => 0,
             'event'      => 'solved',
         ]);
+
+        // Assert - Solution is the trigger for the notification
         $this->assertCount(1, $queued_notifications);
 
         $queued = reset($queued_notifications);
         $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
-        $this->assertEquals($solution_id, $queued['items_id_trigger']);
+        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
 
+        // Assert - Solution document is attached to the sent email
         $transport = new class extends AbstractTransport {
             public $sent_email;
 

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -644,6 +644,264 @@ HTML,
         $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
     }
 
+    public function testFollowupDocumentsAttachedToClosedNotification(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Arrange - Configure notifications
+        $CFG_GLPI['use_notifications'] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+
+        $closed_notif = new \Notification();
+        $this->assertTrue($closed_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'closed']));
+
+        $this->assertTrue($DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            ['id' => ['<>', $closed_notif->getID()]]
+        ));
+        $this->updateItem(\Notification::class, $closed_notif->getID(), [
+            'is_active'        => 1,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
+
+        $notification_notificationtemplate_it = $DB->request([
+            'FROM' => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $closed_notif->getID()],
+        ]);
+        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
+            $notificationtemplate_it = $DB->request([
+                'FROM' => 'glpi_notificationtemplates',
+                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
+            ]);
+            foreach ($notificationtemplate_it as $notificationtemplate_data) {
+                $template_updated = $DB->update(
+                    'glpi_notificationtemplatetranslations',
+                    ['content_html' => null],
+                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
+                );
+                $this->assertTrue($template_updated);
+            }
+        }
+
+        // Arrange - Create ticket with a solution, then a followup accepting it, and attach a document to the followup
+        $ticket = $this->createItem(\Ticket::class, [
+            'name'        => __FUNCTION__,
+            'content'     => '<p>Test ticket</p>',
+            'entities_id' => $entity,
+        ]);
+
+        $this->createItem(\ITILSolution::class, [
+            'itemtype' => \Ticket::class,
+            'items_id' => $ticket->getID(),
+            'content'  => '<p>Solution</p>',
+        ]);
+
+        $followup_doc = $this->createTxtDocument();
+
+        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0, 'event' => 'closed']));
+
+        $followup = new \ITILFollowup();
+        $followup_id = $followup->add([
+            'itemtype'  => \Ticket::class,
+            'items_id'  => $ticket->getID(),
+            'content'   => 'Approving solution',
+            'add_close' => 1,
+        ]);
+        $this->assertGreaterThan(0, $followup_id);
+        $followup->getFromDB($followup_id);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $followup_doc->getID(),
+            'itemtype'     => $followup->getType(),
+            'items_id'     => $followup->getID(),
+        ]);
+
+        // Act - Retrieve queued notification
+        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+            'is_deleted' => 0,
+            'event'      => 'closed',
+        ]);
+
+        // Assert - Followup is the trigger for the notification
+        $this->assertCount(1, $queued_notifications);
+
+        $queued = reset($queued_notifications);
+        $this->assertEquals(\ITILFollowup::class, $queued['itemtype_trigger']);
+        $this->assertEquals($followup->getID(), $queued['items_id_trigger']);
+
+        $transport = new class extends AbstractTransport {
+            public $sent_email;
+
+            protected function doSend(SentMessage $message): void
+            {
+                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
+                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
+            }
+
+            public function __toString(): string
+            {
+                return 'test://';
+            }
+        };
+
+        // Act - Send queued notification
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        // Assert - Followup document is attached to the sent email
+        $attachments = $transport->sent_email->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(DataPart::class, $attachments[0]);
+        $this->assertEquals($followup_doc->fields['filename'], $attachments[0]->getFilename());
+    }
+
+    public function testFollowupDocumentsAttachedToRejectSolutionNotification(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Arrange - Configure notifications
+        $CFG_GLPI['use_notifications'] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+
+        $this->assertTrue($DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            [new \Glpi\DBAL\QueryExpression('true')]
+        ));
+
+        $closed_notif = new \Notification();
+        $this->assertTrue($closed_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'closed']));
+        $closed_template_link = $DB->request([
+            'FROM'  => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $closed_notif->getID()],
+        ])->current();
+
+        $rejectsolution_notif = $this->createItem(\Notification::class, [
+            'name'             => 'Solution rejected test',
+            'itemtype'         => \Ticket::class,
+            'event'            => 'rejectsolution',
+            'is_active'        => 1,
+            'is_recursive'     => 1,
+            'entities_id'      => 0,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
+        $this->createItem(\Notification_NotificationTemplate::class, [
+            'notifications_id'         => $rejectsolution_notif->getID(),
+            'mode'                     => 'mailing',
+            'notificationtemplates_id' => $closed_template_link['notificationtemplates_id'],
+        ]);
+        $this->createItem(\NotificationTarget::class, [
+            'notifications_id' => $rejectsolution_notif->getID(),
+            'type'             => \Notification::USER_TYPE,
+            'items_id'         => \Notification::GLOBAL_ADMINISTRATOR,
+        ]);
+
+        $notification_notificationtemplate_it = $DB->request([
+            'FROM' => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $rejectsolution_notif->getID()],
+        ]);
+        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
+            $notificationtemplate_it = $DB->request([
+                'FROM' => 'glpi_notificationtemplates',
+                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
+            ]);
+            foreach ($notificationtemplate_it as $notificationtemplate_data) {
+                $template_updated = $DB->update(
+                    'glpi_notificationtemplatetranslations',
+                    ['content_html' => null],
+                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
+                );
+                $this->assertTrue($template_updated);
+            }
+        }
+
+        // Arrange - Create ticket with a solution, then a followup rejecting it, and attach a document to the followup
+        $this->updateItem(\Entity::class, $entity, ['autoclose_delay' => \Entity::CONFIG_NEVER]);
+
+        $ticket = $this->createItem(\Ticket::class, [
+            'name'        => __FUNCTION__,
+            'content'     => '<p>Test ticket</p>',
+            'entities_id' => $entity,
+        ]);
+
+        $this->createItem(\ITILSolution::class, [
+            'itemtype' => \Ticket::class,
+            'items_id' => $ticket->getID(),
+            'content'  => '<p>Solution</p>',
+        ]);
+
+        $followup_doc = $this->createTxtDocument();
+
+        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0, 'event' => 'rejectsolution']));
+
+        $followup = new \ITILFollowup();
+        $followup_id = $followup->add([
+            'itemtype'   => \Ticket::class,
+            'items_id'   => $ticket->getID(),
+            'content'    => 'Rejecting solution',
+            'add_reopen' => 1,
+        ]);
+        $this->assertGreaterThan(0, $followup_id);
+        $followup->getFromDB($followup_id);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $followup_doc->getID(),
+            'itemtype'     => $followup->getType(),
+            'items_id'     => $followup->getID(),
+        ]);
+
+        // Act - Retrieve queued notification
+        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+            'is_deleted' => 0,
+            'event'      => 'rejectsolution',
+        ]);
+
+        // Assert - Followup is the trigger for the notification
+        $this->assertCount(1, $queued_notifications);
+
+        $queued = reset($queued_notifications);
+        $this->assertEquals(\ITILFollowup::class, $queued['itemtype_trigger']);
+        $this->assertEquals($followup->getID(), $queued['items_id_trigger']);
+
+        $transport = new class extends AbstractTransport {
+            public $sent_email;
+
+            protected function doSend(SentMessage $message): void
+            {
+                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
+                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
+            }
+
+            public function __toString(): string
+            {
+                return 'test://';
+            }
+        };
+
+        // Act - Send queued notification
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        // Assert - Followup document is attached to the sent email
+        $attachments = $transport->sent_email->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(DataPart::class, $attachments[0]);
+        $this->assertEquals($followup_doc->fields['filename'], $attachments[0]->getFilename());
+    }
+
     /**
      * Simulates upload of a random PNG image and return its filename.
      */

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -551,11 +551,11 @@ HTML,
         $solved_notif = new \Notification();
         $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'solved']));
 
-        $DB->update(
+        $this->assertTrue($DB->update(
             \Notification::getTable(),
             ['is_active' => false],
             ['id' => ['<>', $solved_notif->getID()]]
-        );
+        ));
         $this->updateItem(\Notification::class, $solved_notif->getID(), [
             'is_active'        => 1,
             'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
@@ -617,7 +617,7 @@ HTML,
         $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
         $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
 
-        // Assert - Solution document is attached to the sent email
+        // Act - Send queued notification
         $transport = new class extends AbstractTransport {
             public $sent_email;
 
@@ -637,6 +637,7 @@ HTML,
         \NotificationEventMailing::send($queued_notifications);
         \NotificationEventMailing::setMailer(null);
 
+        // Assert - Solution document is attached to the sent email
         $attachments = $transport->sent_email->getAttachments();
         $this->assertCount(1, $attachments);
         $this->assertInstanceOf(DataPart::class, $attachments[0]);

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -428,21 +428,17 @@ HTML,
         }
     }
 
-    public function testAttachedDocuments(): void
+    /**
+     * Create a mock mail transport that captures sent emails.
+     */
+    private function createCapturingTransport(): AbstractTransport
     {
-        global $CFG_GLPI, $DB;
-
-        $this->login();
-
-        // Mock mailer transport
-        $transport = new class extends AbstractTransport {
+        return new class extends AbstractTransport {
             public $sent_email;
 
             protected function doSend(SentMessage $message): void
             {
-                // Extract message from envelope
                 $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                /* @var \Symfony\Component\Mime\Email $email */
                 $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
             }
 
@@ -451,6 +447,53 @@ HTML,
                 return 'test://';
             }
         };
+    }
+
+    /**
+     * Send queued notifications and return the email attachments.
+     *
+     * @return DataPart[]
+     */
+    private function sendAndGetAttachments(array $queued_notifications): array
+    {
+        $transport = $this->createCapturingTransport();
+
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        return $transport->sent_email->getAttachments();
+    }
+
+    /**
+     * Activate only the notification matching the given itemtype and event,
+     * deactivating all others and resetting attach_documents to INHERIT.
+     */
+    private function activateOnlyNotification(string $itemtype, string $event): void
+    {
+        global $DB;
+
+        $notification = new \Notification();
+        $this->assertTrue($notification->getFromDBByCrit(['itemtype' => $itemtype, 'event' => $event]));
+
+        $this->assertTrue($DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            ['id' => ['<>', $notification->getID()]]
+        ));
+        $this->updateItem(\Notification::class, $notification->getID(), [
+            'is_active'        => 1,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
+    }
+
+    public function testAttachedDocuments(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $transport = $this->createCapturingTransport();
 
         $provider = $this->attachedDocumentsProvider();
         foreach ($provider as $row) {
@@ -537,96 +580,67 @@ HTML,
 
     public function testSolutionDocumentsAttachedToSolvedNotification(): void
     {
-        global $CFG_GLPI, $DB;
+        global $CFG_GLPI;
 
         $this->login();
 
         $entity = getItemByTypeName('Entity', '_test_root_entity', true);
 
-        // Arrange - Configure notifications
-        $CFG_GLPI['use_notifications'] = true;
-        $CFG_GLPI['notifications_mailing'] = true;
-        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+        foreach ([\Ticket::class, \Change::class, \Problem::class] as $itemtype) {
+            // Arrange - Configure notifications
+            $CFG_GLPI['use_notifications'] = true;
+            $CFG_GLPI['notifications_mailing'] = true;
+            $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
 
-        $solved_notif = new \Notification();
-        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'solved']));
+            $this->activateOnlyNotification($itemtype, 'solved');
 
-        $this->assertTrue($DB->update(
-            \Notification::getTable(),
-            ['is_active' => false],
-            ['id' => ['<>', $solved_notif->getID()]]
-        ));
-        $this->updateItem(\Notification::class, $solved_notif->getID(), [
-            'is_active'        => 1,
-            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
-        ]);
+            // Arrange - Create ITIL item with a solution and attach a document to it
+            $itil_item = $this->createItem($itemtype, [
+                'name'        => __FUNCTION__,
+                'content'     => '<p>Test ' . $itemtype . '</p>',
+                'entities_id' => $entity,
+            ]);
 
-        // Arrange - Create ticket with a solution and attach a document to it
-        $ticket = $this->createItem(\Ticket::class, [
-            'name'        => __FUNCTION__,
-            'content'     => '<p>Test ticket</p>',
-            'entities_id' => $entity,
-        ]);
+            $solution_doc = $this->createTxtDocument();
 
-        $solution_doc = $this->createTxtDocument();
+            $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
 
-        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
+            $solution = $this->createItem(\ITILSolution::class, [
+                'itemtype' => $itemtype,
+                'items_id' => $itil_item->getID(),
+                'content'  => '<p>Solution with attachment</p>',
+            ]);
 
-        $solution = $this->createItem(\ITILSolution::class, [
-            'itemtype'   => \Ticket::class,
-            'items_id'   => $ticket->getID(),
-            'content'    => '<p>Solution with attachment</p>',
-        ]);
+            $this->createItem(\Document_Item::class, [
+                'documents_id' => $solution_doc->getID(),
+                'itemtype'     => $solution->getType(),
+                'items_id'     => $solution->getID(),
+            ]);
 
-        $this->createItem(\Document_Item::class, [
-            'documents_id' => $solution_doc->getID(),
-            'itemtype'     => $solution->getType(),
-            'items_id'     => $solution->getID(),
-        ]);
+            // Act - Retrieve queued notification
+            $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+                'is_deleted' => 0,
+                'event'      => 'solved',
+            ]);
 
-        // Act - Retrieve queued notification
-        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
-            'is_deleted' => 0,
-            'event'      => 'solved',
-        ]);
+            // Assert - Solution is the trigger for the notification
+            $this->assertCount(1, $queued_notifications);
 
-        // Assert - Solution is the trigger for the notification
-        $this->assertCount(1, $queued_notifications);
+            $queued = reset($queued_notifications);
+            $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
+            $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
 
-        $queued = reset($queued_notifications);
-        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
-        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
-
-        // Act - Send queued notification
-        $transport = new class extends AbstractTransport {
-            public $sent_email;
-
-            protected function doSend(SentMessage $message): void
-            {
-                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
-            }
-
-            public function __toString(): string
-            {
-                return 'test://';
-            }
-        };
-
-        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
-        \NotificationEventMailing::send($queued_notifications);
-        \NotificationEventMailing::setMailer(null);
-
-        // Assert - Solution document is attached to the sent email
-        $attachments = $transport->sent_email->getAttachments();
-        $this->assertCount(1, $attachments);
-        $this->assertInstanceOf(DataPart::class, $attachments[0]);
-        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
+            // Act - Send queued notification and assert document is attached
+            $attachments = $this->sendAndGetAttachments($queued_notifications);
+            $this->assertCount(1, $attachments);
+            $this->assertInstanceOf(DataPart::class, $attachments[0]);
+            $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
+        }
     }
 
     public function testFollowupDocumentsAttachedToClosedNotification(): void
     {
-        global $CFG_GLPI, $DB;
+        global $CFG_GLPI;
 
         $this->login();
 
@@ -637,18 +651,7 @@ HTML,
         $CFG_GLPI['notifications_mailing'] = true;
         $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
 
-        $closed_notif = new \Notification();
-        $this->assertTrue($closed_notif->getFromDBByCrit(['itemtype' => \Ticket::class, 'event' => 'closed']));
-
-        $this->assertTrue($DB->update(
-            \Notification::getTable(),
-            ['is_active' => false],
-            ['id' => ['<>', $closed_notif->getID()]]
-        ));
-        $this->updateItem(\Notification::class, $closed_notif->getID(), [
-            'is_active'        => 1,
-            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
-        ]);
+        $this->activateOnlyNotification(\Ticket::class, 'closed');
 
         // Arrange - Create ticket with a solution, then a followup accepting it, and attach a document to the followup
         $ticket = $this->createItem(\Ticket::class, [
@@ -696,28 +699,8 @@ HTML,
         $this->assertEquals(\ITILFollowup::class, $queued['itemtype_trigger']);
         $this->assertEquals($followup->getID(), $queued['items_id_trigger']);
 
-        $transport = new class extends AbstractTransport {
-            public $sent_email;
-
-            protected function doSend(SentMessage $message): void
-            {
-                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
-            }
-
-            public function __toString(): string
-            {
-                return 'test://';
-            }
-        };
-
-        // Act - Send queued notification
-        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
-        \NotificationEventMailing::send($queued_notifications);
-        \NotificationEventMailing::setMailer(null);
-
-        // Assert - Followup document is attached to the sent email
-        $attachments = $transport->sent_email->getAttachments();
+        // Act - Send queued notification and assert followup document is attached
+        $attachments = $this->sendAndGetAttachments($queued_notifications);
         $this->assertCount(1, $attachments);
         $this->assertInstanceOf(DataPart::class, $attachments[0]);
         $this->assertEquals($followup_doc->fields['filename'], $attachments[0]->getFilename());
@@ -817,249 +800,11 @@ HTML,
         $this->assertEquals(\ITILFollowup::class, $queued['itemtype_trigger']);
         $this->assertEquals($followup->getID(), $queued['items_id_trigger']);
 
-        $transport = new class extends AbstractTransport {
-            public $sent_email;
-
-            protected function doSend(SentMessage $message): void
-            {
-                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
-            }
-
-            public function __toString(): string
-            {
-                return 'test://';
-            }
-        };
-
-        // Act - Send queued notification
-        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
-        \NotificationEventMailing::send($queued_notifications);
-        \NotificationEventMailing::setMailer(null);
-
-        // Assert - Followup document is attached to the sent email
-        $attachments = $transport->sent_email->getAttachments();
+        // Act - Send queued notification and assert followup document is attached
+        $attachments = $this->sendAndGetAttachments($queued_notifications);
         $this->assertCount(1, $attachments);
         $this->assertInstanceOf(DataPart::class, $attachments[0]);
         $this->assertEquals($followup_doc->fields['filename'], $attachments[0]->getFilename());
-    }
-
-    public function testSolutionDocumentsAttachedToSolvedChangeNotification(): void
-    {
-        global $CFG_GLPI, $DB;
-
-        $this->login();
-
-        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-
-        // Arrange - Configure notifications
-        $CFG_GLPI['use_notifications'] = true;
-        $CFG_GLPI['notifications_mailing'] = true;
-        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
-
-        $solved_notif = new \Notification();
-        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Change::class, 'event' => 'solved']));
-
-        $this->assertTrue($DB->update(
-            \Notification::getTable(),
-            ['is_active' => false],
-            ['id' => ['<>', $solved_notif->getID()]]
-        ));
-        $this->updateItem(\Notification::class, $solved_notif->getID(), [
-            'is_active'        => 1,
-            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
-        ]);
-
-        // Set notification template to plain text (no HTML content)
-        $notification_notificationtemplate_it = $DB->request([
-            'FROM' => 'glpi_notifications_notificationtemplates',
-            'WHERE' => ['notifications_id' => $solved_notif->getID()],
-        ]);
-        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
-            $notificationtemplate_it = $DB->request([
-                'FROM' => 'glpi_notificationtemplates',
-                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
-            ]);
-            foreach ($notificationtemplate_it as $notificationtemplate_data) {
-                $template_updated = $DB->update(
-                    'glpi_notificationtemplatetranslations',
-                    ['content_html' => null],
-                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
-                );
-                $this->assertTrue($template_updated);
-            }
-        }
-
-        // Arrange - Create change with a solution and attach a document to it
-        $change = $this->createItem(\Change::class, [
-            'name'        => __FUNCTION__,
-            'content'     => '<p>Test change</p>',
-            'entities_id' => $entity,
-        ]);
-
-        $solution_doc = $this->createTxtDocument();
-
-        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
-
-        $solution = $this->createItem(\ITILSolution::class, [
-            'itemtype' => \Change::class,
-            'items_id' => $change->getID(),
-            'content'  => '<p>Solution with attachment</p>',
-        ]);
-
-        $this->createItem(\Document_Item::class, [
-            'documents_id' => $solution_doc->getID(),
-            'itemtype'     => $solution->getType(),
-            'items_id'     => $solution->getID(),
-        ]);
-
-        // Act - Retrieve queued notification
-        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
-            'is_deleted' => 0,
-            'event'      => 'solved',
-        ]);
-
-        // Assert - Solution is the trigger for the notification
-        $this->assertCount(1, $queued_notifications);
-
-        $queued = reset($queued_notifications);
-        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
-        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
-
-        // Act - Send queued notification
-        $transport = new class extends AbstractTransport {
-            public $sent_email;
-
-            protected function doSend(SentMessage $message): void
-            {
-                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
-            }
-
-            public function __toString(): string
-            {
-                return 'test://';
-            }
-        };
-
-        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
-        \NotificationEventMailing::send($queued_notifications);
-        \NotificationEventMailing::setMailer(null);
-
-        // Assert - Solution document is attached to the sent email
-        $attachments = $transport->sent_email->getAttachments();
-        $this->assertCount(1, $attachments);
-        $this->assertInstanceOf(DataPart::class, $attachments[0]);
-        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
-    }
-
-    public function testSolutionDocumentsAttachedToSolvedProblemNotification(): void
-    {
-        global $CFG_GLPI, $DB;
-
-        $this->login();
-
-        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
-
-        // Arrange - Configure notifications
-        $CFG_GLPI['use_notifications'] = true;
-        $CFG_GLPI['notifications_mailing'] = true;
-        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
-
-        $solved_notif = new \Notification();
-        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Problem::class, 'event' => 'solved']));
-
-        $this->assertTrue($DB->update(
-            \Notification::getTable(),
-            ['is_active' => false],
-            ['id' => ['<>', $solved_notif->getID()]]
-        ));
-        $this->updateItem(\Notification::class, $solved_notif->getID(), [
-            'is_active'        => 1,
-            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
-        ]);
-
-        // Set notification template to plain text (no HTML content)
-        $notification_notificationtemplate_it = $DB->request([
-            'FROM' => 'glpi_notifications_notificationtemplates',
-            'WHERE' => ['notifications_id' => $solved_notif->getID()],
-        ]);
-        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
-            $notificationtemplate_it = $DB->request([
-                'FROM' => 'glpi_notificationtemplates',
-                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
-            ]);
-            foreach ($notificationtemplate_it as $notificationtemplate_data) {
-                $template_updated = $DB->update(
-                    'glpi_notificationtemplatetranslations',
-                    ['content_html' => null],
-                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
-                );
-                $this->assertTrue($template_updated);
-            }
-        }
-
-        // Arrange - Create problem with a solution and attach a document to it
-        $problem = $this->createItem(\Problem::class, [
-            'name'        => __FUNCTION__,
-            'content'     => '<p>Test problem</p>',
-            'entities_id' => $entity,
-        ]);
-
-        $solution_doc = $this->createTxtDocument();
-
-        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
-
-        $solution = $this->createItem(\ITILSolution::class, [
-            'itemtype' => \Problem::class,
-            'items_id' => $problem->getID(),
-            'content'  => '<p>Solution with attachment</p>',
-        ]);
-
-        $this->createItem(\Document_Item::class, [
-            'documents_id' => $solution_doc->getID(),
-            'itemtype'     => $solution->getType(),
-            'items_id'     => $solution->getID(),
-        ]);
-
-        // Act - Retrieve queued notification
-        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
-            'is_deleted' => 0,
-            'event'      => 'solved',
-        ]);
-
-        // Assert - Solution is the trigger for the notification
-        $this->assertCount(1, $queued_notifications);
-
-        $queued = reset($queued_notifications);
-        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
-        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
-
-        // Act - Send queued notification
-        $transport = new class extends AbstractTransport {
-            public $sent_email;
-
-            protected function doSend(SentMessage $message): void
-            {
-                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
-                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
-            }
-
-            public function __toString(): string
-            {
-                return 'test://';
-            }
-        };
-
-        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
-        \NotificationEventMailing::send($queued_notifications);
-        \NotificationEventMailing::setMailer(null);
-
-        // Assert - Solution document is attached to the sent email
-        $attachments = $transport->sent_email->getAttachments();
-        $this->assertCount(1, $attachments);
-        $this->assertInstanceOf(DataPart::class, $attachments[0]);
-        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
     }
 
     /**

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -778,7 +778,7 @@ HTML,
         $this->assertTrue($DB->update(
             \Notification::getTable(),
             ['is_active' => false],
-            [new \Glpi\DBAL\QueryExpression('true')]
+            [new QueryExpression('true')]
         ));
 
         $closed_notif = new \Notification();
@@ -802,7 +802,7 @@ HTML,
             'mode'                     => 'mailing',
             'notificationtemplates_id' => $closed_template_link['notificationtemplates_id'],
         ]);
-        $this->createItem(\NotificationTarget::class, [
+        $this->createItem(NotificationTarget::class, [
             'notifications_id' => $rejectsolution_notif->getID(),
             'type'             => \Notification::USER_TYPE,
             'items_id'         => \Notification::GLOBAL_ADMINISTRATOR,
@@ -900,6 +900,224 @@ HTML,
         $this->assertCount(1, $attachments);
         $this->assertInstanceOf(DataPart::class, $attachments[0]);
         $this->assertEquals($followup_doc->fields['filename'], $attachments[0]->getFilename());
+    }
+
+    public function testSolutionDocumentsAttachedToSolvedChangeNotification(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Arrange - Configure notifications
+        $CFG_GLPI['use_notifications'] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+
+        $solved_notif = new \Notification();
+        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Change::class, 'event' => 'solved']));
+
+        $this->assertTrue($DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            ['id' => ['<>', $solved_notif->getID()]]
+        ));
+        $this->updateItem(\Notification::class, $solved_notif->getID(), [
+            'is_active'        => 1,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
+
+        // Set notification template to plain text (no HTML content)
+        $notification_notificationtemplate_it = $DB->request([
+            'FROM' => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $solved_notif->getID()],
+        ]);
+        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
+            $notificationtemplate_it = $DB->request([
+                'FROM' => 'glpi_notificationtemplates',
+                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
+            ]);
+            foreach ($notificationtemplate_it as $notificationtemplate_data) {
+                $template_updated = $DB->update(
+                    'glpi_notificationtemplatetranslations',
+                    ['content_html' => null],
+                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
+                );
+                $this->assertTrue($template_updated);
+            }
+        }
+
+        // Arrange - Create change with a solution and attach a document to it
+        $change = $this->createItem(\Change::class, [
+            'name'        => __FUNCTION__,
+            'content'     => '<p>Test change</p>',
+            'entities_id' => $entity,
+        ]);
+
+        $solution_doc = $this->createTxtDocument();
+
+        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
+
+        $solution = $this->createItem(\ITILSolution::class, [
+            'itemtype' => \Change::class,
+            'items_id' => $change->getID(),
+            'content'  => '<p>Solution with attachment</p>',
+        ]);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $solution_doc->getID(),
+            'itemtype'     => $solution->getType(),
+            'items_id'     => $solution->getID(),
+        ]);
+
+        // Act - Retrieve queued notification
+        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+            'is_deleted' => 0,
+            'event'      => 'solved',
+        ]);
+
+        // Assert - Solution is the trigger for the notification
+        $this->assertCount(1, $queued_notifications);
+
+        $queued = reset($queued_notifications);
+        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
+        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
+
+        // Act - Send queued notification
+        $transport = new class extends AbstractTransport {
+            public $sent_email;
+
+            protected function doSend(SentMessage $message): void
+            {
+                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
+                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
+            }
+
+            public function __toString(): string
+            {
+                return 'test://';
+            }
+        };
+
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        // Assert - Solution document is attached to the sent email
+        $attachments = $transport->sent_email->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(DataPart::class, $attachments[0]);
+        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
+    }
+
+    public function testSolutionDocumentsAttachedToSolvedProblemNotification(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Arrange - Configure notifications
+        $CFG_GLPI['use_notifications'] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+        $CFG_GLPI['attach_ticket_documents_to_mail'] = \NotificationSetting::ATTACH_FROM_TRIGGER_ONLY;
+
+        $solved_notif = new \Notification();
+        $this->assertTrue($solved_notif->getFromDBByCrit(['itemtype' => \Problem::class, 'event' => 'solved']));
+
+        $this->assertTrue($DB->update(
+            \Notification::getTable(),
+            ['is_active' => false],
+            ['id' => ['<>', $solved_notif->getID()]]
+        ));
+        $this->updateItem(\Notification::class, $solved_notif->getID(), [
+            'is_active'        => 1,
+            'attach_documents' => \NotificationSetting::ATTACH_INHERIT,
+        ]);
+
+        // Set notification template to plain text (no HTML content)
+        $notification_notificationtemplate_it = $DB->request([
+            'FROM' => 'glpi_notifications_notificationtemplates',
+            'WHERE' => ['notifications_id' => $solved_notif->getID()],
+        ]);
+        foreach ($notification_notificationtemplate_it as $notification_notificationtemplate_data) {
+            $notificationtemplate_it = $DB->request([
+                'FROM' => 'glpi_notificationtemplates',
+                'WHERE' => ['id' => $notification_notificationtemplate_data['notificationtemplates_id']],
+            ]);
+            foreach ($notificationtemplate_it as $notificationtemplate_data) {
+                $template_updated = $DB->update(
+                    'glpi_notificationtemplatetranslations',
+                    ['content_html' => null],
+                    ['notificationtemplates_id' => $notificationtemplate_data['id']]
+                );
+                $this->assertTrue($template_updated);
+            }
+        }
+
+        // Arrange - Create problem with a solution and attach a document to it
+        $problem = $this->createItem(\Problem::class, [
+            'name'        => __FUNCTION__,
+            'content'     => '<p>Test problem</p>',
+            'entities_id' => $entity,
+        ]);
+
+        $solution_doc = $this->createTxtDocument();
+
+        $this->assertEquals(0, countElementsInTable(QueuedNotification::getTable(), ['is_deleted' => 0]));
+
+        $solution = $this->createItem(\ITILSolution::class, [
+            'itemtype' => \Problem::class,
+            'items_id' => $problem->getID(),
+            'content'  => '<p>Solution with attachment</p>',
+        ]);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $solution_doc->getID(),
+            'itemtype'     => $solution->getType(),
+            'items_id'     => $solution->getID(),
+        ]);
+
+        // Act - Retrieve queued notification
+        $queued_notifications = getAllDataFromTable(QueuedNotification::getTable(), [
+            'is_deleted' => 0,
+            'event'      => 'solved',
+        ]);
+
+        // Assert - Solution is the trigger for the notification
+        $this->assertCount(1, $queued_notifications);
+
+        $queued = reset($queued_notifications);
+        $this->assertEquals(\ITILSolution::class, $queued['itemtype_trigger']);
+        $this->assertEquals($solution->getID(), $queued['items_id_trigger']);
+
+        // Act - Send queued notification
+        $transport = new class extends AbstractTransport {
+            public $sent_email;
+
+            protected function doSend(SentMessage $message): void
+            {
+                $envelope_reflection = new \ReflectionClass(DelayedEnvelope::class);
+                $this->sent_email = $envelope_reflection->getProperty('message')->getValue($message->getEnvelope());
+            }
+
+            public function __toString(): string
+            {
+                return 'test://';
+            }
+        };
+
+        \NotificationEventMailing::setMailer(new \GLPIMailer($transport));
+        \NotificationEventMailing::send($queued_notifications);
+        \NotificationEventMailing::setMailer(null);
+
+        // Assert - Solution document is attached to the sent email
+        $attachments = $transport->sent_email->getAttachments();
+        $this->assertCount(1, $attachments);
+        $this->assertInstanceOf(DataPart::class, $attachments[0]);
+        $this->assertEquals($solution_doc->fields['filename'], $attachments[0]->getFilename());
     }
 
     /**


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23071 
- Here is a brief description of what this PR does : 

 When a solution with attachments is added to a ticket, the "solved" notification was missing the solution's documents because the ITILSolution was not passed as the trigger to raiseEvent().
 
- Pass the `ITILSolution` instance as `_solution` in the ticket status update input when solving a ticket
- Use this reference as the `$trigger` parameter in `NotificationEvent::raiseEvent()` so that `itemtype_trigger` correctly points to `ITILSolution` instead of `Ticket`
- This ensures documents attached to the solution are included in email notifications when "Add documents" is set to "Only documents related to the item that triggers the event"

## Screenshots : 


<img width="554" height="479" alt="Capture d’écran du 2026-02-12 14-07-23" src="https://github.com/user-attachments/assets/5710dd8d-90fb-4217-aa6d-fc94343a9304" />
