### PR TITLE
disallow bypass of mandatory param on urgency type question

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -194,6 +194,10 @@ TWIG;
     #[Override]
     public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string
     {
+        if (empty($value)) {
+            return '';
+        }
+
         return strval($value);
     }
 

--- a/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
+++ b/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
@@ -57,6 +57,7 @@ use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeLongText;
 use Glpi\Form\QuestionType\QuestionTypeNumber;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Form\ValidationResult;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
@@ -495,6 +496,20 @@ class AnswersHandlerTest extends DbTestCase
             ],
             'expectedIsValid' => true,
             'expectedErrors' => [],
+        ];
+
+        $mandatory_urgency_form_builder = (new FormBuilder("Mandatory Urgency Test Form"))
+            ->addQuestion("Mandatory Urgency", QuestionTypeUrgency::class, is_mandatory: true);
+
+        yield 'Empty mandatory urgency field - should be invalid' => [
+            'builder' => $mandatory_urgency_form_builder,
+            'answers' => [
+                'Mandatory Urgency' => null,
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory Urgency' => 'This field is mandatory',
+            ],
         ];
     }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

On a question of urgency type, it was possible to bypass the "mandatory" param, and thus send the answer.

This PR add a simple `empty($value)` check in` QuestionTypeUrgency::transformConditionValueForComparisons()` method to fix this unwanted behavior.

## Screenshots :

<img width="590" height="314" alt="image" src="https://github.com/user-attachments/assets/4500295e-5472-4797-81b8-0ee9f89fcfec" />



