### PR TITLE
Fixed actors dropdown infinite scroll issue

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5041,6 +5041,7 @@ HTML;
                 'entity_restrict'     => $entity_restrict,
                 'condition'           => $post['condition'],
                 'page'                => 1,
+                'page_limit'          => 0, // so it's basically get's all of the groups here
             ], false);
             foreach ($groups['results'] as $group) {
                 if (isset($group['children'])) {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5118,14 +5118,14 @@ HTML;
         $elementsCount = 0;
         foreach ($results as $element) {
             $elementsCount++;
-            if(isset($element['children'])) {
-                $elementsCount+= count($element['children']);
+            if (isset($element['children'])) {
+                $elementsCount += count($element['children']);
             }
         }
 
         $return = [
             'results' => $results,
-            'count'   => $elementsCount,
+            'count' => $elementsCount,
         ];
         if ($elementsCount >= $post['page_limit']) {
             $return['pagination'] = [

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5040,6 +5040,7 @@ HTML;
                 'searchText'          => $post['searchText'],
                 'entity_restrict'     => $entity_restrict,
                 'condition'           => $post['condition'],
+                'page'                => 1,
             ], false);
             foreach ($groups['results'] as $group) {
                 if (isset($group['children'])) {
@@ -5114,11 +5115,19 @@ HTML;
         $start = ($post['page'] - 1) * $post['page_limit'];
         $results = array_slice($results, $start, $post['page_limit']);
 
+        $elementsCount = 0;
+        foreach ($results as $element) {
+            $elementsCount++;
+            if(isset($element['children'])) {
+                $elementsCount+= count($element['children']);
+            }
+        }
+
         $return = [
             'results' => $results,
-            'count'   => count($results),
+            'count'   => $elementsCount,
         ];
-        if (count($results) >= $post['page_limit']) {
+        if ($elementsCount >= $post['page_limit']) {
             $return['pagination'] = [
                 'more' => true,
             ];


### PR DESCRIPTION
I changed Dropdown.php file so that now it properly loading groups no matter how much of them you have.

## Description

- It fixes #23644

- Here is a brief description of what this PR does:

Changes getDropdownActors method by adding 'page' attribute for groups, also adds proper counting of elements in results. Early it was counting only root elements without 'childrens'

