### PR TITLE
Fix MA target for ticket list on project tasks

### DIFF
--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -208,6 +208,11 @@ class ProjectTask_Ticket extends CommonDBRelation
             $t['item_id'] = $t['id'];
             return $t;
         }, $tickets));
+        $entries = array_map(static function ($entry) {
+            $entry['itemtype'] = self::class;
+            $entry['id'] = $entry['linkid'];
+            return $entry;
+        }, $entries);
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #21731

Change's the itemtype and id properties of the datatable entries so that massive actions target the link between tickets and project tasks instead of the tickets themselves.
