### PR TITLE
fix(SQLProvider): prevent null completename error for entites

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6531,7 +6531,7 @@ final class SQLProvider implements SearchProviderInterface
                                 $name = (new SanitizedStringsDecoder())->decodeHtmlSpecialCharsInCompletename(
                                     !empty($data[$ID][$k]['trans_completename'])
                                         ? $data[$ID][$k]['trans_completename']
-                                        : $data[$ID][$k]['name']
+                                        : $name
                                 );
                                 $chunks = \explode(' > ', $name);
                                 $completename = '';


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42846
- If the completename is not defined for a CommonTreeDropdown (e.g. entity), an error is thrown.

<img width="2280" height="608" alt="image" src="https://github.com/user-attachments/assets/926bd5bd-15f4-4e7f-9a00-aa335417dbb7" />





