### PR TITLE
Fix mandatory request type

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRequestType.php
@@ -38,13 +38,14 @@ namespace Glpi\Form\QuestionType;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionHandler\RequestTypeConditionHandler;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Override;
 use Ticket;
 
-final class QuestionTypeRequestType extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface
+final class QuestionTypeRequestType extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface, ConditionValueTransformerInterface
 {
     /**
      * Retrieve the default value for the request type question type
@@ -183,4 +184,14 @@ TWIG;
 
     #[Override]
     public function beforeConversion(array $rawData): void {}
+
+    #[Override]
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string
+    {
+        if ($value == 0) {
+            return '';
+        }
+
+        return $value;
+    }
 }

--- a/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
+++ b/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
@@ -57,6 +57,7 @@ use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeLongText;
 use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
@@ -513,6 +514,51 @@ class AnswersHandlerTest extends DbTestCase
             'expectedIsValid' => false,
             'expectedErrors' => [
                 'Mandatory Urgency' => 'This field is mandatory',
+            ],
+        ];
+
+        $mandatory_request_type = new FormBuilder("Mandatory Request type form");
+        $mandatory_request_type->addQuestion(
+            name: "Mandatory type",
+            type: QuestionTypeRequestType::class,
+            is_mandatory: true,
+        );
+        yield 'Empty mandatory type field 1 - should be invalid' => [
+            'builder' => $mandatory_request_type,
+            'answers' => [
+                'Mandatory type' => 0,
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory type' => 'This field is mandatory',
+            ],
+        ];
+        yield 'Empty mandatory type field 2 - should be invalid' => [
+            'builder' => $mandatory_request_type,
+            'answers' => [
+                'Mandatory type' => null,
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory type' => 'This field is mandatory',
+            ],
+        ];
+        yield 'Empty mandatory type field 3 - should be invalid' => [
+            'builder' => $mandatory_request_type,
+            'answers' => [
+                'Mandatory type' => "",
+            ],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory type' => 'This field is mandatory',
+            ],
+        ];
+        yield 'Empty mandatory type field 4 - should be invalid' => [
+            'builder' => $mandatory_request_type,
+            'answers' => [],
+            'expectedIsValid' => false,
+            'expectedErrors' => [
+                'Mandatory type' => 'This field is mandatory',
             ],
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The default "----" options has a value of 0:

<img width="439" height="89" alt="image" src="https://github.com/user-attachments/assets/a1a1803c-50da-4038-8370-cb710ec62ee2" />

This "0" value is not detected as empty by default because it might be valid for some answers (like a numeric field), so we need some extra code to detect it for this question type.

## References

Internal support ticket: !42374


