### PR TITLE
fix(forms): Fix visibility issue in item dropdown configuration by adding conditional class for non-ITILCategory types

### DIFF
--- a/templates/pages/admin/form/question_type/item_dropdown/advanced_configuration.html.twig
+++ b/templates/pages/admin/form/question_type/item_dropdown/advanced_configuration.html.twig
@@ -61,7 +61,8 @@
                 'init': question is not null ? true : false,
                 'add_data_attributes': {
                     'glpi-form-editor-item-dropdown-advanced-configuration-visible-for-itemtype': 'ITILCategory'
-                }
+                },
+                'add_field_class': itemtype != 'ITILCategory' ? 'd-none' : ''
             }
         ) }}
         {{ fields.dropdownField(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

The `Filter ticket categories` field in the advanced configuration of `QuestionTypeItemDropdown` questions should only be visible if the itemtype is `ITILCategory`.
However, if the user defines a question of this type with an itemtype other than `ITILCategory`, when the page is reloaded, the configuration field will be visible when it should not be. (Everything works correctly afterwards if the itemtype is changed).

This modification defines the visibility of the field for existing questions when the page is loaded on the Twig side, which will then be modified by the JS controller if a change is made.