### PR TITLE
Upgrade PHP minimal version to 8.3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@ Follow GLPI’s latest coding standards and best practices: naming, indentation,
 Use the GLPI framework whenever possible.
 Use the snake_case variable naming convention.
 Do not use deprecated code.
-Do not use PHP features older than version 8.2.
+Do not use PHP features older than version 8.3.
 Do not use GLPI code or APIs older than version 11.0.
 Never create .md or .txt files to explain changes.
 Never explain what you did.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {php-version: "8.2"} # Lint on lower PHP version to detected too early usage of new syntaxes
+          - {php-version: "8.3"} # Lint on lower PHP version to detected too early usage of new syntaxes
           - {php-version: "8.5"} # Lint on higher PHP version to detected deprecated elements usage
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml"
@@ -131,7 +131,7 @@ jobs:
               {
                 "include": [
                   {"php-version": "8.5", "db-image": "mariadb:11.8", "run-js-tests": true},
-                  {"php-version": "8.2", "db-image": "mariadb:10.6", "run-js-tests": false},
+                  {"php-version": "8.3", "db-image": "mariadb:10.6", "run-js-tests": false},
                   {"php-version": "8.5", "db-image": "mysql:8.4", "run-js-tests": false},
                   {"php-version": "8.5", "db-image": "mysql:8.0", "run-js-tests": false}
                 ]
@@ -142,7 +142,7 @@ jobs:
               {
                 "include": [
                   {"php-version": "8.5", "db-image": "mariadb:11.8", "run-js-tests": true},
-                  {"php-version": "8.2", "db-image": "mysql:8.4", "run-js-tests": false}
+                  {"php-version": "8.3", "db-image": "mysql:8.4", "run-js-tests": false}
                 ]
               }
             '

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,7 +25,7 @@ jobs:
           # build on lower supported version to ensure building tools are compatible with this version
           - {branch: "10.0/bugfixes", version-name: "10.0", php-version: "7.4"}
           - {branch: "11.0/bugfixes", version-name: "11.0", php-version: "8.2"}
-          - {branch: "main", version-name: "dev", php-version: "8.2"}
+          - {branch: "main", version-name: "dev", php-version: "8.3"}
     services:
       app:
         image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
 
 * A web server (Apache, Nginx, IIS, etc.)
 * MariaDB >= 10.6 or MySQL >= 8.0
-* PHP >= 8.2
+* PHP >= 8.3
 * Mandatory PHP extensions:
     - dom, fileinfo, filter, libxml, simplexml, xmlreader, xmlwriter (these are enabled in PHP by default)
     - bcmath (QRCode generation)

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -79,7 +79,6 @@ return $config
         'symfony/css-selector', // Required by web tests based on the `FrontBaseClass` class
         'symfony/polyfill-ctype',
         'symfony/polyfill-iconv',
-        'symfony/polyfill-php83',
         'symfony/polyfill-php84',
         'symfony/polyfill-php85',
         'symfony/property-access',

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "docs": "https://github.com/glpi-project/doc"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "php-64bit": "*",
         "ext-bcmath": "*",
         "ext-ctype": "*",
@@ -90,7 +90,6 @@
         "symfony/polyfill-ctype": "^1.33",
         "symfony/polyfill-iconv": "^1.33",
         "symfony/polyfill-mbstring": "^1.33",
-        "symfony/polyfill-php83": "^1.33",
         "symfony/polyfill-php84": "^1.33",
         "symfony/polyfill-php85": "^1.33",
         "symfony/property-access": "^7.4",
@@ -147,7 +146,8 @@
         "symfony/polyfill-php74": "*",
         "symfony/polyfill-php80": "*",
         "symfony/polyfill-php81": "*",
-        "symfony/polyfill-php82": "*"
+        "symfony/polyfill-php82": "*",
+        "symfony/polyfill-php83": "*"
     },
     "suggest": {
         "ext-ldap": "Used to provide LDAP authentication and synchronization",
@@ -158,7 +158,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "8.2.99"
+            "php": "8.3.99"
         },
         "sort-packages": true,
         "audit": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "451b9497f74ce79b3fa94cc656466c8c",
+    "content-hash": "580a7ef2b6217d7419a54a74a74fbe54",
     "packages": [
         {
             "name": "altcha-org/altcha",
@@ -7755,86 +7755,6 @@
             "time": "2024-12-23T08:48:59+00:00"
         },
         {
-            "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php83\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-08T02:45:35+00:00"
-        },
-        {
             "name": "symfony/polyfill-php84",
             "version": "v1.33.0",
             "source": {
@@ -15317,7 +15237,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "php-64bit": "*",
         "ext-bcmath": "*",
         "ext-ctype": "*",
@@ -15343,7 +15263,7 @@
         "ext-xml": "*"
     },
     "platform-overrides": {
-        "php": "8.2.99"
+        "php": "8.3.99"
     },
     "plugin-api-version": "2.9.0"
 }

--- a/public/index.php
+++ b/public/index.php
@@ -38,8 +38,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 // Check PHP version not to have trouble
 // Need to be the very fist step before any include
-if (version_compare(PHP_VERSION, '8.2.0', '<') || version_compare(PHP_VERSION, '8.5.999', '>')) {
-    exit('PHP version must be between 8.2 and 8.5.');
+if (version_compare(PHP_VERSION, '8.3.0', '<') || version_compare(PHP_VERSION, '8.5.999', '>')) {
+    exit('PHP version must be between 8.3 and 8.5.');
 }
 
 // Check the resources state before trying to instanciate the Kernel.

--- a/rector.php
+++ b/rector.php
@@ -60,7 +60,7 @@ return RectorConfig::configure()
             __DIR__ . '/install/migrations',
         ],
     ])
-    ->withPhpVersion(PhpVersion::PHP_82)
+    ->withPhpVersion(PhpVersion::PHP_83)
     ->withCache(
         cacheClass: FileCacheStorage::class,
         cacheDirectory: 'files/_cache/rector',

--- a/src/autoload/constants.php
+++ b/src/autoload/constants.php
@@ -55,7 +55,7 @@ define(
     GLPI_VERSION . (is_readable($version_file) ? '-' . hash_file('CRC32c', $version_file) : '')
 );
 
-define('GLPI_MIN_PHP', '8.2'); // Must also be changed in top of public/index.php
+define('GLPI_MIN_PHP', '8.3'); // Must also be changed in top of public/index.php
 define('GLPI_MAX_PHP', '8.5'); // Must also be changed in top of public/index.php
 define('GLPI_YEAR', '2026');
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

PHP 8.2 EOL will be only 2 months after the GLPI 12.0 release.

This version is already available in the majors Linux distributions:
 - RHEL 9.6/10.0 (05/2025): PHP 8.3
 - Debian Trixie (08/2025): PHP 8.4
 - Ubuntu 24.04 (04/2024): PHP 8.3