### PR TITLE
fix(RuleTicket): fix SQL errors related to regex_result operators

### DIFF
--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -1,5 +1,7 @@
 <?php
 
+use Glpi\Toolbox\Sanitizer;
+
 /**
  * ---------------------------------------------------------------------
  *
@@ -486,7 +488,7 @@ class RuleAction extends CommonDBChild
                 }
             }
         }
-        return $action;
+        return Sanitizer::sanitize($action);
     }
 
 

--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -1,7 +1,5 @@
 <?php
 
-use Glpi\Toolbox\Sanitizer;
-
 /**
  * ---------------------------------------------------------------------
  *
@@ -34,6 +32,8 @@ use Glpi\Toolbox\Sanitizer;
  *
  * ---------------------------------------------------------------------
  */
+
+use Glpi\Toolbox\Sanitizer;
 
 class RuleAction extends CommonDBChild
 {

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
 
 class RuleTicket extends Rule
 {
@@ -457,6 +458,7 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $target_itilcategory = ITILCategory::getITILCategoryIDByCode($regexvalue);
                                 if ($target_itilcategory != -1) {
                                     $output["itilcategories_id"] = $target_itilcategory;
@@ -468,6 +470,7 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
@@ -483,10 +486,11 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
-                                        "is_observer" => true,
+                                        "is_watcher" => true,
                                     ])
                                 ) {
                                     $output['_additional_groups_observers'][$group->getID()] = $group->getID();
@@ -498,6 +502,7 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
@@ -520,6 +525,7 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $appliances = new Appliance();
                                 $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
 
@@ -544,6 +550,7 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $projects = new Project();
                                 $target_projects = $projects->find(["name" => $regexvalue]);
 
@@ -568,6 +575,7 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
+                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $contracts = new Contract();
                                 $target_contract = $contracts->find(["name" => $regexvalue, "entities_id" => $output['entities_id']]);
 

--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -33,7 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Toolbox\Sanitizer;
 
 class RuleTicket extends Rule
 {
@@ -458,7 +457,6 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $target_itilcategory = ITILCategory::getITILCategoryIDByCode($regexvalue);
                                 if ($target_itilcategory != -1) {
                                     $output["itilcategories_id"] = $target_itilcategory;
@@ -470,7 +468,6 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
@@ -486,7 +483,6 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
@@ -502,7 +498,6 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $group = new Group();
                                 if (
                                     $group->getFromDBByCrit(["name" => $regexvalue,
@@ -525,7 +520,6 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $appliances = new Appliance();
                                 $target_appliances = $appliances->find(["name" => $regexvalue, "is_helpdesk_visible" => true]);
 
@@ -550,7 +544,6 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $projects = new Project();
                                 $target_projects = $projects->find(["name" => $regexvalue]);
 
@@ -575,7 +568,6 @@ class RuleTicket extends Rule
                             }
 
                             if (!is_null($regexvalue)) {
-                                $regexvalue = Sanitizer::sanitize($regexvalue);
                                 $contracts = new Contract();
                                 $target_contract = $contracts->find(["name" => $regexvalue, "entities_id" => $output['entities_id']]);
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42925
- If a ticket rule contains at least one action using the regex_result operator and the associated criterion includes special characters used in SQL queries (such as an apostrophe '), an SQL error is generated.

Additionally, the column targeted by the "Watcher group" action was incorrect. The query was using is_observer instead of the correct column is_watcher.

## Screenshots (if appropriate):

Actions:
<img width="1434" height="459" alt="image" src="https://github.com/user-attachments/assets/4067f7a1-392e-47af-817f-659a94f47d57" />

Errors before fix:
<img width="1127" height="590" alt="image" src="https://github.com/user-attachments/assets/a9a13c69-15f6-4484-b547-0001bd37c193" />





