### PR TITLE
Add GLPI-specific architecture and coding rules to Copilot instructions and up-to-date structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-GLPI is a Free Asset and IT Management Software written in PHP 8.3+, Symfony 6.4, Vue 3 for frontend, and Playwright for E2E testing. Use the GLPI framework whenever possible.
+GLPI is a Free Asset and IT Management Software written in PHP 8.3+, Symfony 6.4, Twig and some Vue 3 for frontend, and Playwright for E2E testing. Use the GLPI framework whenever possible.
 
 ## Repository Structure
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,11 @@ Do not ask clarification questions, except when a real choice between two techni
 Do not generate tests unless requested.
 When generating code, always ensure it is secure and free from vulnerabilities.
 When importing libraries or packages, prefer already imported ones; if using new ones, they must be compatible with GLPI GPLv3+ License.
+Do not introduce service classes, repositories, DTOs, or dependency injection. GLPI uses static methods, CommonDBTM hooks, `global $DB`, and arrays. Follow existing patterns; never "improve" with external architecture patterns.
+Always reference item types using `ClassName::class`, never string literals such as `'Computer'`.
+Always use `$item->can($id, RIGHT)` for permission checks — never `canUpdateItem()`, `canViewItem()`, or `canDeleteItem()` directly. These methods skip global profile rights verification.
+Front controllers are thin routing layers only. Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()`, not in front controllers or AJAX endpoints.
+Never use `var_dump()`, `print_r()`, or `echo` for debugging. Use `Toolbox::logDebug()`, `Toolbox::logInfo()`, or `Toolbox::logError()`.
 
 ## End-to-end tests (Playwright)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,113 +1,41 @@
-Follow GLPI’s latest coding standards and best practices: naming, indentation, comments, and PER Coding Style 3.0 compliance.
-Use the GLPI framework whenever possible.
-Use the snake_case variable naming convention.
-Do not use deprecated code.
-Do not use PHP features older than version 8.3.
-Do not use GLPI code or APIs older than version 11.0.
-Never create .md or .txt files to explain changes.
-Never explain what you did.
-Do not add unnecessary comments or TODO notes.
-Follow the MVC pattern, routing, and controllers wherever possible.
-Do not create /front/ files — always use controllers and routes if possible.
-Never output raw HTML with echo; always use Twig templates.
-Never execute raw SQL — always use GLPI’s ORM and database abstraction layer.
-Do not ask clarification questions, except when a real choice between two technical solutions must be made.
-Do not generate tests unless requested.
-When generating code, always ensure it is secure and free from vulnerabilities.
-When importing libraries or packages, prefer already imported ones; if using new ones, they must be compatible with GLPI GPLv3+ License.
-Do not introduce service classes, repositories, DTOs, or dependency injection. GLPI uses static methods, CommonDBTM hooks, `global $DB`, and arrays. Follow existing patterns; never "improve" with external architecture patterns.
-Always reference item types using `ClassName::class`, never string literals such as `'Computer'`.
-Always use `$item->can($id, RIGHT)` for permission checks — never `canUpdateItem()`, `canViewItem()`, or `canDeleteItem()` directly. These methods skip global profile rights verification.
-Front controllers are thin routing layers only. Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()`, not in front controllers or AJAX endpoints.
-Never use `var_dump()`, `print_r()`, or `echo` for debugging. Use `Toolbox::logDebug()`, `Toolbox::logInfo()`, or `Toolbox::logError()`.
+# GLPI — Copilot Instructions
 
-## End-to-end tests (Playwright)
+## Project Overview
 
-Before writing or modifying any e2e test, read existing tests in `tests/e2e/specs/` and page objects in `tests/e2e/pages/` to understand established patterns and conventions.
+GLPI is a Free Asset and IT Management Software written in PHP 8.3+, Symfony 6.4, Vue 3 for frontend, and Playwright for E2E testing. Use the GLPI framework whenever possible.
 
-Update these instructions if you learn new information.
+## Repository Structure
 
-### Page Object Model
+- `src/Glpi/` — modern PHP code (controllers, API, assets, helpdesk)
+- `inc/` — legacy code being migrated
+- `templates/` — Twig templates
+- `js/` — JavaScript/Vue source
+- `tests/functional/` — PHPUnit tests
+- `tests/e2e/` — Playwright E2E tests
 
-Always use the Page Object Model pattern. Locators and reusable interactions must live in page classes under `tests/e2e/pages/`, not in spec files.
+## Build & Test Commands
 
-- Every page class extends `GlpiPage` (defined in `tests/e2e/pages/GlpiPage.ts`), which provides helper methods such as `getButton()`, `getLink()`, `getCheckbox()`, `getTextbox()`, `getTab()`, `getRegion()`, `getHeading()`, `getRadio()`, `getSpinButton()`, `getDropdownByLabel()`, `getRichTextByLabel()`, and common actions like `doSetDropdownValue()`, `doAddNote()`, `doLogout()`, etc.
-- Declare locators as public readonly properties initialized in the constructor.
-- Expose user-facing actions as `async do*()` methods on the page object.
-- Spec files should only contain test logic; all element access goes through page objects.
+All commands run inside Docker containers via `make`:
 
-### Selectors
-
-Use Playwright's semantic locators exclusively — prefer `getByRole()`, `getByLabel()`, `getByTestId()`, `getByText()`, `getByTitle()`, `getByAltText()`, and the helper methods inherited from `GlpiPage`.
-
-- **Never use raw CSS or XPath selectors** (`page.locator(...)`) unless there is absolutely no semantic alternative. When a raw locator is unavoidable, add `// eslint-disable-next-line playwright/no-raw-locators` on the line above.
-- Before adding a raw locator, **you MUST first attempt all of the following alternatives** in order:
-  1. Use existing semantic attributes (`role`, `aria-label`, `title`, `alt`, `data-testid`).
-  2. Add an `aria-label` attribute so the element can be targeted with `getByRole()`.
-  3. Add a `data-testid` attribute to the element in the Twig template, PHP source, or JavaScript that generates it.
-  4. Only after exhausting options 1–3 may you use a raw locator with the eslint-disable comment.
-- Targeting elements by `data-glpi-*` attributes with `page.locator('[data-glpi-...]')` **is a raw locator** and is **not allowed**. Add a `data-testid` attribute instead and use `getByTestId()`.
-
-
-### Tab navigation
-
-Use the `forcetab` URL parameter to navigate directly to a specific tab instead of clicking tab elements:
-
-```typescript
-await page.goto(`/front/computer.form.php?id=${id}&forcetab=ItemVirtualMachine$1`);
+```bash
+make vendor                                         # Install PHP dependencies
+make phpunit c='tests/functional/Glpi/MyTest.php'  # Run PHPUnit tests
+make playwright c=tests/e2e/specs/<file>            # Run E2E tests
+make lint                                           # All linters
+make phpcsfixer-fix                                 # Fix PHP coding standards
 ```
 
-To find forcetab IDs, check `getTabNameForItem()` and `defineTabs()` in the relevant PHP class. The default form tab uses `ClassName$main`; numbered tabs follow the keys defined in `getTabNameForItem()` (e.g., `User$1`, `Glpi\Asset\AssetDefinition$2`).
+**CRITICAL**: Never run `npx`, `node`, `npm`, `eslint`, or `tsc` directly — all commands must go through `make` targets (Docker).
 
-Page objects should accept an optional `tab` parameter in navigation methods:
+## General Rules
 
-```typescript
-public async goto(id: number, tab?: string): Promise<void> {
-    let url = `/front/computer.form.php?id=${id}`;
-    if (tab) {
-        url += `&forcetab=${tab}`;
-    }
-    await this.page.goto(url);
-}
-```
-
-Only click tabs directly when you need to set up `page.route()` intercepts before the tab content loads.
-
-### Accessibility testing
-
-Use `@axe-core/playwright` (`AxeBuilder`) for accessibility checks, scoped to the relevant page section:
-
-```typescript
-import AxeBuilder from '@axe-core/playwright';
-
-const a11y_results = await new AxeBuilder({ page })
-    .include('[data-testid="my-component"]')
-    .analyze();
-expect(a11y_results.violations).toEqual([]);
-```
-
-### Linting
-
-All e2e test code must pass lint checks. Run the following command and fix any errors before considering the work done:
-
-```sh
-make lint-playwright lint-js
-```
-
-### Running tests
-
-Always run the relevant tests to validate changes. Use the following command with the correct path to the spec file:
-
-```sh
-make playwright c=tests/e2e/specs/<path-to-spec-file>
-```
-
-Do not skip this step — tests must pass before the task is complete.
-
-### CRITICAL: Always use Makefile commands
-
-**NEVER** run `npx`, `node`, `npm`, `eslint`, `tsc`, or any Node.js tool directly. All commands **MUST** go through `make` targets because the tooling runs inside Docker containers. Direct invocations will fail.
-
-### Test fixtures and utilities
-
-Use the custom GLPI fixture (`tests/e2e/fixtures/glpi_fixture.ts`) which provides `page`, `profile`, `entity`, `csrf`, `formImporter`, and `api` helpers. Use the `api` fixture to create test data instead of navigating the UI for setup.
+- Follow PER Coding Style 3.0; use PHP 8.3+ features only; no deprecated code; no GLPI APIs older than v11.0.
+- Follow the MVC pattern — do not create `/front/` files; always use controllers and routes.
+- Never output raw HTML with `echo` — always use Twig templates.
+- Never execute raw SQL — always use GLPI's ORM and database abstraction layer.
+- When adding a library, prefer already-imported ones; new dependencies must be GPLv3+ compatible.
+- Always ensure generated code is secure and free from vulnerabilities.
+- Do not ask clarification questions unless a real technical choice must be made.
+- Do not generate tests unless requested.
+- Never create `.md` or `.txt` files to explain changes; never explain what you did.
+- Do not add unnecessary comments or TODO notes.

--- a/.github/instructions/e2e.instructions.md
+++ b/.github/instructions/e2e.instructions.md
@@ -1,0 +1,78 @@
+---
+applyTo: "tests/e2e/**"
+---
+
+# End-to-end Tests (Playwright)
+
+Before writing or modifying any e2e test, read existing tests in `tests/e2e/specs/` and page objects in `tests/e2e/pages/` to understand established patterns and conventions.
+
+## Page Object Model
+
+Always use the Page Object Model pattern. Locators and reusable interactions must live in page classes under `tests/e2e/pages/`, not in spec files.
+
+- Every page class extends `GlpiPage` (defined in `tests/e2e/pages/GlpiPage.ts`), which provides helper methods such as `getButton()`, `getLink()`, `getCheckbox()`, `getTextbox()`, `getTab()`, `getRegion()`, `getHeading()`, `getRadio()`, `getSpinButton()`, `getDropdownByLabel()`, `getRichTextByLabel()`, and common actions like `doSetDropdownValue()`, `doAddNote()`, `doLogout()`, etc.
+- Declare locators as public readonly properties initialized in the constructor.
+- Expose user-facing actions as `async do*()` methods on the page object.
+- Spec files should only contain test logic; all element access goes through page objects.
+
+## Selectors
+
+Use Playwright's semantic locators exclusively — prefer `getByRole()`, `getByLabel()`, `getByTestId()`, `getByText()`, `getByTitle()`, `getByAltText()`, and the helper methods inherited from `GlpiPage`.
+
+- **Never use raw CSS or XPath selectors** (`page.locator(...)`) unless there is absolutely no semantic alternative. When a raw locator is unavoidable, add `// eslint-disable-next-line playwright/no-raw-locators` on the line above.
+- Before adding a raw locator, **you MUST first attempt all of the following alternatives** in order:
+  1. Use existing semantic attributes (`role`, `aria-label`, `title`, `alt`, `data-testid`).
+  2. Add an `aria-label` attribute so the element can be targeted with `getByRole()`.
+  3. Add a `data-testid` attribute to the element in the Twig template, PHP source, or JavaScript that generates it.
+  4. Only after exhausting options 1–3 may you use a raw locator with the eslint-disable comment.
+- Targeting elements by `data-glpi-*` attributes with `page.locator('[data-glpi-...]')` **is a raw locator** and is **not allowed**. Add a `data-testid` attribute instead and use `getByTestId()`.
+
+## Tab Navigation
+
+Use the `forcetab` URL parameter to navigate directly to a specific tab instead of clicking tab elements:
+
+```typescript
+await page.goto(`/front/computer.form.php?id=${id}&forcetab=ItemVirtualMachine$1`);
+```
+
+To find forcetab IDs, check `getTabNameForItem()` and `defineTabs()` in the relevant PHP class. The default form tab uses `ClassName$main`; numbered tabs follow the keys defined in `getTabNameForItem()` (e.g., `User$1`, `Glpi\Asset\AssetDefinition$2`).
+
+Page objects should accept an optional `tab` parameter in navigation methods:
+
+```typescript
+public async goto(id: number, tab?: string): Promise<void> {
+    let url = `/front/computer.form.php?id=${id}`;
+    if (tab) {
+        url += `&forcetab=${tab}`;
+    }
+    await this.page.goto(url);
+}
+```
+
+Only click tabs directly when you need to set up `page.route()` intercepts before the tab content loads.
+
+## Accessibility Testing
+
+Use `@axe-core/playwright` (`AxeBuilder`) for accessibility checks, scoped to the relevant page section:
+
+```typescript
+import AxeBuilder from '@axe-core/playwright';
+
+const a11y_results = await new AxeBuilder({ page })
+    .include('[data-testid="my-component"]')
+    .analyze();
+expect(a11y_results.violations).toEqual([]);
+```
+
+## Fixtures and Utilities
+
+Use the custom GLPI fixture (`tests/e2e/fixtures/glpi_fixture.ts`) which provides `page`, `profile`, `entity`, `csrf`, `formImporter`, and `api` helpers. Use the `api` fixture to create test data instead of navigating the UI for setup.
+
+## Running & Linting
+
+Always run the relevant tests and fix lint errors before considering the work done:
+
+```sh
+make playwright c=tests/e2e/specs/<path-to-spec-file>
+make lint-playwright lint-js
+```

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -24,6 +24,7 @@ applyTo: "**/*.php"
 
 - In front controllers, use `$item->check($id, RIGHT, $input)` — it throws `AccessDeniedHttpException` automatically on failure.
 - Use `Session::haveRight($module, $right)` only for module-level (global) checks outside of item context.
+- Never use `canUpdateItem()`, `canViewItem()`, or `canDeleteItem()` for access control — they only check entity access and **skip global rights** (`Session::haveRight()`). Always use `$item->can($id, RIGHT)` which enforces both global rights and item-level checks.
 - Use the standard right constants: `READ`, `UPDATE`, `CREATE`, `DELETE`, `PURGE`, `READNOTE`, `UPDATENOTE`, `UNLOCK`, `READ_ASSIGNED`, `UPDATE_ASSIGNED`, `READ_OWNED`, `UPDATE_OWNED`.
 
 ## Database

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -18,7 +18,7 @@ applyTo: "**/*.php"
 - Classes: `PascalCase`
 - Constants: `UPPER_SNAKE`
 - Always reference item types using `ClassName::class`, never string literals such as `'Computer'`.
-- Use `_s()` for all translatable strings; no hardcoded IDs or magic numbers.
+- Use `__s()` for all translatable strings; no hardcoded IDs or magic numbers.
 
 ## Rights
 

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -1,0 +1,29 @@
+---
+applyTo: "**/*.php"
+---
+
+# PHP / GLPI Rules
+
+## Architecture
+
+- Do not introduce service classes, repositories, DTOs, or dependency injection. GLPI uses static methods, CommonDBTM hooks, `global $DB`, and arrays. Follow existing patterns; never "improve" with external architecture patterns.
+- Front controllers are thin routing layers only. Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()`, not in front controllers or AJAX endpoints.
+
+## Naming Conventions
+
+- Variables and array keys: `snake_case`
+- Methods: `camelCase`
+- Classes: `PascalCase`
+- Constants: `UPPER_SNAKE`
+- Always reference item types using `ClassName::class`, never string literals such as `'Computer'`.
+- Use `_s()` for all translatable strings; no hardcoded IDs or magic numbers.
+
+## Rights
+
+- Always use `$item->can($id, RIGHT)` for permission checks.
+- Never use `canUpdateItem()`, `canViewItem()`, or `canDeleteItem()` directly — these methods skip global profile rights verification.
+
+## Debugging
+
+- Never use `var_dump()`, `print_r()`, or `echo` for debugging.
+- Use `Toolbox::logDebug()`, `Toolbox::logInfo()`, or `Toolbox::logError()`.

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -6,8 +6,9 @@ applyTo: "**/*.php"
 
 ## Architecture
 
-- Do not introduce service classes, repositories, DTOs, or dependency injection. GLPI uses static methods, CommonDBTM hooks, `global $DB`, and arrays. Follow existing patterns; never "improve" with external architecture patterns.
-- Front controllers are thin routing layers only. Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()`, not in front controllers or AJAX endpoints.
+- GLPI is transitioning toward service classes (or singleton pseudo-services), DTOs, and dependency injection. Avoid static methods in new code. Follow the patterns used in the surrounding code — do not make architecture decisions autonomously unless specifically requested.
+- Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()` or in dedicated service classes, not in controllers.
+- Do not create new `/front/` or `/ajax/` files. Use controllers in `src/Glpi/Controller/` with Symfony routing.
 - Modern GLPI code lives in `src/` (namespaced as `Glpi\...`). Plugin code goes in `src/` namespaced as `GlpiPlugin\PluginName\...`. Do not add legacy files in `inc/`.
 - Use Twig templates (`templates/`) for all HTML rendering. Never concatenate raw HTML strings in PHP.
 
@@ -18,7 +19,6 @@ applyTo: "**/*.php"
 - Classes: `PascalCase`
 - Constants: `UPPER_SNAKE`
 - Always reference item types using `ClassName::class`, never string literals such as `'Computer'`.
-- Use `__s()` for all translatable strings; no hardcoded IDs or magic numbers.
 
 ## Rights
 
@@ -50,21 +50,6 @@ applyTo: "**/*.php"
 - `cleanDBonPurge()` — Delete related records before permanent deletion. Always call `parent::cleanDBonPurge()` if overriding.
 - `post_getFromDB()` — Enrich `$this->fields` after a DB read. Keep lightweight; do not run extra queries unless necessary.
 - Never override `add()`, `update()`, or `delete()` directly — use the hooks above.
-
-## Front Controllers
-
-- Always start with `require_once(__DIR__ . '/_check_webserver_config.php')`.
-- Check session access early: `Session::checkCentralAccess()` or `Session::checkLoginUser()`.
-- Route on `$_POST` keys (`isset($_POST['add'])`, `isset($_POST['update'])`, `isset($_POST['purge'])`).
-- After every write action, redirect with `Html::redirect($url)` or `Html::back()`. Never render HTML in a POST handler.
-- If no action matches, throw `new BadRequestHttpException()` — never silently return.
-
-## AJAX Endpoints
-
-- Output JSON directly with `echo json_encode($data)`. Do not use `Html::header()` / `Html::footer()`.
-- Always check session and rights before processing: `Session::checkLoginUser()` or `$item->check()`.
-- Return structured arrays: `['success' => true, 'data' => [...]]` for success, `['success' => false, 'error' => '...']` for failure.
-- Never echo arbitrary user input — always sanitize or encode before output.
 
 ## Translations
 
@@ -119,7 +104,7 @@ applyTo: "**/*.php"
 
 ### Privilege Escalation & Entity Isolation
 
-- Every database query that returns user data must be scoped to the current user's entities: use `getMyEntities()` or `'entities_id' => $_SESSION['glpiactive_entity']` in criteria.
+- Every database query that returns user data must be scoped to the current user's entities: use `getEntitiesRestrictCriteria()` to build the appropriate criteria array.
 - When an item has an `entities_id` column, always check `$item->can($id, $right)` — it enforces entity belonging automatically.
 - Never accept `entities_id` from user input without verifying the user has access to that entity: `Session::haveAccessToEntity($entities_id)`.
 
@@ -152,9 +137,6 @@ applyTo: "**/*.php"
 
 ### API Security
 
-- Declare the required OAuth scope in every new API endpoint using the `#[SecurityStrategy]` attribute or by registering the route with the appropriate middleware.
-- Validate IP restrictions via `IPRestrictionRequestMiddleware` — do not roll your own IP check.
-- Generate API client secrets with `bin2hex(random_bytes(...))` and store them encrypted. Never generate tokens with `rand()`, `uniqid()`, or `mt_rand()`.
 - Never return internal stack traces, SQL queries, or filesystem paths in API error responses. Use generic messages and log details server-side.
 
 ### General Rules

--- a/.github/instructions/php.instructions.md
+++ b/.github/instructions/php.instructions.md
@@ -8,6 +8,8 @@ applyTo: "**/*.php"
 
 - Do not introduce service classes, repositories, DTOs, or dependency injection. GLPI uses static methods, CommonDBTM hooks, `global $DB`, and arrays. Follow existing patterns; never "improve" with external architecture patterns.
 - Front controllers are thin routing layers only. Business logic, input validation, and data transformation belong in `prepareInputForAdd()` and `prepareInputForUpdate()`, not in front controllers or AJAX endpoints.
+- Modern GLPI code lives in `src/` (namespaced as `Glpi\...`). Plugin code goes in `src/` namespaced as `GlpiPlugin\PluginName\...`. Do not add legacy files in `inc/`.
+- Use Twig templates (`templates/`) for all HTML rendering. Never concatenate raw HTML strings in PHP.
 
 ## Naming Conventions
 
@@ -20,10 +22,143 @@ applyTo: "**/*.php"
 
 ## Rights
 
-- Always use `$item->can($id, RIGHT)` for permission checks.
-- Never use `canUpdateItem()`, `canViewItem()`, or `canDeleteItem()` directly — these methods skip global profile rights verification.
+- In front controllers, use `$item->check($id, RIGHT, $input)` — it throws `AccessDeniedHttpException` automatically on failure.
+- Use `Session::haveRight($module, $right)` only for module-level (global) checks outside of item context.
+- Use the standard right constants: `READ`, `UPDATE`, `CREATE`, `DELETE`, `PURGE`, `READNOTE`, `UPDATENOTE`, `UNLOCK`, `READ_ASSIGNED`, `UPDATE_ASSIGNED`, `READ_OWNED`, `UPDATE_OWNED`.
+
+## Database
+
+- Always use `$DB->request([...])` with array-based criteria. Never concatenate raw SQL strings or use `$DB->query()` directly.
+- Use `QueryParam` for parameterized values, `QueryExpression` for raw SQL fragments, `QuerySubQuery` for sub-queries.
+- Use `getTable()` / `static::getTable()` to reference table names — never hardcode `glpi_*` table names.
+- Iterate results with `foreach ($DB->request([...]) as $row)` — `DBmysqlIterator` implements `SeekableIterator`.
+- Use `$DB->insert()`, `$DB->update()`, `$DB->delete()` for simple DML; use `$DB->request()` for SELECT.
+- Wrap multi-step writes in transactions: `$DB->beginTransaction()` / `$DB->commit()` / `$DB->rollBack()`.
 
 ## Debugging
 
 - Never use `var_dump()`, `print_r()`, or `echo` for debugging.
 - Use `Toolbox::logDebug()`, `Toolbox::logInfo()`, or `Toolbox::logError()`.
+
+## CommonDBTM Lifecycle Hooks
+
+- `prepareInputForAdd(array $input): array|false` — Validate and transform input before insert. Return `false` to abort.
+- `prepareInputForUpdate(array $input): array|false` — Validate and transform input before update. Return `false` to abort.
+- `post_addItem()` — Side effects after insert (notifications, related records). Access new data via `$this->fields`.
+- `post_updateItem(bool $history = true)` — Side effects after update. Use `$this->updates` (changed field keys) and `$this->oldvalues` (previous values).
+- `cleanDBonPurge()` — Delete related records before permanent deletion. Always call `parent::cleanDBonPurge()` if overriding.
+- `post_getFromDB()` — Enrich `$this->fields` after a DB read. Keep lightweight; do not run extra queries unless necessary.
+- Never override `add()`, `update()`, or `delete()` directly — use the hooks above.
+
+## Front Controllers
+
+- Always start with `require_once(__DIR__ . '/_check_webserver_config.php')`.
+- Check session access early: `Session::checkCentralAccess()` or `Session::checkLoginUser()`.
+- Route on `$_POST` keys (`isset($_POST['add'])`, `isset($_POST['update'])`, `isset($_POST['purge'])`).
+- After every write action, redirect with `Html::redirect($url)` or `Html::back()`. Never render HTML in a POST handler.
+- If no action matches, throw `new BadRequestHttpException()` — never silently return.
+
+## AJAX Endpoints
+
+- Output JSON directly with `echo json_encode($data)`. Do not use `Html::header()` / `Html::footer()`.
+- Always check session and rights before processing: `Session::checkLoginUser()` or `$item->check()`.
+- Return structured arrays: `['success' => true, 'data' => [...]]` for success, `['success' => false, 'error' => '...']` for failure.
+- Never echo arbitrary user input — always sanitize or encode before output.
+
+## Translations
+
+- `__($str)` — Translate, returns raw string (use only when passing to another escaping layer).
+- `__s($str)` — Translate + `htmlspecialchars`. Use for all text output in PHP.
+- `_n($sing, $plural, $nb)` — Pluralized translation (raw).
+- `_sn($sing, $plural, $nb)` — Pluralized + escaped. Preferred in HTML output.
+- `_x($ctx, $str)` — Contextualized translation (raw). Use when the same word has different meanings.
+- `_sx($ctx, $str)` — Contextualized + escaped.
+- Always pass the plugin domain as second argument in plugin code: `__s('My label', 'mypluginname')`.
+- Never use hardcoded user-facing strings without a translation function.
+
+## Error Handling
+
+- Use HTTP exception classes for flow control in controllers:
+  - `throw new AccessDeniedHttpException()` — permission denied
+  - `throw new NotFoundHttpException()` — item not found
+  - `throw new BadRequestHttpException()` — invalid request
+- Use `Session::addMessageAfterRedirect(__s('Message'), false, ERROR)` to show feedback after redirect.
+- Message severity constants: `INFO` (0), `ERROR` (1), `WARNING` (2).
+- Never swallow exceptions silently. Log unexpected errors and re-throw or redirect with a message.
+
+## Security
+
+### CSRF
+
+- Never write or render a `<form>` without including the CSRF token: use `{{ csrf_token() }}` in Twig or `Html::getCsrfTokenInput()` in PHP.
+- GLPI validates CSRF automatically via `CheckCsrfListener` on all state-changing requests (POST/PUT/PATCH/DELETE). Do not bypass or disable this listener.
+- For AJAX calls, send the token in the `X-Glpi-Csrf-Token` HTTP header, not in the body.
+- CSRF tokens are single-use by default; pass `preserve_token: true` only when a single form can trigger multiple AJAX requests without reload.
+- Never expose CSRF tokens in URLs, logs, or API responses.
+
+### XSS — Output Encoding
+
+- Every variable echoed in PHP must be wrapped in `htmlescape()`. Never use `echo $user_input` directly.
+- In Twig templates, rely on auto-escaping (`{{ var }}`). Use `{{ var|raw }}` only for values that have been explicitly sanitized server-side (e.g., rich text that went through `RichText::getSafeHtml()`).
+- Never mark user-supplied content as `|raw` in Twig.
+- Do not use `Sanitizer::sanitize()` on new code — it is deprecated. Sanitization happens at the output layer (encoding), not at the input layer.
+- Prefer `__s()` / `_sn()` / `_sx()` over `__()` for any string that goes into HTML output.
+
+### SQL Injection
+
+- The only acceptable way to query the database is `$DB->request([...])` with an array-based criteria map. Every value in the criteria array is automatically parameterized.
+- When a raw SQL fragment is unavoidable, wrap it in `new QueryExpression(...)` and bind user values via `new QueryParam(...)` — never interpolate `$_GET` / `$_POST` directly into a `QueryExpression`.
+- Never use `$DB->query()`, `$DB->queryOrDie()`, or `sprintf` to build SQL strings.
+
+### IDOR — Insecure Direct Object Reference
+
+- Before exposing an item ID to the frontend, generate an IDOR token: `Session::getNewIDORToken(MyItem::class)` in PHP or `{{ idor_token('MyItem') }}` in Twig.
+- Validate the token server-side before using the posted ID: `Session::validateIDOR($data)`. If validation fails, throw `new BadRequestHttpException()`.
+- Never trust an item ID from `$_GET` / `$_POST` without either an IDOR token or a full `$item->can($id, READ)` check.
+
+### Privilege Escalation & Entity Isolation
+
+- Every database query that returns user data must be scoped to the current user's entities: use `getMyEntities()` or `'entities_id' => $_SESSION['glpiactive_entity']` in criteria.
+- When an item has an `entities_id` column, always check `$item->can($id, $right)` — it enforces entity belonging automatically.
+- Never accept `entities_id` from user input without verifying the user has access to that entity: `Session::haveAccessToEntity($entities_id)`.
+
+### Sensitive Data & Credential Handling
+
+- Store all secrets (API keys, SMTP passwords, LDAP bind passwords, OAuth secrets) encrypted via `GLPIKey::encrypt()`. Never store them in plaintext in the database.
+- Retrieve encrypted secrets with `GLPIKey::decrypt()` only at the point of use — do not carry decrypted values in session or cache.
+- Declare sensitive fields in `$undisclosedFields` static property so they are stripped from API responses automatically.
+- Never log passwords, tokens, or personal data. Redact before passing to `Toolbox::logError()` / `logDebug()`.
+
+### File Upload
+
+- Validate MIME type and extension against `DocumentType::getUploadableFilePattern()`. Never accept a file based solely on its declared Content-Type.
+- Store uploaded files under `GLPI_DOC_DIR` (outside the web root). Never store uploads inside `public/` or any web-accessible directory.
+- Derive the storage filename server-side (use the SHA1 hash). Never use the original filename from `$_FILES` as the storage path — it enables path traversal.
+- Reject filenames containing `..`, `/`, or `\` before any file operation.
+- Enforce `$CFG_GLPI['document_max_size']` limits in upload handlers.
+
+### Session Security
+
+- Never regenerate the session ID manually — it is handled by `Session::init()` after authentication. Do not call `session_regenerate_id()` elsewhere.
+- Session cookies are configured with `HttpOnly`, `Secure`, and `SameSite=Lax` by the framework. Do not override `session.cookie_*` ini settings in application code.
+- After privilege escalation or profile change, call `Session::changeActiveEntities()` to recompute the entity tree — never reuse a stale entity list.
+
+### Path Traversal
+
+- Resolve all file paths with `realpath()` and verify the result starts with the expected base directory (`GLPI_DOC_DIR`, `GLPI_TMP_DIR`, etc.) before performing any file operation.
+- Use `basename()` to extract filenames from user-supplied paths. Never pass `$_GET`/`$_POST` values directly to `file_get_contents()`, `unlink()`, `fopen()`, or `include`.
+- `GLPI_ROOT` is the only safe root for PHP includes; never include files from paths derived from user input.
+
+### API Security
+
+- Declare the required OAuth scope in every new API endpoint using the `#[SecurityStrategy]` attribute or by registering the route with the appropriate middleware.
+- Validate IP restrictions via `IPRestrictionRequestMiddleware` — do not roll your own IP check.
+- Generate API client secrets with `bin2hex(random_bytes(...))` and store them encrypted. Never generate tokens with `rand()`, `uniqid()`, or `mt_rand()`.
+- Never return internal stack traces, SQL queries, or filesystem paths in API error responses. Use generic messages and log details server-side.
+
+### General Rules
+
+- Never disable or skip security listeners with `NO_CHECK` strategy on endpoints that can modify data or read personal information.
+- Always throw an HTTP exception (`AccessDeniedHttpException`, `NotFoundHttpException`, `BadRequestHttpException`) rather than returning an empty response or `false` for security violations.
+- Never trust the `X-Forwarded-For` header for access control without validating that the request comes through a known proxy.
+- Do not expose PHP version, GLPI version, or server software in custom headers or error pages.


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.

### Description

This is a proposal for more relevant instructions for users with copilot-wrapped LLMs. Potentially useful for any LLMs / models.

Source of "skills" or "reference" are official Github up-to-date documentation: 

- https://docs.github.com/en/copilot/how-tos/configure-custom-instructions
- https://docs.github.com/en/copilot/tutorials/use-custom-instructions
- https://docs.github.com/en/copilot/tutorials/coding-agent/get-the-best-results
- https://docs.github.com/en/copilot/tutorials/customization-library/custom-instructions/your-first-custom-instructions
- https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions
- https://docs.github.com/en/copilot/tutorials/use-custom-instructions

and the repo of the Claude instructions i use daily : 

- https://github.com/f2cmb/glpidev-agents

### Overview

In addition to personal adds about rights, architecture, Front controllers and debug : 

- copilot-instructions.md is now structured with clear sections (Overview, Structure, Commands, Rules) : ~1,400 chars, well under the 4,000-char limit
- PHP/GLPI rules are isolated in a dedicated file that only applies to .php files                                                                                                           
- E2E rules only apply to tests/e2e/** : Copilot won't load them when working on PHP                                                                                                        
- The "CRITICAL: Never run npx..." line is moved into the Build section (its natural context) rather than buried at the end of the E2E section  

### Disclaimer

I don't use Copilot, so this is an agnostic proposal based on official doc recommandations, but those "specs" seems logicals
