### PR TITLE
fix form ribbon padding in iframe modal

### DIFF
--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -37,6 +37,7 @@
         background-color: var(--glpi-form-header-bg);
         color: var(--glpi-form-header-fg);
         border-color: var(--glpi-form-header-border-color);
+        padding: var(--tblr-card-cap-padding-y, 1rem) var(--tblr-card-cap-padding-x, 1.25rem);
 
         &:not(.main-header) {
             border-top: 1px solid var(--glpi-form-header-border-color);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #22840

Since Tabler defined card cap (header and footer) padding variables on the `.card` instead of `.card-header` and `.card-footer` individually, these variables are undefined when asset forms are displayed in iframe modals as there is no parent `.card` element.

I've changed the asset form CSS (not actually used solely for assets) to use these card cap padding values if they exist or fall back explicitly to the known expected values if not defined.

<img width="1114" height="325" alt="Selection_697" src="https://github.com/user-attachments/assets/50d0303e-55db-45f2-8297-f83e47f2eb54" />
