### PR TITLE
force height in mini dashboard to avoid layout shift

### DIFF
--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -67,6 +67,12 @@ $break_tablet: 1400px;
     }
 }
 
+@container miniDashboardGrid (min-width: 100px) {
+    .grid-stack {
+        min-height: calc((100cqw / var(--gs-col-count)) * (var(--gs-row-count) + 1));
+    }
+}
+
 .dashboard {
     --glpi-dashboard-soft-border: rgb(color-mix(in srgb, var(--tblr-light), var(--tblr-dark) 64%), 0.24);
 
@@ -84,6 +90,8 @@ $break_tablet: 1400px;
         margin-bottom: -45px !important;
         z-index: 1;
         box-sizing: content-box;
+        container-name: miniDashboardGrid;
+        container-type: inline-size;
 
         & + .search_page {
             z-index: 2;

--- a/css/standalone/dashboard.scss
+++ b/css/standalone/dashboard.scss
@@ -67,7 +67,7 @@ $break_tablet: 1400px;
     }
 }
 
-@container miniDashboardGrid (min-width: 100px) {
+@container mini-dashboard-grid (min-width: 100px) {
     .grid-stack {
         min-height: calc((100cqw / var(--gs-col-count)) * (var(--gs-row-count) + 1));
     }
@@ -90,7 +90,7 @@ $break_tablet: 1400px;
         margin-bottom: -45px !important;
         z-index: 1;
         box-sizing: content-box;
-        container-name: miniDashboardGrid;
+        container-name: mini-dashboard-grid;
         container-type: inline-size;
 
         & + .search_page {

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -163,10 +163,6 @@ class GLPIDashboard {
             // during the column change, which causes infinite recursion (moveNode <-> _fixCollisions)
             // when float:true is enabled. Mobile layout is managed manually via this.switchColumnLayout().
         };
-        if (params.mini && this.context === 'core') {
-            // Force a known height so we can have a min-height on the dashboard grid to try to avoid layout shifts on the ticket search page.
-            gridstack_options.cellHeight = 40;
-        }
         this.grid = GridStack.init(gridstack_options, `#grid-stack-${options.rand}`);
 
         // set grid in static to prevent edition (unless user click on edit button)

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -73,6 +73,7 @@ window.GLPI.Dashboard = {
  * @property {{}[]} [all_cards] All cards
  * @property {string} [context] Dashboard context
  * @property {string} [current] Current dashboard
+ * @property {boolean} [mini] Whether the dashboard is in mini mode (for ticket search page)
  */
 
 class GLPIDashboard {
@@ -149,7 +150,7 @@ class GLPIDashboard {
         const elem_domRect = this.elem_dom.getBoundingClientRect();
         const width_offset = elem_domRect.left + (window.innerWidth - elem_domRect.right) + 0.02;
 
-        this.grid = GridStack.init({
+        const gridstack_options = {
             column: options.cols,
             maxRow: (options.rows + 1), // +1 for a hidden item at bottom (to fix height)
             margin : this.cell_margin,
@@ -161,7 +162,12 @@ class GLPIDashboard {
             // columnOpts is intentionally NOT used: GridStack v12 triggers GridStackEngine._fixCollisions
             // during the column change, which causes infinite recursion (moveNode <-> _fixCollisions)
             // when float:true is enabled. Mobile layout is managed manually via this.switchColumnLayout().
-        }, `#grid-stack-${options.rand}`);
+        };
+        if (params.mini && this.context === 'core') {
+            // Force a known height so we can have a min-height on the dashboard grid to try to avoid layout shifts on the ticket search page.
+            gridstack_options.cellHeight = 40;
+        }
+        this.grid = GridStack.init(gridstack_options, `#grid-stack-${options.rand}`);
 
         // set grid in static to prevent edition (unless user click on edit button)
         // previously in option, but current version of gridstack has a bug with one column mode (responsive)

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -449,6 +449,7 @@ TWIG, $params);
             'grid_cols' => $this->grid_cols,
             'grid_rows' => $this->grid_rows,
             'js_params' => [
+                'mini'          => $mini,
                 'current'       => $this->current,
                 'cols'          => $this->grid_cols,
                 'rows'          => $this->grid_rows,
@@ -471,7 +472,8 @@ TWIG, $params);
                 <div class='card mb-4 d-none d-md-block dashboard-card'>
                     <div class='card-body p-2'>
             {% endif %}
-            <div class="dashboard {{ embed_class }} {{ mini_class }}" id="dashboard-{{ rand }}">
+            <div class="dashboard {{ embed_class }} {{ mini_class }}" id="dashboard-{{ rand }}"
+                style="{{  mini ? 'min-height: ' ~ ((grid_rows + 1) * 40) ~ 'px;' : '' }}">
                 <span class='glpi_logo'></span>
                 {{ toolbars|raw }}
                 {{ filters|raw }}

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -448,6 +448,7 @@ TWIG, $params);
             'rand' => $rand,
             'grid_cols' => $this->grid_cols,
             'grid_rows' => $this->grid_rows,
+            'cell_margin'   => $this->cell_margin,
             'js_params' => [
                 'mini'          => $mini,
                 'current'       => $this->current,
@@ -472,8 +473,7 @@ TWIG, $params);
                 <div class='card mb-4 d-none d-md-block dashboard-card'>
                     <div class='card-body p-2'>
             {% endif %}
-            <div class="dashboard {{ embed_class }} {{ mini_class }}" id="dashboard-{{ rand }}"
-                style="{{  mini ? 'min-height: ' ~ ((grid_rows + 1) * 40) ~ 'px;' : '' }}">
+            <div class="dashboard {{ embed_class }} {{ mini_class }}" id="dashboard-{{ rand }}">
                 <span class='glpi_logo'></span>
                 {{ toolbars|raw }}
                 {{ filters|raw }}
@@ -481,7 +481,7 @@ TWIG, $params);
                 id="grid-stack-{{ rand }}"
                 gs-column="{{ grid_cols }}"
                 gs-min-row="{{ grid_rows }}"
-                style="width: 100%">
+                style="width: 100%; --gs-col-count: {{ grid_cols }}; --gs-row-count: {{ grid_rows }}; --gs-cell-margin: {{ cell_margin }}px;">
                     {{ grid_guide|raw }}
                     {{ gridstack_items|raw }}
                 </div>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23341

Not an ideal solution but should be safe for a bugfix version. I tested on various screen widths. This does of course mean the cards will not scale differently on different screen sizes but it seems OK on all sizes that show this dashboard. Very small screens hide it completely.