### PR TITLE
feat(ui): Add badge counter LDAP "Replicates" tab

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4011,6 +4011,31 @@ TWIG, $twig_params);
         Rule::cleanForItemCriteria($this, 'LDAP_SERVER');
     }
 
+    /**
+     * Count the number of replicates associated with an LDAP server
+     *
+     * @param CommonGLPI $item The LDAP server item to count replicates for
+     * @return int The total number of replicates associated with the LDAP server
+     */
+    public static function countReplicatesForLDAP(CommonGLPI $item): int
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        if (!$item instanceof AuthLDAP) {
+            return 0;
+        }
+
+        if (!$item->can($item->getID(), READ)) {
+            return 0;
+        }
+
+        return countElementsInTable(
+            'glpi_authldapreplicates',
+            ['authldaps_id' => $item->getID()]
+        );
+    }
+
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         /** @var CommonDBTM $item */
@@ -4023,7 +4048,11 @@ TWIG, $twig_params);
             $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
             $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
             $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config
-            $ong[6]  = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()));
+            $count = 0;
+            if ($_SESSION['glpishow_count_on_tabs']) {
+                $count = self::countReplicatesForLDAP($item);
+            }
+            $ong[6]  = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()), $count);
 
             return $ong;
         }

--- a/tests/functional/AuthLDAPReplicateCountTest.php
+++ b/tests/functional/AuthLDAPReplicateCountTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\DbTestCase;
+
+class AuthLDAPReplicateCountTest extends DbTestCase
+{
+    public function testCountReplicatesForLDAP(): void
+    {
+        $this->login();
+
+        $ldap = new \AuthLDAP();
+        $ldap_id = (int) $ldap->add([
+            'name'        => 'LDAP_count_test',
+            'is_active'   => 1,
+            'is_default'  => 0,
+            'basedn'      => 'ou=people,dc=mycompany',
+            'login_field' => 'uid',
+        ]);
+        $this->assertGreaterThan(0, $ldap_id);
+        $this->assertTrue($ldap->getFromDB($ldap_id));
+
+        $this->assertSame(0, \AuthLDAP::countReplicatesForLDAP($ldap));
+
+        $replicate = new \AuthLdapReplicate();
+        $rep1_id = (int) $replicate->add([
+            'name'         => 'Replicate1',
+            'host'         => 'ldap1.example.com',
+            'port'         => 389,
+            'authldaps_id' => $ldap_id,
+        ]);
+        $this->assertGreaterThan(0, $rep1_id);
+
+        $this->assertTrue($ldap->getFromDB($ldap_id));
+        $this->assertSame(1, \AuthLDAP::countReplicatesForLDAP($ldap));
+
+        $rep2_id = (int) $replicate->add([
+            'name'         => 'Replicate2',
+            'host'         => 'ldap2.example.com',
+            'port'         => 389,
+            'authldaps_id' => $ldap_id,
+        ]);
+        $this->assertGreaterThan(0, $rep2_id);
+
+        $this->assertTrue($ldap->getFromDB($ldap_id));
+        $this->assertSame(2, \AuthLDAP::countReplicatesForLDAP($ldap));
+    }
+
+    public function testGetTabNameForItemWithReplicateCounter(): void
+    {
+        $this->login();
+
+        $ldap = new \AuthLDAP();
+        $ldap_id = (int) $ldap->add([
+            'name'        => 'LDAP_tab_count_test',
+            'is_active'   => 1,
+            'is_default'  => 0,
+            'basedn'      => 'ou=people,dc=mycompany',
+            'login_field' => 'uid',
+        ]);
+        $this->assertGreaterThan(0, $ldap_id);
+        $this->assertTrue($ldap->getFromDB($ldap_id));
+
+        $replicate = new \AuthLdapReplicate();
+        $this->assertGreaterThan(0, (int) $replicate->add([
+            'name'         => 'TabReplicate1',
+            'host'         => 'ldaprep1.example.com',
+            'port'         => 389,
+            'authldaps_id' => $ldap_id,
+        ]));
+
+        $this->assertTrue($ldap->getFromDB($ldap_id));
+
+        $_SESSION['glpishow_count_on_tabs'] = 1;
+        $result = $ldap->getTabNameForItem($ldap);
+        $tab_html = $result[6];
+        $this->assertStringContainsString('badge', $tab_html);
+        $this->assertStringContainsString('1', strip_tags($tab_html));
+
+        $_SESSION['glpishow_count_on_tabs'] = 0;
+        $result = $ldap->getTabNameForItem($ldap);
+        $tab_html = $result[6];
+        $this->assertStringNotContainsString('badge', $tab_html);
+        $this->assertSame('Replicates', strip_tags($tab_html));
+    }
+
+    public function testCountReplicatesForNonExistentLDAP(): void
+    {
+        $this->login();
+
+        $ldap = new \AuthLDAP();
+        $this->assertSame(0, \AuthLDAP::countReplicatesForLDAP($ldap));
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Applies the same tab badge counter pattern (introduced for Budget Items) to the **Replicates** tab (`index 6`) on LDAP server pages.

**`src/AuthLDAP.php`**
- Added `countReplicatesForLDAP(CommonGLPI $item): int` — queries `glpi_authldapreplicates`, returns 0 for non-`AuthLDAP` items or without READ permission.
- Updated `getTabNameForItem()` to conditionally pass the replicate count to `createTabEntry()` when `$_SESSION['glpishow_count_on_tabs']` is enabled:

```php
$count = 0;
if ($_SESSION['glpishow_count_on_tabs']) {
    $count = self::countReplicatesForLDAP($item);
}
$ong[6] = self::createTabEntry(_n('Replicate', 'Replicates', Session::getPluralNumber()), $count);
```

**`tests/functional/AuthLDAPReplicateCountTest.php`** *(new)*
- `testCountReplicatesForLDAP()` — asserts count grows from 0 → 1 → 2 as replicates are added.
- `testGetTabNameForItemWithReplicateCounter()` — asserts badge is present in tab HTML when `glpishow_count_on_tabs=1` and absent when `=0`.
- `testCountReplicatesForNonExistentLDAP()` — asserts unsaved `AuthLDAP` instance (no DB record) returns 0.

The existing `testGetTabNameForItem()` in `tests/LDAP/AuthLdapTest.php` is unaffected: with count=0, `createTabEntry` renders no badge, so `strip_tags` still yields `"Replicates"`.

## Screenshots (if appropriate):

<img width="511" height="391" alt="image" src="https://github.com/user-attachments/assets/4121a3a9-005f-4e49-ba71-d19fe8cd1b13" />
