### PR TITLE
fix 2fa_request.html.twig - wrong url building + action and redirect param are mandatory

### DIFF
--- a/src/Glpi/Security/TOTPManager.php
+++ b/src/Glpi/Security/TOTPManager.php
@@ -494,6 +494,7 @@ final class TOTPManager
     public function showTOTPPrompt(): void
     {
         TemplateRenderer::getInstance()->display('pages/2fa/2fa_request.html.twig', [
+            'action' => 'MFA/Verify',
             'redirect' => $_GET['redirect'] ?? '',
         ]);
     }

--- a/templates/pages/2fa/2fa_request.html.twig
+++ b/templates/pages/2fa/2fa_request.html.twig
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block content_block %}
-   <form method="post" action="{{ path('MFA/Verify') ~ (redirect is not empty ? ('/?redirect=' ~ redirect) : '') }}" data-submit-once autocomplete="off" class="m-md-n4" data-code-type="code">
+   <form method="post" action="{{ path(action, {"redirect": redirect}) }}" data-submit-once autocomplete="off" class="m-md-n4" data-code-type="code">
       <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
       <div>
          {{ tfa.tfa_code_input() }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

First argument of path must be the exact \Glpi\Controller\Security\MFAController::verify() otherwise the route is not matched. Concatenation breaks the route which results in a route not found exception.
Query parameters must be defined in path() second arg.


