### PR TITLE
Improve a few flaky tests behaviors

### DIFF
--- a/tests/e2e/specs/Form/form_translations.spec.ts
+++ b/tests/e2e/specs/Form/form_translations.spec.ts
@@ -174,7 +174,10 @@ test('Can translate a form with many inputs', async ({ page, profile, api }) => 
     await form_translation.addLanguage('Français');
     await form_translation.expectLanguageDropdownOpened('Français');
 
-    // Save the translation
+    // Save the translation (large form with many fields, allow more time for processing)
     await form_translation.saveTranslation();
-    await expect(page.getByRole('alert')).toContainText('Item successfully updated: Français');
+    await expect(page.getByRole('alert')).toContainText(
+        'Item successfully updated: Français',
+        { timeout: 30000 }
+    );
 });

--- a/tests/e2e/specs/Helpdesk/service_catalog.spec.ts
+++ b/tests/e2e/specs/Helpdesk/service_catalog.spec.ts
@@ -385,7 +385,7 @@ test.describe('Service Catalog Page - Isolated', () => {
         await profile.set(Profiles.SuperAdmin);
 
         // Switch back to the worker entity
-        await entity.switchToWithoutRecursion(getWorkerEntityId());
+        await entity.resetToDefaultWorkerEntity();
         api.refreshSession();
     });
 

--- a/tests/e2e/specs/Security/session.spec.ts
+++ b/tests/e2e/specs/Security/session.spec.ts
@@ -109,6 +109,7 @@ test.describe('Session', () => {
     test('can change profile', async ({ page, profile }) => {
         const glpi_page = new GlpiPage(page);
         await profile.set(Profiles.SuperAdmin);
+        await profile.invalidateCachedProfile(); // This test will do some manual profiles changes
         await page.goto('/front/computer.form.php');
 
         await expect(glpi_page.user_menu).toContainText('Super-Admin');

--- a/tests/e2e/utils/ProfileSwitcher.ts
+++ b/tests/e2e/utils/ProfileSwitcher.ts
@@ -78,7 +78,7 @@ export class ProfileSwitcher
         }
 
         // Send http request to change profile.
-        await this.request.post(
+        const response = await this.request.post(
             `/Session/ChangeProfile`,
             {
                 form: {
@@ -90,6 +90,18 @@ export class ProfileSwitcher
                 }
             }
         );
+
+        if (!response.ok()) {
+            throw new Error(
+                `Failed to change profile to ${profile_id}: HTTP ${response.status()}`
+            );
+        }
+
         this.cache.setCurrentProfileId(profile_id);
+    }
+
+    public async invalidateCachedProfile(): Promise<void>
+    {
+        this.cache.setCurrentProfileId(-1);
     }
 }


### PR DESCRIPTION
There has been a few flaky tests recently:

<img width="739" height="323" alt="image" src="https://github.com/user-attachments/assets/c53de139-b1de-4133-8b5c-6ff2f1d09eca" />

It is not blocking because the retries always succeed but I still took the time to look at it and found the following main issues:
- The service_catalog.spec.ts test did no reset the current entity correctly (leading to access denied errors).
- The session.spec.ts test was changing the current profile to self service while the cached profile was still super admin, leading the next "Switch to super admin" instructions in the following tests to be ignored (leading to access denied errors once again). 




