### PR TITLE
Fix(Ticket): Merge as followup

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5789,9 +5789,9 @@ JAVASCRIPT;
                         continue;
                     }
 
+                    $tt = new Ticket_Ticket();
                     if ($p['link_type'] > 0 && $p['link_type'] < 5) {
                         // Clean up any existing links between the tickets to avoid duplicates
-                        $tt = new Ticket_Ticket();
                         $tt->deleteByCriteria([
                             'OR' => [
                                 [

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5780,6 +5780,35 @@ JAVASCRIPT;
                         //Cannot retrieve ticket. Abort/fail the merge
                         throw new RuntimeException(sprintf(__('Failed to load ticket %d'), $id), 1);
                     }
+                    if ($ticket->fields['id'] == $merge_target_id) {
+                        // Cannot merge a ticket into itself. Abort/fail the merge
+                        throw new RuntimeException(sprintf(__('Cannot merge ticket %d into itself'), $id), 1);
+                    }
+                    if ($ticket->isDeleted()) {
+                        //ignore deleted tickets
+                        continue;
+                    }
+
+                    if ($p['link_type'] > 0 && $p['link_type'] < 5) {
+                        // Clean up any existing links between the tickets to avoid duplicates
+                        $tt = new Ticket_Ticket();
+                        $tt->deleteByCriteria([
+                            'OR' => [
+                                [
+                                    'AND' => [
+                                        'tickets_id_1' => $merge_target_id,
+                                        'tickets_id_2' => $id,
+                                    ],
+                                ],
+                                [
+                                    'AND' => [
+                                        'tickets_id_2' => $merge_target_id,
+                                        'tickets_id_1' => $id,
+                                    ],
+                                ],
+                            ],
+                        ]);
+                    }
                     //Build followup from the original ticket
                     $input = [
                         'itemtype'        => Ticket::class,
@@ -5863,28 +5892,11 @@ JAVASCRIPT;
                     }
                     if ($p['link_type'] > 0 && $p['link_type'] < 5) {
                         //Add relation (this is parent of merge target)
-                        $tt = new Ticket_Ticket();
                         $linkparams = [
                             'link'         => $p['link_type'],
                             'tickets_id_1' => $id,
                             'tickets_id_2' => $merge_target_id,
                         ];
-                        $tt->deleteByCriteria([
-                            'OR' => [
-                                [
-                                    'AND' => [
-                                        'tickets_id_1' => $merge_target_id,
-                                        'tickets_id_2' => $id,
-                                    ],
-                                ],
-                                [
-                                    'AND' => [
-                                        'tickets_id_2' => $merge_target_id,
-                                        'tickets_id_1' => $id,
-                                    ],
-                                ],
-                            ],
-                        ]);
                         if (!$tt->add($linkparams)) {
                             //Cannot link tickets. Abort/fail the merge
                             throw new RuntimeException(sprintf(__('Failed to link tickets %d and %d'), $merge_target_id, $id), 1);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42213

When merging tickets into follow-ups, if there is already a link between the tickets, the follow-ups are duplicated in the previously linked tickets.

Scenario:

1. Create Ticket A (this will be the target of the merge)
2. Create Ticket B with 2 followups
3. Create Ticket C with 2 followups
4. From Ticket A, add a parent-child link: Ticket A is a child of Ticket B
5. From the ticket list, select tickets B and C
6. Massiveaction "Merge as followup"
    <img width="308" height="269" alt="image" src="https://github.com/user-attachments/assets/696b54ef-030b-498e-be00-b69434b9bf9a" />
7. Run: Merge

Results Before:
- Ticket A contains some duplicate follow-ups from B.
- Ticket B (deleted) contains the follow-ups from A as well.
- Ticket C (deleted) is correct.