### PR TITLE
Clarify contribution policy regarding IA Agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Please note that current repository is about GLPI core only. All related plugins
 
 ## IA Agents
 
-Many people have the idea to propose code modifications from IA Agents, verbatim )or almost). We rencently get lots of this kind of contriubutions. **That kind of IA only contribution will be refused.**
+Many people have the idea to propose code modifications from IA Agents, verbatim (or almost). We recently get lots of this kind of contributions. **That kind of IA only contribution will be refused.**
 
 You can of course take help from any way you want (including IA agents), but a **human must** review and test proposision; we do not want to debate with an AI bot.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ Please note that current repository is about GLPI core only. All related plugins
 
 **⚠️ Please never use standard issues to report security problems. See [security policy](https://github.com/glpi-project/glpi/security/policy) for more details. ⚠️**
 
+## IA Agents
+
+Many people have the idea to propose code modifications from IA Agents, verbatim )or almost). We rencently get lots of this kind of contriubutions. **That kind of IA only contribution will be refused.**
+
+You can of course take help from any way you want (including IA agents), but a **human must** review and test proposision; we do not want to debate with an AI bot.
+
+
 ## Bugs
 
 Note that issues are handled on a best-effort basis. If you need a quick fix or any guarantee, take a look at **[profesional services](http://services.glpi-network.com/)** or [partners](https://glpi-project.org/partners/).


### PR DESCRIPTION
Added section on IA Agents contributions and guidelines.

(And yes, PR title and description are IA generated :D I'm the only author of the change anyway ;)).