### PR TITLE
fix(forms): enhance formatRawAnswer for QuestionTypeItem to include additional item details

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -402,6 +402,8 @@ class QuestionTypeItem extends AbstractQuestionType implements
     #[Override]
     public function formatRawAnswer(mixed $answer, Question $question): string
     {
+        global $CFG_GLPI;
+
         $item = $answer['itemtype']::getById($answer['items_id']);
         if (!$item) {
             return '';
@@ -412,7 +414,40 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return $item->getFriendlyName();
         }
 
-        return $item->fields['name'];
+        $name = $item->fields['name'];
+
+        // Append additional fields to match what is displayed in renderEndUserTemplate.
+        $itemtype = $answer['itemtype'];
+        $extra_parts = [];
+
+        // For ITIL types, append the numeric ID when it is not already embedded in the name.
+        $is_itil_type = in_array($itemtype, $CFG_GLPI['itil_types']);
+        $id_already_visible = isset($_SESSION['glpiis_ids_visible']) && $_SESSION['glpiis_ids_visible'];
+        if ($is_itil_type && !$id_already_visible) {
+            $extra_parts[] = $item->fields['id'];
+        }
+
+        // For asset types, append serial, otherserial and the linked user when present.
+        if (in_array($itemtype, $CFG_GLPI['asset_types'])) {
+            if ($item->isField('serial') && !empty($item->fields['serial'])) {
+                $extra_parts[] = $item->fields['serial'];
+            }
+            if ($item->isField('otherserial') && !empty($item->fields['otherserial'])) {
+                $extra_parts[] = $item->fields['otherserial'];
+            }
+            if ($item->isField('users_id') && $item->fields['users_id'] > 0) {
+                $user = User::getById($item->fields['users_id']);
+                if ($user) {
+                    $extra_parts[] = $user->getFriendlyName();
+                }
+            }
+        }
+
+        if (!empty($extra_parts)) {
+            $name .= ' - ' . implode(' - ', $extra_parts);
+        }
+
+        return $name;
     }
 
     #[Override]

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -76,8 +76,8 @@ final class QuestionTypeItemTest extends DbTestCase
                         (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
                     ),
                     'question'     => 'Asset',
-                    'content'      => '1) Asset: My Computer', 
-                ], 
+                    'content'      => '1) Asset: My Computer',
+                ],
             ],
 
             'user — friendly name (realname firstname)' => [
@@ -199,7 +199,7 @@ final class QuestionTypeItemTest extends DbTestCase
                     return [
                         'itemtype'  => Ticket::class,
                         'items_id'  => $linked->getID(),
-                        'extra_data' => json_encode(        
+                        'extra_data' => json_encode(
                             (new QuestionTypeItemExtraDataConfig(itemtype: Ticket::class))->jsonSerialize()
                         ),
                         'question'  => 'Linked Ticket',

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -54,12 +54,11 @@ final class QuestionTypeItemTest extends DbTestCase
      * returns a description array:
      *
      *   [
-     *     'itemtype'    => class-string,
-     *     'items_id'    => int,
-     *     'extra_data'  => string (JSON),
-     *     'question'    => string,
-     *     'contains'    => string,   // substring that MUST appear in ticket content
-     *     'not_contains'=> ?string,  // substring that MUST NOT appear (optional)
+     *     'itemtype'   => class-string,
+     *     'items_id'   => int,
+     *     'extra_data' => string (JSON),
+     *     'question'   => string,
+     *     'content'    => string, // expected content in the ticket description (after stripping HTML tags)
      *   ]
      */
     public static function itemAnswerInTicketProvider(): array

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use Computer;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Ticket;
+use User;
+
+final class QuestionTypeItemTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    /**
+     * Each case returns a callable that, when invoked inside the test method
+     * (after the DB transaction has started), creates the necessary items and
+     * returns a description array:
+     *
+     *   [
+     *     'itemtype'    => class-string,
+     *     'items_id'    => int,
+     *     'extra_data'  => string (JSON),
+     *     'question'    => string,
+     *     'contains'    => string,   // substring that MUST appear in ticket content
+     *     'not_contains'=> ?string,  // substring that MUST NOT appear (optional)
+     *   ]
+     */
+    public static function itemAnswerInTicketProvider(): array
+    {
+        return [
+            'basic asset — only name' => [
+                fn(self $t) => [
+                    'itemtype'   => Computer::class,
+                    'items_id'   => $t->createItem(Computer::class, [
+                        'name'        => 'My Computer',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'     => 'Asset',
+                    'content'      => '1) Asset: My Computer', 
+                ], 
+            ],
+
+            'user — friendly name (realname firstname)' => [
+                fn(self $t) => [
+                    'itemtype'  => User::class,
+                    'items_id'  => $t->createItem(User::class, [
+                        'name'      => 'jdoe',
+                        'firstname' => 'John',
+                        'realname'  => 'Doe',
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: User::class))->jsonSerialize()
+                    ),
+                    'question'  => 'Technician',
+                    'content'   => '1) Technician: Doe John',
+                ],
+            ],
+
+            'asset with serial only' => [
+                fn(self $t) => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $t->createItem(Computer::class, [
+                        'name'        => 'My Laptop',
+                        'serial'      => 'SN-1234',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'  => 'Asset',
+                    'content'   => '1) Asset: My Laptop - SN-1234',
+                ],
+            ],
+
+            'asset with serial and otherserial' => [
+                fn(self $t) => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $t->createItem(Computer::class, [
+                        'name'        => 'My Laptop',
+                        'serial'      => 'SN-1234',
+                        'otherserial' => 'INV-5678',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'  => 'Asset',
+                    'content'   => '1) Asset: My Laptop - SN-1234 - INV-5678',
+                ],
+            ],
+
+            'asset with linked user' => [
+                fn(self $t) => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $t->createItem(Computer::class, [
+                        'name'        => 'My Desktop',
+                        'users_id'    => $t->createItem(User::class, [
+                            'name'      => 'jdoe',
+                            'firstname' => 'John',
+                            'realname'  => 'Doe',
+                        ])->getID(),
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'  => 'Asset',
+                    'content'   => '1) Asset: My Desktop - Doe John',
+                ],
+            ],
+
+            'asset with all extra fields' => [
+                fn(self $t) => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $t->createItem(Computer::class, [
+                        'name'        => 'My Workstation',
+                        'serial'      => 'SN-AAAA',
+                        'otherserial' => 'INV-BBBB',
+                        'users_id'    => $t->createItem(User::class, [
+                            'name'      => 'jdoe',
+                            'firstname' => 'John',
+                            'realname'  => 'Doe',
+                        ])->getID(),
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'  => 'Asset',
+                    'content'   => '1) Asset: My Workstation - SN-AAAA - INV-BBBB - Doe John',
+                ],
+            ],
+
+            'asset with empty serial — no parentheses' => [
+                fn(self $t) => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $t->createItem(Computer::class, [
+                        'name'        => 'My Server',
+                        'serial'      => '',
+                        'otherserial' => '',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ])->getID(),
+                    'extra_data' => json_encode(
+                        (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    ),
+                    'question'     => 'Asset',
+                    'content'      => '1) Asset: My Server',
+                ],
+            ],
+
+            'ITIL type — ID appended when not visible in session' => [
+                fn(self $t) => (static function () use ($t) {
+                    $_SESSION['glpiis_ids_visible'] = false;
+                    $linked = $t->createItem(Ticket::class, [
+                        'name'        => 'Some Ticket',
+                        'content'     => 'content',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ]);
+                    return [
+                        'itemtype'  => Ticket::class,
+                        'items_id'  => $linked->getID(),
+                        'extra_data' => json_encode(        
+                            (new QuestionTypeItemExtraDataConfig(itemtype: Ticket::class))->jsonSerialize()
+                        ),
+                        'question'  => 'Linked Ticket',
+                        'content'   => '1) Linked Ticket: Some Ticket - ' . $linked->getID(),
+                    ];
+                })(),
+            ],
+
+            'ITIL type — no ID appended when already visible in session' => [
+                fn(self $t) => (static function () use ($t) {
+                    $_SESSION['glpiis_ids_visible'] = true;
+                    $linked = $t->createItem(Ticket::class, [
+                        'name'        => 'Some Ticket',
+                        'content'     => 'content',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ]);
+                    return [
+                        'itemtype'     => Ticket::class,
+                        'items_id'     => $linked->getID(),
+                        'extra_data'   => json_encode(
+                            (new QuestionTypeItemExtraDataConfig(itemtype: Ticket::class))->jsonSerialize()
+                        ),
+                        'question'     => 'Linked Ticket',
+                        'content'      => '1) Linked Ticket: Some Ticket',
+                    ];
+                })(),
+            ],
+        ];
+    }
+
+    #[DataProvider('itemAnswerInTicketProvider')]
+    public function testItemAnswerIsDisplayedInTicketDescription(callable $setup): void
+    {
+        $this->login();
+
+        $case = $setup($this);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: $case['question'],
+            type: QuestionTypeItem::class,
+            extra_data: $case['extra_data'],
+        );
+        $form = $this->createForm($builder);
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            $case['question'] => [
+                'itemtype' => $case['itemtype'],
+                'items_id' => $case['items_id'],
+            ],
+        ]);
+
+        $content = strip_tags($ticket->fields['content']);
+
+        $this->assertEquals($case['content'], $content);
+
+        // Clean up any session flags set by the case
+        unset($_SESSION['glpiis_ids_visible']);
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !42202

PRs #22327 and #21944 recently changed the values displayed when selecting objects from an `Item` type question.
However, only the text displayed upon selection was changed, leaving the default text (only the object's name) when creating targets.
This PR aligns the value of the question's answer by using the same value as the text displayed during selection.