### PR TITLE
add backend check for base64

### DIFF
--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -570,6 +570,7 @@ JAVASCRIPT;
                 ])
                 ->allowRelativeLinks()
                 ->allowRelativeMedias()
+                ->allowMediaSchemes(['http', 'https'])
                 ->withMaxInputLength(-1);
 
             // Block some elements (tag is removed but contents is preserved)

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -316,7 +316,7 @@ HTML,
 <p>
   img, audio and video are allowed
   <img src="/path/to/img.jpg" alt="img" />
-  <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD&#43;wSzIAAAABlBMVEX///&#43;/v7&#43;jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII" alt="b64 img" />
+  <img alt="b64 img" />
   <audio src="/path/to/audio.mp3"></audio>
   <video><source src="/path/to/video.mp4" type="video/mp4" /></video>
 </p>
@@ -412,6 +412,25 @@ HTML,
             'content'                => '<table border="1" cellspacing="0" cellpadding="5" bgcolor="#f5f5f5"><thead><tr bgcolor="#cccccc"><th>Column 1</th><th>Column 2</th></tr></thead><tbody><tr><td bgcolor="#ffffff">Data 1</td><td>Data 2</td></tr></tbody></table>',
             'encode_output_entities' => false,
             'expected_result'        => '<table border="1" cellspacing="0" cellpadding="5" bgcolor="#f5f5f5"><thead><tr bgcolor="#cccccc"><th>Column 1</th><th>Column 2</th></tr></thead><tbody><tr><td bgcolor="#ffffff">Data 1</td><td>Data 2</td></tr></tbody></table>',
+        ];
+
+        // data: URI scheme should be stripped from media elements (defense-in-depth)
+        yield 'data: URI is stripped from img src' => [
+            'content'                => '<p><img src="data:image/png;base64,iVBORw0KGgo=" alt="b64" /></p>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<p><img alt="b64" /></p>',
+        ];
+
+        yield 'http/https img src is preserved' => [
+            'content'                => '<p><img src="https://example.com/img.png" alt="ok" /><img src="http://example.com/img.png" alt="ok2" /></p>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<p><img src="https://example.com/img.png" alt="ok" /><img src="http://example.com/img.png" alt="ok2" /></p>',
+        ];
+
+        yield 'relative img src is preserved' => [
+            'content'                => '<p><img src="/path/to/img.jpg" alt="rel" /></p>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<p><img src="/path/to/img.jpg" alt="rel" /></p>',
         ];
     }
 


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- This follows comments and suggestion in https://github.com/glpi-project/glpi/pull/23472 

This is an addtionnal protection for cases of failure described in https://github.com/glpi-project/glpi/issues/23110 : 

The backend check acts as a defense-in-depth safety net for cases where the frontend protections don't apply:

1. REST API : a client can POST HTML with data: URIs directly via the API, completely bypassing TinyMCE and the JS upload handlers
2. Mailcollector : inbound emails may contain inline base64 images that aren't converted to Documents
3. JS bypass :  a user could disable JavaScript or manipulate the DOM before form submission
4. Plugins / import scripts : third-party code injecting rich text content via `$item->add()` without going through the frontend


