### PR TITLE
`getKnownSchema()` `null` value is (almost) never handled

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6656,42 +6656,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 6,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getIDForOtherUniqueFieldBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 11,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 6,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 9,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$users_id of method Glpi\\\\Api\\\\HL\\\\Controller\\\\AdministrationController\\:\\:getUsedOrManagedItems\\(\\) expects int, int\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
@@ -6716,148 +6680,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 16,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 16,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$schemas of static method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getUnionSchema\\(\\) expects non\\-empty\\-array\\<string, array\\{x\\-itemtype\\: string, properties\\: mixed\\}\\>, array\\<string, mixed\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset \'properties\' might not exist on array\\|null\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Offset \'x\\-itemtype\' might not exist on array\\|null\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$identifier of method Glpi\\\\OAuth\\\\User\\:\\:setIdentifier\\(\\) expects non\\-empty\\-string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CoreController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\ITILController\\:\\:getSubitemType\\(\\) should return string but returns string\\|null\\.$#',
@@ -6872,105 +6704,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getInputParamsBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$class of static method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getDropdownTypeSchema\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
 ];
 $ignoreErrors[] = [
@@ -6984,66 +6720,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access offset mixed on array\\|void\\.$#',
@@ -7106,36 +6782,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$criterion of static method RuleCriteria\\:\\:getConditions\\(\\) expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -7146,66 +6792,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getProperties\\(\\) should return array\\<string, array\\{type\\: string, format\\?\\: string, properties\\?\\: array, items\\?\\: array\\}\\> but returns array\\<string, array\\<string, mixed\\>\\>\\.$#',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6698,12 +6698,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$name of method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getKnownSchema\\(\\) expects string, class\\-string\\<CommonITILTask\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$class of static method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getDropdownTypeSchema\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -121,12 +121,18 @@ abstract class AbstractController
      * Get a schema by name and API version
      * @param string $name The name of the schema
      * @param string $api_version The API version
-     * @return array|null
+     * @return array
      */
-    protected function getKnownSchema(string $name, string $api_version): ?array
+    protected function getKnownSchema(string $name, string $api_version): array
     {
-        $schemas = static::getKnownSchemas($api_version);
-        return array_change_key_case($schemas)[strtolower($name)] ?? null;
+        $schemas = array_change_key_case(static::getKnownSchemas($api_version));
+
+        $expected_key = strtolower($name);
+        if (!\array_key_exists($expected_key, $schemas)) {
+            throw new RuntimeException(sprintf('Schema not found for `%s`.', $name));
+        }
+
+        return $schemas[$expected_key];
     }
 
     /**

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -1471,7 +1471,7 @@ EOT,
         return $filters;
     }
 
-    private function getKnownSubitemSchema(CommonITILObject $item, string $subitem_type, string $api_version): ?array
+    private function getKnownSubitemSchema(CommonITILObject $item, string $subitem_type, string $api_version): array
     {
         if ($subitem_type === 'Document') {
             $schema = (new ManagementController())->getKnownSchema('Document_Item', $api_version);
@@ -1499,9 +1499,6 @@ EOT,
         foreach ($subitem_types as $subitem_type) {
             $filters = $this->getTimelineItemFilters($item, $request, $subitem_type);
             $schema = $this->getKnownSubitemSchema($item, $subitem_type, $this->getAPIVersion($request));
-            if ($schema === null) {
-                continue;
-            }
 
             /** @var class-string<CommonDBTM> $schema_itemtype */
             $schema_itemtype = $schema['x-itemtype'];

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -82,6 +82,7 @@ use ProblemTask;
 use ProblemTemplate;
 use RecurrentChange;
 use RequestType;
+use RuntimeException;
 use Session;
 use SLA;
 use SlaLevel;
@@ -1476,9 +1477,17 @@ EOT,
         if ($subitem_type === 'Document') {
             $schema = (new ManagementController())->getKnownSchema('Document_Item', $api_version);
         } elseif ($subitem_type === 'Task') {
-            $schema = $this->getKnownSchema($item::getTaskClass(), $api_version);
-        } elseif ($subitem_type === 'Validation' && class_exists($item::getType() . 'Validation')) {
-            $schema = $this->getKnownSchema($item::getType() . 'Validation', $api_version);
+            $schema_name = $item::getTaskClass();
+            if ($schema_name === null) {
+                throw new RuntimeException(sprintf('Task sub item not found for `%s`.', $item::class));
+            }
+            $schema = $this->getKnownSchema($schema_name, $api_version);
+        } elseif ($subitem_type === 'Validation') {
+            $schema_name = $item::getValidationClassName();
+            if ($schema_name === null) {
+                throw new RuntimeException(sprintf('Validation sub item not found for `%s`.', $item::class));
+            }
+            $schema = $this->getKnownSchema($schema_name, $api_version);
         } else {
             $schema = $this->getKnownSchema($subitem_type, $api_version);
         }
@@ -1494,7 +1503,13 @@ EOT,
      */
     private function getITILTimelineItems(CommonITILObject $item, Request $request, array $subitem_types = []): ?array
     {
-        $subitem_types = $subitem_types === [] ? ['Followup', 'Task', 'Document', 'Solution', 'Validation'] : $subitem_types;
+        if ($subitem_types === []) {
+            $subitem_types = ['Followup', 'Task', 'Document', 'Solution'];
+            if ($item::getValidationClassName() !== null) {
+                $subitem_types[] = 'Validation';
+            }
+        }
+
         $results = [];
         foreach ($subitem_types as $subitem_type) {
             $filters = $this->getTimelineItemFilters($item, $request, $subitem_type);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The `Glpi\Api\HL\Controller\AbstractController::getKnownSchema()` may return a `null` value, but most of the code that uses the returned value is not compatible with this potential `null` value. Therefore, I think it is preferable to return an exception rather that returning this `null` value.

Also, it would prevent new issues of this kind to be detected everytime a new API endpoint is created, ee errors in https://github.com/glpi-project/glpi/actions/runs/22175433052/job/64122808683 .