### PR TITLE
vertical labels in ticket panel on smaller screens

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -511,13 +511,39 @@ body pre {
     }
 }
 
-.itil-object-fields .col-12.glpi-full-width {
-    .col-form-label {
-        width: 28%;
+.itil-object-fields {
+    .accordion-body {
+        padding-inline: 0.5rem;
     }
 
-    .field-container {
-        width: 72%;
+    .col-12.glpi-full-width {
+        .form-control-plaintext {
+            padding-block: 0;
+        }
+
+        .col-form-label {
+            width: 28%;
+        }
+
+        .field-container {
+            width: 72%;
+        }
+    }
+}
+
+@media (max-width: 1400px) {
+    .itil-object-fields {
+        .col-12.glpi-full-width {
+            .col-form-label {
+                padding-block-start: 0.5rem;
+                padding-block-end: 0.25rem;
+            }
+
+            .col-form-label,
+            .field-container {
+                width: 100%;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #21857
Adding on to original fix #21478

Brings similar functionality back that existed in GLPI 10.

- Halved inline padding to give more room for labels and fields in horizontal mode
- Added media query for < xxl breakpoint to change labels to show above fields and reduce their block padding a bit to waste less vertical space.

![Peek 2026-03-27 16-35](https://github.com/user-attachments/assets/3f6e28e3-d00f-4393-b942-1e093672a26a)

Alternative solution to consider for a major release:
"Float" labels showing on the field. When field is empty, the label is shown as a placeholder (unless there is a specified placeholder). Otherwise it is showing on top of the top border of the input. This provides better use of vertical space while allowing the labels to use almost all of the horizontal space.

<img width="1199" height="957" alt="Selection_700" src="https://github.com/user-attachments/assets/f9bebf63-d800-43f1-b2c4-9a2d0994ddff" />
