### PR TITLE
ux(planning): prevent until date from being before event start date

### DIFF
--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -751,10 +751,12 @@ trait PlanningEvent
         $rrule = array_merge($defaults, $rrule);
 
         $default_options = [
-            'rand' => mt_rand(),
+            'rand'  => mt_rand(),
+            'begin' => '',
         ];
         $options = array_merge($default_options, $options);
-        $rand    = $options['rand'];
+        $rand  = $options['rand'];
+        $begin = $options['begin'];
 
         $out = "<div class='card' style='padding: 5px; width: 100%;'>";
         $out .= Dropdown::showFromArray('rrule[freq]', [
@@ -801,9 +803,20 @@ trait PlanningEvent
         $out .= "<div>" . Html::showDateField('rrule[until]', [
             'value'   => $rrule['until'],
             'rand'    => $rand,
+            'min'     => $begin,
             'display' => false,
         ]) . "</div>";
         $out .= "</div>";
+
+        $out .= Html::scriptBlock("
+            \$(document).on('change', '[name=\"plan[begin]\"]', function() {
+                const val = \$(this).val();
+                const untilFp = document.getElementById('showdate{$rand}');
+                if (untilFp && untilFp._flatpickr) {
+                    untilFp._flatpickr.set('minDate', val ?? null);
+                }
+            });
+        ");
 
         $out .= "<div class='field'>";
         $out .= "<label for='dropdown_byday$rand'>" . __("By day") . "</label>";

--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -811,7 +811,7 @@ trait PlanningEvent
         $out .= Html::scriptBlock("
             \$(document).on('change', '[name=\"plan[begin]\"]', function() {
                 const val = \$(this).val();
-                const untilFp = document.getElementById('showdate{$rand}');
+                const untilFp = document.getElementById(" . json_encode("showdate{$rand}") . ");
                 if (untilFp && untilFp._flatpickr) {
                     untilFp._flatpickr.set('minDate', val ?? null);
                 }

--- a/src/PlanningExternalEvent.php
+++ b/src/PlanningExternalEvent.php
@@ -336,7 +336,8 @@ JAVASCRIPT;
         echo "<tr class='tab_bg_2'><td  colspan='2'>" . __('Repeat') . "</td>";
         echo "<td>";
         echo self::showRepetitionForm($this->fields['rrule'] ?? '', [
-            'rand' => $rand_rrule,
+            'rand'  => $rand_rrule,
+            'begin' => $this->fields['begin'],
         ]);
         echo "</td></tr>";
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42284
- In the scheduling module, it is possible to select a rehearsal end date that is earlier than the event start date, which is inconsistent. This PR requires the user to select an end date that is after the start date.

## Screenshots (if appropriate):

Start date:
<img width="341" height="47" alt="image" src="https://github.com/user-attachments/assets/ef37d86b-f523-4153-ae5b-1dd2febd203b" />

Date picker:
<img width="477" height="391" alt="image" src="https://github.com/user-attachments/assets/c38b0547-29ec-47e4-8f7a-2d88c776d2e1" />

