### PR TITLE
Fix planning event editability when duration exceeds 50h

### DIFF
--- a/templates/pages/assistance/planning/add_classic_event.html.twig
+++ b/templates/pages/assistance/planning/add_classic_event.html.twig
@@ -59,45 +59,40 @@
                 <span id="user_available{{ params.rand_user }}"></span>
             {% endif %}
 
-            {% if default_delay <= 180000 %}
-                {% do call('Dropdown::showTimeStamp', ['plan[_duration]', {
-                    min: 0,
-                    max: 50 * constant('HOUR_TIMESTAMP'),
-                    value: default_delay,
-                    emptylabel: display_dates ? __('Specify an end date') : constant('Dropdown::EMPTY_VALUE'),
-                    rand: rand,
-                }]) %}
-                <br>
-            {% else %}
-                {{ fields.hiddenField('plan[_duration]', default_delay) }}
-                {{ fields.htmlField(
-                    '',
-                    default_delay|formatted_duration,
-                    '',
-                    {no_label: true, full_width: true, mb: 0}
-                ) }}
-            {% endif %}
+            {% set duration_limit = 50 * constant('HOUR_TIMESTAMP') %}
+            {% set forced_end_date = (default_delay > duration_limit) %}
+            {% do call('Dropdown::showTimeStamp', ['plan[_duration]', {
+                min: 0,
+                max: duration_limit,
+                value: forced_end_date ? 0 : default_delay,
+                emptylabel: __('Specify an end date'),
+                rand: rand,
+            }]) %}
+            <br>
             <div id="date_end{{ rand }}"></div>
 
             {% if display_dates %}
-                {% if default_delay == 0 %}
-                    {% set params = params|merge({
-                        duration: 0,
-                    }) %}
-                    <script>
-                        $('#date_end{{ rand }}').load('{{ path('ajax/planningend.php')|e('js') }}', {{ params|json_encode|raw }});
-                    </script>
-                {% endif %}
                 <script>
-                    $('#dropdown_plan__duration_{{ rand }}').on('change', () => {
-                        const event_params = {
-                            duration: $('#dropdown_plan__duration_{{ rand }}').val(),
-                            end: '{{ end|e('js') }}',
-                            name: 'plan[end]',
-                            global_begin: '{{ config('planning_begin')|e('js') }}',
-                            global_end: '{{ config('planning_end')|e('js') }}',
+                    $(function() {
+                        const getEventParams = (duration) => {
+                            return {
+                                duration: duration,
+                                end: '{{ end|e('js') }}',
+                                name: 'plan[end]',
+                                global_begin: '{{ config('planning_begin')|e('js') }}',
+                                global_end: '{{ config('planning_end')|e('js') }}',
+                                itemtype: '{{ params.itemtype|e('js') }}',
+                                items_id: '{{ params.items_id|default(0)|e('js') }}'
+                            };
                         };
-                        $('#date_end{{ rand }}').load('{{ path('ajax/planningend.php')|e('js') }}', event_params);
+
+                        {% if default_delay == 0 or forced_end_date %}
+                            $('#date_end{{ rand }}').load('{{ path('ajax/planningend.php')|e('js') }}', getEventParams(0));
+                        {% endif %}
+
+                        $('#dropdown_plan__duration_{{ rand }}').on('change', function() {
+                            $('#date_end{{ rand }}').load('{{ path('ajax/planningend.php')|e('js') }}', getEventParams($(this).val()));
+                        });
                     });
                 </script>
             {% endif %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23146

The form now automatically toggles to the 'Specify an end date' mode whenever the duration exceeds the 50h threshold.
It bypasses the large Select2 dropdown list (preserving performance).
It restores editability via the existing end date picker.

Note on UX :
I acknowledge that this is a functional workaround rather than a perfect UX solution. However, as a complete UI refactoring for this field is not currently in the roadmap, this provides an immediate fix for users. For multi-day events, the end date follows the standard GLPI logic (setting the next day at 00:00:00 for a full day).


