### PR TITLE
Fix deprecated usage of `1` criteria

### DIFF
--- a/src/NotImportedEmail.php
+++ b/src/NotImportedEmail.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QueryExpression;
+
 /**
  * NotImportedEmail Class
  **/
@@ -210,7 +212,7 @@ class NotImportedEmail extends CommonDBTM
     {
         global $DB;
 
-        $DB->delete('glpi_notimportedemails', [1]);
+        $DB->delete('glpi_notimportedemails', [new QueryExpression(true)]);
     }
 
 

--- a/src/NotImportedEmail.php
+++ b/src/NotImportedEmail.php
@@ -212,7 +212,7 @@ class NotImportedEmail extends CommonDBTM
     {
         global $DB;
 
-        $DB->delete('glpi_notimportedemails', [new QueryExpression(true)]);
+        $DB->delete('glpi_notimportedemails', [new QueryExpression('true')]);
     }
 
 

--- a/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -1049,7 +1049,7 @@ class AbstractPluginMigrationTest extends DbTestCase
         $computer_2_id = \getItemByTypeName(Computer::class, '_test_pc02', true);
         $computer_3_id = \getItemByTypeName(Computer::class, '_test_pc03', true); // this one will not be migrated
 
-        $DB->delete(Infocom::getTable(), [new QueryExpression(true)]);
+        $DB->delete(Infocom::getTable(), [new QueryExpression('true')]);
         $this->createItems(
             Infocom::class,
             [
@@ -1096,7 +1096,7 @@ class AbstractPluginMigrationTest extends DbTestCase
             ],
         );
 
-        $DB->delete(Contract_Item::getTable(), [new QueryExpression(true)]);
+        $DB->delete(Contract_Item::getTable(), [new QueryExpression('true')]);
         $this->createItems(
             Contract_Item::class,
             [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Spotted in main branch tests.
<img width="1132" height="748" alt="image" src="https://github.com/user-attachments/assets/75c1a43a-f27b-463b-89ed-3c6bd406976f" />
