### PR TITLE
title in history timeline

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -85,11 +85,6 @@ export class GlpiKnowbaseArticleController
     };
 
     /**
-     * @type {string|null} Original subject HTML (saved before diff mode)
-     */
-    #originalSubject = null;
-
-    /**
      * @type {string|null} Original content HTML (saved before diff mode)
      */
     #originalContent = null;
@@ -163,25 +158,22 @@ export class GlpiKnowbaseArticleController
     }
 
     /**
-     * @param {{title_diff: string, content_diff: string}} detail
+     * @param {{content_diff: string}} detail
      */
-    #showDiff({title_diff, content_diff})
+    #showDiff({content_diff})
     {
-        const subjectEl = this.#container.querySelector('[data-glpi-kb-subject]');
         const contentEl = this.#container.querySelector('[data-glpi-kb-content]');
 
-        if (!subjectEl || !contentEl) {
+        if (!contentEl) {
             return;
         }
 
         // Save original content on first activation
-        if (this.#originalSubject === null) {
-            this.#originalSubject = subjectEl.innerHTML;
+        if (this.#originalContent === null) {
             this.#originalContent = contentEl.innerHTML;
         }
 
         // Replace with diff
-        subjectEl.innerHTML = title_diff;
         contentEl.innerHTML = content_diff;
 
         // Add diff-mode class for styling
@@ -199,12 +191,8 @@ export class GlpiKnowbaseArticleController
             return;
         }
 
-        const subjectEl = this.#container.querySelector('[data-glpi-kb-subject]');
         const contentEl = this.#container.querySelector('[data-glpi-kb-content]');
 
-        if (subjectEl && this.#originalSubject !== null) {
-            subjectEl.innerHTML = this.#originalSubject;
-        }
         if (contentEl && this.#originalContent !== null) {
             contentEl.innerHTML = this.#originalContent;
         }
@@ -214,7 +202,6 @@ export class GlpiKnowbaseArticleController
             article.classList.remove('kb-article--diff-mode');
         }
 
-        this.#originalSubject = null;
         this.#originalContent = null;
         this.#isDiffMode = false;
     }

--- a/js/modules/Knowbase/RevisionsPanelController.js
+++ b/js/modules/Knowbase/RevisionsPanelController.js
@@ -123,12 +123,12 @@ export class GlpiKnowbaseRevisionsPanelController
                 throw new Error('Failed to load revision diff');
             }
 
-            const {title_diff, content_diff} = await response.json();
+            const {content_diff} = await response.json();
 
             // Dispatch event to ArticleController
             this.#container.dispatchEvent(new CustomEvent('glpi:kb:compare', {
                 bubbles: true,
-                detail: {revisionId, title_diff, content_diff},
+                detail: {revisionId, content_diff},
             }));
 
             // Update state

--- a/src/Glpi/Controller/Knowbase/CompareRevisionController.php
+++ b/src/Glpi/Controller/Knowbase/CompareRevisionController.php
@@ -73,23 +73,16 @@ final class CompareRevisionController extends AbstractController
         }
 
         // Old = revision content, New = current article content
-        $old_name = $revision->fields['name'];
-        $new_name = $kb->fields['name'];
-
         $old_answer = RichText::getEnhancedHtml($revision->fields['answer'], ['text_maxsize' => 0]);
         $new_answer = RichText::getEnhancedHtml($kb->fields['answer'], ['text_maxsize' => 0]);
 
         // Normalize non-breaking spaces (same as the former JS normalizeHtml)
-        $old_name   = $this->normalizeHtml($old_name);
-        $new_name   = $this->normalizeHtml($new_name);
         $old_answer = $this->normalizeHtml($old_answer);
         $new_answer = $this->normalizeHtml($new_answer);
 
-        $title_diff   = (new Diff($old_name, $new_name))->build();
         $content_diff = (new Diff($old_answer, $new_answer))->build();
 
         return new JsonResponse([
-            'title_diff'   => $title_diff,
             'content_diff' => $content_diff,
         ]);
     }

--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -63,6 +63,7 @@ final class HistoryBuilder
         $this->addAssociatedItemChangesToHistory();
         $this->addDocumentChangesToHistory();
         $this->addPermissionChangesToHistory();
+        $this->addNameChangesToHistory();
 
         $this->history->sort();
         return $this->history;
@@ -176,6 +177,38 @@ final class HistoryBuilder
 
             $this->history->addEvent(new LogEvent(
                 label: __("Permissions updated"),
+                description: $description,
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
+    private function addNameChangesToHistory(): void
+    {
+        global $DB;
+
+        $logs = $DB->request([
+            'SELECT' => ['date_mod', 'user_name', 'old_value', 'new_value'],
+            'FROM'   => Log::getTable(),
+            'WHERE'  => [
+                'itemtype'         => KnowbaseItem::class,
+                'items_id'         => $this->kb->getID(),
+                'linked_action'    => 0, // Update
+                'id_search_option' => 1, // Name
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $description = sprintf(
+                __('%s → %s — Updated by'),
+                $row['old_value'],
+                $row['new_value']
+            );
+
+            $this->history->addEvent(new LogEvent(
+                label: __("Renamed"),
                 description: $description,
                 date: $row['date_mod'],
                 author: $row['user_name'],

--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -201,17 +201,13 @@ final class HistoryBuilder
         ]);
 
         foreach ($logs as $row) {
-            $description = sprintf(
-                __('%s → %s — Updated by'),
-                $row['old_value'],
-                $row['new_value']
-            );
-
             $this->history->addEvent(new LogEvent(
                 label: __("Renamed"),
-                description: $description,
+                description: __("Updated by"),
                 date: $row['date_mod'],
                 author: $row['user_name'],
+                old_value: $row['old_value'],
+                new_value: $row['new_value'],
             ));
         }
     }

--- a/src/Glpi/Knowbase/History/HistoryEventList.php
+++ b/src/Glpi/Knowbase/History/HistoryEventList.php
@@ -68,10 +68,17 @@ final class HistoryEventList
     {
         usort(
             $this->events,
-            static fn(HistoryEventInterface $left, HistoryEventInterface $right): int => strcmp(
-                $right->getDate(),
-                $left->getDate()
-            )
+            static function (HistoryEventInterface $left, HistoryEventInterface $right): int {
+                $date_cmp = strcmp($right->getDate(), $left->getDate());
+                if ($date_cmp !== 0) {
+                    return $date_cmp;
+                }
+
+                // When dates are equal, LogEvents (metadata changes) come
+                // before RevisionEvents (content snapshots).
+                return ($left instanceof RevisionEvent ? 1 : 0)
+                    - ($right instanceof RevisionEvent ? 1 : 0);
+            }
         );
     }
 }

--- a/src/Glpi/Knowbase/History/LogEvent.php
+++ b/src/Glpi/Knowbase/History/LogEvent.php
@@ -76,11 +76,11 @@ final class LogEvent implements HistoryEventInterface
 
     public function getNewValue(): ?string
     {
-        return $this->new_value;
+        return $this->new_value !== null ? strip_tags($this->new_value) : null;
     }
 
     public function getOldValue(): ?string
     {
-        return $this->old_value;
+        return $this->old_value !== null ? strip_tags($this->old_value) : null;
     }
 }

--- a/src/Glpi/Knowbase/History/LogEvent.php
+++ b/src/Glpi/Knowbase/History/LogEvent.php
@@ -45,8 +45,8 @@ final class LogEvent implements HistoryEventInterface
         private string $description,
         private string $date,
         private string $author,
-        private ?string $new_value = null,
         private ?string $old_value = null,
+        private ?string $new_value = null,
     ) {}
 
     #[Override]
@@ -76,19 +76,11 @@ final class LogEvent implements HistoryEventInterface
 
     public function getNewValue(): ?string
     {
-        if ($this->new_value === null) {
-            return null;
-        }
-
-        return strip_tags($this->new_value);
+        return $this->new_value;
     }
 
     public function getOldValue(): ?string
     {
-        if ($this->old_value === null) {
-            return null;
-        }
-
-        return strip_tags($this->old_value);
+        return $this->old_value;
     }
 }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2335,7 +2335,6 @@ TWIG, $twig_params);
 
         $values = [
             'id'     => $this->getID(),
-            'name'   => $revision->fields['name'],
             'answer' => $revision->fields['answer'],
         ];
 

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2260,11 +2260,9 @@ TWIG, $twig_params);
 
     public function pre_updateInDB()
     {
-        // Only create a revision if name or answer was modified.
-        if (
-            !in_array('name', $this->updates)
-            && !in_array('answer', $this->updates)
-        ) {
+        // Only create a revision if the answer was modified.
+        // Name changes are tracked separately as "Renamed" events in the history.
+        if (!in_array('answer', $this->updates)) {
             return;
         }
 

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -182,6 +182,30 @@ test('Document attachment changes appear in history', async ({ page, profile, ap
     await expect(events.filter({ hasText: 'test_attachment.pdf' })).toBeVisible();
 });
 
+test('Name changes appear in history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create a KB item and rename it
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'Original Title',
+        entities_id: getWorkerEntityId(),
+        answer: 'Some content',
+    });
+    await api.updateItem('KnowbaseItem', id, { name: 'Renamed Title' });
+
+    // Go to article and open history panel
+    await kb.goto(id);
+    await page.getByTitle('More actions').click();
+    await kb.getButton('History').click();
+    await expect(kb.getHeading('History')).toBeVisible();
+
+    // Should show "Renamed" event with old and new title
+    const event = page.getByTestId('history-event').filter({ hasText: 'Renamed' });
+    await expect(event).toBeVisible();
+    await expect(event).toContainText('Original Title → Renamed Title');
+});
+
 test('Can compare a revision with the current version', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -203,7 +203,8 @@ test('Name changes appear in history', async ({ page, profile, api }) => {
     // Should show "Renamed" event with old and new title
     const event = page.getByTestId('history-event').filter({ hasText: 'Renamed' });
     await expect(event).toBeVisible();
-    await expect(event).toContainText('Original Title → Renamed Title');
+    await expect(event.getByTitle(/Original Title/)).toBeAttached();
+    await expect(event.getByTitle(/Renamed Title/)).toBeAttached();
 });
 
 test('Can compare a revision with the current version', async ({ page, profile, api }) => {

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -296,17 +296,17 @@ final class HistoryBuilderTest extends DbTestCase
         $history = (new HistoryBuilder($kb))->buildHistory();
         $events = $history->getEvents();
 
-        // Use array_filter since other events may be present alongside the Renamed event
-        $renamed_events = array_values(array_filter(
-            $events,
-            static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
-        ));
+        // Name-only change should not create a revision, just a Renamed event
+        $this->assertCount(2, $events);
 
-        $this->assertCount(1, $renamed_events);
-        $this->assertEquals("Updated by", $renamed_events[0]->getDescription());
-        $this->assertEquals("Original title", $renamed_events[0]->getOldValue());
-        $this->assertEquals("Updated title", $renamed_events[0]->getNewValue());
-        $this->assertEquals("2026-01-15 11:00:00", $renamed_events[0]->getDate());
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Renamed", $events[0]->getLabel());
+        $this->assertEquals("Updated by", $events[0]->getDescription());
+        $this->assertEquals("Original title", $events[0]->getOldValue());
+        $this->assertEquals("Updated title", $events[0]->getNewValue());
+        $this->assertEquals("2026-01-15 11:00:00", $events[0]->getDate());
+
+        $this->assertInstanceOf(CreationEvent::class, $events[1]);
     }
 
     public function testPermissionRemoved(): void
@@ -384,6 +384,9 @@ final class HistoryBuilderTest extends DbTestCase
         $kb->getFromDB($kb->getID());
         $history = (new HistoryBuilder($kb))->buildHistory();
         $events = $history->getEvents();
+
+        // 3 events: 2 Renamed + Creation (no revisions for name-only changes)
+        $this->assertCount(3, $events);
 
         $renamed_events = array_values(array_filter(
             $events,
@@ -484,18 +487,18 @@ final class HistoryBuilderTest extends DbTestCase
         $history = (new HistoryBuilder($kb))->buildHistory();
         $events = $history->getEvents();
 
-        // Current version (content update at 12:00)
+        // 3 events: Current version (content), Renamed, Creation
+        $this->assertCount(3, $events);
+
         $this->assertInstanceOf(LogEvent::class, $events[0]);
         $this->assertEquals("Current version", $events[0]->getLabel());
 
-        // Verify the Renamed event is present
-        $renamed_events = array_values(array_filter(
-            $events,
-            static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
-        ));
-        $this->assertCount(1, $renamed_events);
-        $this->assertEquals("Original title", $renamed_events[0]->getOldValue());
-        $this->assertEquals("New title", $renamed_events[0]->getNewValue());
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("Renamed", $events[1]->getLabel());
+        $this->assertEquals("Original title", $events[1]->getOldValue());
+        $this->assertEquals("New title", $events[1]->getNewValue());
+
+        $this->assertInstanceOf(RevisionEvent::class, $events[2]);
     }
 
     public function testFaqChanges(): void

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -303,10 +303,9 @@ final class HistoryBuilderTest extends DbTestCase
         ));
 
         $this->assertCount(1, $renamed_events);
-        $this->assertEquals(
-            "Original title → Updated title — Updated by",
-            $renamed_events[0]->getDescription()
-        );
+        $this->assertEquals("Updated by", $renamed_events[0]->getDescription());
+        $this->assertEquals("Original title", $renamed_events[0]->getOldValue());
+        $this->assertEquals("Updated title", $renamed_events[0]->getNewValue());
         $this->assertEquals("2026-01-15 11:00:00", $renamed_events[0]->getDate());
     }
 
@@ -392,9 +391,13 @@ final class HistoryBuilderTest extends DbTestCase
         ));
 
         $this->assertCount(2, $renamed_events);
-        $this->assertEquals("Title v2 → Title v3 — Updated by", $renamed_events[0]->getDescription());
+        $this->assertEquals("Updated by", $renamed_events[0]->getDescription());
+        $this->assertEquals("Title v2", $renamed_events[0]->getOldValue());
+        $this->assertEquals("Title v3", $renamed_events[0]->getNewValue());
         $this->assertEquals("2026-01-15 12:00:00", $renamed_events[0]->getDate());
-        $this->assertEquals("Title v1 → Title v2 — Updated by", $renamed_events[1]->getDescription());
+        $this->assertEquals("Updated by", $renamed_events[1]->getDescription());
+        $this->assertEquals("Title v1", $renamed_events[1]->getOldValue());
+        $this->assertEquals("Title v2", $renamed_events[1]->getNewValue());
         $this->assertEquals("2026-01-15 11:00:00", $renamed_events[1]->getDate());
     }
 
@@ -491,8 +494,8 @@ final class HistoryBuilderTest extends DbTestCase
             static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
         ));
         $this->assertCount(1, $renamed_events);
-        $this->assertStringContainsString("Original title", $renamed_events[0]->getDescription());
-        $this->assertStringContainsString("New title", $renamed_events[0]->getDescription());
+        $this->assertEquals("Original title", $renamed_events[0]->getOldValue());
+        $this->assertEquals("New title", $renamed_events[0]->getNewValue());
     }
 
     public function testFaqChanges(): void

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -275,6 +275,41 @@ final class HistoryBuilderTest extends DbTestCase
         ], $events);
     }
 
+    public function testNameChangeAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Original title',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'name' => 'Updated title',
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        // Use array_filter since other events may be present alongside the Renamed event
+        $renamed_events = array_values(array_filter(
+            $events,
+            static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
+        ));
+
+        $this->assertCount(1, $renamed_events);
+        $this->assertEquals(
+            "Original title → Updated title — Updated by",
+            $renamed_events[0]->getDescription()
+        );
+        $this->assertEquals("2026-01-15 11:00:00", $renamed_events[0]->getDate());
+    }
+
     public function testPermissionRemoved(): void
     {
         $this->login();
@@ -323,6 +358,44 @@ final class HistoryBuilderTest extends DbTestCase
                 author: 2,
             ),
         ], $events);
+    }
+
+    public function testMultipleNameChanges(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Title v1',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'name' => 'Title v2',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'name' => 'Title v3',
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $renamed_events = array_values(array_filter(
+            $events,
+            static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
+        ));
+
+        $this->assertCount(2, $renamed_events);
+        $this->assertEquals("Title v2 → Title v3 — Updated by", $renamed_events[0]->getDescription());
+        $this->assertEquals("2026-01-15 12:00:00", $renamed_events[0]->getDate());
+        $this->assertEquals("Title v1 → Title v2 — Updated by", $renamed_events[1]->getDescription());
+        $this->assertEquals("2026-01-15 11:00:00", $renamed_events[1]->getDate());
     }
 
     public function testMultiplePermissionTypes(): void
@@ -380,6 +453,46 @@ final class HistoryBuilderTest extends DbTestCase
                 author: 2,
             ),
         ], $events);
+    }
+
+    public function testNameChangeWithContentRevision(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Original title',
+            'answer' => 'Version 1',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'name' => 'New title',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(KnowbaseItem::class, $kb->getID(), [
+            'answer' => 'Version 2',
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        // Current version (content update at 12:00)
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Current version", $events[0]->getLabel());
+
+        // Verify the Renamed event is present
+        $renamed_events = array_values(array_filter(
+            $events,
+            static fn($e) => $e instanceof LogEvent && $e->getLabel() === "Renamed"
+        ));
+        $this->assertCount(1, $renamed_events);
+        $this->assertStringContainsString("Original title", $renamed_events[0]->getDescription());
+        $this->assertStringContainsString("New title", $renamed_events[0]->getDescription());
     }
 
     public function testFaqChanges(): void

--- a/tests/functional/Glpi/Knowbase/SidePanel/HistoryRendererTest.php
+++ b/tests/functional/Glpi/Knowbase/SidePanel/HistoryRendererTest.php
@@ -64,13 +64,19 @@ final class HistoryRendererTest extends DbTestCase
         $revisions = $this->renderRevisions($kb);
 
         $revisionNodes = $revisions->filter('[data-testid=history-event]');
-        $this->assertEquals(2, $revisionNodes->count());
+        $this->assertEquals(3, $revisionNodes->count());
 
-        $currentVersion = $revisionNodes->first();
+        $renamed = $revisionNodes->eq(0);
+        $this->assertStringContainsString('Renamed', $renamed->text());
+        $this->assertStringContainsString('Original title', $renamed->text());
+        $this->assertStringContainsString('Updated title', $renamed->text());
+        $this->assertEquals(0, $renamed->filter('[data-glpi-revert-revision]')->count());
+
+        $currentVersion = $revisionNodes->eq(1);
         $this->assertStringContainsString('Current version', $currentVersion->text());
         $this->assertEquals(0, $currentVersion->filter('[data-glpi-revert-revision]')->count());
 
-        $initialVersion = $revisionNodes->last();
+        $initialVersion = $revisionNodes->eq(2);
         $this->assertStringContainsString('Version 1', $initialVersion->text());
         $this->assertEquals(1, $initialVersion->filter('[data-glpi-revert-revision]')->count());
     }

--- a/tests/functional/Glpi/Knowbase/SidePanel/HistoryRendererTest.php
+++ b/tests/functional/Glpi/Knowbase/SidePanel/HistoryRendererTest.php
@@ -64,21 +64,18 @@ final class HistoryRendererTest extends DbTestCase
         $revisions = $this->renderRevisions($kb);
 
         $revisionNodes = $revisions->filter('[data-testid=history-event]');
-        $this->assertEquals(3, $revisionNodes->count());
+        $this->assertEquals(2, $revisionNodes->count());
 
         $renamed = $revisionNodes->eq(0);
         $this->assertStringContainsString('Renamed', $renamed->text());
-        $this->assertStringContainsString('Original title', $renamed->text());
-        $this->assertStringContainsString('Updated title', $renamed->text());
+        $tooltip = $renamed->filter('[data-bs-toggle="tooltip"]')->first();
+        $this->assertStringContainsString('Original title', $tooltip->attr('title'));
+        $this->assertStringContainsString('Updated title', $tooltip->attr('title'));
         $this->assertEquals(0, $renamed->filter('[data-glpi-revert-revision]')->count());
 
         $currentVersion = $revisionNodes->eq(1);
         $this->assertStringContainsString('Current version', $currentVersion->text());
         $this->assertEquals(0, $currentVersion->filter('[data-glpi-revert-revision]')->count());
-
-        $initialVersion = $revisionNodes->eq(2);
-        $this->assertStringContainsString('Version 1', $initialVersion->text());
-        $this->assertEquals(1, $initialVersion->filter('[data-glpi-revert-revision]')->count());
     }
 
     private function renderRevisions(KnowbaseItem $kb): Crawler

--- a/tests/functional/KnowbaseItem_RevisionTest.php
+++ b/tests/functional/KnowbaseItem_RevisionTest.php
@@ -79,8 +79,9 @@ final class KnowbaseItem_RevisionTest extends DbTestCase
         $this->assertTrue(
             $kb1->update(
                 [
-                    'id'   => $kb1->getID(),
-                    'name' => '_knowbaseitem01-01',
+                    'id'     => $kb1->getID(),
+                    'name'   => '_knowbaseitem01-01',
+                    'answer' => 'Updated answer',
                 ]
             )
         );


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Proposal for https://github.com/glpi-project/roadmap/issues/126
- Here is a brief description of what this PR does : Display name/title change events ("Renamed") in the Knowbase article history side panel, showing old and new values. Includes PHPUnit and E2E test coverage.

## Screenshot: 

<img width="343" height="825" alt="image" src="https://github.com/user-attachments/assets/094d7c0e-5395-4bca-a23b-d9dad4b1c651" />


