### PR TITLE
fix(form-migration): Use form UUID instead of a specific combination of properties for reconciliation

### DIFF
--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -99,6 +99,7 @@ use LogicException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
+use Ramsey\Uuid\Uuid;
 use Ticket;
 
 final class FormMigrationTest extends DbTestCase
@@ -3959,6 +3960,51 @@ final class FormMigrationTest extends DbTestCase
 
         // Assert: migration should be done without error
         $this->assertTrue($result->isFullyProcessed());
+    }
+
+    public function testFormMigrationWithDuplicateFormNames(): void
+    {
+        global $DB;
+
+        // Arrange: create two formcreator forms with the exact same name, entity
+        // and category. This reproduces a real-world scenario where users had
+        // duplicated form names in formcreator.
+        $duplicate_name = 'Duplicate form name test';
+        $this->createSimpleFormcreatorForm(
+            name: $duplicate_name,
+            questions: [
+                ['name' => 'Question in first form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => Uuid::uuid4(),
+            ]
+        );
+        $this->createSimpleFormcreatorForm(
+            name: $duplicate_name,
+            questions: [
+                ['name' => 'Question in second form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => Uuid::uuid4(),
+            ]
+        );
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Assert: both forms must have been migrated as distinct GLPI forms.
+        $migrated_forms = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => Form::getTable(),
+            'WHERE'  => ['name' => $duplicate_name],
+        ]);
+        $this->assertEquals(
+            2,
+            $migrated_forms->count(),
+            'Two distinct forms should have been created, one per formcreator form'
+        );
     }
 
     public function testFormMigrationActorsWithEmptyDefaultValue(): void


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43197

This pull request improves the migration process for forms by ensuring that forms with duplicate names are handled correctly and that the `uuid` field is consistently migrated and used as a unique identifier. The changes also include a new test to verify proper migration behavior in cases where form names are duplicated.