### PR TITLE
fix again the tinymce overflow menu

### DIFF
--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -275,6 +275,11 @@ $(function() {
       timeline_item.find('.timeline-item-buttons').removeClass('d-none');
       timeline_item.find('.close-edit-content').addClass('d-none');
 
+      // Dispose of the TinyMCE editor if any exists
+       timeline_item.find('.ajax-content').find('textarea').each(function() {
+         window.tinymce?.get($(this).attr('id'))?.destroy();
+      });
+
       timeline_item.find('.ajax-content').html('');
       timeline_item.find('.read-only-content').show();
 

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -41,173 +41,173 @@
         {{ include('components/itilobject/answer.html.twig') }}
     {% endif %}
 
-   {% set status_closed = (item.fields['status'] in item.getClosedStatusArray()) %}
+    {% set status_closed = (item.fields['status'] in item.getClosedStatusArray()) %}
 
-   {# Keep track of loaded user to avoid reloading them from database if they appear multiple time in a ticket #}
-   {% set user_cache = {} %}
+    {# Keep track of loaded user to avoid reloading them from database if they appear multiple time in a ticket #}
+    {% set user_cache = {} %}
 
-   {% for entry in timeline %}
-      {% set entry_i = entry['item'] %}
-      {% set entry_object = entry['object'] ?? get_item(entry['type'], entry_i['id']) %}
-      {% set entry_state = entry_i['state'] ?? null %}
-      {% set users_id = entry_i['users_id'] %}
-      {% set is_private = entry_i['is_private'] ?? false %}
-      {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
-      {% set date_mod = entry_i['date_mod'] ?? date_creation %}
-      {% set entry_rand = random() %}
-      {% set is_current_user = users_id == session('glpiID') %}
-      {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
+    {% for entry in timeline %}
+        {% set entry_i = entry['item'] %}
+        {% set entry_object = entry['object'] ?? get_item(entry['type'], entry_i['id']) %}
+        {% set entry_state = entry_i['state'] ?? null %}
+        {% set users_id = entry_i['users_id'] %}
+        {% set is_private = entry_i['is_private'] ?? false %}
+        {% set date_creation = entry_i['date_creation'] ?? entry_i['date'] %}
+        {% set date_mod = entry_i['date_mod'] ?? date_creation %}
+        {% set entry_rand = random() %}
+        {% set is_current_user = users_id == session('glpiID') %}
+        {% set anonym_user = (get_current_interface() == 'helpdesk' and not is_current_user and entity_config('anonymize_support_agents', session('glpiactive_entity')) != constant('Entity::ANONYMIZE_DISABLED')) %}
 
-      {% set is_private_class = is_private ? "private-item" : "" %}
+        {% set is_private_class = is_private ? "private-item" : "" %}
 
-      {% set can_edit_i  = entry_i['can_edit'] ?? false %}
+        {% set can_edit_i  = entry_i['can_edit'] ?? false %}
 
-      {% set timeline_position = entry_i['timeline_position'] %}
-      {% set item_position = 't-left' %}
-      {% if timeline_position == constant('CommonITILObject::TIMELINE_LEFT') %}
-         {% set item_position = 't-left' %}
-      {% elseif timeline_position == constant('CommonITILObject::TIMELINE_MIDLEFT') %}
-         {% set item_position = 't-left t-middle' %}
-      {% elseif timeline_position == constant('CommonITILObject::TIMELINE_MIDRIGHT') %}
-         {% set item_position = 't-right t-middle' %}
-      {% elseif timeline_position == constant('CommonITILObject::TIMELINE_RIGHT') %}
-         {% set item_position = 't-right' %}
-      {% endif %}
+        {% set timeline_position = entry_i['timeline_position'] %}
+        {% set item_position = 't-left' %}
+        {% if timeline_position == constant('CommonITILObject::TIMELINE_LEFT') %}
+            {% set item_position = 't-left' %}
+        {% elseif timeline_position == constant('CommonITILObject::TIMELINE_MIDLEFT') %}
+            {% set item_position = 't-left t-middle' %}
+        {% elseif timeline_position == constant('CommonITILObject::TIMELINE_MIDRIGHT') %}
+            {% set item_position = 't-right t-middle' %}
+        {% elseif timeline_position == constant('CommonITILObject::TIMELINE_RIGHT') %}
+            {% set item_position = 't-right' %}
+        {% endif %}
 
-      {% set itiltype = entry['itiltype'] is defined ? 'ITIL' ~ entry['itiltype'] : entry['type'] %}
+        {% set itiltype = entry['itiltype'] is defined ? 'ITIL' ~ entry['itiltype'] : entry['type'] %}
 
-      {% set state_class = '' %}
-      {% if entry_state is constant('Planning::INFO') %}
-         {% set state_class = 'info' %}
-      {% endif %}
-      {% if entry_state is constant('Planning::TODO') %}
-         {% set state_class = 'todo' %}
-      {% endif %}
-      {% if entry_state is constant('Planning::DONE') %}
-         {% set state_class = 'done' %}
-      {% endif %}
+        {% set state_class = '' %}
+        {% if entry_state is constant('Planning::INFO') %}
+            {% set state_class = 'info' %}
+        {% endif %}
+        {% if entry_state is constant('Planning::TODO') %}
+            {% set state_class = 'todo' %}
+        {% endif %}
+        {% if entry_state is constant('Planning::DONE') %}
+            {% set state_class = 'done' %}
+        {% endif %}
 
-      {% set solution_class = '' %}
-      {% if (itiltype == 'ITILSolution' or itiltype == 'ITILValidation') and entry_i['status'] is defined %}
-         {% set status = itiltype == 'ITILSolution' ? entry_i['status'] : entry_i['status']|replace({'status_': ''}) %}
-         {% if status == constant('CommonITILValidation::WAITING') %}
-            {% set solution_class = 'waiting' %}
-         {% endif %}
-         {% if status == constant('CommonITILValidation::ACCEPTED') %}
-            {% set solution_class = 'accepted' %}
-         {% endif %}
-         {% if status == constant('CommonITILValidation::REFUSED') %}
-            {% set solution_class = 'refused' %}
-         {% endif %}
-      {% endif %}
+        {% set solution_class = '' %}
+        {% if (itiltype == 'ITILSolution' or itiltype == 'ITILValidation') and entry_i['status'] is defined %}
+            {% set status = itiltype == 'ITILSolution' ? entry_i['status'] : entry_i['status']|replace({'status_': ''}) %}
+            {% if status == constant('CommonITILValidation::WAITING') %}
+                {% set solution_class = 'waiting' %}
+            {% endif %}
+            {% if status == constant('CommonITILValidation::ACCEPTED') %}
+                {% set solution_class = 'accepted' %}
+            {% endif %}
+            {% if status == constant('CommonITILValidation::REFUSED') %}
+                {% set solution_class = 'refused' %}
+            {% endif %}
+        {% endif %}
 
-      {# Cache keys are prefixed by "_" to avoid being converted to integer and thus renumbered #}
-      {# Try to read user from cache #}
-      {% set entry_user = users_id is defined and users_id is not null ? (user_cache["_" ~ users_id] ?? get_item('User', users_id)) : null %}
-      {# Update cache #}
-      {% set user_cache = user_cache|merge({("_" ~ users_id): entry_user}) %}
+        {# Cache keys are prefixed by "_" to avoid being converted to integer and thus renumbered #}
+        {# Try to read user from cache #}
+        {% set entry_user = users_id is defined and users_id is not null ? (user_cache["_" ~ users_id] ?? get_item('User', users_id)) : null %}
+        {# Update cache #}
+        {% set user_cache = user_cache|merge({("_" ~ users_id): entry_user}) %}
 
-      {% set anchor = entry['type'] ~ '_' ~ entry_i['id'] %}
-      <div id="{{ anchor }}" class="timeline-item mb-3 {{ is_private_class }} {{ itiltype }} {{ state_class }} {{ entry['class'] ?? '' }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
-            data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
-            {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
+        {% set anchor = entry['type'] ~ '_' ~ entry_i['id'] %}
+        <div id="{{ anchor }}" class="timeline-item mb-3 {{ is_private_class }} {{ itiltype }} {{ state_class }} {{ entry['class'] ?? '' }} {{ 'right' in item_position ? 'ms-auto' : '' }}"
+             data-itemtype="{{ entry['type'] }}" data-items-id="{{ entry_i['id'] }}"
+             {% if entry['item_action'] is defined %}data-item-action="{{ entry['item_action'] }}"{% endif %}>
 
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
+            {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
 
-         <div class="row">
-            <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
-               {% if entry_state is constant('Planning::TODO') %}
-                  {% if can_edit_i %}
-                     <span class="state state_1" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('To do') }}"></span>
-                  {% else %}
-                     <span class="state state_1" title="{{ __('To do') }}" style="cursor: not-allowed;"></span>
-                  {% endif %}
-               {% elseif entry_state is constant('Planning::DONE') %}
-                  {% if can_edit_i %}
-                     <span class="state state_2" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('Done') }}"></span>
-                  {% else %}
-                     <span class="state state_2" title="{{ __('Done') }}" style="cursor: not-allowed;"></span>
-                  {% endif %}
-               {% endif %}
-            </div>
+            <div class="row">
+                <div class="col-auto todo-list-state {{ 'left' in item_position ? 'ms-auto order-sm-last' : '' }}">
+                    {% if entry_state is constant('Planning::TODO') %}
+                        {% if can_edit_i %}
+                            <span class="state state_1" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('To do') }}"></span>
+                        {% else %}
+                            <span class="state state_1" title="{{ __('To do') }}" style="cursor: not-allowed;"></span>
+                        {% endif %}
+                    {% elseif entry_state is constant('Planning::DONE') %}
+                        {% if can_edit_i %}
+                            <span class="state state_2" onclick="change_task_state({{ entry_i['id']|json_encode|raw }}, this)" title="{{ __('Done') }}"></span>
+                        {% else %}
+                            <span class="state state_2" title="{{ __('Done') }}" style="cursor: not-allowed;"></span>
+                        {% endif %}
+                    {% endif %}
+                </div>
 
-            <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : 'order-first' }}">
-               {% set avatar_rand = random() %}
-               {# log entries have no users_id #}
-               {% if entry_user is not null %}
-                  {% set user_fields = entry_user.fields %}
-                  {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()}) %}
-                  {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
-                  {% if has_profile_right('user', constant('READ')) %}
-                     {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
-                  {% endif %}
-                  <span id="timeline-avatar{{ avatar_rand }}">
+                <div class="col-auto d-flex flex-column user-part {{ 'right' in item_position ? 'ms-auto ms-0 order-sm-last' : 'order-first' }}">
+                    {% set avatar_rand = random() %}
+                    {# log entries have no users_id #}
+                    {% if entry_user is not null %}
+                        {% set user_fields = entry_user.fields %}
+                        {% set user_fields = user_fields|merge({user_name: entry_user.getFriendlyName()}) %}
+                        {% set user_fields = user_fields|merge({email: entry_user.getDefaultEmail()}) %}
+                        {% if has_profile_right('user', constant('READ')) %}
+                            {% set user_fields = user_fields|merge({login: entry_user.fields['name']}) %}
+                        {% endif %}
+                        <span id="timeline-avatar{{ avatar_rand }}">
                      {{ include('components/user/picture.html.twig', {
-                        'users_id': users_id,
-                        'user_object': entry_user,
-                        'enable_anonymization': anonym_user
+                         'users_id': users_id,
+                         'user_object': entry_user,
+                         'enable_anonymization': anonym_user
                      }, with_context = false) }}
                   </span>
-                  {% if not anonym_user and entry_user.canView() %}
-                     {% do call('Html::showToolTip', [
-                        include('components/user/info_card.html.twig', {
-                           'user': user_fields,
-                           'user_object': entry_user,
-                           'enable_anonymization': false,
-                        }, with_context = false), {
-                           'applyto': 'timeline-avatar' ~ avatar_rand
-                        }]) %}
-                  {% endif %}
-               {% else %}
-                  <span id="timeline-avatar{{ avatar_rand }}"><span class="avatar avatar-md rounded"></span></span>
-               {% endif %}
-            </div>
-            <div class="col-12 col-sm d-flex flex-column content-part">
-               <div class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
-                  <div class="card-body px-1 px-xxl-3">
-                     {{ include('components/itilobject/timeline/timeline_item_header.html.twig', {
-                           'user_object': entry_user,
-                     }) }}
-
-                     {% if itiltype in timeline_itemtypes|column('type') %}
-                        {% set matching_types = timeline_itemtypes|filter((v) => v.type == itiltype) %}
-                        {% if matching_types|length > 0 %}
-                           {% set timeline_itemtype = matching_types|first %}
-                           {% if timeline_itemtype.template is defined %}
-                              {{ include(timeline_itemtype.template, {
-                                  'form_mode': 'view',
-                                  'subitem': timeline_itemtype.item,
-                                  'mention_options': mention_options,
-                              }) }}
-                           {% endif %}
+                        {% if not anonym_user and entry_user.canView() %}
+                            {% do call('Html::showToolTip', [
+                                include('components/user/info_card.html.twig', {
+                                    'user': user_fields,
+                                    'user_object': entry_user,
+                                    'enable_anonymization': false,
+                                }, with_context = false), {
+                                    'applyto': 'timeline-avatar' ~ avatar_rand
+                                }]) %}
                         {% endif %}
-                     {% else %}
-                        <div class="read-only-content">
-                            {% if entry_i['is_content_safe'] %}
-                                {{ entry_i['content']|raw }}
+                    {% else %}
+                        <span id="timeline-avatar{{ avatar_rand }}"><span class="avatar avatar-md rounded"></span></span>
+                    {% endif %}
+                </div>
+                <div class="col-12 col-sm d-flex flex-column content-part">
+                    <div class="mt-2 timeline-content {{ solution_class }} flex-grow-1 {{ item_position }} card">
+                        <div class="card-body px-1 px-xxl-3">
+                            {{ include('components/itilobject/timeline/timeline_item_header.html.twig', {
+                                'user_object': entry_user,
+                            }) }}
+
+                            {% if itiltype in timeline_itemtypes|column('type') %}
+                                {% set matching_types = timeline_itemtypes|filter((v) => v.type == itiltype) %}
+                                {% if matching_types|length > 0 %}
+                                    {% set timeline_itemtype = matching_types|first %}
+                                    {% if timeline_itemtype.template is defined %}
+                                        {{ include(timeline_itemtype.template, {
+                                            'form_mode': 'view',
+                                            'subitem': timeline_itemtype.item,
+                                            'mention_options': mention_options,
+                                        }) }}
+                                    {% endif %}
+                                {% endif %}
                             {% else %}
-                                {{ entry_i['content']|safe_html }}
+                                <div class="read-only-content">
+                                    {% if entry_i['is_content_safe'] %}
+                                        {{ entry_i['content']|raw }}
+                                    {% else %}
+                                        {{ entry_i['content']|safe_html }}
+                                    {% endif %}
+                                </div>
                             {% endif %}
+                            <div class="edit-content collapse">
+                                <div class="ajax-content"></div>
+                            </div>
                         </div>
-                     {% endif %}
-                     <div class="edit-content collapse">
-                        <div class="ajax-content"></div>
-                     </div>
-                  </div>
-               </div>
+                    </div>
 
-               {% if entry['documents'] is defined %}
-                  {{ include('components/itilobject/timeline/sub_documents.html.twig', {
-                     'item': item,
-                     'entry': entry
-                  }) }}
-               {% endif %}
+                    {% if entry['documents'] is defined %}
+                        {{ include('components/itilobject/timeline/sub_documents.html.twig', {
+                            'item': item,
+                            'entry': entry
+                        }) }}
+                    {% endif %}
+                </div>
             </div>
-         </div>
 
-         {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
-      </div>
-   {% endfor %}
+            {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_SHOW_ITEM'), {'item': entry_object, 'options': {'parent': item, 'rand': entry_rand}}) }}
+        </div>
+    {% endfor %}
 
     {% if is_timeline_reversed %}
         {{ include('components/itilobject/timeline/main_description.html.twig') }}
@@ -228,84 +228,84 @@
         {{ include('components/itilobject/answer.html.twig') }}
     {% endif %}
 
-   {% if survey is defined and survey %}
-      <form
-         data-testid="survey"
-         class="mt-5 w-100 hide-form-button-separator"
-         method="POST"
-         action="{{ "TicketSatisfaction"|itemtype_form_path }}"
-      >
-         <div>
+    {% if survey is defined and survey %}
+    <form
+        data-testid="survey"
+        class="mt-5 w-100 hide-form-button-separator"
+        method="POST"
+        action="{{ "TicketSatisfaction"|itemtype_form_path }}"
+    >
+        <div>
             {{ survey.showSatisactionForm(item, false) }}
-      {# showSatisactionForm closes the extra div and form tag by itself... #}
-   {% endif %}
-</div>
+            {# showSatisactionForm closes the extra div and form tag by itself... #}
+            {% endif %}
+        </div>
 
-<script type="text/javascript">
-$(function() {
-   $(document).on("click", ".edit-timeline-item", function() {
-      var timeline_item = $(this).closest(".timeline-item");
-      var content_block = timeline_item.find(".timeline-content");
-      var itemtype      = timeline_item.data('itemtype');
-      var items_id      = timeline_item.data('items-id');
-      var item_action   = timeline_item.data('item-action');
+        <script type="text/javascript">
+            $(function() {
+                $(document).on("click", ".edit-timeline-item", function() {
+                    var timeline_item = $(this).closest(".timeline-item");
+                    var content_block = timeline_item.find(".timeline-content");
+                    var itemtype      = timeline_item.data('itemtype');
+                    var items_id      = timeline_item.data('items-id');
+                    var item_action   = timeline_item.data('item-action');
 
-      content_block.find(".read-only-content").hide();
-      content_block.find(".edit-content").show()
-         .find(".ajax-content")
-         .html('<span class="spinner-border ms-auto" role="status" aria-hidden="true"></span>')
-         .load("{{ path('/ajax/timeline.php') }}", {
-            'action'     : 'viewsubitem',
-            'type'       : itemtype,
-            'parenttype' : '{{ item.getType() }}',
-            '{{ item.getForeignKeyField() }}': {{ item.fields['id'] }},
-            'id'         : items_id,
-            'item_action': item_action
-         });
+                    content_block.find(".read-only-content").hide();
+                    content_block.find(".edit-content").show()
+                        .find(".ajax-content")
+                        .html('<span class="spinner-border ms-auto" role="status" aria-hidden="true"></span>')
+                        .load("{{ path('/ajax/timeline.php') }}", {
+                            'action'     : 'viewsubitem',
+                            'type'       : itemtype,
+                            'parenttype' : '{{ item.getType() }}',
+                            '{{ item.getForeignKeyField() }}': {{ item.fields['id'] }},
+                            'id'         : items_id,
+                            'item_action': item_action
+                        });
 
-      timeline_item.find('.timeline-item-buttons').addClass('d-none');
-      timeline_item.find('.close-edit-content').removeClass('d-none');
+                    timeline_item.find('.timeline-item-buttons').addClass('d-none');
+                    timeline_item.find('.close-edit-content').removeClass('d-none');
 
-      $("#itil-footer").find(".main-actions").hide();
-      $("#right-actions").hide();
-   });
+                    $("#itil-footer").find(".main-actions").hide();
+                    $("#right-actions").hide();
+                });
 
-   $(document).on("click", ".close-edit-content", function() {
-      var timeline_item = $(this).closest(".timeline-item");
-      timeline_item.find('.timeline-item-buttons').removeClass('d-none');
-      timeline_item.find('.close-edit-content').addClass('d-none');
+                $(document).on("click", ".close-edit-content", function() {
+                    var timeline_item = $(this).closest(".timeline-item");
+                    timeline_item.find('.timeline-item-buttons').removeClass('d-none');
+                    timeline_item.find('.close-edit-content').addClass('d-none');
 
-      // Dispose of the TinyMCE editor if any exists
-       timeline_item.find('.ajax-content').find('textarea').each(function() {
-         window.tinymce?.get($(this).attr('id'))?.destroy();
-      });
+                    // Dispose of the TinyMCE editor if any exists
+                    timeline_item.find('.ajax-content').find('textarea').each(function() {
+                        window.tinymce?.get($(this).attr('id'))?.destroy();
+                    });
 
-      timeline_item.find('.ajax-content').html('');
-      timeline_item.find('.read-only-content').show();
+                    timeline_item.find('.ajax-content').html('');
+                    timeline_item.find('.read-only-content').show();
 
-      $("#itil-footer .main-actions").show();
-      $("#right-actions").show();
-   });
-});
+                    $("#itil-footer .main-actions").show();
+                    $("#right-actions").show();
+                });
+            });
 
-// Align ITILReminder
-let result = document.evaluate(
-   '//div[contains(@class, "timeline-header")][contains(@id, "ITILReminder_")]',
-   document,
-   null,
-   XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
-   null
-);
+            // Align ITILReminder
+            let result = document.evaluate(
+                '//div[contains(@class, "timeline-header")][contains(@id, "ITILReminder_")]',
+                document,
+                null,
+                XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+                null
+            );
 
-for (let i = 0; i < result.snapshotLength; i++) {
-   let node = result.snapshotItem(i);
-   let width = (i > 0 ? Math.max(result.snapshotItem(i - 1).offsetWidth, node.offsetWidth) : node.offsetWidth) + 1;
-   node.style.setProperty('width', 'var(--itilautobump-header-badge-width)');
-   node.style.setProperty('flex-direction', 'row-reverse');
-   document.documentElement.style.setProperty('--itilautobump-header-badge-width', width + 'px');
-}
+            for (let i = 0; i < result.snapshotLength; i++) {
+                let node = result.snapshotItem(i);
+                let width = (i > 0 ? Math.max(result.snapshotItem(i - 1).offsetWidth, node.offsetWidth) : node.offsetWidth) + 1;
+                node.style.setProperty('width', 'var(--itilautobump-header-badge-width)');
+                node.style.setProperty('flex-direction', 'row-reverse');
+                document.documentElement.style.setProperty('--itilautobump-header-badge-width', width + 'px');
+            }
 
-function toggleTimelinePrivate(checked, check_element) {
-    $(check_element).closest('.timeline-item').toggleClass('private-item', checked);
-}
-</script>
+            function toggleTimelinePrivate(checked, check_element) {
+                $(check_element).closest('.timeline-item').toggleClass('private-item', checked);
+            }
+        </script>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23432
Yet another aspect of the bug with the TinyMCE overflow menu staying visible in some cases and another instance of elements being removed without proper disposal (see the memory leak bug reports). When you edit a followup, the form is loaded via AJAX and the TinyMCE editor gets initialized. When aborting an edit, the AJAX content is simply removed from the DOM. The actual TinyMCE instance still exists though and the elements it places directly under the `body` element, including the overflow menu, remain.