### PR TITLE
add dates and users for costs

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1508,6 +1508,10 @@ $RELATION = [
             'users_id_recipient',
             'users_id_lastupdater',
         ],
+        'glpi_changecosts' => [
+            'users_id',
+            'users_id_lastupdater',
+        ],
         '_glpi_changes_users'           => 'users_id',
         'glpi_changetasks'              => [
             'users_id',
@@ -1529,6 +1533,10 @@ $RELATION = [
         'glpi_consumableitems'          => [
             'users_id_tech',
             'users_id',
+        ],
+        'glpi_contractcosts' => [
+            'users_id',
+            'users_id_lastupdater',
         ],
         '_glpi_dashboards_dashboards'   => 'users_id',
         'glpi_dashboards_filters'       => 'users_id',
@@ -1617,6 +1625,10 @@ $RELATION = [
             'users_id_recipient',
             'users_id_lastupdater',
         ],
+        'glpi_problemcosts' => [
+            'users_id',
+            'users_id_lastupdater',
+        ],
         '_glpi_problems_users'          => 'users_id',
         'glpi_problemtasks'             => [
             'users_id',
@@ -1625,6 +1637,10 @@ $RELATION = [
         ],
         '_glpi_profiles_users'          => 'users_id',
         'glpi_projects'                 => 'users_id',
+        'glpi_projectcosts' => [
+            'users_id',
+            'users_id_lastupdater',
+        ],
         'glpi_projecttasks'             => 'users_id',
         'glpi_projecttasktemplates'     => 'users_id',
         'glpi_racks'                    => [
@@ -1650,6 +1666,10 @@ $RELATION = [
         'glpi_tasktemplates'            => 'users_id_tech',
         'glpi_tickets'                  => [
             'users_id_recipient',
+            'users_id_lastupdater',
+        ],
+        'glpi_ticketcosts' => [
+            'users_id',
             'users_id_lastupdater',
         ],
         '_glpi_tickets_users'           => 'users_id',

--- a/install/migrations/update_11.0.x_to_12.0.0/costs.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/costs.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var Migration $migration
+ */
+
+$cost_tables = ['glpi_changecosts', 'glpi_contractcosts', 'glpi_problemcosts', 'glpi_projectcosts', 'glpi_ticketcosts'];
+
+foreach ($cost_tables as $table) {
+    $migration->addField($table, 'users_id', 'fkey');
+    $migration->addKey($table, 'users_id');
+    $migration->addField($table, 'users_id_lastupdater', 'fkey');
+    $migration->addKey($table, 'users_id_lastupdater');
+    $migration->addField($table, 'date_creation', 'datetime');
+    $migration->addKey($table, 'date_creation');
+    $migration->addField($table, 'date_mod', 'datetime');
+    $migration->addKey($table, 'date_mod');
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -627,6 +627,10 @@ CREATE TABLE `glpi_changecosts` (
   `budgets_id` int unsigned NOT NULL DEFAULT '0',
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_lastupdater` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `changes_id` (`changes_id`),
@@ -634,7 +638,11 @@ CREATE TABLE `glpi_changecosts` (
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `budgets_id` (`budgets_id`)
+  KEY `budgets_id` (`budgets_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
+  KEY `users_id` (`users_id`),
+  KEY `users_id_lastupdater` (`users_id_lastupdater`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -1466,6 +1474,10 @@ CREATE TABLE `glpi_contractcosts` (
   `budgets_id` int unsigned NOT NULL DEFAULT '0',
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_lastupdater` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `contracts_id` (`contracts_id`),
@@ -1473,7 +1485,11 @@ CREATE TABLE `glpi_contractcosts` (
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `budgets_id` (`budgets_id`)
+  KEY `budgets_id` (`budgets_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
+  KEY `users_id` (`users_id`),
+  KEY `users_id_lastupdater` (`users_id_lastupdater`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -5711,13 +5727,21 @@ CREATE TABLE `glpi_problemcosts` (
   `cost_material` decimal(20,4) NOT NULL DEFAULT '0.0000',
   `budgets_id` int unsigned NOT NULL DEFAULT '0',
   `entities_id` int unsigned NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_lastupdater` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `problems_id` (`problems_id`),
   KEY `begin_date` (`begin_date`),
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
-  KEY `budgets_id` (`budgets_id`)
+  KEY `budgets_id` (`budgets_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
+  KEY `users_id` (`users_id`),
+  KEY `users_id_lastupdater` (`users_id_lastupdater`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -5985,6 +6009,10 @@ CREATE TABLE `glpi_projectcosts` (
   `budgets_id` int unsigned NOT NULL DEFAULT '0',
   `entities_id` int unsigned NOT NULL DEFAULT '0',
   `is_recursive` tinyint NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_lastupdater` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `projects_id` (`projects_id`),
@@ -5992,7 +6020,11 @@ CREATE TABLE `glpi_projectcosts` (
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`),
-  KEY `budgets_id` (`budgets_id`)
+  KEY `budgets_id` (`budgets_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
+  KEY `users_id` (`users_id`),
+  KEY `users_id_lastupdater` (`users_id_lastupdater`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 
@@ -7253,13 +7285,21 @@ CREATE TABLE `glpi_ticketcosts` (
   `cost_material` decimal(20,4) NOT NULL DEFAULT '0.0000',
   `budgets_id` int unsigned NOT NULL DEFAULT '0',
   `entities_id` int unsigned NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
+  `date_mod` timestamp NULL DEFAULT NULL,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `users_id_lastupdater` int unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `tickets_id` (`tickets_id`),
   KEY `begin_date` (`begin_date`),
   KEY `end_date` (`end_date`),
   KEY `entities_id` (`entities_id`),
-  KEY `budgets_id` (`budgets_id`)
+  KEY `budgets_id` (`budgets_id`),
+  KEY `date_creation` (`date_creation`),
+  KEY `date_mod` (`date_mod`),
+  KEY `users_id` (`users_id`),
+  KEY `users_id_lastupdater` (`users_id_lastupdater`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -481,6 +481,7 @@ abstract class CommonITILCost extends CommonDBChild
             'SELECT' => [
                 static::$items_id, 'id', 'name', 'begin_date', 'end_date', 'actiontime',
                 'budgets_id', 'cost_time', 'cost_fixed', 'cost_material', 'comment',
+                'date_creation', 'date_mod', 'users_id', 'users_id_lastupdater',
             ],
             'FROM'   => static::getTable(),
             'WHERE'  => [
@@ -552,6 +553,7 @@ TWIG, $twig_params);
         $budget = new Budget();
         $ticket_links = [];
         $budget_links = [];
+        $user_links = [];
         foreach ($iterator as $data) {
             $name = (empty($data['name']) ? sprintf(__('%1$s (%2$s)'), $data['name'], $data['id']) : $data['name']);
 
@@ -570,6 +572,16 @@ TWIG, $twig_params);
                 $budget->getFromDB($data['budgets_id']);
                 $budget_links[$data['budgets_id']] = $budget->getLink();
             }
+            if (!array_key_exists($data['users_id'], $user_links)) {
+                $user = new User();
+                $user->getFromDB($data['users_id']);
+                $user_links[$data['users_id']] = $user->getLink();
+            }
+            if (!array_key_exists($data['users_id_lastupdater'], $user_links)) {
+                $user = new User();
+                $user->getFromDB($data['users_id_lastupdater']);
+                $user_links[$data['users_id_lastupdater']] = $user->getLink();
+            }
             $entry = [
                 'itemtype' => static::class,
                 'id'       => $data['id'],
@@ -582,6 +594,10 @@ TWIG, $twig_params);
                 'cost_fixed' => $data['cost_fixed'],
                 'cost_material' => $data['cost_material'],
                 'totalcost' => $cost,
+                'date_creation' => $data['date_creation'],
+                'date_mod' => $data['date_mod'],
+                'users_id' => $user_links[$data['users_id']],
+                'users_id_lastupdater' => $user_links[$data['users_id_lastupdater']],
             ];
             if ($forproject) {
                 if (!array_key_exists($data[static::$items_id], $ticket_links)) {
@@ -595,6 +611,10 @@ TWIG, $twig_params);
 
         $columns = [
             'name' => __('Name'),
+            'date_creation' => __('Creation date'),
+            'users_id' => User::getTypeName(1),
+            'date_mod' => __('Modification date'),
+            'users_id_lastupdater' => User::getTypeName(1) . ' (' . __('Last updater') . ')',
             'begin_date' => __('Begin date'),
             'end_date' => __('End date'),
             'budget' => Budget::getTypeName(1),
@@ -606,6 +626,10 @@ TWIG, $twig_params);
         ];
         $footer = [
             'name' => '',
+            'date_creation' => '',
+            'users_id' => '',
+            'date_mod' => '',
+            'users_id_lastupdater' => '',
             'begin_date' => '',
             'end_date' => '',
             'budget' => '',
@@ -632,6 +656,10 @@ TWIG, $twig_params);
             'formatters' => [
                 'ticket' => 'raw_html',
                 'name' => 'raw_html',
+                'date_creation' => 'datetime',
+                'users_id' => 'raw_html',
+                'date_mod' => 'datetime',
+                'users_id_lastupdater' => 'raw_html',
                 'begin_date' => 'date',
                 'end_date' => 'date',
                 'budget' => 'raw_html',
@@ -741,5 +769,31 @@ TWIG, $twig_params);
     {
         $cost = ($actiontime * $cost_time / HOUR_TIMESTAMP) + $cost_fixed + $cost_material;
         return Html::formatNumber($cost, $edit);
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        $input = parent::prepareInputForAdd($input);
+
+        if ($input === false) {
+            return false;
+        }
+
+        $input['users_id'] = Session::getLoginUserID();
+
+        return $input;
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $input = parent::prepareInputForUpdate($input);
+
+        if ($input === false) {
+            return false;
+        }
+
+        $input['users_id_lastupdater'] = Session::getLoginUserID();
+
+        return $input;
     }
 }

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -779,7 +779,9 @@ TWIG, $twig_params);
             return false;
         }
 
-        $input['users_id'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id'] = Session::getLoginUserID();
+        }
 
         return $input;
     }
@@ -792,7 +794,9 @@ TWIG, $twig_params);
             return false;
         }
 
-        $input['users_id_lastupdater'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id_lastupdater'] = Session::getLoginUserID();
+        }
 
         return $input;
     }

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -69,6 +69,8 @@ class ContractCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
+        $input['users_id'] = Session::getLoginUserID();
+
         return parent::prepareInputForAdd($input);
     }
 
@@ -83,6 +85,8 @@ class ContractCost extends CommonDBChild
         ) {
             $input['end_date'] = $input['begin_date'];
         }
+
+        $input['users_id_lastupdater'] = Session::getLoginUserID();
 
         return parent::prepareInputForUpdate($input);
     }
@@ -354,6 +358,7 @@ TWIG, $twig_params);
 
         $entries = [];
         $budget_cache = [];
+        $user_links = [];
         foreach ($iterator as $data) {
             $name = empty($data['name']) ? sprintf(
                 __('%1$s (%2$s)'),
@@ -368,6 +373,16 @@ TWIG, $twig_params);
             if (!isset($budget_cache[$data['budgets_id']])) {
                 $budget_cache[$data['budgets_id']] = Dropdown::getDropdownName(table: 'glpi_budgets', id: $data['budgets_id'], default: '');
             }
+            if (!array_key_exists($data['users_id'], $user_links)) {
+                $user = new User();
+                $user->getFromDB($data['users_id']);
+                $user_links[$data['users_id']] = $user->getLink();
+            }
+            if (!array_key_exists($data['users_id_lastupdater'], $user_links)) {
+                $user = new User();
+                $user->getFromDB($data['users_id_lastupdater']);
+                $user_links[$data['users_id_lastupdater']] = $user->getLink();
+            }
             $entries[] = [
                 'itemtype' => self::class,
                 'id' => $data['id'],
@@ -377,6 +392,10 @@ TWIG, $twig_params);
                 'end_date' => $data['end_date'],
                 'budgets_id' => $budget_cache[$data['budgets_id']],
                 'cost' => $data['cost'],
+                'date_creation' => $data['date_creation'],
+                'date_mod' => $data['date_mod'],
+                'users_id' => $user_links[$data['users_id']],
+                'users_id_lastupdater' => $user_links[$data['users_id_lastupdater']],
             ];
         }
 
@@ -388,6 +407,10 @@ TWIG, $twig_params);
             'order' => $order,
             'columns' => [
                 'name' => __('Name'),
+                'date_creation' => __('Creation date'),
+                'users_id' => User::getTypeName(1),
+                'date_mod' => __('Modification date'),
+                'users_id_lastupdater' => User::getTypeName(1) . ' (' . __('Last updater') . ')',
                 'begin_date' => __('Begin date'),
                 'end_date' => __('End date'),
                 'budgets_id' => Budget::getTypeName(1),
@@ -395,12 +418,20 @@ TWIG, $twig_params);
             ],
             'formatters' => [
                 'name' => 'raw_html',
+                'date_creation' => 'datetime',
+                'users_id' => 'raw_html',
+                'date_mod' => 'datetime',
+                'users_id_lastupdater' => 'raw_html',
                 'begin_date' => 'date',
                 'end_date' => 'date',
                 'cost' => 'number',
             ],
             'footers' => [
                 [
+                    '',
+                    '',
+                    '',
+                    '',
                     '',
                     '',
                     '',

--- a/src/ContractCost.php
+++ b/src/ContractCost.php
@@ -69,7 +69,9 @@ class ContractCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
-        $input['users_id'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id'] = Session::getLoginUserID();
+        }
 
         return parent::prepareInputForAdd($input);
     }
@@ -86,7 +88,9 @@ class ContractCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
-        $input['users_id_lastupdater'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id_lastupdater'] = Session::getLoginUserID();
+        }
 
         return parent::prepareInputForUpdate($input);
     }

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -65,6 +65,8 @@ class ProjectCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
+        $input['users_id'] = Session::getLoginUserID();
+
         return parent::prepareInputForAdd($input);
     }
 
@@ -77,6 +79,8 @@ class ProjectCost extends CommonDBChild
         ) {
             $input['end_date'] = $input['begin_date'];
         }
+
+        $input['users_id_lastupdater'] = Session::getLoginUserID();
 
         return parent::prepareInputForUpdate($input);
     }
@@ -344,6 +348,10 @@ class ProjectCost extends CommonDBChild
 
         if (count($iterator)) {
             echo "<tr><th>" . __s('Name') . "</th>";
+            echo "<th>" . __s('Creation date') . "</th>";
+            echo "<th>" . htmlescape(User::getTypeName(1)) . "</th>";
+            echo "<th>" . __s('Modification date') . "</th>";
+            echo "<th>" . htmlescape(User::getTypeName(1)) . ' (' . __s('Last updater') . ')' . "</th>";
             echo "<th>" . __s('Begin date') . "</th>";
             echo "<th>" . __s('End date') . "</th>";
             echo "<th>" . htmlescape(Budget::getTypeName(1)) . "</th>";
@@ -361,9 +369,22 @@ class ProjectCost extends CommonDBChild
                 )
             );
 
+            $user_links = [];
+
             foreach ($iterator as $data) {
                 $cost_id = (int) $data['id'];
                 $project_id = (int) $data['projects_id'];
+
+                if (!array_key_exists($data['users_id'], $user_links)) {
+                    $user = new User();
+                    $user->getFromDB($data['users_id']);
+                    $user_links[$data['users_id']] = $user->getLink();
+                }
+                if (!array_key_exists($data['users_id_lastupdater'], $user_links)) {
+                    $user = new User();
+                    $user->getFromDB($data['users_id_lastupdater']);
+                    $user_links[$data['users_id_lastupdater']] = $user->getLink();
+                }
 
                 echo "<tr class='tab_bg_2' "
                     . ($canedit ? "style='cursor:pointer' onClick=\"viewEditCost" . $project_id . "_" . $cost_id . "_$rand();\"" : '')
@@ -401,6 +422,10 @@ class ProjectCost extends CommonDBChild
                     echo Html::scriptBlock($js);
                 }
                 echo "</td>";
+                echo "<td>" . htmlescape(Html::convDateTime($data['date_creation'])) . "</td>";
+                echo "<td>" . $user_links[$data['users_id']] . "</td>";
+                echo "<td>" . htmlescape(Html::convDateTime($data['date_mod'])) . "</td>";
+                echo "<td>" . $user_links[$data['users_id_lastupdater']] . "</td>";
                 echo "<td>" . htmlescape(Html::convDate($data['begin_date'])) . "</td>";
                 echo "<td>" . htmlescape(Html::convDate($data['end_date'])) . "</td>";
                 echo "<td>" . htmlescape(Dropdown::getDropdownName('glpi_budgets', $data['budgets_id'])) . "</td>";

--- a/src/ProjectCost.php
+++ b/src/ProjectCost.php
@@ -65,7 +65,9 @@ class ProjectCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
-        $input['users_id'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id'] = Session::getLoginUserID();
+        }
 
         return parent::prepareInputForAdd($input);
     }
@@ -80,7 +82,9 @@ class ProjectCost extends CommonDBChild
             $input['end_date'] = $input['begin_date'];
         }
 
-        $input['users_id_lastupdater'] = Session::getLoginUserID();
+        if (Session::getLoginUserID()) {
+            $input['users_id_lastupdater'] = Session::getLoginUserID();
+        }
 
         return parent::prepareInputForUpdate($input);
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

GLPI isn't an accounting software, but it does offer limited functionality of one and when it comes to accounting there are a few things that seem essential but missing in GLPI like:
- Knowing when a cost was added
- Knowing who added the cost
- Knowing when/if a cost was modified
- Knowing who modified the cost

Less important, but the thing that brought it to my attention was with my frontend side-project (personal). I wanted to be able to get rid of the tabs usually present for tickets/changes/problems and have everything in a nice, clean timeline view. Using the end/begin dates for a cost are unsuitable for this task.

<img width="1481" height="1070" alt="Selection_676" src="https://github.com/user-attachments/assets/b8c873fa-f66f-4e73-a696-71032e5194d7" />
