### PR TITLE
Fix - Lock sub-tabs content when creating object from template

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -43,6 +43,8 @@ use Glpi\Search\FilterableInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\parse_url;
+use function Safe\ob_start;
+use function Safe\ob_get_clean;
 
 /**
  * Common GLPI object
@@ -709,30 +711,22 @@ class CommonGLPI implements CommonGLPIInterface
                     return $ret;
                 }
 
-                // Check if we're creating an object from template and this is not the main tab
-                if ($withtemplate == 2 && $tabnum != 'main' && $item instanceof CommonDBTM) {
-                    // Display generic message for template creation
-                    $template = <<<HTML
-                    <div class="alert alert-warning d-flex">
-                        <div class="me-2">
-                            <i class="ti ti-info-circle"></i>
-                        </div>
-                        <div>
-                            <strong>%s</strong><br>
-                            %s
-                        </div>
-                    </div>
-                    HTML;
-                    echo sprintf(
-                        $template,
-                        __s('Creating from template'),
-                        __s('You are currently creating an object from a template. You need to save it, in the main tab, before editing data in other tabs.')
-                    );
-                }
-
                 if ($obj = getItemForItemtype($itemtype)) {
                     $options['tabnum'] = $tabnum;
                     $options['itemtype'] = $itemtype;
+
+                    // When creating from template, display a warning and render tab content
+                    // in a non-interactive wrapper to prevent accidental edits on the template.
+                    if ($withtemplate == 2 && $tabnum != 'main' && $item instanceof CommonDBTM) {
+                        ob_start();
+                        $obj->displayTabContentForItem($item, (int) $tabnum, $withtemplate);
+                        $tab_content = ob_get_clean();
+                        TemplateRenderer::getInstance()->display('components/tab/creating_from_template.html.twig', [
+                            'tab_content' => $tab_content,
+                        ]);
+                        return true;
+                    }
+
                     Plugin::doHook(Hooks::PRE_SHOW_TAB, [ 'item' => $item, 'options' => &$options]);
                     Profiler::getInstance()->start(get_class($obj) . '::displayTabContentForItem');
                     $ret = $obj->displayTabContentForItem($item, (int) $tabnum, $withtemplate);

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -42,9 +42,9 @@ use Glpi\Search\CriteriaFilter;
 use Glpi\Search\FilterableInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-use function Safe\parse_url;
-use function Safe\ob_start;
 use function Safe\ob_get_clean;
+use function Safe\ob_start;
+use function Safe\parse_url;
 
 /**
  * Common GLPI object

--- a/templates/components/tab/creating_from_template.html.twig
+++ b/templates/components/tab/creating_from_template.html.twig
@@ -1,0 +1,45 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="alert alert-warning d-flex">
+    <div class="me-2">
+        <i class="ti ti-info-circle"></i>
+    </div>
+    <div>
+        <strong>{{ __('Creating from template') }}</strong><br>
+        {{ __('You are currently creating an object from a template. You need to save it, in the main tab, before editing data in other tabs.') }}
+    </div>
+</div>
+
+<div class="pe-none opacity-50" aria-hidden="true">
+    {{ tab_content|raw }}
+</div>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !41602
- Here is a brief description of what this PR does

When creating an object from a template (`withtemplate = 2`), sub-tabs were already showing a warning message (introduced in #22293) but their content remained fully interactive. Users could still click links, trigger mass actions, and edit rows — accidentally modifying the original template instead of the new unsaved object.

### Changes

- **CommonGLPI.php** — Consolidated the warning logic in `displayStandardTab()`: the tab content is now captured via output buffering and passed to a Twig template that wraps it in a non-interactive container.
- **creating_from_template.html.twig** — New component that renders the warning alert and the tab content inside a `pe-none opacity-50` wrapper (`pointer-events: none`), blocking all clicks and visually indicating the locked state.

### Result

All sub-tabs (links, mass action checkboxes, edit/delete buttons) are fully non-interactive until the object is saved. The fix is applied at a single point in `CommonGLPI::displayStandardTab()`, covering every tab and every itemtype automatically.

## Screenshots (if appropriate):

Before : 

<img width="981" height="495" alt="image" src="https://github.com/user-attachments/assets/1ea48574-e606-46d9-9a43-2e7a2ce54aab" />

After : 

<img width="981" height="495" alt="image" src="https://github.com/user-attachments/assets/ead102ab-402f-4550-877d-7b3fa70dfdcd" />
