### PR TITLE
fix getType call in document_item template

### DIFF
--- a/templates/pages/management/document_item.html.twig
+++ b/templates/pages/management/document_item.html.twig
@@ -62,7 +62,7 @@
                         {{ inputs.hidden('is_recursive', item.isRecursive() ? '1' : '0') }}
                         {{ inputs.hidden('itemtype', item.getType()) }}
                         {{ inputs.hidden('items_id', item.getID()) }}
-                        {% if item.getType == 'Ticket' %}
+                        {% if item.getType() == 'Ticket' %}
                             {{ inputs.hidden('tickets_id', item.getID()) }}
                         {% endif %}
                         {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Twig should be fairly lenient with how it's dot operator works and I cannot recreate this issue anywhere in GLPI itself, but I guess the releases plugin has a document_item list view while core CommonITILObjects do not and CommonITILObject has an `__isset` method that throws an exception for missing properties instead of simply returning false.

https://twig.symfony.com/doc/3.x/templates.html#dot_operator