### PR TITLE
Add invalid_file_type to UploadHandler::get_error_message()

### DIFF
--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -531,6 +531,9 @@ class UploadHandler
 
             case 'image_resize':
                 return __('Failed to resize image');
+
+	        case 'invalid_file_type':
+                return __('Invalid file type');
         }
 
         return false;

--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -532,7 +532,7 @@ class UploadHandler
             case 'image_resize':
                 return __('Failed to resize image');
 
-	        case 'invalid_file_type':
+            case 'invalid_file_type':
                 return __('Invalid file type');
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Add missing error type 'invalid_file_type' also to get_error_message(). Without this fix, error is silently ignored and causes exception later on as file will be missing.. 


