### PR TITLE
Fix - Restore CRLF line endings in message/rfc822 attachments extracted by mail collector

### DIFF
--- a/phpunit/imap/MailCollectorTest.php
+++ b/phpunit/imap/MailCollectorTest.php
@@ -1506,7 +1506,7 @@ PLAINTEXT,
             'Content-Disposition: attachment',
             '',
             $embedded_email,
-            '--test-boundary-48--'
+            '--test-boundary-48--',
             '',
         ]);
 

--- a/phpunit/imap/MailCollectorTest.php
+++ b/phpunit/imap/MailCollectorTest.php
@@ -1505,7 +1505,10 @@ PLAINTEXT,
             'Content-Type: message/rfc822',
             'Content-Disposition: attachment',
             '',
-        ]) . $crlf . $embedded_email . $crlf . '--test-boundary-48--' . $crlf;
+            $embedded_email,
+            '--test-boundary-48--'
+            '',
+        ]);
 
         $message = new Message(['raw' => $raw]);
 

--- a/phpunit/imap/MailCollectorTest.php
+++ b/phpunit/imap/MailCollectorTest.php
@@ -1450,4 +1450,87 @@ PLAINTEXT,
         $result = $mailcollector->cleanContent($original);
         $this->assertEquals($expected, $result);
     }
+
+    public function testGetAttachedRestoresCrlfForRfc822Parts(): void
+    {
+        // RFC 2822 requires CRLF (\r\n) line endings in email messages.
+        // When the GLPI mail collector receives an email via IMAP, the Laminas MIME parser
+        // strips all \r characters during multipart boundary splitting
+        // (see Laminas\Mime\Decode::splitMime). As a result, embedded emails
+        // (message/rfc822 attachments) lose their CRLF line endings, which breaks
+        // Quoted-Printable soft line breaks (=\r\n becomes =\n) and makes the
+        // extracted EML file unreadable in strict clients such as Outlook.
+        // This test verifies that GLPI restores CRLF line endings in extracted
+        // message/rfc822 attachments.
+
+        // Register EML as a valid document type (not present by default).
+        $this->createItem(\DocumentType::class, [
+            'name'         => 'E-Mail',
+            'ext'          => 'eml',
+            'is_uploadable' => 1,
+        ]);
+
+        $crlf = "\r\n";
+
+        // Build the embedded email (the message/rfc822 part) with CRLF line endings
+        // and Quoted-Printable encoded content that contains non-ASCII characters.
+        // The QP soft line break "=\r\n" must survive extraction to remain valid.
+        $embedded_email = implode($crlf, [
+            'From: original@example.com',
+            'To: receiver@glpi-project.org',
+            'Subject: Original message with special chars',
+            'MIME-Version: 1.0',
+            'Content-Type: text/plain; charset=iso-8859-1',
+            'Content-Transfer-Encoding: quoted-printable',
+            '',
+            'Bonjour, voici un r=E9sum=E9 avec des caract=E8res sp=E9ciaux: caf=E9.',
+            '',
+        ]);
+
+        // Build the outer multipart email that wraps the embedded one.
+        // The whole string uses CRLF, simulating what an IMAP server delivers.
+        $raw = implode($crlf, [
+            'From: sender@example.com',
+            'To: receiver@glpi-project.org',
+            'Message-ID: <rfc822-crlf-test@glpi-project.org>',
+            'Subject: Forwarded: Original message with special chars',
+            'MIME-Version: 1.0',
+            'Content-Type: multipart/mixed; boundary="test-boundary-48"',
+            '',
+            '--test-boundary-48',
+            'Content-Type: text/plain; charset=utf-8',
+            '',
+            'Please find the forwarded email below.',
+            '--test-boundary-48',
+            'Content-Type: message/rfc822',
+            'Content-Disposition: attachment',
+            '',
+        ]) . $crlf . $embedded_email . $crlf . '--test-boundary-48--' . $crlf;
+
+        $message = new Message(['raw' => $raw]);
+
+        $tmp_path = GLPI_TMP_DIR . '/test_rfc822_crlf_' . uniqid();
+        mkdir($tmp_path);
+
+        $collector = new \MailCollector();
+        $files = $collector->getAttached($message, $tmp_path . '/', PHP_INT_MAX);
+
+        $this->assertCount(1, $files, 'Should have extracted exactly one message/rfc822 attachment');
+
+        $filename = array_key_first($files);
+        $extracted_content = file_get_contents($tmp_path . '/' . $filename);
+
+        // Clean up temporary files
+        unlink($tmp_path . '/' . $filename);
+        rmdir($tmp_path);
+
+        // The extracted EML file must use CRLF line endings (RFC 2822 requirement).
+        // Without the fix, Laminas strips all \r during MIME parsing, leaving LF-only
+        // line endings that break Quoted-Printable soft line breaks.
+        $this->assertStringContainsString(
+            "\r\n",
+            $extracted_content,
+            'Extracted EML attachment must use CRLF line endings as required by RFC 2822'
+        );
+    }
 }

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1743,7 +1743,7 @@ class MailCollector extends CommonDBTM
 
             $filename = Toolbox::filename($filename);
 
-            //try to avoid conflict between inline image and attachment
+            //try to avoid conflict between inline image and attachmentPI
             while (in_array($filename, $this->files)) {
                 $info = new SplFileInfo($filename);
                 $extension  = $info->getExtension();
@@ -1791,6 +1791,17 @@ class MailCollector extends CommonDBTM
             }
 
             $contents = $this->getDecodedContent($part);
+
+            // Restore CRLF line endings for message/rfc822 (embedded email) attachments.
+            // The Laminas MIME parser strips all \r characters when splitting multipart
+            // boundaries (see Laminas\Mime\Decode::splitMime), which produces LF-only
+            // line endings. RFC 2822 requires CRLF, and without them, Quoted-Printable
+            // soft line breaks (=\r\n) become invalid (=\n), making the extracted EML
+            // unreadable in strict clients such as Outlook.
+            if (strtolower($content_type) === 'message/rfc822') {
+                $contents = preg_replace('/(?<!\r)\n/', "\r\n", $contents);
+            }
+
             if (file_put_contents($path . $filename, $contents)) {
                 $this->files[$filename] = $filename;
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -1743,7 +1743,7 @@ class MailCollector extends CommonDBTM
 
             $filename = Toolbox::filename($filename);
 
-            //try to avoid conflict between inline image and attachmentPI
+            //try to avoid conflict between inline image and attachment
             while (in_array($filename, $this->files)) {
                 $info = new SplFileInfo($filename);
                 $extension  = $info->getExtension();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43086
- Here is a brief description of what this PR does

### Problem

When a user forwards an email as an attachment via Outlook (Microsoft 365), the mail collector saves it as an `.eml` file. Opening this file shows garbled content — special characters are broken and the HTML structure is corrupted, making it unusable. The same email uploaded manually via "Add a document" works perfectly as `.msg`.

The difference is not a bug in the file format choice (`.eml` is correct for `message/rfc822` MIME parts, `.msg` is a proprietary Outlook binary — they are two distinct representations). The actual bug is that the `.eml` file is written with LF-only line endings instead of the RFC 2822-required `\r\n`, corrupting Quoted-Printable encoding (`=\r\n` → `=\n`).

### Root cause

`Laminas\Mime\Decode::splitMime` strips all `\r` characters before splitting MIME parts — a known upstream limitation introduced when `imap_*` was replaced by Laminas Mail in 2019 (commit `f64859cd4d`). All `message/rfc822` attachments extracted since then silently lose their CRLF line endings.

> Note: `.eml` generation for `message/rfc822` parts was intentionally introduced in 2015 (commit `292337a024`, fixes #321).

### Fix

After extracting a `message/rfc822` part, restore `\r\n` using a negative-lookbehind regex that replaces only standalone `\n` (not existing `\r\n`), before writing to disk.

A regression test is added to `MailCollectorTest`: it builds a multipart email with a CRLF-encoded embedded message, runs `getAttached()`, and asserts `\r\n` line endings in the resulting file.