### PR TITLE
Prevent CI failures due to unexpected git dir ownership

### DIFF
--- a/.github/actions/init_containers-start.sh
+++ b/.github/actions/init_containers-start.sh
@@ -40,7 +40,9 @@ done
 if [[ "$UPDATE_FILES_ACL" = true ]]; then
   # Prevent git to trigger errors related to unexpected directories ownership
   docker compose exec -T app git config --global --add safe.directory /var/www/glpi
-  docker compose exec -T app find /home/www-data/.cache/composer/vcs -mindepth 1 -maxdepth 1 -exec git config --global --add safe.directory {} \;
+  if [[ -d "/home/www-data/.cache/composer/vcs" ]]; then
+    docker compose exec -T app find /home/www-data/.cache/composer/vcs -mindepth 1 -maxdepth 1 -exec git config --global --add safe.directory {} \;
+  fi
 fi
 
 # Always wait for 5 seconds, even when all services are considered as healthy,

--- a/.github/actions/init_containers-start.sh
+++ b/.github/actions/init_containers-start.sh
@@ -37,6 +37,12 @@ for CONTAINER_ID in `docker compose ps -a -q`; do
   done
 done
 
+if [[ "$UPDATE_FILES_ACL" = true ]]; then
+  # Prevent git to trigger errors related to unexpected directories ownership
+  docker compose exec -T app git config --global --add safe.directory /var/www/glpi
+  docker compose exec -T app find /home/www-data/.cache/composer/vcs -mindepth 1 -maxdepth 1 -exec git config --global --add safe.directory {} \;
+fi
+
 # Always wait for 5 seconds, even when all services are considered as healthy,
 # as they may respond even if their startup script is still running (should not take more than 5 seconds).
 # This problem was encountered on mariadb:10.1 service.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Sometimes, dist version of dependencies is not available and composer fetch them using git. When cache is restored by Github, the ownership changes and it result in errors in the subsequent CI executions.

Declaring these directories safe for git should fix this issue.


```
+ bin/console dependencies install '--composer-options=--ignore-platform-req=php+ --prefer-dist --no-progress'
The repository at "/var/www/glpi" does not have the correct ownership and git refuses to use it:

fatal: detected dubious ownership in repository at '/var/www/glpi'
To add an exception for this directory, call:

git config --global --add safe.directory /var/www/glpi

Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 211 installs, 0 updates, 0 removals
  - Downloading ssddanbrown/htmldiff (v2.0.0)
  - Downloading ssddanbrown/htmldiff (v2.0.0)
  - Downloading ssddanbrown/htmldiff (v2.0.0)
  - Downloading ssddanbrown/htmldiff (v2.0.0)
    Failed to download ssddanbrown/htmldiff from dist: The "
https://codeberg.org/api/v1/repos/danb/HtmlDiff/archive/v2.0.0.zip" file could not be downloaded (HTTP/3 500 )
    Now trying to download from source
  - Syncing ssddanbrown/htmldiff (v2.0.0) into cache

In Git.php line 54:

  The repository at "/home/www-data/.cache/composer/vcs/https---codeberg.org-  
  danb-HtmlDiff/" does not have the correct ownership and git refuses to use   
  it:                                                                          

  fatal: detected dubious ownership in repository at '/home/www-data/.cache/c  
  omposer/vcs/https---codeberg.org-danb-HtmlDiff'                              
  To add an exception for this directory, call:                                

  	git config --global --add safe.directory /home/www-data/.cache/composer/vc   
  s/https---codeberg.org-danb-HtmlDiff                                         


install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-security-blocking] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]

Error: Process completed with exit code 1.
```