### PR TITLE
fix  groups id assign action with defaultfromuser

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10767,20 +10767,19 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         $user = new User();
-        if (isset($input["_users_id_requester"])) {
-            if (
-                !is_array($input["_users_id_requester"])
-                && $user->getFromDB($input["_users_id_requester"])
-            ) {
+        foreach (['_users_id_requester', '_users_id_assign'] as $user_field) {
+            if (!isset($input[$user_field])) {
+                continue;
+            }
+
+            $user_id = is_array($input[$user_field])
+                ? reset($input[$user_field])
+                : $input[$user_field];
+
+            if ($user_id !== false && $user->getFromDB($user_id)) {
                 $input['_locations_id_of_requester'] = $user->fields['locations_id'];
                 $input['users_default_groups'] = $user->fields['groups_id'];
                 $input['profiles_id'] = $user->fields['profiles_id']; //default profile
-            } elseif (is_array($input["_users_id_requester"]) && ($user_id = reset($input["_users_id_requester"])) !== false) {
-                if ($user->getFromDB($user_id)) {
-                    $input['_locations_id_of_requester'] = $user->fields['locations_id'];
-                    $input['users_default_groups'] = $user->fields['groups_id'];
-                    $input['profiles_id'] = $user->fields['profiles_id']; //default profile
-                }
             }
         }
 

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -1529,7 +1529,6 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
         // --- act ---
         if ($condition === RuleCommonITILObject::ONADD) {
-            //            $this->markTestSkipped('Currently failing + tested as a user : need a code fix');
             $itil_item = $this->createItem(
                 $itil_class,
                 [

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -46,6 +46,7 @@ use ITILCategory;
 use ITILFollowup;
 use ITILFollowupTemplate;
 use Location;
+use PHPUnit\Framework\Attributes\TestWith;
 use Rule;
 use RuleAction;
 use RuleCommonITILObject;
@@ -1494,6 +1495,77 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
                 'groups_id'          => $group_id3,
                 'type'               => CommonITILActor::REQUESTER,
             ])
+        );
+    }
+
+    #[TestWith(['condition' => RuleCommonITILObject::ONADD])]
+    #[TestWith(['condition' => RuleCommonITILObject::ONUPDATE])]
+    public function testGroupsIdAssignActionDefaultFromUser(int $condition): void
+    {
+        // --- arrange ---
+        $this->login();
+
+        $itil_class = $this->getITILObjectClass();
+        $itil_fk = $itil_class::getForeignKeyField();
+        $itil_group_link_class = $this->getITILLinkClass(Group::class);
+        $user_default_group = getItemByTypeName(Group::class, '_test_group_1');
+
+        assert(1 === $user_default_group->fields['is_assign']);
+
+        // set technician user's default group
+        $tech_user = getItemByTypeName(User::class, 'tech');
+        $this->createItem(Group_User::class, [
+            'users_id'  => $tech_user->getID(),
+            'groups_id' => $user_default_group->getID(),
+        ]);
+        $tech_user = $this->updateItem(User::class, $tech_user->getID(), ['groups_id' => $user_default_group->getID()]);
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, $this->getTestedClass());
+        $rule_builder
+            ->setCondtion($condition)
+            ->addCriteria('priority', Rule::PATTERN_IS, 5)
+            ->addAction('defaultfromuser', '_groups_id_assign', 1);
+        $this->createRule($rule_builder);
+
+        // --- act ---
+        if ($condition === RuleCommonITILObject::ONADD) {
+            //            $this->markTestSkipped('Currently failing + tested as a user : need a code fix');
+            $itil_item = $this->createItem(
+                $itil_class,
+                [
+                    'priority' => 5,
+                    '_users_id_assign' => $tech_user->getID(),
+                ] + $this->getMinimalCreationInput($itil_class)
+            );
+        } elseif ($condition === RuleCommonITILObject::ONUPDATE) {
+            //            $this->markTestSkipped('Currently failing + tested as a user : need a code fix');
+            $itil_item = $this->createItem(
+                $itil_class,
+                $this->getMinimalCreationInput($itil_class)
+            );
+            $this->updateItem(
+                $itil_class,
+                $itil_item->getID(),
+                [
+                    'priority' => 5,
+                    '_users_id_assign' => $tech_user->getID(),
+                ] + $this->getMinimalCreationInput($itil_class)
+            );
+        } else {
+            throw new \InvalidArgumentException("Condition $condition not expected");
+        }
+
+        // --- assert the default group of the assigned user is set as technician group ---
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                $itil_group_link_class::getTable(),
+                [
+                    $itil_fk    => $itil_item->getID(),
+                    'groups_id' => $user_default_group->getID(),
+                    'type'      => CommonITILActor::ASSIGN,
+                ]
+            )
         );
     }
 

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -1537,7 +1537,6 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
                 ] + $this->getMinimalCreationInput($itil_class)
             );
         } elseif ($condition === RuleCommonITILObject::ONUPDATE) {
-            //            $this->markTestSkipped('Currently failing + tested as a user : need a code fix');
             $itil_item = $this->createItem(
                 $itil_class,
                 $this->getMinimalCreationInput($itil_class)


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Rule for CommonITILObject _groups_id_assign - defaultfromuser wasn't working
