### PR TITLE
Fix(Forms): Display dates according to general settings

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -145,16 +145,10 @@ class QuestionTypeDateTime extends AbstractQuestionType implements FormQuestionD
 
     public function formatAnswer(string $answer): string
     {
-        if (str_contains($answer, 'T')) {
-            return (new DateTime($answer))->format('Y-m-d H:i');
-        }
-
-        $answer = \Html::convDateTime(
+        return trim(\Html::convDateTime(
             $answer,
             (int) \Config::getConfigurationValue('core', 'date_format'),
-        );
-
-        return $answer;
+        ));
     }
 
     public function isDefaultValueCurrentTime(?Question $question): bool

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -145,7 +145,11 @@ class QuestionTypeDateTime extends AbstractQuestionType implements FormQuestionD
 
     public function formatAnswer(string $answer): string
     {
-        return trim(\Html::convDateTime(
+        $timePattern = '/^\d{2}:\d{2}(?::\d{2})?$/';
+        if (preg_match($timePattern, trim($answer)) === 1) {
+            return $answer;
+        }
+        return trim((string) \Html::convDateTime(
             $answer,
             (int) \Config::getConfigurationValue('core', 'date_format'),
         ));

--- a/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDateTime.php
@@ -149,6 +149,11 @@ class QuestionTypeDateTime extends AbstractQuestionType implements FormQuestionD
             return (new DateTime($answer))->format('Y-m-d H:i');
         }
 
+        $answer = \Html::convDateTime(
+            $answer,
+            (int) \Config::getConfigurationValue('core', 'date_format'),
+        );
+
         return $answer;
     }
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42299

In the forms, the date display format did not take into account the one defined in the general configuration.

## Screenshots (if appropriate):

<img width="617" height="245" alt="image" src="https://github.com/user-attachments/assets/2841f455-bedf-4963-b291-c0cad231b090" />



