### PR TITLE
Regex hint for form conditions

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/RegexConditionHandler.php
@@ -66,7 +66,9 @@ class RegexConditionHandler implements ConditionHandlerInterface
     #[Override]
     public function getTemplateParameters(ConditionData $condition): array
     {
-        return [];
+        return [
+            'placeholder' => '/regex/',
+        ];
     }
 
     #[Override]

--- a/templates/pages/admin/form/condition_handler_templates/input.html.twig
+++ b/templates/pages/admin/form/condition_handler_templates/input.html.twig
@@ -34,7 +34,7 @@
     class="me-2 form-control value-selector flex-grow-1 min-width-200"
     value="{{ input_value is array ? "" : input_value }}"
     name="{{ input_name }}"
-    placeholder="{{ __("Enter a value...") }}"
+    placeholder="{{ placeholder|default(__("Enter a value...")) }}"
     data-glpi-conditions-editor-value
     aria-label="{{ input_label }}"
     {% for attribute, value in (attributes ?? []) %}


### PR DESCRIPTION
As described in #23267, users may not know that regex must be wrapped with a delimiter.

I propose to add a simple placeholder to showcase that, as it is the most simple solution we can implement on a bugfix release.

Before:
<img width="817" height="329" alt="image" src="https://github.com/user-attachments/assets/742454e8-7134-42a8-a7e6-c349109124de" />

After:
<img width="746" height="261" alt="image" src="https://github.com/user-attachments/assets/08438310-03d4-44f5-b529-4e0d96c396e1" />

Note: it could be nice to add some regex validation when the form is saved to help users figure out their mistakes (I've added it as a separate issue in the backlog as it require more work). 

