### PR TITLE
Fix(GLPITestCase): don't forget to delete yourself

### DIFF
--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -195,7 +195,7 @@ class GLPITestCase extends TestCase
         $dir = GLPI_PICTURE_DIR;
 
         // Delete nested folders and files in dir
-        $this->removeDirectory($dir);
+        $this->removeDirectory($dir, true);
         // We recreate the directory to ensure it's empty and present, as test rely on it being present.
         mkdir($dir);
     }

--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -195,9 +195,11 @@ class GLPITestCase extends TestCase
         $dir = GLPI_PICTURE_DIR;
 
         // Delete nested folders and files in dir
-        $this->removeDirectory($dir, true);
-        // We recreate the directory to ensure it's empty and present, as test rely on it being present.
-        mkdir($dir);
+        $this->removeDirectory($dir);
+        // We recreate the directory (if needed) to ensure it's empty and present, as test rely on it being present.
+        if (!is_dir($dir)) {
+            mkdir($dir);
+        }
     }
 
     protected function removeDirectory(string $dir, bool $delete_self = false): void


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Plugins that use the `DBTestCase` class (which extends `GLPITestCase`) encounter an error during the `setUp()` phase:

```shell
├ Exception: mkdir(): File exists
│
│ /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/plugins/glpiinventory/tests/autoload.php:146
│ /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/tests/src/GLPITestCase.php:200
│ /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/tests/src/GLPITestCase.php:109
│ /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/tests/src/DbTestCase.php:72
│ /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/plugins/glpiinventory/vendor/phpunit/phpunit/src/TextUI/Application.php:211
```

During test initialization, GLPI attempts to delete and then recreate the `pictures` directory (as defined by the `GLPI_PICTURE_DIR` constant).

However, the `removeDirectory()` function does not delete the root directory itself. As a result, when the subsequent instruction `mkdir($dir);` is executed, the directory already exists, which triggers the following exception:

```
Exception: mkdir(): File exists
```

This behavior causes test execution to fail during the `setUp()` process.

https://github.com/glpi-project/glpi-inventory-plugin/actions/runs/22101083331/job/63878002604


## Screenshots (if appropriate):


