### PR TITLE
Warn when saving ticket if timeline form open

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -229,6 +229,14 @@
       $("#right-actions").hide();
    });
 
+   $('#itil-footer .form-buttons button[name="update"]').on('click', () => {
+       const has_opened_new_form = $('#new-itilobject-form .collapse.show').length > 0
+           || $('.timeline-item .edit-content').filter((i, c) => c.textContent.trim().length > 0).length > 0;
+       if (has_opened_new_form) {
+          return confirm('{{ __("You have unsaved changes in the timeline. Are you sure you want to continue?")|e('js') }}');
+       }
+   });
+
    $(function() {
       // when close button of new answer block is clicked, show again the new answer button (and the itil object actions)
       $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23217

Adds a confirmation to the ticket save button if there is a timeline item form open to try to avoid users discarding their changes accidentally. I checked, and this does not affect the approval or solution response forms which always show when they are in the timeline.
