### PR TITLE
Fix/task author reassign on user delete

### DIFF
--- a/src/Features/PlanningEvent.php
+++ b/src/Features/PlanningEvent.php
@@ -295,20 +295,6 @@ trait PlanningEvent
         }
     }
 
-
-    public function pre_updateInDB()
-    {
-        // Set new user if initial user have been deleted
-        if (
-            isset($this->fields['users_id'])
-            && $this->fields['users_id'] == 0
-            && $uid = Session::getLoginUserID()
-        ) {
-            $this->fields['users_id'] = $uid;
-            $this->updates[]          = "users_id";
-        }
-    }
-
     /**
      * Delete a specific instance of a serie
      * Add an exception into the serie


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42485
- Fixes a bug when permanently deleting a user: tasks (TicketTask, ChangeTask, ProblemTask) were reassigned to the administrator who deleted the account instead of being reassigned to ID 0 like follow-ups and solutions.


