### PR TITLE
Fix generic assets unicity check

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -4574,6 +4574,7 @@ class CommonDBTM extends CommonGLPI
                             $entities = getSonsOf('glpi_entities', $fields['entities_id']);
                         }
                         $where[] = getEntitiesRestrictCriteria(static::getTable(), '', $entities);
+                        $where[] = static::getSystemSQLCriteria(static::getTable());
 
                         $tmp = clone $this;
                         if ($tmp->maybeTemplate()) {

--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -532,6 +532,7 @@ class FieldUnicity extends CommonDropdown
         }
 
         $where = [];
+
         if ($item->maybeTemplate()) {
             $where[$item::getTable() . '.is_template'] = 0;
         }
@@ -550,7 +551,7 @@ class FieldUnicity extends CommonDropdown
             'FROM'      => $item_table,
             'WHERE'     => [
                 $item_table . '.entities_id'  => $entities,
-            ] + $where,
+            ] + $where + $item::getSystemSQLCriteria(),
             'GROUPBY'   => $fields,
             'ORDERBY'   => 'cpt DESC',
         ]);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Replaces #23096.

Without this patch, the unicity checks is not filtering assets by their definitions. It means that an asset `Laptop` may be considered a double of an asset `Tablet`.