### PR TITLE
Fix JS module path to rely on importmap

### DIFF
--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -144,7 +144,7 @@
     <script>
         (async function() {
             const module = await import(
-                "{{ js_path('js/modules/Helpdesk/IndexController.js') }}"
+                "js/modules/Helpdesk/IndexController.js"
             );
             new module.GlpiHelpdeskIndexController();
         })();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The `importmap` contains unprefixed path. Therefore, unprefixed path must be used in JS module imports.