### PR TITLE
Fix task template using "Current logged in user" option

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -673,6 +673,11 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 return false;
             }
             $input['tasktemplates_id']  = $input['_tasktemplates_id'];
+            $user = $template->fields['users_id_tech'];
+            if ($user == -1) {
+                $user = Session::getLoginUserID();
+            }
+
             $input = array_replace(
                 [
                     'content'           => $template->getRenderedContent($parent_item),
@@ -680,7 +685,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                     'actiontime'        => $template->fields['actiontime'],
                     'state'             => $template->fields['state'],
                     'is_private'        => $template->fields['is_private'],
-                    'users_id_tech'     => $template->fields['users_id_tech'],
+                    'users_id_tech'     => $user,
                     'groups_id_tech'    => $template->fields['groups_id_tech'],
                 ],
                 $input

--- a/tests/functional/TaskTemplateTest.php
+++ b/tests/functional/TaskTemplateTest.php
@@ -37,6 +37,9 @@ namespace tests\units;
 use AbstractITILChildTemplate;
 use Glpi\Tests\AbstractITILChildTemplateTest;
 use TaskTemplate;
+use Ticket;
+use TicketTask;
+use User;
 
 class TaskTemplateTest extends AbstractITILChildTemplateTest
 {
@@ -166,5 +169,33 @@ class TaskTemplateTest extends AbstractITILChildTemplateTest
 
         $condition = TaskTemplate::addWhere('AND', 0, TaskTemplate::class, 7, 'equals', 0);
         $this->assertEquals(' AND (`glpi_tasktemplates`.`use_current_user` = 0 AND `glpi_tasktemplates`.`users_id_tech` = 0)', $condition);
+    }
+
+    public function testTemplateWithCurrentUserAsAuthor(): void
+    {
+        // Arrange: create a task template with the "current user" as author
+        $template = $this->createItem(TaskTemplate::class, [
+            'name' => 'my template',
+            'content' => '<p>test</p>',
+            'users_id_tech' => -1,
+        ]);
+
+        // Act: use the template to create a ticket with this task
+        $this->login();
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'My ticket',
+            'content' => 'My content',
+            '_tasktemplates_id' => [$template->getID()],
+        ]);
+
+        // Assert: task is created with the current user
+        $task = new TicketTask();
+        $task->getFromDBByCrit([
+            'tickets_id' => $ticket->getID(),
+        ]);
+        $this->assertEquals(
+            getItemByTypeName(User::class, TU_USER, true),
+            $task->fields['users_id_tech']
+        );
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

A task with this option:

<img width="1937" height="705" alt="image" src="https://github.com/user-attachments/assets/8e4cab32-4d7c-42de-a079-69fa08e6a2ef" />

Would lead to an SQL error while trying to add it to a ticket with a rule:

<img width="1940" height="434" alt="image" src="https://github.com/user-attachments/assets/e10191b3-337c-4950-94a8-f45d8a527a56" />




