### PR TITLE
Fix(TinyMCE): auto hide menu

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3781,6 +3781,19 @@ JS;
                                     setupFileUpload(fileupload_config);
                                 });
                         });
+
+                        // Close TinyMCE toolbar dropdowns and blur active buttons when clicking outside editor UI elements
+                        $(document).on('click', function(e) {
+                            const target = $(e.target);
+                            const isEditorElementClicked =
+                                target.closest('.tox-editor-header').length > 0 ||
+                                target.closest('.tox-toolbar__primary').length > 0 ||
+                                target.closest('.tox-menu').length > 0;
+
+                            if (!isEditorElementClicked) {
+                                $('.tox-tbtn.tox-tbtn--enabled').trigger('click').trigger('blur');
+                            }
+                        });
                     }
                 }, {$language_opts});
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42437

The menu remained displayed, even though the TinyMCE editor was no longer visible.
Now, it closes as soon as you click outside the editor.

## Screenshots (if appropriate):

<img width="865" height="336" alt="image" src="https://github.com/user-attachments/assets/ea088664-9d2b-41cf-8ea9-76a8c78d5537" />

<img width="874" height="337" alt="image" src="https://github.com/user-attachments/assets/a233e6d4-c03e-411f-be81-10e35aa68da4" />


