### PR TITLE
Fix(Impersonate): Do not regenerate Session ID

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -117,10 +117,13 @@ class Session
      * Init session for the user is defined
      *
      * @param Auth $auth Auth object to init session
+     * @param bool $regenerate_session_id Whether to regenerate the session ID (default true).
+     *                                    Should be false when switching between users (e.g. impersonation)
+     *                                    to avoid breaking server-side session stores (e.g. GssapiUseSessions).
      *
      * @return void
      **/
-    public static function init(Auth $auth)
+    public static function init(Auth $auth, bool $regenerate_session_id = true)
     {
         global $CFG_GLPI;
 
@@ -137,7 +140,7 @@ class Session
                 }
             }
             self::destroy();
-            if (!defined('TU_USER')) { //FIXME: no idea why this fails with phpunit... :(
+            if ($regenerate_session_id && !defined('TU_USER')) { //FIXME: no idea why this fails with phpunit... :(
                 session_regenerate_id();
             }
             self::start();
@@ -2077,7 +2080,7 @@ class Session
         $auth = new Auth();
         $auth->auth_succeded = true;
         $auth->user = $user;
-        Session::init($auth);
+        Session::init($auth, false);
 
         // Force usage of current user lang and session mode
         $_SESSION['glpilanguage'] = $lang;
@@ -2120,7 +2123,7 @@ class Session
         $auth = new Auth();
         $auth->auth_succeded = true;
         $auth->user = $user;
-        Session::init($auth);
+        Session::init($auth, false);
 
         // Restore previous user values
         if (!empty($impersonator_info)) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes  #23187 

## Problem

When Apache is configured with `mod_auth_gssapi` and `GssapiUseSessions On`, attempting to impersonate another user redirects the admin back to the central page as themselves — impersonation never takes effect.

### Root Cause

* `Session::init()` calls `session_regenerate_id()`, which changes the PHP session ID and updates the session cookie.
* With `GssapiUseSessions On`, Apache's `mod_session` stores GSSAPI authentication data (including the `REMOTE_USER` Kerberos principal) tied to the session ID. When the PHP session ID changes, Apache can no longer locate the GSSAPI session data for the new ID.

On the next request following the impersonation redirect:

1. Apache cannot resolve `REMOTE_USER` from the GSSAPI session because the session ID no longer matches.
2. `Session::checkValidSessionId()` finds `glpi_remote_user` in the PHP session, but `$_SERVER[$ssovariable]` is missing or mismatched, which triggers a `SessionExpiredException`.
3. `AccessErrorListener` destroys the session and redirects to `/?redirect=/front/central.php&error=3`.
4. `IndexController` detects a Kerberos credential via `Auth::checkAlternateAuthSystems()` (Kerberos re-negotiates on this new request) and logs the admin back in as themselves.
5. The admin ends up on `central.php` under their own identity — impersonation is silently lost.

> Note: This issue does **not** occur when `GssapiUseSessions` is off, because Kerberos authenticates on every request, so `REMOTE_USER` is always correctly set regardless of session ID changes.

## Fix

* Add an optional `$regenerate_session_id` parameter (default `true`) to `Session::init()`.
* Both `startImpersonating()` and `stopImpersonating()` now pass `false`, skipping the `session_regenerate_id()` call.

This is safe because impersonation does not involve privilege escalation — the admin already holds the highest privilege level. Session fixation protection via ID regeneration is only relevant at login, which remains the default behavior for all other callers.


## Detecting GSSAPI Session Usage

Another approach is to create a dedicated function to attempt detecting the use of GSSAPI sessions. However, it is unclear whether this alone would always be sufficient.

```php
public static function isGssapiSessionsInUse(): bool
{
    // Signal 1 — Apache sets AUTH_TYPE to "Negotiate" when the request was
    // authenticated via Kerberos/SPNEGO (mod_auth_gssapi or mod_auth_kerb).
    if (($_SERVER['AUTH_TYPE'] ?? '') === 'Negotiate') {
        return true;
    }

    // Signal 2 — GssapiUseSessions On creates a dedicated Apache mod_session
    // cookie whose name starts with "mod_auth_gssapi", configured in Apache as:
    //   SessionCookieName mod_auth_gssapi path=/;HttpOnly;SameSite=Lax
    foreach (array_keys($_COOKIE) as $cookieName) {
        if (str_starts_with($cookieName, 'mod_auth_gssapi')) {
            return true;
        }
    }

    // Signal 3 — KRB5CCNAME is set when a Kerberos credential cache has been
    // forwarded to the PHP process (ticket delegation via GssapiDelegCcacheDir).
    if (!empty($_SERVER['KRB5CCNAME'])) {
        return true;
    }

    // Signal 4 — The Authorization header starts with "Negotiate" when a
    // reverse proxy forwards the raw SPNEGO token instead of consuming it.
    if (stripos($_SERVER['HTTP_AUTHORIZATION'] ?? '', 'negotiate ') === 0) {
        return true;
    }

    return false;
}
```
