### PR TITLE
Permissions modal UI rework

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -210,6 +210,33 @@
     }
 }
 
+// KB permission owner line
+.kb-permission-owner {
+    background-color: var(--tblr-body-bg);
+    margin: calc(-1 * var(--tblr-modal-padding)) calc(-1 * var(--tblr-modal-padding)) 1rem;
+    padding: var(--tblr-modal-padding);
+    border-bottom: 1px solid var(--tblr-border-color);
+}
+
+// KB permission visibility fields (AJAX-loaded from visibility.php)
+.kb-permission-visibility {
+    // Override the inline d-flex from visibility.php to stack fields
+    > .d-flex {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    // Override the legacy table from subvisibility.php
+    .tab_format {
+        width: 100%;
+
+        td {
+            padding: 0.25rem 0.375rem;
+            white-space: nowrap;
+        }
+    }
+}
 
 // KB modal tabs navigation
 .kb-modal-nav {

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -210,12 +210,13 @@
     }
 }
 
-// KB permission owner line
+// KB permission owner footer (full-width, differentiated background)
 .kb-permission-owner {
     background-color: var(--tblr-body-bg);
-    margin: calc(-1 * var(--tblr-modal-padding)) calc(-1 * var(--tblr-modal-padding)) 1rem;
+    margin: 0 calc(-1 * var(--tblr-modal-padding)) calc(-1 * var(--tblr-modal-padding));
     padding: var(--tblr-modal-padding);
-    border-bottom: 1px solid var(--tblr-border-color);
+    border-top: 1px solid var(--tblr-border-color);
+    border-radius: 0 0 var(--tblr-modal-inner-border-radius) var(--tblr-modal-inner-border-radius);
 }
 
 // KB permission visibility fields (AJAX-loaded from visibility.php)

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -34,12 +34,17 @@
 
 namespace Glpi\Controller\Knowbase;
 
+use Entity_KnowbaseItem;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractController;
+use Glpi\Controller\CrudControllerTrait;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\RichText\RichText;
+use Group_KnowbaseItem;
 use KnowbaseItem;
+use KnowbaseItem_Profile;
+use KnowbaseItem_User;
 use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,6 +56,8 @@ use function Safe\json_decode;
 
 final class KnowbaseItemController extends AbstractController
 {
+    use CrudControllerTrait;
+
     #[Route(
         "/Knowbase/KnowbaseItem/{knowbaseitems_id}/Content",
         name: "knowbaseitem_content",
@@ -250,5 +257,35 @@ final class KnowbaseItemController extends AbstractController
         return new StreamedResponse(static function () use ($twig_params) {
             TemplateRenderer::getInstance()->display('pages/tools/search_knowbaseitem.html.twig', $twig_params);
         });
+    }
+
+    private const ALLOWED_PERMISSION_TYPES = [
+        'KnowbaseItem_User'    => KnowbaseItem_User::class,
+        'Group_KnowbaseItem'   => Group_KnowbaseItem::class,
+        'Entity_KnowbaseItem'  => Entity_KnowbaseItem::class,
+        'KnowbaseItem_Profile' => KnowbaseItem_Profile::class,
+    ];
+
+    #[Route(
+        "/Knowbase/KnowbaseItem/Permission/{itemtype}/{permission_id}",
+        name: "knowbaseitem_delete_permission",
+        methods: ["POST"],
+        requirements: [
+            'itemtype' => 'KnowbaseItem_User|Group_KnowbaseItem|Entity_KnowbaseItem|KnowbaseItem_Profile',
+            'permission_id' => '\d+',
+        ]
+    )]
+    public function deletePermission(Request $request): JsonResponse
+    {
+        $itemtype = $request->get('itemtype');
+        $permission_id = (int) $request->get('permission_id');
+
+        if (!isset(self::ALLOWED_PERMISSION_TYPES[$itemtype])) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->purge(self::ALLOWED_PERMISSION_TYPES[$itemtype], $permission_id);
+
+        return new JsonResponse(['success' => true]);
     }
 }

--- a/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
+++ b/src/Glpi/Controller/Knowbase/KnowbaseItemController.php
@@ -277,8 +277,8 @@ final class KnowbaseItemController extends AbstractController
     )]
     public function deletePermission(Request $request): JsonResponse
     {
-        $itemtype = $request->get('itemtype');
-        $permission_id = (int) $request->get('permission_id');
+        $itemtype = $request->attributes->get('itemtype');
+        $permission_id = (int) $request->attributes->get('permission_id');
 
         if (!isset(self::ALLOWED_PERMISSION_TYPES[$itemtype])) {
             throw new NotFoundHttpException();

--- a/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
@@ -35,17 +35,13 @@
 namespace Glpi\Knowbase\SidePanel;
 
 use Dropdown;
-use Entity;
 use Entity_KnowbaseItem;
-use Group;
 use Group_KnowbaseItem;
 use KnowbaseItem;
 use KnowbaseItem_Profile;
 use KnowbaseItem_User;
 use Override;
-use Profile;
 use Session;
-use User;
 
 final class PermissionsRenderer implements RendererInterface
 {
@@ -102,7 +98,7 @@ final class PermissionsRenderer implements RendererInterface
      *
      * @param KnowbaseItem $item
      * @param int $owner_id
-     * @return array<int, array{itemtype: string, id: int, type: string, type_label: string, name: string, icon: string, badge_class: string, entity_name: ?string, is_recursive: bool, is_owner: bool}>
+     * @return array<int, array{itemtype: string, id: int, type: string, name: string, icon: string, badge_class: string, entity_name: ?string, is_recursive: bool, users_id: ?int}>
      */
     private function buildEntries(KnowbaseItem $item, int $owner_id): array
     {
@@ -112,17 +108,19 @@ final class PermissionsRenderer implements RendererInterface
         $users = KnowbaseItem_User::getUsers($id);
         foreach ($users as $val) {
             foreach ($val as $data) {
+                if ((int) $data['users_id'] === $owner_id) {
+                    continue; // Owner displayed separately in footer
+                }
                 $entries[] = [
-                    'itemtype'     => 'KnowbaseItem_User',
+                    'itemtype'     => KnowbaseItem_User::class,
                     'id'           => $data['id'],
                     'type'         => 'User',
-                    'type_label'   => User::getTypeName(1),
                     'name'         => getUserName($data['users_id']),
+                    'users_id'     => (int) $data['users_id'],
                     'icon'         => 'ti-user',
                     'badge_class'  => 'bg-azure-lt',
                     'entity_name'  => null,
                     'is_recursive' => false,
-                    'is_owner'     => ((int) $data['users_id'] === $owner_id),
                 ];
             }
         }
@@ -135,16 +133,15 @@ final class PermissionsRenderer implements RendererInterface
                     $entity_name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
                 }
                 $entries[] = [
-                    'itemtype'     => 'Group_KnowbaseItem',
+                    'itemtype'     => Group_KnowbaseItem::class,
                     'id'           => $data['id'],
                     'type'         => 'Group',
-                    'type_label'   => Group::getTypeName(1),
                     'name'         => Dropdown::getDropdownName('glpi_groups', $data['groups_id']),
+                    'users_id'     => null,
                     'icon'         => 'ti-users-group',
                     'badge_class'  => 'bg-green-lt',
                     'entity_name'  => $entity_name,
                     'is_recursive' => (bool) $data['is_recursive'],
-                    'is_owner'     => false,
                 ];
             }
         }
@@ -153,16 +150,15 @@ final class PermissionsRenderer implements RendererInterface
         foreach ($entities as $val) {
             foreach ($val as $data) {
                 $entries[] = [
-                    'itemtype'     => 'Entity_KnowbaseItem',
+                    'itemtype'     => Entity_KnowbaseItem::class,
                     'id'           => $data['id'],
                     'type'         => 'Entity',
-                    'type_label'   => Entity::getTypeName(1),
                     'name'         => Dropdown::getDropdownName('glpi_entities', $data['entities_id']),
+                    'users_id'     => null,
                     'icon'         => 'ti-building',
                     'badge_class'  => 'bg-yellow-lt',
                     'entity_name'  => null,
                     'is_recursive' => (bool) $data['is_recursive'],
-                    'is_owner'     => false,
                 ];
             }
         }
@@ -175,16 +171,15 @@ final class PermissionsRenderer implements RendererInterface
                     $entity_name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
                 }
                 $entries[] = [
-                    'itemtype'     => 'KnowbaseItem_Profile',
+                    'itemtype'     => KnowbaseItem_Profile::class,
                     'id'           => $data['id'],
                     'type'         => 'Profile',
-                    'type_label'   => Profile::getTypeName(1),
                     'name'         => Dropdown::getDropdownName('glpi_profiles', $data['profiles_id']),
+                    'users_id'     => null,
                     'icon'         => 'ti-id-badge-2',
                     'badge_class'  => 'bg-purple-lt',
                     'entity_name'  => $entity_name,
                     'is_recursive' => (bool) $data['is_recursive'],
-                    'is_owner'     => false,
                 ];
             }
         }

--- a/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/PermissionsRenderer.php
@@ -39,7 +39,6 @@ use Entity;
 use Entity_KnowbaseItem;
 use Group;
 use Group_KnowbaseItem;
-use Html;
 use KnowbaseItem;
 use KnowbaseItem_Profile;
 use KnowbaseItem_User;
@@ -68,8 +67,9 @@ final class PermissionsRenderer implements RendererInterface
         $id = $item->getID();
         $can_edit = $item->canEdit($id);
         $rand = mt_rand();
+        $owner_id = (int) $item->fields['users_id'];
 
-        $entries = $this->buildEntries($item);
+        $entries = $this->buildEntries($item, $owner_id);
 
         $visiblity_dropdown_params = [
             'type'  => '__VALUE__',
@@ -83,32 +83,28 @@ final class PermissionsRenderer implements RendererInterface
             $visiblity_dropdown_params['is_recursive'] = $item->fields['is_recursive'];
         }
 
-        $massive_action_params = [
-            'num_displayed' => count($entries),
-            'container' => 'mass' . KnowbaseItem::class . $rand,
-            'specific_actions' => ['delete' => _x('button', 'Delete permanently')],
-        ];
-        if ($item->fields['users_id'] !== Session::getLoginUserID()) {
-            $massive_action_params['confirm'] = __('Caution! You are not the author of this item. Deleting targets can result in loss of access.');
-        }
-
         return [
             'id' => $id,
             'rand' => $rand,
             'can_edit' => $can_edit,
+            'is_owner' => ($owner_id === Session::getLoginUserID()),
+            'owner' => [
+                'name' => getUserName($owner_id),
+                'users_id' => $owner_id,
+            ],
             'entries' => $entries,
             'visiblity_dropdown_params' => $visiblity_dropdown_params,
-            'massive_action_params' => $massive_action_params,
         ];
     }
 
     /**
-     * Build entries array for the permissions datatable
+     * Build entries array for the permissions list
      *
      * @param KnowbaseItem $item
-     * @return array<int, array{itemtype: string, id: int, type: string, recipient: string}>
+     * @param int $owner_id
+     * @return array<int, array{itemtype: string, id: int, type: string, type_label: string, name: string, icon: string, badge_class: string, entity_name: ?string, is_recursive: bool, is_owner: bool}>
      */
-    private function buildEntries(KnowbaseItem $item): array
+    private function buildEntries(KnowbaseItem $item, int $owner_id): array
     {
         $id = $item->getID();
         $entries = [];
@@ -117,10 +113,16 @@ final class PermissionsRenderer implements RendererInterface
         foreach ($users as $val) {
             foreach ($val as $data) {
                 $entries[] = [
-                    'itemtype' => 'KnowbaseItem_User',
-                    'id' => $data['id'],
-                    'type' => User::getTypeName(1),
-                    'recipient' => htmlescape(getUserName($data['users_id'])),
+                    'itemtype'     => 'KnowbaseItem_User',
+                    'id'           => $data['id'],
+                    'type'         => 'User',
+                    'type_label'   => User::getTypeName(1),
+                    'name'         => getUserName($data['users_id']),
+                    'icon'         => 'ti-user',
+                    'badge_class'  => 'bg-azure-lt',
+                    'entity_name'  => null,
+                    'is_recursive' => false,
+                    'is_owner'     => ((int) $data['users_id'] === $owner_id),
                 ];
             }
         }
@@ -128,37 +130,21 @@ final class PermissionsRenderer implements RendererInterface
         $groups = Group_KnowbaseItem::getGroups($id);
         foreach ($groups as $val) {
             foreach ($val as $data) {
-                $name = Dropdown::getDropdownName('glpi_groups', $data['groups_id']);
-                $tooltip = Dropdown::getDropdownComments('glpi_groups', (int) $data['groups_id']);
-                $recipient = sprintf(
-                    __s('%1$s %2$s'),
-                    htmlescape($name),
-                    Html::showToolTip($tooltip, ['display' => false])
-                );
+                $entity_name = null;
                 if ($data['entities_id'] !== null) {
-                    $recipient = sprintf(
-                        __s('%1$s / %2$s'),
-                        $recipient,
-                        htmlescape(
-                            Dropdown::getDropdownName(
-                                'glpi_entities',
-                                $data['entities_id']
-                            )
-                        )
-                    );
-                    if ($data['is_recursive']) {
-                        $recipient = sprintf(
-                            __s('%1$s %2$s'),
-                            $recipient,
-                            "<span class='fw-bold'>(" . __s('R') . ")</span>"
-                        );
-                    }
+                    $entity_name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
                 }
                 $entries[] = [
-                    'itemtype' => 'Group_KnowbaseItem',
-                    'id' => $data['id'],
-                    'type' => Group::getTypeName(1),
-                    'recipient' => $recipient,
+                    'itemtype'     => 'Group_KnowbaseItem',
+                    'id'           => $data['id'],
+                    'type'         => 'Group',
+                    'type_label'   => Group::getTypeName(1),
+                    'name'         => Dropdown::getDropdownName('glpi_groups', $data['groups_id']),
+                    'icon'         => 'ti-users-group',
+                    'badge_class'  => 'bg-green-lt',
+                    'entity_name'  => $entity_name,
+                    'is_recursive' => (bool) $data['is_recursive'],
+                    'is_owner'     => false,
                 ];
             }
         }
@@ -166,25 +152,17 @@ final class PermissionsRenderer implements RendererInterface
         $entities = Entity_KnowbaseItem::getEntities($id);
         foreach ($entities as $val) {
             foreach ($val as $data) {
-                $name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
-                $tooltip = Dropdown::getDropdownComments('glpi_entities', (int) $data['entities_id']);
-                $recipient = sprintf(
-                    __s('%1$s %2$s'),
-                    htmlescape($name),
-                    Html::showToolTip($tooltip, ['display' => false])
-                );
-                if ($data['is_recursive']) {
-                    $recipient = sprintf(
-                        __s('%1$s %2$s'),
-                        $recipient,
-                        "<span class='fw-bold'>(" . __s('R') . ")</span>"
-                    );
-                }
                 $entries[] = [
-                    'itemtype' => 'Entity_KnowbaseItem',
-                    'id' => $data['id'],
-                    'type' => Entity::getTypeName(1),
-                    'recipient' => $recipient,
+                    'itemtype'     => 'Entity_KnowbaseItem',
+                    'id'           => $data['id'],
+                    'type'         => 'Entity',
+                    'type_label'   => Entity::getTypeName(1),
+                    'name'         => Dropdown::getDropdownName('glpi_entities', $data['entities_id']),
+                    'icon'         => 'ti-building',
+                    'badge_class'  => 'bg-yellow-lt',
+                    'entity_name'  => null,
+                    'is_recursive' => (bool) $data['is_recursive'],
+                    'is_owner'     => false,
                 ];
             }
         }
@@ -192,37 +170,21 @@ final class PermissionsRenderer implements RendererInterface
         $profiles = KnowbaseItem_Profile::getProfiles($id);
         foreach ($profiles as $val) {
             foreach ($val as $data) {
-                $name = Dropdown::getDropdownName('glpi_profiles', $data['profiles_id']);
-                $tooltip = Dropdown::getDropdownComments('glpi_profiles', (int) $data['profiles_id']);
-                $recipient = sprintf(
-                    __s('%1$s %2$s'),
-                    htmlescape($name),
-                    Html::showToolTip($tooltip, ['display' => false])
-                );
+                $entity_name = null;
                 if ($data['entities_id'] !== null) {
-                    $recipient = sprintf(
-                        __s('%1$s / %2$s'),
-                        $recipient,
-                        htmlescape(
-                            Dropdown::getDropdownName(
-                                'glpi_entities',
-                                $data['entities_id']
-                            )
-                        )
-                    );
-                    if ($data['is_recursive']) {
-                        $recipient = sprintf(
-                            __s('%1$s %2$s'),
-                            $recipient,
-                            "<span class='fw-bold'>(" . __s('R') . ")</span>"
-                        );
-                    }
+                    $entity_name = Dropdown::getDropdownName('glpi_entities', $data['entities_id']);
                 }
                 $entries[] = [
-                    'itemtype' => 'KnowbaseItem_Profile',
-                    'id' => $data['id'],
-                    'type' => Profile::getTypeName(1),
-                    'recipient' => $recipient,
+                    'itemtype'     => 'KnowbaseItem_Profile',
+                    'id'           => $data['id'],
+                    'type'         => 'Profile',
+                    'type_label'   => Profile::getTypeName(1),
+                    'name'         => Dropdown::getDropdownName('glpi_profiles', $data['profiles_id']),
+                    'icon'         => 'ti-id-badge-2',
+                    'badge_class'  => 'bg-purple-lt',
+                    'entity_name'  => $entity_name,
+                    'is_recursive' => (bool) $data['is_recursive'],
+                    'is_owner'     => false,
                 ];
             }
         }

--- a/templates/pages/tools/kb/modal/permissions.html.twig
+++ b/templates/pages/tools/kb/modal/permissions.html.twig
@@ -32,18 +32,6 @@
 
 {% import "components/form/fields_macros.html.twig" as fields %}
 
-{# Owner line #}
-<div class="kb-permission-owner d-flex align-items-center gap-2">
-    {{ include('components/user/picture.html.twig', {
-        users_id: owner.users_id,
-        enable_anonymization: false,
-    }) }}
-    <div class="flex-grow-1">
-        <div class="fw-medium">{{ owner.name }}</div>
-        <div class="text-secondary small">{{ __('Owner') }}</div>
-    </div>
-</div>
-
 {# Add target form #}
 {% if can_edit %}
     <div>
@@ -56,12 +44,14 @@
                     rand: rand,
                     mb: '',
                 }) }}
-                <div id="visibility{{ rand }}" class="kb-permission-visibility"></div>
-                <div id="visibility-submit{{ rand }}" class="d-none">
+                <div id="visibility-submit{{ rand }}" class="d-none d-flex gap-2 align-items-center">
+                    <div class="flex-grow-1">
+                        <div id="visibility{{ rand }}" class="kb-permission-visibility"></div>
+                    </div>
                     <input type="submit"
                            name="addvisibility"
                            value="{{ _x('button', 'Add') }}"
-                           class="btn btn-primary w-100">
+                           class="btn btn-primary">
                 </div>
             </div>
             <script>
@@ -69,7 +59,7 @@
                     const $submit = $('#visibility-submit{{ rand }}');
                     if (e.target.value === '') {
                         $('#visibility{{ rand }}').empty();
-                        $submit.addClass('d-none');
+                        $submit.addClass('d-none').removeClass('d-flex');
                         return;
                     }
                     $('#visibility{{ rand }}').load(
@@ -79,65 +69,80 @@
                             type: e.target.value,
                             nobutton: 1,
                         },
-                        () => $submit.removeClass('d-none')
+                        () => $submit.removeClass('d-none').addClass('d-flex')
                     );
                 });
             </script>
         </form>
     </div>
-    <hr class="my-2">
+    <hr class="mt-3 mb-2">
 {% endif %}
 
 {# Permissions list #}
 <div class="list-group list-group-flush" data-glpi-permissions-list>
     {% for entry in entries %}
-        <div class="list-group-item d-flex align-items-center gap-2 px-0"
-             data-glpi-permission-id="{{ entry.id }}"
-             data-glpi-permission-itemtype="{{ entry.itemtype }}">
+            <div class="list-group-item d-flex align-items-center gap-2 px-0"
+                 data-glpi-permission-id="{{ entry.id }}"
+                 data-glpi-permission-itemtype="{{ entry.itemtype }}">
 
-            {# Typed icon #}
-            <span class="avatar avatar-sm rounded {{ entry.badge_class }}">
-                <i class="ti {{ entry.icon }}"></i>
-            </span>
+                {# Avatar: user picture for Users, typed icon for others #}
+                {% if entry.type == 'User' %}
+                    {{ include('components/user/picture.html.twig', {
+                        users_id: entry.users_id,
+                        avatar_size: 'avatar-sm',
+                        with_link: false,
+                        enable_anonymization: false,
+                    }) }}
+                {% else %}
+                    <span class="avatar avatar-sm rounded {{ entry.badge_class }}">
+                        <i class="ti {{ entry.icon }}"></i>
+                    </span>
+                {% endif %}
 
-            {# Info #}
-            <div class="flex-grow-1" style="min-width: 0;">
-                <div class="d-flex align-items-center gap-1">
-                    <span class="fw-medium text-truncate">{{ entry.name }}</span>
-                    <span class="badge {{ entry.badge_class }}">{{ entry.type_label }}</span>
-                    {% if entry.is_recursive %}
-                        <span class="badge bg-secondary-lt"
-                              title="{{ __('Recursive') }}"
-                              data-bs-toggle="tooltip">
-                            <i class="ti ti-arrow-iteration me-1"></i>R
-                        </span>
-                    {% endif %}
-                    {% if entry.is_owner %}
-                        <span class="badge bg-azure-lt">{{ __('Owner') }}</span>
+                {# Info #}
+                <div class="flex-grow-1" style="min-width: 0;">
+                    <div class="d-flex align-items-center gap-1">
+                        <span class="fw-medium text-truncate">{{ entry.name }}</span>
+                        {% if entry.is_recursive %}
+                            <span class="badge bg-secondary-lt"
+                                  title="{{ __('Recursive') }}"
+                                  data-bs-toggle="tooltip">
+                                <i class="ti ti-arrow-iteration me-1"></i>R
+                            </span>
+                        {% endif %}
+                    </div>
+                    <div class="text-secondary small">{{ __('Can view') }}</div>
+                    {% if entry.entity_name %}
+                        <div class="text-secondary small text-truncate">{{ entry.entity_name }}</div>
                     {% endif %}
                 </div>
-                {% if entry.entity_name %}
-                    <div class="text-secondary small text-truncate">{{ entry.entity_name }}</div>
+
+                {# Delete button #}
+                {% if can_edit %}
+                    <button type="button"
+                            class="btn btn-ghost-danger btn-sm btn-icon ms-auto"
+                            data-glpi-permission-delete
+                            title="{{ __('Delete') }}"
+                            data-bs-toggle="tooltip">
+                        <i class="ti ti-trash"></i>
+                    </button>
                 {% endif %}
             </div>
-
-            {# Delete button #}
-            {% if can_edit and not entry.is_owner %}
-                <button type="button"
-                        class="btn btn-ghost-secondary btn-sm btn-icon ms-auto"
-                        data-glpi-permission-delete
-                        title="{{ __('Delete') }}"
-                        data-bs-toggle="tooltip">
-                    <i class="ti ti-x"></i>
-                </button>
-            {% endif %}
-        </div>
-    {% else %}
-        <div class="text-secondary text-center py-3" data-glpi-permissions-empty>
-            <i class="ti ti-lock-open me-1"></i>
-            {{ __('No specific permissions defined.') }}
-        </div>
     {% endfor %}
+</div>
+
+{# Owner footer (full-width, differentiated background) #}
+<div class="kb-permission-owner d-flex align-items-center gap-2">
+    {{ include('components/user/picture.html.twig', {
+        users_id: owner.users_id,
+        avatar_size: 'avatar-sm',
+        with_link: false,
+        enable_anonymization: false,
+    }) }}
+    <div class="flex-grow-1" style="min-width: 0;">
+        <span class="fw-medium text-truncate d-block">{{ owner.name }}</span>
+        <div class="text-secondary small">{{ __('Owner') }}</div>
+    </div>
 </div>
 
 {% if can_edit %}
@@ -187,17 +192,6 @@
                 }
 
                 row.remove();
-
-                // Show empty state if no entries left
-                const remaining = list.querySelectorAll('[data-glpi-permission-id]');
-                if (remaining.length === 0) {
-                    list.innerHTML = `
-                        <div class="text-secondary text-center py-3" data-glpi-permissions-empty>
-                            <i class="ti ti-lock-open me-1"></i>
-                            {{ __('No specific permissions defined.')|e("js") }}
-                        </div>
-                    `;
-                }
             } catch {
                 glpi_toast_error('{{ __("An error occurred while deleting the permission.")|e("js") }}');
             }

--- a/templates/pages/tools/kb/modal/permissions.html.twig
+++ b/templates/pages/tools/kb/modal/permissions.html.twig
@@ -32,48 +32,176 @@
 
 {% import "components/form/fields_macros.html.twig" as fields %}
 
+{# Owner line #}
+<div class="kb-permission-owner d-flex align-items-center gap-2">
+    {{ include('components/user/picture.html.twig', {
+        users_id: owner.users_id,
+        enable_anonymization: false,
+    }) }}
+    <div class="flex-grow-1">
+        <div class="fw-medium">{{ owner.name }}</div>
+        <div class="text-secondary small">{{ __('Owner') }}</div>
+    </div>
+</div>
+
+{# Add target form #}
 {% if can_edit %}
-    <div class="mb-3">
+    <div>
         <form method="post" action="{{ 'KnowbaseItem'|itemtype_form_path }}">
             <input type="hidden" name="knowbaseitems_id" value="{{ id }}">
             {{ fields.csrfField() }}
             <div class="d-flex flex-column gap-2">
-                <div class="d-flex align-items-center gap-2">
-                    {{ fields.dropdownItemTypes('_type', '', __('Add a target'), {
-                        types: ['Entity', 'Group', 'Profile', 'User'],
-                        rand: rand,
-                    }) }}
+                {{ fields.dropdownItemTypes('_type', '', __('Add a target'), {
+                    types: ['Entity', 'Group', 'Profile', 'User'],
+                    rand: rand,
+                    mb: '',
+                }) }}
+                <div id="visibility{{ rand }}" class="kb-permission-visibility"></div>
+                <div id="visibility-submit{{ rand }}" class="d-none">
+                    <input type="submit"
+                           name="addvisibility"
+                           value="{{ _x('button', 'Add') }}"
+                           class="btn btn-primary w-100">
                 </div>
-                <div id="visibility{{ rand }}"></div>
             </div>
             <script>
                 $('#dropdown__type{{ rand }}').on('change', (e) => {
+                    const $submit = $('#visibility-submit{{ rand }}');
+                    if (e.target.value === '') {
+                        $('#visibility{{ rand }}').empty();
+                        $submit.addClass('d-none');
+                        return;
+                    }
                     $('#visibility{{ rand }}').load(
                         `${CFG_GLPI.root_doc}/ajax/visibility.php`,
                         {
                             ...{{ visiblity_dropdown_params|json_encode|raw }},
                             type: e.target.value,
-                        }
+                            nobutton: 1,
+                        },
+                        () => $submit.removeClass('d-none')
                     );
                 });
             </script>
         </form>
     </div>
+    <hr class="my-2">
 {% endif %}
 
-{{ include('components/datatable.html.twig', {
-    is_tab: true,
-    nofilter: true,
-    nosort: true,
-    columns: {
-        'type': _n('Type', 'Types', 1),
-        'recipient': _n('Recipient', 'Recipients', 1),
-    },
-    formatters: {
-        'recipient': 'raw_html',
-    },
-    entries: entries,
-    total_number: entries|length,
-    showmassiveactions: can_edit,
-    massiveactionparams: massive_action_params,
-}) }}
+{# Permissions list #}
+<div class="list-group list-group-flush" data-glpi-permissions-list>
+    {% for entry in entries %}
+        <div class="list-group-item d-flex align-items-center gap-2 px-0"
+             data-glpi-permission-id="{{ entry.id }}"
+             data-glpi-permission-itemtype="{{ entry.itemtype }}">
+
+            {# Typed icon #}
+            <span class="avatar avatar-sm rounded {{ entry.badge_class }}">
+                <i class="ti {{ entry.icon }}"></i>
+            </span>
+
+            {# Info #}
+            <div class="flex-grow-1" style="min-width: 0;">
+                <div class="d-flex align-items-center gap-1">
+                    <span class="fw-medium text-truncate">{{ entry.name }}</span>
+                    <span class="badge {{ entry.badge_class }}">{{ entry.type_label }}</span>
+                    {% if entry.is_recursive %}
+                        <span class="badge bg-secondary-lt"
+                              title="{{ __('Recursive') }}"
+                              data-bs-toggle="tooltip">
+                            <i class="ti ti-arrow-iteration me-1"></i>R
+                        </span>
+                    {% endif %}
+                    {% if entry.is_owner %}
+                        <span class="badge bg-azure-lt">{{ __('Owner') }}</span>
+                    {% endif %}
+                </div>
+                {% if entry.entity_name %}
+                    <div class="text-secondary small text-truncate">{{ entry.entity_name }}</div>
+                {% endif %}
+            </div>
+
+            {# Delete button #}
+            {% if can_edit and not entry.is_owner %}
+                <button type="button"
+                        class="btn btn-ghost-secondary btn-sm btn-icon ms-auto"
+                        data-glpi-permission-delete
+                        title="{{ __('Delete') }}"
+                        data-bs-toggle="tooltip">
+                    <i class="ti ti-x"></i>
+                </button>
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="text-secondary text-center py-3" data-glpi-permissions-empty>
+            <i class="ti ti-lock-open me-1"></i>
+            {{ __('No specific permissions defined.') }}
+        </div>
+    {% endfor %}
+</div>
+
+{% if can_edit %}
+<script>
+    (() => {
+        const list = document.querySelector('[data-glpi-permissions-list]');
+        if (!list) {
+            return;
+        }
+
+        list.addEventListener('click', async (e) => {
+            const btn = e.target.closest('[data-glpi-permission-delete]');
+            if (!btn) {
+                return;
+            }
+
+            const row = btn.closest('[data-glpi-permission-id]');
+            const permission_id = row.dataset.glpiPermissionId;
+            const itemtype = row.dataset.glpiPermissionItemtype;
+
+            {% if not is_owner %}
+                const confirmed = await glpi_confirm_danger({
+                    title: '{{ __("Delete target")|e("js") }}',
+                    message: '{{ __("Caution! You are not the author of this item. Deleting targets can result in loss of access.")|e("js") }}',
+                    confirm_label: '{{ __("Delete")|e("js") }}',
+                });
+                if (!confirmed) {
+                    return;
+                }
+            {% endif %}
+
+            try {
+                const response = await fetch(
+                    `${CFG_GLPI.root_doc}/Knowbase/KnowbaseItem/Permission/${itemtype}/${permission_id}`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
+                        },
+                    }
+                );
+
+                if (!response.ok) {
+                    throw new Error();
+                }
+
+                row.remove();
+
+                // Show empty state if no entries left
+                const remaining = list.querySelectorAll('[data-glpi-permission-id]');
+                if (remaining.length === 0) {
+                    list.innerHTML = `
+                        <div class="text-secondary text-center py-3" data-glpi-permissions-empty>
+                            <i class="ti ti-lock-open me-1"></i>
+                            {{ __('No specific permissions defined.')|e("js") }}
+                        </div>
+                    `;
+                }
+            } catch {
+                glpi_toast_error('{{ __("An error occurred while deleting the permission.")|e("js") }}');
+            }
+        });
+    })();
+</script>
+{% endif %}

--- a/tests/e2e/specs/Knowbase/permissions.spec.ts
+++ b/tests/e2e/specs/Knowbase/permissions.spec.ts
@@ -60,9 +60,7 @@ test('Can view permissions modal', async ({ page, profile, api }) => {
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
 
-    const permission_row = modal.locator('[data-glpi-permission-id]');
-    await expect(permission_row).toBeVisible();
-    await expect(permission_row.locator('.badge', { hasText: 'Entity' })).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'Delete' })).toBeVisible();
 });
 
 test('Can delete a permission from the modal', async ({ page, profile, api }) => {
@@ -88,11 +86,10 @@ test('Can delete a permission from the modal', async ({ page, profile, api }) =>
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
 
-    const entity_row = modal.locator('[data-glpi-permission-itemtype="Entity_KnowbaseItem"]');
-    await expect(entity_row).toBeVisible();
-    await expect(entity_row.locator('.badge', { hasText: 'Entity' })).toBeVisible();
+    const deleteBtn = modal.getByRole('button', { name: 'Delete' });
+    await expect(deleteBtn).toBeVisible();
 
-    await entity_row.locator('[data-glpi-permission-delete]').click();
+    await deleteBtn.click();
 
-    await expect(entity_row).not.toBeAttached();
+    await expect(deleteBtn).not.toBeAttached();
 });

--- a/tests/e2e/specs/Knowbase/permissions.spec.ts
+++ b/tests/e2e/specs/Knowbase/permissions.spec.ts
@@ -59,7 +59,10 @@ test('Can view permissions modal', async ({ page, profile, api }) => {
 
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
-    await expect(modal.getByText('Entity', { exact: true }).first()).toBeVisible();
+
+    const permission_row = modal.locator('[data-glpi-permission-id]');
+    await expect(permission_row).toBeVisible();
+    await expect(permission_row.locator('.badge', { hasText: 'Entity' })).toBeVisible();
 });
 
 test('Can delete a permission from the modal', async ({ page, profile, api }) => {
@@ -85,11 +88,11 @@ test('Can delete a permission from the modal', async ({ page, profile, api }) =>
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
 
-    const permission_row = modal.locator('[data-glpi-permission-id]');
-    await expect(permission_row).toBeVisible();
+    const entity_row = modal.locator('[data-glpi-permission-itemtype="Entity_KnowbaseItem"]');
+    await expect(entity_row).toBeVisible();
+    await expect(entity_row.locator('.badge', { hasText: 'Entity' })).toBeVisible();
 
-    await permission_row.getByTitle('Delete').click();
+    await entity_row.locator('[data-glpi-permission-delete]').click();
 
-    await expect(permission_row).not.toBeAttached();
-    await expect(modal.getByText('No specific permissions defined.')).toBeVisible();
+    await expect(entity_row).not.toBeAttached();
 });

--- a/tests/e2e/specs/Knowbase/permissions.spec.ts
+++ b/tests/e2e/specs/Knowbase/permissions.spec.ts
@@ -59,5 +59,37 @@ test('Can view permissions modal', async ({ page, profile, api }) => {
 
     const modal = page.getByRole('dialog');
     await expect(modal).toBeVisible();
-    await expect(modal.getByRole('cell', { name: 'Entity', exact: true })).toBeVisible();
+    await expect(modal.getByText('Entity', { exact: true }).first()).toBeVisible();
+});
+
+test('Can delete a permission from the modal', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const entity_id = getWorkerEntityId();
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'KB entry for permission delete test',
+        entities_id: entity_id,
+        answer: "Test content",
+    });
+    await api.createItem('Entity_KnowbaseItem', {
+        knowbaseitems_id: id,
+        entities_id: entity_id,
+        is_recursive: 0,
+    });
+
+    await kb.goto(id);
+    await page.getByTitle('More actions').click();
+    await kb.getButton('Targets').click();
+
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    const permission_row = modal.locator('[data-glpi-permission-id]');
+    await expect(permission_row).toBeVisible();
+
+    await permission_row.getByTitle('Delete').click();
+
+    await expect(permission_row).not.toBeAttached();
+    await expect(modal.getByText('No specific permissions defined.')).toBeVisible();
 });


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/103

**Description of what this PR does :** 

- Modernize the KB permissions modal UI: replace the legacy datatable with a typed list using avatars, badges, and inline delete buttons                                                    
- Add owner section at the top of the modal with user avatar     
- Add AJAX endpoint for permission deletion (`POST /Knowbase/KnowbaseItem/Permission/{itemtype}/{id}`)                                                                                      
- Enrich `PermissionsRenderer` to provide typed entry data (icon, badge color, entity name, recursive flag)

The delete endpoint uses $this->purge() from CrudControllerTrait (as seen for FAQ PR #22850) rather than manually calling getFromDB / canEdit / delete .

## Screenshots (if appropriate):
<img width="802" height="612" alt="image" src="https://github.com/user-attachments/assets/6189e70f-e0c0-4ea2-af37-f37d5cc0f409" />


