### PR TITLE
Fix unfixed failure paths for image uploads

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -41,7 +41,7 @@
 /* global glpi_html_dialog */
 /* global glpi_toast_info, glpi_toast_warning, glpi_toast_error */
 /* global _ */
-/* global uploaded_images */
+/* global uploaded_images, removeFailedUploadImage */
 
 var timeoutglobalvar;
 
@@ -1953,6 +1953,7 @@ function setupFileUpload(config) {
                 $.blueimp.fileupload.prototype.options.add.call(this, e, data);
             },
             done: function (event, data) {
+                const form = $(this).closest('form');
                 const uploader_name = $('#' + field_id).fileupload('option', 'formData').name;
                 // eslint-disable-next-line no-undef
                 handleUploadedFile(
@@ -1961,11 +1962,12 @@ function setupFileUpload(config) {
                     config.name,
                     $('#' + CSS.escape(config.filecontainer)),
                     config.editor_id
-                );
-                // enable submit button after upload
-                $(this).closest('form').find(':submit').prop('disabled', false);
-                // remove required
-                $('#' + field_id).removeAttr('required');
+                ).then(() => {
+                    // enable submit button after upload
+                    form.find(':submit').prop('disabled', false);
+                    // remove required
+                    $(`#${field_id}`).removeAttr('required');
+                });
             },
             fail: function (e, data) {
                 // enable submit button after upload
@@ -1974,6 +1976,9 @@ function setupFileUpload(config) {
                     ? data.jqXHR.responseText
                     : data.jqXHR.statusText;
                 alert(err);
+                $.each(data.files, function(index, file) {
+                    removeFailedUploadImage({filename: file.name, editor_id: config.editor_id});
+                });
             },
             processfail: function (e, data) {
                 // enable submit button after upload
@@ -1986,23 +1991,7 @@ function setupFileUpload(config) {
                             .css('width', '100%')
                             .show();
 
-                        // Remove failed image from TinyMCE editor to prevent base64 data in DB
-                        if (config.editor_id && typeof tinyMCE !== 'undefined') {
-                            const editor = tinyMCE.get(config.editor_id);
-                            if (editor) {
-                                const uploaded_image = uploaded_images.find((entry) => entry.filename === file.name);
-                                if (uploaded_image) {
-                                    const img = editor.dom.select('img[data-upload_id="' + CSS.escape(uploaded_image.upload_id) + '"]');
-                                    if (img.length > 0) {
-                                        editor.dom.remove(img);
-                                    }
-                                    const index = uploaded_images.findIndex((entry) => entry.upload_id === uploaded_image.upload_id);
-                                    if (index !== -1) {
-                                        uploaded_images.splice(index, 1);
-                                    }
-                                }
-                            }
-                        }
+                        removeFailedUploadImage({filename: file.name, editor_id: config.editor_id});
                         return;
                     }
                 });

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -38,6 +38,43 @@ var insertIntoEditor = []; // contains flags that indicate if uploaded file (ima
 
 var uploaded_images = []; // Mapping between random identifier and image filename
 
+/**
+ * Remove a failed upload image from the TinyMCE editor to prevent base64 data in DB.
+ *
+ * @param {Object} options
+ * @param {string|null} options.filename   - The filename to look up in uploaded_images
+ * @param {string|null} options.upload_id  - The upload_id to target directly
+ * @param {string|null} options.editor_id  - The TinyMCE editor id
+ */
+function removeFailedUploadImage({filename = null, upload_id = null, editor_id = null} = {}) {
+    let editor = null;
+    if (editor_id && typeof tinyMCE !== 'undefined') {
+        editor = tinyMCE.get(editor_id);
+    }
+    if (!editor) {
+        return;
+    }
+
+    let target_upload_id = upload_id;
+    if (!target_upload_id && filename) {
+        const entry = uploaded_images.find((e) => e.filename === filename);
+        if (entry) {
+            target_upload_id = entry.upload_id;
+        }
+    }
+
+    if (target_upload_id) {
+        const img = editor.dom.select(`img[data-upload_id="${CSS.escape(target_upload_id)}"]`);
+        if (img.length > 0) {
+            editor.dom.remove(img);
+        }
+        const idx = uploaded_images.findIndex((e) => e.upload_id === target_upload_id);
+        if (idx !== -1) {
+            uploaded_images.splice(idx, 1);
+        }
+    }
+}
+
 function uploadFile(file, editor) {
     insertIntoEditor[file.name] = isImage(file);
 
@@ -61,60 +98,67 @@ function uploadFile(file, editor) {
 }
 
 var handleUploadedFile = function (files, files_data, input_name, container, editor_id) {
-    $.ajax(
-        {
-            type: 'POST',
-            url: `${CFG_GLPI.root_doc}/ajax/getFileTag.php`,
-            data: {data: files_data},
-            dataType: 'JSON',
-            success: function(tags) {
-                $.each(
-                    files,
-                    (index, file) => {
-                        if ((files_data[index].error ?? false) !== false) {
-                            container.parent().find('.uploadbar')
-                                .text(files_data[index].error)
-                                .css('width', '100%');
-                            return;
-                        }
-
-                        var tag_data = tags[index];
-
-                        var editor = null;
-                        if (editor_id) {
-                            editor = tinyMCE.get(editor_id);
-                            const uploaded_image = uploaded_images.find((entry) => entry.filename === file.name);
-                            const matching_image = uploaded_image !== undefined
-                                ? editor.dom.select(`img[data-upload_id="${CSS.escape(uploaded_image.upload_id)}"]`)
-                                : [];
-                            if (matching_image.length > 0) {
-                                editor.dom.setAttrib(matching_image, 'id', tag_data.tag.replace(/#/g, ''));
+    return new Promise((resolve) => {
+        $.ajax(
+            {
+                type: 'POST',
+                url: `${CFG_GLPI.root_doc}/ajax/getFileTag.php`,
+                data: {data: files_data},
+                dataType: 'JSON',
+                success: function(tags) {
+                    $.each(
+                        files,
+                        (index, file) => {
+                            if ((files_data[index].error ?? false) !== false) {
+                                container.parent().find('.uploadbar')
+                                    .text(files_data[index].error)
+                                    .css('width', '100%');
+                                removeFailedUploadImage({filename: file.name, editor_id: editor_id});
+                                return;
                             }
+
+                            var tag_data = tags[index];
+
+                            var editor = null;
+                            if (editor_id) {
+                                editor = tinyMCE.get(editor_id);
+                                const uploaded_image = uploaded_images.find((entry) => entry.filename === file.name);
+                                const matching_image = uploaded_image !== undefined
+                                    ? editor.dom.select(`img[data-upload_id="${CSS.escape(uploaded_image.upload_id)}"]`)
+                                    : [];
+                                if (matching_image.length > 0) {
+                                    editor.dom.setAttrib(matching_image, 'id', tag_data.tag.replace(/#/g, ''));
+                                }
+                            }
+
+                            displayUploadedFile(files_data[index], tag_data, editor, input_name, container);
+
+                            container.parent().find('.uploadbar')
+                                .text(__('Upload successful'))
+                                .css('width', '100%')
+                                .delay(2000)
+                                .fadeOut('slow');
                         }
-
-                        displayUploadedFile(files_data[index], tag_data, editor, input_name, container);
-
-                        container.parent().find('.uploadbar')
-                            .text(__('Upload successful'))
-                            .css('width', '100%')
-                            .delay(2000)
-                            .fadeOut('slow');
-                    }
-                );
-            },
-            error: function (request) {
-                console.warn(request.responseText);
-            },
-            complete: function () {
-                $.each(
-                    files,
-                    (index, file) => {
-                        delete(insertIntoEditor[file.name]);
-                    }
-                );
+                    );
+                },
+                error: function (request) {
+                    console.warn(request.responseText);
+                    $.each(files, (index, file) => {
+                        removeFailedUploadImage({filename: file.name, editor_id: editor_id});
+                    });
+                },
+                complete: function () {
+                    $.each(
+                        files,
+                        (index, file) => {
+                            delete(insertIntoEditor[file.name]);
+                        }
+                    );
+                    resolve();
+                }
             }
-        }
-    );
+        );
+    });
 };
 
 /**
@@ -286,6 +330,8 @@ if (typeof tinyMCE != 'undefined') {
                             }
                         );
                         uploadFile(file, editor);
+                    }).catch(() => {
+                        removeFailedUploadImage({upload_id: upload_id, editor_id: editor.id});
                     });
                 }
             });

--- a/tests/e2e/specs/Document/image_paste.spec.ts
+++ b/tests/e2e/specs/Document/image_paste.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { test, expect } from '../../fixtures/glpi_fixture';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+import { pasteImageInRichText } from '../../utils/ImagePasteHelpers';
+
+test('pasted image is uploaded as document, not stored as base64', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    const ticket_id = await api.createItem('Ticket', {
+        name: `Ticket ${crypto.randomUUID()}`,
+        content: 'Test ticket for image paste',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await page.goto(`/front/ticket.form.php?id=${ticket_id}`);
+
+    await page.getByRole('button', { name: 'Answer' }).click();
+    await expect(page.getByRole('application')).toBeVisible();
+
+    const getRichText = async () => {
+        // eslint-disable-next-line playwright/no-raw-locators
+        return page.getByRole('application').locator('iframe').contentFrame().locator('body');
+    };
+
+    await pasteImageInRichText(page, getRichText, '_uploader_filename');
+    await expect((await getRichText()).getByRole('img')).toBeVisible();
+
+    // eslint-disable-next-line playwright/no-raw-locators
+    const add_button = page.locator('#new-ITILFollowup-block button[name="add"]');
+    await expect(add_button).toBeEnabled();
+    await add_button.click();
+    await page.waitForURL(/ticket\.form\.php/);
+    await expect(page.getByRole('alert')).toBeVisible();
+
+    const followups = await api.getSubItems('Ticket', ticket_id, 'ITILFollowup');
+    const last_followup = followups[followups.length - 1];
+    expect(last_followup.content).not.toContain('data:image');
+    expect(last_followup.content).toContain('document.send.php');
+});


### PR DESCRIPTION


- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23110 
- Here is a brief description of what this PR does : 

GLPI converts TinyMCE image uploads from a base64 data: URI into a proper Document via an asynchronous upload flow. 

However, PR #22187 only fixed only one of the seven failure paths that could leave raw base64 data stored in the database. This PR addresses the remaining six paths and adds a server-side safety net.

A shared `removeFailedUploadImage` helper centralizes the cleanup logic and is used across all failure paths:                                                                                 
                                                                                                                                                                                              
**1. Fetch failure** : if converting the data: URI to a Blob fails, the base64 image is removed from the editor
**2. Server error in successful response :** if the upload endpoint returns HTTP 200 but with an error in the JSON body (e.g. upload_max_filesize exceeded), the image is removed
**3. Upload HTTP failure** : if the upload endpoint returns a 4xx/5xx, the image is removed
**4. Tag resolution failure :** if the getFileTag.php call fails, the image is removed
**5. Race condition on form submit** : the submit button is now re-enabled only after tag resolution completes, preventing form submission while base64 content is still in the editor
**6. processfail refactoring** : the existing fix from PR #22187 is refactored to use the shared helper instead of duplicated inline code
**7. Server-side safety net** : the HTML sanitizer now restricts media schemes to http and https, stripping any data: URI that reaches the server as a defense-in-depth measure

The existing RichText unit test is updated accordingly, and a new Playwright E2E test validates the full paste-upload-save flow end to end.

