### PR TITLE
fix tinymce overflow auto-hide

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3791,7 +3791,7 @@ JS;
                                 target.closest('.tox-menu').length > 0;
 
                             if (!isEditorElementClicked) {
-                                $('.tox-tbtn.tox-tbtn--enabled').trigger('click').trigger('blur');
+                                $('.tox-tbtn.tox-tbtn--enabled[data-mce-name="overflow-button"]').trigger('click').trigger('blur');
                             }
                         });
                     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23417

The previous auto-hide fix was not restrictive enough.
Since TinyMCE editors are being loaded even before something is being edited, the editor has the chance to make a button active depending on the content. If a note has a link and the cursor position would be on that link, the link button would be "active". The auto-hide logic would then click this button which would bring up the Insert/Edit link modal any time the user clicked anywhere on the page.

This fix restricts the logic to only work on the "overflow-button" instead of any active button.