### PR TITLE
Fix document transfer from KB

### DIFF
--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -760,6 +760,66 @@ TWIG, $twig_params);
     }
 
     /**
+     * @param CommonDBTM|null $checkitem
+     * @return array<string, string>
+     */
+    public function getSpecificMassiveActions($checkitem = null): array
+    {
+        $actions = parent::getSpecificMassiveActions($checkitem);
+
+        // Replace the generic MassiveAction:add_transfer_list with our own processor so that
+        // we can redirect the transfer to the underlying Document instead of the relation
+        $generic_key = MassiveAction::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list';
+        if (isset($actions[$generic_key])) {
+            $label = $actions[$generic_key];
+            unset($actions[$generic_key]);
+            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list'] = $label;
+        }
+
+        return $actions;
+    }
+
+    /**
+     * @param MassiveAction $ma
+     * @param CommonDBTM $item
+     * @param array<int> $ids
+     */
+    public static function processMassiveActionsForOneItemtype(
+        MassiveAction $ma,
+        CommonDBTM $item,
+        array $ids
+    ): void {
+        global $CFG_GLPI;
+
+        if ($ma->getAction() !== 'add_transfer_list') {
+            parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+            return;
+        }
+
+        if (!isset($_SESSION['glpitransfer_list'])) {
+            $_SESSION['glpitransfer_list'] = [];
+        }
+
+        // Remove any residual Document_Item entries to avoid errors in transfer list.
+        unset($_SESSION['glpitransfer_list'][Document_Item::class]);
+        if (!isset($_SESSION['glpitransfer_list'][Document::class])) {
+            $_SESSION['glpitransfer_list'][Document::class] = [];
+        }
+
+        foreach ($ids as $id) {
+            if (!$item->getFromDB($id)) {
+                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                continue;
+            }
+            $doc_id = (int) $item->fields['documents_id'];
+            $_SESSION['glpitransfer_list'][Document::class][$doc_id] = $doc_id;
+            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+        }
+
+        $ma->setRedirect($CFG_GLPI['root_doc'] . '/front/transfer.action.php');
+    }
+
+    /**
      * Get items for an itemtype
      *
      * @since 9.3.1

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1315,4 +1315,75 @@ class TransferTest extends DbTestCase
 
         $this->assertCount(0, $contract2->find(['id' => $contract2_id]));
     }
+
+    /**
+     * When "add to transfer list" is executed on Document_Item records, the transfer list
+     * must contain the related Documents (not the Document_Item relations themselves).
+     * The Document_Item:add_transfer_list action key ensures the Document_Item processor
+     * handles the dispatch and can redirect to the entity-owning peer (the Document).
+     */
+    public function testAddTransferListResolvesRelationToEntityOwner(): void
+    {
+        $this->login();
+
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $document = $this->createItem(\Document::class, [
+            'name'        => 'Test document linked to FAQ',
+            'entities_id' => $entity_id,
+        ]);
+
+        $kb_item = $this->createItem(\KnowbaseItem::class, [
+            'name'        => 'Test FAQ article',
+            'answer'      => 'Test answer content',
+            'is_faq'      => 1,
+            'entities_id' => $entity_id,
+        ]);
+
+        $doc_item = $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $kb_item->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+
+        // Verify the action is registered under Document_Item processor, not MassiveAction.
+        $actions = (new \Document_Item())->getSpecificMassiveActions();
+        $this->assertArrayNotHasKey(
+            \MassiveAction::class . \MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list',
+            $actions
+        );
+        $this->assertArrayHasKey(
+            \Document_Item::class . \MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list',
+            $actions
+        );
+
+        // Verify that processing the action adds the Document to the transfer list.
+        unset($_SESSION['glpitransfer_list']);
+
+        \Document_Item::processMassiveActionsForOneItemtype(
+            $this->createMassiveActionMock('add_transfer_list'),
+            new \Document_Item(),
+            [$doc_item->getID()]
+        );
+
+        $this->assertArrayNotHasKey(\Document_Item::class, $_SESSION['glpitransfer_list'] ?? []);
+        $this->assertArrayHasKey(\Document::class, $_SESSION['glpitransfer_list'] ?? []);
+        $this->assertArrayHasKey(
+            $document->getID(),
+            $_SESSION['glpitransfer_list'][\Document::class]
+        );
+
+        unset($_SESSION['glpitransfer_list']);
+    }
+
+    private function createMassiveActionMock(string $action): \MassiveAction
+    {
+        $ma = $this->getMockBuilder(\MassiveAction::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAction', 'itemDone', 'setRedirect'])
+            ->getMock();
+        $ma->method('getAction')->willReturn($action);
+        return $ma;
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42613
- Here is a brief description of what this PR does

When a `Document_Item` (link between a Document and a FAQ article) was added to the transfer list via a massive action, navigating to the transfer page produced a fatal MySQL error:
```php
[2026-03-06 16:10:32] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Unknown column 'glpi_documents_items.name' in 'field list' (1054) in SQL query "SELECT `glpi_documents_items`.`id`, `glpi_documents_items`.`name`, `entities`.`completename` AS `entname`, `entities`.`id` AS `entID` FROM `glpi_documents_items` LEFT JOIN `glpi_entities` AS `entities` ON (`entities`.`id` = `glpi_documents_items`.`entities_id`) WHERE `glpi_documents_items`.`id` IN ('1') ORDER BY `entname`, `glpi_documents_items`.`name`"." at DBmysql.php line 416
  Backtrace :
  ./src/DBmysql.php:416                              
  ./src/DBmysqlIterator.php:129                      DBmysql->doQuery()
  ./src/DBmysql.php:1088                             DBmysqlIterator->execute()
  ./src/Transfer.php:4223                            DBmysql->request()
  ./front/transfer.action.php:69                     Transfer->showTransferList()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

Because `Transfer::showTransferList()` called `getNameField()` which returns `'name'` by default, then used it directly in a `SELECT` query. The `glpi_documents_items` table is a pure relation table with no `name` column. The same issue affects any `CommonDBRelation` subclass whose table lacks a `name` column.

### Fix

Two methods overridden in `Document_Item`:

- **`getSpecificMassiveActions()`** — replaces the generic `MassiveAction:add_transfer_list` with
  `Document_Item:add_transfer_list`, making `Document_Item` the action processor.
- **`processMassiveActionsForOneItemtype()`** — intercepts `add_transfer_list` and adds the parent
  `Document` to the transfer list instead of the `Document_Item`. Residual `Document_Item` session
  entries are purged as a precaution.

### Test

`testAddTransferListResolvesRelationToEntityOwner` verifies:
1. the action is registered under `Document_Item`, not `MassiveAction`
2. executing the action adds `Document::class` to the transfer list, not `Document_Item::class`