### PR TITLE
fix(RuleRight): fix default profile and entity assignment

### DIFF
--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -179,16 +179,6 @@ class RuleRight extends Rule
                 $output["_ldap_rules"]["rules_rights"][] = $right;
             }
 
-            // Store default entity and profile to be used
-            if (isset($output['entities_id'])) {
-                $output["_ldap_rules"]["rules_entities_id_default"][] = $output['entities_id'];
-            }
-
-            if (isset($output['profiles_id'])) {
-                $output["_ldap_rules"]["rules_profiles_id_default"][] = $output['profiles_id'];
-            }
-
-
             return $output;
         }
         return $output_src;

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -179,6 +179,16 @@ class RuleRight extends Rule
                 $output["_ldap_rules"]["rules_rights"][] = $right;
             }
 
+            // Store default entity and profile to be used
+            if (isset($output['entities_id'])) {
+                $output["_ldap_rules"]["rules_entities_id_default"][] = $output['entities_id'];
+            }
+
+            if (isset($output['profiles_id'])) {
+                $output["_ldap_rules"]["rules_profiles_id_default"][] = $output['profiles_id'];
+            }
+
+
             return $output;
         }
         return $output_src;

--- a/src/User.php
+++ b/src/User.php
@@ -1298,7 +1298,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         $default_entity_id = [];
 
         // Check if LDAP rules are set in input
-        if (isset($input['_ldap_rules'])) {
+        if ($this->must_process_ruleright === true && isset($input['_ldap_rules'])) {
             // Check if LDAP rules contain entity and profile affectations
             if (isset($input['_ldap_rules']['rules_entities_rights'])) {
                 foreach ($input['_ldap_rules']['rules_entities_rights'] as $rule) {
@@ -1315,22 +1315,21 @@ class User extends CommonDBTM implements TreeBrowseInterface
             }
 
             // Check if LDAP rules contain profile affectations. One entity is required to be able to apply profile affectation.
-            if (isset($input['_ldap_rules']['rules_profiles']) && count($default_entity_id) > 0) {
-                foreach ($input['_ldap_rules']['rules_profiles'] as $rule) {
+            if (isset($input['_ldap_rules']['rules_rights']) && count($default_entity_id) > 0) {
+                foreach ($input['_ldap_rules']['rules_rights'] as $rule) {
                     $default_profile_ids[] = $rule[0];
                 }
             }
         }
 
         // Security on default profile update
-        if (isset($input['profiles_id'])) {
-            if (
-                !in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))
-                && $input['profiles_id'] != 0
-                && !in_array($input['profiles_id'], $default_profile_ids)
-            ) {
-                unset($input['profiles_id']);
-            }
+        if (
+            isset($input['profiles_id'])
+            && !in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))
+            && $input['profiles_id'] != 0
+            && !in_array($input['profiles_id'], $default_profile_ids)
+        ) {
+            unset($input['profiles_id']);
         }
 
         // Security on default entity  update

--- a/src/User.php
+++ b/src/User.php
@@ -1295,7 +1295,11 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
         // Security on default profile update
         if (isset($input['profiles_id'])) {
-            if (!in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id'])) && $input['profiles_id'] != 0) {
+            if (
+                !in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))
+                && !in_array((int) $input['profiles_id'], $input['_ldap_rules']['rules_profiles_id_default'] ?? [])
+                && $input['profiles_id'] != 0
+            ) {
                 unset($input['profiles_id']);
             }
         }
@@ -1303,8 +1307,9 @@ class User extends CommonDBTM implements TreeBrowseInterface
         // Security on default entity  update
         if (isset($input['entities_id'])) {
             if (
-                ($input['entities_id'] > 0)
-                && (!in_array($input['entities_id'], Profile_User::getUserEntities($input['id'])))
+                $input['entities_id'] > 0
+                && !in_array($input['entities_id'], Profile_User::getUserEntities($input['id']))
+                && !in_array((int) $input['entities_id'], $input['_ldap_rules']['rules_entities_id_default'] ?? [])
             ) {
                 unset($input['entities_id']);
             } elseif ($input['entities_id'] == -1) {

--- a/src/User.php
+++ b/src/User.php
@@ -1293,12 +1293,42 @@ class User extends CommonDBTM implements TreeBrowseInterface
             $_SESSION["glpidefault_entity"] = $input["entities_id"];
         }
 
+        // Prepare default profiles and entities for security checks
+        $default_profile_ids = [];
+        $default_entity_id = [];
+
+        // Check if LDAP rules are set in input
+        if (isset($input['_ldap_rules'])) {
+            // Check if LDAP rules contain entity and profile affectations
+            if (isset($input['_ldap_rules']['rules_entities_rights'])) {
+                foreach ($input['_ldap_rules']['rules_entities_rights'] as $rule) {
+                    $default_entity_id[] = $rule[0];
+                    $default_profile_ids[] = $rule[1];
+                }
+            }
+
+            // Check if LDAP rules contain entity affectations
+            if (isset($input['_ldap_rules']['rules_entities'])) {
+                foreach ($input['_ldap_rules']['rules_entities'] as $rule) {
+                    $default_entity_id[] = $rule[0];
+                }
+            }
+
+            // Check if LDAP rules contain profile affectations. One entity is required to be able to apply profile affectation.
+            if (isset($input['_ldap_rules']['rules_profiles']) && count($default_entity_id) > 0) {
+                foreach ($input['_ldap_rules']['rules_profiles'] as $rule) {
+                    $default_profile_ids[] = $rule[0];
+                }
+            }
+        }
+
         // Security on default profile update
         if (isset($input['profiles_id'])) {
             if (
                 !in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))
                 && !in_array((int) $input['profiles_id'], $input['_ldap_rules']['rules_profiles_id_default'] ?? [])
                 && $input['profiles_id'] != 0
+                && !in_array($input['profiles_id'], $default_profile_ids)
             ) {
                 unset($input['profiles_id']);
             }
@@ -1309,7 +1339,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             if (
                 $input['entities_id'] > 0
                 && !in_array($input['entities_id'], Profile_User::getUserEntities($input['id']))
-                && !in_array((int) $input['entities_id'], $input['_ldap_rules']['rules_entities_id_default'] ?? [])
+                && !in_array($input['entities_id'], $default_entity_id)
             ) {
                 unset($input['entities_id']);
             } elseif ($input['entities_id'] == -1) {

--- a/src/User.php
+++ b/src/User.php
@@ -1317,7 +1317,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             // Check if LDAP rules contain profile affectations. One entity is required to be able to apply profile affectation.
             if (isset($input['_ldap_rules']['rules_rights']) && count($default_entity_id) > 0) {
                 foreach ($input['_ldap_rules']['rules_rights'] as $rule) {
-                    $default_profile_ids[] = $rule[0];
+                    $default_profile_ids[] = $rule;
                 }
             }
         }

--- a/src/User.php
+++ b/src/User.php
@@ -1326,7 +1326,6 @@ class User extends CommonDBTM implements TreeBrowseInterface
         if (isset($input['profiles_id'])) {
             if (
                 !in_array($input['profiles_id'], Profile_User::getUserProfiles($input['id']))
-                && !in_array((int) $input['profiles_id'], $input['_ldap_rules']['rules_profiles_id_default'] ?? [])
                 && $input['profiles_id'] != 0
                 && !in_array($input['profiles_id'], $default_profile_ids)
             ) {

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -166,7 +166,7 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                'profiles_id' => 'Profile1',
+                ['profiles_id' => 'Profile1',],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -184,7 +184,7 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                '_profiles_id_default' => 'Profile1',
+                ['_profiles_id_default' => 'Profile1',],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -202,7 +202,7 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                'entities_id' => 'Entity2',
+                ['entities_id' => 'Entity2'],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -220,7 +220,7 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                '_entities_id_default' => 'Entity1',
+                ['_entities_id_default' => 'Entity1'],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -238,10 +238,12 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                'profiles_id' => 'Profile1',
-                '_profiles_id_default' => 'Profile1',
-                'entities_id' => 'Entity1',
-                '_entities_id_default' => 'Entity1',
+                [
+                    'profiles_id' => 'Profile1',
+                    '_profiles_id_default' => 'Profile1',
+                    'entities_id' => 'Entity1',
+                    '_entities_id_default' => 'Entity1',
+                ],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -259,10 +261,12 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                'profiles_id' => 'Profile1',
-                '_profiles_id_default' => 'Profile2',
-                'entities_id' => 'Entity1',
-                '_entities_id_default' => 'Entity2',
+                [
+                    'profiles_id' => 'Profile1',
+                    '_profiles_id_default' => 'Profile2',
+                    'entities_id' => 'Entity1',
+                    '_entities_id_default' => 'Entity2',
+                ],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -280,10 +284,12 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 'Entity1',
             ],
             'actions' => [
-                'profiles_id' => 'Profile1',
-                '_profiles_id_default' => 'Profile1',
-                'entities_id' => 'Entity1',
-                '_entities_id_default' => 'Entity1',
+                [
+                    'profiles_id' => 'Profile1',
+                    '_profiles_id_default' => 'Profile1',
+                    'entities_id' => 'Entity1',
+                    '_entities_id_default' => 'Entity1',
+                ],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
@@ -301,10 +307,12 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 'Entity1',
             ],
             'actions' => [
-                'profiles_id' => 'Profile2',
-                '_profiles_id_default' => 'Profile2',
-                'entities_id' => 'Entity2',
-                '_entities_id_default' => 'Entity2',
+                [
+                    'profiles_id' => 'Profile2',
+                    '_profiles_id_default' => 'Profile2',
+                    'entities_id' => 'Entity2',
+                    '_entities_id_default' => 'Entity2',
+                ],
             ],
             'expected' => [
                 'profiles_id' => 'Profile2',
@@ -322,13 +330,44 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                '_profiles_id_default' => 'Profile2',
+                [
+                    '_profiles_id_default' => 'Profile2',
+                ],
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
                 'entities_id' => 0,
                 '_entities_id_default' => 0,
+            ],
+        ];
+
+        yield 'Assign global profile and entity with two rules' => [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                [
+                    // Rule 1: Assigns profile dynamically, populating rules_rights
+                    // Also attempts to set it as default profile
+                    'profiles_id' => 'Profile2',
+                    '_profiles_id_default' => 'Profile2',
+                ],
+                [
+                    // Rule 2: Assigns entity dynamically, populating rules_entities
+                    // Also attempts to set it as default entity
+                    'entities_id' => 'Entity2',
+                    '_entities_id_default' => 'Entity2',
+                ],
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile2',
+                '_profiles_id_default' => 'Profile2',
+                'entities_id' => 'Entity2',
+                '_entities_id_default' => 'Entity2',
             ],
         ];
     }
@@ -361,8 +400,11 @@ class RuleRightTest extends DbTestCase
         $search_keys = ['Profile1', 'Profile2', 'Entity1', 'Entity2'];
         $replace_ids = [$profile1->getID(), $profile2->getID(), $entity1->getID(), $entity2->getID()];
 
-        foreach ($actions as $key => $value) {
-            $actions[$key] = intval(str_replace($search_keys, $replace_ids, $value));
+        $parsed_actions = [];
+        foreach ($actions as $index => $rule_actions) {
+            foreach ($rule_actions as $key => $value) {
+                $parsed_actions[$index][$key] = intval(str_replace($search_keys, $replace_ids, $value));
+            }
         }
         foreach ($expected as $key => $value) {
             $expected[$key] = intval(str_replace($search_keys, $replace_ids, $value));
@@ -385,15 +427,18 @@ class RuleRightTest extends DbTestCase
             'entities_id' => $user_data['entities_id'],
         ]);
 
-        // Prepare rule to assign the default profile and default entity.
-        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleRight::class);
-        $rule_builder->setEntity(0)
-            ->addCriteria('LOGIN', \Rule::PATTERN_IS, $user->fields['name'])
-            ->setIsRecursive(1);
-        foreach ($actions as $key => $value) {
-            $rule_builder->addAction('assign', $key, $value);
+        // Prepare rules to assign the default profile and default entity.
+        $created_rules = [];
+        foreach ($parsed_actions as $index => $rule_actions) {
+            $rule_builder = new RuleBuilder(__FUNCTION__ . "_$index", \RuleRight::class);
+            $rule_builder->setEntity(0)
+                ->addCriteria('LOGIN', \Rule::PATTERN_IS, $user->fields['name'])
+                ->setIsRecursive(1);
+            foreach ($rule_actions as $key => $value) {
+                $rule_builder->addAction('assign', $key, $value);
+            }
+            $created_rules[] = $this->createRule($rule_builder);
         }
-        $rule = $this->createRule($rule_builder);
 
         // Login to trigger RuleRight processing.
         $this->realLogin($user->fields['name'], 'test', false);
@@ -408,9 +453,11 @@ class RuleRightTest extends DbTestCase
         $this->assertContains($expected['profiles_id'], $profiles);
 
         // Cleanup
-        $rules->delete([
-            'id' => $rule->getID(),
-        ], true);
+        foreach ($created_rules as $rule) {
+            $rules->delete([
+                'id' => $rule->getID(),
+            ], true);
+        }
 
         // Clean singleton to avoid polluting next tests.
         \SingletonRuleList::getInstance(\RuleRight::class, 0)->load = 0;
@@ -728,12 +775,12 @@ class RuleRightTest extends DbTestCase
             'entities_id' => $entity->getID(),
             '_ldap_rules' => [
                 'rules_entities' => [
-                    [$entity->getID(), 1]
+                    [$entity->getID(), 1],
                 ],
                 'rules_profiles' => [
-                    [$profile->getID()]
-                ]
-            ]
+                    [$profile->getID()],
+                ],
+            ],
         ];
 
         // Update the user with the LDAP rules bypass input

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -779,8 +779,8 @@ class RuleRightTest extends DbTestCase
                         $entity->getID(),
                         $profile->getID(),
                         1,
-                    ]
-                ]
+                    ],
+                ],
             ],
         ];
 

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -395,8 +395,8 @@ class RuleRightTest extends DbTestCase
         ], true);
 
         // Clean singleton to avoid polluting next tests.
-        \SingletonRuleList::getInstance('RuleRight', 0)->load = 0;
-        \SingletonRuleList::getInstance('RuleRight', 0)->list = [];
+        \SingletonRuleList::getInstance(\RuleRight::class, 0)->load = 0;
+        \SingletonRuleList::getInstance(\RuleRight::class, 0)->list = [];
     }
 
     public function testLocalAccountNoRules()

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -36,6 +36,7 @@ namespace tests\units;
 
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\RuleBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /* Test for inc/RuleRight.class.php */
 
@@ -155,56 +156,238 @@ class RuleRightTest extends DbTestCase
         $this->assertFalse($found);
     }
 
-    public function testLocalAccountAssignAndDefaultProfileAndEntity()
+    public static function ruleAccountAssignAndDefaultProfileAndEntityProvider()
+    {
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                'profiles_id' => 'Profile1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                '_profiles_id_default' => 'Profile1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 0,
+                '_entities_id_default' => 0,
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                'entities_id' => 'Entity1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                '_entities_id_default' => 'Entity1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 0,
+                '_entities_id_default' => 'Entity1',
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile2',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity2',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ],
+            'actions' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ]
+        ];
+
+        yield [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 'Profile1',
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 'Entity1',
+            ],
+            'actions' => [
+                'profiles_id' => 'Profile2',
+                '_profiles_id_default' => 'Profile2',
+                'entities_id' => 'Entity2',
+                '_entities_id_default' => 'Entity2',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile2',
+                '_profiles_id_default' => 'Profile2',
+                'entities_id' => 'Entity2',
+                '_entities_id_default' => 'Entity2',
+            ]
+        ];
+    }
+
+    #[DataProvider('ruleAccountAssignAndDefaultProfileAndEntityProvider')]
+    public function testRuleAccountAssignAndDefaultProfileAndEntity(array $user_data, array $actions, array $expected)
     {
         $this->login();
 
-        $user = new \User();
         $profile_user = new \Profile_User();
         $rules = new \RuleRight();
 
         // Create an entity and a profile to be assigned by the rule.
-        $entity = $this->createItem('Entity', [
-            'name'        => __FUNCTION__ . '_' . mt_rand(),
-            'entities_id' => 0,
+        [$entity1, $entity2] = $this->createItems(\Entity::class, [
+            [
+                'name'        => 'Entity1',
+                'entities_id' => 0,
+            ],
+            [
+                'name'        => 'Entity2',
+                'entities_id' => 0,
+            ]
         ]);
-        $profile_id = getItemByTypeName('Profile', 'Technician', true);
+        [$profile1, $profile2] = $this->createItems(\Profile::class, [
+            ['name' => 'Profile1'],
+            ['name' => 'Profile2']
+       ]);
+
+        // Replace search keys by created items ids in actions, expected and user data.
+        $search_keys = ['Profile1', 'Profile2', 'Entity1', 'Entity2'];
+        $replace_ids = [$profile1->getID(), $profile2->getID(), $entity1->getID(), $entity2->getID()];
+
+        foreach ($actions as $key => $value) {
+            $actions[$key] = intval(str_replace($search_keys, $replace_ids, $value));
+        }
+        foreach ($expected as $key => $value) {
+            $expected[$key] = intval(str_replace($search_keys, $replace_ids, $value));
+        }
+        foreach ($user_data as $key => $value) {
+            $user_data[$key] = intval(str_replace($search_keys, $replace_ids, $value));
+        }
+
+        $user = $this->createItem(\User::class, [
+            'name'      => __FUNCTION__ . '_user',
+            'password'  => 'test',
+            'password2' => 'test',
+            'profiles_id' => $user_data['_profiles_id_default'],
+            'entities_id' => $user_data['_entities_id_default'],
+        ], ['password', 'password2']);
+
+        $this->createItem(\Profile_User::class, [
+            'users_id' => $user->getID(),
+            'profiles_id' => $user_data['profiles_id'],
+            'entities_id' => $user_data['entities_id'],
+        ]);
 
         // Prepare rule to assign the default profile and default entity.
         $rule_builder = new RuleBuilder(__FUNCTION__, \RuleRight::class);
         $rule_builder->setEntity(0)
-            ->setIsRecursive(1)
-            ->addCriteria('LOGIN', \Rule::PATTERN_IS, TU_USER)
-            ->addAction('assign', 'profiles_id', $profile_id)
-            ->addAction('assign', '_profiles_id_default', $profile_id)
-            ->addAction('assign', 'entities_id', $entity->getID())
-            ->addAction('assign', '_entities_id_default', $entity->getID());
+            ->addCriteria('LOGIN', \Rule::PATTERN_IS, $user->fields['name'])
+            ->setIsRecursive(1);
+        foreach ($actions as $key => $value) {
+            $rule_builder->addAction('assign', $key, $value);
+        }
         $rule = $this->createRule($rule_builder);
 
-        // Get TU_USER id and check initial state.
-        $users_id = \User::getIdByName(TU_USER);
-        $this->assertGreaterThan(0, $users_id);
-
-        // Check the user doesn't have the profile and entity assigned.
-        $this->assertTrue($user->getFromDB($users_id));
-        $this->assertNotEquals($profile_id, $user->fields['profiles_id']);
-        $this->assertNotEquals($entity->getID(), $user->fields['entities_id']);
-
-        // Check the profile is not in the user profiles collection.
-        $profiles = $profile_user->getUserProfiles($users_id);
-        $this->assertNotContains($profile_id, $profiles);
-
         // Login to trigger RuleRight processing.
-        $this->realLogin(TU_USER, TU_PASS, false);
+        $this->realLogin($user->fields['name'], 'test', false);
 
         // Check the user got the entity/profiles assigned.
-        $this->assertTrue($user->getFromDB($users_id));
-        $this->assertEquals($profile_id, $user->fields['profiles_id']);
-        $this->assertEquals($entity->getID(), $user->fields['entities_id']);
+        $this->assertTrue($user->getFromDB($user->getID()));
+        $this->assertEquals($expected['_profiles_id_default'], $user->fields['profiles_id']);
+        $this->assertEquals($expected['_entities_id_default'], $user->fields['entities_id']);
 
         // Check the profile is in the user profiles collection.
-        $profiles = $profile_user->getUserProfiles($users_id);
-        $this->assertContains($profile_id, $profiles);
+        $profiles = $profile_user->getUserProfiles($user->getID());
+        $this->assertContains($expected['profiles_id'], $profiles);
 
         // Cleanup
         $rules->delete([

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -155,6 +155,67 @@ class RuleRightTest extends DbTestCase
         $this->assertFalse($found);
     }
 
+    public function testLocalAccountAssignAndDefaultProfileAndEntity()
+    {
+        $this->login();
+
+        $user = new \User();
+        $profile_user = new \Profile_User();
+        $rules = new \RuleRight();
+
+        // Create an entity and a profile to be assigned by the rule.
+        $entity = $this->createItem('Entity', [
+            'name'        => __FUNCTION__ . '_' . mt_rand(),
+            'entities_id' => 0,
+        ]);
+        $profile_id = getItemByTypeName('Profile', 'Technician', true);
+
+        // Prepare rule to assign the default profile and default entity.
+        $rule_builder = new RuleBuilder(__FUNCTION__, \RuleRight::class);
+        $rule_builder->setEntity(0)
+            ->setIsRecursive(1)
+            ->addCriteria('LOGIN', \Rule::PATTERN_IS, TU_USER)
+            ->addAction('assign', 'profiles_id', $profile_id)
+            ->addAction('assign', '_profiles_id_default', $profile_id)
+            ->addAction('assign', 'entities_id', $entity->getID())
+            ->addAction('assign', '_entities_id_default', $entity->getID());
+        $rule = $this->createRule($rule_builder);
+
+        // Get TU_USER id and check initial state.
+        $users_id = \User::getIdByName(TU_USER);
+        $this->assertGreaterThan(0, $users_id);
+
+        // Check the user doesn't have the profile and entity assigned.
+        $this->assertTrue($user->getFromDB($users_id));
+        $this->assertNotEquals($profile_id, $user->fields['profiles_id']);
+        $this->assertNotEquals($entity->getID(), $user->fields['entities_id']);
+
+        // Check the profile is not in the user profiles collection.
+        $profiles = $profile_user->getUserProfiles($users_id);
+        $this->assertNotContains($profile_id, $profiles);
+
+        // Login to trigger RuleRight processing.
+        $this->realLogin(TU_USER, TU_PASS, false);
+
+        // Check the user got the entity/profiles assigned.
+        $this->assertTrue($user->getFromDB($users_id));
+        $this->assertEquals($profile_id, $user->fields['profiles_id']);
+        $this->assertEquals($entity->getID(), $user->fields['entities_id']);
+
+        // Check the profile is in the user profiles collection.
+        $profiles = $profile_user->getUserProfiles($users_id);
+        $this->assertContains($profile_id, $profiles);
+
+        // Cleanup
+        $rules->delete([
+            'id' => $rule->getID(),
+        ], true);
+
+        // Clean singleton to avoid polluting next tests.
+        \SingletonRuleList::getInstance('RuleRight', 0)->load = 0;
+        \SingletonRuleList::getInstance('RuleRight', 0)->list = [];
+    }
+
     public function testLocalAccountNoRules()
     {
         $testuser = [

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -173,7 +173,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 0,
                 'entities_id' => 'Entity1',
                 '_entities_id_default' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -191,7 +191,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 'Profile1',
                 'entities_id' => 0,
                 '_entities_id_default' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -209,7 +209,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 0,
                 'entities_id' => 'Entity1',
                 '_entities_id_default' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -227,7 +227,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 0,
                 'entities_id' => 0,
                 '_entities_id_default' => 'Entity1',
-            ]
+            ],
         ];
 
         yield [
@@ -248,7 +248,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 'Profile1',
                 'entities_id' => 'Entity1',
                 '_entities_id_default' => 'Entity1',
-            ]
+            ],
         ];
 
         yield [
@@ -269,7 +269,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 0,
                 'entities_id' => 'Entity1',
                 '_entities_id_default' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -290,7 +290,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 'Profile1',
                 'entities_id' => 'Entity1',
                 '_entities_id_default' => 'Entity1',
-            ]
+            ],
         ];
 
         yield [
@@ -311,7 +311,7 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 'Profile2',
                 'entities_id' => 'Entity2',
                 '_entities_id_default' => 'Entity2',
-            ]
+            ],
         ];
     }
 
@@ -332,12 +332,12 @@ class RuleRightTest extends DbTestCase
             [
                 'name'        => 'Entity2',
                 'entities_id' => 0,
-            ]
+            ],
         ]);
         [$profile1, $profile2] = $this->createItems(\Profile::class, [
             ['name' => 'Profile1'],
-            ['name' => 'Profile2']
-       ]);
+            ['name' => 'Profile2'],
+        ]);
 
         // Replace search keys by created items ids in actions, expected and user data.
         $search_keys = ['Profile1', 'Profile2', 'Entity1', 'Entity2'];

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -749,7 +749,7 @@ class RuleRightTest extends DbTestCase
         $this->assertEquals($groups_before, $groups_after);
     }
 
-    public function testBypassLdapRules()
+    public function testBypassRightsRulesOnUserUpdate()
     {
         $this->login();
 
@@ -774,12 +774,13 @@ class RuleRightTest extends DbTestCase
             'profiles_id' => $profile->getID(),
             'entities_id' => $entity->getID(),
             '_ldap_rules' => [
-                'rules_entities' => [
-                    [$entity->getID(), 1],
-                ],
-                'rules_profiles' => [
-                    [$profile->getID()],
-                ],
+                'rules_entities_rights' => [
+                    [
+                        $entity->getID(),
+                        $profile->getID(),
+                        1,
+                    ]
+                ]
             ],
         ];
 

--- a/tests/functional/RuleRightTest.php
+++ b/tests/functional/RuleRightTest.php
@@ -158,7 +158,7 @@ class RuleRightTest extends DbTestCase
 
     public static function ruleAccountAssignAndDefaultProfileAndEntityProvider()
     {
-        yield [
+        yield 'Assign an existing profile without specifying a default' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -176,7 +176,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Set an already associated profile as the default' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -194,7 +194,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Assign an existing entity without specifying a default' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -202,17 +202,17 @@ class RuleRightTest extends DbTestCase
                 '_entities_id_default' => 0,
             ],
             'actions' => [
-                'entities_id' => 'Entity1',
+                'entities_id' => 'Entity2',
             ],
             'expected' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
-                'entities_id' => 'Entity1',
+                'entities_id' => 'Entity2',
                 '_entities_id_default' => 0,
             ],
         ];
 
-        yield [
+        yield 'Set an already associated entity as the default' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -230,7 +230,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Assign profile and entity and set both as defaults' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -251,7 +251,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Attempt to set unassigned profiles and entities as default' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 0,
@@ -272,7 +272,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Re-assign existing default profile and entity' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 'Profile1',
@@ -293,7 +293,7 @@ class RuleRightTest extends DbTestCase
             ],
         ];
 
-        yield [
+        yield 'Update defaults by assigning a new profile and a new entity' => [
             'user_data' => [
                 'profiles_id' => 'Profile1',
                 '_profiles_id_default' => 'Profile1',
@@ -311,6 +311,24 @@ class RuleRightTest extends DbTestCase
                 '_profiles_id_default' => 'Profile2',
                 'entities_id' => 'Entity2',
                 '_entities_id_default' => 'Entity2',
+            ],
+        ];
+
+        yield 'Assign default profile without giving the profile right' => [
+            'user_data' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 'Entity1',
+                '_entities_id_default' => 0,
+            ],
+            'actions' => [
+                '_profiles_id_default' => 'Profile2',
+            ],
+            'expected' => [
+                'profiles_id' => 'Profile1',
+                '_profiles_id_default' => 0,
+                'entities_id' => 0,
+                '_entities_id_default' => 0,
             ],
         ];
     }
@@ -682,5 +700,51 @@ class RuleRightTest extends DbTestCase
         ]);
 
         $this->assertEquals($groups_before, $groups_after);
+    }
+
+    public function testBypassLdapRules()
+    {
+        $this->login();
+
+        $profile_user = new \Profile_User();
+
+        // Create an user and profile and entity to be used in the test
+        $user = $this->createItem(\User::class, [
+            'name'      => __FUNCTION__ . '_user',
+            'password'  => 'test',
+            'password2' => 'test',
+        ], ['password', 'password2']);
+
+        $profile = $this->createItem(\Profile::class, [
+            'name' => 'ProfileBypass',
+        ]);
+
+        $entity = $this->createItem(\Entity::class, [
+            'name' => 'EntityBypass',
+        ]);
+
+        $input = [
+            'profiles_id' => $profile->getID(),
+            'entities_id' => $entity->getID(),
+            '_ldap_rules' => [
+                'rules_entities' => [
+                    [$entity->getID(), 1]
+                ],
+                'rules_profiles' => [
+                    [$profile->getID()]
+                ]
+            ]
+        ];
+
+        // Update the user with the LDAP rules bypass input
+        $user = $this->updateItem(\User::class, $user->getID(), $input, ['profiles_id', 'entities_id']);
+
+        $user->getFromDB($user->getID());
+        $profiles = $profile_user->getUserProfiles($user->getID());
+
+        // Verif if the profile and entity have not been updated by the input because of the LDAP rules bypass in prepareInputForUpdate
+        $this->assertNotEquals($profile->getID(), $user->fields['profiles_id']);
+        $this->assertNotEquals($entity->getID(), $user->fields['entities_id']);
+        $this->assertNotContains($profile->getID(), $profiles);
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42867

The “Default Entity” and “Default Profile” actions do not work when the profile and entity are assigned via the rules engine at the same time as permissions are assigned.

GLPI checks whether the user is authorized to have the default profile and entity before updating their profile. However, permissions are only applied after the user’s profile has been updated, which means that validation occurs before permissions are set. Consequently, the default profile and entity are not assigned to the user.

## Screenshots (if appropriate):

<img width="722" height="170" alt="image" src="https://github.com/user-attachments/assets/5c483a9a-e4ad-42c9-abe9-3d211d0e4b98" />