### PR TITLE
[wording] add missing "send an" (approval request)

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -1013,11 +1013,11 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
             $actions['groups_id_validate_any']['permitseveral']             = ['add_validation'];
 
             // Approval request to requester group manager
-            $actions['users_id_validate_requester_supervisor']['name']  = __('Approval request to requester group manager');
+            $actions['users_id_validate_requester_supervisor']['name']  = __('Send an approval request to requester group manager');
             $actions['users_id_validate_requester_supervisor']['type']  = 'yesno';
             $actions['users_id_validate_requester_supervisor']['force_actions'] = ['add_validation'];
 
-            $actions['users_id_validate_assign_supervisor']['name']     = __('Approval request to technician group manager');
+            $actions['users_id_validate_assign_supervisor']['name']     = __('Send an approval request to technician group manager');
             $actions['users_id_validate_assign_supervisor']['type']     = 'yesno';
             $actions['users_id_validate_assign_supervisor']['force_actions'] = ['add_validation'];
 

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -375,8 +375,8 @@ class RuleTest extends DbTestCase
                 __('Set approval threshold (in percentage)'),
                 'validationsteps_threshold',
             ],
-            [__('Approval request to requester group manager'), 'users_id_validate_requester_supervisor'],
-            [__('Approval request to technician group manager'), 'users_id_validate_assign_supervisor'],
+            [__('Send an approval request to requester group manager'), 'users_id_validate_requester_supervisor'],
+            [__('Send an approval request to technician group manager'), 'users_id_validate_assign_supervisor'],
             [\RequestType::getTypeName(1), 'requesttypes_id'],
         ];
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

wording : add missing "send an" (approval request) to itil rule action names/labels

Before :
<img width="860" height="360" alt="Capture d’écran du 2026-02-16 10-42-22" src="https://github.com/user-attachments/assets/5b5cedab-d1a5-46df-9d4a-3af17d96856a" />

After : 
<img width="860" height="360" alt="Capture d’écran du 2026-02-16 10-41-57" src="https://github.com/user-attachments/assets/71f1fa57-f0f9-4680-83ff-93edcc124bf5" />

--- 

Wording also needs to be fixed in translations, we need to choose _validation_ or _approbation_ word : 
I guess it should be fixed using Transifex. I'll do it.

<img width="860" height="360" alt="Capture d’écran du 2026-02-16 10-43-23" src="https://github.com/user-attachments/assets/794b230c-b2e9-4dc1-9e12-c6481d2f901c" />
<img width="860" height="360" alt="Capture d’écran du 2026-02-16 10-43-08" src="https://github.com/user-attachments/assets/ce6d583a-2d97-43c0-8a71-ec8705ec31df" />



