### PR TITLE
optimize helpdesk translation tab counter

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -16952,12 +16952,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Helpdesk\\\\HelpdeskTranslation\\:\\:getTranslationsForHelpdesk\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Helpdesk\\\\HelpdeskTranslation\\:\\:getTranslationsHandlersForStats\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -16628,12 +16628,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Helpdesk\\\\HelpdeskTranslation\\:\\:getTranslationsForHelpdesk\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Helpdesk\\\\HelpdeskTranslation\\:\\:getTranslationsHandlersForStats\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -10238,12 +10238,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$item of static method Glpi\\\\ItemTranslation\\\\ItemTranslation\\:\\:getTranslationsForItem\\(\\) expects CommonDBTM, Entity\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$entity of method Glpi\\\\Helpdesk\\\\Tile\\\\TilesManager\\:\\:getTilesForEntityRecursive\\(\\) expects Entity, Entity\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 3,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -9140,12 +9140,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$item of static method Glpi\\\\ItemTranslation\\\\ItemTranslation\\:\\:getTranslationsForItem\\(\\) expects CommonDBTM, Entity\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Helpdesk/HelpdeskTranslation.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$entity of method Glpi\\\\Helpdesk\\\\Tile\\\\TilesManager\\:\\:getTilesForEntityRecursive\\(\\) expects Entity, Entity\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 3,

--- a/src/Glpi/Helpdesk/HelpdeskTranslation.php
+++ b/src/Glpi/Helpdesk/HelpdeskTranslation.php
@@ -39,6 +39,8 @@ use Config;
 use Dropdown;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QuerySubQuery;
+use Glpi\Helpdesk\Tile\Item_Tile;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\Context\TranslationHandler;
@@ -80,16 +82,11 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0): string
     {
         if ($item instanceof Config) {
-            $translations = array_reduce(
-                self::getTranslationsForHelpdesk(),
-                fn($carry, $translation) => $carry + [$translation->fields['language'] => $translation],
-                []
-            );
-
-            return self::createTabEntry(
-                self::getTypeName(),
-                count($translations)
-            );
+            $count = 0;
+            if ($_SESSION['glpishow_count_on_tabs']) {
+                $count = self::countTranslationsForHelpdesk();
+            }
+            return self::createTabEntry(self::getTypeName(), $count);
         }
 
         return '';
@@ -140,24 +137,56 @@ final class HelpdeskTranslation extends ItemTranslation implements ProvideTransl
         return array_merge(...$entities_handlers, ...$tiles_handlers);
     }
 
+    /**
+     * @return array<string, mixed> SQL criteria to get translations related to the helpdesk (entities and tiles)
+     */
+    private static function getTranslationsForHelpdeskCriteria(): array
+    {
+        return [
+            'FROM' => self::getTable(),
+            'WHERE' => [
+                'OR' => [
+                    ['itemtype' => Entity::class],
+                    [
+                        'itemtype' => new QuerySubQuery([
+                            'SELECT' => ['itemtype_tile'],
+                            'DISTINCT' => true,
+                            'FROM' => Item_Tile::getTable(),
+                        ]),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private static function countTranslationsForHelpdesk(): int
+    {
+        global $DB;
+        $criteria = self::getTranslationsForHelpdeskCriteria();
+        $criteria['COUNT'] = 'cpt';
+        $criteria['SELECT'] = 'language';
+        $criteria['DISTINCT'] = true;
+        return $DB->request($criteria)->current()['cpt'] ?? 0;
+    }
+
+    /**
+     * Get all translations related to the helpdesk (entities and tiles)
+     *
+     * @return ItemTranslation[]
+     */
     public static function getTranslationsForHelpdesk(): array
     {
-        $tiles_manager = TilesManager::getInstance();
-        $entities = array_map(
-            fn($entity_id) => Entity::getById($entity_id),
-            array_keys((new Entity())->find())
-        );
+        global $DB;
 
-        return array_merge(
-            ...array_map(
-                fn($entity) => self::getTranslationsForItem($entity),
-                $entities
-            ),
-            ...array_map(
-                fn($item) => self::getTranslationsForItem($item),
-                $tiles_manager->getAllTiles()
-            )
-        );
+        $it = $DB->request(self::getTranslationsForHelpdeskCriteria());
+        $translations = [];
+
+        foreach ($it as $data) {
+            $translation = new self();
+            $translation->getFromResultSet($data);
+            $translations[] = $translation;
+        }
+        return $translations;
     }
 
     /**

--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -209,7 +209,11 @@ abstract class ItemTranslation extends CommonDBChild
             static::$itemtype => $item->getType(),
         ]);
 
-        return array_map(fn($id) => static::getById($id), array_keys($translations));
+        return array_map(static function ($translation) {
+            $t = new static();
+            $t->getFromResultSet($translation);
+            return $t;
+        }, $translations);
     }
 
     /**

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -99,7 +99,7 @@ class ConfigTest extends DbTestCase
             'Config$12'     => "Management",
             'DisplayPreference$1' => "Search result display",
             'GLPINetwork$1' => "GLPI Network",
-            'Glpi\Helpdesk\HelpdeskTranslation$1' => 'Helpdesk translations',
+            'Glpi\Helpdesk\HelpdeskTranslation$1' => 'Helpdesk translations 1',
         ];
 
         $instance = new Config();
@@ -130,7 +130,7 @@ class ConfigTest extends DbTestCase
             'Config$11'      => "Impact analysis",
             'DisplayPreference$1' => "Search result display",
             'GLPINetwork$1' => "GLPI Network",
-            'Glpi\Helpdesk\HelpdeskTranslation$1' => 'Helpdesk translations',
+            'Glpi\Helpdesk\HelpdeskTranslation$1' => 'Helpdesk translations 1',
             'Log$1'         => "Historical",
         ];
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23274

Multiple issues remain in Forms/Service Catalog related code. The code is very complex so I am opening very specific PRs. At least then if I break something more in my attempt to fix it, at least they will be small commits.

In general, we need to take better care to check how our code scales on larger instances and avoid over-fetching. There was no need to fetch all data for every entity multiple times just to use their IDs, or to load all data for every helpdesk translation just to get a count for the tab.