### PR TITLE
fix(forms): Encode raw answers from short answer questions

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
@@ -78,6 +78,14 @@ final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implem
     }
 
     #[Override]
+    public function formatRawAnswer(mixed $answer, Question $question): string
+    {
+        $formatted_answer = parent::formatRawAnswer($answer, $question);
+
+        return \htmlescape($formatted_answer);
+    }
+
+    #[Override]
     public function listTranslationsHandlers(Question $question): array
     {
         return [

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
@@ -92,7 +92,7 @@ final class ContentFieldTest extends DbTestCase
         $ticket = $this->sendFormAndAssertTicketContentContains(
             expected_content: [
                 "<b>1) First name</b>: John &lt;john@doe.fr&gt;",
-                "<b>2) Last name</b>: Doe"
+                "<b>2) Last name</b>: Doe",
             ],
             form: $form,
             answers: [

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
@@ -83,6 +83,40 @@ final class ContentFieldTest extends DbTestCase
         );
     }
 
+    public function testAnswersAfterQuestionWithAngleBracketsAreDisplayed(): void
+    {
+        $this->login();
+        $form = $this->createAndGetFormWithFirstAndLastNameQuestions();
+
+        // Act: send form with answer containing angle brackets
+        $ticket = $this->sendFormAndAssertTicketContentContains(
+            expected_content: [
+                "<b>1) First name</b>: John &lt;john@doe.fr&gt;",
+                "<b>2) Last name</b>: Doe"
+            ],
+            form: $form,
+            answers: [
+                "First name" => "John <john@doe.fr>",
+                "Last name"  => "Doe",
+            ],
+            config: null,
+        );
+
+        // Assert: content is correctly escaped in ticket content field
+        $this->assertStringContainsString('John &lt;john@doe.fr&gt;', $ticket->fields['content']);
+        $this->assertStringNotContainsString('John <john@doe.fr>', $ticket->fields['content']);
+
+        // Act: display content in ticket
+        ob_start();
+        $ticket->showForm($ticket->getID());
+        $output = ob_get_clean();
+
+        // Assert: find two lines
+        $this->assertNotFalse($output);
+        $this->assertStringContainsString('<b>1) First name</b>: John &lt;john&#64;doe.fr&gt;', $output);
+        $this->assertStringContainsString("<b>2) Last name</b>: Doe", $output);
+    }
+
     public function testSpecificContent(): void
     {
         $this->sendFormAndAssertTicketContentEquals(
@@ -98,11 +132,13 @@ final class ContentFieldTest extends DbTestCase
         Form $form,
         array $answers,
         ?SimpleValueConfig $config,
-    ): void {
+    ): Ticket {
         $ticket = $this->sendForm($form, $config, $answers);
         foreach ($expected_content as $expected) {
             $this->assertStringContainsString($expected, $ticket->fields['content']);
         }
+
+        return $ticket;
     }
 
     private function sendFormAndAssertTicketContentEquals(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Answers to short questions containing angle brackets (`</>`) were interpreted as HTML, causing the text displayed in the ticket to be truncated—special characters are now escaped using `htmlspecialchars`, and a functional test covers this scenario.