### PR TITLE
use correct field when adding task from Problem/Change ticket list

### DIFF
--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -134,34 +134,32 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
                     $ma->itemDone($item::class, $ids, MassiveAction::ACTION_KO);
                     break;
                 }
-                $ticket = new Ticket();
-                $field = $ticket->getForeignKeyField();
+                $field = Ticket::getForeignKeyField();
 
                 $input = $ma->getInput();
 
                 foreach ($ids as $id) {
                     if ($item->can($id, READ)) {
-                        if ($ticket->getFromDB($item->fields['tickets_id'])) {
-                            $input2 = [$field              => $item->fields['tickets_id'],
-                                'taskcategories_id' => $input['taskcategories_id'],
-                                'actiontime'        => $input['actiontime'],
-                                'content'           => $input['content'],
-                            ];
-                            if ($task->can(-1, CREATE, $input2)) {
-                                if ($task->add($input2)) {
-                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
-                                } else {
-                                    $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
-                                    $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
-                                }
+                        $input2 = [
+                            $field              => $item->getID(),
+                            'taskcategories_id' => $input['taskcategories_id'],
+                            'actiontime'        => $input['actiontime'],
+                            'content'           => $input['content'],
+                        ];
+                        if ($task->can(-1, CREATE, $input2)) {
+                            if ($task->add($input2)) {
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
-                                $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                                $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
                             $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
+                    } else {
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
                 return;

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -118,34 +118,32 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
         switch ($ma->getAction()) {
             case 'add_task':
                 $task = new TicketTask();
-                $ticket = new Ticket();
-                $field = $ticket::getForeignKeyField();
+                $field = Ticket::getForeignKeyField();
 
                 $input = $ma->getInput();
 
                 foreach ($ids as $id) {
                     if ($item->can($id, READ)) {
-                        if ($ticket->getFromDB($item->fields['tickets_id'])) {
-                            $input2 = [$field              => $item->fields['tickets_id'],
-                                'taskcategories_id' => $input['taskcategories_id'],
-                                'actiontime'        => $input['actiontime'],
-                                'content'           => $input['content'],
-                            ];
-                            if ($task->can(-1, CREATE, $input2)) {
-                                if ($task->add($input2)) {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
-                                } else {
-                                    $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
-                                    $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
-                                }
+                        $input2 = [
+                            $field              => $item->getID(),
+                            'taskcategories_id' => $input['taskcategories_id'],
+                            'actiontime'        => $input['actiontime'],
+                            'content'           => $input['content'],
+                        ];
+                        if ($task->can(-1, CREATE, $input2)) {
+                            if ($task->add($input2)) {
+                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
                             } else {
-                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
-                                $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
+                                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                                $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
                             }
                         } else {
                             $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
                             $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                         }
+                    } else {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_NORIGHT);
+                        $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     }
                 }
                 return;

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -34,6 +34,8 @@
 
 namespace tests\units;
 
+use Change;
+use Change_Ticket;
 use CommonDBTM;
 use Contract;
 use Glpi\Search\SearchOption;
@@ -45,9 +47,11 @@ use MassiveAction;
 use Notepad;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
+use Problem_Ticket;
 use Session;
 use Software;
 use Ticket;
+use TicketTask;
 use User;
 use UserEmail;
 
@@ -1458,6 +1462,7 @@ class MassiveActionTest extends DbTestCase
             'items_id' => $ticket_id3,
         ]));
     }
+
     public function testProcessMassiveActionsForOneItemtype_AssociateGroup()
     {
         $this->login();
@@ -1561,5 +1566,93 @@ class MassiveActionTest extends DbTestCase
                 "Group 2 should still be associated for software $sid"
             );
         }
+    }
+
+    public function testAddTaskMassiveActionOnProblemTicketCreatesTicketTask(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'    => 'ticket for problem task',
+            'content' => 'content',
+        ]);
+
+        $problem = $this->createItem(Problem::class, [
+            'name'    => 'problem with linked ticket',
+            'content' => 'content',
+        ]);
+
+        $this->createItem(Problem_Ticket::class, [
+            'tickets_id'  => $ticket->getID(),
+            'problems_id' => $problem->getID(),
+        ]);
+
+        $ticket_item = new Ticket();
+
+        $this->processMassiveActionsForOneItemtype(
+            'add_task',
+            $ticket_item,
+            [$ticket->getID()],
+            [
+                'taskcategories_id' => 0,
+                'actiontime'        => 0,
+                'content'           => 'task from massive action',
+            ],
+            1,
+            0,
+            Problem_Ticket::class
+        );
+
+        $this->assertSame(
+            1,
+            countElementsInTable(TicketTask::getTable(), [
+                'tickets_id' => $ticket->getID(),
+                'content'    => 'task from massive action',
+            ])
+        );
+    }
+
+    public function testAddTaskMassiveActionOnChangeTicketCreatesTicketTask(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'    => 'ticket for change task',
+            'content' => 'content',
+        ]);
+
+        $change = $this->createItem(Change::class, [
+            'name'    => 'change with linked ticket',
+            'content' => 'content',
+        ]);
+
+        $this->createItem(Change_Ticket::class, [
+            'tickets_id' => $ticket->getID(),
+            'changes_id' => $change->getID(),
+        ]);
+
+        $ticket_item = new Ticket();
+
+        $this->processMassiveActionsForOneItemtype(
+            'add_task',
+            $ticket_item,
+            [$ticket->getID()],
+            [
+                'taskcategories_id' => 0,
+                'actiontime'        => 0,
+                'content'           => 'task from change massive action',
+            ],
+            1,
+            0,
+            Change_Ticket::class
+        );
+
+        $this->assertSame(
+            1,
+            countElementsInTable(TicketTask::getTable(), [
+                'tickets_id' => $ticket->getID(),
+                'content'    => 'task from change massive action',
+            ])
+        );
     }
 }


### PR DESCRIPTION


- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23556 

- Fix `Undefined array key "tickets_id"` error when using the "Add a task" massive action on tickets listed inside a problem or a change.
- Root cause: `$item` in `processMassiveActionsForOneItemtype` is a `Ticket`
  instance : it has no `tickets_id` field. The correct field is `id`.
- The same fix is applied proactively to `Change_Ticket`, which shares the same code pattern.       



