### PR TITLE
Playwright shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,9 +318,14 @@ jobs:
     if: github.repository == 'glpi-project/glpi' || github.event_name != 'schedule'
     permissions:
       contents: "read"
-    name: "Playwright tests"
+    name: "Playwright tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})"
     runs-on: "ubuntu-latest"
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
     env:
       COMPOSE_FILE: ".github/actions/docker-compose-app.yml:.github/actions/docker-compose-services.yml"
       APPLICATION_ROOT: "${{ github.workspace }}"
@@ -365,7 +370,7 @@ jobs:
         if: ${{ !cancelled() }}
         run:  |
           docker compose exec -T app bin/console config:set url_base http://localhost:8090 --env=e2e_testing
-          docker compose exec -T app npx playwright test
+          docker compose exec -T app npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Check for PHP errors
         if: ${{ !cancelled() }}
         run: |
@@ -376,14 +381,47 @@ jobs:
             cat /tmp/php-errors-filtered.log
             exit 1
           fi
-      - uses: actions/upload-artifact@v7
+      - name: Upload blob report
         if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report/
+          retention-days: 1
+
+  playwright-merge-reports:
+    if: ${{ !cancelled() }}
+    needs: [playwright]
+    permissions:
+      contents: "read"
+    name: "Merge Playwright reports"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v6"
+      - name: "Setup Node.js"
+        uses: "actions/setup-node@v5"
+        with:
+          node-version: "lts/*"
+      - name: "Install dependencies"
+        run: npm ci
+      - name: "Download blob reports"
+        uses: actions/download-artifact@v7
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+      - name: "Merge into HTML Report"
+        run: npx playwright merge-reports --reporter=html,playwright-ctrf-json-reporter ./all-blob-reports
+      - name: "Upload HTML report"
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-      # See: https://github.com/ctrf-io/github-test-reporter?tab=readme-ov-file#available-inputs
-      - name: Publish test summary results
+      - name: "Publish test summary results"
         if: ${{ !cancelled() }}
         uses: ctrf-io/github-test-reporter@v1
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,16 +67,11 @@ export default defineConfig({
     // - https://playwright.dev/docs/test-reporters
     // - https://playwright.dev/docs/api/class-testconfig#test-config-reporter
     reporter: process.env.CI ? [
-        // Will generate a HTML report that can be downloaded and viewed locally
-        ['html'],
+        // Blob reporter for merging sharded reports
+        // See: https://playwright.dev/docs/test-sharding#merging-reports-from-multiple-shards
+        ['blob'],
         // Easier to read in the terminal output of the CI itself
         ['dot'],
-        // Special reporter that can be viewed from github action results summary
-        // See:
-        // - https://ctrf.io
-        // - https://github.com/ctrf-io/github-test-reporter
-        // - https://github.com/ctrf-io/playwright-ctrf-json-reporter
-        ['playwright-ctrf-json-reporter'],
     ] : [
         // Generate html report in given folder
         ['html', {


### PR DESCRIPTION
As an alternative to getting a premium runner, we can split the tests in two to keep the runtime under 15 min (especially since we will gain 1 runner once the remaining cypress tests are gone).