### PR TITLE
Fix(plugin): deduplicate plugin directories list

### DIFF
--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -224,9 +224,7 @@ final class SystemConfigurator
             }
 
             define('GLPI_PLUGINS_DIRECTORIES', array_values(array_unique(PLUGINS_DIRECTORIES)));
-        }
-
-        if (defined('GLPI_PLUGINS_DIRECTORIES')) {
+        } elseif (defined('GLPI_PLUGINS_DIRECTORIES')) {
             $plugin_directories = constant('GLPI_PLUGINS_DIRECTORIES');
             if (!is_array($plugin_directories)) {
                 throw new \InvalidArgumentException(

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -249,6 +249,10 @@ final class SystemConfigurator
                     $constants[GLPI_ENVIRONMENT_TYPE][$name] ?? $constants['default'][$name]
                 );
 
+                if ($name === 'GLPI_PLUGINS_DIRECTORIES' && is_array($value)) {
+                    $value = array_values(array_unique($value));
+                }
+
                 define($name, $value);
             }
         }

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -226,14 +226,17 @@ final class SystemConfigurator
             define('GLPI_PLUGINS_DIRECTORIES', array_values(array_unique(PLUGINS_DIRECTORIES)));
         }
 
-        if (defined('GLPI_PLUGINS_DIRECTORIES') && !is_array(GLPI_PLUGINS_DIRECTORIES)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'Configuration "%s" must be an array, %s given.',
-                    'GLPI_PLUGINS_DIRECTORIES',
-                    get_debug_type(GLPI_PLUGINS_DIRECTORIES),
-                )
-            );
+        if (defined('GLPI_PLUGINS_DIRECTORIES')) {
+            $plugin_directories = constant('GLPI_PLUGINS_DIRECTORIES');
+            if (!is_array($plugin_directories)) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Configuration "%s" must be an array, %s given.',
+                        'GLPI_PLUGINS_DIRECTORIES',
+                        get_debug_type($plugin_directories),
+                    )
+                );
+            }
         }
 
         // Configure environment type if not defined by user.

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -213,7 +213,27 @@ final class SystemConfigurator
 
         // Handle deprecated/obsolete constants
         if (defined('PLUGINS_DIRECTORIES') && !defined('GLPI_PLUGINS_DIRECTORIES')) {
-            define('GLPI_PLUGINS_DIRECTORIES', PLUGINS_DIRECTORIES);
+            if (!is_array(PLUGINS_DIRECTORIES)) {
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Configuration "%s" must be an array, %s given.',
+                        'PLUGINS_DIRECTORIES',
+                        get_debug_type(PLUGINS_DIRECTORIES),
+                    )
+                );
+            }
+
+            define('GLPI_PLUGINS_DIRECTORIES', array_values(array_unique(PLUGINS_DIRECTORIES)));
+        }
+
+        if (defined('GLPI_PLUGINS_DIRECTORIES') && !is_array(GLPI_PLUGINS_DIRECTORIES)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Configuration "%s" must be an array, %s given.',
+                    'GLPI_PLUGINS_DIRECTORIES',
+                    get_debug_type(GLPI_PLUGINS_DIRECTORIES),
+                )
+            );
         }
 
         // Configure environment type if not defined by user.
@@ -249,7 +269,17 @@ final class SystemConfigurator
                     $constants[GLPI_ENVIRONMENT_TYPE][$name] ?? $constants['default'][$name]
                 );
 
-                if ($name === 'GLPI_PLUGINS_DIRECTORIES' && is_array($value)) {
+                if ($name === 'GLPI_PLUGINS_DIRECTORIES') {
+                    if (!is_array($value)) {
+                        throw new \InvalidArgumentException(
+                            sprintf(
+                                'Configuration "%s" must be an array, %s given.',
+                                $name,
+                                get_debug_type($value),
+                            )
+                        );
+                    }
+
                     $value = array_values(array_unique($value));
                 }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42478
- Prevents duplicate plugin directory processing and related side effects (such as duplicate hook/search option registrations) when directory entries are repeated.



