### PR TITLE
add documents support to history timeline

### DIFF
--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Knowbase\History;
 
+use Document;
 use KnowbaseItem;
 use KnowbaseItem_Revision;
 use Log;
@@ -54,6 +55,7 @@ final class HistoryBuilder
         $this->addRevisionsToHistory();
         $this->addFaqStatusChangesToHistory();
         $this->addAssociatedItemChangesToHistory();
+        $this->addDocumentChangesToHistory();
         $this->history->sort();
         return $this->history;
     }
@@ -209,6 +211,54 @@ final class HistoryBuilder
             $description = sprintf(
                 $is_add ? __('%s — Linked by') : __('%s — Unlinked by'),
                 $type_name . ': ' . $item_name
+            );
+
+            $this->history->addEvent(new LogEvent(
+                label: $label,
+                description: $description,
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
+    private function addDocumentChangesToHistory(): void
+    {
+        global $DB;
+
+        $logs = $DB->request([
+            'SELECT' => [
+                'date_mod',
+                'user_name',
+                'linked_action',
+                'old_value',
+                'new_value',
+            ],
+            'FROM' => Log::getTable(),
+            'WHERE' => [
+                'itemtype'      => KnowbaseItem::class,
+                'items_id'      => $this->kb->getID(),
+                'itemtype_link' => Document::class,
+                'linked_action' => [
+                    Log::HISTORY_ADD_RELATION,
+                    Log::HISTORY_DEL_RELATION,
+                ],
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $is_add = $row['linked_action'] == Log::HISTORY_ADD_RELATION;
+            $document_name = $is_add ? $row['new_value'] : $row['old_value'];
+
+            $label = $is_add
+                ? __("File added")
+                : __("File removed")
+            ;
+
+            $description = sprintf(
+                $is_add ? __('%s — Added by') : __('%s — Removed by'),
+                $document_name
             );
 
             $this->history->addEvent(new LogEvent(

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -121,3 +121,37 @@ test('Associated item changes appear in history', async ({ page, profile, api })
     await expect(events.filter({ hasText: 'Item linked' })).toBeVisible();
     await expect(events.filter({ hasText: 'Computer' })).toBeVisible();
 });
+
+test('Document attachment changes appear in history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create a KB item
+    const kb_id = await api.createItem('KnowbaseItem', {
+        name: 'Article with attachments',
+        entities_id: getWorkerEntityId(),
+        answer: 'Some content',
+    });
+
+    // Create a document and attach it to the KB item
+    const doc_id = await api.createItem('Document', {
+        name: 'test_attachment.pdf',
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('Document_Item', {
+        documents_id: doc_id,
+        itemtype: 'KnowbaseItem',
+        items_id: kb_id,
+    });
+
+    // Go to article and open history panel
+    await kb.goto(kb_id);
+    await page.getByTitle('More actions').click();
+    await kb.getButton('History').click();
+    await expect(kb.getHeading('History')).toBeVisible();
+
+    // Should show "File added" event
+    const events = page.getByTestId('history-event');
+    await expect(events.filter({ hasText: 'File added' })).toBeVisible();
+    await expect(events.filter({ hasText: 'test_attachment.pdf' })).toBeVisible();
+});

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -35,6 +35,8 @@
 namespace Glpi\Knowbase\History;
 
 use Computer;
+use Document;
+use Document_Item;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItem_Item;
@@ -397,6 +399,132 @@ final class HistoryBuilderTest extends DbTestCase
 
         $this->assertInstanceOf(LogEvent::class, $events[1]);
         $this->assertEquals("Item linked", $events[1]->getLabel());
+
+
+        $this->assertInstanceOf(RevisionEvent::class, $events[2]);
+        $this->assertEquals("Version 1", $events[2]->getLabel());
+    }
+
+    public function testDocumentAddedAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $doc = $this->createItem(Document::class, [
+            'name' => 'test_document.pdf',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $this->createItem(Document_Item::class, [
+            'documents_id' => $doc->getID(),
+            'itemtype' => KnowbaseItem::class,
+            'items_id' => $kb->getID(),
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(2, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("File added", $events[0]->getLabel());
+        $this->assertStringContainsString("test_document.pdf", $events[0]->getDescription());
+
+        $this->assertInstanceOf(CreationEvent::class, $events[1]);
+    }
+
+    public function testDocumentRemovedAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $doc = $this->createItem(Document::class, [
+            'name' => 'to_remove.pdf',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $doc_item = $this->createItem(Document_Item::class, [
+            'documents_id' => $doc->getID(),
+            'itemtype' => KnowbaseItem::class,
+            'items_id' => $kb->getID(),
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(Document_Item::class, $doc_item->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(3, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("File removed", $events[0]->getLabel());
+        $this->assertStringContainsString("to_remove.pdf", $events[0]->getDescription());
+
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("File added", $events[1]->getLabel());
+    }
+
+    public function testDocumentChangesWithContentRevisions(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Version 1',
+        ]);
+
+        // Add a document
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $doc = $this->createItem(Document::class, [
+            'name' => 'attached_file.pdf',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $this->createItem(Document_Item::class, [
+            'documents_id' => $doc->getID(),
+            'itemtype' => KnowbaseItem::class,
+            'items_id' => $kb->getID(),
+        ]);
+
+        // Update content (creates a revision)
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'answer' => 'Version 2',
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        // 3 events sorted by date DESC: current version, file added, revision 1
+        $this->assertCount(3, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Current version", $events[0]->getLabel());
+
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("File added", $events[1]->getLabel());
 
         $this->assertInstanceOf(RevisionEvent::class, $events[2]);
         $this->assertEquals("Version 1", $events[2]->getLabel());


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/114
- Here is a brief description of what this PR does : Display document attachment/detachment events (file added/removed) in the Knowbase article history side panel, with PHPUnit and E2E test coverage. 

## Screenshots : 

<img width="333" height="450" alt="image" src="https://github.com/user-attachments/assets/6b747d3e-39cc-4e26-9a39-90ea81e963a8" />



