### PR TITLE
fix: business rule assign action replaces group actor instead of appending

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9543,6 +9543,25 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
             // Search for added/updated actors
             $existings = $this->getActorsForType($actor_type_value);
+
+            // When a business rule uses the "assign" action on a group actor field, the rule
+            // engine flags the field in $this->input["_rule_replace_actor_groups"]. When that
+            // flag is present we delete existing Group actors of this type before adding the new
+            // one, so the assignment REPLACES rather than APPENDS.
+            // See: https://github.com/glpi-project/glpi/issues/17739
+            if (
+                isset($this->input["_rule_replace_actor_groups"])
+                && in_array("_groups_id_" . $actor_type, $this->input["_rule_replace_actor_groups"])
+            ) {
+                foreach ($existings as $existing) {
+                    if ($existing["itemtype"] === Group::class) {
+                        $actor_obj = $this->getActorObjectForItem(Group::class);
+                        $actor_obj->delete(["id" => $existing["id"]]);
+                    }
+                }
+                $existings = $this->getActorsForType($actor_type_value); // reload after deletion
+            }
+
             $added     = [];
             $updated   = [];
 

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -252,6 +252,17 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                     case "assign":
                         $output[$action->fields["field"]] = $action->fields["value"];
 
+                        // When assigning group actor fields via a business rule, mark them for replacement
+                        // (not append) when updating an existing ticket. Without this flag, updateActors()
+                        // appends the new group on top of the existing one instead of replacing it.
+                        // See: https://github.com/glpi-project/glpi/issues/17739
+                        if (in_array($action->fields["field"], ["_groups_id_assign", "_groups_id_requester", "_groups_id_observer"])) {
+                            if (!isset($output["_rule_replace_actor_groups"])) {
+                                $output["_rule_replace_actor_groups"] = [];
+                            }
+                            $output["_rule_replace_actor_groups"][] = $action->fields["field"];
+                        }
+
                         // Special case of status
                         if ($action->fields["field"] === 'status') {
                             // Add a flag to remember that status was forced by rule


### PR DESCRIPTION
## Problem

When a business rule fires on ticket **update** with an `assign` action targeting a group actor field (`_groups_id_assign`, `_groups_id_requester`, `_groups_id_observer`), the new group is **appended** on top of the existing group instead of replacing it.

**Steps to reproduce:**
1. Create a ticket with category X → business rule assigns Group A
2. Edit the ticket, change to category Y → business rule fires again
3. **Result:** ticket ends up with both Group A **and** Group B (bug)
4. **Expected:** only Group B

Closes #17739

## Root cause

Two-function chain:
- `RuleCommonITILObject::executeActions()` — `case "assign":` correctly writes `$output['_groups_id_assign']` but provides no signal that the existing actor should be removed first
- `CommonITILObject::updateActors()` — additive-only by design; never clears prior Group actors before adding the new one

## Fix

**`src/RuleCommonITILObject.php`** — after setting the output value in `case "assign":`, populate a `_rule_replace_actor_groups` flag when the target field is a group actor field.

**`src/CommonITILObject.php`** — in `updateActors()`, when the flag is present, delete all existing `Group` actors of that actor type before processing the new assignment, then reload `$existings` so the duplicate-check is clean.

## Testing

- GLPI 11.0.4, PHP 8.3, MariaDB 10.11
- Created ticket under **SAP S4/Hana > MM** → business rule assigned group **SAP Consultants**
- Changed category to **SAP S4/Hana > SD** → rule fired on update
- **Before patch:** both groups present (bug reproduced)
- **After patch:** only **SD Consultant** remains ✅