### PR TITLE
add tooltips on progress bars to see small percentages

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -1000,7 +1000,7 @@ HTML;
 
         return TemplateRenderer::getInstance()->renderFromStringTemplate(
             <<<TWIG
-              <div class="progress" style="height: 15px; min-width: 50px;">
+              <div class="progress" style="height: 15px; min-width: 50px;" title="{{ label }}" data-bs-toggle="tooltip">
                  <div class="progress-bar bg-info" role="progressbar" style="width: {{ percentage }}%;"
                     aria-valuenow="{{ percentage }}" aria-valuemin="0" aria-valuemax="100">{{ label }}</div>
               </div>


### PR DESCRIPTION
## Description

Allow small percentage to be readable in progress bar. Specific examples: in processes list, the ram and cpu usage.

## Screenshots (if appropriate):

<img width="227" height="56" alt="image" src="https://github.com/user-attachments/assets/74d63292-38a1-4546-89f9-9fa052734799" />

