### PR TITLE
FIX/ Responsible Group display in ITIL Category children tab

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -628,7 +628,7 @@ TWIG, $twig_params);
                     case 'dropdownValue':
                         if (!isset($values_cache[$field['name']][$data[$field['name']]])) {
                             $values_cache[$field['name']][$data[$field['name']]] = Dropdown::getDropdownName(
-                                $field['name'],
+                                getTableNameForForeignKeyField($field['name']),
                                 $data[$field['name']]
                             );
                         }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42821
- The "Group in charge" value in ITIL category children tab is not displayed in UI, instead child categories have a valid "groups_id" in database. However, the child category from itself correcty shows the assigned group.

## Screenshots (if appropriate):

Before :

<img width="2297" height="697" alt="itilcategorie_responsivegroupko" src="https://github.com/user-attachments/assets/44f1fccc-495d-4c67-bf1d-879ea660bc18" />
<img width="2297" height="697" alt="itilcategorie_responsivegroupchild" src="https://github.com/user-attachments/assets/ce3af457-71e2-4ea6-889c-263876134eae" />



After : 

<img width="2297" height="697" alt="itilcategorie_responsivegroupok" src="https://github.com/user-attachments/assets/021adeda-f608-48dc-8ef4-d7008821ad46" />



