### PR TITLE
Fix: Using null as an array offset is deprecated

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4940,7 +4940,7 @@ class CommonDBTM extends CommonGLPI
                         break;
 
                     case "language":
-                        if (isset($CFG_GLPI['languages'][$value])) {
+                        if (isset($CFG_GLPI['languages'][$value ?? ''])) {
                             return htmlescape($CFG_GLPI['languages'][$value][0]);
                         }
                         return __s('Default value');

--- a/src/User.php
+++ b/src/User.php
@@ -4742,7 +4742,7 @@ HTML;
                     if ($data[$field_user] == $ID) {
                         $linktypes[] = self::getTypeName(1);
                     }
-                    if (isset($groups[$data['groups_id']])) {
+                    if (isset($groups[$data['groups_id'] ?? ''])) {
                         $linktypes[] = sprintf(
                             __('%1$s = %2$s'),
                             Group::getTypeName(1),


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

```
glpi.INFO:   *** Deprecated: Using null as an array offset is deprecated, use an empty string instead at User.php line 4745
  Backtrace :
  ./src/User.php:4745                                
  ./src/User.php:394                                 User->showItems()
  ./src/CommonGLPI.php:738                           User::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

```
glpi.INFO:   *** Deprecated: Using null as an array offset is deprecated, use an empty string instead at CommonDBTM.php line 4943
  Backtrace :
  ./src/CommonDBTM.php:4943                          
  ./src/Log.php:866                                  CommonDBTM->getValueToDisplay()
  ./src/Log.php:339                                  Log::getHistoryData()
  ./src/Log.php:125                                  Log::showForItem()
  ./src/CommonGLPI.php:738                           Log::displayTabContentForItem()
  ./ajax/common.tabs.php:108                         CommonGLPI::displayStandardTab()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```