### PR TITLE
fix(dictionary): fix creation of dictionary types for custom assets

### DIFF
--- a/src/Glpi/Asset/RuleDictionaryTypeCollection.php
+++ b/src/Glpi/Asset/RuleDictionaryTypeCollection.php
@@ -66,7 +66,7 @@ abstract class RuleDictionaryTypeCollection extends RuleDictionnaryDropdownColle
     public function __construct()
     {
         $this->item_table  = static::getDefinition()->getAssetTypeClassName()::getTable();
-        $this->menu_option = sprintf('model.%s', static::getDefinition()->fields['system_name']);
+        $this->menu_option = sprintf('type.%s', static::getDefinition()->fields['system_name']);
     }
 
     public function getTitle()


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42498
- When a user clicked on the type of a custom asset from the Dictionaries menu, the breadcrumb was incorrect.
Instead of displaying the custom asset type, it incorrectly displayed the custom asset model.

This issue also impacted the creation process.
When creating a new custom asset type, the record was incorrectly created under the models of the custom asset instead of under its types.

## Screenshots (if appropriate):

Before fix
<img width="583" height="412" alt="image" src="https://github.com/user-attachments/assets/0f79fdf6-b4a5-42d2-94e7-77b6ef5987cb" />

After fix:
<img width="583" height="412" alt="image" src="https://github.com/user-attachments/assets/0a44c928-6fd9-4aa2-8cd1-916ee801e228" />


