### PR TITLE
Fix mandatory validation for User Devices question with Custom Assets 

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php
@@ -326,10 +326,10 @@ TWIG;
                 // Item is formatted as [itemtype, item_id]
                 $itemtype = $device[0];
                 $item_id = $device[1];
-            } elseif (\is_string($device) && preg_match('/^([A-Za-z]+)_\d+$/', $device, $matches)) {
+            } elseif (\is_string($device) && preg_match('/^(?<itemtype>.+)_(?<id>\d+)$/', $device, $matches)) {
                 // Item is formatted as "itemtype_item_id"
-                $itemtype = $matches[1];
-                $item_id = substr($device, strlen($itemtype) + 1); // Get the ID part after the itemtype
+                $itemtype = $matches['itemtype'];
+                $item_id = $matches['id'];
             } else {
                 continue;
             }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeUserDeviceTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeUserDeviceTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\QuestionType;
 
 use Computer;
+use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
@@ -66,5 +67,23 @@ final class QuestionTypeUserDeviceTest extends DbTestCase
             "1) Computer: My computer",
             strip_tags($ticket->fields['content']),
         );
+    }
+
+    public function testMandatoryValidationAcceptsNamespacedDeviceKey(): void
+    {
+        $this->login();
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Device", QuestionTypeUserDevice::class, is_mandatory: true);
+        $form = $this->createForm($builder);
+
+        $question_id = $this->getQuestionId($form, "Device");
+
+        $result = AnswersHandler::getInstance()->validateAnswers(
+            $form,
+            [$question_id => 'Glpi\Asset\CustomAsset_32']
+        );
+
+        $this->assertTrue($result->isValid());
     }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeUserDeviceTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeUserDeviceTest.php
@@ -60,7 +60,7 @@ final class QuestionTypeUserDeviceTest extends DbTestCase
         $form = $this->createForm($builder);
 
         $ticket = $this->sendFormAndGetCreatedTicket($form, [
-            "Computer" => 'Computer_' . $computer->getID(),
+            "Computer" => Computer::class . '_' . $computer->getID(),
         ]);
 
         $this->assertStringContainsString(
@@ -73,6 +73,14 @@ final class QuestionTypeUserDeviceTest extends DbTestCase
     {
         $this->login();
 
+        $definition = $this->initAssetDefinition();
+        $asset_class = $definition->getAssetClassName();
+        $asset = $this->createItem($asset_class, [
+            'name'       => 'My custom asset',
+            'entities_id' => Session::getActiveEntity(),
+            'users_id'   => Session::getLoginUserID(),
+        ]);
+
         $builder = new FormBuilder();
         $builder->addQuestion("Device", QuestionTypeUserDevice::class, is_mandatory: true);
         $form = $this->createForm($builder);
@@ -81,7 +89,7 @@ final class QuestionTypeUserDeviceTest extends DbTestCase
 
         $result = AnswersHandler::getInstance()->validateAnswers(
             $form,
-            [$question_id => 'Glpi\Asset\CustomAsset_32']
+            [$question_id => $asset_class . '_' . $asset->getID()]
         );
 
         $this->assertTrue($result->isValid());


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23332 
- Here is a brief description of what this PR does : 

The regex `[A-Za-z]+` in `transformConditionValueForComparisons()` did not match backslashes in namespaced class names (`Glpi\CustomAsset\ServerAsset_32`), causing mandatory validation to reject valid answers for Custom Assets.       


