### PR TITLE
Fix tree browse not selecting initial category from URL parameter

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5552,6 +5552,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Document.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$itemtype of static method Document\\:\\:getCategoryItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Document.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Document\\:\\:getTreeCategoryList\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -15728,6 +15734,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/KnowbaseItem.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$itemtype of static method KnowbaseItem\\:\\:getCategoryItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/KnowbaseItem.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method KnowbaseItem\\:\\:getTreeCategoryList\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -20636,6 +20648,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Software.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$itemtype of static method Software\\:\\:getCategoryItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Software.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Software\\:\\:getTreeCategoryList\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -21525,6 +21543,12 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of static method Search\\:\\:getDatas\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/User.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$itemtype of static method User\\:\\:getCategoryItem\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/User.php',

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -77,7 +77,7 @@ trait TreeBrowse
                             ? (int) $params['unpublished']
                             : 1;
 
-        $cat_item = static::getCategoryItem($itemtype);
+        $cat_item = static::getCategoryItem($itemtype); // @phpstan-ignore argument.type
         $cat_fk = $cat_item ? $cat_item::getForeignKeyField() : null;
         $initial_cat_id = ($cat_fk && isset($params[$cat_fk])) ? (int) $params[$cat_fk] : -1;
 

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -77,7 +77,7 @@ trait TreeBrowse
                             ? (int) $params['unpublished']
                             : 1;
 
-        $cat_item = static::getCategoryItem($itemtype); // @phpstan-ignore argument.type
+        $cat_item = static::getCategoryItem($itemtype);
         $cat_fk = $cat_item ? $cat_item::getForeignKeyField() : null;
         $initial_cat_id = ($cat_fk && isset($params[$cat_fk])) ? (int) $params[$cat_fk] : -1;
 

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -162,8 +162,11 @@ JAVASCRIPT;
                 });
 
                 var tree = $.ui.fancytree.getTree("#tree_category")
-                if (tree.activeNode === null) {
+                if ($initial_cat_id !== -1) {
+                    // URL parameter takes precedence over persisted state
                     tree.activateKey($initial_cat_id);
+                } else if (tree.activeNode === null) {
+                    tree.activateKey(-1);
                 }
                 $(document).on('keyup', '#browser_tree_search', function() {
                     var search_text = $(this).val();

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -77,6 +77,10 @@ trait TreeBrowse
                             ? (int) $params['unpublished']
                             : 1;
 
+        $cat_item = static::getCategoryItem($itemtype);
+        $cat_fk = $cat_item ? $cat_item::getForeignKeyField() : null;
+        $initial_cat_id = ($cat_fk && isset($params[$cat_fk])) ? (int) $params[$cat_fk] : -1;
+
         $js_itemtype = \jsescape($itemtype);
         $criteria    = json_encode($params['criteria']);
         $sort        = json_encode($_REQUEST['sort'] ?? []);
@@ -159,7 +163,7 @@ JAVASCRIPT;
 
                 var tree = $.ui.fancytree.getTree("#tree_category")
                 if (tree.activeNode === null) {
-                    tree.activateKey(-1);
+                    tree.activateKey($initial_cat_id);
                 }
                 $(document).on('keyup', '#browser_tree_search', function() {
                     var search_text = $(this).val();

--- a/tests/e2e/specs/Knowbase/tree_browse.spec.ts
+++ b/tests/e2e/specs/Knowbase/tree_browse.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { test, expect } from '../../fixtures/glpi_fixture';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test('tree browse selects category from URL parameter', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    const unique = randomUUID().slice(0, 8);
+    const category_name = `E2E Cat ${unique}`;
+    const category_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_name,
+        entities_id: getWorkerEntityId(),
+    });
+
+    await api.createItem('KnowbaseItem', {
+        name: `E2E KB Article ${unique}`,
+        answer: 'Test answer content',
+        is_faq: 0,
+        entities_id: getWorkerEntityId(),
+        _categories: [category_id],
+    });
+
+    await page.goto(
+        `/front/knowbaseitem.php?knowbaseitemcategories_id=${category_id}&browse=1&forcetab=Knowbase$2`
+    );
+
+    // eslint-disable-next-line playwright/no-raw-locators
+    const active_node = page.locator('#tree_category .fancytree-active .fancytree-title');
+    await expect(active_node).toContainText(category_name);
+});
+
+test('tree browse defaults to "Without Category" when no URL parameter', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    await page.goto('/front/knowbaseitem.php?browse=1&forcetab=Knowbase$2');
+
+    // eslint-disable-next-line playwright/no-raw-locators
+    const active_node = page.locator('#tree_category .fancytree-active .fancytree-title');
+    await expect(active_node).toContainText('Without Category');
+});


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23360 
- Here is a brief description of what this PR does : The `knowbaseitemcategories_id` parameter present in the URL after clicking a KB article's category badge was never read by the fancytree JavaScript `code. tree.activateKey(-1) `was hardcoded, always selecting "Without Category". This fix extracts the category ID from the request parameters and passes it as the initial node to `activateKey()`.

**Note about PHPStan** : Ideally, the `$itemtype` parameter should be typed as `class-string<CommonDBTM>` across the trait and interface, but that would also fix errors currently tracked in the PHPStan baseline (`getTreeCategoryList()`, `Search::getDatas()`), requiring baseline cleanup outside the scope of this PR.

A targeted `@phpstan-ignore` keeps the fix minimal.





