### PR TITLE
fix(SQLProvider): fix Entities (Profile) search option

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -396,7 +396,7 @@ final class SQLProvider implements SearchProviderInterface
                             expression: QueryFunction::concat([
                                 "{$table}{$addtable}.completename",
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.entities_id",
+                                "glpi_profiles_users{$addtable2}.profiles_id",
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
                                 "glpi_profiles_users{$addtable2}.is_recursive",
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42894
- Profiles were not displayed correctly in the “Entities (Profile)” column. The entity ID was used instead of the profile ID, which caused an inconsistency.

## Screenshots (if appropriate):

Before fix:
<img width="210" height="154" alt="image" src="https://github.com/user-attachments/assets/ce93f437-e67c-4ae4-8d25-b5a2daf19607" />

After fix:
<img width="210" height="154" alt="image" src="https://github.com/user-attachments/assets/83c4e9d4-ef38-4ac9-ba3c-523dac5dd22b" />



