### PR TITLE
ui(CommonITILObjectItems): add Model column to items list

### DIFF
--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -460,7 +460,8 @@ TWIG, $twig_params);
                 continue;
             }
 
-            $model_fkey = $itemtype::getModelForeignKeyField();
+            $model_class = $itemtype::getModelClass();
+            $model_fkey = $model_class != null ? $model_class::getForeignKeyField() : null;
 
             $iterator = static::getTypeItems($instID, $itemtype);
             foreach ($iterator as $data) {

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -460,8 +460,7 @@ TWIG, $twig_params);
                 continue;
             }
 
-            $model_class = $itemtype . 'Model';
-            $model_fkey = class_exists($model_class) ? getForeignKeyFieldForTable($model_class::getTable()) : null;
+            $model_fkey = $itemtype::getModelForeignKeyField();
 
             $iterator = static::getTypeItems($instID, $itemtype);
             foreach ($iterator as $data) {

--- a/src/CommonItilObject_Item.php
+++ b/src/CommonItilObject_Item.php
@@ -460,19 +460,29 @@ TWIG, $twig_params);
                 continue;
             }
 
+            $model_class = $itemtype . 'Model';
+            $model_fkey = class_exists($model_class) ? getForeignKeyFieldForTable($model_class::getTable()) : null;
+
             $iterator = static::getTypeItems($instID, $itemtype);
             foreach ($iterator as $data) {
                 $item->getFromDB($data["id"]);
+
+                $model = '-';
+                if ($model_fkey !== null && isset($data[$model_fkey]) && $data[$model_fkey] > 0) {
+                    $model = Dropdown::getDropdownName($model_class::getTable(), $data[$model_fkey]);
+                }
+
                 $entry = [
                     'itemtype' => static::class,
                     'id'   => $data["linkid"],
                     'row_class' => $data['is_deleted'] ? 'table-deleted' : '',
                     'linked_itemtype' => $item::getTypeName(1),
+                    'model'  => $model,
                     'serial'  => $data["serial"] ?? "-",
                     'otherserial' => $data["otherserial"] ?? "-",
                     'entity' => Dropdown::getDropdownName("glpi_entities", $data['entity']),
-                    'state' => Dropdown::getDropdownName("glpi_states", $data['states_id']),
-                    'location' => Dropdown::getDropdownName("glpi_locations", $data['locations_id']),
+                    'state' => isset($data['states_id']) ? Dropdown::getDropdownName("glpi_states", $data['states_id']) : "",
+                    'location' => isset($data['locations_id']) ? Dropdown::getDropdownName("glpi_locations", $data['locations_id']) : "",
                     'kb' => $item->getKBLinks(),
                     'showmassiveactions' => $canedit && !$is_closed,
                 ];
@@ -502,6 +512,7 @@ TWIG, $twig_params);
                 'linked_itemtype' => _n('Type', 'Types', 1),
                 'entity'          => Entity::getTypeName(1),
                 'name'            => __('Name'),
+                'model'           => _n('Model', 'Models', 1),
                 'serial'          => __('Serial number'),
                 'otherserial'     => __('Inventory number'),
                 'kb'              => __('Knowledge base entries'),


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42074
- Added the “Model” column to the “Items” tab of ITIL Objects

## Screenshots (if appropriate):

Before:
<img width="1654" height="544" alt="image" src="https://github.com/user-attachments/assets/0524d65d-2373-4c79-8021-ff039f700c4f" />

After:
<img width="1654" height="544" alt="image" src="https://github.com/user-attachments/assets/7e8cc995-1895-47c8-af19-06863e6fad51" />


