### PR TITLE
Fix - CronTaskLog entries must not create history entries on parent CronTask

### DIFF
--- a/src/CronTaskLog.php
+++ b/src/CronTaskLog.php
@@ -43,6 +43,9 @@ class CronTaskLog extends CommonDBChild
     public static $itemtype = CronTask::class;
     public static $items_id  = 'crontasks_id';
 
+    // Prevent CronTaskLog entries from flooding the CronTask historical tab
+    public static $logs_for_parent = false;
+
     // Class constant
     public const STATE_START = 0;
     public const STATE_RUN   = 1;

--- a/tests/functional/CronTaskTest.php
+++ b/tests/functional/CronTaskTest.php
@@ -295,7 +295,8 @@ class CronTaskTest extends DbTestCase
         ]);
 
         // Simulate what CronTask::start() and CronTask::stop() do: add CronTaskLog entries
-        $this->createItem(\CronTaskLog::class,
+        $this->createItem(
+            \CronTaskLog::class,
             [
                 'crontasks_id'    => $crontask->getID(),
                 'date'            => date('Y-m-d H:i:s'),
@@ -306,7 +307,8 @@ class CronTaskTest extends DbTestCase
                 'elapsed'         => 0.0,
             ]
         );
-        $this->createItem(\CronTaskLog::class,
+        $this->createItem(
+            \CronTaskLog::class,
             [
                 'crontasks_id'    => $crontask->getID(),
                 'date'            => date('Y-m-d H:i:s'),

--- a/tests/functional/CronTaskTest.php
+++ b/tests/functional/CronTaskTest.php
@@ -278,4 +278,55 @@ class CronTaskTest extends DbTestCase
             );
         }
     }
+
+    public function testCronTaskLogDoesNotCreateHistoryOnParent(): void
+    {
+        global $DB;
+
+        $crontask = $this->createItem(\CronTask::class, [
+            'itemtype'  => \CronTask::class,
+            'name'      => 'test_no_history',
+            'frequency' => MINUTE_TIMESTAMP,
+        ]);
+
+        $log_count_before = countElementsInTable(\Log::getTable(), [
+            'itemtype' => \CronTask::class,
+            'items_id' => $crontask->getID(),
+        ]);
+
+        // Simulate what CronTask::start() and CronTask::stop() do: add CronTaskLog entries
+        $this->createItem(\CronTaskLog::class,
+            [
+                'crontasks_id'    => $crontask->getID(),
+                'date'            => date('Y-m-d H:i:s'),
+                'content'         => 'Starting',
+                'crontasklogs_id' => 0,
+                'state'           => \CronTaskLog::STATE_START,
+                'volume'          => 0,
+                'elapsed'         => 0.0,
+            ]
+        );
+        $this->createItem(\CronTaskLog::class,
+            [
+                'crontasks_id'    => $crontask->getID(),
+                'date'            => date('Y-m-d H:i:s'),
+                'content'         => 'Stopping',
+                'crontasklogs_id' => 0,
+                'state'           => \CronTaskLog::STATE_STOP,
+                'volume'          => 1,
+                'elapsed'         => 0.1,
+            ]
+        );
+
+        $log_count_after = countElementsInTable(\Log::getTable(), [
+            'itemtype' => \CronTask::class,
+            'items_id' => $crontask->getID(),
+        ]);
+
+        $this->assertSame(
+            $log_count_before,
+            $log_count_after,
+            'CronTaskLog entries must not generate history entries on the parent CronTask'
+        );
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42978
- Here is a brief description of what this PR does

Each `CronTaskLog` entry (created on every cron run start/stop) was generating a `glpi_logs` history entry on the parent `CronTask` because `CommonDBChild::$logs_for_parent` defaults to `true`.

With actions running every minute, this leads to thousands of spurious "Add an item: General (N/A (xxxxxx))" history entries 120,000+ in under 2 months were reported.

Set `$logs_for_parent = false` on `CronTaskLog` to prevent operational log entries from polluting the audit history of `CronTask` objects.