### PR TITLE
Ignore draft form in tab count

### DIFF
--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -220,6 +220,7 @@ final class Form extends CommonDBTM implements
         if ($_SESSION['glpishow_count_on_tabs']) {
             $nb = countElementsInTable(self::getTable(), [
                 'forms_categories_id' => $item->getID(),
+                'is_draft' => 0,
             ]);
         }
 

--- a/tests/functional/Glpi/Form/FormTest.php
+++ b/tests/functional/Glpi/Form/FormTest.php
@@ -41,6 +41,7 @@ use Glpi\Form\AccessControl\ControlType\DirectAccess;
 use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
 use Glpi\Form\AccessControl\FormAccessControl;
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Category;
 use Glpi\Form\Comment;
 use Glpi\Form\Condition\LogicOperator;
 use Glpi\Form\Condition\Type;
@@ -885,5 +886,36 @@ class FormTest extends DbTestCase
 
         // Assert: the conditions should be deleted
         $this->assertEmpty($form->getConfiguredConditionsData());
+    }
+
+    public function testTabCountExcludeDrafts(): void
+    {
+        // Arrange: create 3 forms in a category (one is a draft)
+        $category = $this->createItem(Category::class, [
+            'name' => 'My category',
+        ]);
+        $this->createItem(Form::class, [
+            'name'                => 'Draft form',
+            'is_draft'            => 1,
+            'forms_categories_id' => $category->getID(),
+        ]);
+        $this->createItem(Form::class, [
+            'name'                => 'Normal form 1',
+            'is_draft'            => 0,
+            'forms_categories_id' => $category->getID(),
+        ]);
+        $this->createItem(Form::class, [
+            'name'                => 'Normal form 2',
+            'is_draft'            => 0,
+            'forms_categories_id' => $category->getID(),
+        ]);
+
+        // Act: get tab names for this category
+        $form = new Form();
+        $name = $form->getTabNameForItem($category);
+
+        // Assert: tab count should only indicate two items
+        $name = strip_tags($name);
+        $this->assertEquals("Forms 2", $name);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Draft forms were counted in tab names, thus showing an inaccurate number:

<img width="718" height="331" alt="image" src="https://github.com/user-attachments/assets/1078d2e2-1232-4dc5-9bad-c352902b3279" />

## References

Fix #23088.

