### PR TITLE
Fix (UI) - Restore dashboard mobile layout broken by GridStack v12 upgrade

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -598,7 +598,7 @@ $break_tablet: 1400px;
     }
 
     .grid-stack {
-        &.grid-stack-one-column-mode {
+        &.gs-1 {
             max-width: 100%;
 
             .grid-stack-item {

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -158,13 +158,22 @@ class GLPIDashboard {
             draggable: { // override jquery ui draggable options
                 'cancel': 'textarea' // avoid draggable on some child elements
             },
-            'minWidth': 768 -  width_offset, // breakpoint of one column mode (based on the dashboard container width), trying to reduce to match the `-md` breakpoint of bootstrap (this last is based on viewport width)
+            // columnOpts is intentionally NOT used: GridStack v12 triggers GridStackEngine._fixCollisions
+            // during the column change, which causes infinite recursion (moveNode <-> _fixCollisions)
+            // when float:true is enabled. Mobile layout is managed manually via this.switchColumnLayout().
         }, `#grid-stack-${options.rand}`);
 
         // set grid in static to prevent edition (unless user click on edit button)
         // previously in option, but current version of gridstack has a bug with one column mode (responsive)
         // see https://github.com/gridstack/gridstack.js/issues/1229
         this.grid.setStatic(true);
+
+        this.mobile_threshold = Math.round(768 - width_offset);
+
+        // Apply mobile layout if needed on initial load
+        window.requestAnimationFrame(() => {
+            this.switchColumnLayout(options.cols);
+        });
 
         // set the width of the select box to match the selected option
         this.resizeSelect();
@@ -292,6 +301,8 @@ class GLPIDashboard {
 
             window.clearTimeout(debounce);
             debounce = window.setTimeout(() => {
+                this.switchColumnLayout(this.cols);
+
                 // fit again numbers
                 this.fitNumbers();
             }, 200);
@@ -823,6 +834,35 @@ class GLPIDashboard {
     }
 
     /**
+     * Switch between single-column (mobile) and multi-column (desktop) layout depending on the
+     * current grid container width vs the mobile threshold.
+     *
+     * GridStack v12 columnOpts triggers GridStackEngine._fixCollisions during column changes.
+     * With float:true enabled, this causes infinite recursion (moveNode <-> _fixCollisions).
+     * To prevent this, float is temporarily disabled during the column switch (pushing items
+     * down deterministically terminates), then restored afterwards.
+     *
+     * @param {number} desktop_cols - the original number of columns to restore on desktop
+     */
+    switchColumnLayout(desktop_cols) {
+        const grid_width = this.grid.el.clientWidth || this.elem_dom.clientWidth;
+        const is_mobile  = grid_width > 0 && grid_width <= this.mobile_threshold;
+        const current    = this.grid.getColumn();
+
+        if (is_mobile && current !== 1) {
+            this.grid.float(false);
+            this.grid.column(1, 'compact');
+            this.grid.float(true);
+            this.grid.cellHeight(60, false);
+        } else if (!is_mobile && current === 1) {
+            this.grid.float(false);
+            this.grid.column(desktop_cols, 'moveScale');
+            this.grid.float(true);
+            this.grid.cellHeight('auto', false);
+        }
+    }
+
+    /**
      * Remove the custom width as it should only be used temporarily to 'trick'
      * fitText into using a different fontSize and should not be applied to the
      * actual text
@@ -842,7 +882,7 @@ class GLPIDashboard {
 
         // responsive mode
         if (this.dash_width <= 700
-            || $(this.grid.el).hasClass('grid-stack-one-column-mode')) {
+            || $(this.grid.el).hasClass('gs-1')) {
             text_offset = 1.8;
         }
 

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -845,7 +845,11 @@ class GLPIDashboard {
      * @param {number} desktop_cols - the original number of columns to restore on desktop
      */
     switchColumnLayout(desktop_cols) {
-        const grid_width = this.grid.el.clientWidth || this.elem_dom.clientWidth;
+        if (typeof this.grid?.getColumn !== 'function') {
+            return;
+        }
+
+        const grid_width = (this.grid.el?.clientWidth) || this.elem_dom.clientWidth;
         const is_mobile  = grid_width > 0 && grid_width <= this.mobile_threshold;
         const current    = this.grid.getColumn();
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42310
- Here is a brief description of what this PR does

The upgrade from GridStack v11.5.1 to v12 broke the single-column layout on mobile screens due to two incompatible changes.

### Root causes

- The `minWidth` option was removed in v12 (replaced by `columnOpts`), so no mobile breakpoint was applied
- `columnOpts` triggers `GridStackEngine._fixCollisions()` during column switches, which causes a `Maximum call stack size exceeded` infinite recursion (`moveNode ↔ _fixCollisions`) when `float: true` is active
- The responsive CSS class was renamed from `grid-stack-one-column-mode` to `gs-1`

### Fixes

- Replace `columnOpts` with a manual `switchColumnLayout()` method that temporarily disables `float` before calling `grid.column()` — with `float: false`, collision resolution only pushes items downward (deterministic, always terminates), then `float` is restored
- Apply the layout switch on initial load via `requestAnimationFrame` and on window resize via the existing debounce handler
- Restore the 60px fixed `cellHeight` in single-column mode
- Update the CSS selector and JS class check from `grid-stack-one-column-mode` to `gs-1`

## Screenshots (if appropriate):
Before : 

<img width="447" height="867" alt="image" src="https://github.com/user-attachments/assets/fa6252d2-64f7-4124-8860-95ca3f9ff33f" />

After : 

<img width="447" height="867" alt="image" src="https://github.com/user-attachments/assets/77d0d3cb-5c84-4135-981b-31840bc9a8f5" />
