### PR TITLE
feat(planning): center "No events to display" message in planning list view

### DIFF
--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -311,7 +311,7 @@
          position: initial;
       }
 
-       .fc-scroller:has(.fc-list-empty) {
+      .fc-scroller:has(.fc-list-empty) {
          display: flex;
          align-items: center;
          justify-content: center;

--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -310,6 +310,12 @@
       .fc-list-empty-wrap2 {
          position: initial;
       }
+
+       .fc-scroller:has(.fc-list-empty) {
+         display: flex;
+         align-items: center;
+         justify-content: center;
+      }
    }
 
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):

Currently, when the Planning list view is empty, the "No events to display" message is aligned to the top-center of the container. This creates a large empty space below the text, which can look like a loading error or an unfinished UI.

<img width="1582" height="599" alt="2026-03-05 14_57_00-WhatsApp" src="https://github.com/user-attachments/assets/bab1a1f2-5be4-4643-a993-b45130df019b" />

This PR aligns the empty state message to the vertical and horizontal center of the view container to improve visual balance and user experience.

<img width="1576" height="597" alt="2026-03-05 14_57_20-WhatsApp" src="https://github.com/user-attachments/assets/3d21f9b8-7d71-48ab-b92a-5e155c1d422d" />

Used the CSS `:has()` selector to ensure centering logic is **only active** when the `.fc-list-empty` element is present. This prevents any layout interference when actual events are being displayed.