### PR TITLE
items linking in history timeline

### DIFF
--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -53,6 +53,7 @@ final class HistoryBuilder
         $this->addCurrentVersionToHistory();
         $this->addRevisionsToHistory();
         $this->addFaqStatusChangesToHistory();
+        $this->addAssociatedItemChangesToHistory();
         $this->history->sort();
         return $this->history;
     }
@@ -163,6 +164,56 @@ final class HistoryBuilder
             $this->history->addEvent(new LogEvent(
                 label: $label,
                 description: __("Updated by"),
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
+    private function addAssociatedItemChangesToHistory(): void
+    {
+        global $DB, $CFG_GLPI;
+
+        $logs = $DB->request([
+            'SELECT' => [
+                'date_mod',
+                'user_name',
+                'linked_action',
+                'itemtype_link',
+                'old_value',
+                'new_value',
+            ],
+            'FROM' => Log::getTable(),
+            'WHERE' => [
+                'itemtype'      => KnowbaseItem::class,
+                'items_id'      => $this->kb->getID(),
+                'itemtype_link' => $CFG_GLPI['kb_types'],
+                'linked_action' => [
+                    Log::HISTORY_ADD_RELATION,
+                    Log::HISTORY_DEL_RELATION,
+                ],
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $is_add = $row['linked_action'] == Log::HISTORY_ADD_RELATION;
+            $item_name = $is_add ? $row['new_value'] : $row['old_value'];
+            $type_name = $row['itemtype_link']::getTypeName(1);
+
+            $label = $is_add
+                ? __("Item linked")
+                : __("Item unlinked")
+            ;
+
+            $description = sprintf(
+                $is_add ? __('%s — Linked by') : __('%s — Unlinked by'),
+                $type_name . ': ' . $item_name
+            );
+
+            $this->history->addEvent(new LogEvent(
+                label: $label,
+                description: $description,
                 date: $row['date_mod'],
                 author: $row['user_name'],
             ));

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -87,3 +87,37 @@ test('Can view revision history and restore a previous version', async ({ page, 
     await page.getByTitle('More actions').click();
     await expect(page.getByTestId('history-counter')).toHaveText("4");
 });
+
+test('Associated item changes appear in history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create a KB item
+    const kb_id = await api.createItem('KnowbaseItem', {
+        name: 'Article with linked items',
+        entities_id: getWorkerEntityId(),
+        answer: 'Some content',
+    });
+
+    // Create a computer and link it to the KB item
+    const computer_id = await api.createItem('Computer', {
+        name: 'Test PC',
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItem_Item', {
+        knowbaseitems_id: kb_id,
+        itemtype: 'Computer',
+        items_id: computer_id,
+    });
+
+    // Go to article and open history panel
+    await kb.goto(kb_id);
+    await page.getByTitle('More actions').click();
+    await kb.getButton('History').click();
+    await expect(kb.getHeading('History')).toBeVisible();
+
+    // Should show "Item linked" event with Computer type
+    const events = page.getByTestId('history-event');
+    await expect(events.filter({ hasText: 'Item linked' })).toBeVisible();
+    await expect(events.filter({ hasText: 'Computer' })).toBeVisible();
+});

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -34,9 +34,12 @@
 
 namespace Glpi\Knowbase\History;
 
+use Computer;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
+use KnowbaseItem_Item;
 use KnowbaseItem_Revision;
+use Ticket;
 
 final class HistoryBuilderTest extends DbTestCase
 {
@@ -271,5 +274,131 @@ final class HistoryBuilderTest extends DbTestCase
                 author: 2,
             ),
         ], $events);
+    }
+
+    public function testLinkedItemAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'Test PC',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $this->createItem(KnowbaseItem_Item::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'itemtype' => Computer::class,
+            'items_id' => $computer->getID(),
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(2, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Item linked", $events[0]->getLabel());
+        $this->assertStringContainsString("Computer", $events[0]->getDescription());
+
+        $this->assertInstanceOf(CreationEvent::class, $events[1]);
+    }
+
+    public function testUnlinkedItemAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'Test Ticket',
+            'content' => 'Ticket content',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        $kb_item = $this->createItem(KnowbaseItem_Item::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(KnowbaseItem_Item::class, $kb_item->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(3, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Item unlinked", $events[0]->getLabel());
+        $this->assertStringContainsString("Ticket", $events[0]->getDescription());
+
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("Item linked", $events[1]->getLabel());
+    }
+
+    public function testLinkedItemChangesWithContentRevisions(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Version 1',
+        ]);
+
+        // Link a computer
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'My PC',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $this->createItem(KnowbaseItem_Item::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'itemtype' => Computer::class,
+            'items_id' => $computer->getID(),
+        ]);
+
+        // Update content (creates a revision)
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'answer' => 'Version 2',
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        // 3 events sorted by date DESC: current version, item linked, revision 1
+        $this->assertCount(3, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Current version", $events[0]->getLabel());
+
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("Item linked", $events[1]->getLabel());
+
+        $this->assertInstanceOf(RevisionEvent::class, $events[2]);
+        $this->assertEquals("Version 1", $events[2]->getLabel());
     }
 }


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/115
- Here is a brief description of what this PR does : 
Display associated item link/unlink events (Computer, Ticket, etc.) in the Knowbase article history side panel, with PHPUnit and E2E test coverage.


## Screenshot : 

<img width="345" height="545" alt="image" src="https://github.com/user-attachments/assets/787a659f-1b15-4688-9c38-f4ae1914a6fc" />



