### PR TITLE
feat(planning): show "List" in header for list view and add tooltips to calendar/refresh icons

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -122,7 +122,7 @@ var GLPIPlanning  = {
                 listFull: {
                     type: 'list',
                     titleFormat: function() {
-                        return '';
+                        return __('List');
                     },
                     visibleRange: function(currentDate) {
                         var current_year = currentDate.getFullYear();
@@ -396,8 +396,21 @@ var GLPIPlanning  = {
                     .after(
                         $('<i id="refresh_planning" class="ti ti-refresh pointer"></i>')
                     ).after(
-                        $('<div id="planning_datepicker"><a data-toggle><i class="ti ti-calendar pointer"></i></a>')
+                        $('<div id="planning_datepicker"><a data-toggle><i id="planning_calendar_btn" class="ti ti-calendar pointer"></i></a>')
                     );
+
+                $('#refresh_planning').qtip({
+                    position: { viewport: $(window) },
+                    content: { text: __('Refresh') },
+                    style: { classes: 'qtip-shadow qtip-bootstrap' },
+                    hide: { fixed: true, delay: 200, leave: false }
+                });
+                $('#planning_calendar_btn').qtip({
+                    position: { viewport: $(window) },
+                    content: { text: __('Calendar') },
+                    style: { classes: 'qtip-shadow qtip-bootstrap' },
+                    hide: { fixed: true, delay: 200, leave: false }
+                });
 
                 // specific process for full list
                 if (view.type == 'listFull') {

--- a/js/planning.js
+++ b/js/planning.js
@@ -407,7 +407,7 @@ var GLPIPlanning  = {
                 });
                 $('#planning_calendar_btn').qtip({
                     position: { viewport: $(window) },
-                    content: { text: __('Calendar') },
+                    content: { text: _n('Calendar', 'Calendars', 1) },
                     style: { classes: 'qtip-shadow qtip-bootstrap' },
                     hide: { fixed: true, delay: 200, leave: false }
                 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

Two UI fixes in the Planning view (`js/planning.js`):

- **List view title**: `listFull` view's `titleFormat` returned `''`, leaving the `fc-center` h2 blank. Changed to `return __('List')` — consistent with how other views (Month, Week, Day, Timeline Week) populate the header title.

- **Icon tooltips**: Added qtip tooltips to the `ti-refresh` and `ti-calendar` icons injected into the planning toolbar. Tooltips use `__('Refresh')` and `__('Calendar')` and are initialized inside `datesRender` (where the icons are created) because FullCalendar replaces `.fc-center` content on each render, requiring per-render tooltip binding. The `planning_calendar_btn` ID was added to the calendar icon to make it targetable. Options mirror what `Html::showToolTip` generates (`qtip-shadow qtip-bootstrap` style, hover/fixed-hide behavior).

## Screenshots (if appropriate):

<img width="989" height="424" alt="image" src="https://github.com/user-attachments/assets/7f333bad-5b1a-4a93-a76e-ee77c3d62f83" />
