### PR TITLE
Fix rules static cache

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -654,11 +654,14 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
 
     public function getCriterias()
     {
-        static $criterias = [];
+        static $criterias_by_class = [];
 
-        if (count($criterias)) {
-            return $criterias;
+        $rule_class = static::class;
+        if (isset($criterias_by_class[$rule_class])) {
+            return $criterias_by_class[$rule_class];
         }
+
+        $criterias = [];
 
         $itemtype = static::getItemtype();
         $itil_table = $itemtype::getTable();
@@ -825,6 +828,8 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
             'linkfield'       => '_date_creation_calendars_id',
             'type'            => 'dropdown',
         ];
+
+        $criterias_by_class[$rule_class] = $criterias;
 
         return $criterias;
     }

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -181,10 +181,11 @@ class RuleTicket extends RuleCommonITILObject
     public function getCriterias()
     {
 
-        static $criterias = [];
+        static $criterias_by_class = [];
 
-        if (count($criterias)) {
-            return $criterias;
+        $rule_class = static::class;
+        if (isset($criterias_by_class[$rule_class])) {
+            return $criterias_by_class[$rule_class];
         }
 
         $criterias = parent::getCriterias();
@@ -290,6 +291,8 @@ class RuleTicket extends RuleCommonITILObject
         $criterias['_locations_code']['table']              = 'glpi_locations';
         $criterias['_locations_code']['field']              = 'code';
         $criterias['_locations_code']['name']               = __('Location code');
+
+        $criterias_by_class[$rule_class] = $criterias;
 
         return $criterias;
     }


### PR DESCRIPTION
Fix another potential rule bug identified thanks to a flaky test (https://github.com/glpi-project/glpi/actions/runs/22230417132/job/64308218309?pr=23179).

The `getCriterias()` method use a static local variable as a cache.
Since PHP 8.1, these static variables are shared even if the method is inherited by another class.

This mean any class inheriting `RuleCommonITILObject` will share the same criteria cache, leading to issues where a rule is not applied correctly because its criteria is not found.

Source: https://www.php.net/manual/en/language.variables.scope.php -> "Example #11 Usage of static Variables in Inherited Methods".


