### PR TITLE
Fix peripheralasset connect massive action

### DIFF
--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -260,14 +260,42 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         $is_deleted = false,
         ?CommonDBTM $checkitem = null
     ) {
-        $action_prefix = self::class . MassiveAction::CLASS_ACTION_SEPARATOR;
-        $specificities = self::getRelationMassiveActionsSpecificities();
+        global $CFG_GLPI;
 
-        if (in_array($itemtype, $specificities['itemtypes'], true)) {
+        $action_prefix = self::class . MassiveAction::CLASS_ACTION_SEPARATOR;
+
+        if (in_array($itemtype, $CFG_GLPI['directconnect_types'], true)) {
             $actions[$action_prefix . 'add']    = "<i class='ti ti-plug'></i>" . _sx('button', 'Connect');
             $actions[$action_prefix . 'remove'] = "<i class='ti ti-plug-off'></i>" . _sx('button', 'Disconnect');
         }
         parent::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
+    }
+
+    public static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma)
+    {
+        global $CFG_GLPI;
+
+        $items = $ma->getItems();
+
+        if (
+            count(array_intersect(
+                array_keys($items),
+                $CFG_GLPI['directconnect_types']
+            )) > 0
+        ) {
+            return 1;
+        }
+
+        if (
+            empty(array_diff(
+                array_keys($items),
+                self::getPeripheralHostItemtypes()
+            ))
+        ) {
+            return 2;
+        }
+
+        return parent::getRelationMassiveActionsPeerForSubForm($ma);
     }
 
     public static function getRelationMassiveActionsSpecificities()
@@ -275,7 +303,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         global $CFG_GLPI;
 
         $specificities              = parent::getRelationMassiveActionsSpecificities();
-        $specificities['itemtypes'] = $CFG_GLPI['directconnect_types'];
+        $specificities['itemtypes'] = self::getPeripheralHostItemtypes();
         $specificities['select_items_options_1']['itemtypes']       = self::getPeripheralHostItemtypes();
         $specificities['select_items_options_2']['entity_restrict'] = $_SESSION['glpiactive_entity'];
         $specificities['select_items_options_2']['itemtypes']       = $CFG_GLPI['directconnect_types'];
@@ -847,35 +875,6 @@ TWIG, $twig_params);
         }
 
         return $tab;
-    }
-
-    #[Override]
-    public static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma)
-    {
-        global $CFG_GLPI;
-
-        $items = $ma->getItems();
-
-        if (
-            count(array_intersect(
-                array_keys($items),
-                $CFG_GLPI['directconnect_types']
-            )) > 0
-        ) {
-            return 1;
-        }
-
-        if (
-            empty(array_diff(
-                array_keys($items),
-                self::getPeripheralHostItemtypes()
-            ))
-        ) {
-            return 2;
-        }
-
-        // Else we cannot define !
-        return 0;
     }
 
     /**

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -271,33 +271,6 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         parent::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
     }
 
-    public static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma)
-    {
-        global $CFG_GLPI;
-
-        $items = $ma->getItems();
-
-        if (
-            count(array_intersect(
-                array_keys($items),
-                $CFG_GLPI['directconnect_types']
-            )) > 0
-        ) {
-            return 1;
-        }
-
-        if (
-            empty(array_diff(
-                array_keys($items),
-                self::getPeripheralHostItemtypes()
-            ))
-        ) {
-            return 2;
-        }
-
-        return parent::getRelationMassiveActionsPeerForSubForm($ma);
-    }
-
     public static function getRelationMassiveActionsSpecificities()
     {
         global $CFG_GLPI;
@@ -875,6 +848,33 @@ TWIG, $twig_params);
         }
 
         return $tab;
+    }
+
+    public static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma)
+    {
+        global $CFG_GLPI;
+
+        $items = $ma->getItems();
+
+        if (
+            count(array_intersect(
+                array_keys($items),
+                $CFG_GLPI['directconnect_types']
+            )) > 0
+        ) {
+            return 1;
+        }
+
+        if (
+            empty(array_diff(
+                array_keys($items),
+                self::getPeripheralHostItemtypes()
+            ))
+        ) {
+            return 2;
+        }
+
+        return parent::getRelationMassiveActionsPeerForSubForm($ma);
     }
 
     /**

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -850,6 +850,7 @@ TWIG, $twig_params);
         return $tab;
     }
 
+    #[Override]
     public static function getRelationMassiveActionsPeerForSubForm(MassiveAction $ma)
     {
         global $CFG_GLPI;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42642
- Here is a brief description of what this PR does
On peripherals, monitors, telephones, and printers, the list of item types that could be selected with the mass action contained incorrect values, whereas only the types specified in $CFG_GLPI[‘peripheralhost_types’] should be included.

## Screenshots (if appropriate):
**Before**
<img width="1134" height="354" alt="image" src="https://github.com/user-attachments/assets/ea8d3649-f73b-454f-a4a6-ee5d7db7e7a0" />

**After**
<img width="1129" height="331" alt="image" src="https://github.com/user-attachments/assets/d53045be-a5bd-4958-be82-399a28d809e8" />


