### PR TITLE
prevent unconditional find calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The present file will list all changes made to the project; according to the
 - All `CommonGLPI`, `CommonDBTM` parameters now have a native PHP type
 - `KnowbaseItem_Comment` is now final
 - `KnowbaseItem_Revision` is now final
+- `CommonDBTM::find` now requires a non-empty condition
 
 #### Deprecated
 - `CommonITILSatisfaction::showSatisactionForm()`, use `CommonITILSatisfaction::showSatisfactionForm()` instead.

--- a/ajax/webhook.php
+++ b/ajax/webhook.php
@@ -68,15 +68,29 @@ switch ($action) {
     case 'get_items_from_itemtype':
         if (array_key_exists($_POST['itemtype'], Webhook::getSubItemForAssistance())) {
             $object = getItemForItemtype($_POST['itemtype']);
-            $data = $object->find();
+            $itil_type = null;
+            $foreign_key = null;
+            global $DB;
+            $select = [
+                'id',
+                'itemtype',
+                'items_id',
+            ];
+            if ($object instanceof CommonITILTask || $object instanceof CommonITILValidation) {
+                $itil_type = $object::getItilObjectItemType();
+                $foreign_key = getForeignKeyFieldForItemType($itil_type);
+                $select[] = $foreign_key;
+            }
+            $it = $DB->request([
+                'SELECT' => $select,
+                'FROM'   => $object::class,
+            ]);
             $values = [];
-            foreach ($data as $items_id => $items_data) {
+            foreach ($it as $items_data) {
                 if ($object instanceof CommonITILTask || $object instanceof CommonITILValidation) {
-                    $itil_type = $object::getItilObjectItemType();
-                    $foreign_key = getForeignKeyFieldForItemType($itil_type);
-                    $values[$items_id] = $itil_type::getTypeName(0) . " " . $items_data[$foreign_key] . " => " . $object::getTypeName(0) . " " . $items_id;
+                    $values[$items_data['id']] = $itil_type::getTypeName(0) . " " . $items_data[$foreign_key] . " => " . $object::getTypeName(0) . " " . $items_data['id'];
                 } else {
-                    $values[$items_id] = $items_data['itemtype']::getTypeName(0) . " " . $items_data['items_id'] . " => " . $object::getTypeName(0) . " " . $items_id;
+                    $values[$items_data['id']] = $items_data['itemtype']::getTypeName(0) . " " . $items_data['items_id'] . " => " . $object::getTypeName(0) . " " . $items_data['id'];
                 }
             }
             echo Dropdown::showFromArray('items_id', $values, [

--- a/install/migrations/update_9.4.x_to_9.5.0.php
+++ b/install/migrations/update_9.4.x_to_9.5.0.php
@@ -1438,6 +1438,8 @@ HTML,
     /** /Appliances & webapps */
 
     /** update project and itil task templates to tinymce content **/
+
+    /** @var array<class-string<CommonDBTM>, string> $template_types */
     $template_types = [
         'ProjectTaskTemplate' => 'description',
         'TaskTemplate'        => 'content',
@@ -1454,8 +1456,10 @@ HTML,
         );
         $stmt = $DB->prepare($query);
 
-        $template_inst = new $template_type();
-        $templates = $template_inst->find();
+        $templates = $DB->request([
+            'SELECT' => ['id', $fieldname],
+            'FROM'   => $template_type::getTable(),
+        ]);
         foreach ($templates as $template) {
             $new_description = str_replace("\n", '<br>', $template[$fieldname]);
             $stmt->bind_param(

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -591,15 +591,19 @@ class CommonDBTM extends CommonGLPI
     /**
      * Retrieve all items from the database
      *
-     * @param array        $condition WHERE condition used to filter (can be empty to get all)
+     * @param array        $condition WHERE condition used to filter
      * @param array|string $order     ORDER field (can be empty)
      * @param int      $limit     LIMIT sql clause
      *
      * @return array all retrieved data in an associative array by id
      **/
-    public function find($condition = [], $order = [], $limit = null)
+    public function find($condition, $order = [], $limit = null)
     {
         global $DB;
+
+        if (empty($condition)) {
+            throw new InvalidArgumentException('Argument $condition cannot be empty.');
+        }
 
         $criteria = [
             'FROM'   => static::getTable(),

--- a/src/Document.php
+++ b/src/Document.php
@@ -1447,6 +1447,7 @@ class Document extends CommonDBTM implements TreeBrowseInterface
         }
 
         $criteria = [
+            'SELECT' => ['id', 'name'],
             'FROM'   => 'glpi_documentcategories',
             'WHERE'  => [
                 'id' => new QuerySubQuery([
@@ -1511,9 +1512,12 @@ class Document extends CommonDBTM implements TreeBrowseInterface
         $params['rubdoc'] = $p['rubdoc'] ?? 0;
         $params['value'] = $p['value'] ?? 0;
         if ($readonly) {
-            $document = new Document();
-            $doclist = $document->find([]);
-            foreach ($doclist as $doc) {
+            //FIXME This seems wrong. Original code also used `CommonDBTM::find` to get every single document. It doesn't account for the selected value(s), entity, category, or if the dropdown should accept multiple values or not.
+            $it = $DB->request([
+                'SELECT' => ['id', 'name'],
+                'FROM'   => 'glpi_documents',
+            ]);
+            foreach ($it as $doc) {
                 $docvalue[$doc['id']] = $doc['name'];
             }
 

--- a/src/Glpi/Asset/AssetDefinition.php
+++ b/src/Glpi/Asset/AssetDefinition.php
@@ -354,6 +354,8 @@ TWIG, $twig_params);
 
     public function post_addItem()
     {
+        global $DB;
+
         parent::post_addItem();
 
         // Trigger the `onCapacityEnabled` hooks.
@@ -384,8 +386,11 @@ TWIG, $twig_params);
         // add asset in dropdownvisibilities
         $dropdown_visibility = new \DropdownVisibility();
         // Only State type is handled atm, DropdownVisibility is designed to handle other classes
-        $states = (new \State())->find();
-        foreach ($states as $state) {
+        $it = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => 'glpi_states',
+        ]);
+        foreach ($it as $state) {
             if (!$dropdown_visibility->add(
                 [
                     'visible_itemtype' => $this->getCustomObjectClassName(),

--- a/src/Glpi/Console/Marketplace/UpgradeCommand.php
+++ b/src/Glpi/Console/Marketplace/UpgradeCommand.php
@@ -63,6 +63,8 @@ class UpgradeCommand extends AbstractCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        global $DB;
+
         if (!Controller::isCLIAllowed()) {
             $output->writeln("<error>" . __('Access to the marketplace CLI commands is disallowed by the GLPI configuration') . "</error>");
             return self::FAILURE;
@@ -83,13 +85,19 @@ class UpgradeCommand extends AbstractCommand
         $plugins_manager = new Plugin();
         $plugins_api     = new Plugins();
 
-        $local_plugins_data = $plugins_manager->find();
-        $local_versions     = \array_column($local_plugins_data, 'version', 'directory');
-        $active_plugins     = \array_column(
-            \array_filter($local_plugins_data, fn($plugin_data) => $plugin_data['state'] === Plugin::ACTIVATED),
-            'id',
-            'directory'
-        );
+        $it = $DB->request([
+            'SELECT' => ['id', 'directory', 'version', 'state'],
+            'FROM'   => $plugins_manager::getTable(),
+        ]);
+
+        $local_versions     = [];
+        $active_plugins     = [];
+        foreach ($it as $plugin_data) {
+            $local_versions[$plugin_data['directory']] = $plugin_data['version'];
+            if ($plugin_data['state'] === Plugin::ACTIVATED) {
+                $active_plugins[$plugin_data['directory']] = $plugin_data['id'];
+            }
+        }
 
         // Update all plugins sources, to be sure that all plugins have the latest version.
         $updated_plugins = [];

--- a/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TemplateField.php
@@ -150,8 +150,13 @@ final class TemplateField extends AbstractConfigField implements DestinationFiel
 
     private function getTemplateValuesForDropdown(Form $form): array
     {
+        global $DB;
+
         $values = [];
-        $templates = getItemForItemtype($this->itil_template_class)->find();
+        $templates = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => $this->itil_template_class::getTable(),
+        ]);
 
         foreach ($templates as $template) {
             $values[$template['id']] = $template['name'];

--- a/src/Project.php
+++ b/src/Project.php
@@ -1807,6 +1807,7 @@ TWIG, $twig_params);
 
     public static function getKanbanColumns($ID, $column_field = null, $column_ids = [], $get_default = false)
     {
+        global $DB;
         // TODO Make this function only return the card data and leave rendering to Vue components. This will deduplicate the data between display and filters.
         if ($column_field !== 'projectstates_id') {
             return [];
@@ -1827,8 +1828,10 @@ TWIG, $twig_params);
         }
         $items      = self::getDataToDisplayOnKanban($ID, $criteria);
 
-        $projecttasktype = new ProjectTaskType();
-        $alltypes = $projecttasktype->find();
+        $alltypes = iterator_to_array($DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => ProjectTaskType::getTable(),
+        ]), false);
 
         $extracolumns = self::getAllKanbanColumns('projectstates_id', $column_ids, $get_default);
         foreach ($extracolumns as $column_id => $column) {

--- a/tests/functional/CertificateTest.php
+++ b/tests/functional/CertificateTest.php
@@ -180,7 +180,7 @@ class CertificateTest extends DbTestCase
 
     public function testCronCertificate()
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
 
         $this->login();
         $obj = new \Certificate();
@@ -216,21 +216,24 @@ class CertificateTest extends DbTestCase
 
         // check presence of the id in alerts table
         $alert  = new \Alert();
-        $alerts = $alert->find();
-
+        $alerts = $alert->find([
+            'itemtype' => 'Certificate',
+            'items_id' => $id,
+        ]);
         $this->assertCount(1, $alerts);
         $alert_certificate = array_pop($alerts);
-        $this->assertEquals('Certificate', $alert_certificate['itemtype']);
-        $this->assertEquals($id, $alert_certificate['items_id']);
 
         // No new alert if the last one is less than 1 hour old
         $alert_id = $alert_certificate['id'];
         $ret      = $crontask->launch($force, 1, 'certificate');
         $this->assertNotEquals(false, $ret);
-        $alerts   = $alert->find();
+        $alerts   = $DB->request([
+            'SELECT' => ['id', 'itemtype', 'items_id'],
+            'FROM'   => 'glpi_alerts',
+        ]);
 
         $this->assertCount(1, $alerts);
-        $alert_certificate = array_pop($alerts);
+        $alert_certificate = $alerts->current();
         $this->assertEquals('Certificate', $alert_certificate['itemtype']);
         $this->assertEquals($id, $alert_certificate['items_id']);
         $this->assertEquals($alert_id, $alert_certificate['id']);
@@ -243,10 +246,13 @@ class CertificateTest extends DbTestCase
         ]);
         $ret      = $crontask->launch($force, 1, 'certificate');
         $this->assertNotEquals(false, $ret);
-        $alerts   = $alert->find();
+        $alerts   = $DB->request([
+            'SELECT' => ['id', 'itemtype', 'items_id'],
+            'FROM'   => 'glpi_alerts',
+        ]);
 
         $this->assertCount(1, $alerts);
-        $alert_certificate = array_pop($alerts);
+        $alert_certificate = $alerts->current();
         $this->assertEquals('Certificate', $alert_certificate['itemtype']);
         $this->assertEquals($id, $alert_certificate['items_id']);
         $this->assertEquals($alert_id + 1, $alert_certificate['id']);

--- a/tests/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/tests/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -427,10 +427,14 @@ final class DefaultDataManagerTest extends DbTestCase
 
     public function testsTilesAreAddedAfterInstallation(): void
     {
+        global $DB;
         $this->assertEquals(6, countElementsInTable(Item_Tile::getTable()));
 
         // Default tiles must be attached to the root entity
-        $profile_tiles = (new Item_Tile())->find([]);
+        $profile_tiles = $DB->request([
+            'SELECT' => ['itemtype_item', 'items_id_item'],
+            'FROM' => Item_Tile::getTable(),
+        ]);
         foreach ($profile_tiles as $row) {
             $this->assertEquals(Entity::class, $row['itemtype_item']);
             $this->assertEquals(0, $row['items_id_item']);
@@ -453,18 +457,23 @@ final class DefaultDataManagerTest extends DbTestCase
 
     public function testDefaultTilesAreValid(): void
     {
+        global $DB;
         // Arrange: load valid illustration names
         $illustration_manager = new IllustrationManager();
         $valid_icons = $illustration_manager->getAllIconsIds();
 
         // Act: load the default tiles
-        $profile_tiles = (new Item_Tile())->find([]);
-        $tiles = array_map(function ($row) {
+        $profile_tiles = $DB->request([
+            'SELECT' => ['itemtype_tile', 'items_id_tile'],
+            'FROM' => Item_Tile::getTable(),
+        ]);
+        $tiles = [];
+        foreach ($profile_tiles as $row) {
             $itemtype = $row['itemtype_tile'];
             $tile = new $itemtype();
             $tile->getFromDb($row['items_id_tile']);
-            return $tile;
-        }, $profile_tiles);
+            $tiles[] = $tile;
+        }
 
         // Assert: there should be at least one tile and each tile should have a
         // valid title, description, illustration and link

--- a/tests/functional/Glpi/Inventory/Assets/BatteryTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/BatteryTest.php
@@ -300,8 +300,7 @@ class BatteryTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 batteries
-        $batteries = $device_battery->find();
-        $this->assertCount(3, $batteries);
+        $this->assertEquals(3, countElementsInTable(\DeviceBattery::getTable()));
 
         //we still have 3 batteries items linked to the computer
         $batteries = $item_battery->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -343,8 +342,7 @@ class BatteryTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 batteries
-        $batteries = $device_battery->find();
-        $this->assertCount(3, $batteries);
+        $this->assertEquals(3, countElementsInTable(\DeviceBattery::getTable()));
 
         //we now have 2 batteries linked to computer only
         $batteries = $item_battery->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/CameraTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/CameraTest.php
@@ -246,8 +246,7 @@ class CameraTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 cameras
-        $cams = $device_cam->find();
-        $this->assertCount(3, $cams);
+        $this->assertEquals(3, countElementsInTable(\DeviceCamera::getTable()));
 
         //we still have 3 cameras items linked to the computer
         $cams = $item_cam->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -285,8 +284,7 @@ class CameraTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 cameras
-        $cams = $device_cam->find();
-        $this->assertCount(3, $cams);
+        $this->assertEquals(3, countElementsInTable(\DeviceCamera::getTable()));
 
         //we now have 2 cameras linked to computer only
         $cams = $item_cam->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/ControllerTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ControllerTest.php
@@ -256,8 +256,7 @@ class ControllerTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 controllers
-        $controllers = $device_control->find();
-        $this->assertCount(3, $controllers);
+        $this->assertEquals(3, countElementsInTable(\DeviceControl::getTable()));
 
         //we still have 3 controllers items linked to the computer
         $controllers = $item_control->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -302,8 +301,7 @@ class ControllerTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 controllers
-        $controllers = $device_control->find();
-        $this->assertCount(3, $controllers);
+        $this->assertEquals(3, countElementsInTable(\DeviceControl::getTable()));
 
         //we now have 2 controllers linked to computer only
         $controllers = $item_control->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/DriveTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/DriveTest.php
@@ -280,8 +280,7 @@ class DriveTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 drives
-        $drives = $device_drive->find();
-        $this->assertCount(3, $drives);
+        $this->assertEquals(3, countElementsInTable(\DeviceDrive::getTable()));
 
         //we still have 3 drives items linked to the computer
         $drives = $item_drive->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -324,8 +323,7 @@ class DriveTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 drives
-        $drives = $device_drive->find();
-        $this->assertCount(3, $drives);
+        $this->assertEquals(3, countElementsInTable(\DeviceDrive::getTable()));
 
         //we now have 2 drives linked to computer only
         $drives = $item_drive->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -473,8 +471,7 @@ class DriveTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 harddrives
-        $harddrives = $device_hdd->find();
-        $this->assertCount(3, $harddrives);
+        $this->assertEquals(3, countElementsInTable(\DeviceHardDrive::getTable()));
 
         //we still have 3 harddrives items linked to the computer
         $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -518,8 +515,7 @@ class DriveTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 harddrives
-        $harddrives = $device_hdd->find();
-        $this->assertCount(3, $harddrives);
+        $this->assertEquals(3, countElementsInTable(\DeviceHardDrive::getTable()));
 
         //we now have 2 harddrives linked to computer only
         $harddrives = $item_hdd->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/FirmwareTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/FirmwareTest.php
@@ -179,8 +179,7 @@ class FirmwareTest extends AbstractInventoryAsset
         $agent = $agents->current();
 
         //we still have 2 firmwares + 1 bios
-        $fws = $device_fw->find();
-        $this->assertCount(3, $fws);
+        $this->assertEquals(3, countElementsInTable(\DeviceFirmware::getTable()));
 
         //we still have 2 firmwares items linked to the computer
         $fws = $item_fw->find(['itemtype' => 'Computer', 'items_id' => $agent['items_id']]);
@@ -311,8 +310,7 @@ class FirmwareTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 firmwares + 1 bios
-        $fws = $device_fw->find();
-        $this->assertCount(3 + 1, $fws);
+        $this->assertEquals(3 + 1, countElementsInTable(\DeviceFirmware::getTable()));
 
         //we still have 3 firmwares items linked to the computer
         $fws = $item_fw->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -352,8 +350,7 @@ class FirmwareTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 firmwares + 1 bios
-        $fws = $device_fw->find();
-        $this->assertCount(3 + 1, $fws);
+        $this->assertEquals(3 + 1, countElementsInTable(\DeviceFirmware::getTable()));
 
         //we now have 2 firmwares linked to computer only
         $fws = $item_fw->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/GraphicCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/GraphicCardTest.php
@@ -218,8 +218,7 @@ class GraphicCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 graphic cards
-        $gcs = $device_gc->find();
-        $this->assertCount(3, $gcs);
+        $this->assertEquals(3, countElementsInTable(\DeviceGraphicCard::getTable()));
 
         //we still have 3 graphic cards items linked to the computer
         $gcs = $item_gc->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -258,8 +257,7 @@ class GraphicCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 graphic cards
-        $gcs = $device_gc->find();
-        $this->assertCount(3, $gcs);
+        $this->assertEquals(3, countElementsInTable(\DeviceGraphicCard::getTable()));
 
         //we now have 2 graphic cards linked to computer only
         $gcs = $item_gc->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/MemoryTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/MemoryTest.php
@@ -242,8 +242,7 @@ class MemoryTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 2 memory devices
-        $memories = $device_mem->find();
-        $this->assertCount(2, $memories);
+        $this->assertEquals(2, countElementsInTable(\DeviceMemory::getTable()));
 
         //and one memory model
         $this->assertSame(
@@ -314,7 +313,8 @@ class MemoryTest extends AbstractInventoryAsset
 
     public function testMemoryOneManufactuerOneNot()
     {
-        $device_mem = new \DeviceMemory();
+        global $DB;
+
         $item_mem = new \Item_DeviceMemory();
 
         $json_str = <<<JSON
@@ -375,21 +375,26 @@ JSON;
             print_r($memories, true)
         );
 
-        $manufacturer = new \Manufacturer();
-        $manufacturers = $manufacturer->find();
+        $manufacturers = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => \Manufacturer::getTable(),
+        ]);
         //2 manufacturers ine db: "Hynix" from current inv, "My Manufacturer" from bootstrap data
         $this->assertCount(
             2,
             $manufacturers,
-            print_r($manufacturers, true)
+            print_r(iterator_to_array($manufacturers, false), true)
         );
 
         //we have 2 memory devices: one for Hynix, one without manufacturer
-        $memories = $device_mem->find();
+        $memories = $DB->request([
+            'SELECT' => ['id', 'designation', 'manufacturers_id'],
+            'FROM'   => \DeviceMemory::getTable(),
+        ]);
         $this->assertCount(
             2,
             $memories,
-            print_r($memories, true)
+            print_r(iterator_to_array($memories, false), true)
         );
     }
 }

--- a/tests/functional/Glpi/Inventory/Assets/NetworkCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkCardTest.php
@@ -889,8 +889,7 @@ class NetworkCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 network cards
-        $cards = $device_net->find();
-        $this->assertCount(3, $cards);
+        $this->assertEquals(3, countElementsInTable(\DeviceNetworkCard::getTable()));
 
         //we still have 3 network cards items linked to the computer
         $cards = $item_net->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -953,8 +952,7 @@ class NetworkCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 network cards
-        $cards = $device_net->find();
-        $this->assertCount(3, $cards);
+        $this->assertEquals(3, countElementsInTable(\DeviceNetworkCard::getTable()));
 
         //we now have 2 network cards linked to computer only
         $cards = $item_net->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Inventory\Asset;
 
+use Glpi\DBAL\QueryExpression;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Converter;
 use Glpi\Inventory\Inventory;
@@ -3044,6 +3045,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
 
     public function testRuleMatchedLog()
     {
+        global $DB;
         $xml_source = '<?xml version="1.0" encoding="UTF-8"?>
 <REQUEST>
   <CONTENT>
@@ -3127,8 +3129,8 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
         $this->assertSame('DFGKJ6545684SDF', $networkEquipment->fields['serial']);
 
         $unmanaged = new \Unmanaged();
-        $found_unmanaged = $unmanaged->find();
-        $this->assertCount(1, $found_unmanaged);
+        $found_unmanaged = $unmanaged->find([new QueryExpression('true')]);
+        $this->assertEquals(1, countElementsInTable(\Unmanaged::getTable()));
 
         $rulematchedLog = new \RuleMatchedLog();
         $found_rulematchedLog = $rulematchedLog->find(
@@ -3143,7 +3145,7 @@ Compiled Wed 25-Jan-23 16:15 by mcpre</COMMENTS>
         $inventory = $this->doInventory($xml_source, true);
 
         $unmanaged = new \Unmanaged();
-        $found_unmanaged = $unmanaged->find();
+        $found_unmanaged = $unmanaged->find([new QueryExpression('true')]);
         //get only one RuleMatchedLog
         $this->assertCount(1, $found_unmanaged);
 

--- a/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentUpdateTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkEquipmentUpdateTest.php
@@ -185,7 +185,6 @@ Compiled Fri 26-Mar-10 09:14 by prod_rel_team</DESCRIPTION>
         new Inventory($data);
         $CFG_GLPI["is_contact_autoupdate"] = 1; //reset to default
 
-        $found = $networkEquipment->find();
         $this->assertCount(1, $networkEquipment->find(['name' => 'switchr2d2']));
     }
 

--- a/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -1399,9 +1399,8 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
     {
         global $CFG_GLPI;
 
-        //checks there are no unmanageds
         $unmanaged = new \Unmanaged();
-        $this->assertCount(0, $unmanaged->find());
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
 
         //create a network equipment with 00:01:23:45:67:89 MAC
         $equipment1 = new \NetworkEquipment();
@@ -1445,7 +1444,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         );
 
         //8 connections on port, but one related to existing equipment
-        $this->assertCount(7, $unmanaged->find());
+        $this->assertEquals(7, countElementsInTable(\Unmanaged::getTable()));
     }
 
     public function testNetworkEquipmentsNoConnections()
@@ -1460,8 +1459,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         global $CFG_GLPI;
 
         //checks there are no unmanageds
-        $unmanaged = new \Unmanaged();
-        $this->assertCount(0, $unmanaged->find());
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
 
         // Import the network equipment
         $xml_source = file_get_contents(FIXTURE_DIR . '/inventories/connected_switch.xml');
@@ -1485,16 +1483,16 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         );
 
         //still no unmanageds
-        $this->assertCount(0, $unmanaged->find());
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
     }
 
     public function testNetworkEquipmentsConnectionsConverted(): void
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
 
         //checks there are no unmanageds
         $unmanaged = new \Unmanaged();
-        $this->assertCount(0, $unmanaged->find());
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
 
         // Import the network equipment
         $xml_source = file_get_contents(FIXTURE_DIR . '/inventories/connected_switch.xml');
@@ -1518,10 +1516,10 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         );
 
         //8 connections on port + one hub
-        $this->assertCount(9, $unmanaged->find());
+        $this->assertEquals(9, countElementsInTable(\Unmanaged::getTable()));
 
         $port = new \NetworkPort();
-        $this->assertTrue($port->getFromDBByCrit(['itemtype' => $unmanaged->getType(), 'mac' => '00:01:23:45:67:89']));
+        $this->assertTrue($port->getFromDBByCrit(['itemtype' => \Unmanaged::class, 'mac' => '00:01:23:45:67:89']));
         $this->assertTrue($unmanaged->getFromDB($port->fields['items_id']));
 
         //convert to NetworkEquipment
@@ -1538,12 +1536,15 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         \Unmanaged::processMassiveActionsForOneItemtype($ma, $unmanaged, [$unmanaged->fields['id']]);
 
         //8 connections on port + one hub - 1 converted
-        $unmanageds = $unmanaged->find();
+        $unmanageds = $DB->request([
+            'SELECT' => 'id',
+            'FROM' => \Unmanaged::getTable()
+        ]);
         $this->assertCount(8, $unmanageds);
         foreach ($unmanageds as $toremove) {
             $this->assertTrue($unmanaged->delete(['id' => $toremove['id']], true, false));
         }
-        $this->assertCount(0, $unmanaged->find());
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
 
         // Import the network equipment again
         $xml_source = file_get_contents(FIXTURE_DIR . '/inventories/connected_switch.xml');
@@ -1562,7 +1563,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         $this->assertSame([], $inventory->getErrors());
 
         //8 connections on port, but one related to existing equipment
-        $this->assertCount(7, $unmanaged->find());
+        $this->assertEquals(7, countElementsInTable(\Unmanaged::getTable()));
     }
 
     public function testDefaultInstantiationType()

--- a/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/NetworkPortTest.php
@@ -1538,7 +1538,7 @@ Compiled Mon 23-Jul-12 13:22 by prod_rel_team</COMMENTS>
         //8 connections on port + one hub - 1 converted
         $unmanageds = $DB->request([
             'SELECT' => 'id',
-            'FROM' => \Unmanaged::getTable()
+            'FROM' => \Unmanaged::getTable(),
         ]);
         $this->assertCount(8, $unmanageds);
         foreach ($unmanageds as $toremove) {

--- a/tests/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1035,8 +1035,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
 
         $this->doInventory($xml_source, true);
 
-        $list = $os->find();
-        $this->assertCount(2, $list);
+        $this->assertEquals(2, countElementsInTable(\OperatingSystem::getTable()));
 
         //check that OS is linked to computer, and is now dynamic
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -1088,8 +1087,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //We now have 2 operating systems
-        $list = $os->find();
-        $this->assertCount(3, $list);
+        $this->assertEquals(3, countElementsInTable(\OperatingSystem::getTable()));
 
         //but still only one linked to computer
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -1157,8 +1155,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertTrue($computer->getFromDB($computers_id));
 
         //check found OS
-        $list = $os->find();
-        $this->assertCount(2, $list);
+        $this->assertEquals(2, countElementsInTable(\OperatingSystem::getTable()));
 
         //check found item_OS
         $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/PowerSupplyTest.php
@@ -145,8 +145,7 @@ class PowerSupplyTest extends AbstractInventoryAsset
         $computers_id = $computer->fields['id'];
 
         //we have 1 power supply
-        $pws = $device_ps->find();
-        $this->assertCount(1, $pws);
+        $this->assertEquals(1, countElementsInTable(\DevicePowerSupply::getTable()));
 
         //we have 1 power supply items linked to the computer
         $pws = $item_ps->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/ProcessorTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/ProcessorTest.php
@@ -257,8 +257,7 @@ class ProcessorTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 processors
-        $cpus = $device_proc->find();
-        $this->assertCount(3, $cpus);
+        $this->assertEquals(3, countElementsInTable(\DeviceProcessor::getTable()));
 
         //we still have 3 processors items linked to the computer
         $cpus = $item_proc->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -298,8 +297,7 @@ class ProcessorTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 processors
-        $cpus = $device_proc->find();
-        $this->assertCount(3, $cpus);
+        $this->assertEquals(3, countElementsInTable(\DeviceProcessor::getTable()));
 
         //we now have 2 processors linked to computer only
         $cpus = $item_proc->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/RemoteManagementTest.php
@@ -273,20 +273,16 @@ class RemoteManagementTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 remote managements
-        $mgmts = $mgmt->find();
-        $this->assertCount(3, $mgmts);
+        $this->assertEquals(3, countElementsInTable(\Item_RemoteManagement::getTable()));
 
         //we still have 3 remote managements items linked to the computer
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
-        $this->assertCount(3, $mgmts);
+        $this->assertEquals(3, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id]));
 
         //remote managements present in the inventory source are now dynamic
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]);
-        $this->assertCount(2, $mgmts);
+        $this->assertEquals(2, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]));
 
         //remote management not present in the inventory is still not dynamic
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 0]);
-        $this->assertCount(1, $mgmts);
+        $this->assertEquals(1, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 0]));
 
         //Redo inventory, but with removed "anydesk" remote managements
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -311,26 +307,20 @@ class RemoteManagementTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we now have only 2 remote managements
-        $mgmts = $mgmt->find();
-        $this->assertCount(2, $mgmts);
+        $this->assertEquals(2, countElementsInTable(\Item_RemoteManagement::getTable()));
 
         //we now have 2 remote managements linked to computer only
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
-        $this->assertCount(2, $mgmts);
+        $this->assertEquals(2, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id]));
 
         //remote management present in the inventory source is still dynamic
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]);
-        $this->assertCount(1, $mgmts);
+        $this->assertEquals(1, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 1]));
 
         //remote management not present in the inventory is still not dynamic
-        $mgmts = $mgmt->find(['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 0]);
-        $this->assertCount(1, $mgmts);
+        $this->assertEquals(1, countElementsInTable(\Item_RemoteManagement::getTable(), ['itemtype' => 'Computer', 'items_id' => $computers_id, 'is_dynamic' => 0]));
     }
 
     public function testNoMoreRemoteManagement()
     {
-        $mgmt = new \Item_RemoteManagement();
-
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
   <CONTENT>
@@ -354,8 +344,7 @@ class RemoteManagementTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we have 1 remote managements (anydesk / abcdyz) linked to computer
-        $mgmts = $mgmt->find();
-        $this->assertCount(1, $mgmts);
+        $this->assertEquals(1, countElementsInTable(\Item_RemoteManagement::getTable()));
 
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 <REQUEST>
@@ -375,7 +364,6 @@ class RemoteManagementTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we have no remote managements linked to computer
-        $mgmts = $mgmt->find();
-        $this->assertCount(0, $mgmts);
+        $this->assertCount(0, countElementsInTable(\Item_RemoteManagement::getTable()));
     }
 }

--- a/tests/functional/Glpi/Inventory/Assets/SensorTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SensorTest.php
@@ -253,8 +253,7 @@ class SensorTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 sensors (+ 1 from bootstrap)
-        $sensors = $device_sensor->find();
-        $this->assertCount(3 + 1, $sensors);
+        $this->assertEquals(3 + 1, countElementsInTable(\DeviceSensor::getTable()));
 
         //we still have 3 sensors items linked to the computer
         $sensors = $item_sensor->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -294,8 +293,7 @@ class SensorTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 sensors (+1 from bootstrap)
-        $sensors = $device_sensor->find();
-        $this->assertCount(3 + 1, $sensors);
+        $this->assertEquals(3 + 1, countElementsInTable(\DeviceSensor::getTable()));
 
         //we now have 2 sensors linked to computer only
         $sensors = $item_sensor->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/SoftwareTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SoftwareTest.php
@@ -1871,7 +1871,7 @@ JSON;
 
         //check there is no locked field
         $lockedfields = new \Lockedfield();
-        $this->assertEquals([], $lockedfields->find());
+        $this->assertEquals(0, countElementsInTable(\Lockedfield::getTable()));
 
         //change OS by hand
         $new_osid = $os->add([
@@ -1892,7 +1892,9 @@ JSON;
         );
 
         //check Item_OperatingSystem has been locked
-        $locks = $lockedfields->find();
+        $locks = $lockedfields->find([
+            'field' => 'operatingsystems_id',
+        ]);
         $this->assertCount(1, $locks);
         $lock = array_pop($locks);
         $this->assertSame('operatingsystems_id', $lock['field']);

--- a/tests/functional/Glpi/Inventory/Assets/SoundCardTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/SoundCardTest.php
@@ -213,8 +213,7 @@ class SoundCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 sound cards
-        $sounds = $device_sound->find();
-        $this->assertCount(3, $sounds);
+        $this->assertEquals(3, countElementsInTable(\DeviceSoundCard::getTable()));
 
         //we still have 3 sound cards items linked to the computer
         $sounds = $item_sound->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
@@ -252,8 +251,7 @@ class SoundCardTest extends AbstractInventoryAsset
         $this->doInventory($xml_source, true);
 
         //we still have 3 sound cards
-        $sounds = $device_sound->find();
-        $this->assertCount(3, $sounds);
+        $this->assertEquals(3, countElementsInTable(\DeviceSoundCard::getTable()));
 
         //we now have 2 sound cards linked to computer only
         $sounds = $item_sound->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);

--- a/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/UnmanagedTest.php
@@ -734,9 +734,7 @@ class UnmanagedTest extends AbstractInventoryAsset
         $inventory->doInventory($xml_source, true);
 
         //no Unmanaged create
-        $unmanaged = new \Unmanaged();
-        $found = $unmanaged->find();
-        $this->assertCount(0, $found);
+        $this->assertEquals(0, countElementsInTable(\Unmanaged::getTable()));
 
         //reload computer
         $this->assertTrue($computer->getFromDB($computers_id));

--- a/tests/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/VirtualMachineTest.php
@@ -257,8 +257,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $esx_id_first);
 
         //always one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get ComputervirtualMachine
         $vm_first = new \ItemVirtualMachine();
@@ -388,8 +387,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertSame($esx_id_second, $esx_id_first);
 
         //always one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get ComputervirtualMachine
         $vm_second = new \ItemVirtualMachine();
@@ -478,8 +476,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $esx_id_first);
 
         //get two VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(2, $vm->find());
+        $this->assertEquals(2, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get first ComputervirtualMachine -> not deleted / purged
         $firlst_vm = new \ItemVirtualMachine();
@@ -553,8 +550,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $inventory = $this->doInventory($xml_source, true);
 
         //now one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get first ComputervirtualMachine -> not deleted / purged
         $firlst_vm = new \ItemVirtualMachine();
@@ -702,8 +698,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $esx_id_first);
 
         //get three VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(3, $vm->find());
+        $this->assertEquals(3, countElementsInTable(\ItemVirtualMachine::getTable()));
 
 
         //get related computer with fe040942-926a-e895-13f9-a37fc3607c14 -> exist
@@ -735,8 +730,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $id_first);
 
         //one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get ComputervirtualMachine
         $vm = new \ItemVirtualMachine();
@@ -759,8 +753,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertSame($id_second, $id_first);
 
         //VM still present
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get ComputervirtualMachine
         $vm = new \ItemVirtualMachine();
@@ -781,8 +774,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertSame($id_second, $id_first);
 
         //no VM left
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(0, $vm->find());
+        $this->assertEquals(0, countElementsInTable(\ItemVirtualMachine::getTable()));
     }
 
 
@@ -844,8 +836,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $esx_id);
 
         //get one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get related ComputervirtualMachine
         $firlst_vm = new \ItemVirtualMachine();
@@ -873,8 +864,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->assertGreaterThan(0, $id_first);
 
         //one VM
-        $vm = new \ItemVirtualMachine();
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         //get ComputervirtualMachine
         $vm = new \ItemVirtualMachine();
@@ -891,7 +881,7 @@ class VirtualMachineTest extends AbstractInventoryAsset
         $this->doInventory($source);
 
         //still one VM
-        $this->assertCount(1, $vm->find());
+        $this->assertEquals(1, countElementsInTable(\ItemVirtualMachine::getTable()));
 
         $this->assertTrue($vm->getFromDBByCrit([
             'uuid'     => '420904fe-6a92-95e8-13f9-a37fc3607c14',

--- a/tests/functional/Glpi/Inventory/GenericAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericAssetInventoryTest.php
@@ -96,9 +96,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
         $this->assertGreaterThan(0, $agent['items_id']);
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(1, $found);
+        $this->assertEquals(1, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -886,9 +884,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
         $assets_id = $asset->getID();
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(1, $found);
+        $this->assertEquals(1, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -1007,9 +1003,7 @@ class GenericAssetInventoryTest extends InventoryTestCase
         $assets_id = $asset->getID();
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(3, $found);
+        $this->assertEquals(3, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),

--- a/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
@@ -445,9 +445,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->assertSame($expecteds[$unmanaged['name']], $unmanaged['sysdescr']);
         }
 
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(6, $found);//1 equipment, 5 unmanageds
+        $this->assertEquals(6, countElementsInTable(\RuleMatchedLog::getTable()));//1 equipment, 5 unmanageds
 
         $unmanaged_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),

--- a/tests/functional/Glpi/Inventory/InventoryTest.php
+++ b/tests/functional/Glpi/Inventory/InventoryTest.php
@@ -1159,9 +1159,7 @@ class InventoryTest extends InventoryTestCase
         $this->checkComputer1Batteries($computer);
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(3, $found);
+        $this->assertEquals(3, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -1230,8 +1228,10 @@ class InventoryTest extends InventoryTestCase
         $this->assertSame($agenttype['id'], $agent['agenttypes_id']);
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $mrules_found = $mlogs->find();
+        $mrules_found = $DB->request([
+            'SELECT' => ['id'],
+            'FROM' => \RuleMatchedLog::getTable(),
+        ]);
         $this->assertCount(2, $mrules_found);
 
         $mrules_criteria = [
@@ -1884,8 +1884,8 @@ class InventoryTest extends InventoryTestCase
 
         //check matchedlogs
         $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find(['NOT' => ['id' => array_keys($mrules_found)]]);
-        $mrules_criteria['WHERE'] = ['NOT' => [\RuleMatchedLog::getTable() . '.id' => array_keys($mrules_found)]];
+        $found = $mlogs->find(['NOT' => ['id' => array_column($mrules_found, 'id')]]);
+        $mrules_criteria['WHERE'] = ['NOT' => [\RuleMatchedLog::getTable() . '.id' => array_column($mrules_found, 'id')]];
         $this->assertCount(3, $found);
 
         $monitor_criteria = $mrules_criteria;
@@ -2219,9 +2219,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(6, $found);//1 equipment, 5 unmanageds
+        $this->assertEquals(6, countElementsInTable(\RuleMatchedLog::getTable()));//1 equipment, 5 unmanageds
 
         $mrules_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -2721,9 +2719,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }*/
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(48, $found);
+        $this->assertEquals(48, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $mrules_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -2874,9 +2870,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(2, $found);
+        $this->assertEquals(2, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $mrules_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -2900,6 +2894,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
             $this->assertSame(Request::INVENT_QUERY, $neteq['method']);
         }
     }
+
     public function testImportNetworkEquipmentMultiConnections()
     {
         $json = json_decode(file_get_contents(self::INV_FIXTURES . 'networkequipment_3.json'));
@@ -3546,9 +3541,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(61, $found);
+        $this->assertEquals(61, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $mrules_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -3929,9 +3922,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         }
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount($expected_eq_count + count($unmanageds), $found);
+        $this->assertEquals($expected_eq_count + count($unmanageds), countElementsInTable(\RuleMatchedLog::getTable()));
 
         $mrules_criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -4471,9 +4462,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertEquals($expected, $result);
 
         //check no matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(0, $found);
+        $this->assertEquals(0, countElementsInTable(\RuleMatchedLog::getTable()));
 
         //test inventory from refused equipment, will be accepted since rules has been reset ;)
         $refused = new \RefusedEquipment();
@@ -4507,9 +4496,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame('glpixps', $computer->fields['name']);
 
         //check no matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(3, $found);
+        $this->assertEquals(3, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -5342,9 +5329,7 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertGreaterThan(0, $agent['items_id']);
 
         //check matchedlogs
-        $mlogs = new \RuleMatchedLog();
-        $found = $mlogs->find();
-        $this->assertCount(1, $found);
+        $this->assertEquals(1, countElementsInTable(\RuleMatchedLog::getTable()));
 
         $criteria = [
             'FROM' => \RuleMatchedLog::getTable(),
@@ -8603,8 +8588,7 @@ JSON;
         $this->assertCount(1, $nports);
         $nport_ref = $nports->current();
         $this->assertSame('2', $nport_ref['ifinternalstatus']);
-        $netname = new \NetworkName();
-        $this->assertCount(0, $netname->find());
+        $this->assertEquals(0, countElementsInTable(\NetworkName::getTable()));
 
         //make partial, change vpn status, and redo inventory
         $json = json_decode($json_str);
@@ -8835,7 +8819,7 @@ JSON;
             ])
         );
         $ip = new \IPAddress();
-        $this->assertCount(1, $ip->find(), 'More than one IP found :/');
+        $this->assertEquals(1, countElementsInTable(\IPAddress::getTable()), 'More than one IP found :/');
         $this->assertTrue(
             $ip->getFromDBByCrit([
                 'itemtype' => $netname::getType(),
@@ -8875,7 +8859,7 @@ JSON;
             ])
         );
         $ip = new \IPAddress();
-        $this->assertCount(1, $ip->find(), 'More than one IP found :/');
+        $this->assertEquals(1, countElementsInTable(\IPAddress::getTable()), 'More than one IP found :/');
         $this->assertTrue(
             $ip->getFromDBByCrit([
                 'itemtype' => $netname::getType(),
@@ -8987,7 +8971,7 @@ JSON;
             ])
         );
         $ip = new \IPAddress();
-        $this->assertCount(1, $ip->find(), 'More than one IP found :/');
+        $this->assertEquals(1, countElementsInTable(\IPAddress::getTable()), 'More than one IP found :/');
         $this->assertTrue(
             $ip->getFromDBByCrit([
                 'itemtype' => $netname::getType(),
@@ -9028,7 +9012,7 @@ JSON;
             ])
         );
         $ip = new \IPAddress();
-        $this->assertCount(1, $ip->find(), 'More than one IP found :/');
+        $this->assertEquals(1, countElementsInTable(\IPAddress::getTable()), 'More than one IP found :/');
         $this->assertTrue(
             $ip->getFromDBByCrit([
                 'itemtype' => $netname::getType(),
@@ -9590,7 +9574,7 @@ JSON;
             'name' => 'New location from test',
         ]);
         $this->assertGreaterThan(0, $locations_id);
-        $count_locations = count($location->find());
+        $count_locations = countElementsInTable(\Location::getTable());
 
         $rule = new \Rule();
         $input = [
@@ -9668,7 +9652,7 @@ JSON;
         $this->assertTrue($neteq->getFromDBByCrit(['serial' => 'SSI1912014B']));
         $this->assertSame($locations_id, $neteq->fields['locations_id']);
         //check no location has been added
-        $this->assertCount($count_locations, $location->find());
+        $this->assertEquals($count_locations, countElementsInTable(\Location::getTable()));
     }
 
     public function testRuleLocationStackedEquipment(): void
@@ -9680,7 +9664,7 @@ JSON;
             'name' => 'New location from test',
         ]);
         $this->assertGreaterThan(0, $locations_id);
-        $count_locations = count($location->find());
+        $count_locations = countElementsInTable(\Location::getTable());
 
         $rule = new \Rule();
         $input = [
@@ -9729,7 +9713,7 @@ JSON;
         }
 
         //check no location has been added
-        $this->assertCount($count_locations, $location->find());
+        $this->assertEquals($count_locations, countElementsInTable(\Location::getTable()));
     }
 
     public function testManufacturersRegexpRules()

--- a/tests/functional/NetworkPortConnectionLogTest.php
+++ b/tests/functional/NetworkPortConnectionLogTest.php
@@ -89,12 +89,12 @@ class NetworkPortConnectionLogTest extends DbTestCase
 
         //check connection log has been created
         $connection_log = new \NetworkPortConnectionLog();
-        $logs = $connection_log->find();
+        $logs = $connection_log->find([
+            'connected' => 1,
+            'networkports_id_source' => $ports_id_1,
+            'networkports_id_destination' => $ports_id_2,
+        ]);
         $this->assertCount(1, $logs);
-        $log = array_pop($logs);
-        $this->assertSame(1, $log['connected']);
-        $this->assertSame($ports_id_1, $log['networkports_id_source']);
-        $this->assertSame($ports_id_2, $log['networkports_id_destination']);
 
         //check for display
         ob_start();

--- a/tests/functional/NotificationTargetTest.php
+++ b/tests/functional/NotificationTargetTest.php
@@ -653,16 +653,20 @@ class NotificationTargetTest extends DbTestCase
 
         $this->login();
 
-        $notification = new Notification();
-        $notifications = $notification->find();
+        $notifications = $DB->request([
+            'SELECT' => ['id', 'itemtype', 'event'],
+            'FROM' => Notification::getTable(),
+        ]);
 
         foreach ($notifications as $notification) {
             // Ensure that there is at least one default target
             $iterator = $DB->request([
+                'COUNT' => 'cpt',
                 'FROM' => NotificationTarget::getTable(),
                 'WHERE' => ['notifications_id' => $notification['id']],
+                'LIMIT' => 1,
             ]);
-            $this->assertGreaterThan(0, count($iterator));
+            $this->assertGreaterThan(0, $iterator->current()['cpt']);
 
             // Ensure that the Administrator is one of the default targets, unless it is not a valid target
             // for the current notification.

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -943,9 +943,14 @@ HTML,
                 ],
             ]);
 
-            // Validate notification queue size
-            $queue = (new QueuedNotification())->find();
-            $emails = array_column($queue, 'recipient');
+            $queue = $DB->request([
+                'SELECT' => ['recipient'],
+                'FROM' => QueuedNotification::getTable(),
+            ]);
+            $emails = [];
+            foreach ($queue as $data) {
+                $emails[] = $data['recipient'];
+            }
             sort($emails);
             sort($expected_queue);
             $this->assertEquals($expected_queue, $emails);

--- a/tests/functional/ReservationTest.php
+++ b/tests/functional/ReservationTest.php
@@ -117,7 +117,7 @@ class ReservationTest extends DbTestCase
             "entities_id" => 0,
         ]);
         $reservation = new \Reservation();
-        $this->assertEquals(0, count($reservation->find()));
+        $this->assertEquals(0, countElementsInTable(\Reservation::getTable()));
 
         \Reservation::handleAddForm([
             "itemtype"  => "Computer",
@@ -138,7 +138,7 @@ class ReservationTest extends DbTestCase
             "users_id"  => getItemByTypeName('User', TU_USER, true),
             "comment"   => "",
         ]);
-        $this->assertEquals(5, count($reservation->find()));
+        $this->assertEquals(5, countElementsInTable(\Reservation::getTable()));
     }
 
     public static function dataAddReservationTest(): array
@@ -189,15 +189,17 @@ class ReservationTest extends DbTestCase
 
     public function testDeleteRecurrentReservation(): void
     {
+        global $DB;
         self::testAddRecurrentReservation();
         $reservation = new \Reservation();
-        $this->assertCount(5, $reservation->find());
-        foreach ($reservation->find() as $res) {
-            $firstres = $res;
-            break;
-        }
+        $reservations = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => \Reservation::getTable(),
+        ]);
+        $this->assertCount(5, $reservations);
+        $firstres = $reservations->current();
         $reservation->delete($firstres + ['_delete_group' => 'on']);
-        $this->assertCount(0, $reservation->find());
+        $this->assertEquals(0, countElementsInTable(\Reservation::getTable()));
     }
 
     public function testMassiveActions()
@@ -641,14 +643,13 @@ class ReservationTest extends DbTestCase
         $_SESSION['glpiactiveprofile']['reservation'] = ReservationItem::RESERVEANITEM;
 
         // Count reservations before
-        $reservation = new \Reservation();
-        $count_before = count($reservation->find());
+        $count_before = countElementsInTable(\Reservation::getTable());
 
         // Call handleAddForm - should work without explicit permission checks
         \Reservation::handleAddForm($form_input);
 
         // Count reservations after
-        $count_after = count($reservation->find());
+        $count_after = countElementsInTable(\Reservation::getTable());
 
         $this->assertEquals($count_before + 1, $count_after, "handleAddForm should create reservation without explicit permission checks");
     }
@@ -848,9 +849,9 @@ class ReservationTest extends DbTestCase
             'comment' => 'Simplified interface workflow test',
         ];
 
-        $count_before = count($reservation->find());
+        $count_before = countElementsInTable(\Reservation::getTable());
         \Reservation::handleAddForm($form_data);
-        $count_after = count($reservation->find());
+        $count_after = countElementsInTable(\Reservation::getTable());
         $this->assertEquals($count_before + 1, $count_after, "Should be able to create reservation via form");
 
         // Get the created reservation

--- a/tests/src/FormTesterTrait.php
+++ b/tests/src/FormTesterTrait.php
@@ -754,9 +754,15 @@ trait FormTesterTrait
 
     protected function disableExistingForms(): void
     {
-        $forms = (new Form())->find([]);
+        global $DB;
+
+        $forms = $DB->request([
+            'SELECT' => ['id'],
+            'FROM'   => Form::getTable(),
+        ]);
+
+        $form = new Form();
         foreach ($forms as $row) {
-            $form = new Form();
             $form->update([
                 'id' => $row['id'],
                 'is_active' => false,

--- a/tests/src/autoload/functions.php
+++ b/tests/src/autoload/functions.php
@@ -33,6 +33,7 @@
  */
 
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\DBAL\QueryExpression;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Form\Form;
 use Glpi\Form\FormTranslation;
@@ -982,7 +983,7 @@ function getItemByTypeName(string $type, string $name, bool $onlyid = false): Co
     $item = getItemForItemtype($type);
     $nameField = $type::getNameField();
     if (!$item->getFromDBByCrit([$nameField => $name])) {
-        $found = $item->find();
+        $found = $item->find([new QueryExpression('true')]);
         $found_names = array_column($found, $nameField);
         throw new RuntimeException(sprintf('Unable to load a single `%s` item with the name `%s` (available items names are : ' . implode(', ', $found_names) . ').', $type, $name));
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This function has a high potential for misuse (see #23274) and unconditional finds should not be allowed. If you **really** need to fetch all columns for every record in a table, you should be forced to manually specify an always-true condition.