### PR TITLE
Replace useless calls and Expressions with criteria

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -3782,12 +3782,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CommonITILObject\\:\\:hasValidActorInInput\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CommonITILObject\\:\\:haveAGroup\\(\\) has parameter \\$groups with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3820,7 +3820,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getForeignKeyFieldForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
@@ -6357,12 +6357,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$message of method Glpi\\\\Api\\\\API\\:\\:returnError\\(\\) expects array\\|string, bool\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$ref_table of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:getDefaultJoinCriteria\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
@@ -20493,12 +20487,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Search.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$ref_table of static method Glpi\\\\Search\\\\Provider\\\\SQLProvider\\:\\:getDefaultJoinCriteria\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Search.php',

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9895,7 +9895,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $WHERE += $criteria;
         $WHERE += getEntitiesRestrictCriteria();
         // visibility check hack so we don't have to load the complete DB info for every item
-        $WHERE += SQLProvider::getDefaultWhereCriteria($itemtype);
+        $WHERE[] = SQLProvider::getDefaultWhereCriteria($itemtype);
         $base_common_itil_query = [
             'SELECT' => [static::getTableField('id')],
             'FROM'   => static::getTable(),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9906,7 +9906,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $linked_tables = [];
         $default_join = SQLProvider::getDefaultJoinCriteria($itemtype, getTableForItemType($itemtype), $linked_tables);
         if ($default_join !== []) {
-            $base_common_itil_query += $default_join;
+            $base_common_itil_query = array_merge_recursive($base_common_itil_query, $default_join);
         }
 
         // Load common_itil

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9895,7 +9895,10 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $WHERE += $criteria;
         $WHERE += getEntitiesRestrictCriteria();
         // visibility check hack so we don't have to load the complete DB info for every item
-        $WHERE = array_merge($WHERE, SQLProvider::getDefaultWhereCriteria($itemtype));
+        $visiblity_criteria = SQLProvider::getDefaultWhereCriteria($itemtype);
+        if ($visiblity_criteria !== []) {
+            $WHERE[] = SQLProvider::getDefaultWhereCriteria($itemtype);
+        }
         $base_common_itil_query = [
             'SELECT' => [static::getTableField('id')],
             'FROM'   => static::getTable(),

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -52,6 +52,7 @@ use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
 use Glpi\Search\Output\HTMLSearchOutput;
+use Glpi\Search\Provider\SQLProvider;
 use Glpi\Team\Team;
 use Glpi\Urgency;
 use Safe\Exceptions\DatetimeException;
@@ -9777,6 +9778,10 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
     /**
      * Check if input contains a valid actor for given itemtype / actortype.
+     *
+     * @param array<string, mixed> $input
+     * @param class-string<CommonDBTM> $itemtype
+     * @param CommonITILActor::REQUESTER|CommonITILActor::ASSIGN|CommonITILActor::OBSERVER $actortype
      */
     private function hasValidActorInInput(array $input, string $itemtype, int $actortype): bool
     {
@@ -9890,10 +9895,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $WHERE += $criteria;
         $WHERE += getEntitiesRestrictCriteria();
         // visibility check hack so we don't have to load the complete DB info for every item
-        $visiblity_criteria = Search::addDefaultWhere(static::class);
-        if (!empty($visiblity_criteria)) {
-            $WHERE[] = new QueryExpression(Search::addDefaultWhere(static::class));
-        }
+        $WHERE += SQLProvider::getDefaultWhereCriteria($itemtype);
         $base_common_itil_query = [
             'SELECT' => [static::getTableField('id')],
             'FROM'   => static::getTable(),
@@ -9902,13 +9904,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
         // Add JOIN
         $linked_tables = [];
-        $default_joint = Search::addDefaultJoin(
-            $itemtype,
-            getTableForItemType($itemtype),
-            $linked_tables, // Passed by reference, must be a defined variable even if empty
-        );
-        if (!empty($default_joint)) {
-            $base_common_itil_query['LEFT JOIN'] = [new QueryExpression($default_joint)];
+        $default_joint = SQLProvider::getDefaultJoinCriteria($itemtype, getTableForItemType($itemtype), $linked_tables);
+        if ($default_joint !== []) {
+            $base_common_itil_query['LEFT JOIN'] = $default_joint;
         }
 
         // Load common_itil

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9904,9 +9904,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
         // Add JOIN
         $linked_tables = [];
-        $default_joint = SQLProvider::getDefaultJoinCriteria($itemtype, getTableForItemType($itemtype), $linked_tables);
-        if ($default_joint !== []) {
-            $base_common_itil_query['LEFT JOIN'] = $default_joint;
+        $default_join = SQLProvider::getDefaultJoinCriteria($itemtype, getTableForItemType($itemtype), $linked_tables);
+        if ($default_join !== []) {
+            $base_common_itil_query += $default_join;
         }
 
         // Load common_itil

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9895,7 +9895,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $WHERE += $criteria;
         $WHERE += getEntitiesRestrictCriteria();
         // visibility check hack so we don't have to load the complete DB info for every item
-        $WHERE[] = SQLProvider::getDefaultWhereCriteria($itemtype);
+        $WHERE = array_merge($WHERE, SQLProvider::getDefaultWhereCriteria($itemtype));
         $base_common_itil_query = [
             'SELECT' => [static::getTableField('id')],
             'FROM'   => static::getTable(),

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2998,7 +2998,7 @@ HTML;
                         // Prevent overriding criteria groups sharing the same key
                         $where[] = [$key => $value];
                     } else {
-                        // Keep the criteria key at the rrot level to be able to override defaults.
+                        // Keep the criteria key at the root level to be able to override defaults.
                         // e.g. to override the default `is_template` / `is_deleted` filtering.
                         $where[$key] = $value;
                     }
@@ -3590,7 +3590,7 @@ HTML;
                         $unused_ref = [];
                         $default_join = SQLProvider::getDefaultJoinCriteria($itemtype_class, $itemtype_class::getTable(), $unused_ref);
                         if ($default_join !== []) {
-                            $criteria['LEFT JOIN'] = array_merge($criteria['LEFT JOIN'] ?? [], $default_join['LEFT JOIN']);
+                            $criteria = array_merge_recursive($criteria, $ljoin, $default_join);
                         }
                         $where[] = SQLProvider::getDefaultWhereCriteria($itemtype_class);
                     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -42,6 +42,7 @@ use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Features\AssignableItem;
 use Glpi\Form\Category;
 use Glpi\Plugin\Hooks;
+use Glpi\Search\Provider\SQLProvider;
 use Glpi\SocketModel;
 
 use function Safe\json_encode;
@@ -3587,11 +3588,11 @@ HTML;
                     $itemtype_class = $post['itemtype'];
                     if (!Session::haveRight($itemtype_class::$rightname, $itemtype_class::READALL)) {
                         $unused_ref = [];
-                        $joins_str = Search::addDefaultJoin($itemtype_class, $itemtype_class::getTable(), $unused_ref);
-                        if (!empty($joins_str)) {
-                            $criteria['LEFT JOIN'] = [new QueryExpression($joins_str)];
+                        $default_joint = SQLProvider::getDefaultJoinCriteria($itemtype_class, $itemtype_class::getTable(), $unused_ref);
+                        if ($default_joint !== []) {
+                            $criteria['LEFT JOIN'] = $default_joint;
                         }
-                        $where[] = new QueryExpression(Search::addDefaultWhere($itemtype_class));
+                        $where[] = SQLProvider::getDefaultWhereCriteria($itemtype_class);
                     }
                     break;
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3588,9 +3588,9 @@ HTML;
                     $itemtype_class = $post['itemtype'];
                     if (!Session::haveRight($itemtype_class::$rightname, $itemtype_class::READALL)) {
                         $unused_ref = [];
-                        $default_joint = SQLProvider::getDefaultJoinCriteria($itemtype_class, $itemtype_class::getTable(), $unused_ref);
-                        if ($default_joint !== []) {
-                            $criteria['LEFT JOIN'] = $default_joint;
+                        $default_join = SQLProvider::getDefaultJoinCriteria($itemtype_class, $itemtype_class::getTable(), $unused_ref);
+                        if ($default_join !== []) {
+                            $criteria['LEFT JOIN'] = array_merge($criteria['LEFT JOIN'] ?? [], $default_join['LEFT JOIN']);
                         }
                         $where[] = SQLProvider::getDefaultWhereCriteria($itemtype_class);
                     }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2343,7 +2343,7 @@ final class SQLProvider implements SearchProviderInterface
      * Generic Function to add Default left join to a request
      *
      * @param class-string<CommonDBTM> $itemtype   Reference item type
-     * @param class-string<CommonDBTM> $ref_table  Reference table
+     * @param string $ref_table  Reference table
      * @param array &$already_link_tables  Array of tables already joined
      *
      * @return array Left join criteria array

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\Search\Provider\SQLProvider;
 
 /// Class Ticket links
 class Ticket_Ticket extends CommonITILObject_CommonITILObject
@@ -149,12 +150,12 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
                 ],
             ];
             $unused_ref = [];
-            $joins_str = Search::addDefaultJoin(Ticket::class, Ticket::getTable(), $unused_ref);
-            if (!empty($joins_str)) {
+            $default_joint = SQLProvider::getDefaultJoinCriteria(Ticket::class, Ticket::getTable(), $unused_ref);
+            if ($default_joint !== []) {
                 $db_it = new DBmysqlIterator($DB);
-                $criteria['LEFT JOIN'] = [new QueryExpression($db_it->analyseJoins(['LEFT JOIN' => $criteria['LEFT JOIN']]) . ' ' . $joins_str)];
+                $criteria['LEFT JOIN'] += $default_joint;
             }
-            $criteria['WHERE'][] = new QueryExpression(Search::addDefaultWhere(Ticket::class));
+            $criteria['WHERE'][] = SQLProvider::getDefaultWhereCriteria(Ticket::class);
         }
         $iterator = $DB->request($criteria);
         $tickets = [];

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -150,10 +150,10 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
                 ],
             ];
             $unused_ref = [];
-            $default_joint = SQLProvider::getDefaultJoinCriteria(Ticket::class, Ticket::getTable(), $unused_ref);
-            if ($default_joint !== []) {
+            $default_join = SQLProvider::getDefaultJoinCriteria(Ticket::class, Ticket::getTable(), $unused_ref);
+            if ($default_join !== []) {
                 $db_it = new DBmysqlIterator($DB);
-                $criteria['LEFT JOIN'] += $default_joint;
+                $criteria['LEFT JOIN'] += $default_join['LEFT JOIN'];
             }
             $criteria['WHERE'][] = SQLProvider::getDefaultWhereCriteria(Ticket::class);
         }

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -152,7 +152,6 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
             $unused_ref = [];
             $default_join = SQLProvider::getDefaultJoinCriteria(Ticket::class, Ticket::getTable(), $unused_ref);
             if ($default_join !== []) {
-                $db_it = new DBmysqlIterator($DB);
                 $criteria['LEFT JOIN'] += $default_join['LEFT JOIN'];
             }
             $criteria['WHERE'][] = SQLProvider::getDefaultWhereCriteria(Ticket::class);

--- a/src/Ticket_Ticket.php
+++ b/src/Ticket_Ticket.php
@@ -152,7 +152,7 @@ class Ticket_Ticket extends CommonITILObject_CommonITILObject
             $unused_ref = [];
             $default_join = SQLProvider::getDefaultJoinCriteria(Ticket::class, Ticket::getTable(), $unused_ref);
             if ($default_join !== []) {
-                $criteria['LEFT JOIN'] += $default_join['LEFT JOIN'];
+                $criteria = array_merge_recursive($criteria, $default_join);
             }
             $criteria['WHERE'][] = SQLProvider::getDefaultWhereCriteria(Ticket::class);
         }

--- a/tests/functional/ITILFollowupTest.php
+++ b/tests/functional/ITILFollowupTest.php
@@ -36,14 +36,12 @@ namespace tests\units;
 
 use Change;
 use CommonITILActor;
-use Glpi\DBAL\QueryExpression;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\Search\SearchEngine;
 use Glpi\Tests\DbTestCase;
 use ITILFollowup as CoreITILFollowup;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
-use Search;
 use Ticket;
 use Ticket_User;
 use User;
@@ -738,7 +736,7 @@ HTML,
                 CoreITILFollowup::class,
                 CoreITILFollowup::getTable(),
                 $already_linked_tables
-            ),
+            )['LEFT JOIN'],
             'WHERE' => SQLProvider::getDefaultWhereCriteria(CoreITILFollowup::class),
         ]);
 

--- a/tests/functional/ITILFollowupTest.php
+++ b/tests/functional/ITILFollowupTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use Change;
 use CommonITILActor;
 use Glpi\DBAL\QueryExpression;
+use Glpi\Search\Provider\SQLProvider;
 use Glpi\Search\SearchEngine;
 use Glpi\Tests\DbTestCase;
 use ITILFollowup as CoreITILFollowup;
@@ -733,20 +734,12 @@ HTML,
         $results = $DB->request([
             'COUNT' => 'number_of_followups',
             'FROM' => CoreITILFollowup::getTable(),
-            'JOIN' => [
-                new QueryExpression(
-                    Search::addDefaultJoin(
-                        CoreITILFollowup::class,
-                        CoreITILFollowup::getTable(),
-                        $already_linked_tables
-                    )
-                ),
-            ],
-            'WHERE' => [
-                new QueryExpression(
-                    Search::addDefaultWhere(CoreITILFollowup::class)
-                ),
-            ],
+            'JOIN' => SQLProvider::getDefaultJoinCriteria(
+                CoreITILFollowup::class,
+                CoreITILFollowup::getTable(),
+                $already_linked_tables
+            ),
+            'WHERE' => SQLProvider::getDefaultWhereCriteria(CoreITILFollowup::class),
         ]);
 
         return (int) iterator_to_array($results)[0]['number_of_followups'];


### PR DESCRIPTION
`addDefaultWhere()` and `addDefaultJoin()` both retrieve criteria, setup an iterator; and the result was put in a `QueryExpression`.