### PR TITLE
KB visiblity dates

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -269,6 +269,11 @@
     }
 }
 
+// KB visibility dates
+.kb-schedule-panel {
+    min-width: 280px;
+}
+
 // Handle shared borders for comments in the same thread.
 .kb-comment-card {
     border-radius: 0 !important;

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global glpi_ajax_dialog, glpi_alert, glpi_confirm_danger, glpi_toast_error, glpi_toast_info, getAjaxCsrfToken */
+/* global glpi_ajax_dialog, glpi_alert, glpi_confirm_danger, glpi_toast_error, glpi_toast_info, getAjaxCsrfToken, bootstrap */
 
 import { get, post } from "/js/modules/Ajax.js";
 import { DocumentLinkController } from "/js/modules/Knowbase/DocumentLinkController.js";
@@ -145,6 +145,7 @@ export class GlpiKnowbaseArticleController
                 container.dataset.glpiKbExistingTranslations
             );
             this.#initTranslationMode();
+            this.#initVisibilityDates();
         }
 
         if (mode === 'add') {
@@ -291,6 +292,21 @@ export class GlpiKnowbaseArticleController
             case 'OPEN_MODAL':
                 this.#openModal(params.id, params.key, params.title);
                 break;
+            case 'SCHEDULE_VISIBILITY': {
+                // Show indicator
+                const indicator   = this.#getScheduledArticleIndicator();
+                const toggle_link = this.#getScheduleDropdownToggle();
+                indicator.classList.remove('d-none');
+
+                // Open the dropdown.
+                // Defer show() so that Bootstrap's clearMenus handler (fired
+                // as the triggering click propagates to document) does not
+                // immediately close the dropdown we are about to open.
+                requestAnimationFrame(() => {
+                    bootstrap.Dropdown.getOrCreateInstance(toggle_link).show();
+                });
+                break;
+            }
         }
     }
 
@@ -553,6 +569,59 @@ export class GlpiKnowbaseArticleController
             } catch (e) {
                 checkbox.checked = !value;
                 throw e;
+            }
+        });
+    }
+
+    #initVisibilityDates()
+    {
+        // Gather target nodes
+        const panel       = this.#container.querySelector('[data-glpi-kb-schedule-panel]');
+        const begin_input = panel.querySelector('[data-glpi-kb-begin-date]');
+        const end_input   = panel.querySelector('[data-glpi-kb-end-date]');
+        const apply_btn   = panel.querySelector('[data-glpi-kb-schedule-apply]');
+        const cancel_btn  = panel.querySelector('[data-glpi-kb-schedule-cancel]');
+        const indicator   = this.#getScheduledArticleIndicator();
+        const toggle_link = this.#getScheduleDropdownToggle();
+
+        // Close the dropdown panel on cancel
+        cancel_btn.addEventListener('click', () => {
+            bootstrap.Dropdown.getOrCreateInstance(toggle_link).hide();
+            // Re-hide the indicator if no dates are actually set as the item
+            // won't be "Scheduled".
+            if (!begin_input.value && !end_input.value && indicator) {
+                indicator.classList.add('d-none');
+            }
+        });
+
+        // Save value to backend on apply
+        apply_btn.addEventListener('click', async () => {
+            // Read form values
+            const begin_date = begin_input.value || null;
+            const end_date   = end_input.value || null;
+
+            // Apply loading state feedback to the submit button
+            const original_html = apply_btn.innerHTML;
+            apply_btn.disabled = true;
+            apply_btn.innerHTML = `<i class="ti ti-loader me-1"></i>${__('Saving...')}`;
+
+            try {
+                // Sent value to backend
+                await post(`Knowbase/${this.#item_id}/UpdateVisibilityDates`, {
+                    begin_date,
+                    end_date,
+                });
+
+                // Close dropdown panel and remove the indicator if both dates
+                // were set to null.
+                indicator.classList.toggle('d-none', !begin_date && !end_date);
+                bootstrap.Dropdown.getOrCreateInstance(toggle_link).hide();
+
+                glpi_toast_info(__('Visibility dates updated'));
+            } finally {
+                // Restore submit button
+                apply_btn.disabled = false;
+                apply_btn.innerHTML = original_html;
             }
         });
     }
@@ -1146,5 +1215,19 @@ export class GlpiKnowbaseArticleController
         } else {
             delete_btn.classList.add('d-none');
         }
+    }
+
+    #getScheduledArticleIndicator()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-kb-visibility-dates-indicator]'
+        );
+    }
+
+    #getScheduleDropdownToggle()
+    {
+        return this.#container.querySelector(
+            '[data-glpi-kb-toggle-visibility-dates]'
+        );
     }
 }

--- a/src/Glpi/Controller/Knowbase/UpdateVisibilityDatesController.php
+++ b/src/Glpi/Controller/Knowbase/UpdateVisibilityDatesController.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Controller\CrudControllerTrait;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+use function Safe\json_decode;
+
+final class UpdateVisibilityDatesController extends AbstractController
+{
+    use CrudControllerTrait;
+
+    #[Route(
+        "/Knowbase/{id}/UpdateVisibilityDates",
+        name: "knowbase_update_visibility_dates",
+        methods: ["POST"],
+        requirements: [
+            'id' => '\d+',
+        ]
+    )]
+    public function __invoke(int $id, Request $request): JsonResponse
+    {
+        // Decode data
+        $data = json_decode($request->getContent(), true);
+
+        // Build update input
+        $update_input = [];
+        if (array_key_exists('begin_date', $data)) {
+            $update_input['begin_date'] = $data['begin_date'] ?: null;
+        }
+        if (array_key_exists('end_date', $data)) {
+            $update_input['end_date'] = $data['end_date'] ?: null;
+        }
+        if ($update_input === []) {
+            return new JsonResponse(['error' => 'No fields provided'], 400);
+        }
+
+        // Execute update
+        $this->update(
+            KnowbaseItem::class,
+            $id,
+            $update_input,
+        );
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/src/Glpi/Knowbase/EditorActionType.php
+++ b/src/Glpi/Knowbase/EditorActionType.php
@@ -40,4 +40,5 @@ enum EditorActionType: string
     case TOGGLE_VALUE = 'TOGGLE_VALUE';
     case DELETE_ARTICLE = 'DELETE_ARTICLE';
     case OPEN_MODAL = 'OPEN_MODAL';
+    case SCHEDULE_VISIBILITY = 'SCHEDULE_VISIBILITY';
 }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -867,6 +867,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             $params['existing_translations'] = array_values(KnowbaseItemTranslation::getAlreadyTranslatedForItem($this));
             $params['default_language']      = $CFG_GLPI['language'];
 
+            // Visibility dates
+            $params['begin_date'] = $this->fields['begin_date'];
+            $params['end_date']   = $this->fields['end_date'];
+
             // Add actions
             $params['actions'] = $mode === "edit" ? $this->getEditorActions() : [];
         } elseif ($mode === "add") {
@@ -1057,6 +1061,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                     'key' => 'SidePanel/permissions',
                     'title' => _n('Target', 'Targets', Session::getPluralNumber()),
                 ],
+            );
+            $actions[] = new EditorAction(
+                label: __('Schedule visibility'),
+                icon: 'ti ti-calendar-clock',
+                type: EditorActionType::SCHEDULE_VISIBILITY,
+                params: [],
             );
         }
 

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -240,6 +240,7 @@
         'readonly': false,
         'disabled': false,
         'maybeempty': false,
+        'addCalendarButton': true,
     }|merge(options) %}
 
     {% set editable = not options.readonly and not options.disabled %}
@@ -284,7 +285,7 @@
             'clearable': false
         })) }}
 
-        {% if editable %}
+        {% if editable and options.addCalendarButton %}
             {% set calendar_icon = options.enableTime ? 'ti ti-calendar-time' : 'ti ti-calendar' %}
             <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
                 <i class="{{ calendar_icon }}"></i>

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
+
 <div
     class="d-flex mx-n2 my-n2 pe-none"
     data-glpi-knowbase-article
@@ -267,7 +269,92 @@
                         </a>
                     </div>
                 {% endif %}
+
+                {# Visibility dates indicator #}
+                {% if (begin_date is defined or end_date is defined) and mode == 'edit' and can_edit %}
+                    {% set has_dates = (begin_date is defined and begin_date is not null) or (end_date is defined and end_date is not null) %}
+                    <div
+                        class="d-flex align-items-center position-relative {{ not has_dates ? 'd-none' : '' }}"
+                        data-glpi-kb-visibility-dates-indicator
+                        data-testid="visibility-dates-indicator"
+                    >
+                        <div
+                            data-bs-toggle="dropdown"
+                            {# Auto close must be kept disabled due to issues with flat picker.
+                               Without it, changing the month/year in flat picker will close the
+                               dropdown #}
+                            data-bs-auto-close="false"
+                            data-glpi-kb-toggle-visibility-dates
+                            aria-expanded="false"
+                        >
+                            <i class="ti ti-calendar-clock me-1 fs-3"></i>
+                            <a
+                                href="#"
+                                class="text-muted"
+                            >
+                                {{ __("Scheduled") }}
+                            </a>
+                        </div>
+                        <div
+                            class="dropdown-menu kb-schedule-panel p-3"
+                            data-glpi-kb-schedule-panel
+                            data-testid="schedule-panel"
+                            role="dialog"
+                            aria-label="{{ __('Schedule visibility') }}"
+                        >
+                            <p class="fw-semibold mb-2 small text-muted text-uppercase">
+                                {{ __('Schedule visibility') }}
+                            </p>
+                            <div class="mb-2">
+                                <label
+                                    class="form-label small mb-1"
+                                    for="kb_begin_date_input"
+                                >{{ __('Visible from') }}</label>
+                                {{ inputs.date('begin_date', begin_date ?? '', {
+                                    id: "kb_begin_date",
+                                    enableTime: true,
+                                    input_addclass: "form-control-sm",
+                                    addCalendarButton: false,
+                                    additional_attributes: {
+                                        placeholder: __('No start date'),
+                                        'data-glpi-kb-begin-date': "",
+                                    }
+                                }) }}
+                            </div>
+                            <div class="mb-3">
+                                <label
+                                    class="form-label small mb-1"
+                                    for="kb_end_date_input"
+                                >{{ __('Until') }}</label>
+                                {{ inputs.date('end_date', end_date ?? '', {
+                                    id: "kb_end_date",
+                                    enableTime: true,
+                                    input_addclass: "form-control-sm",
+                                    addCalendarButton: false,
+                                    additional_attributes: {
+                                        placeholder: __('No end date'),
+                                        'data-glpi-kb-end-date': "",
+                                    }
+                                }) }}
+                            </div>
+                            <div class="d-flex justify-content-end gap-2">
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-secondary"
+                                    data-glpi-kb-schedule-cancel
+                                >{{ __('Cancel') }}</button>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-primary"
+                                    data-glpi-kb-schedule-apply
+                                    data-testid="schedule-apply-btn"
+                                >{{ __('Apply') }}</button>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
+
         {% endif %}
 
         <hr class="mt-4 mb-4">

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -178,4 +178,34 @@ export class KnowbaseItemPage extends GlpiPage
         // Wait for page reload after upload
         await this.page.waitForLoadState('load');
     }
+
+    public async doEnableSchedulePanel(): Promise<void>
+    {
+        await this.page.getByTitle('More actions').click();
+        await this.getButton('Schedule visibility').click();
+        await expect(this.page.getByTestId('schedule-panel')).toBeVisible();
+    }
+
+    public async doApplyVisibilityDates(): Promise<void>
+    {
+        // Save values
+        await this.page.getByTestId('schedule-apply-btn').click();
+        await expect(this.getAlert('Visibility dates updated')).toBeVisible();
+    }
+
+    public getVisibilityDatesIndicator(): Locator
+    {
+        return this.getLink("Scheduled");
+    }
+
+    public getScheduledStartDateInput(): Locator
+    {
+        return this.page.getByPlaceholder('No start date').filter({visible: true});
+    }
+
+    public getScheduledEndDateInput(): Locator
+    {
+        return this.page.getByPlaceholder('No end date').filter({visible: true});
+    }
 }
+

--- a/tests/e2e/specs/Knowbase/visibility_dates.spec.ts
+++ b/tests/e2e/specs/Knowbase/visibility_dates.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from "../../fixtures/glpi_fixture";
+import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
+import { Profiles } from "../../utils/Profiles";
+import { getWorkerEntityId } from "../../utils/WorkerEntities";
+
+test('Can set visibility dates and see the indicator', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create an article without start/end dates
+    const id = await api.createItem('KnowbaseItem', {
+        name       : 'KB article for set dates test',
+        answer     : 'Test content',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await kb.goto(id);
+
+    // Indicator should not be visible before any dates are set
+    await expect(kb.getVisibilityDatesIndicator()).toBeHidden();
+
+    // Open panel and set dates
+    await kb.doEnableSchedulePanel();
+    await kb.getScheduledStartDateInput().fill('2026-05-01 00:00:00');
+    await kb.getScheduledStartDateInput().press('Tab');
+    await kb.getScheduledEndDateInput().fill('2026-12-31 23:59:00');
+    await kb.getScheduledEndDateInput().press('Tab');
+    await kb.doApplyVisibilityDates();
+
+    // Indicator should now be visible
+    await expect(kb.getVisibilityDatesIndicator()).toBeVisible();
+    await expect(kb.getVisibilityDatesIndicator()).toContainText('Scheduled');
+
+    // Reload and confirm dates are persisted
+    await kb.goto(id);
+    await expect(kb.getVisibilityDatesIndicator()).toBeVisible();
+    await kb.getVisibilityDatesIndicator().click();
+    await expect(kb.getScheduledStartDateInput()).toHaveValue('2026-05-01 00:00:00');
+    await expect(kb.getScheduledEndDateInput()).toHaveValue('2026-12-31 23:59:00');
+});
+
+test('Can clear visibility dates and the indicator disappears', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Create an article with start/end dates
+    const id = await api.createItem('KnowbaseItem', {
+        name       : 'KB article for clear dates test',
+        answer     : 'Test content',
+        begin_date : '2026-05-01 00:00:00',
+        end_date   : '2026-12-31 23:59:00',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await kb.goto(id);
+
+    // Indicator should be visible since dates are set, click it to edit values
+    await kb.getVisibilityDatesIndicator().click();
+
+    // Clear both dates and apply
+    await kb.getScheduledStartDateInput().clear();
+    await kb.getScheduledStartDateInput().press('Tab');
+    await kb.getScheduledEndDateInput().clear();
+    await kb.getScheduledEndDateInput().press('Tab');
+    await kb.doApplyVisibilityDates();
+
+    // Indicator should disappear
+    await expect(kb.getVisibilityDatesIndicator()).toBeHidden();
+
+    // Reload and confirm cleared state is persisted
+    await kb.goto(id);
+    await expect(kb.getVisibilityDatesIndicator()).toBeHidden();
+    await kb.doEnableSchedulePanel();
+    await expect(kb.getScheduledStartDateInput()).toHaveValue('');
+    await expect(kb.getScheduledEndDateInput()).toHaveValue('');
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Add support for the begin_date/end_date parameters in the new KB UI?

Theses date may be added on an article using the "Schedule" action:
<img width="284" height="360" alt="image" src="https://github.com/user-attachments/assets/49969bf1-eb06-44dc-9bf6-e2181b988bd9" />

This trigger a dropdown menu attached to a "Scheduled" indicator in the document header:
<img width="1115" height="340" alt="image" src="https://github.com/user-attachments/assets/917954af-dd02-4e20-9570-534ba9aa10fa" />

Once scheduled, the "Schedule" indicator in the header will be visible on the article.

Later on, if both dates are cleared it disappears.


