### PR TITLE
Entity badgeCompletenameById optimization

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -3095,9 +3095,15 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
      */
     public static function badgeCompletenameById(int $entity_id): ?string
     {
-        $entity = new self();
-        if ($entity->getFromDB($entity_id)) {
-            return self::badgeCompletename($entity->fields['completename']);
+        global $DB;
+        $it = $DB->request([
+            'SELECT' => 'completename',
+            'FROM'   => 'glpi_entities',
+            'WHERE'  => ['id' => $entity_id],
+            'LIMIT'  => 1,
+        ]);
+        if ($data = $it->current()) {
+            return self::badgeCompletename($data['completename']);
         }
         return null;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Working to mitigate poor performance around the Planning feature as best as possible for a bugfix version.
Baseline `Planning::constructEventsArray` call for a month view with 184 external events with approximately 350 characters in each description takes 630-800ms and 1378 SQL requests on my test page (header, planning call, footer).

This PR specifically addresses optimizations for the entity badge calls. The SQL requests made are incredibly wasteful by requesting all 128 columns just to use only the `completename`. This reduced the `Planning::constructEventsArray` call by 80ms. There are still obvious issues with the entity badge function calls as they are duplicated even if everything is in the same entity. However, since GLPI doesn't have any centralized caching for DB results, that cannot be helped for the moment.