### PR TITLE
Fix asset_peripheralasset list and manual add

### DIFF
--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -310,10 +310,14 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if ($itemtype::canView()) {
                 $iterator = self::getPeripheralAssets($asset, $itemtype);
+                $usediterator = self::getUsedPeripherals($itemtype);
 
                 foreach ($iterator as $data) {
                     $data['assoc_itemtype'] = $itemtype;
                     $datas[]           = $data;
+                }
+
+                foreach ($usediterator as $data) {
                     $used[$itemtype][] = $data['id'];
                 }
             }
@@ -334,7 +338,10 @@ final class Asset_PeripheralAsset extends CommonDBRelation
                 'source_itemtype' => $asset::class,
                 'source_items_id' => $asset->getID(),
                 'link_types' => $CFG_GLPI['directconnect_types'],
-                'asset_target' => true,
+                'generic_source' => true,
+                'generic_target' => true,
+                'source_suffix' => '_asset',
+                'target_suffix' => '_peripheral',
                 'dropdown_options' => [
                     'entity'      => $asset->getEntityID(),
                     'entity_sons' => $asset->isRecursive(),
@@ -985,6 +992,42 @@ TWIG, $twig_params);
                 self::getTable() . '.is_deleted'     => 0,
                 self::getTable() . '.itemtype_asset' => $asset::class,
                 self::getTable() . '.items_id_asset' => $asset->getID(),
+            ] + getEntitiesRestrictCriteria($peripheral::getTable()),
+            'ORDER' => $peripheral::getTable() . '.' . $peripheral::getNameField(),
+        ]);
+    }
+
+        /**
+     * Returns used peripherals.
+     *
+     * @param class-string<CommonDBTM> $itemtype Itemtype of the peripherals to retrieve.
+     *
+     * @return DBmysqlIterator
+    */
+    private static function getUsedPeripherals(string $itemtype): DBmysqlIterator
+    {
+        global $DB;
+
+        $peripheral = getItemForItemtype($itemtype);
+
+        return $DB->request([
+            'SELECT' => self::getTypeItemsQueryParams_Select($peripheral),
+            'FROM'   => $peripheral::getTable(),
+            'LEFT JOIN' => [
+                self::getTable() => [
+                    'FKEY' => [
+                        self::getTable()      => 'items_id_peripheral',
+                        $peripheral::getTable() => 'id',
+                        [
+                            'AND' => [
+                                self::getTable() . '.itemtype_peripheral' => $itemtype,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'WHERE' => [
+                self::getTable() . '.is_deleted'     => 0,
             ] + getEntitiesRestrictCriteria($peripheral::getTable()),
             'ORDER' => $peripheral::getTable() . '.' . $peripheral::getNameField(),
         ]);

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -991,42 +991,6 @@ TWIG, $twig_params);
     }
 
     /**
-     * Returns used peripherals.
-     *
-     * @param class-string<CommonDBTM> $itemtype Itemtype of the peripherals to retrieve.
-     *
-     * @return DBmysqlIterator
-    */
-    private static function getUsedPeripherals(string $itemtype): DBmysqlIterator
-    {
-        global $DB;
-
-        $peripheral = getItemForItemtype($itemtype);
-
-        return $DB->request([
-            'SELECT' => self::getTypeItemsQueryParams_Select($peripheral),
-            'FROM'   => $peripheral::getTable(),
-            'LEFT JOIN' => [
-                self::getTable() => [
-                    'FKEY' => [
-                        self::getTable()      => 'items_id_peripheral',
-                        $peripheral::getTable() => 'id',
-                        [
-                            'AND' => [
-                                self::getTable() . '.itemtype_peripheral' => $itemtype,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'WHERE' => [
-                self::getTable() . '.is_deleted'     => 0,
-            ] + getEntitiesRestrictCriteria($peripheral::getTable()),
-            'ORDER' => $peripheral::getTable() . '.' . $peripheral::getNameField(),
-        ]);
-    }
-
-    /**
      * Returns linked main assets data for given peripheral asset.
      *
      * @param CommonDBTM               $peripheral Peripheral asset.

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -997,7 +997,7 @@ TWIG, $twig_params);
         ]);
     }
 
-        /**
+    /**
      * Returns used peripherals.
      *
      * @param class-string<CommonDBTM> $itemtype Itemtype of the peripherals to retrieve.

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -309,7 +309,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         $used  = [];
         foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if ($itemtype::canView()) {
-                $iterator = self::getUsedPeripherals($itemtype);
+                $iterator = self::getPeripheralAssets($asset, $itemtype);
 
                 foreach ($iterator as $data) {
                     $data['assoc_itemtype'] = $itemtype;
@@ -334,7 +334,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
                 'source_itemtype' => $asset::class,
                 'source_items_id' => $asset->getID(),
                 'link_types' => $CFG_GLPI['directconnect_types'],
-                'generic_target' => true,
+                'asset_target' => true,
                 'dropdown_options' => [
                     'entity'      => $asset->getEntityID(),
                     'entity_sons' => $asset->isRecursive(),

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -39,6 +39,9 @@
       {% if generic_source ?? false %}
           {{ fields.hiddenField('itemtype', source_itemtype) }}
           {{ fields.hiddenField('items_id', source_items_id) }}
+      {% elseif asset_target ?? false %}
+          {{ fields.hiddenField('itemtype_asset', source_itemtype) }}
+          {{ fields.hiddenField('items_id_asset', source_items_id) }}
       {% else %}
           {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
       {% endif %}
@@ -51,6 +54,17 @@
               width: 'auto',
               mb: '',
               no_label: true,
+          }|merge(dropdown_options)) }}
+      {% elseif asset_target ?? false %}
+          {{ fields.dropdownItemsFromItemtypes('items_id_peripheral', '', {
+              itemtypes: link_types,
+              used: used ?? [],
+              field_class: 'd-flex',
+              width: 'auto',
+              mb: '',
+              no_label: true,
+              itemtype_name : 'itemtype_peripheral',
+              items_id_name : 'items_id_peripheral',
           }|merge(dropdown_options)) }}
       {% else %}
           {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -37,11 +37,8 @@
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
       {{ form_label }}
       {% if generic_source ?? false %}
-          {{ fields.hiddenField('itemtype', source_itemtype) }}
-          {{ fields.hiddenField('items_id', source_items_id) }}
-      {% elseif asset_target ?? false %}
-          {{ fields.hiddenField('itemtype_asset', source_itemtype) }}
-          {{ fields.hiddenField('items_id_asset', source_items_id) }}
+          {{ fields.hiddenField('itemtype' ~ source_suffix ?? '', source_itemtype) }}
+          {{ fields.hiddenField('items_id' ~ source_suffix ?? '', source_items_id) }}
       {% else %}
           {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
       {% endif %}
@@ -54,17 +51,8 @@
               width: 'auto',
               mb: '',
               no_label: true,
-          }|merge(dropdown_options)) }}
-      {% elseif asset_target ?? false %}
-          {{ fields.dropdownItemsFromItemtypes('items_id_peripheral', '', {
-              itemtypes: link_types,
-              used: used ?? [],
-              field_class: 'd-flex',
-              width: 'auto',
-              mb: '',
-              no_label: true,
-              itemtype_name : 'itemtype_peripheral',
-              items_id_name : 'items_id_peripheral',
+              itemtype_name : 'itemtype' ~ target_suffix ?? '',
+            items_id_name : 'items_id' ~ target_suffix ?? '',
           }|merge(dropdown_options)) }}
       {% else %}
           {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -37,8 +37,8 @@
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
       {{ form_label }}
       {% if generic_source ?? false %}
-          {{ fields.hiddenField('itemtype' ~ source_suffix ?? '', source_itemtype) }}
-          {{ fields.hiddenField('items_id' ~ source_suffix ?? '', source_items_id) }}
+          {{ fields.hiddenField('itemtype' ~ (source_suffix ?? ''), source_itemtype) }}
+          {{ fields.hiddenField('items_id' ~ (source_suffix ?? ''), source_items_id) }}
       {% else %}
           {{ fields.hiddenField(source_itemtype|itemtype_foreign_key, source_items_id) }}
       {% endif %}
@@ -51,8 +51,8 @@
               width: 'auto',
               mb: '',
               no_label: true,
-              itemtype_name : 'itemtype' ~ target_suffix ?? '',
-            items_id_name : 'items_id' ~ target_suffix ?? '',
+              itemtype_name : 'itemtype' ~ (target_suffix ?? ''),
+              items_id_name : 'items_id' ~ (target_suffix ?? ''),
           }|merge(dropdown_options)) }}
       {% else %}
           {% set primary_dropdown_itemtype = dropdown_options['itemtype']|default(target_itemtype) %}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42566
- Here is a brief description of what this PR does
The list of assets connected to a computer displayed all objects and not just those linked to the computer in question. The reason for this was that showForAsset used getUsedPeripherals, which displayed a list of all peripherals already in use, rather than getPeripheralAssets, which displays a list of peripherals linked to my computer.

The second issue that prevented from manually adding assets to an item was related to the change in asset_peripheralsasset, which now uses itemtype_asset, items_id_asset, itemtyape_peripheral, and items_is_peripheral. However, the current system only supported itemtype and items_id.
## Screenshots (if appropriate):
<img width="797" height="490" alt="image" src="https://github.com/user-attachments/assets/756a5c52-cf3b-4daa-a810-43687d4799e5" />


