### PR TITLE
add dc position field in custom assets

### DIFF
--- a/src/Glpi/Asset/Asset.php
+++ b/src/Glpi/Asset/Asset.php
@@ -44,6 +44,7 @@ use Glpi\CustomObject\CustomObjectTrait;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
+use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\Inventoriable;
 use Glpi\Features\StateInterface;
 use Group;
@@ -76,6 +77,7 @@ abstract class Asset extends CommonDBTM implements AssignableItemInterface, Stat
     use Clonable;
     use \Glpi\Features\State;
     use Inventoriable;
+    use DCBreadcrumb;
 
     /**
      * Asset definition system name.

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -41,6 +41,7 @@ use DisplayPreference;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Capacity\CapacityInterface;
 use Glpi\Asset\CustomFieldType\DropdownType;
+use Glpi\Asset\CustomFieldType\RawType;
 use Glpi\Asset\CustomFieldType\StringType;
 use Glpi\Asset\CustomFieldType\TextType;
 use Glpi\CustomObject\AbstractDefinition;
@@ -723,6 +724,10 @@ TWIG, $twig_params);
             'states_id'        => [
                 'text' => __('Status'),
                 'type' => DropdownType::class,
+            ],
+            '_dc_breadcrumbs' => [
+                'text' => __('Data center position'),
+                'type' => RawType::class,
             ],
             'locations_id'     => [
                 'text' => Location::getTypeName(1),

--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -120,6 +120,7 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
                     && class_exists($classname)
                     && is_subclass_of($classname, TypeInterface::class)
                     && (new ReflectionClass($classname))->isAbstract() === false
+                    && $classname::isAllowedForCustomFields()
                 ) {
                     $this->custom_field_types[] = $classname;
                 }

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -37,6 +37,7 @@ namespace Glpi\Asset;
 use CommonDBChild;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\CustomFieldType\DropdownType;
+use Glpi\Asset\CustomFieldType\RawType;
 use Glpi\Asset\CustomFieldType\TypeInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
@@ -340,6 +341,9 @@ final class CustomFieldDefinition extends CommonDBChild
 
     public function getFieldType(): TypeInterface
     {
+        if ($this->fields['type'] === RawType::class) {
+            return new RawType($this);
+        }
         $field_types = AssetDefinitionManager::getInstance()->getCustomFieldTypes();
         if (in_array($this->fields['type'], $field_types, true)) {
             return new $this->fields['type']($this);

--- a/src/Glpi/Asset/CustomFieldType/AbstractType.php
+++ b/src/Glpi/Asset/CustomFieldType/AbstractType.php
@@ -46,6 +46,11 @@ abstract class AbstractType implements TypeInterface
         protected CustomFieldDefinition $custom_field
     ) {}
 
+    public static function isAllowedForCustomFields(): bool
+    {
+        return true;
+    }
+
     public function getLabel(): string
     {
         return $this->custom_field->getFriendlyName();

--- a/src/Glpi/Asset/CustomFieldType/RawType.php
+++ b/src/Glpi/Asset/CustomFieldType/RawType.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Asset\CustomFieldType;
+
+use Glpi\Asset\CustomFieldOption\BooleanOption;
+use Glpi\Asset\CustomFieldOption\ProfileRestrictOption;
+
+/**
+ * Special type used for native fields that don't fit in any other type, usually because they output raw HTML, but should work with custom assets.
+ * This type only exposes options to make the field show in full width, and to hide it for specific profiles.
+ */
+class RawType extends AbstractType
+{
+    public static function isAllowedForCustomFields(): bool
+    {
+        return false;
+    }
+
+    public static function getName(): string
+    {
+        return '';
+    }
+
+    public function getOptions(): array
+    {
+        return [
+            new BooleanOption($this->custom_field, 'full_width', __('Full width'), false),
+            new ProfileRestrictOption($this->custom_field, 'hidden', __('Hidden for these profiles'), false),
+        ];
+    }
+
+    public function getFormInput(string $name, mixed $value, ?string $label = null, bool $for_default = false): string
+    {
+        return '';
+    }
+}

--- a/src/Glpi/Asset/CustomFieldType/TypeInterface.php
+++ b/src/Glpi/Asset/CustomFieldType/TypeInterface.php
@@ -39,6 +39,8 @@ use InvalidArgumentException;
 
 interface TypeInterface
 {
+    public static function isAllowedForCustomFields(): bool;
+
     /**
      * Get the field type name.
      */


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23362
Allow showing the Data center Position field in custom assets just as it is shown for built-in assets.

- Adds a new "Raw" custom field type which is only used to provide field options for specific native fields. It is not possible to use it for custom fields and provides no other functionality.
- Adds DCBreadcrumb trait to the Asset class

This field only shows when an asset is in a rack/enclosure.