### PR TITLE
fix(forms): handle UUIDs with dots in GET parameters for pre-filling questions

### DIFF
--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -290,6 +290,9 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
     {
         $uuid = $this->fields['uuid'];
 
+        // UUIDs can contain dots, PHP replaces them by underscores in GET parameters, so we need to do the reverse transformation to find the right parameter
+        $uuid = str_replace('.', '_', $uuid);
+
         // Apply value if defined
         if (isset($get[$uuid])) {
             $type = $this->getQuestionType();

--- a/tests/functional/Glpi/Form/QuestionTest.php
+++ b/tests/functional/Glpi/Form/QuestionTest.php
@@ -102,6 +102,45 @@ class QuestionTest extends DbTestCase
         yield [$question, null];
     }
 
+    public static function setDefaultValueFromParametersProvider(): iterable
+    {
+        yield 'Standard UUID without dots applies value' => [
+            'uuid'           => 'abcd1234-ef56-7890-ab12-cd3456789012',
+            'get'            => ['abcd1234-ef56-7890-ab12-cd3456789012' => 'my value'],
+            'expected_value' => 'my value',
+        ];
+
+        yield 'UUID with dot: PHP replaces dots with underscores in GET params' => [
+            'uuid'           => 'abcd.1234',
+            'get'            => ['abcd_1234' => 'my value'],
+            'expected_value' => 'my value',
+        ];
+
+        yield 'UUID not present in GET params does not change default value' => [
+            'uuid'           => 'abcd1234',
+            'get'            => ['other_param' => 'my value'],
+            'expected_value' => 'initial value',
+        ];
+    }
+
+    #[DataProvider('setDefaultValueFromParametersProvider')]
+    public function testSetDefaultValueFromParameters(
+        string $uuid,
+        array $get,
+        string $expected_value,
+    ): void {
+        $question = new Question();
+        $question->fields = [
+            'uuid'          => $uuid,
+            'type'          => QuestionTypeShortText::class,
+            'default_value' => 'initial value',
+        ];
+
+        $question->setDefaultValueFromParameters($get);
+
+        $this->assertEquals($expected_value, $question->fields['default_value']);
+    }
+
     #[DataProvider('getQuestionTypeProvider')]
     public function testGetQuestionType(Question $question, $expected): void
     {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42586

This pull request addresses an edge case in handling UUIDs for form questions, specifically when UUIDs contain dots, which PHP replaces with underscores in GET parameters. It also adds comprehensive tests to ensure correct behavior.

Handling of UUIDs in form questions:

* Updated `setDefaultValueFromParameters` in `Question` to reverse the transformation of dots to underscores in UUIDs, ensuring the correct parameter is found in GET requests.

Testing improvements:

* Added a new data provider and test method in `QuestionTest` to verify that UUIDs with dots are correctly matched to GET parameters, standard UUIDs are handled as expected, and missing UUIDs do not alter default values.