### PR TITLE
Forms: add missing TTR configuration for changes and problems

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLATTRField.php
@@ -85,7 +85,7 @@ final class SLATTRField extends SLMField
     public function convertFieldConfig(FormMigration $migration, Form $form, array $rawData): JsonFieldInterface
     {
         $parent_config = parent::convertFieldConfig($migration, $form, $rawData);
-        if ($parent_config != $this->getDefaultConfig($form)) {
+        if ($parent_config != $this->getDefaultConfig($form) || !isset($rawData['due_date_rule'])) {
             return $parent_config;
         }
 

--- a/src/Glpi/Form/Destination/CommonITILField/SLMField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMField.php
@@ -58,8 +58,12 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
     /** @return class-string<SLMFieldConfig> */
     abstract public function getConfigClass(): string;
     abstract protected function getFieldNameToConvertSpecificSLMID(): string;
+    protected bool $support_only_dates = false;
 
-    final public function __construct() {}
+    final public function __construct(bool $support_only_dates = false)
+    {
+        $this->support_only_dates = $support_only_dates;
+    }
 
     #[Override]
     public function renderConfigForm(
@@ -162,6 +166,10 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
     #[Override]
     public function convertFieldConfig(FormMigration $migration, Form $form, array $rawData): JsonFieldInterface
     {
+        if (!isset($rawData['sla_rule'])) {
+            return $this->getDefaultConfig($form);
+        }
+
         switch ($rawData['sla_rule']) {
             case 1: // PluginFormcreatorAbstractItilTarget::SLA_RULE_NONE
                 return $this->getConfig($form, [$this->getKey() => [
@@ -181,6 +189,9 @@ abstract class SLMField extends AbstractConfigField implements DestinationFieldC
     {
         $values = [];
         foreach (SLMFieldStrategy::cases() as $strategies) {
+            if ($this->support_only_dates && !$strategies->isDateComputation()) {
+                continue;
+            }
             $values[$strategies->value] = $strategies->getLabel($this);
         }
         return $values;

--- a/src/Glpi/Form/Destination/CommonITILField/SLMFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/SLMFieldStrategy.php
@@ -101,6 +101,17 @@ enum SLMFieldStrategy: string
         };
     }
 
+    public function isDateComputation(): bool
+    {
+        return match ($this) {
+            self::FROM_TEMPLATE                           => true,
+            self::SPECIFIC_VALUE                          => false,
+            self::SPECIFIC_DATE_ANSWER                    => true,
+            self::COMPUTED_DATE_FROM_FORM_SUBMISSION      => true,
+            self::COMPUTED_DATE_FROM_SPECIFIC_DATE_ANSWER => true,
+        };
+    }
+
     private function getDateTimeFromSpecificAnswer(
         ?int $question_id,
         AnswersSet $answers_set,

--- a/src/Glpi/Form/Destination/FormDestinationChange.php
+++ b/src/Glpi/Form/Destination/FormDestinationChange.php
@@ -41,6 +41,7 @@ use Glpi\Form\Destination\CommonITILField\CheckListField;
 use Glpi\Form\Destination\CommonITILField\ControlsListField;
 use Glpi\Form\Destination\CommonITILField\DeploymentPlanField;
 use Glpi\Form\Destination\CommonITILField\ImpactsField;
+use Glpi\Form\Destination\CommonITILField\SLATTRField;
 use Override;
 
 final class FormDestinationChange extends AbstractCommonITILFormDestination
@@ -66,6 +67,7 @@ final class FormDestinationChange extends AbstractCommonITILFormDestination
             new DeploymentPlanField(),
             new BackupPlanField(),
             new CheckListField(),
+            new SLATTRField(support_only_dates: true),
         ]);
     }
 }

--- a/src/Glpi/Form/Destination/FormDestinationProblem.php
+++ b/src/Glpi/Form/Destination/FormDestinationProblem.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Destination;
 use CommonITILObject;
 use Glpi\Form\Destination\CommonITILField\CausesField;
 use Glpi\Form\Destination\CommonITILField\ImpactsField;
+use Glpi\Form\Destination\CommonITILField\SLATTRField;
 use Glpi\Form\Destination\CommonITILField\SymptomsField;
 use Override;
 use Problem;
@@ -62,6 +63,7 @@ final class FormDestinationProblem extends AbstractCommonITILFormDestination
             new ImpactsField(),
             new CausesField(),
             new SymptomsField(),
+            new SLATTRField(support_only_dates: true),
         ]);
     }
 }

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/SLATTRFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/SLATTRFieldTest.php
@@ -34,10 +34,12 @@
 
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
+use CommonITILObject;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\SLATTRField;
 use Glpi\Form\Destination\CommonITILField\SLATTRFieldConfig;
 use Glpi\Form\Destination\CommonITILField\SLMFieldStrategy;
+use Glpi\Form\Destination\FormDestinationChange;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeDateTime;
 use Glpi\Form\QuestionType\QuestionTypeDateTimeExtraDataConfig;
@@ -161,18 +163,24 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
 
         $this->setCurrentTime('2026-01-01 10:00:00');
 
-        $form = $this->createAndGetFormWithTicketDestination();
-        $this->checkSLATTRFieldConfiguration(
-            form: $form,
-            config: new SLATTRFieldConfig(
-                strategy: SLMFieldStrategy::SPECIFIC_DATE_ANSWER,
-                question_id: $this->getQuestionId($form, 'Date Question')
-            ),
-            answers: [
-                $this->getQuestionId($form, 'Date Question') => '2026-01-02',
-            ],
-            expected_ttr_date: '2026-01-02 00:00:00'
-        );
+        $forms = [
+            $this->createAndGetFormWithTicketDestination(),
+            $this->createAndGetFormWithChangeDestination(),
+            $this->createAndGetFormWithProblemDestination(),
+        ];
+        foreach ($forms as $form) {
+            $this->checkSLATTRFieldConfiguration(
+                form: $form,
+                config: new SLATTRFieldConfig(
+                    strategy: SLMFieldStrategy::SPECIFIC_DATE_ANSWER,
+                    question_id: $this->getQuestionId($form, 'Date Question')
+                ),
+                answers: [
+                    $this->getQuestionId($form, 'Date Question') => '2026-01-02',
+                ],
+                expected_ttr_date: '2026-01-02 00:00:00'
+            );
+        }
     }
 
     public function testSpecificDateTimeAnswer(): void
@@ -181,18 +189,24 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
 
         $this->setCurrentTime('2026-01-01 10:00:00');
 
-        $form = $this->createAndGetFormWithTicketDestination();
-        $this->checkSLATTRFieldConfiguration(
-            form: $form,
-            config: new SLATTRFieldConfig(
-                strategy: SLMFieldStrategy::SPECIFIC_DATE_ANSWER,
-                question_id: $this->getQuestionId($form, 'Date and Time Question')
-            ),
-            answers: [
-                $this->getQuestionId($form, 'Date and Time Question') => '2026-01-02 12:34:56',
-            ],
-            expected_ttr_date: '2026-01-02 12:34:56'
-        );
+        $forms = [
+            $this->createAndGetFormWithTicketDestination(),
+            $this->createAndGetFormWithChangeDestination(),
+            $this->createAndGetFormWithProblemDestination(),
+        ];
+        foreach ($forms as $form) {
+            $this->checkSLATTRFieldConfiguration(
+                form: $form,
+                config: new SLATTRFieldConfig(
+                    strategy: SLMFieldStrategy::SPECIFIC_DATE_ANSWER,
+                    question_id: $this->getQuestionId($form, 'Date and Time Question')
+                ),
+                answers: [
+                    $this->getQuestionId($form, 'Date and Time Question') => '2026-01-02 12:34:56',
+                ],
+                expected_ttr_date: '2026-01-02 12:34:56'
+            );
+        }
     }
 
     public function testComputedDateFromFormSubmission(): void
@@ -201,16 +215,22 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
 
         $this->setCurrentTime('2026-01-01 10:00:00');
 
-        $form = $this->createAndGetFormWithTicketDestination();
-        $this->checkSLATTRFieldConfiguration(
-            form: $form,
-            config: new SLATTRFieldConfig(
-                strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_FORM_SUBMISSION,
-                time_offset: 2,
-                time_definition: 'day'
-            ),
-            expected_ttr_date: '2026-01-03 10:00:00'
-        );
+        $forms = [
+            $this->createAndGetFormWithTicketDestination(),
+            $this->createAndGetFormWithChangeDestination(),
+            $this->createAndGetFormWithProblemDestination(),
+        ];
+        foreach ($forms as $form) {
+            $this->checkSLATTRFieldConfiguration(
+                form: $form,
+                config: new SLATTRFieldConfig(
+                    strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_FORM_SUBMISSION,
+                    time_offset: 2,
+                    time_definition: 'day'
+                ),
+                expected_ttr_date: '2026-01-03 10:00:00'
+            );
+        }
     }
 
     public function testComputedDateFromSpecificDateAnswer(): void
@@ -219,20 +239,26 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
 
         $this->setCurrentTime('2026-01-01 10:00:00');
 
-        $form = $this->createAndGetFormWithTicketDestination();
-        $this->checkSLATTRFieldConfiguration(
-            form: $form,
-            config: new SLATTRFieldConfig(
-                strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_SPECIFIC_DATE_ANSWER,
-                question_id: $this->getQuestionId($form, 'Date Question'),
-                time_offset: 3,
-                time_definition: 'day'
-            ),
-            answers: [
-                $this->getQuestionId($form, 'Date Question') => '2026-01-05',
-            ],
-            expected_ttr_date: '2026-01-08 00:00:00'
-        );
+        $forms = [
+            $this->createAndGetFormWithTicketDestination(),
+            $this->createAndGetFormWithChangeDestination(),
+            $this->createAndGetFormWithProblemDestination(),
+        ];
+        foreach ($forms as $form) {
+            $this->checkSLATTRFieldConfiguration(
+                form: $form,
+                config: new SLATTRFieldConfig(
+                    strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_SPECIFIC_DATE_ANSWER,
+                    question_id: $this->getQuestionId($form, 'Date Question'),
+                    time_offset: 3,
+                    time_definition: 'day'
+                ),
+                answers: [
+                    $this->getQuestionId($form, 'Date Question') => '2026-01-05',
+                ],
+                expected_ttr_date: '2026-01-08 00:00:00'
+            );
+        }
     }
 
     public function testComputedDateFromSpecificDateTimeAnswer(): void
@@ -241,20 +267,26 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
 
         $this->setCurrentTime('2026-01-01 10:00:00');
 
-        $form = $this->createAndGetFormWithTicketDestination();
-        $this->checkSLATTRFieldConfiguration(
-            form: $form,
-            config: new SLATTRFieldConfig(
-                strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_SPECIFIC_DATE_ANSWER,
-                question_id: $this->getQuestionId($form, 'Date and Time Question'),
-                time_offset: 4,
-                time_definition: 'day'
-            ),
-            answers: [
-                $this->getQuestionId($form, 'Date and Time Question') => '2026-01-05 15:30:00',
-            ],
-            expected_ttr_date: '2026-01-09 15:30:00'
-        );
+        $forms = [
+            $this->createAndGetFormWithTicketDestination(),
+            $this->createAndGetFormWithChangeDestination(),
+            $this->createAndGetFormWithProblemDestination(),
+        ];
+        foreach ($forms as $form) {
+            $this->checkSLATTRFieldConfiguration(
+                form: $form,
+                config: new SLATTRFieldConfig(
+                    strategy: SLMFieldStrategy::COMPUTED_DATE_FROM_SPECIFIC_DATE_ANSWER,
+                    question_id: $this->getQuestionId($form, 'Date and Time Question'),
+                    time_offset: 4,
+                    time_definition: 'day'
+                ),
+                answers: [
+                    $this->getQuestionId($form, 'Date and Time Question') => '2026-01-05 15:30:00',
+                ],
+                expected_ttr_date: '2026-01-09 15:30:00'
+            );
+        }
     }
 
     private function checkSLATTRFieldConfiguration(
@@ -263,7 +295,7 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
         array $answers = [],
         int $expected_slas_ttr_id = 0,
         ?string $expected_ttr_date = null,
-    ): Ticket {
+    ): CommonITILObject {
         // Insert config
         $destinations = $form->getDestinations();
         $this->assertCount(1, $destinations);
@@ -286,18 +318,20 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
         // Get created ticket
         $created_items = $answers->getCreatedItems();
         $this->assertCount(1, $created_items);
-        $ticket = current($created_items);
+        $itil = current($created_items);
 
         // Check sla_id_ttr field
-        $this->assertEquals($expected_slas_ttr_id, $ticket->fields['slas_id_ttr']);
+        if (isset($itil->fields['slas_id_ttr'])) {
+            $this->assertEquals($expected_slas_ttr_id, $itil->fields['slas_id_ttr']);
+        }
 
         // Check time_to_resolve field
         if ($expected_ttr_date !== null) {
-            $this->assertEquals($expected_ttr_date, $ticket->fields['time_to_resolve']);
+            $this->assertEquals($expected_ttr_date, $itil->fields['time_to_resolve']);
         }
 
         // Return the created ticket to be able to check other fields
-        return $ticket;
+        return $itil;
     }
 
     private function createAndGetFormWithTicketDestination(): Form
@@ -319,6 +353,54 @@ final class SLATTRFieldTest extends AbstractDestinationFieldTest
                 is_time_enabled: true
             ))
         );
+        return $this->createForm($builder);
+    }
+
+    private function createAndGetFormWithChangeDestination(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: 'Date Question',
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode(new QuestionTypeDateTimeExtraDataConfig(
+                is_date_enabled: true,
+                is_time_enabled: false
+            ))
+        );
+        $builder->addQuestion(
+            name: 'Date and Time Question',
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode(new QuestionTypeDateTimeExtraDataConfig(
+                is_date_enabled: true,
+                is_time_enabled: true
+            ))
+        );
+        $builder->setShouldInitDestinations(false);
+        $builder->addDestination(FormDestinationChange::class, "Change");
+        return $this->createForm($builder);
+    }
+
+    private function createAndGetFormWithProblemDestination(): Form
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: 'Date Question',
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode(new QuestionTypeDateTimeExtraDataConfig(
+                is_date_enabled: true,
+                is_time_enabled: false
+            ))
+        );
+        $builder->addQuestion(
+            name: 'Date and Time Question',
+            type: QuestionTypeDateTime::class,
+            extra_data: json_encode(new QuestionTypeDateTimeExtraDataConfig(
+                is_date_enabled: true,
+                is_time_enabled: true
+            ))
+        );
+        $builder->setShouldInitDestinations(false);
+        $builder->addDestination(FormDestinationChange::class, "Problem");
         return $this->createForm($builder);
     }
 

--- a/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/TargetsMigrationTest.php
@@ -293,6 +293,9 @@ final class TargetsMigrationTest extends DbTestCase
                         DeploymentPlanField::getKey() => new SimpleValueConfig(""),
                         BackupPlanField::getKey()     => new SimpleValueConfig(""),
                         CheckListField::getKey()      => new SimpleValueConfig(""),
+                        SLATTRField::getKey()         => new SLATTRFieldConfig(
+                            strategy: SLMFieldStrategy::FROM_TEMPLATE
+                        ),
                     ],
                 ],
                 [
@@ -351,6 +354,9 @@ final class TargetsMigrationTest extends DbTestCase
                         ImpactsField::getKey()  => new SimpleValueConfig(""),
                         CausesField::getKey()   => new SimpleValueConfig(""),
                         SymptomsField::getKey() => new SimpleValueConfig(""),
+                        SLATTRField::getKey()   => new SLATTRFieldConfig(
+                            strategy: SLMFieldStrategy::FROM_TEMPLATE
+                        ),
                     ],
                 ],
             ],


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add support for TTR configuration on changes/problems:

<img width="607" height="220" alt="image" src="https://github.com/user-attachments/assets/109e9d50-4314-49e5-bfcc-3ddf779f18aa" />

This was supported by formcreator, we missed it during the initial development.

Note that changes/problems have limited options compared to tickets so some code was added to limit the available options.

## References

Fix #23696. 


