### PR TITLE
Toggle child entities on KB article

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -116,6 +116,7 @@ export class GlpiKnowbaseArticleController
         this.#initEditor();
         this.#initDiffListeners();
         this.#initIllustrationPicker();
+        this.#initRecursiveToggle();
 
         if (mode === 'add') {
             this.#enableEditMode();
@@ -484,6 +485,32 @@ export class GlpiKnowbaseArticleController
 
         await post(`Knowbase/${this.#item_id}/UpdateIllustration`, {
             illustration: illustration,
+        });
+    }
+
+    #initRecursiveToggle()
+    {
+        if (this.#item_id === null) {
+            return;
+        }
+
+        const checkbox = document.querySelector('[data-glpi-child-entities-checkbox]');
+        if (!checkbox || checkbox.disabled) {
+            return;
+        }
+
+        checkbox.addEventListener('change', async () => {
+            const value = checkbox.checked;
+            try {
+                await post(`Knowbase/${this.#item_id}/ToggleField`, {
+                    field: 'is_recursive',
+                    value: value,
+                });
+                glpi_toast_info(value ? __('Child entities enabled') : __('Child entities disabled'));
+            } catch (e) {
+                checkbox.checked = !value;
+                throw e;
+            }
         });
     }
 

--- a/src/Glpi/Controller/Knowbase/ToggleFieldController.php
+++ b/src/Glpi/Controller/Knowbase/ToggleFieldController.php
@@ -48,7 +48,7 @@ final class ToggleFieldController extends AbstractController
 {
     use CrudControllerTrait;
 
-    private const ALLOWED_FIELDS = ['is_faq'];
+    private const ALLOWED_FIELDS = ['is_faq', 'is_recursive'];
 
     #[Route(
         "/Knowbase/{id}/ToggleField",

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -155,7 +155,9 @@
                {% if not disabled %}<input form="main-form" type="hidden" name="is_recursive" value="0" />{% endif %}
                <input form="main-form" class="form-check-input" type="checkbox" name="is_recursive" value="1"
                   {% if item.isRecursive() %}checked="checked"{% endif %}
-                  {% if disabled %}disabled="disabled"{% endif %} />
+                  {% if disabled %}disabled="disabled"{% endif %}
+                  data-glpi-child-entities-checkbox
+               />
                {% if item is instanceof('CommonDBChild') and item.isNewItem() and item.isRecursive() %}
                   {# Send value on hidden field to ensure creation will use inherited recursivity on CommonDBChild #}
                   <input form="main-form" type="hidden" name="is_recursive" value="1" />

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -96,6 +96,19 @@ export class KnowbaseItemPage extends GlpiPage
         await response_promise;
     }
 
+    public get childEntitiesCheckbox(): Locator
+    {
+        return this.page.getByRole('checkbox', { name: 'Child entities' });
+    }
+
+    public async doToggleChildEntities(): Promise<void>
+    {
+        // Wait for ArticleController to finish initialization (it removes pe-none after attaching all listeners)
+        // eslint-disable-next-line playwright/no-raw-locators -- No semantic alternative for article container
+        await this.page.locator('[data-glpi-knowbase-article]:not(.pe-none)').waitFor();
+        await this.childEntitiesCheckbox.click();
+    }
+
     public async doOpenCommentsPanel(): Promise<void>
     {
         await this.page.getByTitle('More actions').click();

--- a/tests/e2e/specs/Knowbase/child_entities.spec.ts
+++ b/tests/e2e/specs/Knowbase/child_entities.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from "../../fixtures/glpi_fixture";
+import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
+import { Profiles } from "../../utils/Profiles";
+import { getWorkerEntityId } from "../../utils/WorkerEntities";
+
+test('Can toggle child entities from false to true', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'KB child entities test',
+        entities_id: getWorkerEntityId(),
+        answer: "My answer",
+        is_recursive: 0,
+    });
+
+    await kb.goto(id);
+
+    // Toggle value
+    await expect(kb.childEntitiesCheckbox).not.toBeChecked();
+    await kb.doToggleChildEntities();
+    await expect(kb.childEntitiesCheckbox).toBeChecked();
+
+    // Confirm toast is shown
+    await expect(kb.getAlert('Child entities enabled')).toBeVisible();
+
+    // Validate value was saved
+    await page.reload();
+    await expect(kb.childEntitiesCheckbox).toBeChecked();
+});
+
+test('Can toggle child entities from true to false', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'KB child entities test',
+        entities_id: getWorkerEntityId(),
+        answer: "My answer",
+        is_recursive: 1,
+    });
+
+    await kb.goto(id);
+
+    // Toggle value
+    await expect(kb.childEntitiesCheckbox).toBeChecked();
+    await kb.doToggleChildEntities();
+    await expect(kb.childEntitiesCheckbox).not.toBeChecked();
+
+    // Confirm toast is shown
+    await expect(kb.getAlert('Child entities disabled')).toBeVisible();
+
+    // Validate value was saved
+    await page.reload();
+    await expect(kb.childEntitiesCheckbox).not.toBeChecked();
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The entity checkbox was already displayed on KB articles (like all CommonDBTM items) but it did nothing because we don't use the standard update form (so there way no way to save the value).

I've added a JS handler to update the value when changed.

![ce](https://github.com/user-attachments/assets/4997e2a5-0fb9-4a11-8d9f-49b7dba36e4b)

