### PR TITLE
show itemtype in saved search form

### DIFF
--- a/templates/pages/tools/savedsearch/form.html.twig
+++ b/templates/pages/tools/savedsearch/form.html.twig
@@ -36,38 +36,39 @@
 {% set params  = params ?? [] %}
 
 {% block form_fields %}
-   {% block more_fields %}
-      {% if params['itemtype'] is defined %}
-         {{ inputs.hidden('itemtype', params['itemtype']) }}
-      {% endif %}
-      {% if params['type'] is defined and params['type'] != 0 %}
-         {{ inputs.hidden('type', params['type']) }}
-      {% endif %}
-      {% if params['url'] is defined %}
-         {{ inputs.hidden('url', params['url']) }}
-      {% endif %}
-      {% if item.isNewItem() %}
-         {{ inputs.hidden('users_id', item.fields['users_id']) }}
-         {% if not can_create %}
-            {{ inputs.hidden('is_private', 1) }}
-         {% endif %}
-      {% endif %}
+    {% block more_fields %}
+        {% if params['itemtype'] is defined %}
+            {{ inputs.hidden('itemtype', params['itemtype']) }}
+        {% endif %}
+        {% if params['type'] is defined and params['type'] != 0 %}
+            {{ inputs.hidden('type', params['type']) }}
+        {% endif %}
+        {% if params['url'] is defined %}
+            {{ inputs.hidden('url', params['url']) }}
+        {% endif %}
+        {% if item.isNewItem() %}
+            {{ inputs.hidden('users_id', item.fields['users_id']) }}
+            {% if not can_create %}
+                {{ inputs.hidden('is_private', 1) }}
+            {% endif %}
+        {% endif %}
 
-      {{ fields.textField('name', item.fields['name'], __('Name')) }}
-      {{ fields.dropdownArrayField('do_count', item.fields['do_count'], {
-         (constant('SavedSearch::COUNT_AUTO')): __('Auto'),
-         (constant('SavedSearch::COUNT_YES')): __('Yes'),
-         (constant('SavedSearch::COUNT_NO')): __('No')
-      }, __('Do count')) }}
-      {% if can_create %}
-         {{ fields.dropdownArrayField('is_private', item.fields['is_private'], {
-            1: __('Private'),
-            0: __('Public')
-         }, __('Visibility')) }}
-         {{ fields.dropdownField('Entity', 'entities_id', item.fields['entities_id'], 'Entity'|itemtype_name(1)) }}
-         {{ fields.dropdownYesNo('is_recursive', item.fields['is_recursive'], __('Child entities')) }}
-      {% else %}
-         {{ fields.htmlField('', (item.fields['is_private']|default(1) ? __('Private') : __('Public'))|e, __('Visibility')) }}
-      {% endif %}
-   {% endblock %}
+        {{ fields.textField('name', item.fields['name'], __('Name')) }}
+        {{ fields.htmlField('itemtype', params['itemtype']|default(item.fields['itemtype'])|itemtype_name(1), __('Itemtype')) }}
+        {{ fields.dropdownArrayField('do_count', item.fields['do_count'], {
+            (constant('SavedSearch::COUNT_AUTO')): __('Auto'),
+            (constant('SavedSearch::COUNT_YES')): __('Yes'),
+            (constant('SavedSearch::COUNT_NO')): __('No')
+        }, __('Do count')) }}
+        {% if can_create %}
+            {{ fields.dropdownArrayField('is_private', item.fields['is_private'], {
+                1: __('Private'),
+                0: __('Public')
+            }, __('Visibility')) }}
+            {{ fields.dropdownField('Entity', 'entities_id', item.fields['entities_id'], 'Entity'|itemtype_name(1)) }}
+            {{ fields.dropdownYesNo('is_recursive', item.fields['is_recursive'], __('Child entities')) }}
+        {% else %}
+            {{ fields.htmlField('', (item.fields['is_private']|default(1) ? __('Private') : __('Public'))|e, __('Visibility')) }}
+        {% endif %}
+    {% endblock %}
 {% endblock %}

--- a/templates/pages/tools/savedsearch/form.html.twig
+++ b/templates/pages/tools/savedsearch/form.html.twig
@@ -54,7 +54,7 @@
         {% endif %}
 
         {{ fields.textField('name', item.fields['name'], __('Name')) }}
-        {{ fields.htmlField('itemtype', params['itemtype']|default(item.fields['itemtype'])|itemtype_name(1), __('Itemtype')) }}
+        {{ fields.htmlField('itemtype', params['itemtype']|default(item.fields['itemtype'])|itemtype_name(1)|e, __('Itemtype')) }}
         {{ fields.dropdownArrayField('do_count', item.fields['do_count'], {
             (constant('SavedSearch::COUNT_AUTO')): __('Auto'),
             (constant('SavedSearch::COUNT_YES')): __('Yes'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Not as important when creating a saved search, but more for viewing an existing one. Currently, the saved search form has no indication of what itemtype it is for. This PR adds this information.

