### PR TITLE
[HLAPI] Deprecate old v2 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The present file will list all changes made to the project; according to the
 ### Changed
 
 ### Deprecated
+- v2.0, v2.1, and v2.2 of the High-Level API. 
+These versions will still be available but will show a warning in the documentation indicating they are deprecated and will be removed in a future major version.
+If you have anything pinned to specific v2 versions, please try to pin to the latest version (v2.3) if possible to avoid future issues when the older versions are removed.
 
 ### Removed
 

--- a/lib/bundles/swagger-ui.js
+++ b/lib/bundles/swagger-ui.js
@@ -31,6 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-import { SwaggerUIBundle } from 'swagger-ui-dist';
+import { SwaggerUIBundle, SwaggerUIStandalonePreset } from 'swagger-ui-dist';
 require('swagger-ui-dist/swagger-ui.css');
 window.SwaggerUIBundle = SwaggerUIBundle;
+window.SwaggerUIStandalonePreset = SwaggerUIStandalonePreset;

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -313,19 +313,28 @@ EOT,
         $favicon = Html::getPrefixedUrl('/pics/favicon.ico');
 
         $hlapi_versions = array_filter(Router::getAPIVersions(), static fn($v) => $v['api_version'] !== '1');
-        //$doc_json_paths = json_encode(array_map(static fn($v) => ['url' => $CFG_GLPI['root_doc'] . '/api.php/v' . $v['version'] . '/doc.json', 'name' => $v['version']], $hlapi_versions));
         $doc_json_paths = [];
         foreach ($hlapi_versions as $version_info) {
             $is_deprecated = $version_info['deprecated'] ?? false;
             $doc_json_paths[] = [
                 'url' => $CFG_GLPI['root_doc'] . '/api.php/v' . $version_info['version'] . '/doc.json',
                 'name' => 'v' . $version_info['version'] . ($is_deprecated ? ' (deprecated)' : ''),
+                'version' => $version_info['version'],
             ];
         }
+        $api_version = $this->getAPIVersion($request);
+        // sort by version number descending and keep the current version first to make sure the right version is always selected
+        usort($doc_json_paths, static function ($a, $b) use ($api_version) {
+            if ($a['version'] === $api_version) {
+                return -1;
+            }
+            if ($b['version'] === $api_version) {
+                return 1;
+            }
+            return version_compare($b['version'], $a['version']);
+        });
         $doc_json_paths = json_encode($doc_json_paths, JSON_THROW_ON_ERROR);
 
-//        $api_version = $this->getAPIVersion($request);
-//        $doc_json_path = $CFG_GLPI['root_doc'] . '/api.php/v' . $api_version . '/doc.json';
         $swagger_content .= <<<HTML
         <link rel="shortcut icon" type="images/x-icon" href="$favicon" />
         </head>

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -311,17 +311,35 @@ EOT,
         $swagger_content .= Html::script('/lib/swagger-ui.js');
         $swagger_content .= Html::css('/lib/swagger-ui.css');
         $favicon = Html::getPrefixedUrl('/pics/favicon.ico');
-        $api_version = $this->getAPIVersion($request);
-        $doc_json_path = $CFG_GLPI['root_doc'] . '/api.php/v' . $api_version . '/doc.json';
+
+        $hlapi_versions = array_filter(Router::getAPIVersions(), static fn($v) => $v['api_version'] !== '1');
+        //$doc_json_paths = json_encode(array_map(static fn($v) => ['url' => $CFG_GLPI['root_doc'] . '/api.php/v' . $v['version'] . '/doc.json', 'name' => $v['version']], $hlapi_versions));
+        $doc_json_paths = [];
+        foreach ($hlapi_versions as $version_info) {
+            $is_deprecated = $version_info['deprecated'] ?? false;
+            $doc_json_paths[] = [
+                'url' => $CFG_GLPI['root_doc'] . '/api.php/v' . $version_info['version'] . '/doc.json',
+                'name' => 'v' . $version_info['version'] . ($is_deprecated ? ' (deprecated)' : ''),
+            ];
+        }
+        $doc_json_paths = json_encode($doc_json_paths, JSON_THROW_ON_ERROR);
+
+//        $api_version = $this->getAPIVersion($request);
+//        $doc_json_path = $CFG_GLPI['root_doc'] . '/api.php/v' . $api_version . '/doc.json';
         $swagger_content .= <<<HTML
         <link rel="shortcut icon" type="images/x-icon" href="$favicon" />
         </head>
-        <body>
+        <body style="margin:0; padding:0;">
             <div id="swagger-ui"></div>
             <script>
                 const ui = window.SwaggerUIBundle({
-                    url: '{$doc_json_path}',
+                    urls: {$doc_json_paths},
                     dom_id: '#swagger-ui',
+                    presets: [
+                      SwaggerUIBundle.presets.apis,
+                      SwaggerUIStandalonePreset
+                    ],
+                    layout: 'StandaloneLayout',
                     docExpansion: 'none',
                     validatorUrl: 'none',
                     filter: true,

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -141,6 +141,14 @@ The High-Level REST API documentation shown here is dynamically generated from t
 If a plugin is not enabled, its routes will not be shown here.
 EOT;
 
+        $api_versions = Router::getAPIVersions();
+        foreach ($api_versions as $version_info) {
+            if ($version_info['version'] === $this->api_version && ($version_info['deprecated'] ?? false)) {
+                $description = "DEPRECATED - " . $description;
+                break;
+            }
+        }
+
         return [
             'title' => 'GLPI High-Level REST API',
             'description' => $description,

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -169,16 +169,19 @@ EOT;
                 'api_version' => '2',
                 'version' => '2.0.0',
                 'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.0',
+                'deprecated' => true,
             ],
             [
                 'api_version' => '2',
                 'version' => '2.1.0',
                 'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.1',
+                'deprecated' => true,
             ],
             [
                 'api_version' => '2',
                 'version' => '2.2.0',
                 'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v2.2',
+                'deprecated' => true,
             ],
             [
                 'api_version' => '2',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

With the release of HLAPI v2.3, the older v2 versions should be considered deprecated. They will remain functional but users should start moving to the latest API version to prevent future issues and to take advantage of hundreds of new endpoints and schemas.

**If users have anything using minor version pinning (/api.php/v2.1 rather than /api.php/v2 or just /api.php) with this API, they should attempt to re-pin those integrations to v2.3. There should be no real breaking changes between the v2 versions.**

These deprecated versions will be removed at some point in the future in a GLPI major release.

With the addition of a deprecation marker for API versions, the Swagger UI was improved to add a version selector along the top of the page and the versions listed will show a "(deprecated)" next to any deprecated version. A "DEPRECATED - " prefix will also be added to start of the description text.

<img width="1523" height="1024" alt="Selection_703" src="https://github.com/user-attachments/assets/d1973399-f3e5-4670-b605-a5f061501672" />
