### PR TITLE
Do not overwrite glpikey on install

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -278,7 +278,7 @@ function step4(string $databasename, string $newdatabasename): void
 
     //create security key
     $glpikey = new GLPIKey();
-    if (!$glpikey->generate(update_db: false)) {
+    if (!$glpikey->keyExists() && !$glpikey->generate(update_db: false)) {
         echo "<p><strong>" . __s('Security key cannot be generated!') . "</strong></p>";
         $prev_form($host, $user, $password);
         return;

--- a/src/Glpi/Console/Database/InstallCommand.php
+++ b/src/Glpi/Console/Database/InstallCommand.php
@@ -226,7 +226,7 @@ class InstallCommand extends AbstractConfigureCommand implements ConfigurationCo
 
         // Create security key
         $glpikey = new GLPIKey();
-        if (!$glpikey->generate(update_db: false)) {
+        if (!$glpikey->keyExists() && !$glpikey->generate(update_db: false)) {
             $message = __('Security key cannot be generated!');
             $output->writeln('<error>' . $message . '</error>', OutputInterface::VERBOSITY_QUIET);
             return self::ERROR_CANNOT_CREATE_ENCRYPTION_KEY_FILE;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

This may only affect me and the way I handle multiple GLPI versions in development, but GLPI should avoid destroying an existing glpikey file during the installation process.

For reference, I use the same GLPI path for both GLPI 10, 11, and 12. My DB config automatically changes the DB class declaration depending on the GLPI version so each version still has its own database.

When I want to reinstall the DB for one version of GLPI, I don't want all encrypted data in the other databases to suddenly become invalid.