### PR TITLE
Fix(ITILValidation): global state

### DIFF
--- a/src/ITIL_ValidationStep.php
+++ b/src/ITIL_ValidationStep.php
@@ -151,7 +151,8 @@ abstract class ITIL_ValidationStep extends CommonDBChild
             return CommonITILValidation::ACCEPTED;
         }
         // required validation threshold can be reached
-        if ($achievements[CommonITILValidation::ACCEPTED] + $achievements[CommonITILValidation::WAITING] >= $required_percent) {
+        $sum = round($achievements[CommonITILValidation::ACCEPTED] + $achievements[CommonITILValidation::WAITING]);
+        if ($sum >= $required_percent) {
             return CommonITILValidation::WAITING;
         }
 

--- a/tests/functional/ValidationStepTest.php
+++ b/tests/functional/ValidationStepTest.php
@@ -303,7 +303,7 @@ class ValidationStepTest extends DbTestCase
          * 2 : expected ValidationStep status
          */
         return [
-            // ---- Refused validation step
+            // --- Refused validation step ---
             // 1 validation
             [100, [CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             // 2 validations
@@ -313,14 +313,17 @@ class ValidationStepTest extends DbTestCase
             [50, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             [80, [CommonITILValidation::REFUSED, CommonITILValidation::WAITING], CommonITILValidation::REFUSED],
             [80, [CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
-            // 3 validations - 100 %
+            // 3 validations
             [100, [CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
             [100, [CommonITILValidation::REFUSED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::REFUSED],
-            // 3 validations - x/3 limit
             [67, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
             [34, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
+            // 5 validations
+            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
+            [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
 
-            // --- Accepted validation step
+            // --- Accepted validation step ---
+            // 1 validation
             [100, [CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
             // 2 validations
             [100, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
@@ -333,28 +336,30 @@ class ValidationStepTest extends DbTestCase
             [66, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING], CommonITILValidation::ACCEPTED],
             [33, [CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
             [20, [CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::ACCEPTED],
+            // 5 validations
+            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
 
-            // --- Waiting validation step
+            // --- Waiting validation step ---
+            // 1 validation
             [100, [CommonITILValidation::WAITING], CommonITILValidation::WAITING],
-
+            // 2 validations
             [100, [CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [100, [CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED], CommonITILValidation::WAITING],
             [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-
+            // 3 validations
             [100, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
+            [100, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [75, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [66, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED], CommonITILValidation::WAITING],
             [66, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-
-            // 5 validations -
-            [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            // 5 validations
             [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
             [20, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-            [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             [40, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            [40, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
 
-            // --- special cases 0% required : one ACCEPTED -> ACCEPTED else one REFUSED -> REFUSED, else WAITING
+            // --- Special cases: 0% required ---
             [0, [CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [0, [CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
             [0, [CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42185

In the case of multiple successive approvals, the global approval status was incorrectly calculated in some cases. For example, 2 ACCEPTED and 1 WAITING resulted in REFUSED instead of WAITING.

_In this case, ACCEPTED = 66.666666 and WAITING = 33.333333, the sum giving 99.999999, but never 100 as expected_.
