### PR TITLE
Fix - Reverse str_starts_with arguments for document.send.php access check

### DIFF
--- a/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
+++ b/src/Glpi/Form/AccessControl/ControlType/DirectAccess.php
@@ -184,7 +184,7 @@ final class DirectAccess implements ControlTypeInterface
             // Disable this fallback for non ajax requests as the token should
             // always be re-specified in this case
             // Keep an exception for links to documents that may be clicked from the form
-            && (Toolbox::isAjax() || str_starts_with('/front/document.send.php', $current_route_path))
+            && (Toolbox::isAjax() || str_starts_with($current_route_path, '/front/document.send.php'))
             // Disable this fallback for the service catalog, as it is out of scope
             && !str_contains($current_route_path, "ServiceCatalog")
         ) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42857
- Here is a brief description of what this PR does

When a form is accessed via a public direct-access link (token-based), images embedded in the form failed to load with a 403 Forbidden error.

The `validateToken()` method in `DirectAccess` has a session fallback that allows `document.send.php` requests to reuse the token stored in session (so users don't need to pass the token manually on each image request). However, the arguments of `str_starts_with()` were swapped:
```php
// Before (always false when URL has query params)
str_starts_with('/front/document.send.php', $current_route_path)

// After (correct)
str_starts_with($current_route_path, '/front/document.send.php')
```

This caused the session fallback to never trigger for document requests, resulting in a missing token and a 403 response.

## Screenshots (if appropriate):

Before : 

<img width="1066" height="394" alt="image" src="https://github.com/user-attachments/assets/92758338-80e6-4ce7-87be-e393e4d457ff" />


After : 

<img width="1065" height="509" alt="image" src="https://github.com/user-attachments/assets/d5b224c3-88c8-49a9-9613-3d605f21b448" />


