### PR TITLE
search html text fields multiples words

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2336,7 +2336,7 @@ final class SQLProvider implements SearchProviderInterface
             ];
         }
 
-        if (isset($opt['htmltext']) && $opt['htmltext'] && !empty($val) && strpos($val, ' ') !== false) {
+        if (isset($opt['htmltext']) && $opt['htmltext'] && !empty($val) && str_contains($val, ' ')) {
             // This handles cases like "<b>text</b> suite" when searching for "text suite"
             $val_with_tags = str_replace(' ', '%', $val);
             return [

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2336,13 +2336,15 @@ final class SQLProvider implements SearchProviderInterface
             ];
         }
 
-        if (isset($opt['htmltext']) && $opt['htmltext'] && !empty($val) && str_contains($val, ' ')) {
-            // This handles cases like "<b>text</b> suite" when searching for "text suite"
-            $val_with_tags = str_replace(' ', '%', $val);
+        if (
+            !empty($opt['htmltext'])
+            && str_contains((string) $val, ' ')
+        ) {
+            $val_with_wildcards = str_replace(' ', '%', (string) $val);
             return [
                 'OR' => [
-                    new QueryExpression(self::makeTextCriteria($tocompute, $val, $nott, '')),
-                    new QueryExpression(self::makeTextCriteria($tocompute, $val_with_tags, $nott, '')),
+                    new QueryExpression(self::makeTextCriteria($tocompute, (string) $val, $nott, '')),
+                    new QueryExpression(self::makeTextCriteria($tocompute, $val_with_wildcards, $nott, '')),
                 ],
             ];
         }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2336,6 +2336,17 @@ final class SQLProvider implements SearchProviderInterface
             ];
         }
 
+        if (isset($opt['htmltext']) && $opt['htmltext'] && !empty($val) && strpos($val, ' ') !== false) {
+            // This handles cases like "<b>text</b> suite" when searching for "text suite"
+            $val_with_tags = str_replace(' ', '%', $val);
+            return [
+                'OR' => [
+                    new QueryExpression(self::makeTextCriteria($tocompute, $val, $nott, '')),
+                    new QueryExpression(self::makeTextCriteria($tocompute, $val_with_tags, $nott, '')),
+                ],
+            ];
+        }
+
         return [new QueryExpression(self::makeTextCriteria($tocompute, $val, $nott, ''))];
     }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2341,10 +2341,26 @@ final class SQLProvider implements SearchProviderInterface
             && str_contains((string) $val, ' ')
         ) {
             $val_with_wildcards = str_replace(' ', '%', (string) $val);
+
             return [
                 'OR' => [
-                    new QueryExpression(self::makeTextCriteria($tocompute, (string) $val, $nott, '')),
-                    new QueryExpression(self::makeTextCriteria($tocompute, $val_with_wildcards, $nott, '')),
+                    new QueryExpression(
+                        self::makeTextCriteria($tocompute, (string) $val, $nott, '')
+                    ),
+                    [
+                        'AND' => [
+                            new QueryExpression(
+                                self::makeTextCriteria($tocompute, $val_with_wildcards, $nott, '')
+                            ),
+                            new QueryExpression(
+                                sprintf(
+                                    "REGEXP_REPLACE(REGEXP_REPLACE(%s, '<[^>]+>', ' '), '\\\\s+', ' ') LIKE %s",
+                                    $DB->quoteName('content'),
+                                    $DB->quoteValue('%' . $val . '%')
+                                )
+                            ),
+                        ],
+                    ],
                 ],
             ];
         }

--- a/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
+++ b/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
@@ -77,4 +77,51 @@ class SQLProviderTest extends DbTestCase
             $it->analyseJoins($item_item_revert_join)
         );
     }
+
+    public function testHtmlTextSearchWithSpaces()
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name'    => 'Test with strong text',
+            'content' => '<strong>1) Option: <strong>option1',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+
+        $ticket_loaded = new \Ticket();
+        $this->assertTrue($ticket_loaded->getFromDB($tickets_id));
+        $this->assertStringContainsString('1) Option:', $ticket_loaded->fields['content']);
+        $this->assertStringContainsString('option1', $ticket_loaded->fields['content']);
+
+        $data = \Search::getDatas('Ticket', [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => [
+                0 => [
+                    'field'      => 21,  // ticket content (Richtext provider)
+                    'searchtype' => 'contains',
+                    'value'      => '1) Option: option1',
+                ],
+            ],
+        ]);
+
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayHasKey('totalcount', $data['data']);
+        $this->assertGreaterThan(
+            0,
+            $data['data']['totalcount'],
+        );
+
+        $found = false;
+        foreach ($data['data']['rows'] as $row) {
+            if ($row['raw']['id'] == $tickets_id) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found);
+    }
 }

--- a/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
+++ b/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
@@ -124,4 +124,42 @@ class SQLProviderTest extends DbTestCase
         }
         $this->assertTrue($found);
     }
+
+    public function testHtmlTextSearchWithPartialWords()
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $tickets_id = $ticket->add([
+            'name'    => 'Test with red light',
+            'content' => 'When the red light starts flashing, you have less than 10 seconds to cut the blue cable.',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+        ]);
+        $this->assertGreaterThan(0, $tickets_id);
+
+        $data = \Search::getDatas('Ticket', [
+            'reset'      => 'reset',
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => [
+                0 => [
+                    'field'      => 21,
+                    'searchtype' => 'contains',
+                    'value'      => 'red cable',
+                ],
+            ],
+        ]);
+
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayHasKey('totalcount', $data['data']);
+
+        $found = false;
+        foreach ($data['data']['rows'] as $row) {
+            if ($row['raw']['id'] == $tickets_id) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertFalse($found);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42779
- Search fails in HTML text fields when tags break word continuity (e.g., searching "text suite" in `<b>text</b> suite` returns no results).
Added dual search pattern for `htmltext=true` fields - normal search + wildcard pattern to handle HTML tags between words.

## Screenshots (if appropriate):

<img width="200" height="75" alt="image" src="https://github.com/user-attachments/assets/6ba1cb84-2889-42b4-b798-0b98375aae56" />
<img width="577" height="60" alt="image" src="https://github.com/user-attachments/assets/cd88dea2-81a1-4053-985b-6d02b21e55d5" />

