### PR TITLE
Fix form allow list not showing recursive item from parent entity

### DIFF
--- a/src/AbstractRightsDropdown.php
+++ b/src/AbstractRightsDropdown.php
@@ -313,7 +313,10 @@ abstract class AbstractRightsDropdown
             'FROM' => Group::getTable(),
             'WHERE' => [
                 'name' => ["LIKE", "%$text%"],
-            ] + getEntitiesRestrictCriteria(Group::getTable()) + $additional_conditions,
+            ] + getEntitiesRestrictCriteria(
+                table: Group::getTable(),
+                is_recursive: true,
+            ) + $additional_conditions,
             'START' => $start,
             'LIMIT' => $page_size,
         ]);
@@ -339,7 +342,10 @@ abstract class AbstractRightsDropdown
         $contacts = $contact_item->find(
             [
                 'name' => ["LIKE", "%$text%"],
-            ] + getEntitiesRestrictCriteria(Contact::getTable()),
+            ] + getEntitiesRestrictCriteria(
+                table: Contact::getTable(),
+                is_recursive: true,
+            ),
             [],
             self::LIMIT
         );
@@ -372,7 +378,10 @@ abstract class AbstractRightsDropdown
             'FROM' => Supplier::getTable(),
             'WHERE' => [
                 'name' => ["LIKE", "%$text%"],
-            ] + getEntitiesRestrictCriteria(Supplier::getTable()),
+            ] + getEntitiesRestrictCriteria(
+                table: Supplier::getTable(),
+                is_recursive: true,
+            ),
             'START' => $start,
             'LIMIT' => $page_size,
         ]);

--- a/tests/functional/Glpi/Form/Dropdown/FormActorsDropdownTest.php
+++ b/tests/functional/Glpi/Form/Dropdown/FormActorsDropdownTest.php
@@ -239,6 +239,58 @@ final class FormActorsDropdownTest extends DbTestCase
         $this->assertEquals(count($expected), $values['count']);
     }
 
+    public function testFetchValuesOnlyReturnsRecursiveGroupsFromParentEntity(): void
+    {
+        $this->login();
+        $root_entity_id = $this->getTestRootEntity(only_id: true);
+        $unique = uniqid('fetchvalues_group_');
+
+        $this->createItem(Group::class, [
+            'name'         => $unique . '_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 1,
+        ]);
+        $this->createItem(Group::class, [
+            'name'         => $unique . '_not_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 0,
+        ]);
+
+        $this->setEntity('_test_child_1', false);
+
+        $values = FormActorsDropdown::fetchValues($unique, ['allowed_types' => [Group::class]]);
+        $text_values = $this->extractTextFromOutput($values);
+
+        $this->assertContains($unique . '_recursive', $text_values);
+        $this->assertNotContains($unique . '_not_recursive', $text_values);
+    }
+
+    public function testFetchValuesOnlyReturnsRecursiveSuppliersFromParentEntity(): void
+    {
+        $this->login();
+        $root_entity_id = $this->getTestRootEntity(only_id: true);
+        $unique = uniqid('fetchvalues_supplier_');
+
+        $this->createItem(Supplier::class, [
+            'name'         => $unique . '_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 1,
+        ]);
+        $this->createItem(Supplier::class, [
+            'name'         => $unique . '_not_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 0,
+        ]);
+
+        $this->setEntity('_test_child_1', false);
+
+        $values = FormActorsDropdown::fetchValues($unique, ['allowed_types' => [Supplier::class]]);
+        $text_values = $this->extractTextFromOutput($values);
+
+        $this->assertContains($unique . '_recursive', $text_values);
+        $this->assertNotContains($unique . '_not_recursive', $text_values);
+    }
+
     private function extractTextFromOutput(array $dropdown_output): array
     {
         // Helper method to compare expected results more easily

--- a/tests/functional/ProjectTaskTeamDropdownTest.php
+++ b/tests/functional/ProjectTaskTeamDropdownTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Contact;
+use Glpi\Tests\DbTestCase;
+use ProjectTaskTeamDropdown;
+
+final class ProjectTaskTeamDropdownTest extends DbTestCase
+{
+    public function testFetchValuesOnlyReturnsRecursiveContactsFromParentEntity(): void
+    {
+        $this->login();
+        $root_entity_id = $this->getTestRootEntity(only_id: true);
+        $unique = uniqid('fetchvalues_contact_');
+
+        $this->createItem(Contact::class, [
+            'name'         => $unique . '_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 1,
+        ]);
+        $this->createItem(Contact::class, [
+            'name'         => $unique . '_not_recursive',
+            'entities_id'  => $root_entity_id,
+            'is_recursive' => 0,
+        ]);
+
+        $this->setEntity('_test_child_1', false);
+
+        $values = ProjectTaskTeamDropdown::fetchValues($unique);
+        $text_values = [];
+        foreach ($values['results'] as $group) {
+            foreach ($group['children'] as $item) {
+                $text_values[] = $item['text'];
+            }
+        }
+
+        $this->assertContains($unique . '_recursive', $text_values);
+        $this->assertNotContains($unique . '_not_recursive', $text_values);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Recursive items from parent entities were not shown in the allow list dropdown.

## References

Fix #23337.


