### PR TITLE
Enhance resilience of automatic actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
+- New `ERROR` status for automatic actions that have repeatedly failed.
+  Action failure is tracked based on a shutdown handler that checks if the action has completed normally, as well as a signal handler (if pctnl extension is available) to catch external terminations.
+  When an action failure is caught, it will go back to a scheduled status and increment an error counter. If the action fails 5 times, the action gets put in an ERROR status and it will need manual intervention.
+  Failed actions get rescheduled using a backoff strategy starting at 1 minute and doubling for each failure up to a max delay of 30 minutes, plus a random delay between 0 and 2 minutes.
+- `status_msg` property for the cronttask (automatic actions) service in the status checker format changed from "RUNNING: %d, STUCK: %d, TOTAL: %d" to "RUNNING: %d, STUCK: %d, ERROR: %d, TOTAL: %d".
+  If your monitoring relies on parsing this string, make sure it can handle the new format.
+- New `errored` property for the cronttask (automatic actions) service in the status checker to indicate the names of the errored actions requiring manual intervention.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ The present file will list all changes made to the project; according to the
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
 - Password policy and 2FA settings moved from `Setup > General` to `Setup > Security`.
 - CLI command `system:status` now gives information about database version.
+- New `ERROR` status for automatic actions that have repeatedly failed.
+  Action failure is tracked based on a shutdown handler that checks if the action has completed normally.
+  When an action failure is caught, it will go back to a scheduled status and increment an error counter. If the action fails 5 times, the action gets put in an ERROR status and it will need manual intervention.
+  Failed actions get rescheduled using a backoff strategy starting at 1 minute and doubling for each failure up to a max delay of 30 minutes, plus a random delay between 0 and 2 minutes.
+- New `ABORTED` status for automatic actions terminated externally (ex: killed process). These actions are scheduled to re-run as soon as possible.
+- `status_msg` property for the cronttask (automatic actions) service in the status checker format changed from "RUNNING: %d, STUCK: %d, TOTAL: %d" to "RUNNING: %d, STUCK: %d, ERROR: %d, TOTAL: %d".
+  If your monitoring relies on parsing this string, make sure it can handle the new format.
+- New `errored` property for the cronttask (automatic actions) service in the status checker to indicate the names of the errored actions requiring manual intervention.
 
 ### Deprecated
 

--- a/install/migrations/update_11.0.x_to_12.0.0/crontask.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/crontask.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+$migration->addField('glpi_crontasks', 'error_count', 'integer');
+$migration->addField('glpi_crontasks', 'next_run', 'timestamp');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1628,6 +1628,8 @@ CREATE TABLE `glpi_crontasks` (
   `comment` text,
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
+  `error_count` int NOT NULL DEFAULT '0',
+  `next_run` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`name`),
   KEY `name` (`name`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -1640,6 +1640,8 @@ CREATE TABLE `glpi_crontasks` (
   `comment` text,
   `date_mod` timestamp NULL DEFAULT NULL,
   `date_creation` timestamp NULL DEFAULT NULL,
+  `error_count` int NOT NULL DEFAULT '0',
+  `next_run` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`itemtype`,`name`),
   KEY `name` (`name`),

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -2054,6 +2054,14 @@ TWIG, ['msg' => __('Last run list')]);
         }
     }
 
+    public function prepareInputForUpdate($input)
+    {
+        if (isset($input['state']) && (int) $this->fields['state'] !== self::STATE_WAITING && (int) $input['state'] === self::STATE_WAITING) {
+            $input['error_count'] = 0;
+        }
+        return parent::prepareInputForUpdate($input);
+    }
+
     /**
      * A cron task that always throws an exception, used to test error handling of cron tasks
      *

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -41,8 +41,8 @@ use Glpi\Event;
 use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
-
 use Symfony\Component\ErrorHandler\Error\FatalError;
+
 use function Safe\filemtime;
 use function Safe\glob;
 use function Safe\ini_get;
@@ -355,7 +355,7 @@ class CronTask extends CommonDBTM
 
         if ($consecutive_errors === 0) {
             // No error, normal scheduling
-            $next_run = new DateTime($this->fields['lastrun']);
+            $next_run = new DateTime($this->fields['lastrun'] ?? 'now');
             $next_run->modify('+' . $this->fields['frequency'] . ' seconds');
             return $next_run;
         }

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -42,6 +42,7 @@ use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
 
+use Symfony\Component\ErrorHandler\Error\FatalError;
 use function Safe\filemtime;
 use function Safe\glob;
 use function Safe\ini_get;
@@ -679,7 +680,7 @@ class CronTask extends CommonDBTM
         if (empty($this->fields['lastrun'])) {
             $next_run_display = __('As soon as possible');
         } else {
-            $next = $this->fields['next_run'];
+            $next = strtotime($this->fields['next_run']);
             $h    = date('H', $next);
             $deb  = ($this->fields['hourmin'] < 10 ? "0" . $this->fields['hourmin']
                                                 : $this->fields['hourmin']);
@@ -2050,6 +2051,52 @@ TWIG, ['msg' => __('Last run list')]);
                 'components/search/status_area.html.twig',
                 $params
             );
+        }
+    }
+
+    /**
+     * A cron task that always throws an exception, used to test error handling of cron tasks
+     *
+     * @param self $task for log
+     *
+     * @return int
+     * @used-by self
+     * @todo REMOVE BEFORE MERGING PULL REQUEST, this is only for testing purpose
+     **/
+    public static function cronException(self $task): int
+    {
+        throw new RuntimeException("This is a test exception thrown by cronException task.");
+    }
+
+    /**
+     * A cron task that always throws a Symfony fatal error, used to test error handling of cron tasks
+     *
+     * @param self $task for log
+     *
+     * @return int
+     * @used-by self
+     * @todo REMOVE BEFORE MERGING PULL REQUEST, this is only for testing purpose
+     **/
+    public static function cronFatalError(self $task): int
+    {
+        throw new FatalError('This is a test fatal error thrown by cronFatalError task.', 1, [
+            'file' => __FILE__,
+            'line' => __LINE__,
+        ]);
+    }
+
+    /**
+     * A cron task that always exceeds the max execution time, used to test handling of long-running cron tasks
+     * @param CronTask $task
+     * @return int
+     * @todo REMOVE BEFORE MERGING PULL REQUEST, this is only for testing purpose
+     */
+    public static function cronMaxExecutionTime(self $task): int
+    {
+        set_time_limit(1); // Set max execution time to 1 second
+        // PHP probably needs actual work, rather than just sleeping, to reach the max execution time, so we do some busy work here
+        while (true) {
+            $x = sha1(random_bytes(100)); // Generate a random hash to keep the CPU busy
         }
     }
 }

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -33,14 +33,12 @@
  * ---------------------------------------------------------------------
  */
 
-// Needed for signal handler to handle SIGTERM in CLI mode
-declare(ticks=1);
-
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Error\ErrorHandler;
 use Glpi\Event;
+use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
 
@@ -75,6 +73,11 @@ class CronTask extends CommonDBTM
     public const STATE_WAITING = 1;
     /** The automatic action was started and hasn't returned to the waiting state yet */
     public const STATE_RUNNING = 2;
+    /** @var int The automatic action has failed repeatedly on consecutive runs and needs manually reset */
+    public const STATE_ERROR = 3;
+
+    /** @var int Maximum number of consecutive errors before considering that the task is in error state and needs administrator intervention */
+    public const MAX_ERROR_COUNT = 5;
 
     /** The automatic action is run internally (run by GLPI via a hidden image src) */
     public const MODE_INTERNAL = 1;
@@ -215,22 +218,36 @@ class CronTask extends CommonDBTM
      *
      * @param int $signo Signal number
      * @since 9.1
-     * @todo Is there an alternative way to handle this? ext-pcntl is not enabled by default in PHP and isn't available on Windows.
-     *
      * @return void
      */
     public function signal(int $signo): void
     {
         if ($signo === SIGTERM) {
             pcntl_signal(SIGTERM, SIG_DFL);
+            $this->handleAbnormalTermination();
+        }
+    }
 
-            // End of this task
-            $this->end(null);
+    /**
+     * Handle cases where the PHP process is terminated before a task is properly ended.
+     *
+     * This may happen if the CLI process receives a termination signal and the pcntl extension is not available, or if the shutdown function is triggered for any reason while the task is running.
+     * @return void
+     */
+    private function handleAbnormalTermination(): void
+    {
+        if (!isset($_SESSION["glpicronuserrunning"])) {
+            return;
+        }
 
-            // End of this cron
-            $_SESSION["glpicronuserrunning"] = '';
-            self::release_lock();
-            Toolbox::logInFile('cron', __('Action aborted') . "\n");
+        // End of this task
+        $this->end(null);
+
+        // End of this cron
+        $_SESSION["glpicronuserrunning"] = '';
+        self::release_lock();
+        Toolbox::logInFile('cron', __('Action aborted') . "\n");
+        if (isCommandLine()) {
             exit(); // @phpstan-ignore glpi.forbidExit (CLI context)
         }
     }
@@ -249,8 +266,11 @@ class CronTask extends CommonDBTM
         }
 
         if (isCommandLine() && function_exists('pcntl_signal')) {
+            pcntl_async_signals(true);
             pcntl_signal(SIGTERM, [$this, 'signal']);
         }
+        // Shutdown handler will be used for normal terminations (exit, exception, etc)
+        register_shutdown_function($this->handleAbnormalTermination(...));
 
         $DB->update(
             self::getTable(),
@@ -318,6 +338,38 @@ class CronTask extends CommonDBTM
     }
 
     /**
+     * Calculate the next run date of a task.
+     *
+     * In the case of a task that failed, an exponential backoff strategy is applied with some random jitter to avoid cases where many tasks are launched at the same time overloading an external system like a mail server which could potentially put them all back in a failed state.
+     * The maximum delay is capped to 30 minutes to avoid too long delays before retrying a failed task.
+     * @return DateTime
+     * @see self::MAX_ERROR_COUNT
+     * @see self::STATE_ERROR
+     * @link https://en.wikipedia.org/wiki/Exponential_backoff
+     * @link https://en.wikipedia.org/wiki/Thundering_herd_problem
+     */
+    private function calculateNextRunDateTime(): DateTime
+    {
+        $consecutive_errors = $this->fields['error_count'] ?? 0;
+
+        if ($consecutive_errors === 0) {
+            // No error, normal scheduling
+            $next_run = new DateTime($this->fields['lastrun']);
+            $next_run->modify('+' . $this->fields['frequency'] . ' seconds');
+            return $next_run;
+        }
+
+        $min_delay = 60; // 1 minute
+        $max_delay = 60 * 30; // 30 minutes. 1 failure = 1 minute, 2 failures = 2 minutes, 3 failures = 4 minutes, 4 failures = 8 minutes, 5 failures = 16 minutes, more than 5 failures = 30 minutes
+        $jitter = random_int(0, 2 * 60); // Random delay between 0 and 2 minutes in case multiple tasks failed for the same reason to avoid thundering herd effect
+
+        $delay = min($min_delay * (2 ** $consecutive_errors) + $jitter, $max_delay);
+        $next_run = new DateTime();
+        $next_run->modify('+' . $delay . ' seconds');
+        return $next_run;
+    }
+
+    /**
      * End a task, timer, stat, log, ...
      *
      * @param int|null $retcode
@@ -326,7 +378,7 @@ class CronTask extends CommonDBTM
      *    <li>0: Nothing to do</li>
      *   <li>&gt; 0: Ok</li>
      * </ul>
-     * @param int $log_state
+     * @param CronTaskLog::STATE_* $log_state
      *
      * @return bool : true if ok (not start by another)
      *
@@ -342,10 +394,25 @@ class CronTask extends CommonDBTM
             return false;
         }
 
+        if (is_null($retcode) || $log_state === CronTaskLog::STATE_ERROR) {
+            $this->fields['error_count'] = ($this->fields['error_count'] ?? 0) + 1;
+        } else {
+            $this->fields['error_count'] = 0;
+        }
+
+        if ($this->fields['error_count'] >= self::MAX_ERROR_COUNT) {
+            $this->fields['state'] = self::STATE_ERROR;
+            $this->sendNotificationOnError();
+        } else {
+            $this->fields['state'] = self::STATE_WAITING;
+        }
+
         $DB->update(
             self::getTable(),
             [
                 'state'  => $this->fields['state'],
+                'next_run' => $this->calculateNextRunDateTime()->format('Y-m-d H:i:s'),
+                'error_count' => $this->fields['error_count'] ?? 0,
             ],
             [
                 'id'     => $this->fields['id'],
@@ -477,7 +544,7 @@ class CronTask extends CommonDBTM
                 $WHERE[] = ['NOT' => ['name' => $locks]];
             }
 
-            // Build query for frequency and allowed hour
+            // Build query for next_run and allowed hour
             $WHERE[] = ['OR' => [
                 ['AND' => [
                     ['hourmin'   => ['<', new QueryExpression($DB::quoteName('hourmax'))]],
@@ -498,7 +565,7 @@ class CronTask extends CommonDBTM
             $WHERE[] = [
                 'OR' => [
                     'lastrun'   => null,
-                    new QueryExpression(QueryFunction::unixTimestamp('lastrun') . ' + ' . $DB::quoteName('frequency') . ' <= ' . QueryFunction::unixTimestamp()),
+                    new QueryExpression(QueryFunction::unixTimestamp('next_run') . ' <= ' . QueryFunction::unixTimestamp()),
                 ],
             ];
         }
@@ -517,7 +584,7 @@ class CronTask extends CommonDBTM
             // Core task before plugins
             'ORDER'  => [
                 'ISPLUGIN',
-                new QueryExpression(QueryFunction::unixTimestamp($DB::quoteName('lastrun')) . ' + ' . $DB::quoteName('frequency')),
+                QueryFunction::unixTimestamp('next_run'),
             ],
         ]);
 
@@ -612,7 +679,7 @@ class CronTask extends CommonDBTM
         if (empty($this->fields['lastrun'])) {
             $next_run_display = __('As soon as possible');
         } else {
-            $next = strtotime($this->fields['lastrun']) + $this->fields['frequency'];
+            $next = $this->fields['next_run'];
             $h    = date('H', $next);
             $deb  = ($this->fields['hourmin'] < 10 ? "0" . $this->fields['hourmin']
                                                 : $this->fields['hourmin']);

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -270,7 +270,7 @@ class CronTask extends CommonDBTM
             pcntl_async_signals(true);
             pcntl_signal(SIGTERM, [$this, 'signal']);
         }
-        // Shutdown handler will be used for normal terminations (exit, exception, etc)
+        // Shutdown handler will be used to catch unexpected PHP script execution ending (unrecoverable errors, uncaught errors, unexpected exit, etc).
         register_shutdown_function($this->handleAbnormalTermination(...));
 
         $DB->update(
@@ -743,7 +743,7 @@ class CronTask extends CommonDBTM
         }
         return $this->update([
             'id'      => $this->fields['id'],
-            'lastrun' => 'NULL',
+            'next_run' => 'NULL',
         ]);
     }
 

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -33,15 +33,13 @@
  * ---------------------------------------------------------------------
  */
 
-// Needed for signal handler to handle SIGTERM in CLI mode
-declare(ticks=1);
-
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Error\ErrorHandler;
 use Glpi\Event;
 use Glpi\Security\SessionTracker;
+use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use Safe\Exceptions\InfoException;
 
@@ -76,6 +74,13 @@ class CronTask extends CommonDBTM
     public const STATE_WAITING = 1;
     /** The automatic action was started and hasn't returned to the waiting state yet */
     public const STATE_RUNNING = 2;
+    /** @var int The automatic action has failed repeatedly on consecutive runs and needs manually reset */
+    public const STATE_ERROR = 3;
+    /** @var int The automatic action was aborted externally (SIGTERM) and will be automatically re-run as soon as possible */
+    public const STATE_ABORTED = 4;
+
+    /** @var int Maximum number of consecutive errors before considering that the task is in error state and needs administrator intervention */
+    public const MAX_ERROR_COUNT = 5;
 
     /** The automatic action is run internally (run by GLPI via a hidden image src) */
     public const MODE_INTERNAL = 1;
@@ -216,22 +221,36 @@ class CronTask extends CommonDBTM
      *
      * @param int $signo Signal number
      * @since 9.1
-     * @todo Is there an alternative way to handle this? ext-pcntl is not enabled by default in PHP and isn't available on Windows.
-     *
      * @return void
      */
     public function signal(int $signo): void
     {
         if ($signo === SIGTERM) {
             pcntl_signal(SIGTERM, SIG_DFL);
+            $this->handleAbnormalTermination();
+        }
+    }
 
-            // End of this task
-            $this->end(null);
+    /**
+     * Handle cases where the PHP process is terminated before a task is properly ended.
+     *
+     * This may happen if the CLI process receives a termination signal and the pcntl extension is not available, or if the shutdown function is triggered for any reason while the task is running.
+     * @return void
+     */
+    private function handleAbnormalTermination(): void
+    {
+        if (!isset($_SESSION["glpicronuserrunning"])) {
+            return;
+        }
 
-            // End of this cron
-            $_SESSION["glpicronuserrunning"] = '';
-            self::release_lock();
-            Toolbox::logInFile('cron', __('Action aborted') . "\n");
+        // End of this task
+        $this->abort();
+
+        // End of this cron
+        $_SESSION["glpicronuserrunning"] = '';
+        self::release_lock();
+        Toolbox::logInFile('cron', __('Action aborted') . "\n");
+        if (isCommandLine()) {
             exit(); // @phpstan-ignore glpi.forbidExit (CLI context)
         }
     }
@@ -250,8 +269,11 @@ class CronTask extends CommonDBTM
         }
 
         if (isCommandLine() && function_exists('pcntl_signal')) {
+            pcntl_async_signals(true);
             pcntl_signal(SIGTERM, [$this, 'signal']);
         }
+        // Shutdown handler will be used to catch unexpected PHP script execution ending (unrecoverable errors, uncaught errors, unexpected exit, etc).
+        register_shutdown_function($this->handleAbnormalTermination(...));
 
         $DB->update(
             self::getTable(),
@@ -319,6 +341,43 @@ class CronTask extends CommonDBTM
     }
 
     /**
+     * Calculate the next run date of a task.
+     *
+     * In the case of a task that failed, an exponential backoff strategy is applied with some random jitter to avoid cases where many tasks are launched at the same time overloading an external system like a mail server which could potentially put them all back in a failed state.
+     * The maximum delay is capped to 30 minutes to avoid too long delays before retrying a failed task.
+     * @return DateTime
+     * @see self::MAX_ERROR_COUNT
+     * @see self::STATE_ERROR
+     * @link https://en.wikipedia.org/wiki/Exponential_backoff
+     * @link https://en.wikipedia.org/wiki/Thundering_herd_problem
+     */
+    private function calculateNextRunDateTime(): DateTime
+    {
+        $consecutive_errors = $this->fields['error_count'] ?? 0;
+
+        if ($consecutive_errors === 0) {
+            if ($this->fields['state'] === self::STATE_ABORTED) {
+                // The task was aborted externally so it should be re-run as soon as possible, bypassing the normal scheduling
+                $next_run = new DateTime();
+            } else {
+                // No error, normal scheduling
+                $next_run = new DateTime($this->fields['lastrun'] ?? 'now');
+                $next_run->modify('+' . $this->fields['frequency'] . ' seconds');
+            }
+            return $next_run;
+        }
+
+        $min_delay = 60; // 1 minute
+        $max_delay = 60 * 30; // 30 minutes. 1 failure = 1 minute, 2 failures = 2 minutes, 3 failures = 4 minutes, 4 failures = 8 minutes, 5 failures = 16 minutes, more than 5 failures = 30 minutes
+        $jitter = random_int(0, 2 * 60); // Random delay between 0 and 2 minutes in case multiple tasks failed for the same reason to avoid thundering herd effect
+
+        $delay = min($min_delay * (2 ** $consecutive_errors) + $jitter, $max_delay);
+        $next_run = new DateTime();
+        $next_run->modify('+' . $delay . ' seconds');
+        return $next_run;
+    }
+
+    /**
      * End a task, timer, stat, log, ...
      *
      * @param int|null $retcode
@@ -327,7 +386,7 @@ class CronTask extends CommonDBTM
      *    <li>0: Nothing to do</li>
      *   <li>&gt; 0: Ok</li>
      * </ul>
-     * @param int $log_state
+     * @param CronTaskLog::STATE_* $log_state
      *
      * @return bool : true if ok (not start by another)
      *
@@ -337,16 +396,52 @@ class CronTask extends CommonDBTM
      */
     public function end(?int $retcode, int $log_state = CronTaskLog::STATE_STOP): bool
     {
-        global $DB;
-
         if (!isset($this->fields['id'])) {
             return false;
         }
+
+        if (is_null($retcode) || $log_state === CronTaskLog::STATE_ERROR) {
+            $this->fields['error_count'] = ($this->fields['error_count'] ?? 0) + 1;
+        } else {
+            $this->fields['error_count'] = 0;
+        }
+
+        if ($this->fields['error_count'] >= self::MAX_ERROR_COUNT) {
+            $this->fields['state'] = self::STATE_ERROR;
+        } else {
+            $this->fields['state'] = self::STATE_WAITING;
+        }
+
+        return $this->updateAfterExecution($retcode, $log_state);
+    }
+
+    private function abort(): void
+    {
+        if (!isset($this->fields['id'])) {
+            return;
+        }
+
+        $this->fields['state'] = self::STATE_ABORTED;
+
+        $this->updateAfterExecution(null, CronTaskLog::STATE_STOP);
+    }
+
+    /**
+     * @param int|null $retcode
+     * @param int $log_state
+     * @return bool
+     * @noinspection SuspiciousAssignmentsInspection For the double assignment used for locale extractions.
+     */
+    private function updateAfterExecution(?int $retcode, int $log_state): bool
+    {
+        global $DB;
 
         $DB->update(
             self::getTable(),
             [
                 'state'  => $this->fields['state'],
+                'next_run' => $this->calculateNextRunDateTime()->format('Y-m-d H:i:s'),
+                'error_count' => $this->fields['error_count'] ?? 0,
             ],
             [
                 'id'     => $this->fields['id'],
@@ -478,7 +573,7 @@ class CronTask extends CommonDBTM
                 $WHERE[] = ['NOT' => ['name' => $locks]];
             }
 
-            // Build query for frequency and allowed hour
+            // Build query for next_run and allowed hour
             $WHERE[] = ['OR' => [
                 ['AND' => [
                     ['hourmin'   => ['<', new QueryExpression($DB::quoteName('hourmax'))]],
@@ -499,7 +594,7 @@ class CronTask extends CommonDBTM
             $WHERE[] = [
                 'OR' => [
                     'lastrun'   => null,
-                    new QueryExpression(QueryFunction::unixTimestamp('lastrun') . ' + ' . $DB::quoteName('frequency') . ' <= ' . QueryFunction::unixTimestamp()),
+                    new QueryExpression(QueryFunction::ifnull(QueryFunction::unixTimestamp('next_run'), new QueryExpression('0')) . ' <= ' . QueryFunction::unixTimestamp()),
                 ],
             ];
         }
@@ -518,7 +613,7 @@ class CronTask extends CommonDBTM
             // Core task before plugins
             'ORDER'  => [
                 'ISPLUGIN',
-                new QueryExpression(QueryFunction::unixTimestamp($DB::quoteName('lastrun')) . ' + ' . $DB::quoteName('frequency')),
+                QueryFunction::unixTimestamp('next_run'),
             ],
         ]);
 
@@ -613,7 +708,7 @@ class CronTask extends CommonDBTM
         if (empty($this->fields['lastrun'])) {
             $next_run_display = __('As soon as possible');
         } else {
-            $next = strtotime($this->fields['lastrun']) + $this->fields['frequency'];
+            $next = strtotime($this->fields['next_run']);
             $h    = date('H', $next);
             $deb  = ($this->fields['hourmin'] < 10 ? "0" . $this->fields['hourmin']
                                                 : $this->fields['hourmin']);
@@ -676,7 +771,7 @@ class CronTask extends CommonDBTM
         }
         return $this->update([
             'id'      => $this->fields['id'],
-            'lastrun' => 'NULL',
+            'next_run' => 'NULL',
         ]);
     }
 
@@ -1995,5 +2090,13 @@ TWIG, ['msg' => __('Last run list')]);
                 $params
             );
         }
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        if (!isset($input['error_count']) && isset($input['state']) && (int) $this->fields['state'] !== self::STATE_WAITING && (int) $input['state'] === self::STATE_WAITING) {
+            $input['error_count'] = 0;
+        }
+        return parent::prepareInputForUpdate($input);
     }
 }

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -478,8 +478,18 @@ final class StatusChecker
                 foreach ($stuck_crontasks as $ct) {
                     $status['stuck'][] = $ct['name'];
                 }
+                $errored_crontasks = array_filter($crontasks, static fn($crontask) => $crontask['state'] === CronTask::STATE_ERROR);
+                foreach ($errored_crontasks as $ct) {
+                    $status['errored'][] = $ct['name'];
+                }
                 $status['status'] = count($status['stuck']) ? self::STATUS_PROBLEM : self::STATUS_OK;
-                $status['status_msg'] = sprintf(_x('glpi_status', 'RUNNING: %d, STUCK: %d, TOTAL: %d'), $running, count($stuck_crontasks), count($crontasks));
+                $status['status_msg'] = sprintf(
+                    _x('glpi_status', 'RUNNING: %d, STUCK: %d, ERRORED: %d, TOTAL: %d'),
+                    $running,
+                    count($stuck_crontasks),
+                    count($errored_crontasks),
+                    count($crontasks)
+                );
             }
             self::$cached_status['crontasks'] = $status;
         }

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -508,8 +508,6 @@ final class StatusChecker
                 'errored' => [],
             ];
             if (self::isDBAvailable()) {
-                global $DB;
-
                 $crontasks = getAllDataFromTable('glpi_crontasks');
                 $running = count(array_filter($crontasks, static fn($crontask) => $crontask['state'] === CronTask::STATE_RUNNING));
                 $stuck_crontasks = CronTask::getZombieCronTasks();
@@ -520,7 +518,7 @@ final class StatusChecker
                 foreach ($errored_crontasks as $ct) {
                     $status['errored'][] = $ct['name'];
                 }
-                $status['status'] = (count($status['stuck']) + count($status['errored'])) ? self::STATUS_PROBLEM : self::STATUS_OK;
+                $status['status'] = (count($status['stuck']) + count($status['errored'])) > 0 ? self::STATUS_PROBLEM : self::STATUS_OK;
                 $status['status_msg'] = sprintf(
                     _x('glpi_status', 'RUNNING: %d, STUCK: %d, ERRORED: %d, TOTAL: %d'),
                     $running,

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -505,6 +505,7 @@ final class StatusChecker
             $status = [
                 'status' => self::STATUS_NO_DATA,
                 'stuck' => [],
+                'errored' => [],
             ];
             if (self::isDBAvailable()) {
                 global $DB;
@@ -515,8 +516,18 @@ final class StatusChecker
                 foreach ($stuck_crontasks as $ct) {
                     $status['stuck'][] = $ct['name'];
                 }
-                $status['status'] = count($status['stuck']) ? self::STATUS_PROBLEM : self::STATUS_OK;
-                $status['status_msg'] = sprintf(_x('glpi_status', 'RUNNING: %d, STUCK: %d, TOTAL: %d'), $running, count($stuck_crontasks), count($crontasks));
+                $errored_crontasks = array_filter($crontasks, static fn($crontask) => $crontask['state'] === CronTask::STATE_ERROR);
+                foreach ($errored_crontasks as $ct) {
+                    $status['errored'][] = $ct['name'];
+                }
+                $status['status'] = (count($status['stuck']) + count($status['errored'])) ? self::STATUS_PROBLEM : self::STATUS_OK;
+                $status['status_msg'] = sprintf(
+                    _x('glpi_status', 'RUNNING: %d, STUCK: %d, ERRORED: %d, TOTAL: %d'),
+                    $running,
+                    count($stuck_crontasks),
+                    count($errored_crontasks),
+                    count($crontasks)
+                );
             }
             self::$cached_status['crontasks'] = $status;
         }

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -74,13 +74,13 @@
                                 (constant('CronTask::STATE_DISABLE')): __('Disabled'),
                                 (constant('CronTask::STATE_WAITING')): __('Scheduled')
                             } %}
-                            {% if item.fields['state'] === constant('CronTask::STATE_ERROR') %}
+                            {% if item.fields['state'] == constant('CronTask::STATE_ERROR') %}
                                 {% set state_options = state_options + {
-                                    (constant('CronTask::STATE_ERROR')): __('Error')
+                                    (constant('CronTask::STATE_ERROR')): _n('Error', 'Errors', 1)
                                 } %}
                             {% endif %}
                             {{ fields.dropdownArrayField('state', item.fields['state'], state_options, __('Status'), {
-                                add_field_html: item.fields['state'] === constant('CronTask::STATE_ERROR') ? '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention') ~ '</span>' : ''
+                                add_field_html: item.fields['state'] == constant('CronTask::STATE_ERROR') ? '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention') ~ '</span>' : ''
                             }) }}
 
                             {# Run mode #}

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -33,145 +33,154 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="asset">
-   {{ include('components/form/header.html.twig') }}
+    {{ include('components/form/header.html.twig') }}
 
-   {% set rand = random() %}
-   {% set params  = params ?? [] %}
-   {% set target       = params['target'] ?? item.getFormURL() %}
-   {% set withtemplate = params['withtemplate'] ?? '' %}
-   {% set item_type = item.getType() %}
-   {% set field_options = {} %}
-   {% set can_execute = item.canEdit(item.fields['id']) %}
+    {% set rand = random() %}
+    {% set params  = params ?? [] %}
+    {% set target       = params['target'] ?? item.getFormURL() %}
+    {% set withtemplate = params['withtemplate'] ?? '' %}
+    {% set item_type = item.getType() %}
+    {% set field_options = {} %}
+    {% set can_execute = item.canEdit(item.fields['id']) %}
 
-   <div class="card-body d-flex flex-wrap">
-      <div class="col-12 col-xxl-12 flex-column">
-         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
-            <div class="row flex-row align-items-start flex-grow-1">
-               <div class="row flex-row">
-                  {% block form_fields %}
-                     {% set name = item.fields['name'] %}
-                     {% if plugin_info %}
-                        {% set name = __('%1$s - %2$s')|format(plugin_info['plugin'], name) %}
-                     {% endif %}
-                     {% set name_field %}
-                        <span class="fw-bold">{{ name }}</span>
-                     {% endset %}
-                     {{ fields.htmlField('name', name_field, __('Name')) }}
+    <div class="card-body d-flex flex-wrap">
+        <div class="col-12 col-xxl-12 flex-column">
+            <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+                <div class="row flex-row align-items-start flex-grow-1">
+                    <div class="row flex-row">
+                        {% block form_fields %}
+                            {% set name = item.fields['name'] %}
+                            {% if plugin_info %}
+                                {% set name = __('%1$s - %2$s')|format(plugin_info['plugin'], name) %}
+                            {% endif %}
+                            {% set name_field %}
+                                <span class="fw-bold">{{ name }}</span>
+                            {% endset %}
+                            {{ fields.htmlField('name', name_field, __('Name')) }}
 
-                     {{ fields.textareaField(
-                        'comment',
-                        item.fields['comment'],
-                        _n('Comment', 'Comments', get_plural_number()),
-                        field_options
-                     ) }}
+                            {{ fields.textareaField(
+                                'comment',
+                                item.fields['comment'],
+                                _n('Comment', 'Comments', get_plural_number()),
+                                field_options
+                            ) }}
 
-                     {{ fields.htmlField('description', item.getDescription(item.getID)|e, __('Description')) }}
+                            {{ fields.htmlField('description', item.getDescription(item.getID)|e, __('Description')) }}
 
-                     {{ fields.dropdownFrequency('frequency', item.fields['frequency'], __('Run frequency')) }}
+                            {{ fields.dropdownFrequency('frequency', item.fields['frequency'], __('Run frequency')) }}
 
-                     {# Status #}
-                     {{ fields.dropdownArrayField('state', item.fields['state'], {
-                        (constant('CronTask::STATE_DISABLE')): __('Disabled'),
-                        (constant('CronTask::STATE_WAITING')): __('Scheduled')
-                     }, __('Status')) }}
+                            {# Status #}
+                            {% set state_options = {
+                                (constant('CronTask::STATE_DISABLE')): __('Disabled'),
+                                (constant('CronTask::STATE_WAITING')): __('Scheduled')
+                            } %}
+                            {% if item.fields['state'] === constant('CronTask::STATE_ERROR') %}
+                                {% set state_options = state_options + {
+                                    (constant('CronTask::STATE_ERROR')): __('Error')
+                                } %}
+                            {% endif %}
+                            {{ fields.dropdownArrayField('state', item.fields['state'], state_options, __('Status'), {
+                                add_field_html: item.fields['state'] === constant('CronTask::STATE_ERROR') ? '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention') ~ '</span>' : ''
+                            }) }}
 
-                     {# Run mode #}
-                     {{ fields.dropdownArrayField('mode', item.fields['mode'], {
-                        (constant('CronTask::MODE_INTERNAL')): __('GLPI'),
-                        (constant('CronTask::MODE_EXTERNAL')): __('CLI')
-                     }, __('Run mode')) }}
+                            {# Run mode #}
+                            {{ fields.dropdownArrayField('mode', item.fields['mode'], {
+                                (constant('CronTask::MODE_INTERNAL')): __('GLPI'),
+                                (constant('CronTask::MODE_EXTERNAL')): __('CLI')
+                            }, __('Run mode')) }}
 
-                     {# Run period #}
-                     {% set run_period_field %}
-                        <div class="d-flex align-items-center">
-                           {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
-                              min: 0,
-                              max: 24,
-                              no_label: true,
-                              field_class: ''
-                           }) }}
-                           <i class="ti ti-arrow-right mb-3"></i>
-                           {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
-                              min: 0,
-                              max: 24,
-                              no_label: true,
-                              field_class: ''
-                           }) }}
-                        </div>
-                     {% endset %}
-                     {{ fields.htmlField('run_period', run_period_field, __('Run period')) }}
+                            {# Run period #}
+                            {% set run_period_field %}
+                                <div class="d-flex align-items-center">
+                                    {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
+                                        min: 0,
+                                        max: 24,
+                                        no_label: true,
+                                        field_class: ''
+                                    }) }}
+                                    <i class="ti ti-arrow-right mb-3"></i>
+                                    {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
+                                        min: 0,
+                                        max: 24,
+                                        no_label: true,
+                                        field_class: ''
+                                    }) }}
+                                </div>
+                            {% endset %}
+                            {{ fields.htmlField('run_period', run_period_field, __('Run period')) }}
 
-                     {# Number of days this action logs are stored #}
-                     {{ fields.dropdownNumberField('logs_lifetime', item.fields['logs_lifetime'], __('Number of days this action logs are stored'), {
-                        min: 10,
-                        max: 360,
-                        step: 10,
-                        toadd: {
-                           0: __('Infinite')
-                        }
-                     }) }}
+                            {# Number of days this action logs are stored #}
+                            {{ fields.dropdownNumberField('logs_lifetime', item.fields['logs_lifetime'], __('Number of days this action logs are stored'), {
+                                min: 10,
+                                max: 360,
+                                step: 10,
+                                toadd: {
+                                    0: __('Infinite')
+                                }
+                            }) }}
 
-                     {# Param #}
-                     {% if item_meta.param_description is not empty %}
-                        {{ fields.dropdownNumberField('param', item.fields['param'], item_meta.param_description, {
-                           min: 0,
-                           max: 10000
-                        }) }}
-                     {% endif %}
+                            {# Param #}
+                            {% if item_meta.param_description is not empty %}
+                                {{ fields.dropdownNumberField('param', item.fields['param'], item_meta.param_description, {
+                                    min: 0,
+                                    max: 10000
+                                }) }}
+                            {% endif %}
 
-                     <div class="row flex-row">
-                        {# Last run #}
-                        {% set last_run_field %}
-                           {% if item.fields['lastrun'] is empty %}
-                              {{ __('Never') }}
-                           {% else %}
-                              {{ item.fields['lastrun']|formatted_datetime }}
-                              {% if can_execute %}
-                                 {# ID field is defined in components/form/buttons.html.twig #}
-                                 <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
-                                    <i class="ti ti-circle-x me-1"></i>
-                                 </button>
-                              {% endif %}
-                           {% endif %}
-                        {% endset %}
-                        {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
+                            <div class="row flex-row">
+                                {# Last run #}
+                                {% set last_run_field %}
+                                    {% if item.fields['lastrun'] is empty %}
+                                        {{ __('Never') }}
+                                    {% else %}
+                                        {{ item.fields['lastrun']|formatted_datetime }}
+                                        {% if can_execute %}
+                                            {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                            <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
+                                                <i class="ti ti-circle-x me-1"></i>
+                                            </button>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endset %}
+                                {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
 
-                        {# Next run #}
-                        {% set launch = item.fields['state'] != constant('CronTask::STATE_RUNNING') and (item.fields['allowmode'] b-and constant('CronTask::MODE_INTERNAL')) %}
-                        {% set next_run_field %}
-                           {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
-                              {{ item.getStateName(item.fields['state']) }}
-                           {% else %}
-                              {{ item_meta.next_run_display }}
-                           {% endif %}
-                           {% if config('maintenance_mode') %}
-                              <div class="alert alert-warning">
-                                 {{ __('Maintenance mode enabled, running tasks is disabled') }}
-                              </div>
-                           {% elseif can_execute and launch %}
-                              {# ID is defined in components/form/buttons.html.twig #}
-                              <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
-                                 <i class="ti ti-player-play me-1"></i>
-                                 {{ __('Execute') }}
-                              </button>
-                           {% endif %}
+                                {# Next run #}
+                                {% set launch = item.fields['state'] != constant('CronTask::STATE_RUNNING') and (item.fields['allowmode'] b-and constant('CronTask::MODE_INTERNAL')) %}
+                                {% set next_run_field %}
+                                    {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
+                                        {{ item.getStateName(item.fields['state']) }}
+                                    {% else %}
+                                        {{ item_meta.next_run_display }}
+                                    {% endif %}
+                                    {% if config('maintenance_mode') %}
+                                        <div class="alert alert-warning">
+                                            {{ __('Maintenance mode enabled, running tasks is disabled') }}
+                                        </div>
+                                    {% elseif can_execute and launch %}
+                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
+                                            <i class="ti ti-player-play me-1"></i>
+                                            {{ __('Execute') }}
+                                        </button>
+                                    {% endif %}
 
-                           {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
-                              {# ID field is defined in components/form/buttons.html.twig #}
-                              <button class="btn btn-primary" type="submit" name="resetstate">
-                                 <i class="ti ti-circle-x me-1"></i>
-                                 {{ __('Blank') }}
-                              </button>
-                           {% endif %}
-                        {% endset %}
-                        {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}
-                     </div>
-                  {% endblock %}
-               </div> {# .row #}
-            </div> {# .row #}
-         </div> {# .flex-row #}
-      </div>
-   </div> {# .card-body #}
+                                    {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
+                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        <button class="btn btn-primary" type="submit" name="resetstate">
+                                            <i class="ti ti-circle-x me-1"></i>
+                                            {{ __('Blank') }}
+                                        </button>
+                                    {% endif %}
+                                {% endset %}
+                                {{ fields.htmlField('error_count', item.fields['error_count'], __('Consecutive error count')) }}
+                                {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}
+                            </div>
+                        {% endblock %}
+                    </div> {# .row #}
+                </div> {# .row #}
+            </div> {# .flex-row #}
+        </div>
+    </div> {# .card-body #}
 
-   {{ include('components/form/buttons.html.twig') }}
+    {{ include('components/form/buttons.html.twig') }}
 </div>

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -135,7 +135,7 @@
                                     {% else %}
                                         {{ item.fields['lastrun']|formatted_datetime }}
                                         {% if can_execute %}
-                                            {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                            {# ID defined in components/form/buttons.html.twig #}
                                             <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
                                                 <i class="ti ti-circle-x me-1"></i>
                                             </button>

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -33,145 +33,160 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="asset">
-   {{ include('components/form/header.html.twig') }}
+    {{ include('components/form/header.html.twig') }}
 
-   {% set rand = random() %}
-   {% set params  = params ?? [] %}
-   {% set target       = params['target'] ?? item.getFormURL() %}
-   {% set withtemplate = params['withtemplate'] ?? '' %}
-   {% set item_type = item.getType() %}
-   {% set field_options = {} %}
-   {% set can_execute = item.canEdit(item.fields['id']) %}
+    {% set rand = random() %}
+    {% set params  = params ?? [] %}
+    {% set target       = params['target'] ?? item.getFormURL() %}
+    {% set withtemplate = params['withtemplate'] ?? '' %}
+    {% set item_type = item.getType() %}
+    {% set field_options = {} %}
+    {% set can_execute = item.canEdit(item.fields['id']) %}
 
-   <div class="card-body d-flex flex-wrap">
-      <div class="col-12 col-xxl-12 flex-column">
-         <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
-            <div class="row flex-row align-items-start flex-grow-1">
-               <div class="row flex-row">
-                  {% block form_fields %}
-                     {% set name = item.fields['name'] %}
-                     {% if plugin_info %}
-                        {% set name = __('%1$s - %2$s')|format(plugin_info['plugin'], name) %}
-                     {% endif %}
-                     {% set name_field %}
-                        <span class="fw-bold">{{ name }}</span>
-                     {% endset %}
-                     {{ fields.htmlField('name', name_field, __('Name')) }}
+    <div class="card-body d-flex flex-wrap">
+        <div class="col-12 col-xxl-12 flex-column">
+            <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
+                <div class="row flex-row align-items-start flex-grow-1">
+                    <div class="row flex-row">
+                        {% block form_fields %}
+                            {% set name = item.fields['name'] %}
+                            {% if plugin_info %}
+                                {% set name = __('%1$s - %2$s')|format(plugin_info['plugin'], name) %}
+                            {% endif %}
+                            {% set name_field %}
+                                <span class="fw-bold">{{ name }}</span>
+                            {% endset %}
+                            {{ fields.htmlField('name', name_field, __('Name')) }}
 
-                     {{ fields.textareaField(
-                        'comment',
-                        item.fields['comment'],
-                        _n('Comment', 'Comments', get_plural_number()),
-                        field_options
-                     ) }}
+                            {{ fields.textareaField(
+                                'comment',
+                                item.fields['comment'],
+                                _n('Comment', 'Comments', get_plural_number()),
+                                field_options
+                            ) }}
 
-                     {{ fields.htmlField('description', item.getDescription(item.getID)|e, __('Description')) }}
+                            {{ fields.htmlField('description', item.getDescription(item.getID)|e, __('Description')) }}
 
-                     {{ fields.dropdownFrequency('frequency', item.fields['frequency'], __('Run frequency')) }}
+                            {{ fields.dropdownFrequency('frequency', item.fields['frequency'], __('Run frequency')) }}
 
-                     {# Status #}
-                     {{ fields.dropdownArrayField('state', item.fields['state'], {
-                        (constant('CronTask::STATE_DISABLE')): __('Disabled'),
-                        (constant('CronTask::STATE_WAITING')): __('Scheduled')
-                     }, __('Status')) }}
+                            {# Status #}
+                            {% set state_options = {
+                                (constant('CronTask::STATE_DISABLE')): __('Disabled'),
+                                (constant('CronTask::STATE_WAITING')): __('Scheduled')
+                            } %}
+                            {% if item.fields['state'] == constant('CronTask::STATE_ERROR') %}
+                                {% set state_options = state_options + {
+                                    (constant('CronTask::STATE_ERROR')): _n('Error', 'Errors', 1)
+                                } %}
+                            {% elseif item.fields['state'] == constant('CronTask::STATE_ABORTED') %}
+                                {% set state_options = state_options + {
+                                    (constant('CronTask::STATE_ABORTED')): __('Aborted')
+                                } %}
+                            {% endif %}
+                            {% set error_state_msg = '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention') ~ '</span>' %}
+                            {% set aborted_state_msg = '<span class="text-danger ms-2">' ~ __('This action was aborted externally and will be retried as soon as possible') ~ '</span>' %}
+                            {{ fields.dropdownArrayField('state', item.fields['state'], state_options, __('Status'), {
+                                add_field_html: item.fields['state'] == constant('CronTask::STATE_ERROR') ? error_state_msg : (item.fields['state'] == constant('CronTask::STATE_ABORTED') ? aborted_state_msg : '')
+                            }) }}
 
-                     {# Run mode #}
-                     {{ fields.dropdownArrayField('mode', item.fields['mode'], {
-                        (constant('CronTask::MODE_INTERNAL')): __('GLPI'),
-                        (constant('CronTask::MODE_EXTERNAL')): __('CLI')
-                     }, __('Run mode')) }}
+                            {# Run mode #}
+                            {{ fields.dropdownArrayField('mode', item.fields['mode'], {
+                                (constant('CronTask::MODE_INTERNAL')): __('GLPI'),
+                                (constant('CronTask::MODE_EXTERNAL')): __('CLI')
+                            }, __('Run mode')) }}
 
-                     {# Run period #}
-                     {% set run_period_field %}
-                        <div class="d-flex align-items-center">
-                           {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
-                              min: 0,
-                              max: 24,
-                              no_label: true,
-                              field_class: ''
-                           }) }}
-                           <i class="ti ti-arrow-right mb-3"></i>
-                           {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
-                              min: 0,
-                              max: 24,
-                              no_label: true,
-                              field_class: ''
-                           }) }}
-                        </div>
-                     {% endset %}
-                     {{ fields.htmlField('run_period', run_period_field, __('Run period')) }}
+                            {# Run period #}
+                            {% set run_period_field %}
+                                <div class="d-flex align-items-center">
+                                    {{ fields.dropdownNumberField('hourmin', item.fields['hourmin'], null, {
+                                        min: 0,
+                                        max: 24,
+                                        no_label: true,
+                                        field_class: ''
+                                    }) }}
+                                    <i class="ti ti-arrow-right mb-3"></i>
+                                    {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
+                                        min: 0,
+                                        max: 24,
+                                        no_label: true,
+                                        field_class: ''
+                                    }) }}
+                                </div>
+                            {% endset %}
+                            {{ fields.htmlField('run_period', run_period_field, __('Run period')) }}
 
-                     {# Number of days this action logs are stored #}
-                     {{ fields.dropdownNumberField('logs_lifetime', item.fields['logs_lifetime'], __('Number of days this action logs are stored'), {
-                        min: 10,
-                        max: 360,
-                        step: 10,
-                        toadd: {
-                           0: __('Infinite')
-                        }
-                     }) }}
+                            {# Number of days this action logs are stored #}
+                            {{ fields.dropdownNumberField('logs_lifetime', item.fields['logs_lifetime'], __('Number of days this action logs are stored'), {
+                                min: 10,
+                                max: 360,
+                                step: 10,
+                                toadd: {
+                                    0: __('Infinite')
+                                }
+                            }) }}
 
-                     {# Param #}
-                     {% if item_meta.param_description is not empty %}
-                        {{ fields.dropdownNumberField('param', item.fields['param'], item_meta.param_description, {
-                           min: 0,
-                           max: 10000
-                        }) }}
-                     {% endif %}
+                            {# Param #}
+                            {% if item_meta.param_description is not empty %}
+                                {{ fields.dropdownNumberField('param', item.fields['param'], item_meta.param_description, {
+                                    min: 0,
+                                    max: 10000
+                                }) }}
+                            {% endif %}
 
-                     <div class="row flex-row">
-                        {# Last run #}
-                        {% set last_run_field %}
-                           {% if item.fields['lastrun'] is empty %}
-                              {{ __('Never') }}
-                           {% else %}
-                              {{ item.fields['lastrun']|formatted_datetime }}
-                              {% if can_execute %}
-                                 {# ID field is defined in components/form/buttons.html.twig #}
-                                 <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
-                                    <i class="ti ti-circle-x me-1"></i>
-                                 </button>
-                              {% endif %}
-                           {% endif %}
-                        {% endset %}
-                        {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
+                            <div class="row flex-row">
+                                {# Last run #}
+                                {% set last_run_field %}
+                                    {% if item.fields['lastrun'] is empty %}
+                                        {{ __('Never') }}
+                                    {% else %}
+                                        {{ item.fields['lastrun']|formatted_datetime }}
+                                        {% if can_execute %}
+                                            {# ID defined in components/form/buttons.html.twig #}
+                                            <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
+                                                <i class="ti ti-circle-x me-1"></i>
+                                            </button>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endset %}
+                                {{ fields.htmlField('last_run', last_run_field, __('Last run')) }}
 
-                        {# Next run #}
-                        {% set launch = item.fields['state'] != constant('CronTask::STATE_RUNNING') and (item.fields['allowmode'] b-and constant('CronTask::MODE_INTERNAL')) %}
-                        {% set next_run_field %}
-                           {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
-                              {{ item.getStateName(item.fields['state']) }}
-                           {% else %}
-                              {{ item_meta.next_run_display }}
-                           {% endif %}
-                           {% if config('maintenance_mode') %}
-                              <div class="alert alert-warning">
-                                 {{ __('Maintenance mode enabled, running tasks is disabled') }}
-                              </div>
-                           {% elseif can_execute and launch %}
-                              {# ID is defined in components/form/buttons.html.twig #}
-                              <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
-                                 <i class="ti ti-player-play me-1"></i>
-                                 {{ __('Execute') }}
-                              </button>
-                           {% endif %}
+                                {# Next run #}
+                                {% set launch = item.fields['state'] != constant('CronTask::STATE_RUNNING') and (item.fields['allowmode'] b-and constant('CronTask::MODE_INTERNAL')) %}
+                                {% set next_run_field %}
+                                    {% if item.fields['state'] != constant('CronTask::STATE_WAITING') %}
+                                        {{ item.getStateName(item.fields['state']) }}
+                                    {% else %}
+                                        {{ item_meta.next_run_display }}
+                                    {% endif %}
+                                    {% if config('maintenance_mode') %}
+                                        <div class="alert alert-warning">
+                                            {{ __('Maintenance mode enabled, running tasks is disabled') }}
+                                        </div>
+                                    {% elseif can_execute and launch %}
+                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
+                                            <i class="ti ti-player-play me-1"></i>
+                                            {{ __('Execute') }}
+                                        </button>
+                                    {% endif %}
 
-                           {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
-                              {# ID field is defined in components/form/buttons.html.twig #}
-                              <button class="btn btn-primary" type="submit" name="resetstate">
-                                 <i class="ti ti-circle-x me-1"></i>
-                                 {{ __('Blank') }}
-                              </button>
-                           {% endif %}
-                        {% endset %}
-                        {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}
-                     </div>
-                  {% endblock %}
-               </div> {# .row #}
-            </div> {# .row #}
-         </div> {# .flex-row #}
-      </div>
-   </div> {# .card-body #}
+                                    {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
+                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        <button class="btn btn-primary" type="submit" name="resetstate">
+                                            <i class="ti ti-circle-x me-1"></i>
+                                            {{ __('Blank') }}
+                                        </button>
+                                    {% endif %}
+                                {% endset %}
+                                {{ fields.htmlField('error_count', item.fields['error_count'], __('Consecutive error count')) }}
+                                {{ fields.htmlField('next_run', next_run_field, __('Next run')) }}
+                            </div>
+                        {% endblock %}
+                    </div> {# .row #}
+                </div> {# .row #}
+            </div> {# .flex-row #}
+        </div>
+    </div> {# .card-body #}
 
-   {{ include('components/form/buttons.html.twig') }}
+    {{ include('components/form/buttons.html.twig') }}
 </div>

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -74,19 +74,20 @@
                                 (constant('CronTask::STATE_DISABLE')): __('Disabled'),
                                 (constant('CronTask::STATE_WAITING')): __('Scheduled')
                             } %}
+                            {% set state_msg = '' %}
                             {% if item.fields['state'] == constant('CronTask::STATE_ERROR') %}
                                 {% set state_options = state_options + {
                                     (constant('CronTask::STATE_ERROR')): _n('Error', 'Errors', 1)
                                 } %}
+                                {% set state_msg = '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention')|e ~ '</span>' %}
                             {% elseif item.fields['state'] == constant('CronTask::STATE_ABORTED') %}
                                 {% set state_options = state_options + {
                                     (constant('CronTask::STATE_ABORTED')): __('Aborted')
                                 } %}
+                                {% set state_msg = '<span class="text-danger ms-2">' ~ __('This action was aborted externally and will be retried as soon as possible')|e ~ '</span>' %}
                             {% endif %}
-                            {% set error_state_msg = '<span class="text-danger ms-2">' ~ __('This action has repeatedly failed and needs manual intervention') ~ '</span>' %}
-                            {% set aborted_state_msg = '<span class="text-danger ms-2">' ~ __('This action was aborted externally and will be retried as soon as possible') ~ '</span>' %}
                             {{ fields.dropdownArrayField('state', item.fields['state'], state_options, __('Status'), {
-                                add_field_html: item.fields['state'] == constant('CronTask::STATE_ERROR') ? error_state_msg : (item.fields['state'] == constant('CronTask::STATE_ABORTED') ? aborted_state_msg : '')
+                                add_field_html: state_msg
                             }) }}
 
                             {# Run mode #}
@@ -141,7 +142,7 @@
                                     {% else %}
                                         {{ item.fields['lastrun']|formatted_datetime }}
                                         {% if can_execute %}
-                                            {# ID defined in components/form/buttons.html.twig #}
+                                            {# ID field is defined in components/form/buttons.html.twig #}
                                             <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
                                                 <i class="ti ti-circle-x me-1"></i>
                                             </button>
@@ -163,7 +164,7 @@
                                             {{ __('Maintenance mode enabled, running tasks is disabled') }}
                                         </div>
                                     {% elseif can_execute and launch %}
-                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        {# ID is defined in components/form/buttons.html.twig #}
                                         <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
                                             <i class="ti ti-player-play me-1"></i>
                                             {{ __('Execute') }}
@@ -171,7 +172,7 @@
                                     {% endif %}
 
                                     {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
-                                        {# ID and CSRF token fields are defined in components/form/buttons.html.twig #}
+                                        {# ID field is defined in components/form/buttons.html.twig #}
                                         <button class="btn btn-primary" type="submit" name="resetstate">
                                             <i class="ti ti-circle-x me-1"></i>
                                             {{ __('Blank') }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

I assume there won't be time for a proper rework of automatic actions for GLPI 12, so I am attempting some smaller enhancements to hopefully reduce the long-standing issues of tasks getting stuck "running".

For a proper rework, it seems like a good use of [Symfony Scheduler](https://outline.teclib.com/doc/symfony-scheduler-for-automatic-actions-cepfLh52p3).

Changes:
- Replace `declare(ticks=1)` with recommended replacement `pcntl_async_signals(true);` if `pcntl` available.
- Add shutdown handler for normal/graceful terminations including when exceptions are thrown or the max execution time is exceeded. `pctnl` still can be used to handle external terminations like SIGTERM if the extension is available.
- Replace basic `lastrun + frequency` calculation for determining tasks that are ready to run with a `next_run` field that allows for more flexibility.
- Add an error counter to track consecutive failures and implemented an exponential backoff strategy.
- If a task reaches a maximum number of consecutive errors, the task will be put in a new error state which would require administrator intervention to reset.