### PR TITLE
fix click event listener for impact badges

### DIFF
--- a/src/Impact.php
+++ b/src/Impact.php
@@ -579,7 +579,7 @@ TWIG, $twig_params);
             $extra = 'id="' . $id . '" style="background-color:' . htmlescape($user->fields["priority_$priority"]) . '; cursor:pointer;"';
 
             echo Html::scriptBlock('
-                $(document).on("click", "#$id", () => {
+                $(document).on("click", "#' . $id . '", () => {
                     window.open("' . jsescape($link) . '");
                 });
             ');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

"$id" was being used as a plain string instead of using the PHP variable storing the element ID.