### PR TITLE
Fix flaky test using hardcoded rule ID

### DIFF
--- a/tests/functional/RuleDictionnarySoftwareCollectionTest.php
+++ b/tests/functional/RuleDictionnarySoftwareCollectionTest.php
@@ -125,8 +125,8 @@ class RuleDictionnarySoftwareCollectionTest extends DbTestCase
             )
         );
 
-        $this->assertFalse($collection->moveLicenses('100', $new_software->getID()));
-        $this->assertFalse($collection->moveLicenses($old_software->getID(), '100'));
+        $this->assertFalse($collection->moveLicenses(99999999, $new_software->getID()));
+        $this->assertFalse($collection->moveLicenses($old_software->getID(), 99999999));
     }
 
     public function testPutOldSoftsInTrash()


### PR DESCRIPTION
This test expect no rules with the id `100` to exist, which is a bit dangerous as rules created just before might end up with this ID.
I've bumped the value to be safe.

It should prevent failures like this: https://github.com/glpi-project/glpi/actions/runs/22146329517/job/64024791493
