### PR TITLE
Upgrade dependencies to get latest security fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,6 +120,9 @@
                 "laminas/laminas-mail": "No replacement package found yet",
                 "laminas/laminas-mime": "Used by `laminas/laminas-mail`",
                 "true/punycode": "Replacement done in GLPI 11.0"
+            },
+            "ignore": {
+                "CVE-2025-45769": "Patch has been applied manually."
             }
         }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8761,15 +8761,6 @@
                 }
             ]
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/raw-loader": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
@@ -9096,12 +9087,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
             "dev": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/set-function-length": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7849,9 +7849,9 @@
             }
         },
         "node_modules/mini-css-extract-plugin": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-            "integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.0.tgz",
+            "integrity": "sha512-540P2c5dYnJlyJxTaSloliZexv8rji6rY8FhQN+WF/82iHQfA23j/xtJx97L+mXOML27EqksSek/g4eK7jaL3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7870,9 +7870,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-            "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
         "terser": "^5.43.1",
         "webpack": "^5.105.3",
         "webpack-cli": "^6.0.1"
+    },
+    "overrides": {
+        "serialize-javascript": "^7.0.3"
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

1. Mark CVE-2025-45769 as fixed (see #23211).
2. Update `mini-css-extract-plugin` and `minimatch` to get latest security fixes.
3. Force upgrade of `serialize-javascript` to get latest security fixes.