### PR TITLE
Collapse large CTRF reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+      # See: https://github.com/ctrf-io/github-test-reporter?tab=readme-ov-file#available-inputs
       - name: Publish test summary results
         if: ${{ !cancelled() }}
-        run: npx github-actions-ctrf ctrf/ctrf-report.json
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: ctrf/ctrf-report.json
+          collapse-large-reports: true


### PR DESCRIPTION
The "tests" section of the report was starting to get a bit too long now that we have migrated at lot of tests.
This meant you had to scroll a lot of tests to reach the bottom of the page when you want to download an artifact.

Now, they are collapsed by default:
<img width="1050" height="796" alt="image" src="https://github.com/user-attachments/assets/f4d4b0ac-9b13-4805-bdf5-f7d28e3664a0" />
