### PR TITLE
Remove redundant Document tab from KnowbaseItem

### DIFF
--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -293,7 +293,6 @@ class Document_Item extends CommonDBRelation
                     Document::canView()
                     || ($item::class === Ticket::class)
                     || ($item::class === Reminder::class)
-                    || ($item::class === KnowbaseItem::class)
                 ) {
                     if ($_SESSION['glpishow_count_on_tabs']) {
                         $nbitem = self::countForItem($item);
@@ -503,7 +502,6 @@ TWIG, $twig_params);
 
         if (
             ($item::class !== Ticket::class)
-            && ($item::class !== KnowbaseItem::class)
             && ($item::class !== Reminder::class)
             && !Document::canView()
         ) {

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -243,7 +243,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         $ong = [];
         $this->addStandardTab(self::class, $ong, $options);
         $this->addStandardTab(KnowbaseItem_Item::class, $ong, $options);
-        $this->addStandardTab(Document_Item::class, $ong, $options);
         $this->addStandardTab(KnowbaseItemTranslation::class, $ong, $options);
         $this->addStandardTab(Log::class, $ong, $options);
 


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

https://github.com/glpi-project/roadmap/issues/106

Since PR #22750 introduced an inline document section directly in the KB article template (article.html.twig), the standard GLPI Document_Item tab registered in `KnowbaseItem::defineTabs()` became redundant : both interfaces displayed the same document relations.

