### PR TITLE
truncate name ticket

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1274,7 +1274,7 @@ class MailCollector extends CommonDBTM
     public function cleanSubject($text)
     {
         $text = str_replace("=20", "\n", $text);
-        return $text;
+        return mb_substr($text, 0, 255, 'UTF-8');
     }
 
 

--- a/tests/emails-tests/52-long-subject.eml
+++ b/tests/emails-tests/52-long-subject.eml
@@ -1,0 +1,30 @@
+Return-Path: normal@glpi-project.org
+Received: from 192.168.1.3 (LHLO mail.glpi-project.org) (192.168.1.3)
+ by mail.glpi-project.org with LMTP; Thu, 11 Jul 2019 14:36:19 +0200
+ (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id E93F77E80CDC
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id DDBE07E80832
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from mail.glpi-project.org ([127.0.0.1])
+	by localhost (mail.glpi-project.org [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id 5TmiDey5TKGa for <unittest@glpi-project.org>;
+	Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id CAB177E806B4
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Date: Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <799153164.8345898.1562848579774.JavaMail.zimbra@glpi-project.org>
+Subject: This email subject is designed to test how inboxes handle very long text. It contains exactly three hundred characters to check whether everything displays correctly, whether the text is truncated, or if the mail client handles maximum length properly 12345678901234567890
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.0.9_GA_6191 (ZimbraWebClient - FF67 (Linux)/8.0.9_GA_6191)
+Thread-Topic: Test'ed issue
+Thread-Index: eef846xn0XKdiVTHN4sDmnVcwOWRRA==
+
+This is jsut a subject test.

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -101,6 +101,9 @@ class MailCollectorTest extends DbTestCase
             ], [ //dunno why...
                 'raw'       => 'Subject with =20 character',
                 'expected'  => "Subject with \n character",
+            ], [
+                'raw'       => str_repeat('A', 300),
+                'expected'  => str_repeat('A', 255),
             ],
         ];
     }
@@ -980,7 +983,7 @@ PLAINTEXT,
       <p class=MsoNormal>
         <span style='font-family:Roboto'></span>
       </p>
-      
+
     </div>
 HTML,
             '39 - Link in content' => <<<PLAINTEXT

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -835,6 +835,8 @@ class MailCollectorTest extends DbTestCase
         $this->assertSame($not_imported_specs, $not_imported_values);
 
         // Check created tickets and their actors
+        $long_subject = 'This email subject is designed to test how inboxes handle very long text. It contains exactly three hundred characters to check whether everything displays correctly, whether the text is truncated, or if the mail client handles maximum length properly 12345678901234567890';
+        $long_subject_expected = substr($long_subject, 0, 255);
         $actors_specs = [
             // Mails having "tech" user as requester
             [
@@ -892,6 +894,7 @@ class MailCollectorTest extends DbTestCase
                     '44 - Hebrew encoding issue',
                     '47 - Missing charset parameter',
                     '49 - Message with invalid CC email address',
+                    $long_subject_expected,
                 ],
             ],
             // Mails having "normal" user as observer

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -983,7 +983,7 @@ PLAINTEXT,
       <p class=MsoNormal>
         <span style='font-family:Roboto'></span>
       </p>
-
+      
     </div>
 HTML,
             '39 - Link in content' => <<<PLAINTEXT


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42252

Fix regression : ticket name longer than 255 characters were no longer truncated before DB insert, causing a MySQL “Data too long for column 'name'” exception.
Reintroduce truncation to 255 characters before persistence.
