### PR TITLE
fix impact list counter colors

### DIFF
--- a/src/Impact.php
+++ b/src/Impact.php
@@ -535,7 +535,6 @@ TWIG, $twig_params);
         $user->computePreferences();
 
         $count = count($itil_objects) ?: "";
-        $extra = "";
         $node_details = explode(self::NODE_ID_DELIMITER, $node_id);
 
         if ($count) {
@@ -576,16 +575,26 @@ TWIG, $twig_params);
                     $priority = $itil_object['priority'];
                 }
             }
-            $extra = 'id="' . $id . '" style="background-color:' . htmlescape($user->fields["priority_$priority"]) . '; cursor:pointer;"';
+            $color = htmlescape($user->fields["priority_$priority"]);
 
             echo Html::scriptBlock('
                 $(document).on("click", "#$id", () => {
                     window.open("' . jsescape($link) . '");
                 });
             ');
-        }
 
-        echo '<td class="text-center" ' . $extra . '><div>' . $count . '</div></td>';
+            echo <<<HTML
+                <td class="text-center">
+                    <div class="badge_block" style="border-color: $color">
+                        <span class="me-1" style="background: $color"></span>
+                        $count
+                    </div>
+                </td>
+HTML;
+
+        } else {
+            echo '<td class="text-center"><div>' . $count . '</div></td>';
+        }
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Impact list view uses the priority colors to fill the background of the counter cells and doesn't handle changing the text color. This causes issues with dark themes and the default priority colors, but in general are just bad for accessibility because there is no control over the contrast between the background and foreground. In other places, we use a "badge" UI to have a color without interfering with text contrast.

Before:
<img width="988" height="397" alt="Selection_688" src="https://github.com/user-attachments/assets/92b9f875-30b2-40a6-8a26-f70451aa123c" />

After:
<img width="988" height="397" alt="Selection_689" src="https://github.com/user-attachments/assets/c00489f6-ab4d-4ae5-a7a0-e27e2b4d5648" />



