### PR TITLE
Fix log viewers tests

### DIFF
--- a/tests/e2e/specs/Admin/log_viewer.spec.ts
+++ b/tests/e2e/specs/Admin/log_viewer.spec.ts
@@ -51,7 +51,7 @@ test('Log list has items', async ({ page, profile }) => {
 test('Log viewer has entries', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
     const log_viewer_page = new LogViewerPage(page);
-    await log_viewer_page.gotoLogViewer('php-errors.log');
+    await log_viewer_page.gotoLogViewer('event.log');
     await expect(log_viewer_page.log_entries.first()).toBeVisible();
 
     const a11y_results = await new AxeBuilder({ page })


### PR DESCRIPTION
This test was failing because it needs a non empty log file and `php-errors` is now empty (previously it contained "Test logger", which we removed in #23128.

The `event` file seems a good replacement as it always contains data.