### PR TITLE
feat(planning): Make FullCalendar buttons respect GLPI dynamic themes

### DIFF
--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -227,6 +227,19 @@
 
       }
 
+      .fc-button-primary {
+         background-color: var(--tblr-secondary) !important;
+         border-color: var(--tblr-secondary) !important;
+         color: var(--tblr-secondary-fg, #fff) !important;
+
+         &:not(:disabled):active,
+         &:not(:disabled).fc-button-active {
+            background-color: var(--tblr-primary) !important;
+            border-color: var(--tblr-primary) !important;
+            color: var(--tblr-primary-fg, #fff) !important;
+         }
+      }
+
       .event_today {
          background: #fcf8e3;
       }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This PR updates the [FullCalendar ](https://fullcalendar.io/demos) button styles in the planning view to respect GLPI's dynamic themes and dark mode.

## Screenshots (if appropriate):

Currently, FullCalendar v4 uses hardcoded hex colors (`#1a252f` and `#151e27`) for its `.fc-button-primary` classes. Because these are statically imported from the `@fullcalendar/core` node module, the buttons remain dark regardless of the user's selected GLPI palette, which causes contrast and UI consistency issues.

<img width="1578" height="133" alt="2026-03-05 14_43_24-WhatsApp" src="https://github.com/user-attachments/assets/96b30f93-85a5-43b0-b978-fcb8356b11c5" />

Added a CSS override in `css/legacy/includes/_planning.scss` to map the `.fc-button-primary` classes to standard Tabler variables. 
* Standard buttons now use `--tblr-secondary` and `--tblr-secondary-fg`.
* Active/Pressed buttons (`.fc-button-active`) now use `--tblr-primary` and `--tblr-primary-fg`.

<img width="1583" height="138" alt="2026-03-05 14_39_18-WhatsApp" src="https://github.com/user-attachments/assets/0f254586-c8ae-4c4e-b4d7-0430d1ff8882" />

This ensures the buttons automatically adapt to any user-selected palette and remain fully accessible in dark mode.