### PR TITLE
Fix creating change and problem from asset

### DIFF
--- a/src/Change.php
+++ b/src/Change.php
@@ -159,13 +159,6 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
             return false;
         }
 
-        // Normalize inputs from "add from item" form
-        if (isset($input['_add_fromitem'], $input['itemtype'], $input['items_id']) && !is_array($input['items_id'])) {
-            $input['_from_itemtype'] = $input['itemtype'];
-            $input['_from_items_id'] = $input['items_id'];
-            $input['items_id'] = [$input['itemtype'] => [$input['items_id']]];
-        }
-
         $this->processRules(RuleCommonITILObject::ONADD, $input);
 
         if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
@@ -466,19 +459,6 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
         }
 
         $this->handleNewItemNotifications();
-
-        if (
-            isset($this->input['_from_items_id'])
-            && isset($this->input['_from_itemtype'])
-        ) {
-            $change_item = new Change_Item();
-            $change_item->add([
-                'items_id'      => (int) $this->input['_from_items_id'],
-                'itemtype'      => $this->input['_from_itemtype'],
-                'changes_id'    => $this->fields['id'],
-                '_disablenotif' => true,
-            ]);
-        }
     }
 
     #[Override]

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -330,13 +330,6 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
             return false;
         }
 
-        // Normalize inputs from "add from item" form
-        if (isset($input['_add_fromitem'], $input['itemtype'], $input['items_id']) && !is_array($input['items_id'])) {
-            $input['_from_itemtype'] = $input['itemtype'];
-            $input['_from_items_id'] = $input['items_id'];
-            $input['items_id'] = [$input['itemtype'] => [$input['items_id']]];
-        }
-
         $this->processRules(RuleCommonITILObject::ONADD, $input);
 
         if (!isset($input['_skip_auto_assign']) || $input['_skip_auto_assign'] === false) {
@@ -416,19 +409,6 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
         }
 
         $this->handleNewItemNotifications();
-
-        if (
-            isset($this->input['_from_items_id'])
-            && isset($this->input['_from_itemtype'])
-        ) {
-            $item_problem = new Item_Problem();
-            $item_problem->add([
-                'items_id'      => (int) $this->input['_from_items_id'],
-                'itemtype'      => $this->input['_from_itemtype'],
-                'problems_id'   => $this->fields['id'],
-                '_disablenotif' => true,
-            ]);
-        }
     }
 
     #[Override]

--- a/tests/e2e/specs/Asset/computer.spec.ts
+++ b/tests/e2e/specs/Asset/computer.spec.ts
@@ -34,6 +34,7 @@ import { test, expect } from '../../fixtures/glpi_fixture';
 import { ComputerPage } from '../../pages/ComputerPage';
 import { Profiles } from '../../utils/Profiles';
 import { getWorkerEntityId } from '../../utils/WorkerEntities';
+import {GlpiPage} from "../../pages/GlpiPage";
 
 test('Main form loads', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
@@ -90,4 +91,50 @@ test('Antivirus tab loads', async ({ page, profile, api }) => {
     await tabpanel.getByRole('textbox', { name: 'Name', exact: true }).fill('Test AV');
     await tabpanel.getByRole('button', { name: 'Add', exact: true }).click();
     await expect(tabpanel.getByRole('cell', { name: 'Test AV' })).toBeVisible();
+});
+
+test('Create ITIL objects from computer', async ({ page, profile, api, context }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const computer_id = await api.createItem('Computer', {
+        name: 'Test computer for ITIL',
+        entities_id: getWorkerEntityId(),
+    });
+
+    const computer_page = new ComputerPage(page);
+    await computer_page.goto(computer_id, 'Item_Problem$1');
+    const tabpanel = page.getByRole('tabpanel');
+    const new_problem_page_event = context.waitForEvent('page');
+    await tabpanel.getByRole('button', { name: 'New Problem for this item' }).click();
+    const new_problem_page = new GlpiPage(await new_problem_page_event);
+    await new_problem_page.page.getByLabel('Title').fill('Test problem');
+    await new_problem_page.getRichTextByLabel('Content').fill('Problem content');
+    const problem_page_event = context.waitForEvent('page');
+    await new_problem_page.page.getByRole('button', { name: 'Add' }).click();
+    const problem_page = new GlpiPage(await problem_page_event);
+    await expect(problem_page.page.getByRole('heading', { name: 'Test problem' })).toBeVisible();
+    await expect(problem_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
+
+    await computer_page.goto(computer_id, 'Change_Item$1');
+    const new_change_page_event = context.waitForEvent('page');
+    await tabpanel.getByRole('button', { name: 'New Change for this item' }).click();
+    const new_change_page = new GlpiPage(await new_change_page_event);
+    await new_change_page.page.getByLabel('Title').fill('Test change');
+    await new_change_page.getRichTextByLabel('Content').fill('Change content');
+    const change_page_event = context.waitForEvent('page');
+    await new_change_page.page.getByRole('button', { name: 'Add' }).click();
+    const change_page = new GlpiPage(await change_page_event);
+    await expect(change_page.page.getByRole('heading', { name: 'Test change' })).toBeVisible();
+    await expect(change_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
+
+    await computer_page.goto(computer_id, 'Item_Ticket$1');
+    const new_ticket_page_event = context.waitForEvent('page');
+    await tabpanel.getByRole('button', { name: 'New Ticket for this item' }).click();
+    const new_ticket_page = new GlpiPage(await new_ticket_page_event);
+    await new_ticket_page.page.getByLabel('Title').fill('Test ticket');
+    await new_ticket_page.getRichTextByLabel('Content').fill('Ticket content');
+    const ticket_page_event = context.waitForEvent('page');
+    await new_ticket_page.page.getByRole('button', { name: 'Add' }).click();
+    const ticket_page = new GlpiPage(await ticket_page_event);
+    await expect(ticket_page.page.getByRole('heading', { name: 'Test ticket' })).toBeVisible();
+    await expect(ticket_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
 });

--- a/tests/e2e/specs/Asset/computer.spec.ts
+++ b/tests/e2e/specs/Asset/computer.spec.ts
@@ -34,7 +34,7 @@ import { test, expect } from '../../fixtures/glpi_fixture';
 import { ComputerPage } from '../../pages/ComputerPage';
 import { Profiles } from '../../utils/Profiles';
 import { getWorkerEntityId } from '../../utils/WorkerEntities';
-import {GlpiPage} from "../../pages/GlpiPage";
+import { GlpiPage } from '../../pages/GlpiPage';
 
 test('Main form loads', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
@@ -93,7 +93,7 @@ test('Antivirus tab loads', async ({ page, profile, api }) => {
     await expect(tabpanel.getByRole('cell', { name: 'Test AV' })).toBeVisible();
 });
 
-test('Create ITIL objects from computer', async ({ page, profile, api, context }) => {
+test('Create ITIL objects from computer', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const computer_id = await api.createItem('Computer', {
         name: 'Test computer for ITIL',
@@ -101,40 +101,35 @@ test('Create ITIL objects from computer', async ({ page, profile, api, context }
     });
 
     const computer_page = new ComputerPage(page);
+    const glpi_page = new GlpiPage(page);
+
+    // Create a Problem from the computer's Problem tab
     await computer_page.goto(computer_id, 'Item_Problem$1');
-    const tabpanel = page.getByRole('tabpanel');
-    const new_problem_page_event = context.waitForEvent('page');
-    await tabpanel.getByRole('button', { name: 'New Problem for this item' }).click();
-    const new_problem_page = new GlpiPage(await new_problem_page_event);
-    await new_problem_page.page.getByLabel('Title').fill('Test problem');
-    await new_problem_page.getRichTextByLabel('Content').fill('Problem content');
-    const problem_page_event = context.waitForEvent('page');
-    await new_problem_page.page.getByRole('button', { name: 'Add' }).click();
-    const problem_page = new GlpiPage(await problem_page_event);
-    await expect(problem_page.page.getByRole('heading', { name: 'Test problem' })).toBeVisible();
-    await expect(problem_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
+    await page.getByRole('tabpanel').getByText('New Problem for this item').click();
+    await page.getByLabel('Title').fill('Test problem');
+    await glpi_page.getRichTextByLabel('Description').fill('Problem content');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await page.waitForLoadState('load');
+    await computer_page.goto(computer_id, 'Item_Problem$1');
+    await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test problem' })).toBeVisible();
 
+    // Create a Change from the computer's Change tab
     await computer_page.goto(computer_id, 'Change_Item$1');
-    const new_change_page_event = context.waitForEvent('page');
-    await tabpanel.getByRole('button', { name: 'New Change for this item' }).click();
-    const new_change_page = new GlpiPage(await new_change_page_event);
-    await new_change_page.page.getByLabel('Title').fill('Test change');
-    await new_change_page.getRichTextByLabel('Content').fill('Change content');
-    const change_page_event = context.waitForEvent('page');
-    await new_change_page.page.getByRole('button', { name: 'Add' }).click();
-    const change_page = new GlpiPage(await change_page_event);
-    await expect(change_page.page.getByRole('heading', { name: 'Test change' })).toBeVisible();
-    await expect(change_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
+    await page.getByRole('tabpanel').getByText('New Change for this item').click();
+    await page.getByLabel('Title').fill('Test change');
+    await glpi_page.getRichTextByLabel('Description').fill('Change content');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await page.waitForLoadState('load');
+    await computer_page.goto(computer_id, 'Change_Item$1');
+    await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test change' })).toBeVisible();
 
+    // Create a Ticket from the computer's Ticket tab
     await computer_page.goto(computer_id, 'Item_Ticket$1');
-    const new_ticket_page_event = context.waitForEvent('page');
-    await tabpanel.getByRole('button', { name: 'New Ticket for this item' }).click();
-    const new_ticket_page = new GlpiPage(await new_ticket_page_event);
-    await new_ticket_page.page.getByLabel('Title').fill('Test ticket');
-    await new_ticket_page.getRichTextByLabel('Content').fill('Ticket content');
-    const ticket_page_event = context.waitForEvent('page');
-    await new_ticket_page.page.getByRole('button', { name: 'Add' }).click();
-    const ticket_page = new GlpiPage(await ticket_page_event);
-    await expect(ticket_page.page.getByRole('heading', { name: 'Test ticket' })).toBeVisible();
-    await expect(ticket_page.page.getByRole('link', { name: 'Test computer for ITIL' })).toBeVisible();
+    await page.getByRole('tabpanel').getByText('New Ticket for this item').click();
+    await page.getByLabel('Title').fill('Test ticket');
+    await glpi_page.getRichTextByLabel('Description').fill('Ticket content');
+    await page.getByRole('button', { name: 'Add' }).click();
+    await page.waitForLoadState('load');
+    await computer_page.goto(computer_id, 'Item_Ticket$1');
+    await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test ticket' })).toBeVisible();
 });

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -64,33 +64,6 @@ class ChangeTest extends DbTestCase
         $this->assertTrue($change_item->getFromDBForItems($change, $computer));
     }
 
-    public function testAddFromItemFormFlow(): void
-    {
-        $computer = getItemByTypeName(Computer::class, '_test_pc01');
-        $change   = new Change();
-
-        // Simulate raw inputs as received by the front controller
-        $changes_id = $change->add([
-            'name'           => 'test add from item form flow',
-            'content'        => 'test add from item form flow',
-            '_add_fromitem'  => true,
-            'itemtype'       => Computer::class,
-            'items_id'       => $computer->getID(),
-        ]);
-        $this->assertGreaterThan(0, $changes_id);
-
-        $change_item = new \Change_Item();
-        $this->assertTrue($change_item->getFromDBForItems($change, $computer));
-        $this->assertEquals(
-            1,
-            countElementsInTable(\Change_Item::getTable(), [
-                'changes_id' => $changes_id,
-                'itemtype'   => Computer::class,
-                'items_id'   => $computer->getID(),
-            ])
-        );
-    }
-
     public function testAssignFromCategory()
     {
         $this->login('glpi', 'glpi');

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -36,7 +36,6 @@ namespace tests\units;
 
 use Change;
 use CommonITILObject;
-use Computer;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -44,26 +44,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class ChangeTest extends DbTestCase
 {
-    public function testAddFromItem()
-    {
-        // add change from a computer
-        $computer   = getItemByTypeName('Computer', '_test_pc01');
-        $change     = new Change();
-        $changes_id = $change->add([
-            'name'           => "test add from computer \'_test_pc01\'",
-            'content'        => "test add from computer \'_test_pc01\'",
-            '_add_from_item' => true,
-            '_from_itemtype' => 'Computer',
-            '_from_items_id' => $computer->getID(),
-        ]);
-        $this->assertGreaterThan(0, $changes_id);
-        $this->assertTrue($change->getFromDB($changes_id));
-
-        // check relation
-        $change_item = new \Change_Item();
-        $this->assertTrue($change_item->getFromDBForItems($change, $computer));
-    }
-
     public function testAssignFromCategory()
     {
         $this->login('glpi', 'glpi');

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -35,7 +35,6 @@
 namespace tests\units;
 
 use CommonITILObject;
-use Computer;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -44,26 +44,6 @@ use Problem;
 
 class ProblemTest extends DbTestCase
 {
-    public function testAddFromItem()
-    {
-        // add problem from a computer
-        $computer   = getItemByTypeName('Computer', '_test_pc01');
-        $problem     = new Problem();
-        $problems_id = $problem->add([
-            'name'           => "test add from computer \'_test_pc01\'",
-            'content'        => "test add from computer \'_test_pc01\'",
-            '_add_from_item' => true,
-            '_from_itemtype' => 'Computer',
-            '_from_items_id' => $computer->getID(),
-        ]);
-        $this->assertGreaterThan(0, $problems_id);
-        $this->assertTrue($problem->getFromDB($problems_id));
-
-        // check relation
-        $problem_item = new \Item_Problem();
-        $this->assertTrue($problem_item->getFromDBForItems($problem, $computer));
-    }
-
     public function testAssignFromCategory()
     {
         $this->login('glpi', 'glpi');

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -64,33 +64,6 @@ class ProblemTest extends DbTestCase
         $this->assertTrue($problem_item->getFromDBForItems($problem, $computer));
     }
 
-    public function testAddFromItemFormFlow(): void
-    {
-        $computer = getItemByTypeName(Computer::class, '_test_pc01');
-        $problem  = new Problem();
-
-        // Simulate raw inputs as received by the front controller
-        $problems_id = $problem->add([
-            'name'           => 'test add from item form flow',
-            'content'        => 'test add from item form flow',
-            '_add_fromitem'  => true,
-            'itemtype'       => Computer::class,
-            'items_id'       => $computer->getID(),
-        ]);
-        $this->assertGreaterThan(0, $problems_id);
-
-        $item_problem = new \Item_Problem();
-        $this->assertTrue($item_problem->getFromDBForItems($problem, $computer));
-        $this->assertEquals(
-            1,
-            countElementsInTable(\Item_Problem::getTable(), [
-                'problems_id' => $problems_id,
-                'itemtype'    => Computer::class,
-                'items_id'    => $computer->getID(),
-            ])
-        );
-    }
-
     public function testAssignFromCategory()
     {
         $this->login('glpi', 'glpi');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Reverts #23198 and removes other unneeded code for changes and problems.
When creating a ticket/change/problem from an asset, code in CommonITILObject handled the link.
For change and problem, there was extra code which was using different (older?) input data format which also tried handling the link and causing a PHP exception. Tickets, changes and problems should now handle asset links the same way.

The last fix tried to adapt data to the other format and then tested the other format specifically which doesn't seem to match real usage.

I left the _from_itemtype and _from_items_id hidden inputs in the ITIL form in case plugins relied on them, but they seem safe to remove in the next version.

Waiting for confirmation from issue reporter, and then need to brave the E2E test suite to add a real-life use test.