### PR TITLE
Fix(Location): fix GeolocationField map reference

### DIFF
--- a/js/modules/Form/GeolocationField.js
+++ b/js/modules/Form/GeolocationField.js
@@ -88,7 +88,7 @@ class GeolocationField {
             placeholder: __('Search')
         });
         geocoder.on('markgeocode', (e) => {
-            this._map.fitBounds(e.geocode.bbox);
+            this.map.fitBounds(e.geocode.bbox);
         });
         this.map.addControl(geocoder);
         this.#autoSearch();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42966

When searching for a location by name (e.g., London),

<img width="1307" height="469" alt="image" src="https://github.com/user-attachments/assets/daf93bec-7c5e-4ef5-87ea-a50f38a2197c" />

OpenStreetMap suggests **"Greater London"**.

However, when clicking to position the map, a JavaScript error appears in the browser console.

<img width="1439" height="236" alt="image" src="https://github.com/user-attachments/assets/877a55d5-2908-4649-86bc-f173c078bcee" />




## Screenshots (if appropriate):


