### PR TITLE
legacy api add_keys_names polymorphic support

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6320,12 +6320,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/API.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of function getItemForItemtype expects string, string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/API.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of function getTableForItemType expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -2914,7 +2914,7 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
         $fkeys = array_filter($params['add_keys_names'], isForeignKeyField(...));
 
         foreach ($fkeys as $kn_fkey) {
-            if (!isset($data[$kn_fkey])) {
+            if ($kn_fkey !== "id" && !isset($data[$kn_fkey])) {
                 trigger_error(sprintf('Invalid value: "%s" doesn\'t exist.', $kn_fkey), E_USER_WARNING);
                 continue;
             }

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -2911,20 +2911,29 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
     ) {
         $_names = [];
 
-        foreach ($params['add_keys_names'] as $kn_fkey) {
-            if ($kn_fkey == "id") {
+        $fkeys = array_filter($params['add_keys_names'], isForeignKeyField(...));
+
+        foreach ($fkeys as $kn_fkey) {
+            if (!isset($data[$kn_fkey])) {
+                trigger_error(sprintf('Invalid value: "%s" doesn\'t exist.', $kn_fkey), E_USER_WARNING);
+                continue;
+            }
+            $kn_id = $data[$kn_fkey];
+
+            if ($kn_fkey === "id") {
                 // Get friendlyname for current item
                 $kn_itemtype = $self_itemtype;
                 $kn_id = $data[$kn_itemtype::getIndexName()];
-            } else {
-                if (!isset($data[$kn_fkey])) {
-                    trigger_error(sprintf('Invalid value: "%s" doesn\'t exist.', $kn_fkey), E_USER_WARNING);
+            } elseif (str_contains($kn_fkey, 'items_id')) {
+                $itemtype_key = str_replace('items_id', 'itemtype', $kn_fkey);
+                if (!isset($data[$itemtype_key])) {
+                    trigger_error(sprintf('Invalid value: "%s" is missing.', $itemtype_key), E_USER_WARNING);
                     continue;
                 }
-
+                $kn_itemtype = $data[$itemtype_key];
+            } else {
                 // Get friendlyname for given fkey
                 $kn_itemtype = getItemtypeForForeignKeyField($kn_fkey);
-                $kn_id = $data[$kn_fkey];
             }
 
             // Check itemtype is valid

--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -38,6 +38,8 @@ use APIClient;
 use Auth;
 use Computer;
 use Config;
+use Glpi\Api\API;
+use Glpi\Api\APIRest;
 use Glpi\Form\Form;
 use Glpi\Form\FormTranslation;
 use Glpi\Form\Question;
@@ -61,8 +63,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use QueuedNotification;
+use ReflectionClass;
+use Ticket;
 use TicketTemplate;
 use TicketTemplateMandatoryField;
+use TicketValidation;
 use User;
 
 class APIRestTest extends TestCase
@@ -1032,7 +1037,7 @@ class APIRestTest extends TestCase
         );
 
         // create a ticket for another user (glpi - super-admin)
-        $ticket = new \Ticket();
+        $ticket = new Ticket();
         $tickets_id = $ticket->add([
             'name'                => 'test post-only',
             'content'             => 'test post-only',
@@ -3555,5 +3560,28 @@ class APIRestTest extends TestCase
         foreach ($not_expected as $v) {
             $this->assertNotContains($v, $values);
         }
+    }
+
+    public function testGetFriendlyNames(): void
+    {
+        $rc = new ReflectionClass(API::class);
+        $method = $rc->getMethod('getFriendlyNames');
+        $keys_names = $method->invoke(new APIRest(), [
+            'users_id' => getItemByTypeName(User::class, TU_USER, true),
+            'tickets_id' => getItemByTypeName(Ticket::class, '_ticket01', true),
+            'itemtype_target' => User::class,
+            'items_id_target' => getItemByTypeName(User::class, 'glpi', true),
+        ], [
+            'add_keys_names' => ['users_id', 'tickets_id', 'items_id_target'],
+        ], TicketValidation::class);
+
+        $this->assertEquals(
+            [
+                'users_id' => TU_USER,
+                'tickets_id' => '_ticket01',
+                'items_id_target' => 'glpi',
+            ],
+            $keys_names
+        );
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

fixes #22842

Filters out non-foreign keys.
Adds support for polymorphic foreign keys like "items_id" and "items_id_target".