### PR TITLE
Fix/task pending btn rights check 10.0

### DIFF
--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -410,7 +410,7 @@
 
             {% set pending_reasons %}
                {% set show_pending_reasons_actions = item.fields['status'] == constant('CommonITILObject::WAITING') and not has_pending_reason %}
-               {% if call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
+               {% if item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::WAITING')) and call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
                   <span
                      class="input-group-text bg-yellow-lt py-0 pe-0 {{ show_pending_reasons_actions ? 'flex-fill' : '' }}"
                      id="pending-reasons-control-{{ rand }}"


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42748
- The pending action available from ticket tasks was not checking whether the ticket was actually allowed to move to the `WAITING` status.
This created an inconsistency with followups, where the pending action is already hidden when the current profile or lifecycle does not allow switching the ticket to `WAITING`.



