### PR TITLE
feat(forms): Add multi-line paste support for selectable question options

### DIFF
--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -187,7 +187,8 @@ export class GlpiFormQuestionTypeSelectable {
         option
             .find('input[type="text"]')
             .on('input', (event) => this.#handleOptionChange(event))
-            .on('keydown', (event) => this.#handleKeydown(event));
+            .on('keydown', (event) => this.#handleKeydown(event))
+            .on('paste', (event) => this.#handlePaste(event));
 
         option
             .find('button[data-glpi-form-editor-question-option-remove]')
@@ -500,6 +501,52 @@ export class GlpiFormQuestionTypeSelectable {
         }
 
         // Reload sortable
+        sortable(container);
+    }
+
+    /**
+     * Handle the paste event.
+     * When pasting multi-line text, create one option per line.
+     *
+     * @param {ClipboardEvent} event - The paste event.
+     */
+    #handlePaste(event) {
+        const clipboardData = event.originalEvent.clipboardData || window.clipboardData;
+        const pastedText = clipboardData.getData('text');
+        const lines = pastedText.split(/\r?\n/).filter(line => line.trim() !== '');
+
+        // Only handle multi-line paste
+        if (lines.length <= 1) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const input = event.target;
+
+        // Set the first line as the value of the current option
+        $(input).val($(input).val() + lines[0]);
+        this.#showOption(input);
+        this.#addNewOptionIfNeeded(input);
+
+        // Create new options for the remaining lines
+        let currentInput = input;
+        for (let i = 1; i < lines.length; i++) {
+            this.#addOption(currentInput, false, true);
+            const nextInput = $(currentInput).parent().next().find('input[type="text"]').get(0);
+            $(nextInput).val(lines[i]);
+            this.#showOption(nextInput);
+            currentInput = nextInput;
+        }
+
+        // Ensure an empty option exists at the end
+        this.#addNewOptionIfNeeded(currentInput);
+
+        this.#reindexOptions();
+        this.#getFormController().computeState();
+
+        // Reload sortable
+        const container = $(input).closest('div[data-glpi-form-editor-selectable-question-options]');
         sortable(container);
     }
 }

--- a/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
@@ -76,3 +76,56 @@ test('Can reorder options of a dropdown question and keep the order after saving
     await expect(options.nth(2)).toHaveValue('Option 2');
     await expect(options.nth(3)).toHaveValue('');
 });
+
+for (const questionType of ['Radio', 'Checkbox', 'Dropdown']) {
+    test(`Can paste multi-line text to create multiple options for ${questionType} question`, async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const form = new FormPage(page);
+
+        // Create a form and navigate to its editor
+        const uuid = randomUUID();
+        const form_id = await api.createItem('Glpi\\Form\\Form', {
+            name: `Form - ${uuid}`,
+            entities_id: getWorkerEntityId(),
+        });
+        await form.goto(form_id);
+
+        const question = await form.addQuestion(`${questionType} question`);
+        await form.setQuestionType(question, questionType);
+
+        // Simulate pasting multi-line text into the first option
+        const firstOption = question.getByRole('textbox', { name: 'Selectable option' }).last();
+        await firstOption.click();
+
+        const pastedText = "Option A\nOption B\nOption C";
+        await firstOption.evaluate((input, text) => {
+            const clipboardData = new DataTransfer();
+            clipboardData.setData('text/plain', text);
+            const pasteEvent = new ClipboardEvent('paste', {
+                clipboardData,
+                bubbles: true,
+                cancelable: true,
+            });
+            input.dispatchEvent(pasteEvent);
+        }, pastedText);
+
+        // Assert that three options were created from the pasted text
+        const options = question.getByRole('textbox', { name: 'Selectable option' });
+        await expect(options.nth(0)).toHaveValue('Option A');
+        await expect(options.nth(1)).toHaveValue('Option B');
+        await expect(options.nth(2)).toHaveValue('Option C');
+
+        // Save and reload the form
+        await form.doSaveFormEditor();
+        await form.goto(form_id);
+
+        // Focus on the question to load its options
+        await form.getLastQuestion().click({ position: { x: 0, y: 0 } });
+
+        // Assert that all options are preserved after reload
+        const savedOptions = question.getByRole('textbox', { name: 'Selectable option' });
+        await expect(savedOptions.nth(0)).toHaveValue('Option A');
+        await expect(savedOptions.nth(1)).toHaveValue('Option B');
+        await expect(savedOptions.nth(2)).toHaveValue('Option C');
+    });
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42492

Historically, Formcreator allowed users to copy and paste text comprising several lines so that each line would be considered an option for Radio, Checkbox, or Dropdown questions.

With the new form integration, this behavior is no longer possible, as each option is defined in a separate text field.
To fix this regression, I made sure that when the user pastes multi-line text content into a question input, each line is interpreted as a new option.

## Screenshots (if appropriate):


<img width="819" height="585" alt="image" src="https://github.com/user-attachments/assets/0af30642-dea8-406d-beb0-55716ce0f971" />