### PR TITLE
add echarts data view translations

### DIFF
--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -60,6 +60,48 @@ class Widget
     /** @var int */
     public static $animation_duration = 1000; // in millseconds
 
+    /**
+     * Get toolbox options for ECharts, with colors adapted to the widget palette.
+     * @param string $fg_color
+     * @param string $bg_color
+     * @return array<string, mixed>
+     */
+    public static function getEChartsToolboxOptions(string $fg_color, string $bg_color): array
+    {
+        return [
+            'show'    => false,
+            'feature' => [
+                'dataView'    => [
+                    'show'     => true,
+                    'readOnly' => true,
+                    'title'    => __('View data'),
+                    'emphasis' => [
+                        'iconStyle' => [
+                            'color' => $fg_color,
+                            'textBackgroundColor' => $bg_color,
+                            'textPadding' => 5,
+                        ],
+                    ],
+                    'lang' => [
+                        __('Data view'),
+                        __('Close'),
+                        __('Refresh'),
+                    ],
+                ],
+                'saveAsImage' => [
+                    'show'  => true,
+                    'title' => __('Save as image'),
+                    'emphasis' => [
+                        'iconStyle' => [
+                            'color' => $fg_color,
+                            'textBackgroundColor' => $bg_color,
+                            'textPadding' => 5,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 
     /**
      * Define all possible widget types with their $labels/
@@ -714,34 +756,7 @@ HTML;
                 'trigger'      => 'item',
                 'appendToBody' => true,
             ],
-            'toolbox' => [
-                'show'    => false,
-                'feature' => [
-                    'dataView'    => [
-                        'show'     => true,
-                        'readOnly' => true,
-                        'title'    => __('View data'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                    'saveAsImage' => [
-                        'show'  => true,
-                        'title' => __('Save as image'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'toolbox' => self::getEChartsToolboxOptions($dark_fg_color, $dark_bg_color),
             'series' => [
                 [
                     'type'              => 'pie',
@@ -1213,34 +1228,7 @@ HTML;
                 'top'          => $p['legend'] ? '40' : '20',
                 'containLabel' => true,
             ],
-            'toolbox' => [
-                'show'    => false,
-                'feature' => [
-                    'dataView'    => [
-                        'show'     => true,
-                        'readOnly' => true,
-                        'title'    => __('View data'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                    'saveAsImage' => [
-                        'show'  => true,
-                        'title' => __('Save as image'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'toolbox' => self::getEChartsToolboxOptions($dark_fg_color, $dark_bg_color),
             'series' => $echarts_series,
             'xAxis'  => [
                 'type' => 'category',
@@ -1606,34 +1594,7 @@ HTML;
                 'bottom'       => '3%',
                 'containLabel' => true,
             ],
-            'toolbox' => [
-                'show'    => false,
-                'feature' => [
-                    'dataView'    => [
-                        'show'     => true,
-                        'readOnly' => true,
-                        'title' => __('View data'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                    'saveAsImage' => [
-                        'show'  => true,
-                        'title' => __('Save as image'),
-                        'emphasis' => [
-                            'iconStyle' => [
-                                'color' => $dark_fg_color,
-                                'textBackgroundColor' => $dark_bg_color,
-                                'textPadding' => 5,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'toolbox' => self::getEChartsToolboxOptions($dark_fg_color, $dark_bg_color),
             'xAxis'  => [
                 'type'        => 'category',
                 'data'        => $labels,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23569

Add translations for elements in eCharts data view mode. Close and Refresh strings already exist in GLPI, while "Data view" is a new one.

The eCharts toolbox options were moved to a function for easy reuse by different widgets in the core and plugins.