### PR TITLE
fix(forms): Ensure consistent dropdown labels for Item questions in f…

### DIFF
--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -57,7 +57,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
 
     $field_id = Html::cleanId("dropdown_" . $_POST["name"] . $rand);
 
-    $displaywith = is_a($_POST['idtable'], CommonITILObject::class, true) ? ['id'] : ['otherserial', 'serial'];
+    $displaywith = Dropdown::getDisplayWith($_POST["idtable"]);
     $p = [
         'value'               => 0,
         'valuename'           => Dropdown::EMPTY_VALUE,

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5167,4 +5167,44 @@ HTML;
 
         return $durationDropdown;
     }
+
+    /**
+     * Compute the list of additional fields to display alongside item names in dropdowns.
+     *
+     * @param string|null $itemtype The itemtype to compute displaywith for.
+     * @return array<string>
+     */
+    public static function getDisplayWith(?string $itemtype): array
+    {
+        global $CFG_GLPI;
+
+        if ($itemtype === null || $itemtype === '0') {
+            return [];
+        }
+
+        $displaywith = [];
+        $is_itil_type = in_array($itemtype, $CFG_GLPI['itil_types']);
+        $id_already_visible = isset($_SESSION['glpiis_ids_visible']) && $_SESSION['glpiis_ids_visible'];
+
+        if ($is_itil_type && !$id_already_visible) {
+            $displaywith[] = 'id';
+        }
+
+        if (in_array($itemtype, $CFG_GLPI['asset_types'])) {
+            $item = getItemForItemtype($itemtype);
+            if ($item) {
+                if ($item->isField('serial')) {
+                    $displaywith[] = 'serial';
+                }
+                if ($item->isField('otherserial')) {
+                    $displaywith[] = 'otherserial';
+                }
+                if ($item->isField('users_id')) {
+                    $displaywith[] = 'users_id';
+                }
+            }
+        }
+
+        return $displaywith;
+    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -321,7 +321,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
                 'itemtypes'        => $this->getAllowedItemtypes(),
                 'aria_label'       => $this->items_id_aria_label,
                 'advanced_config'  => $this->renderAdvancedConfigurationTemplate($question),
-                'displaywith'      => $this->getDisplayWith($default_itemtype),
+                'displaywith'      => Dropdown::getDisplayWith($default_itemtype),
             ]
         );
     }
@@ -357,51 +357,10 @@ class QuestionTypeItem extends AbstractQuestionType implements
         );
     }
 
-    /**
-     * Compute the list of additional fields to display alongside item names in dropdowns.
-     *
-     * @param string|null $itemtype The itemtype to compute displaywith for.
-     * @return array<string>
-     */
-    public function getDisplayWith(?string $itemtype): array
-    {
-        global $CFG_GLPI;
-
-        if ($itemtype === null || $itemtype === '0') {
-            return [];
-        }
-
-        $displaywith = [];
-        $is_itil_type = in_array($itemtype, $CFG_GLPI['itil_types']);
-        $id_already_visible = isset($_SESSION['glpiis_ids_visible']) && $_SESSION['glpiis_ids_visible'];
-
-        if ($is_itil_type && !$id_already_visible) {
-            $displaywith[] = 'id';
-        }
-
-        if (in_array($itemtype, $CFG_GLPI['asset_types'])) {
-            $item = getItemForItemtype($itemtype);
-            if ($item) {
-                if ($item->isField('otherserial')) {
-                    $displaywith[] = 'otherserial';
-                }
-                if ($item->isField('serial')) {
-                    $displaywith[] = 'serial';
-                }
-                if ($item->isField('users_id')) {
-                    $displaywith[] = 'users_id';
-                }
-            }
-        }
-
-        return $displaywith;
-    }
-
     #[Override]
     public function renderEndUserTemplate(Question $question): string
     {
         $itemtype = $this->getDefaultValueItemtype($question) ?? '0';
-        $displaywith = $this->getDisplayWith($itemtype);
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
@@ -413,7 +372,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
                 'aria_label'                  => $question->fields['name'],
                 'sub_types'                   => $this->getSubTypes(),
                 'dropdown_restriction_params' => $this->getDropdownRestrictionParams($question),
-                'displaywith'                 => $displaywith,
+                'displaywith'                 => Dropdown::getDisplayWith($itemtype),
             ]
         );
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -361,7 +361,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
      * Compute the list of additional fields to display alongside item names in dropdowns.
      *
      * @param string|null $itemtype The itemtype to compute displaywith for.
-     * @return array
+     * @return array<string>
      */
     public function getDisplayWith(?string $itemtype): array
     {

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -308,6 +308,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
     #[Override]
     public function renderAdministrationTemplate(?Question $question): string
     {
+        $default_itemtype = $this->getDefaultValueItemtype($question);
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
             'pages/admin/form/question_type/item/administration_template.html.twig',
@@ -315,11 +316,12 @@ class QuestionTypeItem extends AbstractQuestionType implements
                 'init'             => $question != null,
                 'question'         => $question,
                 'question_type'    => $this::class,
-                'default_itemtype' => $this->getDefaultValueItemtype($question),
+                'default_itemtype' => $default_itemtype,
                 'default_items_id' => $this->getDefaultValueItemId($question),
                 'itemtypes'        => $this->getAllowedItemtypes(),
                 'aria_label'       => $this->items_id_aria_label,
                 'advanced_config'  => $this->renderAdvancedConfigurationTemplate($question),
+                'displaywith'      => $this->getDisplayWith($default_itemtype),
             ]
         );
     }
@@ -355,16 +357,24 @@ class QuestionTypeItem extends AbstractQuestionType implements
         );
     }
 
-    #[Override]
-    public function renderEndUserTemplate(Question $question): string
+    /**
+     * Compute the list of additional fields to display alongside item names in dropdowns.
+     *
+     * @param string|null $itemtype The itemtype to compute displaywith for.
+     * @return array
+     */
+    public function getDisplayWith(?string $itemtype): array
     {
         global $CFG_GLPI;
 
-        $itemtype = $this->getDefaultValueItemtype($question) ?? '0';
+        if ($itemtype === null || $itemtype === '0') {
+            return [];
+        }
+
+        $displaywith = [];
         $is_itil_type = in_array($itemtype, $CFG_GLPI['itil_types']);
         $id_already_visible = isset($_SESSION['glpiis_ids_visible']) && $_SESSION['glpiis_ids_visible'];
 
-        $displaywith = [];
         if ($is_itil_type && !$id_already_visible) {
             $displaywith[] = 'id';
         }
@@ -372,17 +382,26 @@ class QuestionTypeItem extends AbstractQuestionType implements
         if (in_array($itemtype, $CFG_GLPI['asset_types'])) {
             $item = getItemForItemtype($itemtype);
             if ($item) {
-                if ($item->isField('serial')) {
-                    $displaywith[] = 'serial';
-                }
                 if ($item->isField('otherserial')) {
                     $displaywith[] = 'otherserial';
+                }
+                if ($item->isField('serial')) {
+                    $displaywith[] = 'serial';
                 }
                 if ($item->isField('users_id')) {
                     $displaywith[] = 'users_id';
                 }
             }
         }
+
+        return $displaywith;
+    }
+
+    #[Override]
+    public function renderEndUserTemplate(Question $question): string
+    {
+        $itemtype = $this->getDefaultValueItemtype($question) ?? '0';
+        $displaywith = $this->getDisplayWith($itemtype);
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render(

--- a/templates/pages/admin/form/question_type/item/administration_template.html.twig
+++ b/templates/pages/admin/form/question_type/item/administration_template.html.twig
@@ -36,26 +36,33 @@
 
 <div class="input-group">
     {# Define empty choice manually to handle root entity #}
+    {% set dropdown_options = {
+        'init'               : init,
+        'no_label'           : true,
+        'right'              : 'all',
+        'width'              : '100%',
+        'mb'                 : '',
+        'comments'           : false,
+        'addicon'            : false,
+        'aria_label'         : aria_label,
+        'nochecklimit'       : true,
+        'display_emptychoice': false,
+        'toadd'              : {
+            '-1': constant('Dropdown::EMPTY_VALUE'),
+        },
+    } %}
+
+    {# Display additional fields in dropdown: IDs for ITIL objects, serial/user for assets #}
+    {% if displaywith is not empty %}
+        {% set dropdown_options = dropdown_options|merge({'displaywith': displaywith}) %}
+    {% endif %}
+
     {{ fields.dropdownField(
         default_itemtype|default(itemtypes|first|first),
         'default_value',
         default_items_id,
         '',
-        {
-            'init'               : init,
-            'no_label'           : true,
-            'right'              : 'all',
-            'width'              : '100%',
-            'mb'                 : '',
-            'comments'           : false,
-            'addicon'            : false,
-            'aria_label'         : aria_label,
-            'nochecklimit'       : true,
-            'display_emptychoice': false,
-            'toadd'              : {
-                '-1': constant('Dropdown::EMPTY_VALUE'),
-            },
-        }
+        dropdown_options
     ) }}
     {{ advanced_config|raw }}
 </div>

--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -111,6 +111,26 @@ export class FormPage extends GlpiPage
         );
     }
 
+    public async setSubQuestionType(question: Locator, type: string): Promise<void>
+    {
+        await this.doSetDropdownValue(
+            this.getDropdownByLabel('Question sub type', question)
+                .filter({visible : true}),
+            type,
+            false
+        );
+    }
+
+    public async setItemTypeForItemQuestion(question: Locator, item_type: string): Promise<void>
+    {
+        await this.doSetDropdownValue(
+            this.getDropdownByLabel('Select an itemtype', question)
+                .filter({visible : true}),
+            item_type,
+            false
+        );
+    }
+
     public async addComment(name: string): Promise<Locator>
     {
         await this.getButton("Add a comment").click();

--- a/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
@@ -84,7 +84,7 @@ test.describe('Item form question type', () => {
 
         await form.getDropdownByLabel('Select an item', persisted_question).click();
         await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
-        await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
+        await expect(form.page.getByRole('option', { name: 'Computer 2 - 123456 - 654321' })).toBeVisible();
 
         const new_question = await form.addQuestion('Item question');
         await form.setQuestionType(new_question, 'Item');
@@ -93,6 +93,6 @@ test.describe('Item form question type', () => {
 
         await form.getDropdownByLabel('Select an item', new_question).click();
         await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
-        await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
+        await expect(form.page.getByRole('option', { name: 'Computer 2 - 123456 - 654321' })).toBeVisible();
     });
 });

--- a/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { test, expect } from '../../../fixtures/glpi_fixture';
+import { FormPage } from '../../../pages/FormPage';
+import { Profiles } from '../../../utils/Profiles';
+import { getWorkerEntityId } from '../../../utils/WorkerEntities';
+
+test.describe('Item form question type', () => {
+    let form: FormPage;
+    let form_id: number;
+    let entity_id: number;
+
+    test.beforeEach(async ({ page, profile, entity, api, formImporter }) => {
+        await profile.set(Profiles.SuperAdmin);
+        form = new FormPage(page);
+
+        // Create new entity
+        entity_id = await api.createItem('Entity', {
+            name: `Entity ${Date.now()}`,
+            entities_id: getWorkerEntityId(),
+        });
+
+        // Switch to the new entity and refresh session to ensure the new entity is taken into account in the session
+        entity.switchToWithoutRecursion(entity_id);
+        api.refreshSession();
+
+        const info = await formImporter.importForm('question_types/item-editor-test.json');
+        form_id = info.getId();
+        await form.goto(form_id);
+
+    });
+
+    test('Adding new item option and compare select option labels', async ({ api }) => {
+        // Add two computers
+        await api.createItem('Computer', {
+            name: 'Computer 1',
+            entities_id: entity_id
+        });
+        await api.createItem('Computer', {
+            name: 'Computer 2',
+            entities_id: entity_id,
+            serial: '123456',
+            otherserial: '654321'
+        });
+
+        const persisted_question = form.getLastQuestion();
+        await persisted_question.click({ position: { x: 0, y: 0 } });
+
+        form.getDropdownByLabel('Select an item', persisted_question).click();
+        await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
+        await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
+
+        const new_question = await form.addQuestion('Item question');
+        await form.setQuestionType(new_question, 'Item');
+        await form.setSubQuestionType(new_question, 'GLPI Objects');
+        await form.setItemTypeForItemQuestion(new_question, 'Computers');
+
+        form.getDropdownByLabel('Select an item', new_question).click();
+        await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
+        await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
+    });
+});

--- a/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
@@ -60,6 +60,12 @@ test.describe('Item form question type', () => {
 
     });
 
+    test.afterEach(async ({ entity, api }) => {
+        // Reset entity to default one to avoid issues with other tests in the same worker
+        entity.resetToDefaultWorkerEntity();
+        api.refreshSession();
+    });
+
     test('Adding new item option and compare select option labels', async ({ api }) => {
         // Add two computers
         await api.createItem('Computer', {

--- a/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/item.spec.ts
@@ -51,7 +51,7 @@ test.describe('Item form question type', () => {
         });
 
         // Switch to the new entity and refresh session to ensure the new entity is taken into account in the session
-        entity.switchToWithoutRecursion(entity_id);
+        await entity.switchToWithoutRecursion(entity_id);
         api.refreshSession();
 
         const info = await formImporter.importForm('question_types/item-editor-test.json');
@@ -62,7 +62,7 @@ test.describe('Item form question type', () => {
 
     test.afterEach(async ({ entity, api }) => {
         // Reset entity to default one to avoid issues with other tests in the same worker
-        entity.resetToDefaultWorkerEntity();
+        await entity.resetToDefaultWorkerEntity();
         api.refreshSession();
     });
 
@@ -82,7 +82,7 @@ test.describe('Item form question type', () => {
         const persisted_question = form.getLastQuestion();
         await persisted_question.click({ position: { x: 0, y: 0 } });
 
-        form.getDropdownByLabel('Select an item', persisted_question).click();
+        await form.getDropdownByLabel('Select an item', persisted_question).click();
         await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
         await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
 
@@ -91,7 +91,7 @@ test.describe('Item form question type', () => {
         await form.setSubQuestionType(new_question, 'GLPI Objects');
         await form.setItemTypeForItemQuestion(new_question, 'Computers');
 
-        form.getDropdownByLabel('Select an item', new_question).click();
+        await form.getDropdownByLabel('Select an item', new_question).click();
         await expect(form.page.getByRole('option', { name: 'Computer 1' })).toBeVisible();
         await expect(form.page.getByRole('option', { name: 'Computer 2 - 654321 - 123456' })).toBeVisible();
     });

--- a/tests/fixtures/forms/question_types/item-editor-test.json
+++ b/tests/fixtures/forms/question_types/item-editor-test.json
@@ -1,0 +1,77 @@
+{
+    "version": 1,
+    "forms": [
+        {
+            "id": 1,
+            "uuid": "dd000001-0001-0001-0001-000000000001",
+            "name": "Tests form for the item form question type suite",
+            "header": null,
+            "description": null,
+            "entity_name": "Root entity",
+            "is_recursive": true,
+            "is_active": false,
+            "submit_button_visibility_strategy": "always_visible",
+            "illustration": "",
+            "submit_button_conditions": [],
+            "sections": [
+                {
+                    "id": 1,
+                    "uuid": "dd000001-0001-0001-0001-000000000010",
+                    "name": "First section",
+                    "description": null,
+                    "rank": 0,
+                    "visibility_strategy": "always_visible",
+                    "conditions": []
+                }
+            ],
+            "comments": [],
+            "questions": [
+                {
+                    "id": 1,
+                    "uuid": "dd000001-0001-0001-0001-000000000100",
+                    "name": "Test item question",
+                    "type": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                    "is_mandatory": false,
+                    "vertical_rank": 0,
+                    "horizontal_rank": null,
+                    "description": "",
+                    "default_value": "",
+                    "extra_data": {
+                        "root_items_id": "0",
+                        "subtree_depth": "0",
+                        "selectable_tree_root": "0",
+                        "itemtype": "Computer"
+                    },
+                    "section_id": 1,
+                    "visibility_strategy": "always_visible",
+                    "validation_strategy": "no_validation",
+                    "conditions": [],
+                    "validation_conditions": []
+                }
+            ],
+            "policies": [
+                {
+                    "strategy": "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                    "config": {
+                        "user_ids": [
+                            "all"
+                        ],
+                        "group_ids": [],
+                        "profile_ids": []
+                    },
+                    "is_active": true
+                }
+            ],
+            "destinations": [],
+            "translations": [],
+            "data_requirements": [
+                {
+                    "itemtype": "Entity",
+                    "name": "Root entity"
+                }
+            ],
+            "custom_types_requirements": [],
+            "plugin_requirements": []
+        }
+    ]
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Ensure that the labels in the dropdown menus for “Item” questions remain the same regardless of whether they have been saved or not.
Currently, we have more information available when selecting an item before saving and reloading the page.
The display is now consistent between the form editor and the end-user interface.

## Screenshots (if appropriate):

## Before (for saved question)
<img width="777" height="280" alt="image" src="https://github.com/user-attachments/assets/9314dd75-2aa7-473e-91ef-9b73958c51f4" />


## After (for saved question)
<img width="777" height="280" alt="image" src="https://github.com/user-attachments/assets/1d0a0ba7-2968-4094-8fb2-5465ee856a5b" />
