### PR TITLE
fix: normalize Windows paths in SCSS compilation

### DIFF
--- a/src/Glpi/Console/Build/CompileScssCommand.php
+++ b/src/Glpi/Console/Build/CompileScssCommand.php
@@ -118,7 +118,7 @@ class CompileScssCommand extends Command
         $dry_run = $input->getOption('dry-run');
 
         if (empty($files)) {
-            $root_path = realpath(GLPI_ROOT);
+            $root_path = str_replace(DIRECTORY_SEPARATOR, '/', realpath(GLPI_ROOT));
 
             $css_dir_iterator = new RecursiveIteratorIterator(
                 new RecursiveDirectoryIterator($root_path . '/css'),
@@ -126,17 +126,19 @@ class CompileScssCommand extends Command
             );
             /** @var SplFileInfo $file */
             foreach ($css_dir_iterator as $file) {
+                $file_path = str_replace(DIRECTORY_SEPARATOR, '/', $file->getPath());
                 if (
                     !$file->isReadable() || !$file->isFile() || $file->getExtension() !== 'scss'
-                     || preg_match('/^' . preg_quote(GLPI_ROOT . '/css/lib/', '/') . '/', $file->getPath()) === 1
+                     || preg_match('/^' . preg_quote($root_path . '/css/lib/', '/') . '/', $file_path) === 1
                      || preg_match('/^_/', $file->getBasename()) === 1
                 ) {
                     continue;
                 }
 
-                $files[] = str_replace($root_path . '/', '', dirname($file->getRealPath()))
-                . '/'
-                . preg_replace('/^_?(.*)\.scss$/', '$1', $file->getBasename());
+                $dir_path = str_replace(DIRECTORY_SEPARATOR, '/', dirname($file->getRealPath()));
+                $files[] = str_replace($root_path . '/', '', $dir_path)
+                    . '/'
+                    . preg_replace('/^_?(.*)\.scss$/', '$1', $file->getBasename());
             }
         }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -6664,6 +6664,8 @@ CSS;
     {
         $file = preg_replace('/\.scss$/', '', $file);
 
+        $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
+
         return self::getScssCompileDir($root_dir) . '/' . str_replace('/', '_', $file) . '.min.css';
     }
 
@@ -6676,7 +6678,7 @@ CSS;
      */
     public static function getScssCompileDir(string $root_dir = GLPI_ROOT)
     {
-        return $root_dir . '/public/css_compiled';
+        return str_replace(DIRECTORY_SEPARATOR, '/', $root_dir) . '/public/css_compiled';
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes #22868

On Windows, the `build:compile_scss` command produces malformed output paths because `DIRECTORY_SEPARATOR` is a backslash (`\`), leading to paths like:

```
D:\Sites\glpi-test/public/css_compiled/D:\Sites\glpi-test\css_core_palettes.min.css
```

## Changes

Normalize all filesystem paths to use forward slashes (`/`) before constructing output paths:

- **`CompileScssCommand.php`**: Normalize `realpath()` output, `dirname()` result, and `getPath()` in the lib exclusion regex
- **`Html::getScssCompilePath()`**: Normalize the `$file` parameter before replacing `/` with `_`
- **`Html::getScssCompileDir()`**: Normalize `$root_dir` before appending the compile directory

On Linux/macOS this is a no-op since `DIRECTORY_SEPARATOR` is already `/`.