### PR TITLE
quick fix undefined $CFG_GLPI['url_base']

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -161,22 +161,22 @@ EOT;
                 'api_version' => '1',
                 'version'    => '1.0.0',
                 'description' => str_replace(PHP_EOL, ' ', $low_level_api_description),
-                'endpoint'   => $CFG_GLPI['url_base'] . '/api.php/v1',
+                'endpoint'   => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v1',
             ],
             [
                 'api_version' => '2',
                 'version' => '2.0.0',
-                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.0',
+                'endpoint' => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v2.0',
             ],
             [
                 'api_version' => '2',
                 'version' => '2.1.0',
-                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.1',
+                'endpoint' => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v2.1',
             ],
             [
                 'api_version' => '2',
                 'version' => '2.2.0',
-                'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.2',
+                'endpoint' => ($CFG_GLPI['url_base'] ?? '') . '/api.php/v2.2',
             ],
         ];
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

When installaling database `bin/console database:install ...` a warning is added a lot of times in log file `files/_log/php-errors.log` . It pollute the logs and harden it's inspection.

```
[2026-03-18 11:08:26] glpi.WARNING:   *** Warning: Undefined array key "url_base" at Router.php line 171
  Backtrace :
  ./src/Glpi/Api/HL/Router.php:171                   
  ./src/Glpi/Api/HL/Router.php:188                   Glpi\Api\HL\Router::getAPIVersions()
  ./src/Glpi/Api/HL/Doc/Schema.php:341               Glpi\Api\HL\Router::normalizeAPIVersion()
  ...pi/Api/HL/Controller/AbstractController.php:113 Glpi\Api\HL\Doc\Schema::filterSchemaByAPIVersion()
  ./src/Webhook.php:415                              Glpi\Api\HL\Controller\AbstractController::getKnownSchemas()
  ./src/Webhook.php:1120                             Webhook::getAPIItemtypeData()
  ./src/CommonDBTM.php:1432                          Webhook::raise()
  ./src/Glpi/Form/Form.php:793                       CommonDBTM->add()
  ./src/Glpi/Form/Form.php:326                       Glpi\Form\Form->createFirstSection()
  ./src/CommonDBTM.php:1397                          Glpi\Form\Form->post_addItem()
  ./src/Glpi/Helpdesk/DefaultDataManager.php:312     CommonDBTM->add()
  ./src/Glpi/Helpdesk/DefaultDataManager.php:186     Glpi\Helpdesk\DefaultDataManager->createForm()
  ./src/Glpi/Helpdesk/DefaultDataManager.php:94      Glpi\Helpdesk\DefaultDataManager->createIncidentForm()
  ./src/Toolbox.php:2245                             Glpi\Helpdesk\DefaultDataManager->initializeData()
  ./src/Glpi/Console/Database/InstallCommand.php:328 Toolbox::createSchema()
  ./vendor/symfony/console/Command/Command.php:326   Glpi\Console\Database\InstallCommand->execute()
  ./vendor/symfony/console/Application.php:1088      Symfony\Component\Console\Command\Command->run()
  ./src/Glpi/Console/Application.php:330             Symfony\Component\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:324       Glpi\Console\Application->doRunCommand()
  ./vendor/symfony/console/Application.php:175       Symfony\Component\Console\Application->doRun()
  ./bin/console:144                                  Symfony\Component\Console\Application->run()
```

It happens when creating default forms, which triggers Webhook::raise() - ./src/Webhook.php:1120

Webhook probably don't have to be trigger on db installation but fixing it requires an in depth work that I don't pretend to do now.
So that's a quick and efficient fix (that don't fix the underlying problem) (maybe it deserve to create an issue).

