### PR TITLE
Update Contract.php

### DIFF
--- a/src/Contract.php
+++ b/src/Contract.php
@@ -458,6 +458,14 @@ class Contract extends CommonDBTM implements StateInterface
                 (int) $values['renewal'] === self::RENEWAL_TACIT,
                 $values['periodicity']
             ),
+	    '_virtual_expire_notice' => Infocom::getWarrantyExpir(
+                $values['begin_date'],
+                $values['renewal'] == self::RENEWAL_EXPRESS ? $values['duration'] + $values['periodicity'] : $values['duration'],
+                $values['notice'],
+                true,
+                (int) $values['renewal'] === self::RENEWAL_TACIT,
+                $values['periodicity']
+            ),
             default => parent::getSpecificValueToDisplay($field, $values, $options),
         };
     }
@@ -653,19 +661,21 @@ class Contract extends CommonDBTM implements StateInterface
         $tab[] = [
             'id'                 => '13',
             'table'              => static::getTable(),
-            'field'              => 'expire_notice',
-            'name'               => __('Expiration date + notice'),
-            'datatype'           => 'date_delay',
-            'datafields'         => [
-                '1'                  => 'begin_date',
-                '2'                  => 'duration',
-                '3'                  => 'notice',
+            'field'              => '_virtual_expire_notice', // virtual field
+            'additionalfields'   => [
+                'begin_date',
+                'duration',
+                'renewal',
+                'notice',
+                'periodicity',
             ],
-            'searchunit'         => 'DAY',
-            'delayunit'          => 'MONTH',
-            'maybefuture'        => true,
+            'name'               => __('Expiration date + notice'),
+            'datatype'           => 'specific',
+            'nosearch'           => true,
+            'nosort'             => true,
             'massiveaction'      => false,
         ];
+
 
         $tab[] = [
             'id'                 => '16',


### PR DESCRIPTION
FIX search field 13 "Expiration date + notice" to calculate notice from the expiration date rather than start date + duration - notice

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23084
- Change the "Expiration date + notice" search field to calculate from _virtual_expiration field instead of start date + duration (useful for tacitaly renewed contracts)

## Screenshots (if appropriate):


