### PR TITLE
Fix(RichText): missing href

### DIFF
--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -74,7 +74,7 @@ final class RichText
 
         $content = preg_replace_callback(
             '/href="([^"]*)"/',
-            fn($matches) => 'href="' . str_replace(' ', '&nbsp;', $matches[1]) . '"',
+            fn($matches) => 'href="' . str_replace(' ', '%20', $matches[1]) . '"',
             $content
         );
 

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -72,6 +72,12 @@ final class RichText
 
         $content = self::normalizeHtmlContent($content);
 
+        $content = preg_replace_callback(
+            '/href="([^"]*)"/',
+            fn($matches) => 'href="' . str_replace(' ', '&nbsp;', $matches[1]) . '"',
+            $content
+        );
+
         $content = self::getHtmlSanitizer()->sanitize($content);
 
         // Remove extra lines

--- a/src/Glpi/RichText/UserMention.php
+++ b/src/Glpi/RichText/UserMention.php
@@ -255,8 +255,8 @@ final class UserMention
             . 'data-user-id="' . $user_id . '"[^>]+data-user-mention="true"'
             . ')'
             . '[^>]*>'
-            // @Name
-            . '@[^>]+'
+            // @Name (or &#64;Name)
+            . '(?:&#64;|@)[^>]+'
             // span closing
             . '<\/span>'
             . '/';

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -413,6 +413,25 @@ HTML,
             'encode_output_entities' => false,
             'expected_result'        => '<table border="1" cellspacing="0" cellpadding="5" bgcolor="#f5f5f5"><thead><tr bgcolor="#cccccc"><th>Column 1</th><th>Column 2</th></tr></thead><tbody><tr><td bgcolor="#ffffff">Data 1</td><td>Data 2</td></tr></tbody></table>',
         ];
+
+        yield [
+            'content'                => '<a href="mailto:?subject=[GLPI #1234]&amp;cc=glpi@test.fr">[GLPI #1234]</a>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI #1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
+        ];
+
+        yield [
+            'content'                => '<span contenteditable="false" data-user-mention="true" data-user-id="5">@normal</span>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<span contenteditable="false" data-user-mention="true" data-user-id="5">&#64;normal</span>',
+        ];
+
+        global $CFG_GLPI;
+        yield [
+            'content'                => '<a class="user-mention" href="' . $CFG_GLPI['root_doc'] . '/front/user.form.php?id=5">@normal</a>',
+            'encode_output_entities' => false,
+            'expected_result'        => '<a class="user-mention" href="' . $CFG_GLPI['root_doc'] . '/front/user.form.php?id&#61;5">&#64;normal</a>',
+        ];
     }
 
     #[DataProvider('getSafeHtmlProvider')]

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -417,7 +417,7 @@ HTML,
         yield [
             'content'                => '<a href="mailto:?subject=[GLPI #1234]&amp;cc=glpi@test.fr">[GLPI #1234]</a>',
             'encode_output_entities' => false,
-            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI #1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
+            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI%20#1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
         ];
 
         yield [
@@ -742,7 +742,7 @@ HTML,
 
         yield [
             'content'                => '<a href="mailto:?subject=[GLPI #1234]&amp;cc=glpi@test.fr">[GLPI #1234]</a>',
-            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI #1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
+            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI%20#1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
         ];
 
         global $CFG_GLPI;

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -720,6 +720,17 @@ HTML,
                 . '<img src="/path/to/image3.jpg" alt="an image" loading="lazy">'
                 . '</p>', 1000),
         ];
+
+        yield [
+            'content'                => '<a href="mailto:?subject=[GLPI #1234]&amp;cc=glpi@test.fr">[GLPI #1234]</a>',
+            'expected_result'        => '<a href="mailto:?subject&#61;[GLPI #1234]&amp;cc&#61;glpi&#64;test.fr">[GLPI #1234]</a>',
+        ];
+
+        global $CFG_GLPI;
+        yield [
+            'content'                => '<span contenteditable="false" data-user-mention="true" data-user-id="5">@normal</span>',
+            'expected_result'        => '<a class="user-mention" href="' . $CFG_GLPI['root_doc'] . '/front/user.form.php?id=5">@normal</a>',
+        ];
     }
 
     #[DataProvider('getEnhancedHtmlProvider')]


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43129

Some link tags no longer had an href attribute in the rendered output, even though the data in the database is correct.

## Screenshots (if appropriate):
Before (non-clickable links):
<img width="680" height="283" alt="image" src="https://github.com/user-attachments/assets/b329b491-b2aa-4fc1-81ed-86ba8cdf93d5" />

After (functional links):
<img width="680" height="283" alt="image" src="https://github.com/user-attachments/assets/c6b9b4d7-6b97-4c01-9b55-089927fc2edb" />

