### PR TITLE
docs(cli): clarify marketplace:upgrade command description

### DIFF
--- a/src/Glpi/Console/Marketplace/UpgradeCommand.php
+++ b/src/Glpi/Console/Marketplace/UpgradeCommand.php
@@ -51,7 +51,7 @@ class UpgradeCommand extends AbstractCommand
         parent::configure();
 
         $this->setName('marketplace:upgrade');
-        $this->setDescription(__('Download all plugins to their latest compatible versions, update all active plugins and reactivate those that are active.'));
+        $this->setDescription(__('Download all plugins to their latest compatible versions, update all active plugins and reactivate those that were active.'));
 
         $this->addOption(
             'username',

--- a/src/Glpi/Console/Marketplace/UpgradeCommand.php
+++ b/src/Glpi/Console/Marketplace/UpgradeCommand.php
@@ -51,7 +51,7 @@ class UpgradeCommand extends AbstractCommand
         parent::configure();
 
         $this->setName('marketplace:upgrade');
-        $this->setDescription(__('Download and update all plugins to their latest compatible versions, then reactivate active ones.'));
+        $this->setDescription(__('Download all plugins to their latest compatible versions, update all active plugins and reactivate those that are active.'));
 
         $this->addOption(
             'username',


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42082
- Clarify the description of the marketplace:upgrade command.

The previous message could be misleading about the command behavior.
This change updates the wording to better explain that:

1. the command downloads the latest compatible versions of plugins from the marketplace,
2. only plugins that were active before the download are upgraded,
3. previously active plugins are re-enabled after the upgrade.


