### PR TITLE
Refactor LogsWriteAccess: filesystem checks instead of Monolog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,11 +363,10 @@ jobs:
       - name: Check for PHP errors
         if: ${{ !cancelled() }}
         run: |
-          grep -v '\*\*\* Test logger' tests/e2e/glpi_files/_log/php-errors.log > /tmp/php-errors-filtered.log || true
-          if [[ $(wc -l < /tmp/php-errors-filtered.log) -ge 1 ]]; then
+          if [[ -s tests/e2e/glpi_files/_log/php-errors.log ]]; then
             echo "PHP errors detected in log file"
             echo "==============================="
-            cat /tmp/php-errors-filtered.log
+            cat tests/e2e/glpi_files/_log/php-errors.log
             exit 1
           fi
       - uses: actions/upload-artifact@v6

--- a/src/Glpi/System/Requirement/LogsWriteAccess.php
+++ b/src/Glpi/System/Requirement/LogsWriteAccess.php
@@ -44,6 +44,17 @@ use function Safe\touch;
  */
 class LogsWriteAccess extends AbstractRequirement
 {
+    private const LOG_FILES = [
+        'php-errors.log',
+        'access-errors.log',
+        'api.log',
+        'cron.log',
+        'event.log',
+        'mail-error.log',
+        'mailgate.log',
+        'webhook.log',
+    ];
+
     private string $log_dir;
 
     public function __construct(string $log_dir)
@@ -63,26 +74,29 @@ class LogsWriteAccess extends AbstractRequirement
             return;
         }
 
-        $file_path = $this->log_dir . '/php-errors.log';
+        $this->validated = true;
 
-        if (file_exists($file_path)) {
-            if (!is_writable($file_path)) {
-                $this->validated = false;
-                $this->validation_messages[] = sprintf(__('The log file %s is not writable.'), $file_path);
-                return;
-            }
-        } else {
-            // Do not remove the file after touch(), as SELinux may prevent re-creation.
-            try {
-                touch($file_path);
-            } catch (FilesystemException) {
-                $this->validated = false;
-                $this->validation_messages[] = sprintf(__('The log file %s could not be created.'), $file_path);
-                return;
+        foreach (self::LOG_FILES as $log_file) {
+            $file_path = $this->log_dir . '/' . $log_file;
+
+            if (file_exists($file_path)) {
+                if (!is_writable($file_path)) {
+                    $this->validated = false;
+                    $this->validation_messages[] = sprintf(__('The log file %s is not writable.'), $file_path);
+                }
+            } else {
+                // Do not remove the file after touch(), as SELinux may prevent re-creation.
+                try {
+                    touch($file_path);
+                } catch (FilesystemException) {
+                    $this->validated = false;
+                    $this->validation_messages[] = sprintf(__('The log file %s could not be created.'), $file_path);
+                }
             }
         }
 
-        $this->validated = true;
-        $this->validation_messages[] = __('Write access to log files has been validated.');
+        if ($this->validated) {
+            $this->validation_messages[] = __('Write access to log files has been validated.');
+        }
     }
 }

--- a/src/Glpi/System/Requirement/LogsWriteAccess.php
+++ b/src/Glpi/System/Requirement/LogsWriteAccess.php
@@ -37,6 +37,7 @@ namespace Glpi\System\Requirement;
 
 use Safe\Exceptions\FilesystemException;
 
+use function Safe\mkdir;
 use function Safe\touch;
 
 /**
@@ -50,8 +51,10 @@ class LogsWriteAccess extends AbstractRequirement
         'api.log',
         'cron.log',
         'event.log',
+        'mail.log',
         'mail-error.log',
         'mailgate.log',
+        'notification.log',
         'webhook.log',
     ];
 
@@ -68,7 +71,17 @@ class LogsWriteAccess extends AbstractRequirement
 
     protected function check()
     {
-        if (!is_dir($this->log_dir) || !is_writable($this->log_dir)) {
+        if (!is_dir($this->log_dir)) {
+            try {
+                mkdir($this->log_dir, 0o755, true);
+            } catch (FilesystemException) {
+                $this->validated = false;
+                $this->validation_messages[] = sprintf(__('The log directory %s could not be created.'), $this->log_dir);
+                return;
+            }
+        }
+
+        if (!is_writable($this->log_dir)) {
             $this->validated = false;
             $this->validation_messages[] = sprintf(__('The log directory %s is not writable.'), $this->log_dir);
             return;
@@ -85,7 +98,6 @@ class LogsWriteAccess extends AbstractRequirement
                     $this->validation_messages[] = sprintf(__('The log file %s is not writable.'), $file_path);
                 }
             } else {
-                // Do not remove the file after touch(), as SELinux may prevent re-creation.
                 try {
                     touch($file_path);
                 } catch (FilesystemException) {

--- a/src/Glpi/System/Requirement/LogsWriteAccess.php
+++ b/src/Glpi/System/Requirement/LogsWriteAccess.php
@@ -35,43 +35,54 @@
 
 namespace Glpi\System\Requirement;
 
-use Psr\Log\LoggerInterface;
-use UnexpectedValueException;
+use Safe\Exceptions\FilesystemException;
+
+use function Safe\touch;
 
 /**
  * @since 9.5.0
  */
 class LogsWriteAccess extends AbstractRequirement
 {
-    /**
-     * Logger.
-     *
-     */
-    private LoggerInterface $logger;
+    private string $log_dir;
 
-    /**
-     *
-     * @param LoggerInterface $logger
-     */
-    public function __construct(LoggerInterface $logger)
+    public function __construct(string $log_dir)
     {
         parent::__construct(
             __('Permissions for log files')
         );
 
-        $this->logger = $logger;
+        $this->log_dir = $log_dir;
     }
 
     protected function check()
     {
-        // Only write test for GLPI_LOG as SElinux prevent removing log file.
-        try {
-            $this->logger->warning('Test logger');
-            $this->validated = true;
-            $this->validation_messages[] = __('The log file has been created successfully.');
-        } catch (UnexpectedValueException $e) {
+        if (!is_dir($this->log_dir) || !is_writable($this->log_dir)) {
             $this->validated = false;
-            $this->validation_messages[] = sprintf(__('The log file could not be created in %s.'), GLPI_LOG_DIR);
+            $this->validation_messages[] = sprintf(__('The log directory %s is not writable.'), $this->log_dir);
+            return;
         }
+
+        $file_path = $this->log_dir . '/php-errors.log';
+
+        if (file_exists($file_path)) {
+            if (!is_writable($file_path)) {
+                $this->validated = false;
+                $this->validation_messages[] = sprintf(__('The log file %s is not writable.'), $file_path);
+                return;
+            }
+        } else {
+            // Do not remove the file after touch(), as SELinux may prevent re-creation.
+            try {
+                touch($file_path);
+            } catch (FilesystemException) {
+                $this->validated = false;
+                $this->validation_messages[] = sprintf(__('The log file %s could not be created.'), $file_path);
+                return;
+            }
+        }
+
+        $this->validated = true;
+        $this->validation_messages[] = __('Write access to log files has been validated.');
     }
 }

--- a/src/Glpi/System/RequirementsManager.php
+++ b/src/Glpi/System/RequirementsManager.php
@@ -142,8 +142,7 @@ class RequirementsManager
             $requirements[] = new DbEngine($db);
         }
 
-        global $PHPLOGGER;
-        $requirements[] = new LogsWriteAccess($PHPLOGGER);
+        $requirements[] = new LogsWriteAccess(GLPI_LOG_DIR);
 
         $requirements[] = new DirectoriesWriteAccess(
             __('Permissions for GLPI data directories'),

--- a/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
+++ b/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
@@ -36,23 +36,18 @@ namespace tests\units\Glpi\System\Requirement;
 
 use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\Tests\GLPITestCase;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
 use org\bovigo\vfs\vfsStream;
 
 class LogsWriteAccessTest extends GLPITestCase
 {
     public function testCheckOnExistingWritableDir()
     {
-        vfsStream::setup('root', 0o777, []);
+        vfsStream::setup('root', 0o777, ['php-errors.log' => '']);
 
-        $logger = new Logger('test_log');
-        $logger->pushHandler(new StreamHandler(vfsStream::url('root/test.log')));
-
-        $instance = new LogsWriteAccess($logger);
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
         $this->assertTrue($instance->isValidated());
         $this->assertEquals(
-            ['The log file has been created successfully.'],
+            ['Write access to log files has been validated.'],
             $instance->getValidationMessages()
         );
     }
@@ -61,13 +56,35 @@ class LogsWriteAccessTest extends GLPITestCase
     {
         vfsStream::setup('root', 0o555, []);
 
-        $logger = new Logger('test_log');
-        $logger->pushHandler(new StreamHandler(vfsStream::url('root/test.log')));
-
-        $instance = new LogsWriteAccess($logger);
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
         $this->assertFalse($instance->isValidated());
         $this->assertEquals(
-            ['The log file could not be created in ' . GLPI_LOG_DIR . '.'],
+            ['The log directory ' . vfsStream::url('root') . ' is not writable.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckOnExistingNonWritableLogFile()
+    {
+        $structure = vfsStream::setup('root', 0o777, ['php-errors.log' => '']);
+        $structure->getChild('php-errors.log')->chmod(0o444);
+
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            ['The log file ' . vfsStream::url('root/php-errors.log') . ' is not writable.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckOnMissingLogFileInWritableDir()
+    {
+        vfsStream::setup('root', 0o777, []);
+
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
+        $this->assertTrue($instance->isValidated());
+        $this->assertEquals(
+            ['Write access to log files has been validated.'],
             $instance->getValidationMessages()
         );
     }

--- a/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
+++ b/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
@@ -88,4 +88,73 @@ class LogsWriteAccessTest extends GLPITestCase
             $instance->getValidationMessages()
         );
     }
+
+    public function testCheckAllLogFilesWritable()
+    {
+        vfsStream::setup('root', 0o777, [
+            'php-errors.log'    => '',
+            'access-errors.log' => '',
+            'api.log'           => '',
+            'cron.log'          => '',
+            'event.log'         => '',
+            'mail-error.log'    => '',
+            'mailgate.log'      => '',
+            'webhook.log'       => '',
+        ]);
+
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
+        $this->assertTrue($instance->isValidated());
+        $this->assertEquals(
+            ['Write access to log files has been validated.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckWithOneUnwritableFile()
+    {
+        $structure = vfsStream::setup('root', 0o777, [
+            'php-errors.log'    => '',
+            'access-errors.log' => '',
+            'api.log'           => '',
+            'cron.log'          => '',
+            'event.log'         => '',
+            'mail-error.log'    => '',
+            'mailgate.log'      => '',
+            'webhook.log'       => '',
+        ]);
+        $structure->getChild('mailgate.log')->chmod(0o444);
+
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            ['The log file ' . vfsStream::url('root/mailgate.log') . ' is not writable.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckWithMultipleUnwritableFiles()
+    {
+        $structure = vfsStream::setup('root', 0o777, [
+            'php-errors.log'    => '',
+            'access-errors.log' => '',
+            'api.log'           => '',
+            'cron.log'          => '',
+            'event.log'         => '',
+            'mail-error.log'    => '',
+            'mailgate.log'      => '',
+            'webhook.log'       => '',
+        ]);
+        $structure->getChild('cron.log')->chmod(0o444);
+        $structure->getChild('webhook.log')->chmod(0o444);
+
+        $instance = new LogsWriteAccess(vfsStream::url('root'));
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            [
+                'The log file ' . vfsStream::url('root/cron.log') . ' is not writable.',
+                'The log file ' . vfsStream::url('root/webhook.log') . ' is not writable.',
+            ],
+            $instance->getValidationMessages()
+        );
+    }
 }

--- a/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
+++ b/tests/functional/Glpi/System/Requirement/LogsWriteAccessTest.php
@@ -52,6 +52,29 @@ class LogsWriteAccessTest extends GLPITestCase
         );
     }
 
+    public function testCheckOnMissingDirCreatesIt()
+    {
+        vfsStream::setup('root', 0o777, []);
+
+        $dir = vfsStream::url('root/logs');
+        $instance = new LogsWriteAccess($dir);
+        $this->assertTrue($instance->isValidated());
+        $this->assertTrue(is_dir($dir));
+    }
+
+    public function testCheckOnNonCreatableDir()
+    {
+        vfsStream::setup('root', 0o555, []);
+
+        $dir = vfsStream::url('root/logs');
+        $instance = new LogsWriteAccess($dir);
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            ['The log directory ' . $dir . ' could not be created.'],
+            $instance->getValidationMessages()
+        );
+    }
+
     public function testCheckOnExistingProtectedDir()
     {
         vfsStream::setup('root', 0o555, []);
@@ -97,8 +120,10 @@ class LogsWriteAccessTest extends GLPITestCase
             'api.log'           => '',
             'cron.log'          => '',
             'event.log'         => '',
+            'mail.log'          => '',
             'mail-error.log'    => '',
             'mailgate.log'      => '',
+            'notification.log'  => '',
             'webhook.log'       => '',
         ]);
 
@@ -118,8 +143,10 @@ class LogsWriteAccessTest extends GLPITestCase
             'api.log'           => '',
             'cron.log'          => '',
             'event.log'         => '',
+            'mail.log'          => '',
             'mail-error.log'    => '',
             'mailgate.log'      => '',
+            'notification.log'  => '',
             'webhook.log'       => '',
         ]);
         $structure->getChild('mailgate.log')->chmod(0o444);
@@ -140,8 +167,10 @@ class LogsWriteAccessTest extends GLPITestCase
             'api.log'           => '',
             'cron.log'          => '',
             'event.log'         => '',
+            'mail.log'          => '',
             'mail-error.log'    => '',
             'mailgate.log'      => '',
+            'notification.log'  => '',
             'webhook.log'       => '',
         ]);
         $structure->getChild('cron.log')->chmod(0o444);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes #22422 

- Replaced Monolog dependency in LogsWriteAccess with direct filesystem checks (is_dir, is_writable, Safe\touch()), eliminating log pollution (*** Test logger written on every requirement check)
- Extended write access verification from only php-errors.log to all 8 log files actually used by GLPI
- Removed the grep -v 'Test logger' CI workaround in the Playwright workflow, now unnecessary

**Difference from issue description**

The issue listed mail.log and notification.log, but neither is ever written by GLPI (no Toolbox::logInFile call exists for them). Conversely, api.log (used in Glpi\Api\API.php) was missing from the issue. The final list of verified files is: php-errors.log, access-errors.log, api.log, cron.log, event.log, mail-error.log, mailgate.log, webhook.log.


**Tests**

PHPUnit :

- testCheckOnExistingWritableDir — directory + file writable
- testCheckOnExistingProtectedDir — directory not writable
- testCheckOnExistingNonWritableLogFile — existing file with 0o444 permissions
- testCheckOnMissingLogFileInWritableDir — missing file, touch succeeds
- testCheckAllLogFilesWritable — all 8 files present and writable
- testCheckWithOneUnwritableFile — single file failure + specific error message
- testCheckWithMultipleUnwritableFiles — multiple failures + accumulated error messages
  
Manual verification :

Each log file was cleared, a scenario was executed, and output was verified via `tail -f:`

- event.log — login/logout
- cron.log — run automatic action
- access-errors.log — invalid CSRF token submission
- php-errors.log — PHP warning (trigger_error)
- mail-error.log — invalid SMTP server + test email
- mailgate.log — Toolbox::logInFile call during collect
- webhook.log — webhook with invalid target URL
- api.log — API call with logging set to "Logs"

CI validation

The CI workflow change (removal of the `grep -v 'Test logger'` workaround) will be validated by the Playwright job running on this PR, as it cannot be tested locally.
