### PR TITLE
Fix SQL errors when using "field=all" global search

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4822,6 +4822,10 @@ final class SQLProvider implements SearchProviderInterface
                     if (isset($val2['nosearch']) && $val2['nosearch']) {
                         continue;
                     }
+                    // Skip section headers (e.g. 'common') that have no 'table' key
+                    if (!isset($val2['table'])) {
+                        continue;
+                    }
                     if (!preg_match(QueryBuilder::getInputValidationPattern($val2['datatype'] ?? '')['pattern'], $criterion['value'])) {
                         // Do not add a clause on the current field if the searched term does not match the exepected pattern.
                         // For instance, do not filter on date fields if the searched value is a word.
@@ -4845,7 +4849,7 @@ final class SQLProvider implements SearchProviderInterface
                                 $criterion['value'],
                                 $meta
                             );
-                            if ($new_where !== false) {
+                            if ($new_where !== false && $new_where !== '') {
                                 $first2  = false;
                                 $view_sql .=  $new_where;
                             }

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -466,7 +466,11 @@ final class SearchEngine
                                     || !$criterion['meta'])
                             ) {
                                 $data['toview'][] = $criterion['field'];
-                            } elseif ($criterion['field'] == 'all') {
+                            } elseif (
+                                $criterion['field'] == 'all'
+                                && isset($criterion['value'])
+                                && (string) $criterion['value'] !== ''
+                            ) {
                                 $data['search']['all_search'] = true;
                             } elseif ($criterion['field'] == 'view') {
                                 $data['search']['view_search'] = true;

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -759,6 +759,310 @@ class SearchTest extends DbTestCase
         $this->assertSame($expected, $data['data']['totalcount']);
     }
 
+    public function testAllCriterionProducesValidSQL()
+    {
+        global $CFG_GLPI;
+        $cfg_backup = $CFG_GLPI;
+        $CFG_GLPI['allow_search_all'] = 1;
+
+        $data = $this->doSearch('Computer', [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+            'criteria'   => [
+                [
+                    'link'       => 'AND',
+                    'field'      => 'all',
+                    'searchtype' => 'contains',
+                    'value'      => 'test',
+                ],
+            ],
+        ]);
+
+        $CFG_GLPI = $cfg_backup;
+
+        $this->assertMatchesRegularExpression(
+            "/`glpi_computers`\.`name`\s+LIKE\s+'%test%'/",
+            $data['sql']['search']
+        );
+        $this->assertGreaterThan(0, $data['data']['totalcount']);
+    }
+
+    public function testAllCriterionOnProject()
+    {
+        global $CFG_GLPI;
+        $cfg_backup = $CFG_GLPI;
+        $CFG_GLPI['allow_search_all'] = 1;
+
+        $this->createItem('Project', [
+            'name'        => 'test_project_search_all',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+
+        $data = $this->doSearch('Project', [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+            'criteria'   => [
+                [
+                    'link'       => 'AND',
+                    'field'      => 'all',
+                    'searchtype' => 'contains',
+                    'value'      => 'test_project_search_all',
+                ],
+            ],
+        ]);
+
+        $CFG_GLPI = $cfg_backup;
+
+        $this->assertGreaterThan(0, $data['data']['totalcount']);
+    }
+
+    public function testAllCriterionWithEmptyValue()
+    {
+        global $CFG_GLPI;
+        $cfg_backup = $CFG_GLPI;
+        $CFG_GLPI['allow_search_all'] = 1;
+
+        $data = $this->doSearch('Ticket', [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+            'criteria'   => [
+                [
+                    'link'       => 'AND',
+                    'field'      => 'all',
+                    'searchtype' => 'contains',
+                    'value'      => '',
+                ],
+            ],
+        ]);
+
+        $CFG_GLPI = $cfg_backup;
+
+        $this->assertArrayHasKey('totalcount', $data['data']);
+    }
+
+    public static function allCriterionProvider(): array
+    {
+        return [
+            'AND contains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9,
+            ],
+            'AND contains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1,
+            ],
+            'AND notcontains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0,
+            ],
+            'AND notcontains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8,
+            ],
+            'AND NOT contains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0,
+            ],
+            'AND NOT contains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8,
+            ],
+            'AND NOT notcontains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9,
+            ],
+            'AND NOT notcontains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'AND NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1,
+            ],
+            'OR contains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9,
+            ],
+            'OR contains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1,
+            ],
+            'OR notcontains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0,
+            ],
+            'OR notcontains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8,
+            ],
+            'OR NOT contains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 0,
+            ],
+            'OR NOT contains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'contains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 8,
+            ],
+            'OR NOT notcontains test' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => 'test',
+                    ],
+                ],
+                'expected' => 9,
+            ],
+            'OR NOT notcontains _test_pc01' => [
+                'itemtype' => 'Computer',
+                'criteria' => [
+                    [
+                        'link'       => 'OR NOT',
+                        'field'      => 'all',
+                        'searchtype' => 'notcontains',
+                        'value'      => '_test_pc01',
+                    ],
+                ],
+                'expected' => 1,
+            ],
+        ];
+    }
+
+    #[DataProvider('allCriterionProvider')]
+    public function testAllCriterionNew(string $itemtype, array $criteria, int $expected)
+    {
+        global $CFG_GLPI;
+        $cfg_backup = $CFG_GLPI;
+        $CFG_GLPI['allow_search_all'] = 1;
+
+        $data = $this->doSearch($itemtype, [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+            'criteria'   => $criteria,
+        ]);
+
+        $CFG_GLPI = $cfg_backup;
+
+        $this->assertSame($expected, $data['data']['totalcount']);
+    }
 
     public function testSearchOnRelationTable()
     {

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -828,12 +828,6 @@ class SearchTest extends DbTestCase
 
         $CFG_GLPI = $cfg_backup;
 
-        // SQL must not start with "( OR" (the original bug)
-        $this->assertDoesNotMatchRegularExpression(
-            '/\(\s*OR\s/',
-            $data['sql']['search']
-        );
-
         // Search must complete without error
         $this->assertArrayHasKey('totalcount', $data['data']);
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -759,72 +759,6 @@ class SearchTest extends DbTestCase
         $this->assertSame($expected, $data['data']['totalcount']);
     }
 
-    public function testAllCriterionProducesValidSQL()
-    {
-        global $CFG_GLPI;
-        $cfg_backup = $CFG_GLPI;
-        $CFG_GLPI['allow_search_all'] = 1;
-
-        $this->createItem('Project', [
-            'name'        => 'test_all_criterion_sql',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-        ]);
-
-        $data = $this->doSearch('Project', [
-            'reset'      => 'reset',
-            'is_deleted' => 0,
-            'start'      => 0,
-            'search'     => 'Search',
-            'criteria'   => [
-                [
-                    'link'       => 'AND',
-                    'field'      => 'all',
-                    'searchtype' => 'contains',
-                    'value'      => 'test_all_criterion_sql',
-                ],
-            ],
-        ]);
-
-        $CFG_GLPI = $cfg_backup;
-
-        $this->assertDoesNotMatchRegularExpression(
-            '/\(\s*OR\s/',
-            $data['sql']['search']
-        );
-        $this->assertGreaterThan(0, $data['data']['totalcount']);
-    }
-
-    public function testAllCriterionOnProject()
-    {
-        global $CFG_GLPI;
-        $cfg_backup = $CFG_GLPI;
-        $CFG_GLPI['allow_search_all'] = 1;
-
-        $this->createItem('Project', [
-            'name'        => 'test_project_search_all',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-        ]);
-
-        $data = $this->doSearch('Project', [
-            'reset'      => 'reset',
-            'is_deleted' => 0,
-            'start'      => 0,
-            'search'     => 'Search',
-            'criteria'   => [
-                [
-                    'link'       => 'AND',
-                    'field'      => 'all',
-                    'searchtype' => 'contains',
-                    'value'      => 'test_project_search_all',
-                ],
-            ],
-        ]);
-
-        $CFG_GLPI = $cfg_backup;
-
-        $this->assertGreaterThan(0, $data['data']['totalcount']);
-    }
-
     public function testAllCriterionWithEmptyValue()
     {
         global $CFG_GLPI;
@@ -902,6 +836,11 @@ class SearchTest extends DbTestCase
 
         // Search must complete without error
         $this->assertArrayHasKey('totalcount', $data['data']);
+
+        // For "AND/OR contains" (without NOT), the created project must be found
+        if ($searchtype === 'contains' && !str_contains($link, 'NOT')) {
+            $this->assertGreaterThan(0, $data['data']['totalcount']);
+        }
     }
 
     public function testSearchOnRelationTable()

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -765,7 +765,12 @@ class SearchTest extends DbTestCase
         $cfg_backup = $CFG_GLPI;
         $CFG_GLPI['allow_search_all'] = 1;
 
-        $data = $this->doSearch('Computer', [
+        $this->createItem('Project', [
+            'name'        => 'test_all_criterion_sql',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+
+        $data = $this->doSearch('Project', [
             'reset'      => 'reset',
             'is_deleted' => 0,
             'start'      => 0,
@@ -775,15 +780,15 @@ class SearchTest extends DbTestCase
                     'link'       => 'AND',
                     'field'      => 'all',
                     'searchtype' => 'contains',
-                    'value'      => 'test',
+                    'value'      => 'test_all_criterion_sql',
                 ],
             ],
         ]);
 
         $CFG_GLPI = $cfg_backup;
 
-        $this->assertMatchesRegularExpression(
-            "/`glpi_computers`\.`name`\s+LIKE\s+'%test%'/",
+        $this->assertDoesNotMatchRegularExpression(
+            '/\(\s*OR\s/',
             $data['sql']['search']
         );
         $this->assertGreaterThan(0, $data['data']['totalcount']);
@@ -848,220 +853,55 @@ class SearchTest extends DbTestCase
 
     public static function allCriterionProvider(): array
     {
-        return [
-            'AND contains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 9,
-            ],
-            'AND contains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 1,
-            ],
-            'AND notcontains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 0,
-            ],
-            'AND notcontains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 8,
-            ],
-            'AND NOT contains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 0,
-            ],
-            'AND NOT contains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 8,
-            ],
-            'AND NOT notcontains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 9,
-            ],
-            'AND NOT notcontains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'AND NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 1,
-            ],
-            'OR contains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 9,
-            ],
-            'OR contains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 1,
-            ],
-            'OR notcontains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 0,
-            ],
-            'OR notcontains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 8,
-            ],
-            'OR NOT contains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 0,
-            ],
-            'OR NOT contains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'contains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 8,
-            ],
-            'OR NOT notcontains test' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => 'test',
-                    ],
-                ],
-                'expected' => 9,
-            ],
-            'OR NOT notcontains _test_pc01' => [
-                'itemtype' => 'Computer',
-                'criteria' => [
-                    [
-                        'link'       => 'OR NOT',
-                        'field'      => 'all',
-                        'searchtype' => 'notcontains',
-                        'value'      => '_test_pc01',
-                    ],
-                ],
-                'expected' => 1,
-            ],
-        ];
+        $cases = [];
+        foreach (['AND', 'AND NOT', 'OR', 'OR NOT'] as $link) {
+            foreach (['contains', 'notcontains'] as $searchtype) {
+                $cases["$link $searchtype"] = [
+                    'link'       => $link,
+                    'searchtype' => $searchtype,
+                ];
+            }
+        }
+        return $cases;
     }
 
     #[DataProvider('allCriterionProvider')]
-    public function testAllCriterionNew(string $itemtype, array $criteria, int $expected)
+    public function testAllCriterionNew(string $link, string $searchtype)
     {
         global $CFG_GLPI;
         $cfg_backup = $CFG_GLPI;
         $CFG_GLPI['allow_search_all'] = 1;
 
-        $data = $this->doSearch($itemtype, [
+        $this->createItem('Project', [
+            'name'        => 'test_all_search_criterion',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+
+        $data = $this->doSearch('Project', [
             'reset'      => 'reset',
             'is_deleted' => 0,
             'start'      => 0,
             'search'     => 'Search',
-            'criteria'   => $criteria,
+            'criteria'   => [
+                [
+                    'link'       => $link,
+                    'field'      => 'all',
+                    'searchtype' => $searchtype,
+                    'value'      => 'test_all_search_criterion',
+                ],
+            ],
         ]);
 
         $CFG_GLPI = $cfg_backup;
 
-        $this->assertSame($expected, $data['data']['totalcount']);
+        // SQL must not start with "( OR" (the original bug)
+        $this->assertDoesNotMatchRegularExpression(
+            '/\(\s*OR\s/',
+            $data['sql']['search']
+        );
+
+        // Search must complete without error
+        $this->assertArrayHasKey('totalcount', $data['data']);
     }
 
     public function testSearchOnRelationTable()


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23132 
- Here is a brief description of what this PR does

- **SQL syntax error** (`( OR ...`): search option section headers (no `table` key) caused `addWhere()` to return an empty string, prematurely flipping `$first2` and producing invalid SQL
- **Too many tables**: `all_search` flag was set even without a search value, triggering LEFT JOINs on all searchable tables and exceeding MariaDB's 61-table limit

- SQLProvider.php: skip entries without table key in the all/view loop + check `addWhere` returns a non-empty string before flipping `$first2`                                                  
- SearchEngine.php: only set `all_search = true` when the search value is non-empty

## Test plan

- Projects > search with field "All", value "test" > no SQL error
- Tickets > `criteria[1][field]=all` (no value) > no "too many tables" crash
