### PR TITLE
fix _validationsteps_id criteria not match if validation is not from a user with ticket update right

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1843,6 +1843,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     )
                 ) {
                     $allowed_fields[] = 'global_validation';
+                    $allowed_fields[] = '_validationsteps_id';
                 }
                 // Manage assign and steal right
                 if (static::getType() === Ticket::getType() && Session::haveRightsOr(static::$rightname, [Ticket::ASSIGN, Ticket::STEAL])) {


### PR DESCRIPTION


<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

_validationsteps_id is removed by \CommonITILObject::handleTemplateFields() if user doesn't have the right to update a ticket.
So rule condition (on validation) can never match.

CommonITILValidation::post_updateItem() -> CommonITILValidation::recomputeItilStatus() -> Ticket update() -> CommonITILObject::handleTemplateFields() - _validationsteps_id was removed here -> ProcessRules()

