### PR TITLE
use correct route parameter name in getRuleActions()

### DIFF
--- a/src/Glpi/Api/HL/Controller/RuleController.php
+++ b/src/Glpi/Api/HL/Controller/RuleController.php
@@ -588,7 +588,7 @@ final class RuleController extends AbstractController
 
         $params = $request->getParameters();
         $filter = $params['filter'] ?? '';
-        $filter .= ';rule.id==' . $request->getAttribute('rule_id');
+        $filter .= ';rule.id==' . $request->getAttribute('id');
         $params['filter'] = $filter;
 
         return ResourceAccessor::searchBySchema($this->getKnownSchema('RuleAction', $this->getAPIVersion($request)), $params);


### PR DESCRIPTION


- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does : 

The getRuleActions() method seems to be copied from getRuleAction() without adapting the route parameter name : in the detail route `/Rule/{rule_id}/Action/{id}`, the rule parameter is named `{rule_id}` (to free `{id}` for the child resource ?).                                                                                                                  
In the list route `/Rule/{id}/Action`, the rule parameter is simply `{id}`. The copy kept `getAttribute('rule_id')` instead of `getAttribute('id')`, causing a null value.

## Test 

Call `GET /api.php/v2/Rule/Collection/Ticket/Rule/{id}/Action` with a valid rule ID. 

- Before fix : returns HTTP 400
- After fix : returns HTTP 200



