### PR TITLE
make editable Title

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -52,7 +52,7 @@
     &.is-editing {
         outline: none;
         padding: 2px 6px;
-        margin: -2px -6px;
+        margin: 0 -6px;
 
         &:focus {
             background-color: rgb(var(--tblr-primary-rgb) / 4%);

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -45,6 +45,27 @@
     }
 }
 
+.kb-title-editable {
+    transition: background-color 0.2s ease;
+    border-radius: 4px;
+
+    &.is-editing {
+        outline: none;
+        padding: 2px 6px;
+        margin: -2px -6px;
+
+        &:focus {
+            background-color: rgb(var(--tblr-primary-rgb) / 4%);
+        }
+
+        &:empty::before {
+            content: attr(data-placeholder);
+            color: var(--tblr-muted);
+            pointer-events: none;
+        }
+    }
+}
+
 .kb-article {
     max-height: calc(100vh - 150px);
     overflow: auto;

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global getAjaxCsrfToken, glpi_ajax_dialog, glpi_confirm_danger, glpi_toast_error, glpi_toast_info, */
+/* global glpi_ajax_dialog, glpi_confirm_danger, glpi_toast_error, glpi_toast_info, */
 
 import { post } from "/js/modules/Ajax.js";
 import { GlpiKnowbaseArticleSidePanelController } from "/js/modules/Knowbase/ArticleSidePanelController.js";
@@ -57,10 +57,32 @@ export class GlpiKnowbaseArticleController
      */
     #original_content = '';
 
+    /** @type {HTMLElement|null} */
+    #title_element = null;
+
+    /** @type {string} */
+    #original_title = '';
+
     /**
      * @type {number|null}
      */
     #item_id = null;
+
+    #handleTitleKeydown = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            this.#editor.focus();
+        }
+    };
+
+    #handleTitlePaste = (e) => {
+        e.preventDefault();
+        const text = (e.clipboardData || window.clipboardData)
+            .getData('text/plain')
+            .replace(/[\r\n]+/g, ' ')
+            .trim();
+        document.execCommand('insertText', false, text);
+    };
 
     /**
      * @param {HTMLElement} container
@@ -226,6 +248,12 @@ export class GlpiKnowbaseArticleController
         // Store original content for cancel functionality
         this.#original_content = editor_element.innerHTML;
 
+        // Store title element for inline editing
+        this.#title_element = this.#container.querySelector('[data-field="name"]');
+        if (this.#title_element) {
+            this.#original_title = this.#title_element.textContent.trim();
+        }
+
         // Toggle edit mode (lazy load editor on first click)
         edit_button.addEventListener('click', async () => {
             await this.#enableEditMode(editor_element, edit_button, save_button, cancel_button);
@@ -235,6 +263,9 @@ export class GlpiKnowbaseArticleController
         cancel_button.addEventListener('click', () => {
             this.#editor.setContent(this.#original_content);
             this.#editor.setEditable(false);
+
+            this.#disableTitleEditing(true);
+
             edit_button.classList.remove('d-none');
             save_button.classList.add('d-none');
             cancel_button.classList.add('d-none');
@@ -270,10 +301,38 @@ export class GlpiKnowbaseArticleController
             this.#editor.setEditable(true);
         }
 
+        this.#enableTitleEditing();
+
         this.#editor.focus();
         edit_button.classList.add('d-none');
         save_button.classList.remove('d-none');
         cancel_button.classList.remove('d-none');
+    }
+
+    #enableTitleEditing()
+    {
+        if (this.#title_element) {
+            this.#title_element.contentEditable = 'true';
+            this.#title_element.classList.add('is-editing');
+            this.#title_element.addEventListener('keydown', this.#handleTitleKeydown);
+            this.#title_element.addEventListener('paste', this.#handleTitlePaste);
+        }
+    }
+
+    /**
+     * @param {boolean} restore - Whether to restore the original title text
+     */
+    #disableTitleEditing(restore = false)
+    {
+        if (this.#title_element) {
+            if (restore) {
+                this.#title_element.textContent = this.#original_title;
+            }
+            this.#title_element.contentEditable = 'false';
+            this.#title_element.classList.remove('is-editing');
+            this.#title_element.removeEventListener('keydown', this.#handleTitleKeydown);
+            this.#title_element.removeEventListener('paste', this.#handleTitlePaste);
+        }
     }
 
     /**
@@ -289,41 +348,46 @@ export class GlpiKnowbaseArticleController
             return;
         }
 
+        // Validate title is not empty
+        const new_title = this.#title_element
+            ? this.#title_element.textContent.trim()
+            : null;
+        if (this.#title_element && new_title.length === 0) {
+            glpi_toast_error(__("Title cannot be empty"));
+            this.#title_element.focus();
+            return;
+        }
+
         const original_button_html = save_button.innerHTML;
         save_button.disabled = true;
         save_button.innerHTML = `<i class="ti ti-loader me-1"></i>${__("Saving...")}`;
 
         try {
-            const response = await fetch(
-                `${CFG_GLPI.root_doc}/Knowbase/KnowbaseItem/${this.#item_id}/Answer`,
-                {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest',
-                        'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-                    },
-                    body: JSON.stringify({
-                        answer: this.#editor.getHTML(),
-                    }),
-                }
-            );
-
-            if (!response.ok) {
-                throw new Error(__("Failed to save"));
+            const body = {
+                answer: this.#editor.getHTML(),
+            };
+            if (new_title !== null) {
+                body.name = new_title;
             }
 
-            // Update original content for future cancel operations
+            await post(`Knowbase/KnowbaseItem/${this.#item_id}/Answer`, body);
+
+            // Update originals for future cancel operations
             this.#original_content = this.#editor.getHTML();
+            if (new_title !== null) {
+                this.#original_title = new_title;
+            }
             this.#editor.setEditable(false);
+            this.#disableTitleEditing();
+
             edit_button.classList.remove('d-none');
             save_button.classList.add('d-none');
             cancel_button.classList.add('d-none');
 
             // Show success notification
             glpi_toast_info(__("Article saved successfully"));
-        } catch (error) {
-            glpi_toast_error(error.message || __("An error occurred while saving"));
+        } catch {
+            // Error toast already shown by post()
         } finally {
             save_button.disabled = false;
             save_button.innerHTML = original_button_html;

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -114,7 +114,7 @@ final class KnowbaseItemController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        if (!$kbitem->can($id, UPDATE, $input)) {
+        if (!$kbitem->can($id, UPDATE)) {
             throw new AccessDeniedHttpException();
         }
 
@@ -131,10 +131,24 @@ final class KnowbaseItemController extends AbstractController
         // Sanitize HTML content to prevent XSS
         $answer = RichText::getSafeHtml($answer);
 
-        $success = $kbitem->update([
+        $update_data = [
             'id' => $id,
             'answer' => $answer,
-        ]);
+        ];
+
+        // Handle optional title update
+        if (isset($data['name'])) {
+            $name = strip_tags(trim($data['name']));
+            if ($name === '') {
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => __('Title cannot be empty'),
+                ], Response::HTTP_BAD_REQUEST);
+            }
+            $update_data['name'] = $name;
+        }
+
+        $success = $kbitem->update($update_data);
 
         if ($success) {
             return new JsonResponse([

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -36,7 +36,11 @@
      data-glpi-kb-can-edit="{{ can_edit ? 'true' : 'false' }}">
     <article class="col-9 container ms-0 px-4 py-3 kb-article">
         <div class="d-flex align-items-center mb-3">
-            <h1 class="fw-bold mb-0" data-testid="subject">{{ subject }}</h1>
+            <h1 class="fw-bold mb-0 kb-title-editable"
+                data-testid="subject"
+                data-field="name"
+                data-placeholder="{{ __('Untitled') }}"
+                spellcheck="true">{{ subject }}</h1>
             <div class="ms-auto d-flex align-items-center gap-2">
                 {# Edit/Save/Cancel buttons #}
                 {% if can_edit %}

--- a/tests/e2e/specs/Knowbase/Editor/core.spec.ts
+++ b/tests/e2e/specs/Knowbase/Editor/core.spec.ts
@@ -94,4 +94,88 @@ test.describe('Knowledge Base Editor - Core', () => {
 
         await kb.editor.assertContainsText('Original content');
     });
+
+    test('Can edit title inline', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Original Title',
+            entities_id: getWorkerEntityId(),
+            answer: '<p>Some content</p>',
+        });
+
+        await kb.goto(id);
+        const subject = page.getByTestId('subject');
+        await expect(subject).toHaveText('Original Title');
+
+        await kb.editor.enterEditMode();
+
+        // Title should be contenteditable
+        await expect(subject).toHaveAttribute('contenteditable', 'true');
+
+        // Clear and type new title
+        await subject.click();
+        await page.keyboard.press('Control+a');
+        await page.keyboard.type('Updated Title');
+
+        await kb.editor.save();
+
+        await expect(subject).toHaveText('Updated Title');
+
+        // Verify persistence after reload
+        await page.reload();
+        await expect(page.getByTestId('subject')).toHaveText('Updated Title');
+    });
+
+    test('Enter in title moves focus to editor', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Focus Test Title',
+            entities_id: getWorkerEntityId(),
+            answer: '<p>Editor content</p>',
+        });
+
+        await kb.goto(id);
+        await kb.editor.enterEditMode();
+
+        const subject = page.getByTestId('subject');
+        await subject.click();
+        await page.keyboard.press('Enter');
+
+        // The ProseMirror editor should now be focused
+        // eslint-disable-next-line playwright/no-raw-locators
+        const editor = page.getByTestId('content').locator('.ProseMirror');
+        await expect(editor).toBeFocused();
+    });
+
+    test('Cancel restores original title', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Title Before Cancel',
+            entities_id: getWorkerEntityId(),
+            answer: '<p>Content</p>',
+        });
+
+        await kb.goto(id);
+        const subject = page.getByTestId('subject');
+        await expect(subject).toHaveText('Title Before Cancel');
+
+        await kb.editor.enterEditMode();
+
+        // Modify the title
+        await subject.click();
+        await page.keyboard.press('Control+a');
+        await page.keyboard.type('Modified Title');
+        await expect(subject).toHaveText('Modified Title');
+
+        // Cancel should restore
+        await kb.editor.cancel();
+        await expect(subject).toHaveText('Title Before Cancel');
+        await expect(subject).toHaveAttribute('contenteditable', 'false');
+    });
 });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/105 
- Here is a brief description of what this PR does

The title is rendered as a static `<h1>` with a data-field="name" attribute. When the user clicks Edit, the JS controller sets contentEditable="true" on the element and binds keyboard/paste  handler : 

Enter moves focus to the Tiptap body editor, and paste is sanitized to plain text. On save, the title is sent alongside the answer content in the existing /Answer POST endpoint, where the PHP controller validates it's non-empty, strips HTML tags, and includes it in the KnowbaseItem::update() call. On cancel, the original text is restored. This approach avoids a separate form or input field, giving a Notion-like inline editing experience while reusing the existing save flow.


