### PR TITLE
Render permissions changes in history timeline

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -92,6 +92,11 @@
 
 [data-glpi-knowbase-side-panel-offcanvas] {
     width: min(400px, 85vw);
+
+    .steps-vertical {
+        margin-left: 0;
+        --tblr-steps-padding: 1.5rem;
+    }
 }
 
 // KB Documents footer section

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -94,8 +94,9 @@
     width: min(400px, 85vw);
 
     .steps-vertical {
-        margin-left: 0;
         --tblr-steps-padding: 1.5rem;
+
+        margin-left: 0;
     }
 }
 

--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -35,9 +35,13 @@
 namespace Glpi\Knowbase\History;
 
 use Document;
+use Entity;
+use Group;
 use KnowbaseItem;
 use KnowbaseItem_Revision;
 use Log;
+use Profile;
+use User;
 
 final class HistoryBuilder
 {
@@ -142,10 +146,10 @@ final class HistoryBuilder
         global $DB;
 
         $target_types = [
-            \Entity::class,
-            \Group::class,
-            \Profile::class,
-            \User::class,
+            Entity::class,
+            Group::class,
+            Profile::class,
+            User::class,
         ];
 
         $logs = $DB->request([
@@ -218,10 +222,10 @@ final class HistoryBuilder
         // Exclude permission types (Entity, Group, Profile, User) as they
         // are handled separately by addPermissionChangesToHistory().
         $permission_types = [
-            \Entity::class,
-            \Group::class,
-            \Profile::class,
-            \User::class,
+            Entity::class,
+            Group::class,
+            Profile::class,
+            User::class,
         ];
         $item_types = array_values(array_diff($CFG_GLPI['kb_types'], $permission_types));
 

--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -167,13 +167,13 @@ final class HistoryBuilder
         foreach ($logs as $row) {
             $is_add = (int) $row['linked_action'] === Log::HISTORY_ADD_RELATION;
             $target_name = $is_add ? $row['new_value'] : $row['old_value'];
-            $label = $is_add
-                ? sprintf(__("Permission added: %s"), $target_name)
-                : sprintf(__("Permission removed: %s"), $target_name);
+            $description = $is_add
+                ? sprintf(__("Access granted to %s by"), $target_name)
+                : sprintf(__("Access revoked from %s by"), $target_name);
 
             $this->history->addEvent(new LogEvent(
-                label: $label,
-                description: __("Updated by"),
+                label: __("Permissions updated"),
+                description: $description,
                 date: $row['date_mod'],
                 author: $row['user_name'],
             ));

--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -56,6 +56,7 @@ final class HistoryBuilder
         $this->addFaqStatusChangesToHistory();
         $this->addAssociatedItemChangesToHistory();
         $this->addDocumentChangesToHistory();
+        $this->addPermissionChangesToHistory();
         $this->history->sort();
         return $this->history;
     }
@@ -136,6 +137,45 @@ final class HistoryBuilder
         ));
     }
 
+    private function addPermissionChangesToHistory(): void
+    {
+        global $DB;
+
+        $target_types = [
+            \Entity::class,
+            \Group::class,
+            \Profile::class,
+            \User::class,
+        ];
+
+        $logs = $DB->request([
+            'SELECT' => ['date_mod', 'user_name', 'linked_action', 'old_value', 'new_value'],
+            'FROM'   => Log::getTable(),
+            'WHERE'  => [
+                'itemtype'      => KnowbaseItem::class,
+                'items_id'      => $this->kb->getID(),
+                'linked_action' => [Log::HISTORY_ADD_RELATION, Log::HISTORY_DEL_RELATION],
+                'itemtype_link' => $target_types,
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $is_add = (int) $row['linked_action'] === Log::HISTORY_ADD_RELATION;
+            $target_name = $is_add ? $row['new_value'] : $row['old_value'];
+            $label = $is_add
+                ? sprintf(__("Permission added: %s"), $target_name)
+                : sprintf(__("Permission removed: %s"), $target_name);
+
+            $this->history->addEvent(new LogEvent(
+                label: $label,
+                description: __("Updated by"),
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
     private function addFaqStatusChangesToHistory(): void
     {
         global $DB;
@@ -156,7 +196,6 @@ final class HistoryBuilder
             'ORDER' => 'id DESC',
         ]);
 
-
         foreach ($logs as $row) {
             $label = $row['new_value']
                 ? __("Added to the FAQ")
@@ -176,6 +215,16 @@ final class HistoryBuilder
     {
         global $DB, $CFG_GLPI;
 
+        // Exclude permission types (Entity, Group, Profile, User) as they
+        // are handled separately by addPermissionChangesToHistory().
+        $permission_types = [
+            \Entity::class,
+            \Group::class,
+            \Profile::class,
+            \User::class,
+        ];
+        $item_types = array_values(array_diff($CFG_GLPI['kb_types'], $permission_types));
+
         $logs = $DB->request([
             'SELECT' => [
                 'date_mod',
@@ -189,7 +238,7 @@ final class HistoryBuilder
             'WHERE' => [
                 'itemtype'      => KnowbaseItem::class,
                 'items_id'      => $this->kb->getID(),
-                'itemtype_link' => $CFG_GLPI['kb_types'],
+                'itemtype_link' => $item_types,
                 'linked_action' => [
                     Log::HISTORY_ADD_RELATION,
                     Log::HISTORY_DEL_RELATION,

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -144,7 +144,8 @@ test('Permission changes appear in history', async ({ page, profile, api }) => {
     await expect(kb.getHeading('History')).toBeVisible();
 
     const events = page.getByTestId('history-event');
-    await expect(events.filter({ hasText: /Permission added/ })).toBeVisible();
+    await expect(events.filter({ hasText: /Permissions updated/ })).toBeVisible();
+    await expect(events.filter({ hasText: /Access granted to/ })).toBeVisible();
 });
 
 test('Document attachment changes appear in history', async ({ page, profile, api }) => {

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -122,6 +122,31 @@ test('Associated item changes appear in history', async ({ page, profile, api })
     await expect(events.filter({ hasText: 'Computer' })).toBeVisible();
 });
 
+test('Permission changes appear in history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const entity_id = getWorkerEntityId();
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'KB entry for permission history test',
+        entities_id: entity_id,
+        answer: 'Test content',
+    });
+    await api.createItem('Entity_KnowbaseItem', {
+        knowbaseitems_id: id,
+        entities_id: entity_id,
+        is_recursive: 0,
+    });
+
+    await kb.goto(id);
+    await page.getByTitle('More actions').click();
+    await kb.getButton('History').click();
+    await expect(kb.getHeading('History')).toBeVisible();
+
+    const events = page.getByTestId('history-event');
+    await expect(events.filter({ hasText: /Permission added/ })).toBeVisible();
+});
+
 test('Document attachment changes appear in history', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -37,11 +37,15 @@ namespace Glpi\Knowbase\History;
 use Computer;
 use Document;
 use Document_Item;
+use Entity;
+use Entity_KnowbaseItem;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItem_Item;
 use KnowbaseItem_Revision;
+use KnowbaseItem_User;
 use Ticket;
+use User;
 
 final class HistoryBuilderTest extends DbTestCase
 {
@@ -227,6 +231,154 @@ final class HistoryBuilderTest extends DbTestCase
         $version_1 = $events[2];
         $this->assertInstanceOf(RevisionEvent::class, $version_1);
         $this->assertEquals("Created by", $version_1->getDescription());
+    }
+
+    public function testPermissionAdded(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->createItem(Entity_KnowbaseItem::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'entities_id'      => $this->getTestRootEntity(only_id: true),
+            'is_recursive'     => 1,
+        ]);
+
+        $root_entity = new Entity();
+        $root_entity->getFromDB($this->getTestRootEntity(only_id: true));
+        $entity_name = $root_entity->getNameID(['forceid' => true]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: sprintf("Permission added: %s", $entity_name),
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testPermissionRemoved(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $relation = $this->createItem(Entity_KnowbaseItem::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'entities_id'      => $this->getTestRootEntity(only_id: true),
+            'is_recursive'     => 1,
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(Entity_KnowbaseItem::class, $relation->getID());
+
+        $root_entity = new Entity();
+        $root_entity->getFromDB($this->getTestRootEntity(only_id: true));
+        $entity_name = $root_entity->getNameID(['forceid' => true]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: sprintf("Permission removed: %s", $entity_name),
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: sprintf("Permission added: %s", $entity_name),
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testMultiplePermissionTypes(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->createItem(Entity_KnowbaseItem::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'entities_id'      => $this->getTestRootEntity(only_id: true),
+            'is_recursive'     => 1,
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->createItem(KnowbaseItem_User::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'users_id'         => 2,
+        ]);
+
+        $root_entity = new Entity();
+        $root_entity->getFromDB($this->getTestRootEntity(only_id: true));
+        $entity_name = $root_entity->getNameID(['forceid' => true]);
+
+        $user = new User();
+        $user->getFromDB(2);
+        $user_name = $user->getNameID(['forceid' => true]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: sprintf("Permission added: %s", $user_name),
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: sprintf("Permission added: %s", $entity_name),
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
     }
 
     public function testFaqChanges(): void

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -262,8 +262,8 @@ final class HistoryBuilderTest extends DbTestCase
 
         $this->assertEquals([
             new LogEvent(
-                label: sprintf("Permission added: %s", $entity_name),
-                description: "Updated by",
+                label: "Permissions updated",
+                description: sprintf("Access granted to %s by", $entity_name),
                 date: "2026-01-15 11:00:00",
                 author: "_test_user (8)",
             ),
@@ -306,14 +306,14 @@ final class HistoryBuilderTest extends DbTestCase
 
         $this->assertEquals([
             new LogEvent(
-                label: sprintf("Permission removed: %s", $entity_name),
-                description: "Updated by",
+                label: "Permissions updated",
+                description: sprintf("Access revoked from %s by", $entity_name),
                 date: "2026-01-15 12:00:00",
                 author: "_test_user (8)",
             ),
             new LogEvent(
-                label: sprintf("Permission added: %s", $entity_name),
-                description: "Updated by",
+                label: "Permissions updated",
+                description: sprintf("Access granted to %s by", $entity_name),
                 date: "2026-01-15 11:00:00",
                 author: "_test_user (8)",
             ),
@@ -363,14 +363,14 @@ final class HistoryBuilderTest extends DbTestCase
 
         $this->assertEquals([
             new LogEvent(
-                label: sprintf("Permission added: %s", $user_name),
-                description: "Updated by",
+                label: "Permissions updated",
+                description: sprintf("Access granted to %s by", $user_name),
                 date: "2026-01-15 12:00:00",
                 author: "_test_user (8)",
             ),
             new LogEvent(
-                label: sprintf("Permission added: %s", $entity_name),
-                description: "Updated by",
+                label: "Permissions updated",
+                description: sprintf("Access granted to %s by", $entity_name),
                 date: "2026-01-15 11:00:00",
                 author: "_test_user (8)",
             ),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/109
- Here is a brief description of what this PR does : 

Display permission changes (add/remove Entity, User, Group, Profile targets) as events in the Knowbase article history side panel. The HistoryBuilder queries the glpi_logs table for relation add/delete entries.

- `HistoryBuilder::addPermissionChangesToHistory() `: new method which query logs 
- PHPUnit tests covering add, remove, and mixed permission scenarios
- E2E test verifying a permission event is visible in the history panel


## Screenshot :

![Uploading Capture d
<img width="526" height="551" alt="Capture d’écran du 2026-02-23 12-04-12" src="https://github.com/user-attachments/assets/f4f27425-1748-4ad3-8457-34f5cb261bcb" />
’écran du 2026-02-23 12-04-12.png…]()
