### PR TITLE
Fix checkbox conditions invalidating valid data

### DIFF
--- a/src/Glpi/Form/Condition/ConditionHandler/ArrayConditionHandlerTrait.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/ArrayConditionHandlerTrait.php
@@ -57,6 +57,10 @@ trait ArrayConditionHandlerTrait
             return false;
         }
 
+        // HTML forms might produce default empty values for optional inputs like
+        // checkboxes, we'll need to remove them
+        $a = array_filter($a, fn($v) => $v !== "");
+
         // Normalize values
         $a = array_values($a);
         $b = array_values($b);

--- a/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
+++ b/tests/functional/Glpi/Form/AnswersHandler/AnswersHandlerTest.php
@@ -50,6 +50,7 @@ use Glpi\Form\Destination\FormDestinationProblem;
 use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
@@ -58,6 +59,7 @@ use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeLongText;
 use Glpi\Form\QuestionType\QuestionTypeNumber;
 use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
@@ -885,5 +887,54 @@ class AnswersHandlerTest extends DbTestCase
 
         // Assert: no assertions, we just make sure no fatal errors occurred
         $this->assertNotNull($set);
+    }
+
+    /**
+     * Regression test for https://github.com/glpi-project/glpi/issues/23210
+     */
+    public function testAnswerForConditionnalCheckboxIsDisplayed(): void
+    {
+        // Arrange: create a form with a condition on a checkbox
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Do you like GLPI?",
+            type: QuestionTypeCheckbox::class,
+            extra_data: json_encode(new QuestionTypeSelectableExtraDataConfig([
+                'fake-uuid' => 'Yes',
+            ])),
+        );
+        $builder->addQuestion("Tell us why", QuestionTypeShortText::class);
+        $builder->setQuestionVisibility(
+            "Tell us why",
+            VisibilityStrategy::VISIBLE_IF,
+            [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "Do you like GLPI?",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => ["fake-uuid"],
+                ],
+            ]
+        );
+        $form = $this->createForm($builder);
+
+        // Act: send anwsers for this form
+        $this->login();
+        $handler = AnswersHandler::getInstance();
+        $input = [
+            // "" simulate the default empty value that is always sent by the HTML form.
+            $this->getQuestionId($form, "Do you like GLPI?") => ["", "fake-uuid"],
+            $this->getQuestionId($form, "Tell us why") => "Because it is great",
+        ];
+        $input = $handler->removeUnusedAnswers($form, $input);
+        $answers = $handler->saveAnswers($form, $input, Session::getLoginUserID());
+
+        // Assert: ticket description should contain both answers
+        $ticket = $answers->getCreatedItems()[0];
+        $this->assertEquals(
+            "<p><b>1) Do you like GLPI?</b>: Yes<br><b>2) Tell us why</b>: Because it is great<br></p>",
+            $ticket->fields['content'],
+        );
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Given this form:
<img width="1519" height="721" alt="image" src="https://github.com/user-attachments/assets/35a5d757-0522-4320-bcbf-dc00340297f7" />

And these submitted answers:
<img width="1021" height="355" alt="image" src="https://github.com/user-attachments/assets/8eb09091-a01c-4625-a49c-b261a49cca4f" />

It would create a ticket like this (notice the second answer is missing):
<img width="780" height="226" alt="image" src="https://github.com/user-attachments/assets/0c095da3-137b-4366-8ef3-89b0206ba0d4" />

This was caused by the default value for the checkboxes being sent to the backend along the real answer:
<img width="570" height="53" alt="image" src="https://github.com/user-attachments/assets/4b4a569c-42fc-4329-a0dc-6d3c04889500" />

So on the backend it messed up the condition as we compare ['', 'Yes'] to ['Yes'].
Fixing it on the client can be messy because we need this default hidden input in case the user doesn't select any value.

I've chosen to fix it on the backend instead where we can safely ignore empty values when handling array comparisons as they are not valid options anyway.

## References

Fix #23210.


