### PR TITLE
Fix - Prevent infinite redirect loop with external SSO authentication

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -1017,12 +1017,16 @@ class Session
         }
 
         // Check if remote user changed (SSO case)
+        // Only invalidate session when the SSO variable IS present but has a different value,
+        // which indicates a different user is now authenticated (e.g., shared workstation scenario).
+        // When the SSO variable is absent (e.g., pages not protected by mod_auth_gssapi),
+        // we should not invalidate the session.
         if ($valid_user && array_key_exists('glpi_remote_user', $_SESSION)) {
             $ssovariable = Dropdown::getDropdownName(
                 'glpi_ssovariables',
                 $CFG_GLPI["ssovariables_id"]
             );
-            if (!array_key_exists($ssovariable, $_SERVER) || $_SERVER[$ssovariable] !== $_SESSION['glpi_remote_user']) {
+            if (array_key_exists($ssovariable, $_SERVER) && $_SERVER[$ssovariable] !== $_SESSION['glpi_remote_user']) {
                 $valid_user = false;
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42161
- Here is a brief description of what this PR does

### Problem
After upgrading to GLPI `10.0.23`, users experience infinite redirect loops ("too many redirects"), making GLPI completely inaccessible.

A recent fix added validation in `Session::checkValidSessionId()` to detect remote user changes. However, the condition also invalidates the session when `$_SERVER[$ssovariable]` is **absent** — which is the case on all pages not protected by SSO.

This creates an infinite loop:
1. User accesses `central.php` → SSO variable absent → session invalidated → redirect to `index.php`
2. `index.php` detects SSO → redirect to `login.php`
3. SSO authenticates user → redirect to `central.php` → **back to step 1**

### Solution
Only invalidate the session when the SSO variable is **present AND has changed**:
```php
// Before
if (!array_key_exists($ssovariable, $_SERVER) || $_SERVER[$ssovariable] !== $_SESSION['glpi_remote_user']) {

// After
if (array_key_exists($ssovariable, $_SERVER) && $_SERVER[$ssovariable] !== $_SESSION['glpi_remote_user']) {
```

The precedent fix is fully preserved.

### References

- mod_auth_gssapi: https://github.com/gssapi/mod_auth_gssapi


## Screenshots (if appropriate):

<img width="732" height="395" alt="image" src="https://github.com/user-attachments/assets/10d79c21-9b81-4ef1-abeb-1d641c1c1145" />