### PR TITLE
Fix id and password autocompleted in phone2 and api_token fields

### DIFF
--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -257,7 +257,11 @@
                             {{ fields.textField('phone', item.fields['phone'], 'Phone'|itemtype_name(1)) }}
                             {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone')) }}
                             {% if not simple_form %}
-                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2')) }}
+                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2'), {
+                                    additional_attributes: {
+                                        autocomplete: 'off',
+                                    },
+                                }) }}
                             {% endif %}
 
                             {% if not item.isNewItem() and ((caneditpassword ?? false) or is_preference_form) %}
@@ -268,7 +272,7 @@
                                     clearable: false,
                                     is_copyable: true,
                                     additional_attributes: {
-                                        autocomplete: 'off',
+                                        autocomplete: 'new-password',
                                     },
                                 }) }}
                                 {% if not external_auth %}

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -257,11 +257,7 @@
                             {{ fields.textField('phone', item.fields['phone'], 'Phone'|itemtype_name(1)) }}
                             {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone')) }}
                             {% if not simple_form %}
-                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2'), {
-                                    additional_attributes: {
-                                        autocomplete: 'off',
-                                    },
-                                }) }}
+                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2')) }}
                             {% endif %}
 
                             {% if not item.isNewItem() and ((caneditpassword ?? false) or is_preference_form) %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42268
- Here is a brief description of what this PR does
When our username and password fields are saved in our browser, as soon as we go to a user's page, these values are pre-filled in the phone 2 and api_token fields.
## Screenshots (if appropriate):
<img width="1143" height="203" alt="image" src="https://github.com/user-attachments/assets/3f73b041-f053-4f87-8a66-cec8dc69ab18" />


