### PR TITLE
Fix LDAP import and sync failures when only one directory is active

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3654,13 +3654,13 @@ TWIG, $twig_params);
                 $entity->getFromDB($_REQUEST['entities_id'])
                 && $entity->fields['authldaps_id'] > 0
             ) {
-                $authldap->getFromDB($_REQUEST['authldaps_id']);
-
                 if ($_REQUEST['authldaps_id'] === 0) {
                     // authldaps_id wasn't submitted by the user -> take entity config
                     $_REQUEST['authldaps_id'] = $entity->fields['authldaps_id'];
                 }
 
+                $authldap->getFromDB($_REQUEST['authldaps_id']);
+                
                 $_REQUEST['basedn']       = $entity->fields['ldap_dn'];
 
                 // No dn specified in entity : use standard one

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3660,7 +3660,6 @@ TWIG, $twig_params);
                 }
 
                 $authldap->getFromDB($_REQUEST['authldaps_id']);
-                
                 $_REQUEST['basedn']       = $entity->fields['ldap_dn'];
 
                 // No dn specified in entity : use standard one


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #22452 
- Here is a brief description of what this PR does

This PR fixes a critical bug where importing or synchronizing users from an LDAP directory fails if there is only **one** active directory configured in GLPI. 

When a single directory is active, the UI does not send the `authldaps_id` parameter (it defaults to `0`). Inside `src/AuthLDAP.php::manageRequestValues()`, the system was attempting to hydrate the `$authldap` object from the database using `authldaps_id = 0` **before** the code block that resolves the default ID from the entity. 

Because `getFromDB(0)` returns false/empty, the `$authldap->fields` array remained empty, causing a cascade of undefined key warnings and ultimately generating a malformed LDAP filter (e.g., falling back to `N/A`).

### Errors Resolved
This fix eliminates the following errors that occur during the import/sync process:
* `PHP Warning (2): Undefined array key "basedn" in src/AuthLDAP.php at line 3667`
* `PHP Warning (2): Undefined array key "login_field" in src/AuthLDAP.php at line 3813`
* `PHP Warning (2): Undefined array key "condition" in src/AuthLDAP.php at line 3824`
* `LDAP search with base DN N/A and filter (& (N/A=*usuario*) N/A) failed error: Bad search filter (-7) at AuthLDAP.php line 1803`

### Solution
The line of code that loads the database object (`$authldap->getFromDB($_REQUEST['authldaps_id']);`) was placed in the wrong order. 

I moved it to sit directly **below** the `if ($_REQUEST['authldaps_id'] === 0) { ... }` block. This ensures the object is only fetched from the database *after* the `authldaps_id` has been correctly replaced by the entity's default LDAP ID.
