### PR TITLE
Improve form submit error logs

### DIFF
--- a/src/Glpi/Controller/Form/SubmitAnswerController.php
+++ b/src/Glpi/Controller/Form/SubmitAnswerController.php
@@ -92,7 +92,11 @@ final class SubmitAnswerController extends AbstractController
             ]);
         } catch (\Throwable $th) {
             $this->logger->error(
-                sprintf('An error occured during the form `%s` submission.', $form->getName()),
+                sprintf(
+                    'An error occured during the form `%s` submission: %s',
+                    $form->getName(),
+                    $th->getMessage(),
+                ),
                 ['exception' => $th]
             );
 


### PR DESCRIPTION
Right now the original exception message is lost (for example a failed SQL query).

