### PR TITLE
Use getFromResultSet instead of double fetching in planning

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -1475,10 +1475,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
         if (count($iterator)) {
             foreach ($iterator as $data) {
-                if (
-                    $item->getFromDB($data["id"])
-                    && $item->canViewItem()
-                ) {
+                $item->getFromResultSet($data);
+                if ($item->canViewItem()) {
                     if ($parentitem->getFromDBwithData($item->fields[$parentitem->getForeignKeyField()])) {
                         //not planned
                         if (isset($data['notp_date'])) {

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -587,7 +587,8 @@ trait PlanningEvent
 
         if (count($iterator)) {
             foreach ($iterator as $data) {
-                if ($event_obj->getFromDB($data["id"]) && $event_obj->canViewItem()) {
+                $event_obj->getFromResultSet($data);
+                if ($event_obj->canViewItem()) {
                     $key = $data["begin"]
                       . "$$" . $itemtype
                       . "$$" . $data["id"]
@@ -598,7 +599,7 @@ trait PlanningEvent
                     }
 
                     $url = (!$options['genical'])
-                    ? $event_obj->getFormURLWithID($data['id'])
+                    ? static::getFormURLWithID($data['id'])
                     : $CFG_GLPI["url_base"]
                     . static::getFormURLWithID($data['id'], false);
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1937,54 +1937,53 @@ TWIG, $twig_params);
 
         if (count($iterator)) {
             foreach ($iterator as $data) {
-                if ($task->getFromDB($data["id"])) {
-                    if (isset($data['notp_date'])) {
-                        $data['plan_start_date'] = $data['notp_date'];
-                        $data['plan_end_date'] = $data['notp_edate'];
-                    }
-                    $key = $data["plan_start_date"]
-                      . "$$$" . "ProjectTask"
-                      . "$$$" . $data["id"]
-                      . "$$$" . $who . "$$$" . $whogroup;
-                    $interv[$key]['color']            = $options['color'];
-                    $interv[$key]['event_type_color'] = $options['event_type_color'];
-                    $interv[$key]['itemtype']         = 'ProjectTask';
-                    if (!$options['genical']) {
-                        $interv[$key]["url"] = Project::getFormURLWithID($task->fields['projects_id']);
-                    } else {
-                        $interv[$key]["url"] = $CFG_GLPI["url_base"]
-                                        . Project::getFormURLWithID($task->fields['projects_id'], false);
-                    }
-                    $interv[$key]["ajaxurl"] = $CFG_GLPI["root_doc"] . "/ajax/planning.php"
-                                          . "?action=edit_event_form"
-                                          . "&itemtype=ProjectTask"
-                                          . "&id=" . $data['id'];
-
-                    $interv[$key][$task::getForeignKeyField()] = $data["id"];
-                    $interv[$key]["id"]                        = $data["id"];
-                    $interv[$key]["users_id"]                  = $data["users_id"];
-
-                    if (strcmp($begin, $data["plan_start_date"]) > 0) {
-                        $interv[$key]["begin"] = $begin;
-                    } else {
-                        $interv[$key]["begin"] = $data["plan_start_date"];
-                    }
-
-                    if (strcmp($end, $data["plan_end_date"]) < 0) {
-                        $interv[$key]["end"]   = $end;
-                    } else {
-                        $interv[$key]["end"]   = $data["plan_end_date"];
-                    }
-
-                    $interv[$key]["name"]     = $task->fields["name"];
-                    $interv[$key]["content"]  = $task->fields["content"] !== null
-                    ? RichText::getSafeHtml($task->fields["content"])
-                    : '';
-                    $interv[$key]["status"]   = $task->fields["percent_done"];
-
-                    $ttask->getFromDB($data["id"]);
-                    $interv[$key]["editable"] = $ttask->canUpdateItem();
+                $task->getFromResultSet($data);
+                if (isset($data['notp_date'])) {
+                    $data['plan_start_date'] = $data['notp_date'];
+                    $data['plan_end_date'] = $data['notp_edate'];
                 }
+                $key = $data["plan_start_date"]
+                  . "$$$" . "ProjectTask"
+                  . "$$$" . $data["id"]
+                  . "$$$" . $who . "$$$" . $whogroup;
+                $interv[$key]['color']            = $options['color'];
+                $interv[$key]['event_type_color'] = $options['event_type_color'];
+                $interv[$key]['itemtype']         = 'ProjectTask';
+                if (!$options['genical']) {
+                    $interv[$key]["url"] = Project::getFormURLWithID($task->fields['projects_id']);
+                } else {
+                    $interv[$key]["url"] = $CFG_GLPI["url_base"]
+                                    . Project::getFormURLWithID($task->fields['projects_id'], false);
+                }
+                $interv[$key]["ajaxurl"] = $CFG_GLPI["root_doc"] . "/ajax/planning.php"
+                                      . "?action=edit_event_form"
+                                      . "&itemtype=ProjectTask"
+                                      . "&id=" . $data['id'];
+
+                $interv[$key][$task::getForeignKeyField()] = $data["id"];
+                $interv[$key]["id"]                        = $data["id"];
+                $interv[$key]["users_id"]                  = $data["users_id"];
+
+                if (strcmp($begin, $data["plan_start_date"]) > 0) {
+                    $interv[$key]["begin"] = $begin;
+                } else {
+                    $interv[$key]["begin"] = $data["plan_start_date"];
+                }
+
+                if (strcmp($end, $data["plan_end_date"]) < 0) {
+                    $interv[$key]["end"]   = $end;
+                } else {
+                    $interv[$key]["end"]   = $data["plan_end_date"];
+                }
+
+                $interv[$key]["name"]     = $task->fields["name"];
+                $interv[$key]["content"]  = $task->fields["content"] !== null
+                ? RichText::getSafeHtml($task->fields["content"])
+                : '';
+                $interv[$key]["status"]   = $task->fields["percent_done"];
+
+                $ttask->getFromDB($data["id"]);
+                $interv[$key]["editable"] = $ttask->canUpdateItem();
             }
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Not as impactful as the other PRs related to planning optimizations but still had a little improvement. In several places, every column for a planned itemtype is fetched from the DB, then the ID is used to again load every column for the item from the DB instead of using the `getFromResultSet` function to load the data into the `fields` of an item instance to be able to use instance functions like permission checks.
