### PR TITLE
Add approved device SearchOption for Unmanaged Assets

### DIFF
--- a/src/Unmanaged.php
+++ b/src/Unmanaged.php
@@ -153,6 +153,14 @@ class Unmanaged extends CommonDBTM implements AssignableItemInterface, StateInte
         ];
 
         $tab[] = [
+            'id'        => '72',
+            'table'     => $this->getTable(),
+            'field'     => 'accepted',
+            'name'      => __('Approved device'),
+            'datatype'  => 'bool',
+        ];
+
+        $tab[] = [
             'id'        => '8',
             'table'     => 'glpi_entities',
             'field'     => 'completename',


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42645
- Currently, in the Unmanaged Assets tab, it was not possible to filter results by the Approved device criterion. This PR adds that option.



