### PR TITLE
memoize richtext sanitizer object

### DIFF
--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -544,98 +544,103 @@ JAVASCRIPT;
 
     private static function getHtmlSanitizer(): HtmlSanitizer
     {
-        $config = (new HtmlSanitizerConfig())
-            ->allowSafeElements()
-            ->allowLinkSchemes([
-                'aim',
-                'app',
-                'feed',
-                'file',
-                'ftp',
-                'gopher',
-                'http',
-                'https',
-                'irc',
-                'mailto',
-                'news',
-                'nntp',
-                'sftp',
-                'ssh',
-                'tel',
-                'telnet',
-                'notes',
-            ])
-            ->allowRelativeLinks()
-            ->allowRelativeMedias()
-            ->withMaxInputLength(-1)
-        ;
+        static $sanitizer = null;
 
-        // Block some elements (tag is removed but contents is preserved)
-        $blocked_elements = [
-            'html',
-            'body',
+        if ($sanitizer === null) {
+            $config = (new HtmlSanitizerConfig())
+                ->allowSafeElements()
+                ->allowLinkSchemes([
+                    'aim',
+                    'app',
+                    'feed',
+                    'file',
+                    'ftp',
+                    'gopher',
+                    'http',
+                    'https',
+                    'irc',
+                    'mailto',
+                    'news',
+                    'nntp',
+                    'sftp',
+                    'ssh',
+                    'tel',
+                    'telnet',
+                    'notes',
+                ])
+                ->allowRelativeLinks()
+                ->allowRelativeMedias()
+                ->withMaxInputLength(-1);
 
-            // form elements
-            'form',
-            'button',
-            'input',
-            'select',
-            'datalist',
-            'option',
-            'optgroup',
-            'textarea',
-        ];
-        foreach ($blocked_elements as $blocked_element) {
-            $config = $config->blockElement($blocked_element);
+            // Block some elements (tag is removed but contents is preserved)
+            $blocked_elements = [
+                'html',
+                'body',
+
+                // form elements
+                'form',
+                'button',
+                'input',
+                'select',
+                'datalist',
+                'option',
+                'optgroup',
+                'textarea',
+            ];
+            foreach ($blocked_elements as $blocked_element) {
+                $config = $config->blockElement($blocked_element);
+            }
+
+            // Drop some elements (tag and contents are removed)
+            $dropped_elements = [
+                'head',
+                'script',
+
+                // header elements used to link external resources
+                'link',
+                'meta',
+
+                // elements used to embed potential malicious external application
+                'applet',
+                'canvas',
+                'embed',
+                'object',
+            ];
+            foreach ($dropped_elements as $dropped_element) {
+                $config = $config->dropElement($dropped_element);
+            }
+
+            // Allow class and style attribute
+            $config = $config->allowAttribute('class', '*');
+            $config = $config->allowAttribute('style', '*');
+            // Allow layout attribute for table tags
+            $config = $config->allowAttribute('bgcolor', ['table', 'tr', 'th', 'td']);
+            $config = $config->allowAttribute('border', ['table']);
+
+
+            if (GLPI_ALLOW_IFRAME_IN_RICH_TEXT) {
+                $config = $config->allowElement('iframe')->dropAttribute('srcdoc', '*');
+            }
+
+            // Keep attributes specific to rich text auto completion
+            $rich_text_completion_attributes = [
+                // required for proper display of autocompleted tags
+                'contenteditable',
+
+                // required for user mentions and form tags
+                'data-user-mention',
+                'data-user-id',
+                'data-form-tag',
+                'data-form-tag-value',
+                'data-form-tag-provider',
+            ];
+            foreach ($rich_text_completion_attributes as $attribute) {
+                $config = $config->allowAttribute($attribute, 'span');
+            }
+
+            $sanitizer = new HtmlSanitizer($config);
         }
 
-        // Drop some elements (tag and contents are removed)
-        $dropped_elements = [
-            'head',
-            'script',
-
-            // header elements used to link external resources
-            'link',
-            'meta',
-
-            // elements used to embed potential malicious external application
-            'applet',
-            'canvas',
-            'embed',
-            'object',
-        ];
-        foreach ($dropped_elements as $dropped_element) {
-            $config = $config->dropElement($dropped_element);
-        }
-
-        // Allow class and style attribute
-        $config = $config->allowAttribute('class', '*');
-        $config = $config->allowAttribute('style', '*');
-        // Allow layout attribute for table tags
-        $config = $config->allowAttribute('bgcolor', ['table', 'tr', 'th', 'td']);
-        $config = $config->allowAttribute('border', ['table']);
-
-
-        if (GLPI_ALLOW_IFRAME_IN_RICH_TEXT) {
-            $config = $config->allowElement('iframe')->dropAttribute('srcdoc', '*');
-        }
-
-        // Keep attributes specific to rich text auto completion
-        $rich_text_completion_attributes = [
-            // required for proper display of autocompleted tags
-            'contenteditable',
-
-            // required for user mentions and form tags
-            'data-user-mention',
-            'data-user-id',
-            'data-form-tag',
-            'data-form-tag-value',
-            'data-form-tag-provider',
-        ];
-        foreach ($rich_text_completion_attributes as $attribute) {
-            $config = $config->allowAttribute($attribute, 'span');
-        }
-
-        return new HtmlSanitizer($config);
+        return $sanitizer;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Working to mitigate poor performance around the Planning feature as best as possible for a bugfix version.
Baseline Planning::constructEventsArray call for a month view with 184 external events with approximately 350 characters in each description takes 630-800ms and 1378 SQL requests on my test page (header, planning call, footer).

This PR specifically memoizes the sanitizer object used in `Glpi\RichText\RichText` as the config doesn't change based on external state within a request yet seems to take a fair amount of time to create. In testing, the memoization reduced the `Planning::constructEventsArray` call time by nearly 300ms.

There are still obvious issues with the richtext handling. I am not sure the content of events is ever actually shown in the planning views directly until you hover over an event. So, loading all of it from the DB, sanitizing it and putting it into the DOM is wasteful. Further, given the nature of GLPI's frontend we aren't even reusing this loaded data when the user clicks on an event to view/edit it.