### PR TITLE
FIX / User profile assigment by Massive Actions

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -1113,6 +1113,7 @@ TWIG, $avatar_params) . $username;
 
         $specificities['dropdown_method_2']       = 'dropdownUnder';
         $specificities['can_remove_all_at_once']  = false;
+        $specificities['can_link_several_times']  = true;
 
         return $specificities;
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43141
- Previously, the generic massive action relation handler treated the User/Profile pair as a unique link during bulk processing. For Profile_User relations, this is incorrect because the relation also depends on the target entity. As a result, bulk assignment could fail with an already defined error even when the profile was being assigned on a different entity.

This patch marks Profile_User as a relation that can be linked several times in massive actions, which prevents the generic duplicate detection from rejecting valid assignments across entities.
