### PR TITLE
Use CURLSSLOPT_NATIVE_CA if available

### DIFF
--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -189,13 +189,6 @@ class Telemetry extends CommonGLPI
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
-        $curl_version = curl_version();
-        if (defined('CURLSSLOPT_NATIVE_CA')
-            && $curl_version
-            && version_compare($curl_version['version'], '7.71', '>=')) {
-            curl_setopt($ch, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
-        }
-
         if ($response = curl_exec($ch)) {
             $headers = substr($response, 0, curl_getinfo($ch, CURLINFO_HEADER_SIZE));
             $header_matches = [];

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -189,6 +189,13 @@ class Telemetry extends CommonGLPI
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
+        $curl_version = curl_version();
+        if (defined('CURLSSLOPT_NATIVE_CA')
+            && $curl_version
+            && version_compare($curl_version['version'], '7.71', '>=')) {
+            curl_setopt($ch, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+        }
+
         if ($response = curl_exec($ch)) {
             $headers = substr($response, 0, curl_getinfo($ch, CURLINFO_HEADER_SIZE));
             $header_matches = [];

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1405,6 +1405,15 @@ class Toolbox
             }
         }
 
+        $curl_version = curl_version();
+        if (defined('CURLSSLOPT_NATIVE_CA')
+            && $curl_version
+            && version_compare($curl_version['version'], '7.71', '>=')) {
+            $opts += [
+                CURLOPT_SSL_OPTIONS => CURLSSLOPT_NATIVE_CA,
+            ];
+        }
+
         curl_setopt_array($ch, $opts);
         $content = curl_exec($ch);
         $curl_info = curl_getinfo($ch);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I've seen several posts on the forum and the GitHub issues over the years regarding getting a "unable to get local issuer certificate" curl error. With PHP 8.2 and curl 7.71 there is an option to tell curl to use the system's CA bundle. This should prevent admins from needing to download and maintain a separate `cacert.pem`.

I have seen some older reports this had some issue a few years ago though, so I don't know how good it would be to implement in GLPI 11. If issues arise in GLPI 12 betas/early releases, I suppose this could be controlled by a constant but enabled by default.

https://php.watch/articles/php-curl-windows-cainfo-fix