### PR TITLE
block formula datatype detection in spreadsheet outputs

### DIFF
--- a/src/Glpi/Search/Output/Spreadsheet.php
+++ b/src/Glpi/Search/Output/Spreadsheet.php
@@ -77,6 +77,9 @@ abstract class Spreadsheet extends ExportSearchOutput
         $spread = $this->getSpreasheet();
         $writer = $this->getWriter();
 
+        // Set custom value binder to prevent values starting with "=" to be interpreted as formulas
+        $spread->setValueBinder(new SpreadsheetValueBinder());
+
         //set styles
         $style = $spread->getDefaultStyle();
         $font = $style->getFont();

--- a/src/Glpi/Search/Output/SpreadsheetValueBinder.php
+++ b/src/Glpi/Search/Output/SpreadsheetValueBinder.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Search\Output;
+
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+
+/**
+ * Custom value binder for spreadsheet export.
+ *
+ * This class extends the default value binder to ensure that values that look like formulas are treated as strings, preventing them from being evaluated as formulas in the spreadsheet.
+ */
+class SpreadsheetValueBinder extends DefaultValueBinder
+{
+    public static function dataTypeForValue(mixed $value): string
+    {
+        $datatype = parent::dataTypeForValue($value);
+        return $datatype === DataType::TYPE_FORMULA ? DataType::TYPE_STRING : $datatype;
+    }
+}

--- a/tests/functional/Glpi/Search/Output/SpreadsheetValueBinderTest.php
+++ b/tests/functional/Glpi/Search/Output/SpreadsheetValueBinderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace functional\Glpi\Search\Output;
+
+use Glpi\Search\Output\SpreadsheetValueBinder;
+use Glpi\Tests\GLPITestCase;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+
+class SpreadsheetValueBinderTest extends GLPITestCase
+{
+    public function testDataTypeForValue(): void
+    {
+        $binder = new SpreadsheetValueBinder();
+
+        // Test that a formula is treated as a string
+        $this->assertSame(
+            DataType::TYPE_STRING,
+            $binder::dataTypeForValue('=SUM(A1:A10)')
+        );
+
+        // Test that a regular string is still treated as a string
+        $this->assertSame(
+            DataType::TYPE_STRING,
+            $binder::dataTypeForValue('Hello, World!')
+        );
+
+        // Test that a number is still treated as numeric
+        $this->assertSame(
+            DataType::TYPE_NUMERIC,
+            $binder::dataTypeForValue(12345)
+        );
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

fixes #23231

Adds a custom value binder based on the default one that keeps the original auto-detection logic but switches out the formula type with string.