### PR TITLE
Fix flaky webhook test

### DIFF
--- a/src/Glpi/Api/HL/Middleware/OAuthRequestMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/OAuthRequestMiddleware.php
@@ -81,7 +81,7 @@ class OAuthRequestMiddleware extends AbstractMiddleware implements RequestMiddle
             return;
         }
         foreach ($scopes_required['OR'] as $scope) {
-            if (in_array($scope, $client['scopes'], true)) {
+            if (in_array($scope, $client['scopes'] ?? [], true)) {
                 $next($input);
                 return;
             }

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -606,6 +606,9 @@ EOT;
     {
         global $CFG_GLPI;
 
+        // Reset client state so each request starts with a clean slate
+        $this->current_client = null;
+
         // Start an output buffer to capture any potential debug errors
         $current_output_buffer_level = ob_get_level();
         ob_start();


### PR DESCRIPTION
Fix a failure identified here: https://github.com/glpi-project/glpi/actions/runs/23006552638/job/66804950888

The flakiness is caused by the Router singleton retaining stale current_client state across handleRequest() calls.

For example:
- Another test uses the Router and sets current_client to an OAuth client (without scopes key, or not internal).
- When the Webhook tests run, Router::getInstance() returns that same singleton. The ??= assignment at Router.php:688 won't overwrite the stale value.
- OAuthRequestMiddleware sees a non-internal client without scopes, causing the in_array() TypeError, or the request is denied, causing raise() to throw, which means no QueuedWebhook is created, leading to count(false).

