### PR TITLE
Add BOM to Search Engine CVS output for better Excel compatibility

### DIFF
--- a/src/Glpi/Search/Output/Csv.php
+++ b/src/Glpi/Search/Output/Csv.php
@@ -44,6 +44,7 @@ final class Csv extends Spreadsheet
         $this->writer
             ->setDelimiter($_SESSION["glpicsv_delimiter"])
             ->setEnclosure('"')
+            ->setUseBOM(true)
             ->setLineEnding("\r\n")
             ->setSheetIndex(0);
     }


### PR DESCRIPTION

## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

- It fixes #23291 
- GLPI 10.x Search engine export created CSV output with BOM which provided better Excel compatibility (encoding detection). This PR restores this behavior and adds BOM also to PhpSpreadsheet output in GLPI11.


