### PR TITLE
fix itemtype param being used for FieldUnicity itemtype field

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3332,6 +3332,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonDevice.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method CommonDevice\\:\\:displayFullPageForItem\\(\\) has parameter \\$menus with no value type specified in iterable type array\\.$#',
+	'identifier' => 'missingType.iterableValue',
+	'count' => 1,
+	'path' => __DIR__ . '/src/CommonDevice.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method CommonDevice\\:\\:getDeviceTypes\\(\\) should return array\\<array\\<class\\-string\\<CommonDevice\\>\\>\\|class\\-string\\<CommonDevice\\>\\> but returns array\\<int\\<0, max\\>\\|string, array\\<int\\<0, max\\>, class\\-string\\<CommonDevice\\>\\|CommonDevice\\>\\|class\\-string\\<CommonDevice\\>\\|CommonDevice\\>\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -663,4 +663,10 @@ abstract class CommonDevice extends CommonDropdown
     {
         return "ti ti-components";
     }
+
+    public static function displayFullPageForItem($id, ?array $menus = null, array $options = []): void
+    {
+        $options['itemtype'] = static::class;
+        parent::displayFullPageForItem($id, $menus, $options);
+    }
 }

--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -209,7 +209,6 @@ class DropdownFormController extends AbstractController
         }
         $options['formoptions'] = ($options['formoptions'] ?? '') . ' data-track-changes=true';
         $options['id'] = $id;
-        $options['itemtype'] = $class;
 
         $dropdown::displayFullPageForItem($id, $dropdown->getSectorizedDetails(), $options);
         $content = ob_get_clean();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22994
Adjustment to change made in #22673 to only add the `itemtype` parameter for devices.

GLPI pushes the options array values into the item's fields array in some cases which causes unwanted behavior. At least if it is limited to devices, any potential damage can be limited.