### PR TITLE
fix empty IN error for kb comment panel

### DIFF
--- a/src/Glpi/Knowbase/SidePanel/CommentsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/CommentsRenderer.php
@@ -61,9 +61,8 @@ final class CommentsRenderer implements RendererInterface
 
         // Load users
         $user_ids = $this->extractRequiredUsersIds($threads);
-        if (count($user_ids) === 0) {
-            $users = [];
-        } else {
+        $users = [];
+        if (count($user_ids) > 0) {
             $users = User::getSeveralFromDBByCrit([
                 'id' => $user_ids,
             ]);

--- a/src/Glpi/Knowbase/SidePanel/CommentsRenderer.php
+++ b/src/Glpi/Knowbase/SidePanel/CommentsRenderer.php
@@ -60,10 +60,15 @@ final class CommentsRenderer implements RendererInterface
         $threads = KnowbaseItem_Comment::getCommentsThreads($item);
 
         // Load users
-        $users = User::getSeveralFromDBByCrit([
-            'id' => $this->extractRequiredUsersIds($threads),
-        ]);
-        $users = iterator_to_array($users);
+        $user_ids = $this->extractRequiredUsersIds($threads);
+        if (count($user_ids) === 0) {
+            $users = [];
+        } else {
+            $users = User::getSeveralFromDBByCrit([
+                'id' => $user_ids,
+            ]);
+            $users = iterator_to_array($users);
+        }
 
         // Transform the user list into an id -> user hash map
         $users = array_combine(

--- a/tests/functional/Glpi/Knowbase/SidePanel/CommentsRendererTest.php
+++ b/tests/functional/Glpi/Knowbase/SidePanel/CommentsRendererTest.php
@@ -88,6 +88,14 @@ final class CommentsRendererTest extends DbTestCase
             ],
             $comments->filter('[data-testid=comment-content]')->each(fn($node) => $node->text()),
         );
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'My article without comments',
+        ]);
+        $comments = $this->renderComments($kb);
+        $this->assertStringContainsString('No comments yet', $comments->html());
     }
 
     private function renderComments(KnowbaseItem $kb): Crawler


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Opening the comment panel for a new article in the KB rewrite causes a 500 error as it tries using an empty array of user IDs in a query.

```
[2026-03-13 19:24:38] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "Empty IN are not allowed" at DBmysqlIterator.php line 573
  Backtrace :
  ./src/DBmysqlIterator.php:573                      
  ./src/DBmysqlIterator.php:539                      DBmysqlIterator->analyseCriterion()
  ./src/DBmysqlIterator.php:303                      DBmysqlIterator->analyseCrit()
  ./src/DBmysqlIterator.php:120                      DBmysqlIterator->buildQuery()
  ./src/DBmysql.php:1050                             DBmysqlIterator->execute()
  ./src/CommonDBTM.php:624                           DBmysql->request()
  ./src/CommonDBTM.php:6755                          CommonDBTM->find()
  :                                                  CommonDBTM::getSeveralFromDBByCrit()
  ...Glpi/Knowbase/SidePanel/CommentsRenderer.php:66 iterator_to_array()
  .../Controller/Knowbase/SidePanelController.php:78 Glpi\Knowbase\SidePanel\CommentsRenderer->getParams()
  ./vendor/symfony/http-kernel/HttpKernel.php:183    Glpi\Controller\Knowbase\SidePanelController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:193        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```