### PR TITLE
Fix main branch PHP version

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -25,7 +25,7 @@ jobs:
           # build on lower supported version to ensure building tools are compatible with this version
           - {branch: "10.0/bugfixes", version-name: "10.0", php-version: "7.4"}
           - {branch: "11.0/bugfixes", version-name: "11.0", php-version: "8.2"}
-          - {branch: "main", version-name: "dev", php-version: "8.2"}
+          - {branch: "main", version-name: "dev", php-version: "8.3"}
     services:
       app:
         image: "ghcr.io/glpi-project/githubactions-php:${{ matrix.php-version }}"


### PR DESCRIPTION
I saw this issue on nightly build:
```
Fatal error: Uncaught RuntimeException: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.3.0". You are running 8.2.30. in /var/www/glpi/vendor/composer/platform_check.php:26
```

Since PHP version is correct on main branch actions setup; I guess it fails because it relies on the default branch.