### PR TITLE
Clean sourceof_items_id and sourceitems_id on ticket purge

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -899,6 +899,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
     public function cleanDBonPurge()
     {
+        global $DB;
 
         // OlaLevel_Ticket does not extends CommonDBConnexity
         $olaLevel_ticket = new OlaLevel_Ticket();
@@ -917,6 +918,24 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         // CommonITILTask does not extends CommonDBConnexity
         $tt = new TicketTask();
         $tt->deleteByCriteria(['tickets_id' => $this->fields['id']]);
+
+        // sourceof_items_id / sourceitems_id are not named properly for foreign keys so they cannot be handled by relation.constant.php
+        $DB->update(ITILFollowup::getTable(),
+            ['sourceof_items_id' => 0],
+            ['sourceof_items_id' => $this->fields['id']]
+        );
+        $DB->update(ITILFollowup::getTable(),
+            ['sourceitems_id' => 0],
+            ['sourceitems_id' => $this->fields['id']]
+        );
+        $DB->update(TicketTask::getTable(),
+            ['sourceof_items_id' => 0],
+            ['sourceof_items_id' => $this->fields['id']]
+        );
+        $DB->update(TicketTask::getTable(),
+            ['sourceitems_id' => 0],
+            ['sourceitems_id' => $this->fields['id']]
+        );
 
         $this->deleteChildrenAndRelationsFromDb(
             [

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -920,19 +920,23 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         $tt->deleteByCriteria(['tickets_id' => $this->fields['id']]);
 
         // sourceof_items_id / sourceitems_id are not named properly for foreign keys so they cannot be handled by relation.constant.php
-        $DB->update(ITILFollowup::getTable(),
+        $DB->update(
+            ITILFollowup::getTable(),
             ['sourceof_items_id' => 0],
             ['sourceof_items_id' => $this->fields['id']]
         );
-        $DB->update(ITILFollowup::getTable(),
+        $DB->update(
+            ITILFollowup::getTable(),
             ['sourceitems_id' => 0],
             ['sourceitems_id' => $this->fields['id']]
         );
-        $DB->update(TicketTask::getTable(),
+        $DB->update(
+            TicketTask::getTable(),
             ['sourceof_items_id' => 0],
             ['sourceof_items_id' => $this->fields['id']]
         );
-        $DB->update(TicketTask::getTable(),
+        $DB->update(
+            TicketTask::getTable(),
             ['sourceitems_id' => 0],
             ['sourceitems_id' => $this->fields['id']]
         );

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -595,7 +595,7 @@ class TicketTest extends DbTestCase
             'date'       => '2015-02-01 00:00:00',
         ]);
 
-        $task = new \TicketTask();
+        $task = new TicketTask();
         $this->assertGreaterThan(
             0,
             (int) $task->add([
@@ -1079,7 +1079,7 @@ class TicketTest extends DbTestCase
         $this->assertFalse($ticket->isNewItem());
 
         // 6 - check creation of the tasks
-        $tickettask = new \TicketTask();
+        $tickettask = new TicketTask();
         $found_tasks = $tickettask->find(['tickets_id' => $tickets_id], "id ASC");
 
         // 6.1 -> check first task
@@ -2368,7 +2368,7 @@ class TicketTest extends DbTestCase
             'content' => 'Ticket to check cloning',
         ]);
         $this->assertGreaterThan(0, $ticket_id);
-        $task = new \TicketTask();
+        $task = new TicketTask();
         $this->assertGreaterThan(
             0,
             (int) $task->add([
@@ -2613,7 +2613,7 @@ class TicketTest extends DbTestCase
             );
 
             // TicketTask
-            $task = new \TicketTask();
+            $task = new TicketTask();
             $this->assertGreaterThan(
                 0,
                 (int) $task->add([
@@ -4009,7 +4009,7 @@ class TicketTest extends DbTestCase
             'status'      => CommonITILObject::INCOMING,
         ]);
 
-        $task = new \TicketTask();
+        $task = new TicketTask();
         $fup = new ITILFollowup();
         $task->add([
             'tickets_id'   => $ticket2,
@@ -4296,7 +4296,7 @@ class TicketTest extends DbTestCase
         ]));
 
         // Add a task to the child ticket
-        $task = new \TicketTask();
+        $task = new TicketTask();
         $this->assertGreaterThan(
             0,
             $task->add([
@@ -7414,7 +7414,7 @@ HTML,
         );
 
         $task1 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'    => $ticket->getID(),
                 'content'       => 'public task',
@@ -7423,7 +7423,7 @@ HTML,
         );
 
         $task2 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'    => $ticket->getID(),
                 'content'       => 'private task of tech user',
@@ -7434,7 +7434,7 @@ HTML,
         );
 
         $task3 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'    => $ticket->getID(),
                 'content'       => 'private task of normal user',
@@ -7445,7 +7445,7 @@ HTML,
         );
 
         $task4 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'    => $ticket->getID(),
                 'content'       => 'private task assigned to normal user',
@@ -7456,7 +7456,7 @@ HTML,
         );
 
         $task5 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'        => $ticket->getID(),
                 'content'           => 'private task assigned to see group',
@@ -7467,7 +7467,7 @@ HTML,
         );
 
         $task6 = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id'    => $ticket->getID(),
                 'content'       => 'private task assign to tech user',
@@ -7493,32 +7493,32 @@ HTML,
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task1->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task2->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task3->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task4->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task5->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $document->getID(),
                     'items_id'       => $task6->getID(),
-                    'itemtype'       => \TicketTask::class,
+                    'itemtype'       => TicketTask::class,
                 ],
                 [
                     'documents_id'   => $weblink_document->getID(),
@@ -7681,7 +7681,7 @@ HTML,
                 array_values(
                     array_filter(
                         $timeline,
-                        fn($entry) => $entry['type'] === \TicketTask::class
+                        fn($entry) => $entry['type'] === TicketTask::class
                     )
                 ),
             );
@@ -7690,7 +7690,7 @@ HTML,
             $has_weblink = false;
             foreach ($timeline as $entry) {
                 if (
-                    $entry['type'] === \TicketTask::class
+                    $entry['type'] === TicketTask::class
                     && isset($entry['item']['content'])
                     && $entry['item']['content'] !== 'private task assigned to normal user'
                 ) {
@@ -7724,7 +7724,7 @@ HTML,
             ])
         );
 
-        $task = new \TicketTask();
+        $task = new TicketTask();
         $date = date('Y-m-d H:i:s');
         // Create one task with a different creation date after the others
         $this->assertGreaterThan(
@@ -7759,7 +7759,7 @@ HTML,
         $timeline_items = $ticket->getTimelineItems();
 
         // Ensure that the tasks are ordered by creation date. And, if they have the same creation date, by ID
-        $tasks = array_values(array_filter($timeline_items, static fn($entry) => $entry['type'] === \TicketTask::class));
+        $tasks = array_values(array_filter($timeline_items, static fn($entry) => $entry['type'] === TicketTask::class));
         // Check tasks are in order of creation date
         $creation_dates = array_map(static fn($entry) => $entry['item']['date_creation'], $tasks);
         $sorted_dates = $creation_dates;
@@ -7774,7 +7774,7 @@ HTML,
 
         // Check reverse timeline order
         $timeline_items = $ticket->getTimelineItems(['sort_by_date_desc' => true]);
-        $tasks = array_values(array_filter($timeline_items, static fn($entry) => $entry['type'] === \TicketTask::class));
+        $tasks = array_values(array_filter($timeline_items, static fn($entry) => $entry['type'] === TicketTask::class));
         $creation_dates = array_map(static fn($entry) => $entry['item']['date_creation'], $tasks);
         $sorted_dates = $creation_dates;
         sort($sorted_dates);
@@ -9983,14 +9983,14 @@ HTML,
         ];
         yield [
             'parent_itil_itemtype' => Ticket::class,
-            'timeline_item_type' => \TicketTask::class,
+            'timeline_item_type' => TicketTask::class,
             'is_private' => true,
             'test_user' => 'post-only',
             'expected' => false,
         ];
         yield [
             'parent_itil_itemtype' => Ticket::class,
-            'timeline_item_type' => \TicketTask::class,
+            'timeline_item_type' => TicketTask::class,
             'is_private' => false,
             'test_user' => 'post-only',
             'expected' => true,
@@ -10013,14 +10013,14 @@ HTML,
         ];
         yield [
             'parent_itil_itemtype' => Ticket::class,
-            'timeline_item_type' => \TicketTask::class,
+            'timeline_item_type' => TicketTask::class,
             'is_private' => false,
             'test_user' => null, // anonymous
             'expected' => true,
         ];
         yield [
             'parent_itil_itemtype' => Ticket::class,
-            'timeline_item_type' => \TicketTask::class,
+            'timeline_item_type' => TicketTask::class,
             'is_private' => true,
             'test_user' => null, // anonymous
             'expected' => false,

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -72,6 +72,7 @@ use Ticket;
 use Ticket_Contract;
 use Ticket_User;
 use TicketSatisfaction;
+use TicketTask;
 use TicketTemplate;
 use TicketTemplateMandatoryField;
 use TicketValidation;
@@ -10228,5 +10229,58 @@ HTML,
         ]);
 
         $this->checkActors($ticket, []);
+    }
+
+    /**
+     * Test that sourceof_items_id / sourceitems_id references in followups and tasks are cleaned when a ticket is purged
+     * @return void
+     */
+    public function testSourceOfSourceItemCleanup(): void
+    {
+        $this->login();
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'Ticket with source item',
+            'content' => 'test',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $ticket2 = $this->createItem(Ticket::class, [
+            'name' => 'Another ticket',
+            'content' => 'test',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $followup = $this->createItem(ITILFollowup::class, [
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket2->getID(),
+            'content' => 'Followup content',
+        ]);
+
+        $task = $this->createItem(TicketTask::class, [
+            'tickets_id' => $ticket2->getID(),
+            'content' => 'Task content',
+        ]);
+
+        $followup->update([
+            'id' => $followup->getID(),
+            'sourceof_items_id' => $ticket->getID(),
+            'sourceitems_id' => $ticket->getID(),
+        ]);
+        $task->update([
+            'id' => $task->getID(),
+            'sourceof_items_id' => $ticket->getID(),
+            'sourceitems_id' => $ticket->getID(),
+        ]);
+
+        $this->assertTrue($ticket->delete(['id' => $ticket->getID()], true));
+
+        $this->assertTrue($followup->getFromDB($followup->getID()));
+        $task->getFromDB($task->getID());
+
+        $this->assertEquals(0, $followup->fields['sourceof_items_id']);
+        $this->assertEquals(0, $task->fields['sourceof_items_id']);
+        $this->assertEquals(0, $followup->fields['sourceitems_id']);
+        $this->assertEquals(0, $task->fields['sourceitems_id']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

When purging a ticket, followups and tasks with `sourceof_items_id` or `sourceitems_id` referencing that ticket did not get updated and they still had the reference. This caused the UI in the timeline for the item to show it was linked to an empty ticket and blocked splitting it into a new ticket.

Automatic cleanup via the `relation.constant.php` file is not possible as these fields do not follow the standard for foreign keys. I will address this in another PR for `main`.

This PR does not address any existing followups or tasks with orphaned references.