### PR TITLE
Remove KB side panel border when hidden

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -49,7 +49,7 @@
     }
 
     &.closed {
-        border-left: 0px;
+        border-left: 0;
         width: 0;
         overflow: hidden;
         padding: 0 !important;

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -49,6 +49,7 @@
     }
 
     &.closed {
+        border-left: 0px;
         width: 0;
         overflow: hidden;
         padding: 0 !important;

--- a/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
+++ b/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
@@ -127,5 +127,5 @@ test('Side panel displays normally on large screens', async ({
     await close_button.click();
 
     // Side panel should be reduced after close
-    await expect(side_panel).toHaveCSS('width', '1px');
+    await expect(side_panel).toHaveCSS('width', '0px');
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

A small UI fix, when the side panel is closed its border are still visible on the public FAQ:

<img width="1195" height="733" alt="image" src="https://github.com/user-attachments/assets/95e1cc95-455e-4e2f-b920-39fd8b9792c8" />


