### PR TITLE
Fix(Plugin): Force order by directory

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1096,7 +1096,7 @@ class Plugin extends CommonDBTM
      *
      * @return array
      */
-    public function getList(array $fields = [], array $order = ['name', 'directory'])
+    public function getList(array $fields = [], array $order = ['directory'])
     {
         global $DB;
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

During the installation or update of a plugin, its name may be translated into the administrator interface language.

As a result, when the page reloads, the plugin may appear in a different position due to the translation of its name.

I propose to enforce ordering based on the `directory` rather than the plugin name to ensure consistent placement.

For @CupidSG 


## Screenshots (if appropriate):


