### PR TITLE
Fix Twig error on ChangeTask timeline by initializing missing source …

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7742,10 +7742,10 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     ;
                     // Initialize fields that only exist for TicketTask
                     if (!isset($task_row['sourceitems_id'])) {
-                        $task_row['sourceitems_id'] = 0;
+                        $task_row['sourceitems_id'] = $this->getID();
                     }
                     if (!isset($task_row['sourceof_items_id'])) {
-                        $task_row['sourceof_items_id'] = 0;
+                        $task_row['sourceof_items_id'] = $this->getID();
                     }
                     $timeline[$tltask::getType() . "_" . $tasks_id] = [
                         'type'     => $taskClass,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7696,6 +7696,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $followup->fields = $followup_row;
                 $followup->post_getFromDB();
 
+                Toolbox::logDebug($followup_row);
                 if (!$params['check_view_rights'] || $followup->canViewItem()) {
                     $followup_row['can_edit'] = $followup->canUpdateItem();
                     $followup_row['can_promote']
@@ -7703,6 +7704,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         && $this instanceof Ticket
                         && Ticket::canCreate()
                     ;
+
+                    if (!isset($followup_row['sourceitems_id'])) {
+                        $followup_row['sourceitems_id'] = 0;
+                    }
+                    if (!isset($followup_row['sourceof_items_id'])) {
+                        $followup_row['sourceof_items_id'] = 0;
+                    }
                     $timeline["ITILFollowup_" . $followups_id] = [
                         'type'     => ITILFollowup::class,
                         'item'     => $followup_row,
@@ -7733,6 +7741,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         && $this instanceof Ticket
                         && Ticket::canCreate()
                     ;
+                    // Initialize fields that only exist for TicketTask
+                    if (!isset($task_row['sourceitems_id'])) {
+                        $task_row['sourceitems_id'] = 0;
+                    }
+                    if (!isset($task_row['sourceof_items_id'])) {
+                        $task_row['sourceof_items_id'] = 0;
+                    }
                     $timeline[$tltask::getType() . "_" . $tasks_id] = [
                         'type'     => $taskClass,
                         'item'     => $task_row,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7696,7 +7696,6 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 $followup->fields = $followup_row;
                 $followup->post_getFromDB();
 
-                Toolbox::logDebug($followup_row);
                 if (!$params['check_view_rights'] || $followup->canViewItem()) {
                     $followup_row['can_edit'] = $followup->canUpdateItem();
                     $followup_row['can_promote']
@@ -7706,10 +7705,10 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     ;
 
                     if (!isset($followup_row['sourceitems_id'])) {
-                        $followup_row['sourceitems_id'] = 0;
+                        $followup_row['sourceitems_id'] = $this->getID();
                     }
                     if (!isset($followup_row['sourceof_items_id'])) {
-                        $followup_row['sourceof_items_id'] = 0;
+                        $followup_row['sourceof_items_id'] = $this->getID();
                     }
                     $timeline["ITILFollowup_" . $followups_id] = [
                         'type'     => ITILFollowup::class,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7704,11 +7704,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         && Ticket::canCreate()
                     ;
 
+                    // Initialize fields that only exist for ChangeTask
+                    // 0 when is not a ticket
                     if (!isset($followup_row['sourceitems_id'])) {
-                        $followup_row['sourceitems_id'] = $this->getID();
+                        $followup_row['sourceitems_id'] = 0;
                     }
                     if (!isset($followup_row['sourceof_items_id'])) {
-                        $followup_row['sourceof_items_id'] = $this->getID();
+                        $followup_row['sourceof_items_id'] = 0;
                     }
                     $timeline["ITILFollowup_" . $followups_id] = [
                         'type'     => ITILFollowup::class,
@@ -7740,12 +7742,13 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         && $this instanceof Ticket
                         && Ticket::canCreate()
                     ;
-                    // Initialize fields that only exist for TicketTask
+                    // Initialize fields that only exist for ChangeTask
+                    // 0 when is not a ticket
                     if (!isset($task_row['sourceitems_id'])) {
-                        $task_row['sourceitems_id'] = $this->getID();
+                        $task_row['sourceitems_id'] = 0;
                     }
                     if (!isset($task_row['sourceof_items_id'])) {
-                        $task_row['sourceof_items_id'] = $this->getID();
+                        $task_row['sourceof_items_id'] = 0;
                     }
                     $timeline[$tltask::getType() . "_" . $tasks_id] = [
                         'type'     => $taskClass,


### PR DESCRIPTION
…fields

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes
Fixes a Twig error that occurs when displaying tasks in a change. The `sourceitems_id` and `sourceof_items_id` fields do not exist for changes.
Initializes these fields in `CommonITILObject::getTimelineItems()` for all ITIL types, preventing the “Key does not exist” error in Twig templates.

## Screenshots (if appropriate):
<img width="809" height="202" alt="image" src="https://github.com/user-attachments/assets/3601fbf0-fe2f-4f14-8a1a-02254bdd6477" />


