### PR TITLE
Fix - Only propagate followups/tasks/documents to parent ticket when child is deleted

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6042,16 +6042,25 @@ JAVASCRIPT;
     {
         global $DB;
 
-        //look for merged tickets
+        //look for merged tickets (only when the source ticket is deleted, i.e. actually merged)
         $merged = [];
         $iterator = $DB->request(
             [
                 'FROM' => Ticket_Ticket::getTable(),
-                'SELECT' => ['tickets_id_2'],
+                'SELECT' => [Ticket_Ticket::getTable() . '.tickets_id_2'],
                 'DISTINCT' => true,
+                'INNER JOIN' => [
+                    Ticket::getTable() => [
+                        'ON' => [
+                            Ticket_Ticket::getTable() => 'tickets_id_1',
+                            Ticket::getTable()        => 'id',
+                        ],
+                    ],
+                ],
                 'WHERE' => [
-                    'tickets_id_1' => $id,
-                    'link'        => Ticket_Ticket::SON_OF,
+                    Ticket_Ticket::getTable() . '.tickets_id_1' => $id,
+                    Ticket_Ticket::getTable() . '.link'         => Ticket_Ticket::SON_OF,
+                    Ticket::getTable() . '.is_deleted'          => 1,
                 ],
             ]
         );

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4350,37 +4350,44 @@ class TicketTest extends DbTestCase
         $_SESSION['glpiactiveprofile']['interface'] = '';
         $this->setEntity('Root entity', true);
 
-        $ticket = new Ticket();
-        $parent_id = $ticket->add([
-            'name'        => 'Parent ticket',
-            'content'     => 'Parent ticket',
-            'entities_id' => 0,
-            'status'      => CommonITILObject::INCOMING,
-        ]);
-        $child_id = $ticket->add([
-            'name'        => 'Child ticket',
-            'content'     => 'Child ticket',
-            'entities_id' => 0,
-            'status'      => CommonITILObject::INCOMING,
-        ]);
+        $parent_id = $this->createItem(
+            Ticket::class,
+            [
+                'name'        => 'Parent ticket',
+                'content'     => 'Parent ticket',
+                'entities_id' => 0,
+                'status'      => CommonITILObject::INCOMING,
+            ]
+        )->getID();
+
+        $child_id = $this->createItem(
+            Ticket::class,
+            [
+                'name'        => 'Child ticket',
+                'content'     => 'Child ticket',
+                'entities_id' => 0,
+                'status'      => CommonITILObject::INCOMING,
+            ]
+        )->getID();
 
         // Create a SON_OF link WITHOUT merging (child is not deleted)
-        $tt = new \Ticket_Ticket();
-        $tt->add([
-            'link'         => \Ticket_Ticket::SON_OF,
-            'tickets_id_1' => $child_id,
-            'tickets_id_2' => $parent_id,
-        ]);
+        $this->createItem(
+            \Ticket_Ticket::class,
+            [
+                'link'         => \Ticket_Ticket::SON_OF,
+                'tickets_id_1' => $child_id,
+                'tickets_id_2' => $parent_id,
+            ]
+        );
 
         // Add a followup to the child ticket
-        $followup = new ITILFollowup();
-        $this->assertGreaterThan(
-            0,
-            $followup->add([
+        $followup = $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype' => 'Ticket',
                 'items_id' => $child_id,
                 'content'  => 'Followup on non-deleted child',
-            ])
+            ]
         );
 
         // The followup must NOT have been copied to the parent
@@ -4391,13 +4398,12 @@ class TicketTest extends DbTestCase
         ]));
 
         // Add a task to the child ticket
-        $task = new \TicketTask();
-        $this->assertGreaterThan(
-            0,
-            $task->add([
+        $task = $this->createItem(
+            \TicketTask::class,
+            [
                 'tickets_id' => $child_id,
                 'content'    => 'Task on non-deleted child',
-            ])
+            ]
         );
 
         // The task must NOT have been copied to the parent
@@ -4407,24 +4413,24 @@ class TicketTest extends DbTestCase
         ]));
 
         // Add a document to the child ticket
-        $document = new \Document();
-        $documents_id = $document->add([
-            'name'     => 'Child ticket document',
-            'filename' => 'doc.xls',
-            'users_id' => '2',
-        ]);
-        $this->assertGreaterThan(0, $documents_id);
+        $documents_id = $this->createItem(
+            \Document::class,
+            [
+                'name'     => 'Child ticket document',
+                'filename' => 'doc.xls',
+                'users_id' => Session::getLoginUserID(),
+            ]
+        )->getID();
 
-        $document_item = new \Document_Item();
-        $this->assertGreaterThan(
-            0,
-            $document_item->add([
+        $document_item = $this->createItem(
+            \Document_Item::class,
+            [
                 'itemtype'     => 'Ticket',
                 'items_id'     => $child_id,
                 'documents_id' => $documents_id,
                 'entities_id'  => '0',
                 'is_recursive' => 0,
-            ])
+            ]
         );
 
         // The document must NOT have been copied to the parent

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4340,6 +4340,101 @@ class TicketTest extends DbTestCase
         ]));
     }
 
+    /**
+     * When two tickets have a SON_OF link but the child is NOT deleted (not actually merged),
+     * responses added to the child must NOT be propagated to the parent.
+     */
+    public function testResponsesNotPropagatedWhenChildNotDeleted(): void
+    {
+        $this->login();
+        $_SESSION['glpiactiveprofile']['interface'] = '';
+        $this->setEntity('Root entity', true);
+
+        $ticket = new Ticket();
+        $parent_id = $ticket->add([
+            'name'        => 'Parent ticket',
+            'content'     => 'Parent ticket',
+            'entities_id' => 0,
+            'status'      => CommonITILObject::INCOMING,
+        ]);
+        $child_id = $ticket->add([
+            'name'        => 'Child ticket',
+            'content'     => 'Child ticket',
+            'entities_id' => 0,
+            'status'      => CommonITILObject::INCOMING,
+        ]);
+
+        // Create a SON_OF link WITHOUT merging (child is not deleted)
+        $tt = new \Ticket_Ticket();
+        $tt->add([
+            'link'         => \Ticket_Ticket::SON_OF,
+            'tickets_id_1' => $child_id,
+            'tickets_id_2' => $parent_id,
+        ]);
+
+        // Add a followup to the child ticket
+        $followup = new ITILFollowup();
+        $this->assertGreaterThan(
+            0,
+            $followup->add([
+                'itemtype' => 'Ticket',
+                'items_id' => $child_id,
+                'content'  => 'Followup on non-deleted child',
+            ])
+        );
+
+        // The followup must NOT have been copied to the parent
+        $this->assertEmpty($followup->find([
+            'itemtype'       => 'Ticket',
+            'items_id'       => $parent_id,
+            'sourceitems_id' => $child_id,
+        ]));
+
+        // Add a task to the child ticket
+        $task = new \TicketTask();
+        $this->assertGreaterThan(
+            0,
+            $task->add([
+                'tickets_id' => $child_id,
+                'content'    => 'Task on non-deleted child',
+            ])
+        );
+
+        // The task must NOT have been copied to the parent
+        $this->assertEmpty($task->find([
+            'tickets_id'     => $parent_id,
+            'sourceitems_id' => $child_id,
+        ]));
+
+        // Add a document to the child ticket
+        $document = new \Document();
+        $documents_id = $document->add([
+            'name'     => 'Child ticket document',
+            'filename' => 'doc.xls',
+            'users_id' => '2',
+        ]);
+        $this->assertGreaterThan(0, $documents_id);
+
+        $document_item = new \Document_Item();
+        $this->assertGreaterThan(
+            0,
+            $document_item->add([
+                'itemtype'     => 'Ticket',
+                'items_id'     => $child_id,
+                'documents_id' => $documents_id,
+                'entities_id'  => '0',
+                'is_recursive' => 0,
+            ])
+        );
+
+        // The document must NOT have been copied to the parent
+        $this->assertEmpty($document_item->find([
+            'itemtype'     => 'Ticket',
+            'items_id'     => $parent_id,
+            'documents_id' => $documents_id,
+        ]));
+    }
+
     public function testKeepScreenshotsOnFormReload()
     {
         //login to get session

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4399,7 +4399,7 @@ class TicketTest extends DbTestCase
 
         // Add a task to the child ticket
         $task = $this->createItem(
-            \TicketTask::class,
+            TicketTask::class,
             [
                 'tickets_id' => $child_id,
                 'content'    => 'Task on non-deleted child',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #17124
- Here is a brief description of what this PR does

`getMergedTickets()` previously returned all tickets linked via a `SON_OF` relation, regardless of whether the child ticket was actually merged (deleted). This could cause unwanted propagation of followups, tasks, and documents to the parent ticket when, for example, an e-mail response is received on a closed child ticket that is only linked but not merged.

The fix adds a join on `glpi_tickets` to filter results to tickets where `is_deleted = 1`, ensuring propagation only happens on truly merged (soft-deleted) child tickets.

A regression test (`testResponsesNotPropagatedWhenChildNotDeleted`) is added to cover this scenario.