### PR TITLE
Fix anonymous webhooks

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -816,8 +816,10 @@ final class DbUtils
             !$complete_request
             && ($value != '0')
             && empty($value)
-            && isset($_SESSION['glpishowallentities'])
-            && $_SESSION['glpishowallentities']
+            && (
+                (isset($_SESSION['glpishowallentities']) && $_SESSION['glpishowallentities'])
+                || Session::isRightChecksDisabled()
+            )
         ) {
             // Not ADD "AND 1" if not needed
             if (trim($separator) == "AND") {
@@ -938,6 +940,8 @@ final class DbUtils
         if (!is_array($value) && strlen($value) == 0) {
             if (isset($_SESSION['glpiactiveentities'])) {
                 $value = $_SESSION['glpiactiveentities'];
+            } elseif (Session::isRightChecksDisabled()) {
+                return [new QueryExpression('true')];
             } elseif (isCommandLine() || Session::isCron()) {
                 $value = '0'; // If value is not set, fallback to root entity in cron / command line
             }

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1225,7 +1225,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 $api_data = $webhook->getAPIResponse($path);
                 $body = $webhook->getWebhookBody($event, $api_data, $item::class, $item->getID());
                 // Check if the item matches the webhook filters
-                if (!$webhook->itemMatchFilter($item)) {
+                if (!Session::callAsSystem(fn() => $webhook->itemMatchFilter($item))) {
                     continue;
                 }
                 $timestamp = time();

--- a/tests/functional/WebhookTest.php
+++ b/tests/functional/WebhookTest.php
@@ -35,10 +35,15 @@
 namespace tests\units;
 
 use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Search\CriteriaFilter;
 use Glpi\Search\SearchOption;
 use Glpi\Tests\DbTestCase;
 use Psr\Log\LogLevel;
+use QueuedWebhook;
+use Ticket;
 use Webhook;
+
+use function Safe\json_encode;
 
 class WebhookTest extends DbTestCase
 {
@@ -115,7 +120,7 @@ JSON;
             'content' => 'Test followup',
         ]);
 
-        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhooks = getAllDataFromTable(QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
         $queued_webhook = reset($queued_webhooks);
 
         $this->assertGreaterThan(0, count($queued_webhook));
@@ -164,7 +169,7 @@ JSON;
             'content' => 'Test followup',
         ]);
 
-        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhooks = getAllDataFromTable(QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
         $queued_webhook = reset($queued_webhooks);
 
         $this->assertGreaterThan(0, count($queued_webhook));
@@ -215,7 +220,7 @@ JSON;
             'content' => 'Test followup',
         ]);
 
-        $queued_webhooks = getAllDataFromTable(\QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
+        $queued_webhooks = getAllDataFromTable(QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]);
         $queued_webhook = reset($queued_webhooks);
 
         $this->assertGreaterThan(0, count($queued_webhook));
@@ -392,5 +397,55 @@ JSON;
         $this->assertFalse($webhook->canCreateItem());
         $webhook->fields['itemtype'] = 'Monitor';
         $this->assertTrue($webhook->canCreateItem());
+    }
+
+    public function testWebhookWithoutSession(): void
+    {
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        // Arrange: setup a webhook with a filter
+        $webhook = $this->createItem(Webhook::class, [
+            'name'                => 'Test webhook',
+            'entities_id'         => $entity_id,
+            'url'                 => 'http://localhost',
+            'itemtype'            => Ticket::class,
+            'event'               => 'new',
+            'is_active'           => 1,
+            'use_default_payload' => 1,
+        ]);
+        $this->createItem(CriteriaFilter::class, [
+            'itemtype' => Webhook::class,
+            'items_id' => $webhook->getID(),
+            'search_itemtype' => Ticket::class,
+            'search_criteria' => json_encode([
+                [
+                    "link"       => "AND",
+                    "field"      => "12",
+                    "searchtype" => "equals",
+                    "value"      => "notold",
+                ],
+            ]),
+        ], ['search_criteria']);
+
+        // Act: trigger the webhook by creating a ticket
+        $base_count = $this->countQueuedRequestForWebhook($webhook);
+        $this->createItem(Ticket::class, [
+            'name'        => 'Test ticket',
+            'content'     => 'Test ticket content',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Assert: one webhook request should have been added to the queue
+        $this->assertEquals(
+            $base_count + 1,
+            $this->countQueuedRequestForWebhook($webhook),
+        );
+    }
+
+    private function countQueuedRequestForWebhook(Webhook $webhook): int
+    {
+        return countElementsInTable(QueuedWebhook::getTable(), [
+            'webhooks_id' => $webhook->getID(),
+        ]);
     }
 }

--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -141,20 +141,6 @@ class GLPITestCase extends TestCase
         // impact others tests that depend on it.
         assert(true === Plugin::isPluginActive('tester'), 'The tester plugin must be active for tests to run properly. Make sure test db is initialized and tester plugin directory doesn\'t exist.');
 
-        if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
-            unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);
-            $this->assertSame(
-                [],
-                $_SESSION['MESSAGE_AFTER_REDIRECT'],
-                sprintf(
-                    "Some messages has not been handled in %s::%s:\n%s",
-                    static::class,
-                    __METHOD__/*$method*/,
-                    print_r($_SESSION['MESSAGE_AFTER_REDIRECT'], true)
-                )
-            );
-        }
-
         if (!$this->has_failed) {
             $this->assertIsArray($this->log_handler->getRecords());
             $clean_logs = array_map(
@@ -184,6 +170,23 @@ class GLPITestCase extends TestCase
                     static::class,
                     __METHOD__/*$method*/,
                     print_r($clean_logs, true)
+                )
+            );
+        }
+
+        // Keep this after the logs checks, logs contains more detailled
+        // information so we prefer that the test fail with the log details
+        // rather than with the session messages details for easier debugging.
+        if (isset($_SESSION['MESSAGE_AFTER_REDIRECT']) && !$this->has_failed) {
+            unset($_SESSION['MESSAGE_AFTER_REDIRECT'][INFO]);
+            $this->assertSame(
+                [],
+                $_SESSION['MESSAGE_AFTER_REDIRECT'],
+                sprintf(
+                    "Some messages has not been handled in %s::%s:\n%s",
+                    static::class,
+                    __METHOD__/*$method*/,
+                    print_r($_SESSION['MESSAGE_AFTER_REDIRECT'], true)
                 )
             );
         }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

There were multiple issues preventing webhooks from working for unauthenticated users (e.g. on a public form).
Most of it is due to checks on entities ID, which should not happen in the context of an internal item like a webhook.

## References

Fix #23647.


