### PR TITLE
UI / Fix task state icon visibility with Midnight theme

### DIFF
--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -51,6 +51,18 @@
         margin-left: 0.5rem;
         margin-right: -0.5rem;
 
+        .task-state-checkbox {
+            width: 20px;
+            height: 20px;
+            vertical-align: middle;
+            margin: 0;
+            cursor: pointer;
+        }
+
+        .task-state-checkbox:disabled {
+            cursor: not-allowed;
+        }
+
         .state {
             display: inline-block;
             width: 20px;

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -130,18 +130,19 @@
                   '{{ item.getForeignKeyField()|e('js') }}': {{ item.fields.id|json_encode|raw }}
                })
                .done(function(response) {
-                  $(target).closest('.timeline-item').find('.state')
-                     .removeClass('state_1 state_2')
-                     .addClass('state_'+response.state)
-                     .attr('title', response.label);
+                  var is_done = parseInt(response.state, 10) === {{ constant('Planning::DONE') }};
+
+                  $(target)
+                     .prop('checked', is_done)
+                     .attr('title', response.label)
+                     .attr('aria-label', response.label);
 
                   $(target).closest('.timeline-item').find('.read-only-content')
                      .toggleClass('done');
 
-                  var todo_tasks   = $('.todo-list-state .state.state_1').length;
-                  var done_tasks   = $('.todo-list-state .state.state_2').length;
-                  var total_tasks  = todo_tasks + done_tasks;
-                  var percent_done = Math.floor(100 * done_tasks / total_tasks);
+                  var total_tasks = $('.todo-list-state .task-state-checkbox').length;
+                  var done_tasks = $('.todo-list-state .task-state-checkbox:checked').length;
+                  var percent_done = total_tasks > 0 ? Math.floor(100 * done_tasks / total_tasks) : 0;
 
                   $('.timeline-progress')
                      .css('width', percent_done + '%')

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -114,22 +114,35 @@
 
             {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
 
-            <div class="row">
-                <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
-                    {% if entry_state is constant('Planning::TODO') %}
-                        {% if can_edit_i %}
-                            <span class="state state_1" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('To do') }}"></span>
-                        {% else %}
-                            <span class="state state_1" title="{{ __('To do') }}" style="cursor: not-allowed;"></span>
-                        {% endif %}
-                    {% elseif entry_state is constant('Planning::DONE') %}
-                        {% if can_edit_i %}
-                            <span class="state state_2" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('Done') }}"></span>
-                        {% else %}
-                            <span class="state state_2" title="{{ __('Done') }}" style="cursor: not-allowed;"></span>
-                        {% endif %}
-                    {% endif %}
-                </div>
+         <div class="row">
+            <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
+               {% if entry_state is constant('Planning::TODO') %}
+                  <input
+                     type="checkbox"
+                     class="form-check-input task-state-checkbox"
+                     aria-label="{{ __('To do') }}"
+                     title="{{ __('To do') }}"
+                     {% if can_edit_i %}
+                        onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)"
+                     {% else %}
+                        disabled
+                     {% endif %}
+                  >
+               {% elseif entry_state is constant('Planning::DONE') %}
+                  <input
+                     type="checkbox"
+                     class="form-check-input task-state-checkbox"
+                     aria-label="{{ __('Done') }}"
+                     title="{{ __('Done') }}"
+                     checked
+                     {% if can_edit_i %}
+                        onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)"
+                     {% else %}
+                        disabled
+                     {% endif %}
+                  >
+               {% endif %}
+            </div>
 
                 <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : 'order-first' }}">
                     {% set avatar_rand = random() %}

--- a/tests/cypress/e2e/ITILObject/ticket_form.cy.js
+++ b/tests/cypress/e2e/ITILObject/ticket_form.cy.js
@@ -435,7 +435,7 @@ describe("Ticket Form", () => {
 
         cy.get('.itil-timeline div[data-itemtype="TicketTask"]:last').within(() => {
             cy.get('.read-only-content .rich_text_container').should('contain.text', 'Test task content');
-            cy.get('.todo-list-state .state').should('have.attr', 'title', 'Done');
+            cy.get('.todo-list-state input.task-state-checkbox').should('be.checked');
             cy.get('.timeline-header .is-private .ti-eye-off').should('be.visible');
             cy.get('span.actiontime').should('contain.text', '1 hours 30 minutes 0 seconds');
         });


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42596
- Fixes visual feedback when toggling task state in dark themes by replacing span.state elements with native checkbox inputs in timeline.

Before:
<img width="274" height="124" alt="image_paste5094866" src="https://github.com/user-attachments/assets/b00128c9-7db0-4a13-b711-592fdff46191" />


After:
<img width="196" height="188" alt="Capture d’écran du 2026-03-11 10-20-51" src="https://github.com/user-attachments/assets/85675d60-6417-4194-91f0-c004d330f65b" />



