### PR TITLE
FIX / Add missing itemtype key in ticket project task tab

### DIFF
--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -305,6 +305,8 @@ class ProjectTask_Ticket extends CommonDBRelation
                     'toobserve' => "dropdown_projects_id$rand",
                     'toupdate' => [
                         "id" => "results_projects$rand",
+                        "itemtype" => ProjectTask::class,
+                        "params" => [],
                     ],
                     'url' => $CFG_GLPI["root_doc"] . "/ajax/dropdownProjectTaskTicket.php",
                     'params' => $p,


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42546
- Fix this error when trying to access Project Task tab on ticket : `Uncaught PHP Exception Twig\Error\RuntimeError: "Key "itemtype" for sequence/mapping with keys "id" does not exist in "components/form/link_existing_or_new.html.twig" at line 81." at link_existing_or_new.html.twig line 81` - Add 'itemtype' key with `ProjectTask::class` value to inform template about target type. Add empty 'params' for dropdown parameter.


