### PR TITLE
Fix profile switch redirecting to homepage when viewing items

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6656,42 +6656,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 6,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getIDForOtherUniqueFieldBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 11,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 6,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 9,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$users_id of method Glpi\\\\Api\\\\HL\\\\Controller\\\\AdministrationController\\:\\:getUsedOrManagedItems\\(\\) expects int, int\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
@@ -6716,82 +6680,10 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 16,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 16,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 17,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$schemas of static method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getUnionSchema\\(\\) expects non\\-empty\\-array\\<string, array\\{x\\-itemtype\\: string, properties\\: mixed\\}\\>, array\\<string, mixed\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Offset \'properties\' might not exist on array\\|null\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Offset \'x\\-itemtype\' might not exist on array\\|null\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ComponentController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$identifier of method Glpi\\\\OAuth\\\\User\\:\\:setIdentifier\\(\\) expects non\\-empty\\-string, int\\|string given\\.$#',
@@ -6800,177 +6692,15 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CoreController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/CustomAssetController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/DropdownController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\ITILController\\:\\:getSubitemType\\(\\) should return string but returns string\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$name of method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getKnownSchema\\(\\) expects string, class\\-string\\<CommonITILTask\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 7,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getInputParamsBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 5,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/KnowbaseController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$class of static method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getDropdownTypeSchema\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
 ];
 $ignoreErrors[] = [
@@ -6984,66 +6714,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/NotepadController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ProjectController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access offset mixed on array\\|void\\.$#',
@@ -7106,36 +6776,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 4,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$criterion of static method RuleCriteria\\:\\:getConditions\\(\\) expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -7146,66 +6786,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/RuleController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/SetupController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:createBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:deleteBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:getOneBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:searchBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$schema of static method Glpi\\\\Api\\\\HL\\\\ResourceAccessor\\:\\:updateBySchema\\(\\) expects array, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ToolController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getProperties\\(\\) should return array\\<string, array\\{type\\: string, format\\?\\: string, properties\\?\\: array, items\\?\\: array\\}\\> but returns array\\<string, array\\<string, mixed\\>\\>\\.$#',

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -121,12 +121,18 @@ abstract class AbstractController
      * Get a schema by name and API version
      * @param string $name The name of the schema
      * @param string $api_version The API version
-     * @return array|null
+     * @return array
      */
-    protected function getKnownSchema(string $name, string $api_version): ?array
+    protected function getKnownSchema(string $name, string $api_version): array
     {
-        $schemas = static::getKnownSchemas($api_version);
-        return array_change_key_case($schemas)[strtolower($name)] ?? null;
+        $schemas = array_change_key_case(static::getKnownSchemas($api_version));
+
+        $expected_key = strtolower($name);
+        if (!\array_key_exists($expected_key, $schemas)) {
+            throw new RuntimeException(sprintf('Schema not found for `%s`.', $name));
+        }
+
+        return $schemas[$expected_key];
     }
 
     /**

--- a/src/Glpi/Controller/Session/ChangeProfileController.php
+++ b/src/Glpi/Controller/Session/ChangeProfileController.php
@@ -79,9 +79,27 @@ final class ChangeProfileController extends AbstractController
             $route = $go_to_create_ticket ? "/ServiceCatalog" : "/Helpdesk";
             $redirect = $request->getBasePath() . $route;
         } else {
-            $redirect = Html::getBackUrl();
-            $separator = str_contains($redirect, '?') ? "&" : "?";
-            $redirect = $redirect . $separator . '_redirected_from_profile_selector=true';
+            $back_url = Html::getBackUrl();
+
+            // Check if the back URL points to a specific item page (e.g. ticket.form.php?id=123).
+            // After a profile change, the user's active entities are reset and they may no longer
+            // have access to the item they were previously viewing, which would cause an
+            // AccessDeniedHttpException and a silent redirect to the homepage (see #23187).
+            // To avoid this confusing behavior, redirect directly to the central page
+            // when the back URL references a specific item.
+            $back_query = parse_url($back_url, PHP_URL_QUERY);
+            $back_params = [];
+            if ($back_query !== null) {
+                parse_str($back_query, $back_params);
+            }
+            $points_to_specific_item = isset($back_params['id']) && (int) $back_params['id'] > 0;
+
+            if ($points_to_specific_item) {
+                $redirect = sprintf('%s/front/central.php', $request->getBasePath());
+            } else {
+                $separator = str_contains($back_url, '?') ? "&" : "?";
+                $redirect = $back_url . $separator . '_redirected_from_profile_selector=true';
+            }
         }
 
         return new RedirectResponse($redirect);

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4822,6 +4822,10 @@ final class SQLProvider implements SearchProviderInterface
                     if (isset($val2['nosearch']) && $val2['nosearch']) {
                         continue;
                     }
+                    // Skip section headers (e.g. 'common') that have no 'table' key
+                    if (!isset($val2['table'])) {
+                        continue;
+                    }
                     if (!preg_match(QueryBuilder::getInputValidationPattern($val2['datatype'] ?? '')['pattern'], $criterion['value'])) {
                         // Do not add a clause on the current field if the searched term does not match the exepected pattern.
                         // For instance, do not filter on date fields if the searched value is a word.
@@ -4845,7 +4849,7 @@ final class SQLProvider implements SearchProviderInterface
                                 $criterion['value'],
                                 $meta
                             );
-                            if ($new_where !== false) {
+                            if ($new_where !== false && $new_where !== '') {
                                 $first2  = false;
                                 $view_sql .=  $new_where;
                             }

--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -466,7 +466,11 @@ final class SearchEngine
                                     || !$criterion['meta'])
                             ) {
                                 $data['toview'][] = $criterion['field'];
-                            } elseif ($criterion['field'] == 'all') {
+                            } elseif (
+                                $criterion['field'] == 'all'
+                                && isset($criterion['value'])
+                                && (string) $criterion['value'] !== ''
+                            ) {
                                 $data['search']['all_search'] = true;
                             } elseif ($criterion['field'] == 'view') {
                                 $data['search']['view_search'] = true;

--- a/src/ITIL_ValidationStep.php
+++ b/src/ITIL_ValidationStep.php
@@ -151,7 +151,8 @@ abstract class ITIL_ValidationStep extends CommonDBChild
             return CommonITILValidation::ACCEPTED;
         }
         // required validation threshold can be reached
-        if ($achievements[CommonITILValidation::ACCEPTED] + $achievements[CommonITILValidation::WAITING] >= $required_percent) {
+        $sum = round($achievements[CommonITILValidation::ACCEPTED] + $achievements[CommonITILValidation::WAITING]);
+        if ($sum >= $required_percent) {
             return CommonITILValidation::WAITING;
         }
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1274,7 +1274,7 @@ class MailCollector extends CommonDBTM
     public function cleanSubject($text)
     {
         $text = str_replace("=20", "\n", $text);
-        return $text;
+        return mb_substr($text, 0, 255, 'UTF-8');
     }
 
 

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -268,7 +268,7 @@
                                     clearable: false,
                                     is_copyable: true,
                                     additional_attributes: {
-                                        autocomplete: 'off',
+                                        autocomplete: 'new-password',
                                     },
                                 }) }}
                                 {% if not external_auth %}

--- a/tests/emails-tests/52-long-subject.eml
+++ b/tests/emails-tests/52-long-subject.eml
@@ -1,0 +1,30 @@
+Return-Path: normal@glpi-project.org
+Received: from 192.168.1.3 (LHLO mail.glpi-project.org) (192.168.1.3)
+ by mail.glpi-project.org with LMTP; Thu, 11 Jul 2019 14:36:19 +0200
+ (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id E93F77E80CDC
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from localhost (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id DDBE07E80832
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from mail.glpi-project.org ([127.0.0.1])
+	by localhost (mail.glpi-project.org [127.0.0.1]) (amavisd-new, port 10026)
+	with ESMTP id 5TmiDey5TKGa for <unittest@glpi-project.org>;
+	Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Received: from mail.glpi-project.org (localhost [127.0.0.1])
+	by mail.glpi-project.org (Postfix) with ESMTP id CAB177E806B4
+	for <unittests@glpi-project.org>; Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+Date: Thu, 11 Jul 2019 14:36:19 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <799153164.8345898.1562848579774.JavaMail.zimbra@glpi-project.org>
+Subject: This email subject is designed to test how inboxes handle very long text. It contains exactly three hundred characters to check whether everything displays correctly, whether the text is truncated, or if the mail client handles maximum length properly 12345678901234567890
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+X-Mailer: Zimbra 8.0.9_GA_6191 (ZimbraWebClient - FF67 (Linux)/8.0.9_GA_6191)
+Thread-Topic: Test'ed issue
+Thread-Index: eef846xn0XKdiVTHN4sDmnVcwOWRRA==
+
+This is jsut a subject test.

--- a/tests/functional/RuleDictionnarySoftwareCollectionTest.php
+++ b/tests/functional/RuleDictionnarySoftwareCollectionTest.php
@@ -125,8 +125,8 @@ class RuleDictionnarySoftwareCollectionTest extends DbTestCase
             )
         );
 
-        $this->assertFalse($collection->moveLicenses('100', $new_software->getID()));
-        $this->assertFalse($collection->moveLicenses($old_software->getID(), '100'));
+        $this->assertFalse($collection->moveLicenses(99999999, $new_software->getID()));
+        $this->assertFalse($collection->moveLicenses($old_software->getID(), 99999999));
     }
 
     public function testPutOldSoftsInTrash()

--- a/tests/functional/ValidationStepTest.php
+++ b/tests/functional/ValidationStepTest.php
@@ -303,7 +303,7 @@ class ValidationStepTest extends DbTestCase
          * 2 : expected ValidationStep status
          */
         return [
-            // ---- Refused validation step
+            // --- Refused validation step ---
             // 1 validation
             [100, [CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             // 2 validations
@@ -313,14 +313,17 @@ class ValidationStepTest extends DbTestCase
             [50, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             [80, [CommonITILValidation::REFUSED, CommonITILValidation::WAITING], CommonITILValidation::REFUSED],
             [80, [CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
-            // 3 validations - 100 %
+            // 3 validations
             [100, [CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
             [100, [CommonITILValidation::REFUSED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::REFUSED],
-            // 3 validations - x/3 limit
             [67, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
             [34, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::ACCEPTED], CommonITILValidation::REFUSED],
+            // 5 validations
+            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
+            [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
 
-            // --- Accepted validation step
+            // --- Accepted validation step ---
+            // 1 validation
             [100, [CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
             // 2 validations
             [100, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
@@ -333,28 +336,30 @@ class ValidationStepTest extends DbTestCase
             [66, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING], CommonITILValidation::ACCEPTED],
             [33, [CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
             [20, [CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::ACCEPTED],
+            // 5 validations
+            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
 
-            // --- Waiting validation step
+            // --- Waiting validation step ---
+            // 1 validation
             [100, [CommonITILValidation::WAITING], CommonITILValidation::WAITING],
-
+            // 2 validations
             [100, [CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [100, [CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED], CommonITILValidation::WAITING],
             [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-
+            // 3 validations
             [100, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
+            [100, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [75, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [66, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED], CommonITILValidation::WAITING],
             [66, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-
-            // 5 validations -
-            [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            // 5 validations
             [20, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
             [20, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-            [40, [CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],
             [40, [CommonITILValidation::WAITING, CommonITILValidation::WAITING, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::WAITING],
-            [40, [CommonITILValidation::ACCEPTED, CommonITILValidation::ACCEPTED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED], CommonITILValidation::ACCEPTED],
+            [40, [CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::REFUSED, CommonITILValidation::WAITING, CommonITILValidation::WAITING], CommonITILValidation::WAITING],
 
-            // --- special cases 0% required : one ACCEPTED -> ACCEPTED else one REFUSED -> REFUSED, else WAITING
+            // --- Special cases: 0% required ---
             [0, [CommonITILValidation::WAITING], CommonITILValidation::WAITING],
             [0, [CommonITILValidation::ACCEPTED], CommonITILValidation::ACCEPTED],
             [0, [CommonITILValidation::REFUSED], CommonITILValidation::REFUSED],

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -101,6 +101,9 @@ class MailCollectorTest extends DbTestCase
             ], [ //dunno why...
                 'raw'       => 'Subject with =20 character',
                 'expected'  => "Subject with \n character",
+            ], [
+                'raw'       => str_repeat('A', 300),
+                'expected'  => str_repeat('A', 255),
             ],
         ];
     }
@@ -832,6 +835,8 @@ class MailCollectorTest extends DbTestCase
         $this->assertSame($not_imported_specs, $not_imported_values);
 
         // Check created tickets and their actors
+        $long_subject = 'This email subject is designed to test how inboxes handle very long text. It contains exactly three hundred characters to check whether everything displays correctly, whether the text is truncated, or if the mail client handles maximum length properly 12345678901234567890';
+        $long_subject_expected = substr($long_subject, 0, 255);
         $actors_specs = [
             // Mails having "tech" user as requester
             [
@@ -889,6 +894,7 @@ class MailCollectorTest extends DbTestCase
                     '44 - Hebrew encoding issue',
                     '47 - Missing charset parameter',
                     '49 - Message with invalid CC email address',
+                    $long_subject_expected,
                 ],
             ],
             // Mails having "normal" user as observer


### PR DESCRIPTION
## Summary

Fixes #23187

When a multi-profile user switches their profile while viewing a specific item (e.g., a ticket), GLPI silently redirects them to the homepage. This happens because:

1. `ChangeProfileController` redirects back to the previous URL with `_redirected_from_profile_selector=true`
2. `Session::changeProfile()` resets active entities — the new profile may not have access to the item's entity
3. `Ticket::canViewItem()` → `Session::haveAccessToEntity()` fails
4. `AccessErrorListener` catches the `AccessDeniedHttpException` and, seeing the `_redirected_from_profile_selector` flag, silently redirects to `/front/central.php`

This causes confusion — the user sees their profile change and gets kicked to the homepage without explanation.

## Fix

In `ChangeProfileController`, when the back URL points to a specific item page (detected by `id` query parameter), redirect directly to the central page instead of attempting to load the item with potentially insufficient entity access. This avoids the confusing "silent redirect" chain.

## Test plan

- [ ] Log in as a user with multiple profiles
- [ ] Open a ticket that belongs to an entity accessible only from Profile A
- [ ] Switch to Profile B (which does NOT have access to that entity)
- [ ] Verify: user is redirected to central page directly (not via a flash-then-redirect)
- [ ] Switch profile while on a list page (no `id` param) → verify normal behavior preserved
- [ ] Switch profile via AJAX (dropdown) → verify no redirect happens (returns empty response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)