### PR TITLE
[HLAPI] snmpcredentials and agent types

### DIFF
--- a/src/AgentType.php
+++ b/src/AgentType.php
@@ -38,6 +38,8 @@
  **/
 class AgentType extends CommonDBTM
 {
+    public static $rightname = 'agent';
+
     public static function getTypeName($nb = 0)
     {
         return _n('Agent type', 'Agents types', $nb);

--- a/src/Glpi/Api/HL/Controller/InventoryController.php
+++ b/src/Glpi/Api/HL/Controller/InventoryController.php
@@ -45,8 +45,8 @@ use Glpi\Api\HL\RouteVersion;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
-
 use SNMPCredential;
+
 use function Safe\file_get_contents;
 
 #[Route(path: '/Inventory', priority: 1, tags: ['Inventory'])]

--- a/src/Glpi/Api/HL/Controller/InventoryController.php
+++ b/src/Glpi/Api/HL/Controller/InventoryController.php
@@ -35,6 +35,7 @@
 namespace Glpi\Api\HL\Controller;
 
 use Agent;
+use AgentType;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
@@ -45,6 +46,7 @@ use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 
+use SNMPCredential;
 use function Safe\file_get_contents;
 
 #[Route(path: '/Inventory', priority: 1, tags: ['Inventory'])]
@@ -63,6 +65,7 @@ final class InventoryController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
+                    'type' => self::getDropdownTypeSchema(class: AgentType::class, full_schema: 'AgentType') + ['readOnly' => true],
                     'deviceid' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
                     'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
                     'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity') + ['readOnly' => true],
@@ -128,45 +131,143 @@ final class InventoryController extends AbstractController
                     'use_module_collect_data' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'readOnly' => true],
                 ],
             ],
+            'AgentType' => [
+                'x-version-introduced' => '2.3.0',
+                'x-itemtype' => AgentType::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                ],
+            ],
+            'SNMPCredential' => [
+                'x-version-introduced' => '2.3.0',
+                'x-itemtype' => SNMPCredential::class,
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 64],
+                    'snmp_version' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'x-field' => 'snmpversion',
+                        'enum' => ['1', '2c', '3'],
+                        'required' => true,
+                    ],
+                    'community' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                    'username' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                    'authentication' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => [1, 2, 3, 4, 5, 6],
+                        'description' => <<<EOT
+                        - 1: MD5
+                        - 2: SHA
+                        - 3: SHA224
+                        - 4: SHA256
+                        - 5: SHA384
+                        - 6: SHA512
+EOT,
+                    ],
+                    'auth_passphrase' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'writeOnly' => true],
+                    'encryption' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => [1, 2, 3, 4, 5, 6, 7],
+                        'description' => <<<EOT
+                        - 1: DES
+                        - 2: AES
+                        - 3: 3DES
+                        - 4: AES192C
+                        - 5: AES256C
+                        - 6: CFB192-AES
+                        - 7: CFB256-AES
+EOT,
+                    ],
+                    'priv_passphrase' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'writeOnly' => true],
+                    'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
+                ],
+            ],
         ];
     }
 
-    #[Route(path: '/Agent', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[Route(path: '/{itemtype}', methods: ['GET'], requirements: [
+        'itemtype' => 'Agent|SNMPCredential',
+    ], middlewares: [ResultFormatterMiddleware::class])]
     #[RouteVersion(introduced: '2.3')]
-    #[Doc\SearchRoute(schema_name: 'Agent')]
+    #[Doc\SearchRoute(schema_name: '{itemtype}')]
     public function search(Request $request): Response
     {
-        return ResourceAccessor::searchBySchema($this->getKnownSchema('Agent', $this->getAPIVersion($request)), $request->getParameters());
+        return ResourceAccessor::searchBySchema(
+            $this->getKnownSchema($request->getAttribute('itemtype'), $this->getAPIVersion($request)),
+            $request->getParameters(),
+        );
     }
 
-    #[Route(path: '/Agent/{id}', methods: ['GET'], requirements: [
+    #[Route(path: '/{itemtype}/{id}', methods: ['GET'], requirements: [
+        'itemtype' => 'Agent|SNMPCredential',
         'id' => '\d+',
     ], middlewares: [ResultFormatterMiddleware::class])]
     #[RouteVersion(introduced: '2.3')]
-    #[Doc\GetRoute(schema_name: 'Agent')]
+    #[Doc\GetRoute(schema_name: '{itemtype}')]
     public function getItem(Request $request): Response
     {
-        return ResourceAccessor::getOneBySchema($this->getKnownSchema('Agent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
+        return ResourceAccessor::getOneBySchema(
+            schema: $this->getKnownSchema($request->getAttribute('itemtype'), $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters(),
+        );
     }
 
-    #[Route(path: '/Agent/{id}', methods: ['PATCH'], requirements: [
+    #[Route(path: '/{itemtype}', methods: ['POST'], requirements: [
+        'itemtype' => 'SNMPCredential',
         'id' => '\d+',
     ])]
     #[RouteVersion(introduced: '2.3')]
-    #[Doc\UpdateRoute(schema_name: 'Agent')]
+    #[Doc\CreateRoute(schema_name: '{itemtype}')]
+    public function createItem(Request $request): Response
+    {
+        return ResourceAccessor::createBySchema(
+            schema: $this->getKnownSchema($request->getAttribute('itemtype'), $this->getAPIVersion($request)),
+            request_params: $request->getParameters(),
+            get_route: [self::class, 'getItem'],
+            extra_get_route_params: ['mapped' => ['itemtype' => $request->getAttribute('itemtype')]],
+        );
+    }
+
+    #[Route(path: '/{itemtype}/{id}', methods: ['PATCH'], requirements: [
+        'itemtype' => 'Agent|SNMPCredential',
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.3')]
+    #[Doc\UpdateRoute(schema_name: '{itemtype}')]
     public function updateItem(Request $request): Response
     {
-        return ResourceAccessor::updateBySchema($this->getKnownSchema('Agent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
+        return ResourceAccessor::updateBySchema(
+            schema: $this->getKnownSchema($request->getAttribute('itemtype'), $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters(),
+        );
     }
 
     #[Route(path: '/{itemtype}/{id}', methods: ['DELETE'], requirements: [
+        'itemtype' => 'Agent|SNMPCredential',
         'id' => '\d+',
     ])]
     #[RouteVersion(introduced: '2.3')]
-    #[Doc\DeleteRoute(schema_name: 'Agent')]
+    #[Doc\DeleteRoute(schema_name: '{itemtype}')]
     public function deleteItem(Request $request): Response
     {
-        return ResourceAccessor::deleteBySchema($this->getKnownSchema('Agent', $this->getAPIVersion($request)), $request->getAttributes(), $request->getParameters());
+        return ResourceAccessor::deleteBySchema(
+            schema: $this->getKnownSchema($request->getAttribute('itemtype'), $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters(),
+        );
     }
 
     #[Route(path: '/Agent/{id}/InventoryRequest', methods: ['POST'], requirements: [

--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -233,14 +233,16 @@ class SNMPCredential extends CommonDBTM
     private function checkRequiredFields(array $input): bool
     {
         // Require a snmpversion
-        if (!isset($input['snmpversion']) || $input['snmpversion'] == '0') {
+        $snmp_version = (int) ($input['snmpversion'] ?? $this->fields['snmpversion'] ?? 0);
+        if ($snmp_version === 0) {
             Session::addMessageAfterRedirect(__s('You must select an SNMP version'), false, ERROR);
             return false;
         }
 
         // Require username if using version 3
-        if ($input['snmpversion'] == 3) {
-            if (empty($input['username'])) {
+        if ($snmp_version === 3) {
+            $username = $input['username'] ?? $this->fields['username'] ?? null;
+            if (empty($username)) {
                 Session::addMessageAfterRedirect(__s('You must enter a username'), false, ERROR);
                 return false;
             }

--- a/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
@@ -130,7 +130,7 @@ class InventoryControllerTest extends HLAPITestCase
             itemtype: SNMPCredential::class,
             items_id: $sc->getID(),
             create_params: [
-                'snmp_version' => '2c'
+                'snmp_version' => '2c',
             ]
         );
 

--- a/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Api\HL\Controller;
+
+use Agent;
+use AgentType;
+use Computer;
+use Glpi\Http\Request;
+use Glpi\Tests\HLAPICallAsserter;
+use Glpi\Tests\HLAPITestCase;
+use SNMPCredential;
+
+class InventoryControllerTest extends HLAPITestCase
+{
+    public function testAutoTestCRUD()
+    {
+        $this->api->autoTestCRUD('/Inventory/SNMPCredential', [
+            'snmp_version' => '2c',
+        ]);
+    }
+
+    public function testCRUDAgent()
+    {
+        $this->loginWeb();
+
+        // Manually create an agent and type as it isn't supported in the API.
+        // Normally these are automatically created during the automatic inventory process
+        $agenttypes_id = $this->createItem(AgentType::class, [
+            'name' => 'Test Agent Type',
+        ])->getID();
+        $agents_id = $this->createItem(Agent::class, [
+            'name' => 'Test Agent',
+            'entities_id' => $this->getTestRootEntity(true),
+            'itemtype' => Computer::class,
+            'items_id' => getItemByTypeName(Computer::class, '_test_pc01', true),
+            'deviceid' => '_test_deviceid01',
+            'agenttypes_id' => $agenttypes_id,
+        ])->getID();
+
+        // test update, get, search and delete in REST
+
+        $this->login();
+
+        $this->api->call(new Request('GET', '/Inventory/Agent'), function ($call) {
+            /** @var HLAPICallAsserter $call */
+            $call->response->isOK();
+            $call->response->jsonContent(function ($content) {
+                $found_agent = false;
+                foreach ($content as $agent) {
+                    if ($agent['name'] === 'Test Agent') {
+                        $found_agent = true;
+                        break;
+                    }
+                }
+                $this->assertTrue($found_agent);
+            });
+        });
+
+        $update_request = new Request('PATCH', "/Inventory/Agent/{$agents_id}");
+        $update_request->setParameter('threads_network_discovery', 6);
+        $this->api->call($update_request, function ($call) {
+            /** @var HLAPICallAsserter $call */
+            $call->response->isOK();
+            $call->response->jsonContent(function ($content) {
+                $this->assertEquals(6, $content['threads_network_discovery']);
+            });
+        });
+
+        $this->api->call(new Request('GET', "/Inventory/Agent/{$agents_id}"), function ($call) {
+            /** @var HLAPICallAsserter $call */
+            $call->response->isOK();
+            $call->response->jsonContent(function ($content) {
+                $this->assertEquals(6, $content['threads_network_discovery']);
+            });
+        });
+
+        $this->api->call(new Request('DELETE', "/Inventory/Agent/{$agents_id}"), function ($call) {
+            /** @var HLAPICallAsserter $call */
+            $call->response->isOK();
+        });
+
+        $this->api->call(new Request('GET', "/Inventory/Agent/{$agents_id}"), function ($call) {
+            /** @var HLAPICallAsserter $call */
+            $call->response->isNotFoundError();
+        });
+    }
+
+    public function testAutoTestCRUDNoRights()
+    {
+        $this->login();
+
+        $sc = $this->createItem(SNMPCredential::class, [
+            'name' => 'Test SNMP Credential',
+            'snmpversion' => '2c',
+        ]);
+        $this->api->autoTestCRUDNoRights(
+            endpoint: '/Inventory/SNMPCredential',
+            itemtype: SNMPCredential::class,
+            items_id: $sc->getID(),
+            create_params: [
+                'snmp_version' => '2c'
+            ]
+        );
+
+        $agenttypes_id = $this->createItem(AgentType::class, [
+            'name' => 'Test Agent Type',
+        ])->getID();
+        $agents_id = $this->createItem(Agent::class, [
+            'name' => 'Test Agent',
+            'entities_id' => $this->getTestRootEntity(true),
+            'itemtype' => Computer::class,
+            'items_id' => getItemByTypeName(Computer::class, '_test_pc01', true),
+            'deviceid' => '_test_deviceid01',
+            'agenttypes_id' => $agenttypes_id,
+        ])->getID();
+        $this->api->autoTestCRUDNoRights(
+            endpoint: '/Inventory/Agent',
+            itemtype: Agent::class,
+            items_id: $agents_id,
+            extra_options: ['skip_create_test' => true]
+        );
+    }
+}

--- a/tests/src/HLAPITestCase.php
+++ b/tests/src/HLAPITestCase.php
@@ -552,6 +552,7 @@ final class HLAPIHelper
         ?callable $deny_restore = null,
         ?array $create_params = null,
         ?array $update_params = null,
+        ?array $extra_options = []
     ): self {
         $this->test->loginWeb();
         $this->router->registerAuthMiddleware(new InternalAuthMiddleware());
@@ -588,33 +589,37 @@ final class HLAPIHelper
             $call->response->isNotOK();
         }, false);
 
-        $deny_create();
-        // No CREATE = Access denied
-        $create_request = new Request('POST', $endpoint);
-        if ($create_params !== null) {
-            foreach ($create_params as $key => $value) {
-                $create_request->setParameter($key, $value);
+        if (!($extra_options['skip_create_test'] ?? false)) {
+            $deny_create();
+            // No CREATE = Access denied
+            $create_request = new Request('POST', $endpoint);
+            if ($create_params !== null) {
+                foreach ($create_params as $key => $value) {
+                    $create_request->setParameter($key, $value);
+                }
             }
+            $this->call($create_request, function ($call) {
+                /** @var HLAPICallAsserter $call */
+                $call->response->isAccessDenied();
+            }, false);
         }
-        $this->call($create_request, function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response->isAccessDenied();
-        }, false);
 
-        $deny_update();
-        $update_request = new Request('PATCH', $endpoint . '/' . $items_id);
-        // Property does not need to exist, but we try to act like a real update
-        $update_request->setParameter('name', 'updated');
-        if ($update_params !== null) {
-            foreach ($update_params as $key => $value) {
-                $update_request->setParameter($key, $value);
+        if (!($extra_options['skip_update_test'] ?? false)) {
+            $deny_update();
+            $update_request = new Request('PATCH', $endpoint . '/' . $items_id);
+            // Property does not need to exist, but we try to act like a real update
+            $update_request->setParameter('name', 'updated');
+            if ($update_params !== null) {
+                foreach ($update_params as $key => $value) {
+                    $update_request->setParameter($key, $value);
+                }
             }
+            // No UPDATE = Access denied
+            $this->call($update_request, function ($call) {
+                /** @var HLAPICallAsserter $call */
+                $call->response->isAccessDenied();
+            }, false);
         }
-        // No UPDATE = Access denied
-        $this->call($update_request, function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response->isAccessDenied();
-        }, false);
 
         if ($item->maybeDeleted()) {
             $deny_delete();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- Adds SNMPCredential and AgentType support
- Adds missing rightname for AgentType which is usually only handled internally and not directly searchable, but now it would be via GraphQL
- Fixes input checks for SNMPCredential which expected some fields to always be present even when already set on the item