### PR TITLE
tests actor actions of RuleCommonITILObject

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -865,6 +865,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
         $actions['_users_id_requester']['appendtoarrayfield']       = 'users_id';
 
         // set a requester group
+        // defaultfromuser means use the requester's default group
         $actions['_groups_id_requester']['name']                    = _n('Requester group', 'Requester groups', 1);
         $actions['_groups_id_requester']['type']                    = 'dropdown';
         $actions['_groups_id_requester']['table']                   = 'glpi_groups';
@@ -892,6 +893,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
         $actions['_users_id_assign']['appendtoarrayfield']          = 'users_id';
 
         // set a technician group
+        // defaultfromuser means use the requester's default group (not the assigned technician's default group)
         $actions['_groups_id_assign']['table']                      = 'glpi_groups';
         $actions['_groups_id_assign']['name']                       = __('Technician group');
         $actions['_groups_id_assign']['type']                       = 'dropdown';
@@ -929,6 +931,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
         $actions['_users_id_observer']['appendtoarrayfield']        = 'users_id';
 
         // set an observer group
+        // defaultfromuser means use the requester's default group
         $actions['_groups_id_observer']['table']                    = 'glpi_groups';
         $actions['_groups_id_observer']['name']                     = _n('Observer group', 'Observer groups', 1);
         $actions['_groups_id_observer']['type']                     = 'dropdown';

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -3143,7 +3143,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
     /**
      * Test _groups_id_requester action with 'defaultfromuser'
-     * Rule with 'defaultfromuser' should set the requester group to the default group of the requester user.
+     * Set an itil's requester group, the group is the requester default's group.
      */
     #[TestWith(['condition' => RuleCommonITILObject::ONADD])]
     #[TestWith(['condition' => RuleCommonITILObject::ONUPDATE])]
@@ -3200,7 +3200,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
             throw new \InvalidArgumentException("Condition $condition not expected");
         }
 
-        // --- assert the default group of the requester is set as requester group ---
+        // --- assert the itil requester group is set to requester group ---
         $this->assertEquals(
             1,
             countElementsInTable(
@@ -4397,7 +4397,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
     /**
      * Test _groups_id_assign action with 'defaultfromuser'
-     * Rule with 'defaultfromuser' should set the technician group to the default group of the assigned user.
+     * Set an itil's assigned group, the group is the requester default's group.
      */
     #[TestWith(['condition' => RuleCommonITILObject::ONADD])]
     #[TestWith(['condition' => RuleCommonITILObject::ONUPDATE])]
@@ -4409,17 +4409,17 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $itil_class = $this->getITILObjectClass();
         $itil_fk = $itil_class::getForeignKeyField();
         $itil_group_link_class = $this->getITILLinkClass(Group::class);
-        $user_default_group = getItemByTypeName(Group::class, '_test_group_1');
+        $requester_default_group = getItemByTypeName(Group::class, '_test_group_1');
 
-        assert(1 === $user_default_group->fields['is_assign']);
+        assert(1 === $requester_default_group->fields['is_assign']);
 
-        // set technician user's default group
-        $tech_user = getItemByTypeName(User::class, 'tech');
+        // set requester default group
+        $requester = getItemByTypeName(User::class, 'post-only');
         $this->createItem(Group_User::class, [
-            'users_id'  => $tech_user->getID(),
-            'groups_id' => $user_default_group->getID(),
+            'users_id'  => $requester->getID(),
+            'groups_id' => $requester_default_group->getID(),
         ]);
-        $tech_user = $this->updateItem(User::class, $tech_user->getID(), ['groups_id' => $user_default_group->getID()]);
+        $requester = $this->updateItem(User::class, $requester->getID(), ['groups_id' => $requester_default_group->getID()]);
 
         $rule_builder = new RuleBuilder(__FUNCTION__, $this->getTestedClass());
         $rule_builder
@@ -4434,7 +4434,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
                 $itil_class,
                 [
                     'priority' => 5,
-                    '_users_id_assign' => $tech_user->getID(),
+                    '_users_id_requester' => $requester->getID(),
                 ] + $this->getMinimalCreationInput($itil_class)
             );
         } elseif ($condition === RuleCommonITILObject::ONUPDATE) {
@@ -4447,21 +4447,21 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
                 $itil_item->getID(),
                 [
                     'priority' => 5,
-                    '_users_id_assign' => $tech_user->getID(),
+                    '_users_id_requester' => $requester->getID(),
                 ] + $this->getMinimalCreationInput($itil_class)
             );
         } else {
             throw new \InvalidArgumentException("Condition $condition not expected");
         }
 
-        // --- assert the default group of the assigned user is set as technician group ---
+        // --- assert the itil assignees' group is the requester default group ---
         $this->assertEquals(
             1,
             countElementsInTable(
                 $itil_group_link_class::getTable(),
                 [
                     $itil_fk    => $itil_item->getID(),
-                    'groups_id' => $user_default_group->getID(),
+                    'groups_id' => $requester_default_group->getID(),
                     'type'      => CommonITILActor::ASSIGN,
                 ]
             )
@@ -4844,7 +4844,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
     /**
      * Test _groups_id_observer action with 'defaultfromuser'
-     * Rule with 'defaultfromuser' should set the observer group to the default group of the requester user.
+     * Set the observer group to the default group of the requester user.
      */
     #[TestWith(['condition' => RuleCommonITILObject::ONADD])]
     #[TestWith(['condition' => RuleCommonITILObject::ONUPDATE])]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.



## Description

Add tests for actors of RuleCommonITILObjectTest.php

Tests cover both ONUPDATE & ONADD conditions.

* \_groups_id_requester
  * assign
  * append
  * defaultfromuser
  * fromitem
  * regex_result
* _groups_id_requester_by_completename
  * regex_result
* _users_id_requester
  * assign
  *  append
* _users_id_assign
  * assign
  * append
* \_users_id_observer
  * assign
  * append
* \_suppliers_id_assign
  * assign
  * append
* \_groups_id_assign
  * assign
  * append
  * regex_result
  * fromitem
  * defaultfromuser
* \_groups_id_assign_by_completename
  * regex_result
* \_groups_id_observer
  * assign
  * append
  * regex_result
  * fromitem
  * defaultfromuser
* \_groups_id_observer_by_completename
  * regex_result

I discovered failures, fixed in related PR (#23381 ~& #23393~) that need to be merged before this PR.
- Some rules only apply to Tickets but should be also for Changes & Problems.
- Some don't run on any type
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 