### PR TITLE
Use effective body CRC token in webhooks

### DIFF
--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -188,7 +188,11 @@ class QueuedWebhook extends CommonDBChild
 
         if (GLPI_WEBHOOK_CRA_MANDATORY || $webhook->fields['use_cra_challenge']) {
             // Send CRA challenge
-            $result = $webhook::validateCRAChallenge($queued_webhook->fields['url'], (string) $queued_webhook->fields['body'], $webhook->fields['secret']);
+            $result = $webhook::validateCRAChallenge(
+                $queued_webhook->fields['url'],
+                $queued_webhook->fields['body'] ?: sha1((string) $queued_webhook->getID()),
+                $webhook->fields['secret']
+            );
             if ($result['status'] !== true) {
                 Toolbox::logInFile('webhook', "CRA challenge failed for webhook {$webhook->fields['name']} ({$webhook->getID()})");
                 return false;

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -188,7 +188,7 @@ class QueuedWebhook extends CommonDBChild
 
         if (GLPI_WEBHOOK_CRA_MANDATORY || $webhook->fields['use_cra_challenge']) {
             // Send CRA challenge
-            $result = $webhook::validateCRAChallenge($queued_webhook->fields['url'], 'validate_cra_challenge', $webhook->fields['secret']);
+            $result = $webhook::validateCRAChallenge($queued_webhook->fields['url'], (string) $queued_webhook->fields['body'], $webhook->fields['secret']);
             if ($result['status'] !== true) {
                 Toolbox::logInFile('webhook', "CRA challenge failed for webhook {$webhook->fields['name']} ({$webhook->getID()})");
                 return false;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Having a different CRC for each request will make any amn-in-the-middle attack far more complex.