### PR TITLE
Fix - Allow zero as valid ID in CommonDBRelation attached fields

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3064,7 +3064,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$subject of function Safe\\\\preg_match expects string, string\\|null given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 22,
+	'count' => 20,
 	'path' => __DIR__ . '/src/CommonDBRelation.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2930,12 +2930,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDBRelation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call static method getTypeName\\(\\) on string\\|null\\.$#',
-	'identifier' => 'staticMethod.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/src/CommonDBRelation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CommonDBRelation\\:\\:getItemField\\(\\) should return string but returns string\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 2,

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2175,7 +2175,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         $required_fields = [];
         $must_check = $input !== null && $right == CREATE;
 
-        if ($must_check && static::$mustBeAttached_1 === true && (!isset($input[static::$items_id_1]) || $input[static::$items_id_1] === null || $input[static::$items_id_1] === '')) {
+        if ($must_check && static::$mustBeAttached_1 === true && $this->isValueEmpty($input[static::$items_id_1] ?? null, static::$itemtype_1, $input)) {
             $itemtype = static::$itemtype_1;
             if (!preg_match('/^itemtype/', $itemtype)) {
                 $itemtype = static::$itemtype_1::getTypeName(1);
@@ -2183,7 +2183,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
             $error_types[] = $itemtype;
             $required_fields[] = static::$items_id_1;
         }
-        if ($must_check && static::$mustBeAttached_2 === true && (!isset($input[static::$items_id_2]) || $input[static::$items_id_2] === null || $input[static::$items_id_2] === '')) {
+        if ($must_check && static::$mustBeAttached_2 === true && $this->isValueEmpty($input[static::$items_id_2] ?? null, static::$itemtype_2, $input)) {
             $itemtype = static::$itemtype_2;
             if (!preg_match('/^itemtype/', $itemtype)) {
                 $itemtype = static::$itemtype_2::getTypeName(1);
@@ -2208,5 +2208,39 @@ abstract class CommonDBRelation extends CommonDBConnexity
         }
 
         parent::check($ID, $right, $input);
+    }
+
+    /**
+     * Check if a value is empty for validation purposes.
+     * For Entity itemtype, 0 is a valid value (root entity).
+     * For other itemtypes, 0 means no link.
+     *
+     * @param mixed $value The value to check
+     * @param string $itemtype_field The itemtype field name or class
+     * @param array $input The complete input array
+     * @return bool True if the value should be considered empty
+     */
+    private function isValueEmpty($value, string $itemtype_field, array $input): bool
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if ($value === 0 || $value === '0') {
+            $itemtype = null;
+            if (preg_match('/^itemtype/', $itemtype_field)) {
+                $itemtype = $input[$itemtype_field] ?? null;
+            } else {
+                $itemtype = $itemtype_field;
+            }
+
+            if ($itemtype === \Entity::class) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2233,10 +2233,6 @@ abstract class CommonDBRelation extends CommonDBConnexity
             $itemtype = $itemtype_field;
         }
 
-        if ($itemtype === Entity::class) {
-            return false;
-        }
-
         if (!is_a($itemtype, CommonDBTM::class, true)) {
             throw new RuntimeException('Unable to get itemtype from relation input.');
         }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2175,7 +2175,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         $required_fields = [];
         $must_check = $input !== null && $right == CREATE;
 
-        if ($must_check && static::$mustBeAttached_1 === true && (!isset($input[static::$items_id_1]) || empty($input[static::$items_id_1]))) {
+        if ($must_check && static::$mustBeAttached_1 === true && (!isset($input[static::$items_id_1]) || $input[static::$items_id_1] === null || $input[static::$items_id_1] === '')) {
             $itemtype = static::$itemtype_1;
             if (!preg_match('/^itemtype/', $itemtype)) {
                 $itemtype = static::$itemtype_1::getTypeName(1);
@@ -2183,7 +2183,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
             $error_types[] = $itemtype;
             $required_fields[] = static::$items_id_1;
         }
-        if ($must_check && static::$mustBeAttached_2 === true && (!isset($input[static::$items_id_2]) || empty($input[static::$items_id_2]))) {
+        if ($must_check && static::$mustBeAttached_2 === true && (!isset($input[static::$items_id_2]) || $input[static::$items_id_2] === null || $input[static::$items_id_2] === '')) {
             $itemtype = static::$itemtype_2;
             if (!preg_match('/^itemtype/', $itemtype)) {
                 $itemtype = static::$itemtype_2::getTypeName(1);

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2216,11 +2216,11 @@ abstract class CommonDBRelation extends CommonDBConnexity
      * For other itemtypes, 0 means no link.
      *
      * @param mixed $value The value to check
-     * @param string $itemtype_field The itemtype field name or class
-     * @param array $input The complete input array
+     * @param string|null $itemtype_field The itemtype field name or class
+     * @param array<string, mixed> $input The complete input array
      * @return bool True if the value should be considered empty
      */
-    private function isValueEmpty($value, string $itemtype_field, array $input): bool
+    private function isValueEmpty($value, ?string $itemtype_field, array $input): bool
     {
         if ($value === null || $value === '') {
             return true;
@@ -2228,7 +2228,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
         if ($value === 0 || $value === '0') {
             $itemtype = null;
-            if (preg_match('/^itemtype/', $itemtype_field)) {
+            if ($itemtype_field !== null && preg_match('/^itemtype/', $itemtype_field)) {
                 $itemtype = $input[$itemtype_field] ?? null;
             } else {
                 $itemtype = $itemtype_field;

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2238,7 +2238,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         }
 
         if (!is_a($itemtype, CommonDBTM::class, true)) {
-            throw new \RuntimeException('Unable to get itemtype from relation input.');
+            throw new RuntimeException('Unable to get itemtype from relation input.');
         }
 
         return $itemtype::isNewID($value);

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2234,7 +2234,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 $itemtype = $itemtype_field;
             }
 
-            if ($itemtype === \Entity::class) {
+            if ($itemtype === Entity::class) {
                 return false;
             }
 

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2226,25 +2226,21 @@ abstract class CommonDBRelation extends CommonDBConnexity
             return true;
         }
 
-        if ($value === 0 || $value === '0') {
-            $itemtype = null;
-            if ($itemtype_field !== null && preg_match('/^itemtype/', $itemtype_field)) {
-                $itemtype = $input[$itemtype_field] ?? $this->fields[$itemtype_field] ?? null;
-            } else {
-                $itemtype = $itemtype_field;
-            }
-
-            if ($itemtype === Entity::class) {
-                return false;
-            }
-
-            if (!is_a($itemtype, CommonDBTM::class, true)) {
-                throw new \RuntimeException('Unable to get itemtype from relation input.');
-            }
-
-            return $itemtype::isNewID($value);
+        $itemtype = null;
+        if ($itemtype_field !== null && preg_match('/^itemtype/', $itemtype_field)) {
+            $itemtype = $input[$itemtype_field] ?? $this->fields[$itemtype_field] ?? null;
+        } else {
+            $itemtype = $itemtype_field;
         }
 
-        return false;
+        if ($itemtype === Entity::class) {
+            return false;
+        }
+
+        if (!is_a($itemtype, CommonDBTM::class, true)) {
+            throw new \RuntimeException('Unable to get itemtype from relation input.');
+        }
+
+        return $itemtype::isNewID($value);
     }
 }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2229,7 +2229,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         if ($value === 0 || $value === '0') {
             $itemtype = null;
             if ($itemtype_field !== null && preg_match('/^itemtype/', $itemtype_field)) {
-                $itemtype = $input[$itemtype_field] ?? null;
+                $itemtype = $input[$itemtype_field] ?? $this->fields[$itemtype_field] ?? null;
             } else {
                 $itemtype = $itemtype_field;
             }

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2171,62 +2171,93 @@ abstract class CommonDBRelation extends CommonDBConnexity
 
     public function check($ID, int $right, ?array &$input = null): void
     {
-        $error_types = [];
-        $required_fields = [];
-        $must_check = $input !== null && $right == CREATE;
+        if ($input !== null && $right == CREATE) {
+            $error_types = [];
+            $required_fields = [];
 
-        if ($must_check && static::$mustBeAttached_1 === true && $this->isValueEmpty($input[static::$items_id_1] ?? null, static::$itemtype_1, $input)) {
-            $itemtype = static::$itemtype_1;
-            if (!preg_match('/^itemtype/', $itemtype)) {
-                $itemtype = static::$itemtype_1::getTypeName(1);
+            foreach (
+                [
+                    [static::$mustBeAttached_1, static::$items_id_1, static::$itemtype_1],
+                    [static::$mustBeAttached_2, static::$items_id_2, static::$itemtype_2],
+                ] as [$must_be_attached, $items_id_field, $itemtype_field]
+            ) {
+                $result = $this->validateAttachedItem($must_be_attached, $items_id_field, $itemtype_field, $input);
+                if ($result !== null) {
+                    $error_types[] = $result['error_type'];
+                    $required_fields[] = $result['required_field'];
+                }
             }
-            $error_types[] = $itemtype;
-            $required_fields[] = static::$items_id_1;
-        }
-        if ($must_check && static::$mustBeAttached_2 === true && $this->isValueEmpty($input[static::$items_id_2] ?? null, static::$itemtype_2, $input)) {
-            $itemtype = static::$itemtype_2;
-            if (!preg_match('/^itemtype/', $itemtype)) {
-                $itemtype = static::$itemtype_2::getTypeName(1);
+
+            if ($error_types !== []) {
+                $message = sprintf(
+                    __('Mandatory fields are not filled. Please correct: %s'),
+                    implode(', ', $error_types)
+                );
+                Session::addMessageAfterRedirect(htmlescape($message), true, ERROR);
+
+                throw new ItemLinkException(
+                    sprintf(
+                        'Post data must contain a valid value for: %s',
+                        implode(', ', $required_fields),
+                    )
+                );
             }
-            $error_types[] = $itemtype;
-            $required_fields[] = static::$items_id_2;
-        }
-
-        if (count($error_types) > 0) {
-            $message = sprintf(
-                __('Mandatory fields are not filled. Please correct: %s'),
-                implode(', ', $error_types)
-            );
-            Session::addMessageAfterRedirect(htmlescape($message), true, ERROR);
-
-            throw new ItemLinkException(
-                sprintf(
-                    'Post data must contain (greater than 0): %s',
-                    implode(', ', $required_fields),
-                )
-            );
         }
 
         parent::check($ID, $right, $input);
     }
 
     /**
-     * Check if a value is empty for validation purposes.
-     * For Entity itemtype, 0 is a valid value (root entity).
-     * For other itemtypes, 0 means no link.
+     * Validate that an attached item field contains a valid (non-new) ID.
      *
-     * @param mixed $value The value to check
-     * @param string|null $itemtype_field The itemtype field name or class
-     * @param array<string, mixed> $input The complete input array
-     * @return bool True if the value should be considered empty
+     * @param bool        $must_be_attached Whether the item must be attached
+     * @param string|null $items_id_field   The field name for the item ID
+     * @param string|null $itemtype_field   The itemtype field name or class name
+     * @param array<string, mixed> $input   The input data
+     * @return array{error_type: string, required_field: string}|null Validation error info, or null if valid
      */
-    private function isValueEmpty($value, ?string $itemtype_field, array $input): bool
+    private function validateAttachedItem(
+        bool $must_be_attached,
+        ?string $items_id_field,
+        ?string $itemtype_field,
+        array $input,
+    ): ?array {
+        if (!$must_be_attached || $items_id_field === null || $itemtype_field === null) {
+            return null;
+        }
+
+        $value = $input[$items_id_field] ?? null;
+
+        if (!$this->isValueEmpty($value, $itemtype_field, $input)) {
+            return null;
+        }
+
+        if (preg_match('/^itemtype/', $itemtype_field)) {
+            $error_type = $itemtype_field;
+        } else {
+            $error_type = $itemtype_field::getTypeName(1);
+        }
+
+        return ['error_type' => $error_type, 'required_field' => $items_id_field];
+    }
+
+    /**
+     * Check if a value should be considered empty for attached item validation.
+     *
+     * Delegates to the resolved itemtype's `isNewID()` method, which allows
+     * classes like `Entity` to accept 0 as a valid ID (root entity).
+     *
+     * @param mixed                $value          The value to check
+     * @param string|null          $itemtype_field The itemtype field name or class name
+     * @param array<string, mixed> $input          The complete input array
+     * @return bool True if the value should be considered empty/invalid
+     */
+    private function isValueEmpty(mixed $value, ?string $itemtype_field, array $input): bool
     {
         if ($value === null || $value === '') {
             return true;
         }
 
-        $itemtype = null;
         if ($itemtype_field !== null && preg_match('/^itemtype/', $itemtype_field)) {
             $itemtype = $input[$itemtype_field] ?? $this->fields[$itemtype_field] ?? null;
         } else {

--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2238,7 +2238,11 @@ abstract class CommonDBRelation extends CommonDBConnexity
                 return false;
             }
 
-            return true;
+            if (!is_a($itemtype, CommonDBTM::class, true)) {
+                throw new \RuntimeException('Unable to get itemtype from relation input.');
+            }
+
+            return $itemtype::isNewID($value);
         }
 
         return false;

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -372,15 +372,19 @@ class CommonDBRelationTest extends DbTestCase
             public static $itemtype_2 = 'itemtype';
             public static $items_id_2 = 'items_id';
             public static $mustBeAttached_2 = true;
+
+            public static function getTable($classname = null)
+            {
+                return 'glpi_knowbaseitems_items'; // ensure using a table with expected fields, some backend code rely on table columns
+            }
         };
 
         // items_id = 0 with Entity itemtype should pass validation
         $input = ['knowbaseitems_id' => 42, 'itemtype' => \Entity::class, 'items_id' => 0];
         try {
             $instance->check(-1, CREATE, $input);
-        } catch (\RuntimeException $e) {
-            // CommonDBTM::getTable() will fail because we're using a fake object
-            $this->assertStringContainsString('SHOW COLUMNS FROM `glpi_commondbrelation', $e->getMessage());
+        } catch (AccessDeniedHttpException $e) {
+            // no session is set up, so rights check fails after validation; this is expected
         }
 
         // items_id = 0 with non-Entity itemtype should fail validation

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -63,7 +63,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1, $instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -89,7 +89,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1, $instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -115,7 +115,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -141,7 +141,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1])
                 ),
                 $e->getMessage()
@@ -204,7 +204,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1])
                 ),
                 $e->getMessage()
@@ -241,7 +241,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -308,7 +308,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1, $instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -345,7 +345,7 @@ class CommonDBRelationTest extends DbTestCase
             $exception_thrown = true;
             $this->assertEquals(
                 sprintf(
-                    'Post data must contain (greater than 0): %1$s',
+                    'Post data must contain a valid value for: %1$s',
                     implode(', ', [$instance::$items_id_1, $instance::$items_id_2])
                 ),
                 $e->getMessage()
@@ -362,5 +362,52 @@ class CommonDBRelationTest extends DbTestCase
             ]
         );
         /** /first only specific, second suffixed, all attached */
+
+        /** Entity with items_id = 0 is valid (root entity) */
+        $instance = new class extends CommonDBRelation {
+            public static $itemtype_1 = \KnowbaseItem::class;
+            public static $items_id_1 = 'knowbaseitems_id';
+            public static $mustBeAttached_1 = true;
+
+            public static $itemtype_2 = 'itemtype';
+            public static $items_id_2 = 'items_id';
+            public static $mustBeAttached_2 = true;
+        };
+
+        // items_id = 0 with Entity itemtype should pass validation
+        $input = ['knowbaseitems_id' => 42, 'itemtype' => \Entity::class, 'items_id' => 0];
+        try {
+            $instance->check(-1, CREATE, $input);
+        } catch (\RuntimeException $e) {
+            // CommonDBTM::getTable() will fail because we're using a fake object
+            $this->assertStringContainsString('SHOW COLUMNS FROM `glpi_commondbrelation', $e->getMessage());
+        }
+
+        // items_id = 0 with non-Entity itemtype should fail validation
+        $exception_thrown = false;
+        try {
+            $input = ['knowbaseitems_id' => 42, 'itemtype' => \Computer::class, 'items_id' => 0];
+            $instance->check(-1, CREATE, $input);
+        } catch (ItemLinkException $e) {
+            $exception_thrown = true;
+            $this->assertEquals(
+                sprintf(
+                    'Post data must contain a valid value for: %1$s',
+                    'items_id'
+                ),
+                $e->getMessage()
+            );
+        }
+        $this->assertTrue($exception_thrown);
+        $this->hasSessionMessages(
+            ERROR,
+            [
+                sprintf(
+                    'Mandatory fields are not filled. Please correct: %1$s',
+                    'itemtype'
+                ),
+            ]
+        );
+        /** /Entity with items_id = 0 is valid (root entity) */
     }
 }

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -36,6 +36,7 @@ namespace test\units;
 
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasKnowbaseCapacity;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem_Item;
@@ -269,7 +270,7 @@ class KnowbaseItem_ItemTest extends DbTestCase
 
         try {
             $kb_item_item->check(-1, CREATE, $input);
-        } catch (\Glpi\Exception\Http\AccessDeniedHttpException $e) {
+        } catch (AccessDeniedHttpException $e) {
         }
 
         $link_id = $kb_item_item->add($input);

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -250,31 +250,4 @@ class KnowbaseItem_ItemTest extends DbTestCase
         $name = $kb_item->getTabNameForItem($ticket3);
         $this->assertSame("Knowledge base", strip_tags($name));
     }
-
-    public function testLinkToRootEntity(): void
-    {
-        $this->login();
-
-        $kb_item = $this->createItem(
-            \KnowbaseItem::class,
-            [
-                'name' => 'Test KB for root entity',
-                'answer' => 'Test answer',
-            ]
-        );
-
-        $link_id = $this->createItem(
-            KnowbaseItem_Item::class,
-            [
-                'knowbaseitems_id' => $kb_item->getID(),
-                'itemtype' => \Entity::class,
-                'items_id' => 0,
-            ]
-        )->getID();
-
-        $kb_item_item = new KnowbaseItem_Item();
-        $this->assertTrue($kb_item_item->getFromDB($link_id));
-        $this->assertEquals(0, $kb_item_item->fields['items_id']);
-        $this->assertEquals(\Entity::class, $kb_item_item->fields['itemtype']);
-    }
 }

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -36,7 +36,6 @@ namespace test\units;
 
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasKnowbaseCapacity;
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem_Item;
@@ -256,26 +255,24 @@ class KnowbaseItem_ItemTest extends DbTestCase
     {
         $this->login();
 
-        $kb_item = $this->createItem(\KnowbaseItem::class, [
-            'name' => 'Test KB for root entity',
-            'answer' => 'Test answer',
-        ]);
+        $kb_item = $this->createItem(
+            \KnowbaseItem::class,
+            [
+                'name' => 'Test KB for root entity',
+                'answer' => 'Test answer',
+            ]
+        );
+
+        $link_id = $this->createItem(
+            KnowbaseItem_Item::class,
+            [
+                'knowbaseitems_id' => $kb_item->getID(),
+                'itemtype' => \Entity::class,
+                'items_id' => 0,
+            ]
+        )->getID();
 
         $kb_item_item = new KnowbaseItem_Item();
-        $input = [
-            'knowbaseitems_id' => $kb_item->getID(),
-            'itemtype' => \Entity::class,
-            'items_id' => 0,
-        ];
-
-        try {
-            $kb_item_item->check(-1, CREATE, $input);
-        } catch (AccessDeniedHttpException $e) {
-        }
-
-        $link_id = $kb_item_item->add($input);
-
-        $this->assertGreaterThan(0, $link_id);
         $this->assertTrue($kb_item_item->getFromDB($link_id));
         $this->assertEquals(0, $kb_item_item->fields['items_id']);
         $this->assertEquals(\Entity::class, $kb_item_item->fields['itemtype']);

--- a/tests/functional/KnowbaseItem_ItemTest.php
+++ b/tests/functional/KnowbaseItem_ItemTest.php
@@ -250,4 +250,33 @@ class KnowbaseItem_ItemTest extends DbTestCase
         $name = $kb_item->getTabNameForItem($ticket3);
         $this->assertSame("Knowledge base", strip_tags($name));
     }
+
+    public function testLinkToRootEntity(): void
+    {
+        $this->login();
+
+        $kb_item = $this->createItem(\KnowbaseItem::class, [
+            'name' => 'Test KB for root entity',
+            'answer' => 'Test answer',
+        ]);
+
+        $kb_item_item = new KnowbaseItem_Item();
+        $input = [
+            'knowbaseitems_id' => $kb_item->getID(),
+            'itemtype' => \Entity::class,
+            'items_id' => 0,
+        ];
+
+        try {
+            $kb_item_item->check(-1, CREATE, $input);
+        } catch (\Glpi\Exception\Http\AccessDeniedHttpException $e) {
+        }
+
+        $link_id = $kb_item_item->add($input);
+
+        $this->assertGreaterThan(0, $link_id);
+        $this->assertTrue($kb_item_item->getFromDB($link_id));
+        $this->assertEquals(0, $kb_item_item->fields['items_id']);
+        $this->assertEquals(\Entity::class, $kb_item_item->fields['itemtype']);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42130
- Here is a brief description of what this PR does

Fixed validation in `CommonDBRelation::check()` that incorrectly rejected ID value `0` as empty, preventing users from linking items to the root entity (ID 0).

## Problem

When attempting to link elements (e.g., `KnowbaseItem` records) to the root entity (ID `0`), the system would throw an error: "Mandatory fields are not filled. Please correct: Entity".

The issue was caused by using `empty()` to validate required foreign key fields in `CommonDBRelation::check()`. Since `empty(0)` returns `true` in PHP, any item with ID `0` was incorrectly considered as missing.

## Solution

Two private methods have been introduced:

- `validateAttachedItem()` — removes the duplication in `check()` by handling both item slots (item 1 and item 2) with a single method. Returns `null` if valid, or an array with the error details otherwise.
- `isValueEmpty()` — delegates emptiness check to the resolved itemtype's `isNewID()` method. This is generic: any class that overrides `isNewID()` (such as `Entity`, which accepts `0` as the root entity) will be handled correctly without targeting specific classes explicitly. Negative values are also properly rejected.

The `check()` method is also restructured to only run the validation when `$input !== null && $right == CREATE`, which avoids unnecessary work in other contexts.

The exception message has been updated to `'Post data must contain a valid value for: ...'`, which is more accurate now that `0` can be valid.

## Testing

Updated `CommonDBRelationTest::testCreateCheck()` with two new cases:

- `items_id = 0` with `Entity` itemtype → passes validation (0 is the root entity ID)
- `items_id = 0` with `Computer` itemtype → fails validation (0 is not a valid ID)

All existing `testCreateCheck()` assertions updated to reflect the new exception message.

## Screenshots (if appropriate):

<img width="1799" height="862" alt="image" src="https://github.com/user-attachments/assets/038ace4c-30f3-49bc-a386-a69a1c18e74e" />


