### PR TITLE
fix display new domain record form

### DIFF
--- a/src/DomainRecordType.php
+++ b/src/DomainRecordType.php
@@ -225,7 +225,7 @@ class DomainRecordType extends CommonDropdown
 
         switch ($field_type) {
             case 'fields':
-                $printable = json_encode(json_decode($field_value), JSON_PRETTY_PRINT);
+                $printable = !empty($field_value) ? json_encode(json_decode($field_value), JSON_PRETTY_PRINT) : '';
                 echo '<textarea name="' . htmlescape($field_name) . '" cols="75" rows="25">' . htmlescape($printable) . '</textarea >';
                 break;
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When displaying the new domain record form, the "fields" value was JSON decoded and re-encoded in pretty format. With the mass replacements to using "Safe" PHP functions the previous behavior which would have resulted in an empty string being re-encoded as false which gets implicitly cast to an empty string as expected no longer happens. Now, an exception is thrown and not handled.