### PR TITLE
Deprecate usage of coma separated list of fields in `ORDER BY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The present file will list all changes made to the project; according to the
 - `KnowbaseItem_Revision` is now final
 
 #### Deprecated
+- Usage of coma separated list of fields in `ORDER BY` clause.
 - `CommonITILSatisfaction::showSatisactionForm()`, use `CommonITILSatisfaction::showSatisfactionForm()` instead.
 - `Glpi\Features\Inventoriable::showInventoryInfo()`
 - `Glpi\Features\Inventoriable::displayAgentInformation()`

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -345,7 +345,9 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         $cleanorderby = [];
         foreach ($clause as $o) {
-            if (is_string($o)) {
+            if (is_string($o) && str_contains($o, ',')) {
+                Toolbox::deprecated('Using coma separated list of fields is deprecated in ORDER BY clause.');
+
                 $fields = explode(',', $o);
                 foreach ($fields as $field) {
                     $new = '';
@@ -357,6 +359,11 @@ class DBmysqlIterator implements SeekableIterator, Countable
                     }
                     $cleanorderby[] = $new;
                 }
+            } elseif (is_string($o)) {
+                $parts = explode(' ', trim($o));
+                $cleanorderby[] = DBmysql::quoteName($parts[0])
+                    . (isset($parts[1]) && in_array($parts[1], ['ASC', 'DESC']) ? ' ' . $parts[1] : '');
+
             } elseif ($o instanceof QueryExpression) {
                 $cleanorderby[] = $o->getValue();
             } else {

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -346,7 +346,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
         $cleanorderby = [];
         foreach ($clause as $o) {
             if (is_string($o) && str_contains($o, ',')) {
-                Toolbox::deprecated('Using coma separated list of fields is deprecated in ORDER BY clause.');
+                Toolbox::deprecated('Using comma separated list of fields is deprecated in ORDER BY clause.');
 
                 $fields = explode(',', $o);
                 foreach ($fields as $field) {
@@ -361,8 +361,11 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 }
             } elseif (is_string($o)) {
                 $parts = explode(' ', trim($o));
-                $cleanorderby[] = DBmysql::quoteName($parts[0])
-                    . (isset($parts[1]) && in_array($parts[1], ['ASC', 'DESC']) ? ' ' . $parts[1] : '');
+                $name = trim($parts[0]);
+                $direction = trim($parts[1] ?? '');
+
+                $cleanorderby[] = DBmysql::quoteName($name)
+                    . (in_array($direction, ['ASC', 'DESC']) ? ' ' . $direction : '');
 
             } elseif ($o instanceof QueryExpression) {
                 $cleanorderby[] = $o->getValue();

--- a/src/Glpi/Console/Plugin/ListCommand.php
+++ b/src/Glpi/Console/Plugin/ListCommand.php
@@ -75,7 +75,7 @@ class ListCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $plug     = new Plugin();
-        $pluglist = $plug->find([], "name, directory");
+        $pluglist = $plug->find([], ['name', 'directory']);
         $data = [];
         foreach ($pluglist as $plugin) {
             $record = [];

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -608,7 +608,7 @@ final class Form extends CommonDBTM implements
             // because the keys must be preserved
             $questions_data = (new Question())->find(
                 [$section::getForeignKeyField() => $section->fields['id']],
-                'vertical_rank ASC, horizontal_rank ASC',
+                ['vertical_rank ASC', 'horizontal_rank ASC'],
             );
             foreach ($questions_data as $row) {
                 $question = new Question();

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -298,7 +298,7 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             // Read from database
             $questions_data = (new Question())->find(
                 [self::getForeignKeyField() => $this->fields['id']],
-                'vertical_rank ASC, horizontal_rank ASC',
+                ['vertical_rank ASC', 'horizontal_rank ASC'],
             );
             foreach ($questions_data as $row) {
                 $question = new Question();
@@ -332,7 +332,7 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             // Read from database
             $comments_data = (new Comment())->find(
                 [self::getForeignKeyField() => $this->fields['id']],
-                'vertical_rank ASC, horizontal_rank ASC',
+                ['vertical_rank ASC', 'horizontal_rank ASC'],
             );
             foreach ($comments_data as $row) {
                 $comment = new Comment();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1641,7 +1641,7 @@ class Plugin extends CommonDBTM
         $content = '';
 
         $plug     = new Plugin();
-        $pluglist = $plug->find([], "state, name, directory");
+        $pluglist = $plug->find([], ['state', 'name', 'directory']);
         foreach ($pluglist as $plugin) {
             $name = Toolbox::stripTags($plugin['name']);
             $version = Toolbox::stripTags($plugin['version']);

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -207,16 +207,16 @@ class DBmysqlIteratorTest extends DbTestCase
         $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => ['`a`', 'b ASC', 'c DESC']]);
         $this->assertSame('SELECT * FROM `foo` ORDER BY `a`, `b` ASC, `c` DESC', $it->getSql());
 
-        $it = $this->it->execute(['FROM' => 'foo', 'ORDERBY' => 'bar, baz ASC']);
+        $it = @$this->it->execute(['FROM' => 'foo', 'ORDERBY' => 'bar, baz ASC']);
         $this->assertSame('SELECT * FROM `foo` ORDER BY `bar`, `baz` ASC', $it->getSql());
 
-        $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => 'bar, baz ASC']);
+        $it = @$this->it->execute(['FROM' => 'foo', 'ORDER' => 'bar, baz ASC']);
         $this->assertSame('SELECT * FROM `foo` ORDER BY `bar`, `baz` ASC', $it->getSql());
 
-        $it = $this->it->execute(['FROM' => 'foo', 'ORDERBY' => 'bar DESC, baz ASC']);
+        $it = @$this->it->execute(['FROM' => 'foo', 'ORDERBY' => 'bar DESC, baz ASC']);
         $this->assertSame('SELECT * FROM `foo` ORDER BY `bar` DESC, `baz` ASC', $it->getSql());
 
-        $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => 'bar DESC, baz ASC']);
+        $it = @$this->it->execute(['FROM' => 'foo', 'ORDER' => 'bar DESC, baz ASC']);
         $this->assertSame('SELECT * FROM `foo` ORDER BY `bar` DESC, `baz` ASC', $it->getSql());
 
         $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => new QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END")]);
@@ -225,7 +225,7 @@ class DBmysqlIteratorTest extends DbTestCase
         $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => [new QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC']]);
         $this->assertSame("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC", $it->getSql());
 
-        $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => [new QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC, baz DESC']]);
+        $it = @$this->it->execute(['FROM' => 'foo', 'ORDER' => [new QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC, baz DESC']]);
         $this->assertSame("SELECT * FROM `foo` ORDER BY CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END, `bar` ASC, `baz` DESC", $it->getSql());
 
         $it = $this->it->execute(['FROM' => 'foo', 'ORDER' => [new QueryExpression("CASE WHEN `foo` LIKE 'test%' THEN 0 ELSE 1 END"), 'bar ASC', 'baz DESC']]);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Maybe some occurences remains, so I prefer using a deprecation rather than removing the complete support of it.