### PR TITLE
Fix dev LDAP command

### DIFF
--- a/tools/src/Command/CreateDevLdapCommand.php
+++ b/tools/src/Command/CreateDevLdapCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Command;
 
+use AuthLDAP;
 use Glpi\Console\AbstractCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
This command was broken by #22568, which added a new namespace without updating the existing use statements.