### PR TITLE
fix(forms): Filter unauthorized form destination actors

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -56,7 +56,9 @@ use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Group;
 use InvalidArgumentException;
 use Override;
+use Profile;
 use Supplier;
+use Ticket;
 use User;
 
 abstract class ITILActorField extends AbstractConfigField implements DestinationFieldConverterInterface
@@ -118,6 +120,7 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                 'values'          => $specific_actors,
                 'input_name'      => $input_name . "[" . ITILActorFieldConfig::SPECIFIC_ITILACTORS_IDS . "]",
                 'allowed_types'   => $this->getAllowedActorTypes(),
+                'dropdown_options' => $this->getActorDropdownOptions(),
             ],
 
             // Specific additional config for SPECIFIC_ANSWERS strategy
@@ -162,11 +165,101 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
 
             // Process each actor found by the strategy
             foreach ($itilactors as $itilactor) {
+                if (!$this->isActorAllowed($itilactor, $answers_set)) {
+                    continue;
+                }
                 $this->addActorToInput($input, $itilactor);
             }
         }
 
         return $input;
+    }
+
+    /**
+     * @return array{
+     *     right_for_users?: string,
+     *     group_conditions?: array<string, int>
+     * }
+     */
+    private function getActorDropdownOptions(): array
+    {
+        return match ($this->getActorType()) {
+            'requester' => [
+                'right_for_users' => 'all',
+                'group_conditions' => ['is_requester' => 1],
+            ],
+            'observer' => [
+                'right_for_users' => 'all',
+                'group_conditions' => ['is_watcher' => 1],
+            ],
+            'assign' => [
+                'right_for_users' => 'own_ticket',
+                'group_conditions' => ['is_assign' => 1],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * @param array{
+     *     itemtype?: class-string<\CommonDBTM>|string,
+     *     items_id?: int|string,
+     *     use_notification?: int|string,
+     *     alternative_email?: string
+     * } $itilactor
+     */
+    private function isActorAllowed(array $itilactor, AnswersSet $answers_set): bool
+    {
+        if (!isset($itilactor['itemtype'], $itilactor['items_id'])) {
+            return false;
+        }
+
+        $actor_type = $this->getActorType();
+        $itemtype = $itilactor['itemtype'];
+        $items_id = (int) $itilactor['items_id'];
+
+        if ($items_id <= 0) {
+            return true;
+        }
+
+        if ($itemtype === User::class) {
+            if ($actor_type !== 'assign') {
+                return true;
+            }
+
+            $form = $answers_set->getItem();
+            $entities_id = $form instanceof Form ? $form->getEntityID() : 0;
+            if ($entities_id < 0) {
+                return false;
+            }
+
+            return Profile::haveUserRight(
+                $items_id,
+                Ticket::$rightname,
+                Ticket::OWN,
+                $entities_id
+            );
+        }
+
+        if ($itemtype === Group::class) {
+            $group = Group::getById($items_id);
+            if ($group === false) {
+                return false;
+            }
+
+            return match ($actor_type) {
+                'requester' => (int) $group->fields['is_requester'] === 1,
+                'observer'  => (int) $group->fields['is_watcher'] === 1,
+                'assign'    => (int) $group->fields['is_assign'] === 1,
+                default     => false,
+            };
+        }
+
+        if ($itemtype === Supplier::class) {
+            return $actor_type === 'assign';
+        }
+
+        return false;
     }
 
     /**

--- a/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/itilactor.html.twig
@@ -43,6 +43,8 @@
                 multiple: true,
                 allowed_types: specific_value_extra_field.allowed_types,
                 aria_label: specific_value_extra_field.aria_label,
+                right_for_users: specific_value_extra_field.dropdown_options.right_for_users,
+                group_conditions: specific_value_extra_field.dropdown_options.group_conditions,
             }
     ]) %}
 

--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -675,10 +675,10 @@ export class FormPage extends GlpiPage
         value: string,
     ): Promise<void> {
         await dropdown.click();
-        await this.page.getByRole('listbox').focus();
         await this.page.keyboard.type(value);
         await expect(
-            this.page.getByRole('listbox').getByText(value, { exact: true })
+            // eslint-disable-next-line playwright/no-raw-locators
+            this.page.locator('.select2-results__options').getByText(value, { exact: true })
         ).toHaveCount(0);
         await this.page.keyboard.press('Escape');
     }

--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -670,6 +670,19 @@ export class FormPage extends GlpiPage
         await this.page.goto(href);
     }
 
+    public async doAssertDropdownValueIsNotAvailable(
+        dropdown: Locator,
+        value: string,
+    ): Promise<void> {
+        await dropdown.click();
+        await this.page.getByRole('listbox').focus();
+        await this.page.keyboard.type(value);
+        await expect(
+            this.page.getByRole('listbox').getByText(value, { exact: true })
+        ).toHaveCount(0);
+        await this.page.keyboard.press('Escape');
+    }
+
     public getValidationErrorMessage(textbox: Locator): Locator
     {
         // eslint-disable-next-line playwright/no-raw-locators

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -103,6 +103,7 @@ export class GlpiPage
         exact: boolean = true
     ):  Promise<void> {
         await dropdown.click();
+        await this.page.getByRole('listbox').focus();
         await this.page.keyboard.type(value);
 
         // Select2 roles are different if the dropdown group some values
@@ -126,6 +127,7 @@ export class GlpiPage
         check_value: boolean = true,
     ):  Promise<void> {
         await dropdown.click();
+        await this.page.getByRole('listbox').focus();
 
         // Select2 roles are different if the dropdown group some values
         const simple_dropdown = this.page

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -103,7 +103,6 @@ export class GlpiPage
         exact: boolean = true
     ):  Promise<void> {
         await dropdown.click();
-        await this.page.getByRole('listbox').focus();
         await this.page.keyboard.type(value);
 
         // Select2 roles are different if the dropdown group some values
@@ -127,7 +126,6 @@ export class GlpiPage
         check_value: boolean = true,
     ):  Promise<void> {
         await dropdown.click();
-        await this.page.getByRole('listbox').focus();
 
         // Select2 roles are different if the dropdown group some values
         const simple_dropdown = this.page

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -131,7 +131,7 @@ for (const actor_type of actor_types) {
         });
 
 
-        test.beforeEach(async ({ page, profile, api, formImporter }) => {
+        test.beforeEach(async ({ page, formImporter }) => {
             form_page = new FormPage(page);
             const info = await formImporter.importForm(actor_type.fixture);
             await form_page.gotoDestinationTab(info.getId());

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -69,12 +69,9 @@ for (const actor_type of actor_types) {
         const authorized_group_name = `Test ${actor_type.name} group authorized - ${unique}`;
         const unauthorized_group_name = `Test ${actor_type.name} group unauthorized - ${unique}`;
 
-        test.beforeEach(async ({ page, profile, api, formImporter }) => {
+        test.beforeAll(async ({ profile, api }) => {
             await profile.set(Profiles.SuperAdmin);
-            form_page = new FormPage(page);
             const entity_id = getWorkerEntityId();
-
-            const info = await formImporter.importForm(actor_type.fixture);
 
             // Create a possible actor
             const actor_id = await api.createItem('User', {
@@ -131,7 +128,12 @@ for (const actor_type of actor_types) {
                 groups_id: authorized_group_id,
                 groups_id_tech: authorized_group_id,
             });
+        });
 
+
+        test.beforeEach(async ({ page, profile, api, formImporter }) => {
+            form_page = new FormPage(page);
+            const info = await formImporter.importForm(actor_type.fixture);
             await form_page.gotoDestinationTab(info.getId());
         });
 

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -42,18 +42,21 @@ const actor_types = [
         fixture: 'destination_config_fields/requester-config.json',
         data_attr: 'requester',
         default_value: 'User who filled the form',
+        group_right_field: 'is_requester',
     },
     {
         name: 'Assignee',
         fixture: 'destination_config_fields/assignee-config.json',
         data_attr: 'assign',
         default_value: 'From template',
+        group_right_field: 'is_assign',
     },
     {
         name: 'Observer',
         fixture: 'destination_config_fields/observer-config.json',
         data_attr: 'observer',
         default_value: 'From template',
+        group_right_field: 'is_watcher',
     },
 ];
 
@@ -61,7 +64,10 @@ for (const actor_type of actor_types) {
     test.describe(`${actor_type.name} configuration`, () => {
         let form_page: FormPage;
         const unique = randomUUID();
-        const actor_name = `Test ${actor_type.name} - ${unique}`;
+        const authorized_actor_name = `Test ${actor_type.name} authorized - ${unique}`;
+        const unauthorized_actor_name = `Test ${actor_type.name} unauthorized - ${unique}`;
+        const authorized_group_name = `Test ${actor_type.name} group authorized - ${unique}`;
+        const unauthorized_group_name = `Test ${actor_type.name} group unauthorized - ${unique}`;
 
         test.beforeEach(async ({ page, profile, api, formImporter }) => {
             await profile.set(Profiles.SuperAdmin);
@@ -72,7 +78,7 @@ for (const actor_type of actor_types) {
 
             // Create a possible actor
             const actor_id = await api.createItem('User', {
-                name: actor_name,
+                name: authorized_actor_name,
             });
             await api.createItem('Profile_User', {
                 users_id: actor_id,
@@ -81,10 +87,38 @@ for (const actor_type of actor_types) {
                 is_recursive: 1,
             });
 
-            // Create a Group
-            const group_id = await api.createItem('Group', {
-                name: `Test Group - ${unique}`,
+            if (actor_type.name === 'Assignee') {
+                const unauthorized_actor_id = await api.createItem('User', {
+                    name: unauthorized_actor_name,
+                });
+                await api.createItem('Profile_User', {
+                    users_id: unauthorized_actor_id,
+                    profiles_id: Profiles.SelfService,
+                    entities_id: entity_id,
+                    is_recursive: 1,
+                });
+            }
+
+            const no_group_rights = {
+                is_requester: 0,
+                is_watcher: 0,
+                is_assign: 0,
+            };
+            const authorized_group_right = {
+                [actor_type.group_right_field]: 1,
+            };
+
+            // Create groups for authorized and unauthorized checks
+            const authorized_group_id = await api.createItem('Group', {
+                name: authorized_group_name,
                 entities_id: entity_id,
+                ...no_group_rights,
+                ...authorized_group_right,
+            });
+            await api.createItem('Group', {
+                name: unauthorized_group_name,
+                entities_id: entity_id,
+                ...no_group_rights,
             });
 
             // Create a Computer with assigned user and group
@@ -94,8 +128,8 @@ for (const actor_type of actor_types) {
                 entities_id: entity_id,
                 users_id: worker_user_id,
                 users_id_tech: worker_user_id,
-                groups_id: group_id,
-                groups_id_tech: group_id,
+                groups_id: authorized_group_id,
+                groups_id_tech: authorized_group_id,
             });
 
             await form_page.gotoDestinationTab(info.getId());
@@ -133,7 +167,7 @@ for (const actor_type of actor_types) {
                 /* eslint-disable playwright/no-conditional-in-test */
                 if (option === 'Specific actors') {
                     const actors_dropdown = form_page.getDropdownByLabel('Select actors...', config);
-                    await form_page.doSearchAndClickDropdownValue(actors_dropdown, actor_name, false);
+                    await form_page.doSearchAndClickDropdownValue(actors_dropdown, authorized_actor_name, false);
                 } else if (option === 'Answer from specific questions') {
                     const questions_dropdown = form_page.getDropdownByLabel('Select questions...', config);
                     await form_page.doSetDropdownValue(questions_dropdown, `My ${actor_type.name} question`);
@@ -149,6 +183,23 @@ for (const actor_type of actor_types) {
 
                 await form_page.doSaveDestinationAndReopenAccordion('Actors');
                 await expect(strategy_dropdown).toHaveText(option);
+            }
+        });
+
+        test('Cannot select unauthorized actors with "Specific actors"', async () => {
+            await form_page.doOpenDestinationAccordionItem('Actors');
+
+            const config = form_page.getRegion(`${actor_type.name}s configuration`);
+            const strategy_dropdown = form_page.getStrategyDropdown(config);
+            await form_page.doSetDropdownValue(strategy_dropdown, 'Specific actors');
+
+            const actors_dropdown = form_page.getDropdownByLabel('Select actors...', config);
+            await form_page.doSearchAndClickDropdownValue(actors_dropdown, authorized_group_name, false);
+
+            await form_page.doAssertDropdownValueIsNotAvailable(actors_dropdown, unauthorized_group_name);
+
+            if (actor_type.name === 'Assignee') {
+                await form_page.doAssertDropdownValueIsNotAvailable(actors_dropdown, unauthorized_actor_name);
             }
         });
 

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -52,6 +52,8 @@ use Glpi\Tests\FormBuilder;
 use Group;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Profile;
+use Profile_User;
 use Session;
 use Supplier;
 use Ticket;
@@ -158,7 +160,11 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
         // Login is required to assign actors
         $this->login();
 
-        $supervisor = $this->createItem(User::class, ['name' => 'testAssigneeFormFillerSupervisor Supervisor']);
+        $technician_profiles_id = getItemByTypeName(Profile::class, 'Technician', true);
+        $supervisor = $this->createItem(User::class, [
+            'name' => 'testAssigneeFormFillerSupervisor Supervisor',
+            '_profiles_id' => $technician_profiles_id,
+        ]);
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $form_filler_supervisor_config = new AssigneeFieldConfig(
             [ITILActorFieldStrategy::FORM_FILLER_SUPERVISOR]
@@ -198,8 +204,15 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
         $this->login();
 
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
-        $user = $this->createItem(User::class, ['name' => 'testSpecificActors User']);
-        $group = $this->createItem(Group::class, ['name' => 'testSpecificActors Group']);
+        $technician_profiles_id = getItemByTypeName(Profile::class, 'Technician', true);
+        $user = $this->createItem(User::class, [
+            'name' => 'testSpecificActors User',
+            '_profiles_id' => $technician_profiles_id,
+        ]);
+        $group = $this->createItem(Group::class, [
+            'name' => 'testSpecificActors Group',
+            'is_assign' => 1,
+        ]);
         $supplier = $this->createItem(Supplier::class, [
             'name' => 'testSpecificActors Supplier',
             'entities_id' => $this->getTestRootEntity(true),
@@ -245,6 +258,55 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
             ),
             answers: [],
             expected_actors: [['items_id' => $user->getID()], ['items_id' => $group->getID()], ['items_id' => $supplier->getID()]]
+        );
+    }
+
+    public function testSpecificActorsExcludesUnauthorizedActors(): void
+    {
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $entities_id = $this->getTestRootEntity(only_id: true);
+        $authorized_user = $this->createItem(User::class, [
+            'name' => 'testSpecificActorsExcludesUnauthorizedActors Authorized user',
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id'    => $authorized_user->getID(),
+            'profiles_id' => getItemByTypeName(Profile::class, 'Technician', true),
+            'entities_id' => $entities_id,
+        ]);
+        $unauthorized_user = $this->createItem(User::class, [
+            'name' => 'testSpecificActorsExcludesUnauthorizedActors Unauthorized user',
+        ]);
+        $authorized_group = $this->createItem(Group::class, [
+            'name'      => 'testSpecificActorsExcludesUnauthorizedActors Authorized group',
+            'is_assign' => 1,
+        ]);
+        $unauthorized_group = $this->createItem(Group::class, [
+            'name'      => 'testSpecificActorsExcludesUnauthorizedActors Unauthorized group',
+            'is_assign' => 0,
+        ]);
+        $supplier = $this->createItem(Supplier::class, [
+            'name'       => 'testSpecificActorsExcludesUnauthorizedActors Supplier',
+            'entities_id' => $entities_id,
+        ]);
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
+                specific_itilactors_ids: [
+                    User::getForeignKeyField() . '-' . $authorized_user->getID(),
+                    User::getForeignKeyField() . '-' . $unauthorized_user->getID(),
+                    Group::getForeignKeyField() . '-' . $authorized_group->getID(),
+                    Group::getForeignKeyField() . '-' . $unauthorized_group->getID(),
+                    Supplier::getForeignKeyField() . '-' . $supplier->getID(),
+                ]
+            ),
+            answers: [],
+            expected_actors: [
+                ['items_id' => $authorized_user->getID()],
+                ['items_id' => $authorized_group->getID()],
+                ['items_id' => $supplier->getID()],
+            ]
         );
     }
 
@@ -529,9 +591,19 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
         $this->login();
 
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
-        $user1 = $this->createItem(User::class, ['name' => 'testMultipleStrategies User 1']);
-        $user2 = $this->createItem(User::class, ['name' => 'testMultipleStrategies User 2']);
-        $group = $this->createItem(Group::class, ['name' => 'testMultipleStrategies Group']);
+        $technician_profiles_id = getItemByTypeName(Profile::class, 'Technician', true);
+        $user1 = $this->createItem(User::class, [
+            'name' => 'testMultipleStrategies User 1',
+            '_profiles_id' => $technician_profiles_id,
+        ]);
+        $user2 = $this->createItem(User::class, [
+            'name' => 'testMultipleStrategies User 2',
+            '_profiles_id' => $technician_profiles_id,
+        ]);
+        $group = $this->createItem(Group::class, [
+            'name' => 'testMultipleStrategies Group',
+            'is_assign' => 1,
+        ]);
         $supplier = $this->createItem(Supplier::class, [
             'name' => 'testMultipleStrategies Supplier',
             'entities_id' => $this->getTestRootEntity(true),
@@ -864,8 +936,10 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
 
         // Check actors
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
+        $this->assertSameSize($expected_actors, $actors);
         foreach ($expected_actors as $expected_actor) {
             $actor = array_shift($actors);
+            $this->assertIsArray($actor);
             $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(
                 $expected_actor,
                 $actor,

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
@@ -215,6 +215,32 @@ final class ObserverFieldTest extends AbstractActorFieldTest
         );
     }
 
+    public function testSpecificActorsExcludesUnauthorizedGroups(): void
+    {
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $authorized_group = $this->createItem(Group::class, [
+            'name'       => 'testSpecificActorsExcludesUnauthorizedGroups Authorized',
+            'is_watcher' => 1,
+        ]);
+        $unauthorized_group = $this->createItem(Group::class, [
+            'name'       => 'testSpecificActorsExcludesUnauthorizedGroups Unauthorized',
+            'is_watcher' => 0,
+        ]);
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new ObserverFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
+                specific_itilactors_ids: [
+                    Group::getForeignKeyField() . '-' . $authorized_group->getID(),
+                    Group::getForeignKeyField() . '-' . $unauthorized_group->getID(),
+                ]
+            ),
+            answers: [],
+            expected_actors: [['items_id' => $authorized_group->getID()]]
+        );
+    }
+
     public function testActorsFromSpecificQuestions(): void
     {
         $form = $this->createAndGetFormWithMultipleActorsQuestions();

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -221,6 +221,32 @@ final class RequesterFieldTest extends AbstractActorFieldTest
         );
     }
 
+    public function testSpecificActorsExcludesUnauthorizedGroups(): void
+    {
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $authorized_group = $this->createItem(Group::class, [
+            'name'         => 'testSpecificActorsExcludesUnauthorizedGroups Authorized',
+            'is_requester' => 1,
+        ]);
+        $unauthorized_group = $this->createItem(Group::class, [
+            'name'         => 'testSpecificActorsExcludesUnauthorizedGroups Unauthorized',
+            'is_requester' => 0,
+        ]);
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_VALUES],
+                specific_itilactors_ids: [
+                    Group::getForeignKeyField() . '-' . $authorized_group->getID(),
+                    Group::getForeignKeyField() . '-' . $unauthorized_group->getID(),
+                ]
+            ),
+            answers: [],
+            expected_actors: [['items_id' => $authorized_group->getID()]]
+        );
+    }
+
     public function testActorsFromSpecificQuestions(): void
     {
         $form = $this->createAndGetFormWithMultipleActorsQuestions();

--- a/tests/src/AbstractActorFieldTest.php
+++ b/tests/src/AbstractActorFieldTest.php
@@ -36,12 +36,14 @@ namespace Glpi\Tests;
 
 use Computer;
 use Glpi\Asset\AssetDefinition;
+use Glpi\Form\Destination\CommonITILField\AssigneeField;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldConfig;
 use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Group;
+use Profile;
 use User;
 
 abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
@@ -70,9 +72,13 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             strategies: [ITILActorFieldStrategy::USER_FROM_OBJECT_ANSWER],
             specific_question_ids: [$this->getQuestionId($form, "Computer question")]
         );
+        $user_data = ['name' => 'testUserActorsFromSpecificItemQuestions User'];
+        if ($this->getFieldClass() === AssigneeField::class) {
+            $user_data['_profiles_id'] = getItemByTypeName(Profile::class, 'Technician', true);
+        }
         $users = $this->createItems(User::class, [
-            ['name' => 'testUserActorsFromSpecificItemQuestions User 1'],
-            ['name' => 'testUserActorsFromSpecificItemQuestions User 2'],
+            array_merge($user_data, ['name' => 'testUserActorsFromSpecificItemQuestions User 1']),
+            array_merge($user_data, ['name' => 'testUserActorsFromSpecificItemQuestions User 2']),
         ]);
         $computers = $this->createItems(Computer::class, [
             [
@@ -135,9 +141,13 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             strategies: [ITILActorFieldStrategy::TECH_USER_FROM_OBJECT_ANSWER],
             specific_question_ids: [$this->getQuestionId($form, "Computer question")]
         );
+        $user_data = ['name' => 'testTechUserActorsFromSpecificItemQuestions User'];
+        if ($this->getFieldClass() === AssigneeField::class) {
+            $user_data['_profiles_id'] = getItemByTypeName(Profile::class, 'Technician', true);
+        }
         $users = $this->createItems(User::class, [
-            ['name' => 'testTechUserActorsFromSpecificItemQuestions User 1'],
-            ['name' => 'testTechUserActorsFromSpecificItemQuestions User 2'],
+            array_merge($user_data, ['name' => 'testTechUserActorsFromSpecificItemQuestions User 1']),
+            array_merge($user_data, ['name' => 'testTechUserActorsFromSpecificItemQuestions User 2']),
         ]);
         $computers = $this->createItems(Computer::class, [
             [
@@ -346,9 +356,13 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             specific_question_ids: [$this->getQuestionId($form, "Custom asset question")]
         );
 
+        $user_data = ['name' => 'testTechUserActorsFromCustomAssetItemQuestions User'];
+        if ($this->getFieldClass() === AssigneeField::class) {
+            $user_data['_profiles_id'] = getItemByTypeName(Profile::class, 'Technician', true);
+        }
         $users = $this->createItems(User::class, [
-            ['name' => 'testTechUserActorsFromCustomAssetItemQuestions User 1'],
-            ['name' => 'testTechUserActorsFromCustomAssetItemQuestions User 2'],
+            array_merge($user_data, ['name' => 'testTechUserActorsFromCustomAssetItemQuestions User 1']),
+            array_merge($user_data, ['name' => 'testTechUserActorsFromCustomAssetItemQuestions User 2']),
         ]);
 
         $assets = $this->createItems($asset_class, [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43133

Added restrictions on the display of available actors for destination fields in the "Actors" category.
Added back-end validation logic to ensure that users added as requesters, observers, or assignees have the necessary permissions.