### PR TITLE
Remove deprecated code in iterator 

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -5642,18 +5642,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysqlIterator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DBmysqlIterator\\:\\:convertOldRequestArgsToCriteria\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysqlIterator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method DBmysqlIterator\\:\\:convertOldRequestArgsToCriteria\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysqlIterator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method DBmysqlIterator\\:\\:execute\\(\\) has parameter \\$criteria with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/install/migrations/update_10.0.x_to_11.0.0/changesatisfactions.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/changesatisfactions.php
@@ -152,7 +152,7 @@ foreach (['glpi_changesatisfactions', 'glpi_ticketsatisfactions'] as $table) {
         $migration->addPostQuery(
             $DB->buildUpdate($table, [
                 'satisfaction_scaled_to_5' => new QueryExpression($DB->quoteName('satisfaction')),
-            ], [1])
+            ], [new QueryExpression('true')])
         );
     }
 }

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -103,7 +103,7 @@ function update91xto920()
                 'completename' =>  new QueryExpression(DBmysql::quoteName("name")),
                 'is_recursive' => "1",
             ],
-            [true]
+            [new QueryExpression('true')]
         );
     }
 
@@ -653,7 +653,7 @@ function update91xto920()
             [
                 'completename' => new QueryExpression(DBmysql::quoteName("name")),
             ],
-            [true]
+            [new QueryExpression('true')]
         );
     }
 
@@ -1161,7 +1161,7 @@ function update91xto920()
         $DB->buildUpdate(
             "glpi_queuednotifications",
             ['mode' => Notification_NotificationTemplate::MODE_MAIL],
-            [true]
+            [new QueryExpression('true')]
         ),
         "9.2 set default mode in queue"
     );

--- a/install/migrations/update_9.5.x_to_10.0.0/entity.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/entity.php
@@ -104,7 +104,7 @@ foreach ($fkey_config_fields as $fkey_config_field) {
                         sprintf('GREATEST(%s, 0)', $DB->quoteName($fkey_config_field))
                     ),
                 ],
-                ['1'] // Update all entities
+                [new QueryExpression('true')] // Update all entities
             );
         }
     }

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1943,7 +1943,7 @@ class DBmysql
                 $excludes[] = 3778; // 'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
             }
             if (!$this->log_deprecation_warnings) {
-                // Mute deprecations related to elements that are heavilly used in old migrations and in plugins
+                // Mute deprecations related to elements that are heavily used in old migrations and in plugins
                 // as it may require a lot of work to fix them.
                 $excludes[] = 1681; // Integer display width is deprecated and will be removed in a future release.
             }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -112,10 +112,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$debug` parameter has been removed.
      */
-    public function execute($criteria): self
+    public function execute(array $criteria): self
     {
-        $criteria = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
-
         $this->buildQuery($criteria);
         $this->res = $this->conn ? $this->conn->doQuery($this->sql) : false;
         $this->count = $this->res instanceof mysqli_result ? $this->conn->numrows($this->res) : 0;
@@ -132,10 +130,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$log` parameter has been removed.
      */
-    public function buildQuery($criteria): void
+    public function buildQuery(array $criteria): void
     {
-        $criteria = $this->convertOldRequestArgsToCriteria(func_get_args(), __METHOD__);
-
         $this->sql = null;
         $this->res = false;
 
@@ -504,25 +500,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
      */
     public function analyseCrit($crit, $bool = "AND")
     {
-        if (is_string($crit)) {
-            Toolbox::deprecated(
-                sprintf(
-                    'Passing SQL request criteria as strings is deprecated for security reasons. Criteria was `` %s ``.',
-                    $crit
-                ),
-                version: '12.0'
-            );
-
-            /**
-             * Delegate the safeness check to the caller.
-             * There is no such usage in GLPI, it is the plugin developer responsibility to switch to safer criteria specs.
-             * @psalm-taint-escape sql
-             */
-            $safe_crit = $crit;
-
-            return $safe_crit;
-        }
-
         if (!is_array($crit)) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -543,15 +520,6 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     $ret .= $value->getValue();
                 } elseif ($value instanceof QuerySubQuery) {
                     $ret .= $value->getQuery();
-                } elseif (in_array($value, [1, 0, '1', '0', true, false], true)) {
-                    Toolbox::deprecated(
-                        sprintf(
-                            'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("%s");`.',
-                            $value ? 'true' : 'false'
-                        ),
-                        version: '12.0'
-                    );
-                    $ret .= $value ? 'true' : 'false';
                 } else {
                     // No Key case => recurse.
                     $ret .= "(" . $this->analyseCrit($value) . ")";
@@ -906,44 +874,5 @@ class DBmysqlIterator implements SeekableIterator, Countable
     public function fetchFields(): array
     {
         return $this->res->fetch_fields();
-    }
-
-    /**
-     * Convert arguments used for `DBmysql::request()`, `DBmysqlIterator::buildQuery()` and `DBmysqlIterator::execute()` methods
-     * from old signature to new signature.
-     * For security reasons, an exception is thrown whenever the arguments contains a direct raw query.
-     *
-     * @param array $args
-     * @return array
-     */
-    private function convertOldRequestArgsToCriteria(array $args, string $method): array
-    {
-        if (is_string($args[0]) && str_contains($args[0], " ")) {
-            $names = preg_split('/\s+AS\s+/i', $args[0]);
-            if (isset($names[1]) && strpos($names[1], ' ') || !isset($names[1]) || strpos($names[0], ' ')) {
-                throw new InvalidArgumentException(
-                    sprintf('Building and executing raw queries with the `%s()` method is prohibited.', $method)
-                );
-            }
-        }
-
-        if (is_array($args[0])) {
-            // The new signature ($criteria, $debug = false) is already used
-            $criteria = $args[0];
-        } else {
-            // The old signature ($tableorsql, $crit = "", $debug = false) is still used
-            Toolbox::deprecated(
-                sprintf('The `%s()` method signature changed. Its previous signature is deprecated.', $method)
-            );
-            $criteria = $args[1] ?? [];
-            if (is_string($criteria)) {
-                $criteria = $criteria !== ''
-                    ? ['WHERE' => [new QueryExpression($criteria)]]
-                    : [];
-            }
-            $criteria['FROM'] = $args[0];
-        }
-
-        return $criteria;
     }
 }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -112,13 +112,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$debug` parameter has been removed.
      */
-    public function execute($criteria): self
+    public function execute(array $criteria): self
     {
-        if (!is_array($criteria)) {
-            throw new RuntimeException(
-                'Criteria must be an array, ' . get_debug_type($criteria) . ' given.'
-            );
-        }
         $this->buildQuery($criteria);
         $this->res = $this->conn ? $this->conn->doQuery($this->sql) : false;
         $this->count = $this->res instanceof mysqli_result ? $this->conn->numrows($this->res) : 0;
@@ -135,14 +130,8 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$log` parameter has been removed.
      */
-    public function buildQuery($criteria): void
+    public function buildQuery(array $criteria): void
     {
-        if (!is_array($criteria)) {
-            throw new RuntimeException(
-                'Criteria must be an array, ' . get_debug_type($criteria) . ' given.'
-            );
-        }
-
         $this->sql = null;
         $this->res = false;
 
@@ -504,23 +493,13 @@ class DBmysqlIterator implements SeekableIterator, Countable
     /**
      * Generate the SQL statement for a array of criteria
      *
-     * @param array|string $crit Criteria
+     * @param array $crit Criteria
      * @param string   $bool Boolean operator (default AND)
      *
      * @return string
      */
-    public function analyseCrit($crit, $bool = "AND")
+    public function analyseCrit(array $crit, $bool = "AND")
     {
-        if (!is_array($crit)) {
-            var_dump(debug_backtrace(2));
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Invalid criteria type. Expected `array`, `%s` received.',
-                    get_debug_type($crit)
-                )
-            );
-        }
-
         $ret = "";
         foreach ($crit as $name => $value) {
             if (!empty($ret)) {

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -112,8 +112,13 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$debug` parameter has been removed.
      */
-    public function execute(array $criteria): self
+    public function execute($criteria): self
     {
+        if (!is_array($criteria)) {
+            throw new RuntimeException(
+                'Criteria must be an array, ' . get_debug_type($criteria) . ' given.'
+            );
+        }
         $this->buildQuery($criteria);
         $this->res = $this->conn ? $this->conn->doQuery($this->sql) : false;
         $this->count = $this->res instanceof mysqli_result ? $this->conn->numrows($this->res) : 0;
@@ -130,8 +135,14 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @since 11.0.0 The `$log` parameter has been removed.
      */
-    public function buildQuery(array $criteria): void
+    public function buildQuery($criteria): void
     {
+        if (!is_array($criteria)) {
+            throw new RuntimeException(
+                'Criteria must be an array, ' . get_debug_type($criteria) . ' given.'
+            );
+        }
+
         $this->sql = null;
         $this->res = false;
 
@@ -501,6 +512,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
     public function analyseCrit($crit, $bool = "AND")
     {
         if (!is_array($crit)) {
+            var_dump(debug_backtrace(2));
             throw new InvalidArgumentException(
                 sprintf(
                     'Invalid criteria type. Expected `array`, `%s` received.',

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -726,13 +726,6 @@ class DBmysqlIteratorTest extends DbTestCase
 
     public function testWhere()
     {
-        $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => 'id=1']);
-        $this->assertSame('SELECT * FROM `foo` WHERE id=1', $it->getSql());
-        $this->hasPhpLogRecordThatContains(
-            'Passing SQL request criteria as strings is deprecated for security reasons.',
-            LogLevel::INFO
-        );
-
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => null]]);
         $this->assertSame('SELECT * FROM `foo` WHERE `bar` IS NULL', $it->getSql());
 
@@ -765,24 +758,6 @@ class DBmysqlIteratorTest extends DbTestCase
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['bar' => new QueryParam()]]);
         $this->assertSame('SELECT * FROM `foo` WHERE `bar` = ?', $it->getSql());
-
-        foreach ([false, 0, '0'] as $false) {
-            $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => [$false]]);
-            $this->assertSame('SELECT * FROM `foo` WHERE false', $it->getSql());
-            $this->hasPhpLogRecordThatContains(
-                'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("false");`',
-                LogLevel::INFO
-            );
-        }
-
-        foreach ([true, 1, '1'] as $true) {
-            $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => [$true]]);
-            $this->assertSame('SELECT * FROM `foo` WHERE true', $it->getSql());
-            $this->hasPhpLogRecordThatContains(
-                'Passing SQL request criteria as booleans is deprecated. Please use `new \Glpi\DBAL\QueryExpression("true");`',
-                LogLevel::INFO
-            );
-        }
 
         $stringable_object = new class ("L'Appel de Cthulhu") {
             public function __construct(private string $val) {}
@@ -1807,142 +1782,5 @@ class DBmysqlIteratorTest extends DbTestCase
                 'ON' => new QueryExpression("glpi_tickets.id=(CASE WHEN glpi_tickets_tickets.tickets_id_1=103 THEN glpi_tickets_tickets.tickets_id_2 ELSE glpi_tickets_tickets.tickets_id_1 END)"),
             ])
         );
-    }
-
-    public static function requestArgsProvider(): iterable
-    {
-        // Table name as first param, default value for criteria argument
-        yield [
-            'params'   => ['glpi_computers', ''],
-            'expected' => [
-                'FROM' => 'glpi_computers',
-            ],
-            'sql'      => 'SELECT * FROM `glpi_computers`',
-        ];
-
-        // Table name as first param, criteria as a string
-        yield [
-            'params'   => ['glpi_computers', 'is_deleted = 0'],
-            'expected' => [
-                'FROM'  => 'glpi_computers',
-                'WHERE' => [new QueryExpression('is_deleted = 0')],
-            ],
-            'sql'      => 'SELECT * FROM `glpi_computers` WHERE is_deleted = 0',
-        ];
-
-        // Table name as first param, criteria as an array
-        yield [
-            'params'   => ['glpi_computers', ['WHERE' => ['is_deleted' => 0], 'ORDER' => 'id DESC']],
-            'expected' => [
-                'FROM'  => 'glpi_computers',
-                'WHERE' => ['is_deleted' => 0],
-                'ORDER' => 'id DESC',
-            ],
-            'sql'      => 'SELECT * FROM `glpi_computers` WHERE `is_deleted` = \'0\' ORDER BY `id` DESC',
-        ];
-
-        // Table name as first param, criteria as an array but not encapsulated inside a `WHERE` key
-        yield [
-            'params'   => ['glpi_computers', ['is_deleted' => 1]],
-            'expected' => [
-                'FROM'  => 'glpi_computers',
-                'is_deleted' => 1,
-            ],
-            'sql'      => 'SELECT * FROM `glpi_computers` WHERE `is_deleted` = \'1\'',
-        ];
-
-        // First argument is a QueryUnion
-        $union = new QueryUnion(
-            [
-                ['SELECT' => 'serial', 'FROM' => 'glpi_computers'],
-                ['SELECT' => 'serial', 'FROM' => 'glpi_printers'],
-            ],
-            false,
-            'testalias'
-        );
-        yield [
-            'params'   => [$union, ''],
-            'expected' => [
-                'FROM'  => $union,
-            ],
-            'sql'      => 'SELECT * FROM ((SELECT `serial` FROM `glpi_computers`) UNION ALL (SELECT `serial` FROM `glpi_printers`)) AS `testalias`',
-        ];
-    }
-
-    #[DataProvider('requestArgsProvider')]
-    public function testConvertOldRequestArgsToCriteria(array $params, array $expected, string $sql): void
-    {
-        $db = $this->getMockBuilder('DBMysql')
-            ->disableOriginalConstructor()
-             ->getMock();
-        $iterator = new \DBmysqlIterator($db);
-
-        $reporting_level = \error_reporting(E_ALL); // be sure to report deprecations
-        $result = $this->callPrivateMethod($iterator, 'convertOldRequestArgsToCriteria', $params, 'test');
-        \error_reporting($reporting_level); // restore previous level
-
-        $this->hasPhpLogRecordThatContains(
-            'The `test()` method signature changed. Its previous signature is deprecated.',
-            LogLevel::INFO
-        );
-        $this->assertEquals($expected, $result);
-    }
-
-    #[DataProvider('requestArgsProvider')]
-    public function testExecuteWithOldSignature(array $params, array $expected, string $sql): void
-    {
-        $iterator = new \DBmysqlIterator(null);
-
-        $reporting_level = \error_reporting(E_ALL); // be sure to report deprecations
-        $iterator->execute(...$params);
-        \error_reporting($reporting_level); // restore previous level
-
-        $this->hasPhpLogRecordThatContains(
-            'The `DBmysqlIterator::execute()` method signature changed. Its previous signature is deprecated.',
-            LogLevel::INFO
-        );
-        $this->assertEquals($sql, $iterator->getSql());
-    }
-
-    public function testExecuteWithRawDirectQuery(): void
-    {
-        $db = $this->getMockBuilder('DBMysql')
-            ->disableOriginalConstructor()
-             ->getMock();
-
-        $iterator = new \DBmysqlIterator($db);
-        $this->expectExceptionMessage('Building and executing raw queries with the `DBmysqlIterator::execute()` method is prohibited.');
-        $iterator->execute('SELECT * FROM `glpi_computers`');
-    }
-
-    #[DataProvider('requestArgsProvider')]
-    public function testBuildQueryWithOldSignature(array $params, array $expected, string $sql): void
-    {
-        $db = $this->getMockBuilder('DBMysql')
-            ->disableOriginalConstructor()
-             ->getMock();
-
-        $iterator = new \DBmysqlIterator($db);
-
-        $reporting_level = \error_reporting(E_ALL); // be sure to report deprecations
-        $iterator->buildQuery(...$params);
-        \error_reporting($reporting_level); // restore previous level
-
-        $this->hasPhpLogRecordThatContains(
-            'The `DBmysqlIterator::buildQuery()` method signature changed. Its previous signature is deprecated.',
-            LogLevel::INFO
-        );
-        $this->assertEquals($sql, $iterator->getSql());
-    }
-
-    public function testBuildQueryWithRawDirectQuery(): void
-    {
-        $db = $this->getMockBuilder('DBMysql')
-            ->disableOriginalConstructor()
-             ->getMock();
-
-        $iterator = new \DBmysqlIterator($db);
-        $this->expectExceptionMessage('Building and executing raw queries with the `DBmysqlIterator::buildQuery()` method is prohibited.');
-        $iterator->buildQuery('SELECT * FROM `glpi_computers`');
     }
 }

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -40,7 +40,6 @@ use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Psr\Log\LogLevel;
 
 class DBmysqlIteratorTest extends DbTestCase
 {

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -854,18 +854,6 @@ class DbUtilsTest extends DbTestCase
             $it->getSql()
         );
 
-        // Entity value is empty array
-        $it->execute('glpi_entities', $instance->getEntitiesRestrictCriteria('glpi_entities', '', [], true));
-        $this->hasPhpLogRecordThatContains(
-            'User Deprecated: The `DBmysqlIterator::execute()` method signature changed. Its previous signature is deprecated.',
-            LogLevel::INFO
-        );
-        $this->assertSame(0, $it->count());
-        $this->assertSame(
-            'SELECT * FROM `glpi_entities` WHERE false',
-            $it->getSql()
-        );
-
         //keep testing old method from db.function
         $this->assertSame(
             "WHERE ( `entities_id` IN ('$child2')  OR (`is_recursive`='1' AND `entities_id` IN (0, $root)) ) ",
@@ -886,18 +874,6 @@ class DbUtilsTest extends DbTestCase
         $it->execute(['FROM' => 'glpi_entities', 'WHERE' => getEntitiesRestrictCriteria('glpi_entities', '', 9, true)]);
         $this->assertSame(
             'SELECT * FROM `glpi_entities` WHERE (`glpi_entities`.`id` = \'9\')',
-            $it->getSql()
-        );
-
-        // Entity value is empty array
-        $it->execute('glpi_entities', getEntitiesRestrictCriteria('glpi_entities', '', [], true));
-        $this->hasPhpLogRecordThatContains(
-            'User Deprecated: The `DBmysqlIterator::execute()` method signature changed. Its previous signature is deprecated.',
-            LogLevel::INFO
-        );
-        $this->assertSame(0, $it->count());
-        $this->assertSame(
-            'SELECT * FROM `glpi_entities` WHERE (false)',
             $it->getSql()
         );
     }

--- a/tools/cachebench.php
+++ b/tools/cachebench.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QueryExpression;
 use Glpi\Kernel\Kernel;
 
 if (PHP_SAPI != 'cli') {
@@ -97,7 +98,7 @@ echo "+ Clear sons cache\n";
 $DB->update(
     'glpi_entities',
     ['sons_cache' => null],
-    [true]
+    [new QueryExpression('true')]
 );
 
 $tps = microtime(true);


### PR DESCRIPTION
This code was already deprecated in v11.

I've fixed remaining cases; not sure exactly why those did not throw deprecated messages in tests (maybe because it's on update tests?).