### PR TITLE
Upgrade `monaco-editor` and `dompurify` to get latest security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
                 "leaflet.markercluster": "^1.4.1",
                 "lodash": "^4.17.23",
                 "masonry-layout": "^4.2.2",
-                "monaco-editor": "^0.52.2",
+                "monaco-editor": "^0.55.1",
                 "path-browserify": "^1.0.1",
                 "photoswipe": "^5.4.4",
                 "process": "^0.11.10",
@@ -5055,6 +5055,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -8430,6 +8437,15 @@
             "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dompurify": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/dotenv": {
             "version": "17.2.4",
@@ -13124,6 +13140,18 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/marked": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+            "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/masonry-layout": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/masonry-layout/-/masonry-layout-4.2.2.tgz",
@@ -13361,9 +13389,14 @@
             }
         },
         "node_modules/monaco-editor": {
-            "version": "0.52.2",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-            "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
+            "version": "0.55.1",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+            "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+            "license": "MIT",
+            "dependencies": {
+                "dompurify": "3.2.7",
+                "marked": "14.0.0"
+            }
         },
         "node_modules/monaco-editor-webpack-plugin": {
             "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "leaflet.markercluster": "^1.4.1",
         "lodash": "^4.17.23",
         "masonry-layout": "^4.2.2",
-        "monaco-editor": "^0.52.2",
+        "monaco-editor": "^0.55.1",
         "path-browserify": "^1.0.1",
         "photoswipe": "^5.4.4",
         "process": "^0.11.10",
@@ -144,6 +144,9 @@
         "webpack-dev-server": "^5.2.3"
     },
     "overrides": {
-        "serialize-javascript": "^7.0.3"
+        "serialize-javascript": "^7.0.3",
+        "monaco-editor": {
+            "dompurify": "^3.3.3"
+        }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

`dompurify` library was embed in `monaco-editor` distributions in versions < 0.54. Therefore, the audit task scheduled every week was not able to detect the presence of a vulnerable version of `dompurify` (see https://nvd.nist.gov/vuln/detail/CVE-2025-26791 and https://nvd.nist.gov/vuln/detail/CVE-2026-0540).

The solution is to upgrade `monaco-editor` to then be able to force the version of `dompurify`.