### PR TITLE
Fix default user profile deletion

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1229,6 +1229,14 @@ TWIG, $avatar_params) . $username;
 
     public function post_deleteFromDB()
     {
+        $selected_user = User::getById($this->fields['users_id']);
+        if ($selected_user->fields['profiles_id'] == $this->fields['profiles_id']) {
+            $user = new User();
+            $user->update([
+                'id' => $this->fields['users_id'],
+                'profiles_id' => 0
+            ]);
+        }
         $this->logOperation('delete');
     }
 

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1234,7 +1234,7 @@ TWIG, $avatar_params) . $username;
             $user = new User();
             $user->update([
                 'id' => $this->fields['users_id'],
-                'profiles_id' => 0
+                'profiles_id' => 0,
             ]);
         }
         $this->logOperation('delete');

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1231,7 +1231,7 @@ TWIG, $avatar_params) . $username;
     {
         $selected_user = User::getById($this->fields['users_id']);
 
-        if ($selected_user instanceof User && $selected_user != false && $selected_user->fields['profiles_id'] == $this->fields['profiles_id']) {
+        if ($selected_user instanceof User && $selected_user->fields['profiles_id'] == $this->fields['profiles_id']) {
             $user = new User();
             $user->update([
                 'id' => $this->fields['users_id'],

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1230,7 +1230,8 @@ TWIG, $avatar_params) . $username;
     public function post_deleteFromDB()
     {
         $selected_user = User::getById($this->fields['users_id']);
-        if ($selected_user->fields['profiles_id'] == $this->fields['profiles_id']) {
+
+        if ($selected_user instanceof User && $selected_user != false && $selected_user->fields['profiles_id'] == $this->fields['profiles_id']) {
             $user = new User();
             $user->update([
                 'id' => $this->fields['users_id'],

--- a/src/User.php
+++ b/src/User.php
@@ -1295,7 +1295,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
         // Security on default profile update
         if (isset($input['profiles_id'])) {
-            if (!in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))) {
+            if (!in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id'])) && $input['profiles_id'] != 0) {
                 unset($input['profiles_id']);
             }
         }

--- a/tests/functional/Profile_UserTest.php
+++ b/tests/functional/Profile_UserTest.php
@@ -438,4 +438,41 @@ class Profile_UserTest extends DbTestCase
         $this->assertStringContainsString('<span class="badge glpi-badge">3</span>', $profile_user->getTabNameForItem($profile));
 
     }
+
+    public function testDeleteProfileUserWhenIsTheDefaultProfile(): void
+    {
+        // When a Profile_User entry is deleted and it corresponds to the default profile of the user, the default profile should be set to 0
+        $this->login();
+        $profile = getItemByTypeName(Profile::class, 'Technician');
+        $user = getItemByTypeName(User::class, 'glpi');
+
+        // Set the profile for the user and add it as default profile
+        $this->assertNotFalse((new Profile_User())->add([
+            'users_id' => $user->getId(),
+            'profiles_id' => $profile->getId(),
+            'entities_id' => getItemByTypeName(\Entity::class, '_test_root_entity', true),
+        ]));
+        $user->update([
+            'id' => $user->getId(),
+            'profiles_id' => $profile->getId(),
+        ]);
+
+        $this->assertEquals($profile->getId(), $user->fields['profiles_id']);
+
+        $profile_user = new Profile_User();
+        $this->assertTrue($profile_user->deleteByCriteria([
+            'users_id' => $user->getId(),
+            'profiles_id' => $profile->getId(),
+        ]));
+
+        //Check that the Profile_User entry has been deleted
+        $this->assertEquals(0, countElementsInTable($profile_user->getTable(), [
+            'users_id' => $user->getId(),
+            'profiles_id' => $profile->getId(),
+        ]));
+
+        //Check that the default profile of the user has been set to 0
+        $user->getFromDB($user->getId());
+        $this->assertEquals(0, $user->fields['profiles_id']);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42852
- Here is a brief description of what this PR does
Two related issues have been fixed.

The first concerns the inability to delete a user's default profile. The reason for this was that, to determine whether to set a profile as the default, GLPI used `Profile_User::getUserProfiles` to verify that the default profile was one the user already possessed; however, the condition `profiles_id == 0` was missing, making it impossible to deselect the default profile.

The second issue was related to the first because when a profile is the default, it is possible to remove it from a user’s list of permissions; however, this kept it as the default profile in the database. Consequently, when searching the user pages using the “default profile” criterion, incorrect results were displayed because the value was still present in the database.

## Screenshots (if appropriate):


