### PR TITLE
Fix locales reset in tests

### DIFF
--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -97,9 +97,6 @@ class GLPITestCase extends TestCase
 
     public function setUp(): void
     {
-        /** @var Translator $TRANSLATE */
-        global $TRANSLATE;
-
         $this->storeGlobals();
 
         global $DB;
@@ -107,12 +104,6 @@ class GLPITestCase extends TestCase
 
         // By default, no session, not connected
         $this->resetSession();
-
-        // Locale from previous session may persist until another login is done.
-        if ($TRANSLATE->getLocale() !== "en_GB") {
-            // Reload default language only if needed to prevent performance hit
-            Session::loadLanguage();
-        }
 
         // By default, there shouldn't be any pictures in the test files
         $this->resetPictures();
@@ -522,11 +513,19 @@ class GLPITestCase extends TestCase
      */
     private function resetGlobalsAndStaticValues(): void
     {
+        /** @var Translator $TRANSLATE */
+        global $TRANSLATE;
+
         // Super globals
         $_GET = $this->superglobals_copy['GET'];
         $_POST = $this->superglobals_copy['POST'];
         $_REQUEST = $this->superglobals_copy['REQUEST'];
         $_SERVER = $this->superglobals_copy['SERVER'];
+
+        // Reset language to English if it was changed by a test
+        if ($TRANSLATE->getLocale() !== 'en_GB') {
+            Session::loadLanguage('en_GB');
+        }
 
         // Globals
         global $CFG_GLPI, $FOOTER_LOADED, $HEADER_LOADED;


### PR DESCRIPTION
## Description

The locale state reset was done at the start of a test.
Since data providers are run before the `setUp()` method, they would not benefit from the reset.

Moving the reset to the `tearDown()` hook should be more reliable.

I think this is the reason for failures like this one: https://github.com/glpi-project/glpi/actions/runs/22095749381/job/63852258913
