### PR TITLE
Use iterator criteria instead of QueryExpression

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -13484,18 +13484,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Binary operation "\\." between array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string and \' \\<\\> \' results in an error\\.$#',
-	'identifier' => 'binaryOp.invalid',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Binary operation "\\." between array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string and \' \\= \' results in an error\\.$#',
-	'identifier' => 'binaryOp.invalid',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access offset \'id\' on non\\-empty\\-array\\<non\\-empty\\-string, string\\|null\\>\\|int\\<1, max\\>\\|string\\.$#',
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
@@ -13583,24 +13571,6 @@ $ignoreErrors[] = [
 	'message' => '#^Cannot call method isField\\(\\) on CommonDBTM\\|null\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$expression of class Glpi\\\\DBAL\\\\QueryExpression constructor expects string, array\\<string\\>\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$expression of static method Glpi\\\\DBAL\\\\QueryFunction\\:\\:convert\\(\\) expects Glpi\\\\DBAL\\\\QueryExpression\\|string, array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$field of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:makeTextCriteria\\(\\) expects string, array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
@@ -13712,27 +13682,9 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Part \\$date_computation \\(array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#',
-	'identifier' => 'encapsedStringPart.nonString',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Part \\$tocompute \\(array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string\\) of encapsed string cannot be cast to string\\.$#',
-	'identifier' => 'encapsedStringPart.nonString',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Part \\$token \\(array\\<int\\>\\|int\\|string\\|null\\) of encapsed string cannot be cast to string\\.$#',
 	'identifier' => 'encapsedStringPart.nonString',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Possibly invalid array key type array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string\\.$#',
-	'identifier' => 'array.invalidKey',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -4784,12 +4784,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Session\\:\\:haveTranslations\\(\\) expects string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/DbUtils.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$object_or_class of function is_a expects object\\|string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 3,
@@ -5333,12 +5327,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Dropdown.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Session\\:\\:haveTranslations\\(\\) expects string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Dropdown.php',
 ];
 $ignoreErrors[] = [
@@ -13612,7 +13600,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$field of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:makeTextCriteria\\(\\) expects string, array\\<string\\>\\|Glpi\\\\DBAL\\\\QueryExpression\\|string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 3,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
@@ -13643,12 +13631,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Session\\:\\:haveTranslations\\(\\) expects string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
@@ -13694,12 +13676,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$val of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:makeTextSearchValue\\(\\) expects string, int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$val of static method Html\\:\\:computeGenericDateTimeSearch\\(\\) expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -13733,18 +13709,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$subject of function Safe\\\\preg_match expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$val of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:makeTextCriteria\\(\\) expects string, int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$itemtype of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:getDropdownTranslationJoinCriteria\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
 ];
 $ignoreErrors[] = [

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -1314,8 +1314,8 @@ final class DbUtils
         $SELECTCOMMENT = new QueryExpression("'' AS " . $DB->quoteName('transcomment'));
         $JOIN          = [];
         $JOINS         = [];
-        if ($translate) {
-            if (Session::haveTranslations($this->getItemTypeForTable($table), 'name')) {
+        if ($translate && $transitemtype = $this->getItemTypeForTable($table)) {
+            if (Session::haveTranslations($transitemtype, 'name')) {
                 $SELECTNAME = 'namet.value AS transname';
                 $JOINS['glpi_dropdowntranslations AS namet'] = [
                     'ON' => [
@@ -1330,7 +1330,8 @@ final class DbUtils
                     ],
                 ];
             }
-            if (Session::haveTranslations($this->getItemTypeForTable($table), 'comment')) {
+            $transitemtype = $this->getItemTypeForTable($table);
+            if ($transitemtype && Session::haveTranslations($transitemtype, 'comment')) {
                 $SELECTCOMMENT = 'namec.value AS transcomment';
                 $JOINS['glpi_dropdowntranslations AS namec'] = [
                     'ON' => [
@@ -1420,8 +1421,8 @@ final class DbUtils
         $SELECTNAME    = new QueryExpression("'' AS " . $DB->quoteName('transname'));
         $JOIN          = [];
         $JOINS         = [];
-        if ($translate) {
-            if (Session::haveTranslations($this->getItemTypeForTable($table), 'completename')) {
+        if ($translate && $transitemtype = $this->getItemTypeForTable($table)) {
+            if (Session::haveTranslations($transitemtype, 'completename')) {
                 $SELECTNAME = 'namet.value AS transname';
                 $JOINS['glpi_dropdowntranslations AS namet'] = [
                     'ON' => [

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -570,7 +570,8 @@ class Dropdown
         if ($id) {
             $SELECTNAME    = new QueryExpression("'' AS " . $DB->quoteName('transname'));
             $JOIN          = [];
-            if ($translate && Session::haveTranslations(getItemTypeForTable($table), 'name')) {
+            $transitemtype = getItemTypeForTable($table);
+            if ($translate && $transitemtype && Session::haveTranslations($transitemtype, 'name')) {
                 $SELECTNAME = 'namet.value AS transname';
                 $JOIN = [
                     'LEFT JOIN' => [
@@ -682,6 +683,7 @@ class Dropdown
 
         if (
             $translate
+            && $itemtype
             && Session::haveTranslations($itemtype, 'comment')
         ) {
             $criteria['SELECT'][] = 'comment_translations.value AS translated_comment';

--- a/src/Glpi/Api/HL/Search/RecordSet.php
+++ b/src/Glpi/Api/HL/Search/RecordSet.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Api\HL\Search;
 
+use CommonDBTM;
 use Glpi\Api\HL\APIException;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Search;
@@ -149,6 +150,7 @@ final class RecordSet
                 $field_parts = explode('.', $sql_field);
                 $field_only = end($field_parts);
                 // Handle translatable fields
+                /** @var class-string<CommonDBTM> $itemtype */
                 if (Session::haveTranslations($itemtype, $field_only)) {
                     $trans_alias = "{$join_name}__{$field_only}__trans";
                     $trans_alias = hash('xxh3', $trans_alias);

--- a/src/Glpi/DBAL/Operator.php
+++ b/src/Glpi/DBAL/Operator.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/DBAL/Operator.php
+++ b/src/Glpi/DBAL/Operator.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\DBAL;
+
+use InvalidArgumentException;
+
+enum Operator: string
+{
+    case AND = 'AND';
+    case OR = 'OR';
+    case NONE = '';
+
+    public static function fromString(?string $operator): Operator
+    {
+        if ($operator !== null) {
+            $operator = strtoupper($operator);
+        }
+        return match ($operator) {
+            'AND' => self::AND,
+            'OR' => self::OR,
+            null, '' => self::NONE,
+            default => throw new InvalidArgumentException("Invalid operator: $operator"),
+        };
+    }
+}

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1475,7 +1475,7 @@ final class SQLProvider implements SearchProviderInterface
 
                         return $criteria;
                     }
-                    return [new QueryExpression(self::makeTextCriteria("`$table`.`$field`", $val, $nott, ''))];
+                    return self::getTextCriteria($table . '.' . $field, $val, $nott, Operator::NONE);
                 }
                 if ($_SESSION["glpinames_format"] == User::FIRSTNAME_BEFORE) {
                     $name1 = 'firstname';
@@ -1892,7 +1892,7 @@ final class SQLProvider implements SearchProviderInterface
                             if ($searchtype === 'notequals') {
                                 $nott = !$nott;
                             }
-                            return [new QueryExpression(self::makeTextCriteria("`$table`.`$field`", $val, $nott, ''))];
+                            return self::getTextCriteria($table . '.' . $field, $val, $nott, Operator::NONE);
                         }
                     }
                     if ($searchtype === 'lessthan') {
@@ -2321,8 +2321,8 @@ final class SQLProvider implements SearchProviderInterface
         if (Session::haveTranslations($transitemtype, $field)) {
             return [
                 'OR' => [
-                    new QueryExpression(self::makeTextCriteria($tocompute, $val, $nott, '')),
-                    new QueryExpression(self::makeTextCriteria($tocomputetrans, $val, $nott, '')),
+                    self::getTextCriteria($tocompute, $val, $nott, Operator::NONE),
+                    self::getTextCriteria($tocomputetrans, $val, $nott, Operator::NONE),
                 ],
             ];
         }
@@ -4081,7 +4081,7 @@ final class SQLProvider implements SearchProviderInterface
             }
         }
 
-        return [new QueryExpression(self::makeTextCriteria("`$NAME`", $val, $NOT, ''))];
+        return [self::getTextCriteria($NAME, $val, $NOT, Operator::NONE)];
     }
 
 
@@ -5380,15 +5380,21 @@ final class SQLProvider implements SearchProviderInterface
     /**
      * Create SQL search condition
      *
-     * @param string   $field Name (should **NOT** be ` protected)
-     * @param ?string  $val   Value to search
-     * @param bool     $not   Is a negative search ? (false by default)
-     * @param Operator $link  With previous criteria (default 'AND')
+     * @param string|QueryExpression $field Name (should **NOT** be ` protected)
+     * @param string|int|null        $val   Value to search
+     * @param bool                   $not   Is a negative search ? (false by default)
+     * @param Operator               $link  With previous criteria (default 'AND')
      *
      * @return array<int, mixed>
      */
-    public static function getTextCriteria(string $field, ?string $val, bool $not = false, Operator $link = Operator::AND): array
+    public static function getTextCriteria(string|QueryExpression $field, string|int|null $val, bool $not = false, Operator $link = Operator::AND): array
     {
+        if (is_a($field, QueryExpression::class)) {
+            //This case seems often not realistic; but let's keep for backward compatibility
+            return [new QueryExpression(self::makeTextCriteria($field, $val, $not, $link->value))];
+        }
+        $old =  self::makeTextCriteria($field, $val ?? '', $not, $link->value);
+
         $field = str_replace('`', '', $field);
         $search_val = self::makeTextSearchValue($val);
         if ($search_val == null) {
@@ -5398,24 +5404,13 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         if (strtolower($val ?? 'null') == 'null') {
-            // FIXME
-            // `OR field = ''` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
-            // when following datatype are used:
-            //  - integer
-            //  - number
-            //  - decimal
-            //  - count
-            //  - mio
-            //  - percentage
-            //  - timestamp
-            //  - datetime
-            //  - date_delay
-            //
-            // Removing this condition requires, at least, to use the `int`/`float`/`double`/`timestamp`/`date` types in DB,
-            // to ensure that the `''` value will not be stored in DB.
-
             if ($not) {
-                $criteria[] = [$field => ''];
+                $criteria = [
+                    'OR' => [
+                        [$criteria],
+                        [$field => ''],
+                    ],
+                ];
             } else {
                 $criteria = [
                     'OR' => [
@@ -5502,12 +5497,16 @@ final class SQLProvider implements SearchProviderInterface
      *
      * @since 9.4
      *
-     * @param string  $val value to search
+     * @param ?string $val value to search
      *
      * @return string|null
      **/
-    public static function makeTextSearchValue($val)
+    public static function makeTextSearchValue(?string $val): ?string
     {
+        if ($val === 'NULL' || $val === 'null' || $val === null) {
+            return null;
+        }
+
         // Backslashes must be doubled in LIKE clause, according to MySQL documentation:
         // https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html
         // > To search for \, specify it as \\\\; this is because the backslashes are stripped once by the parser
@@ -5518,10 +5517,6 @@ final class SQLProvider implements SearchProviderInterface
 
         // escape _ char used as wildcard in mysql likes
         $val = str_replace('_', '\_', $val);
-
-        if ($val === 'NULL' || $val === 'null') {
-            return null;
-        }
 
         $val = trim($val);
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5390,8 +5390,6 @@ final class SQLProvider implements SearchProviderInterface
             //This case seems often not realistic; but let's keep for backward compatibility
             return [new QueryExpression(self::makeTextCriteria($field, $val, $not, $link->value))];
         }
-        $old =  self::makeTextCriteria($field, $val ?? '', $not, $link->value);
-
         $field = str_replace('`', '', $field);
         $search_val = self::makeTextSearchValue($val);
         if ($search_val == null) {

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -57,6 +57,7 @@ use Entity;
 use Entity_KnowbaseItem;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\DBAL\Operator;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
@@ -2326,7 +2327,7 @@ final class SQLProvider implements SearchProviderInterface
             ];
         }
 
-        return [new QueryExpression(self::makeTextCriteria($tocompute, $val, $nott, ''))];
+        return [self::getTextCriteria($tocompute, $val, $nott, Operator::NONE)];
     }
 
     /**
@@ -5374,6 +5375,78 @@ final class SQLProvider implements SearchProviderInterface
             }
         }
         Profiler::getInstance()->stop('SQLProvider::constructData');
+    }
+
+    /**
+     * Create SQL search condition
+     *
+     * @param string   $field Name (should **NOT** be ` protected)
+     * @param ?string  $val   Value to search
+     * @param bool     $not   Is a negative search ? (false by default)
+     * @param Operator $link  With previous criteria (default 'AND')
+     *
+     * @return array<int, mixed>
+     */
+    public static function getTextCriteria(string $field, ?string $val, bool $not = false, Operator $link = Operator::AND): array
+    {
+        $field = str_replace('`', '', $field);
+        $search_val = self::makeTextSearchValue($val);
+        if ($search_val == null) {
+            $criteria = [$field => $search_val];
+        } else {
+            $criteria = [$field => ['LIKE', $search_val]];
+        }
+
+        if (strtolower($val ?? 'null') == 'null') {
+            // FIXME
+            // `OR field = ''` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
+            // when following datatype are used:
+            //  - integer
+            //  - number
+            //  - decimal
+            //  - count
+            //  - mio
+            //  - percentage
+            //  - timestamp
+            //  - datetime
+            //  - date_delay
+            //
+            // Removing this condition requires, at least, to use the `int`/`float`/`double`/`timestamp`/`date` types in DB,
+            // to ensure that the `''` value will not be stored in DB.
+
+            if ($not) {
+                $criteria[] = [$field => ''];
+            } else {
+                $criteria = [
+                    'OR' => [
+                        [$criteria],
+                        [$field => ''],
+                    ],
+                ];
+            }
+        }
+
+        if ($not) {
+            $criteria = ['NOT' => $criteria];
+        }
+
+        if (
+            ($not && ($val != 'NULL') && ($val != 'null') && ($val != '^$')) // Not something
+            || (!$not && ($val == '^$'))
+        ) {   // Empty
+            $criteria = [
+                'OR' => [
+                    [$criteria],
+                    [$field => null],
+                ],
+            ];
+        }
+        if ($link !== Operator::NONE) {
+            $criteria = [
+                $link->value => $criteria,
+            ];
+        }
+        return $criteria;
     }
 
     /**

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -7083,12 +7083,9 @@ final class SQLProvider implements SearchProviderInterface
         return $suffix;
     }
 
-    private static function getOptComputation(mixed $opt_value, string $table): QueryExpression
+    private static function getOptComputation(string|QueryExpression $opt_value, string $table): QueryExpression
     {
         global $DB;
-        if (!is_string($opt_value) && !$opt_value instanceof QueryExpression) {
-            throw new RuntimeException('Computation parameter must be a string or a QueryExpression');
-        }
         return new QueryExpression(
             str_replace(
                 "TABLE",

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5398,7 +5398,7 @@ final class SQLProvider implements SearchProviderInterface
         $field = str_replace('`', '', $field);
         $search_val = self::makeTextSearchValue($val);
         if ($search_val == null) {
-            $criteria = [$field => $search_val];
+            $criteria = [$field => null];
         } else {
             $criteria = [$field => ['LIKE', $search_val]];
         }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -94,7 +94,6 @@ use Reminder;
 use Reservation;
 use ReservationItem;
 use RSSFeed;
-use RuntimeException;
 use SavedSearch;
 use Search;
 use Session;

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -94,6 +94,7 @@ use Reminder;
 use Reservation;
 use ReservationItem;
 use RSSFeed;
+use RuntimeException;
 use SavedSearch;
 use Search;
 use Session;
@@ -544,9 +545,7 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         if (isset($opt["computation"])) {
-            $tocompute = $opt["computation"];
-            $tocompute = str_replace($DB::quoteName('TABLE'), 'TABLE', $tocompute);
-            $tocompute = new QueryExpression(str_replace("TABLE", $DB::quoteName("$table$addtable"), $tocompute));
+            $tocompute = self::getOptComputation($opt["computation"], "$table$addtable");
         } else {
             $tocompute = new QueryExpression($DB::quoteName($tocompute));
         }
@@ -1832,13 +1831,7 @@ final class SQLProvider implements SearchProviderInterface
         $tocompute      = "`$table`.`$field`";
         $tocomputetrans = "`" . $table . "_trans_" . $field . "`.`value`";
         if (isset($opt["computation"])) {
-            $is_query_exp = is_a($opt["computation"], QueryExpression::class);
-            $tocompute = $opt["computation"];
-            $tocompute = str_replace($DB::quoteName('TABLE'), 'TABLE', $tocompute);
-            $tocompute = str_replace("TABLE", $DB::quoteName("$table"), $tocompute);
-            if ($is_query_exp) {
-                $tocompute = new QueryExpression($tocompute);
-            }
+            $tocompute = self::getOptComputation($opt["computation"], $table);
         }
 
         // Preformat items
@@ -1868,7 +1861,7 @@ final class SQLProvider implements SearchProviderInterface
                             $criteria = [
                                 $l => [
                                     [
-                                        $tocompute => [$nott ? '<>' : '=', ''],
+                                        (string) $tocompute => [$nott ? '<>' : '=', ''],
                                     ],
                                 ],
                             ];
@@ -1905,7 +1898,7 @@ final class SQLProvider implements SearchProviderInterface
                     if ($searchtype) {
                         $date_computation = $tocompute;
                     }
-                    if (!isset($opt["computation"]) && in_array($searchtype, ["contains", "notcontains"])) {
+                    if (!isset($opt["computation"]) && $date_computation && in_array($searchtype, ["contains", "notcontains"])) {
                         // FIXME Maybe address the existing fixme instead of bypassing it when the field is computed (uses a function)
                         // FIXME `CONVERT` operation should not be necessary if we only allow legitimate date/time chars
                         $default_charset = DBConnection::getDefaultCharset();
@@ -1989,7 +1982,7 @@ final class SQLProvider implements SearchProviderInterface
                     if ($searchtype == 'notequals') {
                         $nott = !$nott;
                     }
-                    $criteria = [$tocompute => ['&', $val]];
+                    $criteria = [(string) $tocompute => ['&', $val]];
                     return $nott ? ['NOT' => $criteria] : $criteria;
 
                 case "bool":
@@ -2089,7 +2082,7 @@ final class SQLProvider implements SearchProviderInterface
                         $criteria = [
                             $l => [
                                 [
-                                    $tocompute => [$nott ? '<>' : '=', ''],
+                                    (string) $tocompute => [$nott ? '<>' : '=', ''],
                                 ],
                             ],
                         ];
@@ -7099,5 +7092,24 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         return $suffix;
+    }
+
+    private static function getOptComputation(mixed $opt_value, string $table): QueryExpression
+    {
+        global $DB;
+        if (!is_string($opt_value) && !$opt_value instanceof QueryExpression) {
+            throw new RuntimeException('Computation parameter must be a string or a QueryExpression');
+        }
+        return new QueryExpression(
+            str_replace(
+                "TABLE",
+                $DB::quoteName($table),
+                str_replace(
+                    $DB::quoteName('TABLE'),
+                    'TABLE',
+                    $opt_value
+                )
+            )
+        );
     }
 }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2317,14 +2317,15 @@ final class SQLProvider implements SearchProviderInterface
             }
             return $criteria;
         }
-        $transitemtype = getItemTypeForTable($inittable);
-        if (Session::haveTranslations($transitemtype, $field)) {
-            return [
-                'OR' => [
-                    self::getTextCriteria($tocompute, $val, $nott, Operator::NONE),
-                    self::getTextCriteria($tocomputetrans, $val, $nott, Operator::NONE),
-                ],
-            ];
+        if ($transitemtype = getItemTypeForTable($inittable)) {
+            if (Session::haveTranslations($transitemtype, $field)) {
+                return [
+                    'OR' => [
+                        self::getTextCriteria($tocompute, $val, $nott, Operator::NONE),
+                        self::getTextCriteria($tocomputetrans, $val, $nott, Operator::NONE),
+                    ],
+                ];
+            }
         }
 
         return [self::getTextCriteria($tocompute, $val, $nott, Operator::NONE)];
@@ -2777,15 +2778,16 @@ final class SQLProvider implements SearchProviderInterface
 
         // Auto link
         if ($ref_table === $new_table && empty($complexjoin) && !$is_fkey_composite_on_self) {
-            $transitemtype = getItemTypeForTable($new_table);
-            if (Session::haveTranslations($transitemtype, $field)) {
-                $transAS            = $nt . '_trans_' . $field;
-                return self::getDropdownTranslationJoinCriteria(
-                    $transAS,
-                    $nt,
-                    $transitemtype,
-                    $field
-                );
+            if ($transitemtype = getItemTypeForTable($new_table)) {
+                if (Session::haveTranslations($transitemtype, $field)) {
+                    $transAS = $nt . '_trans_' . $field;
+                    return self::getDropdownTranslationJoinCriteria(
+                        $transAS,
+                        $nt,
+                        $transitemtype,
+                        $field
+                    );
+                }
             }
             return [];
         }
@@ -3242,15 +3244,16 @@ final class SQLProvider implements SearchProviderInterface
 
                     case "custom_condition_only":
                         $specific_leftjoin_criteria = ['LEFT JOIN' => ["$new_table$AS" => $add_criteria]];
-                        $transitemtype = getItemTypeForTable($new_table);
-                        if (Session::haveTranslations($transitemtype, $field)) {
-                            $transAS            = $nt . '_trans_' . $field;
-                            $specific_leftjoin_criteria = array_merge_recursive($specific_leftjoin_criteria, self::getDropdownTranslationJoinCriteria(
-                                $transAS,
-                                $nt,
-                                $transitemtype,
-                                $field
-                            ));
+                        if ($transitemtype = getItemTypeForTable($new_table)) {
+                            if (Session::haveTranslations($transitemtype, $field)) {
+                                $transAS = $nt . '_trans_' . $field;
+                                $specific_leftjoin_criteria = array_merge_recursive($specific_leftjoin_criteria, self::getDropdownTranslationJoinCriteria(
+                                    $transAS,
+                                    $nt,
+                                    $transitemtype,
+                                    $field
+                                ));
+                            }
                         }
                         break;
 
@@ -3305,15 +3308,16 @@ final class SQLProvider implements SearchProviderInterface
                             $append_join_criteria($standard_join['LEFT JOIN']["$new_table$AS"]['ON'], $add_criteria);
                         }
                         $specific_leftjoin_criteria = array_merge_recursive($specific_leftjoin_criteria, $standard_join);
-                        $transitemtype = getItemTypeForTable($new_table);
-                        if (Session::haveTranslations($transitemtype, $field)) {
-                            $transAS            = $nt . '_trans_' . $field;
-                            $specific_leftjoin_criteria = array_merge_recursive($specific_leftjoin_criteria, self::getDropdownTranslationJoinCriteria(
-                                $transAS,
-                                $nt,
-                                $transitemtype,
-                                $field
-                            ));
+                        if ($transitemtype = getItemTypeForTable($new_table)) {
+                            if (Session::haveTranslations($transitemtype, $field)) {
+                                $transAS = $nt . '_trans_' . $field;
+                                $specific_leftjoin_criteria = array_merge_recursive($specific_leftjoin_criteria, self::getDropdownTranslationJoinCriteria(
+                                    $transAS,
+                                    $nt,
+                                    $transitemtype,
+                                    $field
+                                ));
+                            }
                         }
                         break;
                 }
@@ -5385,11 +5389,11 @@ final class SQLProvider implements SearchProviderInterface
      * @param bool                   $not   Is a negative search ? (false by default)
      * @param Operator               $link  With previous criteria (default 'AND')
      *
-     * @return array<int, mixed>
+     * @return array<string|int, mixed>
      */
     public static function getTextCriteria(string|QueryExpression $field, string|int|null $val, bool $not = false, Operator $link = Operator::AND): array
     {
-        if (is_a($field, QueryExpression::class)) {
+        if (!is_string($field)) {
             //This case seems often not realistic; but let's keep for backward compatibility
             return [new QueryExpression(self::makeTextCriteria($field, $val, $not, $link->value))];
         }
@@ -5403,7 +5407,7 @@ final class SQLProvider implements SearchProviderInterface
             $criteria = [$field => ['LIKE', $search_val]];
         }
 
-        if (strtolower($val ?? 'null') == 'null') {
+        if (strtolower((string) ($val ?? 'null')) == 'null') {
             if ($not) {
                 $criteria = [
                     'OR' => [
@@ -5448,7 +5452,7 @@ final class SQLProvider implements SearchProviderInterface
      * Create SQL search condition
      *
      * @param string  $field  Name (should be ` protected)
-     * @param string  $val    Value to search
+     * @param string|int|null $val    Value to search
      * @param bool $not    Is a negative search ? (false by default)
      * @param string  $link   With previous criteria (default 'AND')
      *
@@ -5459,7 +5463,7 @@ final class SQLProvider implements SearchProviderInterface
 
         $sql = $field . self::makeTextSearch($val, $not);
 
-        if (strtolower($val) == "null") {
+        if (strtolower((string) ($val ?? 'null')) == "null") {
             // FIXME
             // `OR field = ''` condition is not supposed to be relevant, and can sometimes result in SQL performances issues/warnings/errors,
             // when following datatype are used:
@@ -5497,15 +5501,16 @@ final class SQLProvider implements SearchProviderInterface
      *
      * @since 9.4
      *
-     * @param ?string $val value to search
+     * @param string|int|null $val value to search
      *
-     * @return string|null
-     **/
-    public static function makeTextSearchValue(?string $val): ?string
+     * @return ?string
+     */
+    public static function makeTextSearchValue(string|int|null $val): ?string
     {
         if ($val === 'NULL' || $val === 'null' || $val === null) {
             return null;
         }
+        $val = (string) $val;
 
         // Backslashes must be doubled in LIKE clause, according to MySQL documentation:
         // https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html
@@ -5551,7 +5556,7 @@ final class SQLProvider implements SearchProviderInterface
     /**
      * Create SQL search condition
      *
-     * @param string  $val  Value to search
+     * @param string|int|null $val  Value to search
      * @param bool $not  Is a negative search? (false by default)
      *
      * @return string Search string

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5399,21 +5399,12 @@ final class SQLProvider implements SearchProviderInterface
         }
 
         if (strtolower((string) ($val ?? 'null')) == 'null') {
-            if ($not) {
-                $criteria = [
-                    'OR' => [
-                        [$criteria],
-                        [$field => ''],
-                    ],
-                ];
-            } else {
-                $criteria = [
-                    'OR' => [
-                        [$criteria],
-                        [$field => ''],
-                    ],
-                ];
-            }
+            $criteria = [
+                'OR' => [
+                    [$criteria],
+                    [$field => ''],
+                ],
+            ];
         }
 
         if ($not) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -1952,7 +1952,7 @@ class Session
      *
      * @since 0.85
      *
-     * @param string $itemtype itemtype
+     * @param class-string<CommonDBTM> $itemtype itemtype
      * @param string $field    field
      *
      * @return bool

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3255,7 +3255,8 @@ class SearchTest extends DbTestCase
             'search_option'     => 4, // type
             'value'             => 'test',
             'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%test%' OR `glpi_computertypes`.`name` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_computertypes`.`name` LIKE '%test%'))) OR (`glpi_computertypes`.`name` IS NULL))",
+
         ];
 
         // datatype=dropdown (usehaving=true)
@@ -3264,7 +3265,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 142, // document name
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%test%' OR `ITEM_Ticket_142` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_142` LIKE '%test%'))) OR (`ITEM_Ticket_142` IS NULL))",
         ];
 
         // datatype=itemlink
@@ -3273,7 +3274,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 1, // name
             'value'             => 'test',
             'expected_and'      => "(`glpi_computers`.`name` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%test%' OR `glpi_computers`.`name` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_computers`.`name` LIKE '%test%'))) OR (`glpi_computers`.`name` IS NULL))",
         ];
 
         // datatype=itemlink (usehaving=true)
@@ -3282,7 +3283,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 50, // parent tickets
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Ticket_50` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%test%' OR `ITEM_Ticket_50` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_50` LIKE '%test%'))) OR (`ITEM_Ticket_50` IS NULL))",
         ];
 
         // datatype=string
@@ -3291,7 +3292,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 47, // uuid
             'value'             => 'test',
             'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%test%' OR `glpi_computers`.`uuid` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_computers`.`uuid` LIKE '%test%'))) OR (`glpi_computers`.`uuid` IS NULL))))",
         ];
 
         // datatype=text
@@ -3300,7 +3301,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 16, // comment
             'value'             => 'test',
             'expected_and'      => "(`glpi_computers`.`comment` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%test%' OR `glpi_computers`.`comment` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_computers`.`comment` LIKE '%test%'))) OR (`glpi_computers`.`comment` IS NULL))",
         ];
 
         // datatype=integer
@@ -3341,7 +3342,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 115, // harddrive capacity
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Computer_115` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Computer_115` NOT LIKE '%test%' OR `ITEM_Computer_115` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Computer_115` LIKE '%test%'))) OR (`ITEM_Computer_115` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
@@ -3364,14 +3365,14 @@ class SearchTest extends DbTestCase
             'search_option'     => 7, // value
             'value'             => '1500',
             'expected_and'      => "(`glpi_budgets`.`value` LIKE '%1500.%')",
-            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%1500.%' OR `glpi_budgets`.`value` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_budgets`.`value` LIKE '%1500.%'))) OR (`glpi_budgets`.`value` IS NULL))",
         ];
         yield [
             'itemtype'          => \Budget::class,
             'search_option'     => 7, // value
             'value'             => '10.25',
             'expected_and'      => "(`glpi_budgets`.`value` LIKE '%10.2%')",
-            'expected_and_not'  => "(`glpi_budgets`.`value` NOT LIKE '%10.2%' OR `glpi_budgets`.`value` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_budgets`.`value` LIKE '%10.2%'))) OR (`glpi_budgets`.`value` IS NULL))",
         ];
 
         // datatype=decimal (usehaving=true)
@@ -3380,7 +3381,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 11, // totalcost
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Contract_11` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Contract_11` NOT LIKE '%test%' OR `ITEM_Contract_11` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Contract_11` LIKE '%test%'))) OR (`ITEM_Contract_11` IS NULL))",
         ];
         yield [
             'itemtype'          => \Contract::class,
@@ -3396,7 +3397,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 27, // number of followups
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Ticket_27` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_27` NOT LIKE '%test%' OR `ITEM_Ticket_27` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_27` LIKE '%test%'))) OR (`ITEM_Ticket_27` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
@@ -3412,7 +3413,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 111, // memory size
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Computer_111` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Computer_111` NOT LIKE '%test%' OR `ITEM_Computer_111` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Computer_111` LIKE '%test%'))) OR (`ITEM_Computer_111` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
@@ -3460,7 +3461,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 49, // actiontime
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Ticket_49` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_49` NOT LIKE '%test%' OR `ITEM_Ticket_49` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_49` LIKE '%test%'))) OR (`ITEM_Ticket_49` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
@@ -3492,14 +3493,14 @@ class SearchTest extends DbTestCase
             'search_option'     => 188, // next_escalation_level
             'value'             => 'test',
             'expected_and'      => "(`ITEM_Ticket_188` LIKE '%test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%test%' OR `ITEM_Ticket_188` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_188` LIKE '%test%'))) OR (`ITEM_Ticket_188` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
             'search_option'     => 188, // next_escalation_level
             'value'             => '2023-06',
             'expected_and'      => "(`ITEM_Ticket_188` LIKE '%2023-06%')",
-            'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%2023-06%' OR `ITEM_Ticket_188` IS NULL)",
+            'expected_and_not'  => "(((NOT (`ITEM_Ticket_188` LIKE '%2023-06%'))) OR (`ITEM_Ticket_188` IS NULL))",
         ];
 
         // datatype=date
@@ -3540,7 +3541,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 6, // email
             'value'             => 'test',
             'expected_and'      => "(`glpi_contacts`.`email` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%test%' OR `glpi_contacts`.`email` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_contacts`.`email` LIKE '%test%'))) OR (`glpi_contacts`.`email` IS NULL))",
         ];
 
         // datatype=weblink
@@ -3549,7 +3550,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 4, // link
             'value'             => 'test',
             'expected_and'      => "(`glpi_documents`.`link` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%test%' OR `glpi_documents`.`link` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_documents`.`link` LIKE '%test%'))) OR (`glpi_documents`.`link` IS NULL))",
         ];
 
         // datatype=mac
@@ -3558,14 +3559,14 @@ class SearchTest extends DbTestCase
             'search_option'     => 11, // mac_default
             'value'             => 'test',
             'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%test%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_devicenetworkcards`.`mac_default` LIKE '%test%'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
         ];
         yield [
             'itemtype'          => \DeviceNetworkCard::class,
             'search_option'     => 11, // mac_default
             'value'             => 'a2:ef:00',
             'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:ef:00%')",
-            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%a2:ef:00%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:ef:00%'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
         ];
 
         // datatype=color
@@ -3581,7 +3582,7 @@ class SearchTest extends DbTestCase
             'search_option'     => 15, // color
             'value'             => '#ffffff',
             'expected_and'      => "(`glpi_cables`.`color` LIKE '%#ffffff%')",
-            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%#ffffff%' OR `glpi_cables`.`color` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_cables`.`color` LIKE '%#ffffff%'))) OR (`glpi_cables`.`color` IS NULL))",
         ];
 
         // datatype=language
@@ -3590,14 +3591,14 @@ class SearchTest extends DbTestCase
             'search_option'     => 17, // language
             'value'             => 'test',
             'expected_and'      => "(`glpi_users`.`language` LIKE '%test%')",
-            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%test%' OR `glpi_users`.`language` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_users`.`language` LIKE '%test%'))) OR (`glpi_users`.`language` IS NULL))",
         ];
         yield [
             'itemtype'          => User::class,
             'search_option'     => 17, // language
             'value'             => 'en_',
             'expected_and'      => "(`glpi_users`.`language` LIKE '%en\\\\_%')",
-            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%en\\\\_%' OR `glpi_users`.`language` IS NULL)",
+            'expected_and_not'  => "(((NOT (`glpi_users`.`language` LIKE '%en\\\\_%'))) OR (`glpi_users`.`language` IS NULL))",
         ];
 
         // Check `NULL` special value
@@ -3607,8 +3608,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 4, // type
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_computertypes`.`name` IS NULL OR `glpi_computertypes`.`name` = '')",
-                'expected_and_not'  => "(`glpi_computertypes`.`name` IS NOT NULL AND `glpi_computertypes`.`name` <> '')",
+                'expected_and'      => "(((`glpi_computertypes`.`name` IS NULL)) OR (`glpi_computertypes`.`name` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_computertypes`.`name` IS NULL)) OR (`glpi_computertypes`.`name` = '')))",
             ];
 
             // datatype=dropdown (usehaving=true)
@@ -3616,8 +3617,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Ticket::class,
                 'search_option'     => 142, // document name
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Ticket_142` IS NULL OR `ITEM_Ticket_142` = '')",
-                'expected_and_not'  => "(`ITEM_Ticket_142` IS NOT NULL AND `ITEM_Ticket_142` <> '')",
+                'expected_and'      => "(((`ITEM_Ticket_142` IS NULL)) OR (`ITEM_Ticket_142` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Ticket_142` IS NULL)) OR (`ITEM_Ticket_142` = '')))",
             ];
 
             // datatype=itemlink
@@ -3625,8 +3626,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 1, // name
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_computers`.`name` IS NULL OR `glpi_computers`.`name` = '')",
-                'expected_and_not'  => "(`glpi_computers`.`name` IS NOT NULL AND `glpi_computers`.`name` <> '')",
+                'expected_and'      => "(((`glpi_computers`.`name` IS NULL)) OR (`glpi_computers`.`name` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_computers`.`name` IS NULL)) OR (`glpi_computers`.`name` = '')))",
             ];
 
             // datatype=itemlink (usehaving=true)
@@ -3634,8 +3635,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Ticket::class,
                 'search_option'     => 50, // parent tickets
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Ticket_50` IS NULL OR `ITEM_Ticket_50` = '')",
-                'expected_and_not'  => "(`ITEM_Ticket_50` IS NOT NULL AND `ITEM_Ticket_50` <> '')",
+                'expected_and'      => "(((`ITEM_Ticket_50` IS NULL)) OR (`ITEM_Ticket_50` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Ticket_50` IS NULL)) OR (`ITEM_Ticket_50` = '')))",
             ];
 
             // datatype=string
@@ -3643,8 +3644,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 47, // uuid
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_computers`.`uuid` IS NULL OR `glpi_computers`.`uuid` = '')",
-                'expected_and_not'  => "(`glpi_computers`.`uuid` IS NOT NULL AND `glpi_computers`.`uuid` <> '')",
+                'expected_and'      => "(((`glpi_computers`.`uuid` IS NULL)) OR (`glpi_computers`.`uuid` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_computers`.`uuid` IS NULL)) OR (`glpi_computers`.`uuid` = '')))",
             ];
 
             // datatype=text
@@ -3652,8 +3653,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 16, // comment
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_computers`.`comment` IS NULL OR `glpi_computers`.`comment` = '')",
-                'expected_and_not'  => "(`glpi_computers`.`comment` IS NOT NULL AND `glpi_computers`.`comment` <> '')",
+                'expected_and'      => "(((`glpi_computers`.`comment` IS NULL)) OR (`glpi_computers`.`comment` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_computers`.`comment` IS NULL)) OR (`glpi_computers`.`comment` = '')))",
             ];
 
             // datatype=integer
@@ -3661,8 +3662,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \AuthLDAP::class,
                 'search_option'     => 4, // port
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_authldaps`.`port` IS NULL OR `glpi_authldaps`.`port` = '')",
-                'expected_and_not'  => "(`glpi_authldaps`.`port` IS NOT NULL AND `glpi_authldaps`.`port` <> '')",
+                'expected_and'      => "(((`glpi_authldaps`.`port` IS NULL)) OR (`glpi_authldaps`.`port` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_authldaps`.`port` IS NULL)) OR (`glpi_authldaps`.`port` = '')))",
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
@@ -3675,8 +3676,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \AuthLDAP::class,
                 'search_option'     => 32, // timeout
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_authldaps`.`timeout` IS NULL OR `glpi_authldaps`.`timeout` = '')",
-                'expected_and_not'  => "(`glpi_authldaps`.`timeout` IS NOT NULL AND `glpi_authldaps`.`timeout` <> '')",
+                'expected_and'      => "(((`glpi_authldaps`.`timeout` IS NULL)) OR (`glpi_authldaps`.`timeout` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_authldaps`.`timeout` IS NULL)) OR (`glpi_authldaps`.`timeout` = '')))",
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
@@ -3689,8 +3690,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 115, // harddrive capacity
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Computer_115` IS NULL OR `ITEM_Computer_115` = '')",
-                'expected_and_not'  => "(`ITEM_Computer_115` IS NOT NULL AND `ITEM_Computer_115` <> '')",
+                'expected_and'      => "(((`ITEM_Computer_115` IS NULL)) OR (`ITEM_Computer_115` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Computer_115` IS NULL)) OR (`ITEM_Computer_115` = '')))",
             ];
 
             // datatype=decimal
@@ -3698,8 +3699,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \Budget::class,
                 'search_option'     => 7, // value
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_budgets`.`value` IS NULL OR `glpi_budgets`.`value` = '')",
-                'expected_and_not'  => "(`glpi_budgets`.`value` IS NOT NULL AND `glpi_budgets`.`value` <> '')",
+                'expected_and'      => "(((`glpi_budgets`.`value` IS NULL)) OR (`glpi_budgets`.`value` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_budgets`.`value` IS NULL)) OR (`glpi_budgets`.`value` = '')))",
             ];
             // log for both AND and AND NOT cases
             $this->hasPhpLogRecordThatContains("Truncated incorrect DECIMAL value: ''", LogLevel::WARNING);
@@ -3710,8 +3711,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \Contract::class,
                 'search_option'     => 11, // totalcost
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Contract_11` IS NULL OR `ITEM_Contract_11` = '')",
-                'expected_and_not'  => "(`ITEM_Contract_11` IS NOT NULL AND `ITEM_Contract_11` <> '')",
+                'expected_and'      => "(((`ITEM_Contract_11` IS NULL)) OR (`ITEM_Contract_11` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Contract_11` IS NULL)) OR (`ITEM_Contract_11` = '')))",
             ];
 
             // datatype=count (usehaving=true)
@@ -3719,8 +3720,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Ticket::class,
                 'search_option'     => 27, // number of followups
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Ticket_27` IS NULL OR `ITEM_Ticket_27` = '')",
-                'expected_and_not'  => "(`ITEM_Ticket_27` IS NOT NULL AND `ITEM_Ticket_27` <> '')",
+                'expected_and'      => "(((`ITEM_Ticket_27` IS NULL)) OR (`ITEM_Ticket_27` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Ticket_27` IS NULL)) OR (`ITEM_Ticket_27` = '')))",
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
@@ -3733,8 +3734,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Computer::class,
                 'search_option'     => 111, // memory size
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Computer_111` IS NULL OR `ITEM_Computer_111` = '')",
-                'expected_and_not'  => "(`ITEM_Computer_111` IS NOT NULL AND `ITEM_Computer_111` <> '')",
+                'expected_and'      => "(((`ITEM_Computer_111` IS NULL)) OR (`ITEM_Computer_111` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Computer_111` IS NULL)) OR (`ITEM_Computer_111` = '')))",
             ];
 
             // datatype=progressbar (with computation)
@@ -3751,8 +3752,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \CronTask::class,
                 'search_option'     => 6, // frequency
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_crontasks`.`frequency` IS NULL OR `glpi_crontasks`.`frequency` = '')",
-                'expected_and_not'  => "(`glpi_crontasks`.`frequency` IS NOT NULL AND `glpi_crontasks`.`frequency` <> '')",
+                'expected_and'      => "(((`glpi_crontasks`.`frequency` IS NULL)) OR (`glpi_crontasks`.`frequency` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_crontasks`.`frequency` IS NULL)) OR (`glpi_crontasks`.`frequency` = '')))",
             ];
             // log for both AND and AND NOT cases
             if ($is_mariadb) {
@@ -3765,8 +3766,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Ticket::class,
                 'search_option'     => 49, // actiontime
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Ticket_49` IS NULL OR `ITEM_Ticket_49` = '')",
-                'expected_and_not'  => "(`ITEM_Ticket_49` IS NOT NULL AND `ITEM_Ticket_49` <> '')",
+                'expected_and'      => "(((`ITEM_Ticket_49` IS NULL)) OR (`ITEM_Ticket_49` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Ticket_49` IS NULL)) OR (`ITEM_Ticket_49` = '')))",
             ];
 
             // datatype=datetime
@@ -3783,8 +3784,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Ticket::class,
                 'search_option'     => 188, // next_escalation_level
                 'value'             => $null_value,
-                'expected_and'      => "(`ITEM_Ticket_188` IS NULL OR `ITEM_Ticket_188` = '')",
-                'expected_and_not'  => "(`ITEM_Ticket_188` IS NOT NULL AND `ITEM_Ticket_188` <> '')",
+                'expected_and'      => "(((`ITEM_Ticket_188` IS NULL)) OR (`ITEM_Ticket_188` = ''))",
+                'expected_and_not'  => "(NOT ((((`ITEM_Ticket_188` IS NULL)) OR (`ITEM_Ticket_188` = '')))",
             ];
 
             // datatype=date
@@ -3813,8 +3814,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \Contact::class,
                 'search_option'     => 6, // email
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_contacts`.`email` IS NULL OR `glpi_contacts`.`email` = '')",
-                'expected_and_not'  => "(`glpi_contacts`.`email` IS NOT NULL AND `glpi_contacts`.`email` <> '')",
+                'expected_and'      => "(((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
             ];
 
             // datatype=weblink
@@ -3822,8 +3823,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => Document::class,
                 'search_option'     => 4, // link
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_documents`.`link` IS NULL OR `glpi_documents`.`link` = '')",
-                'expected_and_not'  => "(`glpi_documents`.`link` IS NOT NULL AND `glpi_documents`.`link` <> '')",
+                'expected_and'      => "(((`glpi_documents`.`link` IS NULL)) OR (`glpi_documents`.`link` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_documents`.`link` IS NULL)) OR (`glpi_documents`.`link` = '')))",
             ];
 
             // datatype=mac
@@ -3831,8 +3832,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \DeviceNetworkCard::class,
                 'search_option'     => 11, // mac_default
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` IS NULL OR `glpi_devicenetworkcards`.`mac_default` = '')",
-                'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` IS NOT NULL AND `glpi_devicenetworkcards`.`mac_default` <> '')",
+                'expected_and'      => "(((`glpi_devicenetworkcards`.`mac_default` IS NULL)) OR (`glpi_devicenetworkcards`.`mac_default` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_devicenetworkcards`.`mac_default` IS NULL)) OR (`glpi_devicenetworkcards`.`mac_default` = '')))",
             ];
 
             // datatype=color
@@ -3840,8 +3841,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => \Cable::class,
                 'search_option'     => 15, // color
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_cables`.`color` IS NULL OR `glpi_cables`.`color` = '')",
-                'expected_and_not'  => "(`glpi_cables`.`color` IS NOT NULL AND `glpi_cables`.`color` <> '')",
+                'expected_and'      => "(((`glpi_cables`.`color` IS NULL)) OR (`glpi_cables`.`color` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_cables`.`color` IS NULL)) OR (`glpi_cables`.`color` = '')))",
             ];
 
             // datatype=language
@@ -3849,8 +3850,8 @@ class SearchTest extends DbTestCase
                 'itemtype'          => User::class,
                 'search_option'     => 17, // language
                 'value'             => $null_value,
-                'expected_and'      => "(`glpi_users`.`language` IS NULL OR `glpi_users`.`language` = '')",
-                'expected_and_not'  => "(`glpi_users`.`language` IS NOT NULL AND `glpi_users`.`language` <> '')",
+                'expected_and'      => "(((`glpi_users`.`language` IS NULL)) OR (`glpi_users`.`language` = ''))",
+                'expected_and_not'  => "(NOT ((((`glpi_users`.`language` IS NULL)) OR (`glpi_users`.`language` = '')))",
             ];
         }
 
@@ -3863,21 +3864,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 4, // type
             'value'             => '^test',
             'expected_and'      => "(`glpi_computertypes`.`name` LIKE 'test%')",
-            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE 'test%' OR `glpi_computertypes`.`name` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computertypes`.`name` LIKE 'test%'))) OR (`glpi_computertypes`.`name` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 4, // type
             'value'             => 'test$',
             'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%test')",
-            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%test' OR `glpi_computertypes`.`name` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computertypes`.`name` LIKE '%test'))) OR (`glpi_computertypes`.`name` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 4, // type
             'value'             => '^test$',
             'expected_and'      => "(`glpi_computertypes`.`name` LIKE 'test')",
-            'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE 'test' OR `glpi_computertypes`.`name` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computertypes`.`name` LIKE 'test'))) OR (`glpi_computertypes`.`name` IS NULL))",
         ];
 
         // datatype=dropdown (usehaving=true)
@@ -3887,6 +3888,7 @@ class SearchTest extends DbTestCase
             'value'             => '^test',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test%')",
             'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test%' OR `ITEM_Ticket_142` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
         yield [
             'itemtype'          => Ticket::class,
@@ -3894,6 +3896,7 @@ class SearchTest extends DbTestCase
             'value'             => 'test$',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE '%test')",
             'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%test' OR `ITEM_Ticket_142` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
         yield [
             'itemtype'          => Ticket::class,
@@ -3901,6 +3904,7 @@ class SearchTest extends DbTestCase
             'value'             => '^test$',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test')",
             'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test' OR `ITEM_Ticket_142` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
 
         // datatype=itemlink
@@ -3910,6 +3914,7 @@ class SearchTest extends DbTestCase
             'value'             => '^test',
             'expected_and'      => "(`glpi_computers`.`name` LIKE 'test%')",
             'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test%' OR `glpi_computers`.`name` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
         yield [
             'itemtype'          => Computer::class,
@@ -3917,6 +3922,7 @@ class SearchTest extends DbTestCase
             'value'             => 'test$',
             'expected_and'      => "(`glpi_computers`.`name` LIKE '%test')",
             'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%test' OR `glpi_computers`.`name` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
         yield [
             'itemtype'          => Computer::class,
@@ -3924,6 +3930,7 @@ class SearchTest extends DbTestCase
             'value'             => '^test$',
             'expected_and'      => "(`glpi_computers`.`name` LIKE 'test')",
             'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test' OR `glpi_computers`.`name` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
 
         // datatype=itemlink (usehaving=true)
@@ -3933,6 +3940,7 @@ class SearchTest extends DbTestCase
             'value'             => '^test',
             'expected_and'      => "(`ITEM_Ticket_50` LIKE 'test%')",
             'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE 'test%' OR `ITEM_Ticket_50` IS NULL)",
+            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
         ];
         yield [
             'itemtype'          => Ticket::class,

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -205,7 +205,7 @@ class SearchTest extends DbTestCase
         $data = $this->doSearch('Software', $search_params);
 
         $this->assertMatchesRegularExpression(
-            "/HAVING\s*\(`ITEM_Computer_2`\s+IS\s+NOT\s+NULL\s*\)/",
+            "/HAVING\s*\(\s+NOT\s+\(`ITEM_Computer_2`\s+IS\s+NULL\s*\)/",
             $data['sql']['search']
         );
     }
@@ -453,7 +453,7 @@ class SearchTest extends DbTestCase
             '/LEFT JOIN\s*`glpi_assets_assets_peripheralassets`\s*AS `glpi_assets_assets_peripheralassets_Printer`\s*ON\s*\(`glpi_assets_assets_peripheralassets_Printer`\.`items_id_asset`\s*=\s*`glpi_computers`\.`id`\s*AND\s*`glpi_assets_assets_peripheralassets_Printer`.`itemtype_asset`\s*=\s*\'Computer\'\s*AND\s*`glpi_assets_assets_peripheralassets_Printer`.`itemtype_peripheral`\s*=\s*\'Printer\'\s*AND\s*`glpi_assets_assets_peripheralassets_Printer`.`is_deleted`\s*=\s*\'0\'\)/im',
             '/LEFT JOIN\s*`glpi_printers`\s*ON\s*\(`glpi_assets_assets_peripheralassets_Printer`\.`items_id_peripheral`\s*=\s*`glpi_printers`\.`id`/im',
             // match having
-            "/HAVING\s*`ITEM_Budget_2`\s+<>\s+'5'\s+AND\s+\(\(`ITEM_Printer_1`\s+NOT LIKE\s+'%HP%'\s+OR\s+`ITEM_Printer_1`\s+IS NULL\)\s*\)/",
+            "/HAVING\s*`ITEM_Budget_2`\s+<>\s+'5'\s+AND\s+\(\(\(\(\s+NOT\s+\(`ITEM_Printer_1`\s+LIKE\s+'%HP%'\)\)\)\s+OR\s+\(`ITEM_Printer_1`\s+IS NULL\)\)\)/",
         ];
 
         foreach ($regexps as $regexp) {

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3887,24 +3887,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 142, // document name
             'value'             => '^test',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test%' OR `ITEM_Ticket_142` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_142` LIKE 'test%'))) OR (`ITEM_Ticket_142` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
             'search_option'     => 142, // document name
             'value'             => 'test$',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE '%test')",
-            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%test' OR `ITEM_Ticket_142` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_142` LIKE '%test'))) OR (`ITEM_Ticket_142` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
             'search_option'     => 142, // document name
             'value'             => '^test$',
             'expected_and'      => "(`ITEM_Ticket_142` LIKE 'test')",
-            'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE 'test' OR `ITEM_Ticket_142` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_142` LIKE 'test'))) OR (`ITEM_Ticket_142` IS NULL))",
         ];
 
         // datatype=itemlink
@@ -3913,24 +3910,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 1, // name
             'value'             => '^test',
             'expected_and'      => "(`glpi_computers`.`name` LIKE 'test%')",
-            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test%' OR `glpi_computers`.`name` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`name` LIKE 'test%'))) OR (`glpi_computers`.`name` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 1, // name
             'value'             => 'test$',
             'expected_and'      => "(`glpi_computers`.`name` LIKE '%test')",
-            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%test' OR `glpi_computers`.`name` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`name` LIKE '%test'))) OR (`glpi_computers`.`name` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 1, // name
             'value'             => '^test$',
             'expected_and'      => "(`glpi_computers`.`name` LIKE 'test')",
-            'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE 'test' OR `glpi_computers`.`name` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`name` LIKE 'test'))) OR (`glpi_computers`.`name` IS NULL))",
         ];
 
         // datatype=itemlink (usehaving=true)
@@ -3939,22 +3933,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 50, // parent tickets
             'value'             => '^test',
             'expected_and'      => "(`ITEM_Ticket_50` LIKE 'test%')",
-            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE 'test%' OR `ITEM_Ticket_50` IS NULL)",
-            //'expected_and_not'  => "(NOT ((((`glpi_contacts`.`email` IS NULL)) OR (`glpi_contacts`.`email` = '')))",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_50` LIKE 'test%'))) OR (`ITEM_Ticket_50` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
             'search_option'     => 50, // parent tickets
             'value'             => 'test$',
             'expected_and'      => "(`ITEM_Ticket_50` LIKE '%test')",
-            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%test' OR `ITEM_Ticket_50` IS NULL)",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_50` LIKE '%test'))) OR (`ITEM_Ticket_50` IS NULL))",
         ];
         yield [
             'itemtype'          => Ticket::class,
             'search_option'     => 50, // parent tickets
             'value'             => '^test$',
             'expected_and'      => "(`ITEM_Ticket_50` LIKE 'test')",
-            'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE 'test' OR `ITEM_Ticket_50` IS NULL)",
+            'expected_and_not'  => "(NOT (`ITEM_Ticket_50` LIKE 'test'))) OR (`ITEM_Ticket_50` IS NULL))",
         ];
 
         // datatype=string
@@ -3963,21 +3956,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 47, // uuid
             'value'             => '^test',
             'expected_and'      => "(`glpi_computers`.`uuid` LIKE 'test%')",
-            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE 'test%' OR `glpi_computers`.`uuid` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`uuid` LIKE 'test%'))) OR (`glpi_computers`.`uuid` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 47, // uuid
             'value'             => 'test$',
             'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%test')",
-            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%test' OR `glpi_computers`.`uuid` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`uuid` LIKE '%test'))) OR (`glpi_computers`.`uuid` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 47, // uuid
             'value'             => '^test$',
             'expected_and'      => "(`glpi_computers`.`uuid` LIKE 'test')",
-            'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE 'test' OR `glpi_computers`.`uuid` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`uuid` LIKE 'test'))) OR (`glpi_computers`.`uuid` IS NULL))",
         ];
 
         // datatype=text
@@ -3986,21 +3979,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 16, // comment
             'value'             => '^test',
             'expected_and'      => "(`glpi_computers`.`comment` LIKE 'test%')",
-            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE 'test%' OR `glpi_computers`.`comment` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`comment` LIKE 'test%'))) OR (`glpi_computers`.`comment` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 16, // comment
             'value'             => 'test$',
             'expected_and'      => "(`glpi_computers`.`comment` LIKE '%test')",
-            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%test' OR `glpi_computers`.`comment` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`comment` LIKE '%test'))) OR (`glpi_computers`.`comment` IS NULL))",
         ];
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 16, // comment
             'value'             => '^test$',
             'expected_and'      => "(`glpi_computers`.`comment` LIKE 'test')",
-            'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE 'test' OR `glpi_computers`.`comment` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_computers`.`comment` LIKE 'test'))) OR (`glpi_computers`.`comment` IS NULL))",
         ];
 
         // datatype=email
@@ -4009,21 +4002,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 6, // email
             'value'             => '^myname@',
             'expected_and'      => "(`glpi_contacts`.`email` LIKE 'myname@%')",
-            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE 'myname@%' OR `glpi_contacts`.`email` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_contacts`.`email` LIKE 'myname@%'))) OR (`glpi_contacts`.`email` IS NULL))",
         ];
         yield [
             'itemtype'          => \Contact::class,
             'search_option'     => 6, // email
             'value'             => '@domain.tld$',
             'expected_and'      => "(`glpi_contacts`.`email` LIKE '%@domain.tld')",
-            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%@domain.tld' OR `glpi_contacts`.`email` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_contacts`.`email` LIKE '%@domain.tld'))) OR (`glpi_contacts`.`email` IS NULL))",
         ];
         yield [
             'itemtype'          => \Contact::class,
             'search_option'     => 6, // email
             'value'             => '^myname@domain.tld$',
             'expected_and'      => "(`glpi_contacts`.`email` LIKE 'myname@domain.tld')",
-            'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE 'myname@domain.tld' OR `glpi_contacts`.`email` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_contacts`.`email` LIKE 'myname@domain.tld'))) OR (`glpi_contacts`.`email` IS NULL))",
         ];
 
         // datatype=weblink
@@ -4032,21 +4025,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 4, // link
             'value'             => '^ftp://',
             'expected_and'      => "(`glpi_documents`.`link` LIKE 'ftp://%')",
-            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE 'ftp://%' OR `glpi_documents`.`link` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_documents`.`link` LIKE 'ftp://%'))) OR (`glpi_documents`.`link` IS NULL))",
         ];
         yield [
             'itemtype'          => Document::class,
             'search_option'     => 4, // link
             'value'             => '.pdf$',
             'expected_and'      => "(`glpi_documents`.`link` LIKE '%.pdf')",
-            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%.pdf' OR `glpi_documents`.`link` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_documents`.`link` LIKE '%.pdf'))) OR (`glpi_documents`.`link` IS NULL))",
         ];
         yield [
             'itemtype'          => Document::class,
             'search_option'     => 4, // link
             'value'             => '^ftp://domain.tld/document.pdf$',
             'expected_and'      => "(`glpi_documents`.`link` LIKE 'ftp://domain.tld/document.pdf')",
-            'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE 'ftp://domain.tld/document.pdf' OR `glpi_documents`.`link` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_documents`.`link` LIKE 'ftp://domain.tld/document.pdf'))) OR (`glpi_documents`.`link` IS NULL))",
         ];
 
         // datatype=mac
@@ -4055,21 +4048,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 11, // mac_default
             'value'             => '^a2:e5:aa',
             'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE 'a2:e5:aa%')",
-            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE 'a2:e5:aa%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_devicenetworkcards`.`mac_default` LIKE 'a2:e5:aa%'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
         ];
         yield [
             'itemtype'          => \DeviceNetworkCard::class,
             'search_option'     => 11, // mac_default
             'value'             => 'a2:e5:aa$',
             'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:e5:aa')",
-            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%a2:e5:aa' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_devicenetworkcards`.`mac_default` LIKE '%a2:e5:aa'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
         ];
         yield [
             'itemtype'          => \DeviceNetworkCard::class,
             'search_option'     => 11, // mac_default
             'value'             => '^15:f4:q4:a2:e5:aa$',
             'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '15:f4:q4:a2:e5:aa')",
-            'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '15:f4:q4:a2:e5:aa' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_devicenetworkcards`.`mac_default` LIKE '15:f4:q4:a2:e5:aa'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
         ];
 
         // datatype=color
@@ -4078,21 +4071,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 15, // color
             'value'             => '^#00',
             'expected_and'      => "(`glpi_cables`.`color` LIKE '#00%')",
-            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '#00%' OR `glpi_cables`.`color` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_cables`.`color` LIKE '#00%'))) OR (`glpi_cables`.`color` IS NULL))",
         ];
         yield [
             'itemtype'          => \Cable::class,
             'search_option'     => 15, // color
             'value'             => 'ff$',
             'expected_and'      => "(`glpi_cables`.`color` LIKE '%ff')",
-            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '%ff' OR `glpi_cables`.`color` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_cables`.`color` LIKE '%ff'))) OR (`glpi_cables`.`color` IS NULL))",
         ];
         yield [
             'itemtype'          => \Cable::class,
             'search_option'     => 15, // color
             'value'             => '^#00aaff$',
             'expected_and'      => "(`glpi_cables`.`color` LIKE '#00aaff')",
-            'expected_and_not'  => "(`glpi_cables`.`color` NOT LIKE '#00aaff' OR `glpi_cables`.`color` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_cables`.`color` LIKE '#00aaff'))) OR (`glpi_cables`.`color` IS NULL))",
         ];
 
         // datatype=language
@@ -4101,21 +4094,21 @@ class SearchTest extends DbTestCase
             'search_option'     => 17, // language
             'value'             => '^en_',
             'expected_and'      => "(`glpi_users`.`language` LIKE 'en\\\\_%')",
-            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE 'en\\\\_%' OR `glpi_users`.`language` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_users`.`language` LIKE 'en\\\\_%'))) OR (`glpi_users`.`language` IS NULL))",
         ];
         yield [
             'itemtype'          => User::class,
             'search_option'     => 17, // language
             'value'             => '_GB$',
             'expected_and'      => "(`glpi_users`.`language` LIKE '%\\\\_GB')",
-            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%\\\\_GB' OR `glpi_users`.`language` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_users`.`language` LIKE '%\\\\_GB'))) OR (`glpi_users`.`language` IS NULL))",
         ];
         yield [
             'itemtype'          => User::class,
             'search_option'     => 17, // language
             'value'             => '^en_GB$',
             'expected_and'      => "(`glpi_users`.`language` LIKE 'en\\\\_GB')",
-            'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE 'en\\\\_GB' OR `glpi_users`.`language` IS NULL)",
+            'expected_and_not'  => "(NOT (`glpi_users`.`language` LIKE 'en\\\\_GB'))) OR (`glpi_users`.`language` IS NULL))",
         ];
 
         // Check `>`, `>=`, `<` and `<=` operators on textual fields.
@@ -4130,7 +4123,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 4, // type
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_computertypes`.`name` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_computertypes`.`name` NOT LIKE '%{$searched_value}%' OR `glpi_computertypes`.`name` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_computertypes`.`name` LIKE '%{$searched_value}%'))) OR (`glpi_computertypes`.`name` IS NULL))",
                 ];
 
                 // datatype=dropdown (usehaving=true)
@@ -4139,7 +4132,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 142, // document name
                     'value'             => $searched_value,
                     'expected_and'      => "(`ITEM_Ticket_142` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`ITEM_Ticket_142` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_142` IS NULL)",
+                    'expected_and_not'  => "(NOT (`ITEM_Ticket_142` LIKE '%{$searched_value}%'))) OR (`ITEM_Ticket_142` IS NULL))",
                 ];
 
                 // datatype=itemlink
@@ -4148,7 +4141,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 1, // name
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_computers`.`name` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_computers`.`name` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`name` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_computers`.`name` LIKE '%{$searched_value}%'))) OR (`glpi_computers`.`name` IS NULL))",
                 ];
 
                 // datatype=itemlink (usehaving=true)
@@ -4157,7 +4150,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 50, // parent tickets
                     'value'             => $searched_value,
                     'expected_and'      => "(`ITEM_Ticket_50` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`ITEM_Ticket_50` NOT LIKE '%{$searched_value}%' OR `ITEM_Ticket_50` IS NULL)",
+                    'expected_and_not'  => "(NOT (`ITEM_Ticket_50` LIKE '%{$searched_value}%'))) OR (`ITEM_Ticket_50` IS NULL))",
                 ];
 
                 // datatype=string
@@ -4166,7 +4159,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 47, // uuid
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_computers`.`uuid` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_computers`.`uuid` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`uuid` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_computers`.`uuid` LIKE '%{$searched_value}%'))) OR (`glpi_computers`.`uuid` IS NULL))",
                 ];
 
                 // datatype=text
@@ -4175,7 +4168,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 16, // comment
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_computers`.`comment` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_computers`.`comment` NOT LIKE '%{$searched_value}%' OR `glpi_computers`.`comment` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_computers`.`comment` LIKE '%{$searched_value}%'))) OR (`glpi_computers`.`comment` IS NULL))",
                 ];
 
                 // datatype=email
@@ -4184,7 +4177,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 6, // email
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_contacts`.`email` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_contacts`.`email` NOT LIKE '%{$searched_value}%' OR `glpi_contacts`.`email` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_contacts`.`email` LIKE '%{$searched_value}%'))) OR (`glpi_contacts`.`email` IS NULL))",
                 ];
 
                 // datatype=weblink
@@ -4193,7 +4186,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 4, // link
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_documents`.`link` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_documents`.`link` NOT LIKE '%{$searched_value}%' OR `glpi_documents`.`link` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_documents`.`link` LIKE '%{$searched_value}%'))) OR (`glpi_documents`.`link` IS NULL))",
                 ];
 
                 // datatype=mac
@@ -4202,7 +4195,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 11, // mac_default
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_devicenetworkcards`.`mac_default` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_devicenetworkcards`.`mac_default` NOT LIKE '%{$searched_value}%' OR `glpi_devicenetworkcards`.`mac_default` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_devicenetworkcards`.`mac_default` LIKE '%{$searched_value}%'))) OR (`glpi_devicenetworkcards`.`mac_default` IS NULL))",
                 ];
 
                 // datatype=color
@@ -4220,7 +4213,7 @@ class SearchTest extends DbTestCase
                     'search_option'     => 17, // language
                     'value'             => $searched_value,
                     'expected_and'      => "(`glpi_users`.`language` LIKE '%{$searched_value}%')",
-                    'expected_and_not'  => "(`glpi_users`.`language` NOT LIKE '%{$searched_value}%' OR `glpi_users`.`language` IS NULL)",
+                    'expected_and_not'  => "(NOT (`glpi_users`.`language` LIKE '%{$searched_value}%'))) OR (`glpi_users`.`language` IS NULL))",
                 ];
             }
         }
@@ -4370,7 +4363,7 @@ class SearchTest extends DbTestCase
                         'search_option'     => 188, // next_escalation_level
                         'value'             => $searched_value,
                         'expected_and'      => "(`ITEM_Ticket_188` LIKE '%{$like_value}%')",
-                        'expected_and_not'  => "(`ITEM_Ticket_188` NOT LIKE '%{$like_value}%' OR `ITEM_Ticket_188` IS NULL)",
+                        'expected_and_not'  => "(NOT (`ITEM_Ticket_188` LIKE '%{$like_value}%'))) OR (`ITEM_Ticket_188` IS NULL))",
                     ];
 
                     // datatype=date


### PR DESCRIPTION
The goal is to rely on "standard" iterator instructions rather than just encapsulating raw SQL code in a QueryExpression.

I also made minor changes; to fix phpstan issues that were already existing, but which also impact the new code.