### PR TITLE
Fix group rule action assign value from regex

### DIFF
--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -142,6 +142,19 @@ class RuleRight extends Rule
                                     $continue = false;
                                 }
                                 break;
+                            case "specific_groups_id":
+                                foreach ($this->regex_results as $regex_result) {
+                                    $res = RuleAction::getRegexResultById(
+                                        $action->fields["value"],
+                                        $regex_result
+                                    );
+                                    $group = new Group();
+                                    $group_id = $group->getFromDBByCrit(['name' => $res]);
+                                    if ($group_id) {
+                                        $output["_ldap_rules"]['groups_id'][] = $group->getID();
+                                        break;
+                                    }
+                                }
                         }
                         break;
                 }
@@ -307,6 +320,7 @@ class RuleRight extends Rule
         $actions['specific_groups_id']['name'] = Group::getTypeName(Session::getPluralNumber());
         $actions['specific_groups_id']['type'] = 'dropdown';
         $actions['specific_groups_id']['table'] = 'glpi_groups';
+        $actions['specific_groups_id']['force_actions'] = ['assign', 'regex_result'];
 
         $actions['groups_id']['table']                        = 'glpi_groups';
         $actions['groups_id']['field']                        = 'name';

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -149,7 +149,7 @@ class RuleRight extends Rule
                                         $regex_result
                                     );
                                     $group = new Group();
-                                    $group_id = $group->getFromDBByCrit(['name' => $res]);
+                                    $group_id = $group->getFromDBByCrit(['name' => $res, 'entities_id' => $this->getEntityID()]);
                                     if ($group_id) {
                                         $output["_ldap_rules"]['groups_id'][] = $group->getID();
                                         break;

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -149,10 +149,9 @@ class RuleRight extends Rule
                                         $regex_result
                                     );
                                     $group = new Group();
-                                    $group_id = $group->getFromDBByCrit(['name' => $res, 'entities_id' => $this->getEntityID()]);
-                                    if ($group_id) {
-                                        $output["_ldap_rules"]['groups_id'][] = $group->getID();
-                                        break;
+                                    $groups = $group->find(['name' => $res]);
+                                    foreach ($groups as $group) {
+                                        $output["_ldap_rules"]['groups_id'][] = $group['id'];
                                     }
                                 }
                         }

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -324,4 +324,184 @@ class RuleRightTest extends DbTestCase
         $user->getFromDBByName(TU_USER);
         $this->assertEquals('fr_FR', $user->getField('language'));
     }
+
+    public function testAssignGroupByRegexResult()
+    {
+        $group = $this->createItem(\Group::class, [
+            'name' => '_test_user_group_rule',
+            'entities_id' => 0,
+        ]);
+
+        $rule = $this->createItem(\RuleRight::class, [
+            'sub_type'     => 'RuleRight',
+            'name'         => __METHOD__,
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'LOGIN',
+            'condition' => \Rule::REGEX_MATCH,
+            'pattern'   => '/(.*)/',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'regex_result',
+            'field'       => 'specific_groups_id',
+            'value'       => '#0_group_rule',
+        ]);
+
+        $user = new \User();
+        $user->getFromDBByName(TU_USER);
+        $users_id = $user->getID();
+
+        $group_user = new \Group_User();
+        $this->assertFalse(
+            $group_user->getFromDBByCrit([
+                'users_id'  => $users_id,
+                'groups_id' => $group->getID(),
+            ])
+        );
+
+        $this->realLogin(TU_USER, TU_PASS, false);
+
+        $this->assertTrue(
+            $group_user->getFromDBByCrit([
+                'users_id'  => $users_id,
+                'groups_id' => $group->getID(),
+                'is_dynamic' => 1,
+            ])
+        );
+    }
+
+    public function testAssignMultipleGroupsByRegexResult()
+    {
+        $group1 = $this->createItem(\Group::class, [
+            'name' => '_test_user_group_rule_alpha',
+            'entities_id' => 0,
+        ]);
+        $group2 = $this->createItem(\Group::class, [
+            'name' => '_test_user_group_rule_beta',
+            'entities_id' => 0,
+        ]);
+
+        $rule1 = $this->createItem(\RuleRight::class, [
+            'sub_type'     => 'RuleRight',
+            'name'         => __METHOD__ . '_alpha',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule1->getID(),
+            'criteria'  => 'LOGIN',
+            'condition' => \Rule::REGEX_MATCH,
+            'pattern'   => '/^(.+)$/',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule1->getID(),
+            'action_type' => 'regex_result',
+            'field'       => 'specific_groups_id',
+            'value'       => '#0_group_rule_alpha',
+        ]);
+
+        $rule2 = $this->createItem(\RuleRight::class, [
+            'sub_type'     => 'RuleRight',
+            'name'         => __METHOD__ . '_beta',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule2->getID(),
+            'criteria'  => 'LOGIN',
+            'condition' => \Rule::REGEX_MATCH,
+            'pattern'   => '/^(.+)$/',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule2->getID(),
+            'action_type' => 'regex_result',
+            'field'       => 'specific_groups_id',
+            'value'       => '#0_group_rule_beta',
+        ]);
+
+        $user = new \User();
+        $user->getFromDBByName(TU_USER);
+        $users_id = $user->getID();
+
+        $this->realLogin(TU_USER, TU_PASS, false);
+
+        $group_user = new \Group_User();
+        $this->assertTrue(
+            $group_user->getFromDBByCrit([
+                'users_id'  => $users_id,
+                'groups_id' => $group1->getID(),
+                'is_dynamic' => 1,
+            ])
+        );
+        $this->assertTrue(
+            $group_user->getFromDBByCrit([
+                'users_id'  => $users_id,
+                'groups_id' => $group2->getID(),
+                'is_dynamic' => 1,
+            ])
+        );
+    }
+
+    public function testAssignGroupByRegexResultNoMatch()
+    {
+        $rule = $this->createItem(\RuleRight::class, [
+            'sub_type'     => 'RuleRight',
+            'name'         => __METHOD__,
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'LOGIN',
+            'condition' => \Rule::REGEX_MATCH,
+            'pattern'   => '/^(.+)$/',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'regex_result',
+            'field'       => 'specific_groups_id',
+            'value'       => 'nonexistent_group_#0',
+        ]);
+
+        $user = new \User();
+        $user->getFromDBByName(TU_USER);
+        $users_id = $user->getID();
+
+        $groups_before = countElementsInTable(\Group_User::getTable(), [
+            'users_id'   => $users_id,
+            'is_dynamic' => 1,
+        ]);
+
+        \SingletonRuleList::getInstance("RuleRight", 0)->load = 0;
+        \SingletonRuleList::getInstance("RuleRight", 0)->list = [];
+
+        $this->realLogin(TU_USER, TU_PASS, false);
+
+        $groups_after = countElementsInTable(\Group_User::getTable(), [
+            'users_id'   => $users_id,
+            'is_dynamic' => 1,
+        ]);
+
+        $this->assertEquals($groups_before, $groups_after);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42129
- Here is a brief description of what this PR does
Add the “Assign from regular expression” action to the “Group” field in the authorization engine.

## Screenshots (if appropriate):


