### PR TITLE
Fix card color for uninstalled plugins

### DIFF
--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -531,7 +531,9 @@ JS;
     {
         $plugin_key   = $plugin['key'];
         $plugin_inst  = new Plugin();
-        $plugin_inst->getFromDBbyDir($plugin_key);
+        $exist = $plugin_inst->getFromDBbyDir($plugin_key);
+
+        $must_be_cleaned   = !$exist || !$plugin_inst->isLoadable($plugin_key);
 
         $plugin_info = [
             'key'           => $plugin['key'],
@@ -552,7 +554,7 @@ JS;
             'buttons'       => self::getButtons($plugin_key),
             'authors'       => array_column($plugin['authors'] ?? [], 'name', 'id'),
             'stars'         => ($plugin['note'] ?? -1) > 0 ? self::getStarsHtml($plugin['note']) : '',
-            'updatable'     => version_compare($plugin['version'], $plugin['highest_available_version'] ?? '0', '<'),
+            'updatable'     => !$must_be_cleaned && version_compare($plugin['version'], $plugin['highest_available_version'] ?? '0', '<'),
         ];
         return TemplateRenderer::getInstance()->render('pages/setup/marketplace/card.html.twig', [
             'tab'    => $tab,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Here is a brief description of what this PR does
When a plugin folder is deleted, meaning that it must either be reinstalled or cleaned up, the card still appears in orange if the version of the plugin prior to its deletion was lower than the highest version available.

I therefore added a check that verifies whether the plugin exists and whether it is loadable, and if this is not the case, I leave plugins[‘updatable’]. 

## Screenshots (if appropriate):


