### PR TITLE
New Feature : Add target on private saved search

### DIFF
--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -42,7 +42,6 @@ Session::checkCentralAccess();
 
 if (
     isset($_POST['type']) && !empty($_POST['type'])
-    && isset($_POST['right'])
 ) {
     $display = false;
     $rand    = mt_rand();
@@ -59,9 +58,16 @@ if (
     switch ($_POST['type']) {
         case 'User':
             $params = [
-                'right' => isset($_POST['allusers']) ? 'all' : $_POST['right'],
+                'right' => 'all',
                 'name' => $prefix . 'users_id' . $suffix,
             ];
+            if (isset($_POST['right']) && !isset($_POST['allusers'])) {
+                $params['right'] = $_POST['right'];
+            }
+            if (isset($_POST['entity']) && $_POST['entity'] >= 0) {
+                $params['entity'] = $_POST['entity'];
+                $params['entity_sons'] = $_POST['is_recursive'] ?? false;
+            }
             User::dropdown($params);
             $display = true;
             break;
@@ -98,27 +104,26 @@ if (
             break;
 
         case 'Profile':
-            $checkright   = (READ | CREATE | UPDATE | PURGE);
-            $righttocheck = $_POST['right'];
-            if ($_POST['right'] == 'faq') {
-                $righttocheck = 'knowbase';
-                $checkright   = KnowbaseItem::READFAQ;
+            $righttocheck = $_POST['right'] ?? null;
+            if ($righttocheck) {
+                $checkright   = (READ | CREATE | UPDATE | PURGE);
+                if ($_POST['right'] == 'faq') {
+                    $righttocheck = 'knowbase';
+                    $checkright   = KnowbaseItem::READFAQ;
+                }
+                $params['condition'] = [
+                    'glpi_profilerights.name' => $righttocheck,
+                    'glpi_profilerights.rights' => ['&', $checkright],
+                ];
             }
-            $params             = [
-                'rand'      => $rand,
-                'name'      => $prefix . 'profiles_id' . $suffix,
-                'condition' => [
-                    'glpi_profilerights.name'     => $righttocheck,
-                    'glpi_profilerights.rights'   => ['&', $checkright],
-                ],
-            ];
-            $params['toupdate'] = ['value_fieldname'
-                                                  => 'value',
-                'to_update'  => "subvisibility$rand",
-                'url'        => $CFG_GLPI["root_doc"] . "/ajax/subvisibility.php",
-                'moreparams' => ['items_id' => '__VALUE__',
-                    'type'     => $_POST['type'],
-                    'prefix'   => $_POST['prefix'],
+            $params['toupdate'] = [
+                'value_fieldname' => 'value',
+                'to_update' => "subvisibility$rand",
+                'url' => $CFG_GLPI["root_doc"] . "/ajax/subvisibility.php",
+                'moreparams' => [
+                    'items_id' => '__VALUE__',
+                    'type' => $_POST['type'],
+                    'prefix' => $_POST['prefix'],
                 ],
             ];
 

--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -589,6 +589,7 @@ $RELATION = [
         '_glpi_entities_knowbaseitems'     => 'entities_id',
         '_glpi_entities_reminders'         => 'entities_id',
         '_glpi_entities_rssfeeds'          => 'entities_id',
+        '_glpi_entities_savedsearches'     => 'entities_id',
         'glpi_fieldblacklists'             => 'entities_id',
         'glpi_fieldunicities'              => 'entities_id',
         'glpi_forms_forms'                 => 'entities_id',
@@ -598,6 +599,7 @@ $RELATION = [
         'glpi_groups_knowbaseitems'        => 'entities_id',
         'glpi_groups_reminders'            => 'entities_id',
         'glpi_groups_rssfeeds'             => 'entities_id',
+        'glpi_groups_savedsearches'        => 'entities_id',
         'glpi_holidays'                    => 'entities_id',
         'glpi_imageformats'                => 'entities_id',
         'glpi_imageresolutions'            => 'entities_id',
@@ -742,6 +744,7 @@ $RELATION = [
         '_glpi_groups_problems'      => 'groups_id',
         '_glpi_groups_reminders'     => 'groups_id',
         '_glpi_groups_rssfeeds'      => 'groups_id',
+        '_glpi_groups_savedsearches' => 'groups_id',
         '_glpi_groups_tickets'       => 'groups_id',
         '_glpi_groups_users'         => 'groups_id',
         'glpi_itilcategories'        => 'groups_id',
@@ -1273,8 +1276,11 @@ $RELATION = [
     ],
 
     'glpi_savedsearches' => [
-        '_glpi_savedsearches_alerts' => 'savedsearches_id',
-        '_glpi_savedsearches_users'  => 'savedsearches_id',
+        '_glpi_entities_savedsearches'    => 'savedsearches_id',
+        '_glpi_groups_savedsearches'      => 'savedsearches_id',
+        '_glpi_savedsearches_alerts'      => 'savedsearches_id',
+        '_glpi_savedsearches_users'       => 'savedsearches_id',
+        '_glpi_savedsearches_usertargets' => 'savedsearches_id',
     ],
 
     'glpi_slalevels' => [
@@ -1652,6 +1658,7 @@ $RELATION = [
         '_glpi_rssfeeds_users'          => 'users_id',
         '_glpi_savedsearches'           => 'users_id',
         '_glpi_savedsearches_users'     => 'users_id',
+        '_glpi_savedsearches_usertargets' => 'users_id',
         'glpi_softwarelicenses'         => [
             'users_id_tech',
             'users_id',

--- a/install/migrations/update_11.0.x_to_12.0.0/entity_savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/entity_savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/install/migrations/update_11.0.x_to_12.0.0/entity_savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/entity_savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,31 +33,25 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
 
-require_once(__DIR__ . '/_check_webserver_config.php');
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
-} else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), '', 'tools', 'savedsearch');
+if (!$DB->tableExists('glpi_entities_savedsearches')) {
+    $query = "CREATE TABLE `glpi_entities_savedsearches` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `savedsearches_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        `entities_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        `is_recursive` tinyint NOT NULL DEFAULT '0',
+        PRIMARY KEY (`id`),
+        KEY `savedsearches_id` (`savedsearches_id`),
+        KEY `entities_id` (`entities_id`),
+        KEY `is_recursive` (`is_recursive`)
+    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
+    $DB->doQuery($query);
 }
-
-$savedsearch = new SavedSearch();
-
-if (
-    isset($_GET['action']) && $_GET["action"] == "load"
-    && isset($_GET["id"]) && ($_GET["id"] > 0)
-) {
-    $savedsearch->getFromDB($_GET['id']);
-    if ($savedsearch->canViewItem()) {
-        $savedsearch->load($_GET["id"]);
-    } else {
-        $info = "User can not access the SavedSearch " . $_GET['id'];
-        throw new AccessDeniedHttpException($info);
-    }
-    return;
-}
-
-Search::show('SavedSearch');
-Html::footer();

--- a/install/migrations/update_11.0.x_to_12.0.0/group_savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/group_savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/install/migrations/update_11.0.x_to_12.0.0/group_savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/group_savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,31 +33,28 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
 
-require_once(__DIR__ . '/_check_webserver_config.php');
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
-} else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), '', 'tools', 'savedsearch');
+if (!$DB->tableExists('glpi_groups_savedsearches')) {
+    $query = "CREATE TABLE `glpi_groups_savedsearches` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `savedsearches_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        `groups_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        `entities_id` int {$default_key_sign} DEFAULT NULL,
+        `is_recursive` tinyint NOT NULL DEFAULT '0',
+        `no_entity_restriction` tinyint NOT NULL DEFAULT '0',
+        PRIMARY KEY (`id`),
+        KEY `savedsearches_id` (`savedsearches_id`),
+        KEY `groups_id` (`groups_id`),
+        KEY `entities_id` (`entities_id`),
+        KEY `is_recursive` (`is_recursive`)
+    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
+    $DB->doQuery($query);
 }
-
-$savedsearch = new SavedSearch();
-
-if (
-    isset($_GET['action']) && $_GET["action"] == "load"
-    && isset($_GET["id"]) && ($_GET["id"] > 0)
-) {
-    $savedsearch->getFromDB($_GET['id']);
-    if ($savedsearch->canViewItem()) {
-        $savedsearch->load($_GET["id"]);
-    } else {
-        $info = "User can not access the SavedSearch " . $_GET['id'];
-        throw new AccessDeniedHttpException($info);
-    }
-    return;
-}
-
-Search::show('SavedSearch');
-Html::footer();

--- a/install/migrations/update_11.0.x_to_12.0.0/savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/install/migrations/update_11.0.x_to_12.0.0/savedsearch.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/savedsearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,31 +33,32 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\DBAL\QuerySubQuery;
+use Glpi\DBAL\QueryExpression;
 
-require_once(__DIR__ . '/_check_webserver_config.php');
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ * @var array $DELFROMDISPLAYPREF
+ */
 
-if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
-} else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), '', 'tools', 'savedsearch');
+$table = SavedSearch::getTable();
+$field = 'is_private';
+if ($DB->fieldExists($table, $field)) {
+    $DB->insert('glpi_entities_savedsearches', new QuerySubQuery([
+        'SELECT' => [
+            new QueryExpression('null AS `id`'),
+            'id as savedsearches_id',
+            'entities_id',
+            'is_recursive',
+        ],
+        'FROM'   => 'glpi_savedsearches',
+        'WHERE'  => [
+        'is_private' => ['<>', 0],
+    ],
+    ]));
+
+    $migration->dropField($table, $field);
+
+    $DELFROMDISPLAYPREF['SavedSearch'] = 4;
 }
-
-$savedsearch = new SavedSearch();
-
-if (
-    isset($_GET['action']) && $_GET["action"] == "load"
-    && isset($_GET["id"]) && ($_GET["id"] > 0)
-) {
-    $savedsearch->getFromDB($_GET['id']);
-    if ($savedsearch->canViewItem()) {
-        $savedsearch->load($_GET["id"]);
-    } else {
-        $info = "User can not access the SavedSearch " . $_GET['id'];
-        throw new AccessDeniedHttpException($info);
-    }
-    return;
-}
-
-Search::show('SavedSearch');
-Html::footer();

--- a/install/migrations/update_11.0.x_to_12.0.0/savedsearch_usertarget.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/savedsearch_usertarget.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/install/migrations/update_11.0.x_to_12.0.0/savedsearch_usertarget.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/savedsearch_usertarget.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
@@ -33,31 +33,23 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
+/**
+ * @var \DBmysql $DB
+ * @var \Migration $migration
+ */
 
-require_once(__DIR__ . '/_check_webserver_config.php');
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(SavedSearch::getTypeName(Session::getPluralNumber()));
-} else {
-    Html::header(SavedSearch::getTypeName(Session::getPluralNumber()), '', 'tools', 'savedsearch');
+if (!$DB->tableExists('glpi_savedsearches_usertargets')) {
+    $query = "CREATE TABLE `glpi_savedsearches_usertargets` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `savedsearches_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        `users_id` int {$default_key_sign}  NOT NULL DEFAULT '0',
+        PRIMARY KEY (`id`),
+        KEY `savedsearches_id` (`savedsearches_id`),
+        KEY `users_id` (`users_id`)
+    ) ENGINE = InnoDB ROW_FORMAT = DYNAMIC DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation};";
+    $DB->doQuery($query);
 }
-
-$savedsearch = new SavedSearch();
-
-if (
-    isset($_GET['action']) && $_GET["action"] == "load"
-    && isset($_GET["id"]) && ($_GET["id"] > 0)
-) {
-    $savedsearch->getFromDB($_GET['id']);
-    if ($savedsearch->canViewItem()) {
-        $savedsearch->load($_GET["id"]);
-    } else {
-        $info = "User can not access the SavedSearch " . $_GET['id'];
-        throw new AccessDeniedHttpException($info);
-    }
-    return;
-}
-
-Search::show('SavedSearch');
-Html::footer();

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -292,6 +292,17 @@ CREATE TABLE `glpi_savedsearches_alerts` (
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+### Dump table glpi_savedsearches_usertargets
+
+DROP TABLE IF EXISTS `glpi_savedsearches_usertargets`;
+CREATE TABLE `glpi_savedsearches_usertargets` (
+                                                  `id` int unsigned NOT NULL AUTO_INCREMENT,
+                                                  `users_id` int unsigned NOT NULL DEFAULT '0',
+                                                  `savedsearches_id` int unsigned NOT NULL DEFAULT '0',
+                                                  PRIMARY KEY (`id`),
+                                                  KEY `savedsearches_id` (`savedsearches_id`),
+                                                  KEY `users_id` (`users_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 ### Dump table glpi_budgets
 
@@ -2972,6 +2983,20 @@ CREATE TABLE `glpi_entities_rssfeeds` (
   KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+### Dump table glpi_entities_savedsearches
+
+DROP TABLE IF EXISTS `glpi_entities_savedsearches`;
+CREATE TABLE `glpi_entities_savedsearches` (
+   `id`           int unsigned NOT NULL AUTO_INCREMENT,
+   `savedsearches_id`  int unsigned NOT NULL DEFAULT '0',
+   `entities_id`  int unsigned NOT NULL DEFAULT '0',
+   `is_recursive` tinyint NOT NULL DEFAULT '0',
+   PRIMARY KEY (`id`),
+   KEY            `savedsearches_id` (`savedsearches_id`),
+   KEY            `entities_id` (`entities_id`),
+   KEY            `is_recursive` (`is_recursive`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 
 ### Dump table glpi_events
 
@@ -3194,6 +3219,23 @@ CREATE TABLE `glpi_groups_rssfeeds` (
   KEY `groups_id` (`groups_id`),
   KEY `entities_id` (`entities_id`),
   KEY `is_recursive` (`is_recursive`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+### Dump table glpi_groups_savedsearches
+
+DROP TABLE IF EXISTS `glpi_groups_savedsearches`;
+CREATE TABLE `glpi_groups_savedsearches` (
+ `id` int unsigned NOT NULL AUTO_INCREMENT,
+ `savedsearches_id` int unsigned NOT NULL DEFAULT '0',
+ `groups_id` int unsigned NOT NULL DEFAULT '0',
+ `entities_id` int unsigned DEFAULT NULL,
+ `is_recursive` tinyint NOT NULL DEFAULT '0',
+ `no_entity_restriction` tinyint NOT NULL DEFAULT '0',
+ PRIMARY KEY (`id`),
+ KEY `savedsearches_id` (`savedsearches_id`),
+ KEY `groups_id` (`groups_id`),
+ KEY `entities_id` (`entities_id`),
+ KEY `is_recursive` (`is_recursive`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -34,12 +34,19 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Event;
 
 /**
  * Common DataBase visibility for items
  */
 abstract class CommonDBVisible extends CommonDBTM
 {
+    /**
+     * Types of target available for the itemtype
+     * @var string[]
+     */
+    public static $types = ['Entity', 'Group', 'Profile', 'User'];
+
     /**
      * Entities on which item is visible.
      * Keys are ID, values are DB fields values.
@@ -63,6 +70,58 @@ abstract class CommonDBVisible extends CommonDBTM
      * Keys are ID, values are DB fields values.
      */
     protected array $users = [];
+
+    /**
+     * Class defining relation to $users
+     * @var string
+     */
+    protected $userClass;
+
+    /**
+     * Class defining relation to $profiles
+     * @var string
+     */
+    protected $profileClass;
+
+    /**
+     * Class defining relation to $groups
+     * @var string
+     */
+    protected $groupClass;
+
+    /**
+     * Class defining relation to entities
+     * @var string
+     */
+    protected $entityClass;
+
+    /**
+     * Service for visibility target log
+     * @var string
+     */
+    protected $service;
+
+    public function __construct()
+    {
+        // define default values
+        if (!$this->userClass) {
+            $this->userClass = $this->getType() . '_UserTarget';
+        }
+        if (!$this->groupClass) {
+            $this->groupClass = 'Group_' . $this->getType();
+        }
+        if (!$this->entityClass) {
+            $this->entityClass = 'Entity_' . $this->getType();
+        }
+        if (!$this->profileClass) {
+            $this->profileClass = 'Profile_' . $this->getType();
+        }
+        if (!$this->service) {
+            $this->service =  'tools';
+        }
+
+        parent::__construct();
+    }
 
     /**
      * Is the login user have access to item based on visibility configuration
@@ -159,6 +218,15 @@ abstract class CommonDBVisible extends CommonDBTM
     }
 
     /**
+     * Get right which will be used to determine which users can be targeted
+     * @return string
+     */
+    public function getVisibilityRight()
+    {
+        return strtolower($this::getType()) . '_public';
+    }
+
+    /**
      * Show visibility configuration
      *
      * @since 9.2 moved from each class to parent class
@@ -173,9 +241,10 @@ abstract class CommonDBVisible extends CommonDBTM
 
         if ($canedit) {
             TemplateRenderer::getInstance()->display('components/add_visibility_target.html.twig', [
-                'type' => static::class,
-                'rand' => $rand,
-                'id'   => $ID,
+                'type'  => static::class,
+                'types' => static::$types,
+                'rand'  => $rand,
+                'id'    => $ID,
                 'add_target_msg' => __('Add a target'),
                 'visiblity_dropdown_params' => $this->getShowVisibilityDropdownParams(),
             ]);
@@ -186,7 +255,7 @@ abstract class CommonDBVisible extends CommonDBTM
         foreach ($this->users as $val) {
             foreach ($val as $data) {
                 $entries[] = [
-                    'itemtype' => static::class . '_User',
+                    'itemtype' => $this instanceof SavedSearch ? SavedSearch_UserTarget::class : static::class . '_User',
                     'id' => $data['id'],
                     'type' => User::getTypeName(1),
                     'recipient' => htmlescape(getUserName($data['users_id'])),
@@ -329,10 +398,10 @@ abstract class CommonDBVisible extends CommonDBTM
      */
     protected function getShowVisibilityDropdownParams()
     {
-        $params = [
-            'type'          => '__VALUE__',
-            'right'         => strtolower(static::class) . '_public',
-        ];
+        $params = ['type' => '__VALUE__'];
+        if ($right = $this->getVisibilityRight()) {
+            $params['right'] = $right;
+        }
         if (isset($this->fields['entities_id'])) {
             $params['entity'] = $this->fields['entities_id'];
         }
@@ -340,5 +409,58 @@ abstract class CommonDBVisible extends CommonDBTM
             $params['is_recursive'] = $this->fields['is_recursive'];
         }
         return $params;
+    }
+
+    /**
+     * Add a visibility target to the item
+     * @param array $inputs key '_type' determine the type of target
+     * @return void
+     */
+    public function addVisibility(array $inputs)
+    {
+        $fkField = getForeignKeyFieldForItemType($this->getType());
+        $item = null;
+        switch ($inputs['_type']) {
+            case User::class:
+                $class = $this->getType() . '_UserTarget';
+                if (is_a($class, CommonDBRelation::class, true)) {
+                    $item = new $class();
+                }
+                break;
+            case Group::class:
+                $class = 'Group_' . $this->getType();
+                if (is_a($class, CommonDBRelation::class, true)) {
+                    $item = new $class();
+                }
+                break;
+            case Entity::class:
+                $class = 'Entity_' . $this->getType();
+                if (is_a($class, CommonDBRelation::class, true)) {
+                    $item = new $class();
+                }
+                break;
+            case Profile::class:
+                $class = 'Profile_' . $this->getType();
+                if (is_a($class, CommonDBRelation::class, true)) {
+                    $item = new $class();
+                }
+                break;
+        }
+        if (array_key_exists('entities_id', $inputs) && $inputs['entities_id'] == -1) {
+            // "No restriction" value selected
+            $inputs['entities_id'] = 'NULL';
+            $inputs['no_entity_restriction'] = 1;
+        }
+        if (!is_null($item)) {
+            $item->add($inputs);
+            Event::log(
+                $inputs[$fkField],
+                $this->getType(),
+                4,
+                $this->service,
+                //TRANS: %s is the user login
+                sprintf(__('%s adds a target'), $_SESSION["glpiname"])
+            );
+        }
     }
 }

--- a/src/Entity_SavedSearch.php
+++ b/src/Entity_SavedSearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Entity_SavedSearch.php
+++ b/src/Entity_SavedSearch.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+class Entity_SavedSearch extends CommonDBRelation
+{
+    // From CommonDBRelation
+    public static ?string $itemtype_1          = SavedSearch::class;
+    public static ?string $items_id_1          = 'savedsearches_id';
+    public static ?string $itemtype_2          = Entity::class;
+    public static ?string $items_id_2          = 'entities_id';
+
+    public static int $checkItem_2_Rights  = self::DONT_CHECK_ITEM_RIGHTS;
+    public static bool $logs_for_item_2     = false;
+
+
+    /**
+     * Get entities for a saved search
+     *
+     * @param SavedSearch $savedSearch SavedSearch instance
+     *
+     * @return array of entities linked to a saved search
+     **/
+    public static function getEntities(SavedSearch $savedSearch)
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $results   = [];
+        $iterator = $DB->request([
+            'FROM'   => self::getTable(),
+            'WHERE'  => [
+                self::$items_id_1 => $savedSearch->getID(),
+            ],
+        ]);
+
+        foreach ($iterator as $data) {
+            $results[$data[self::$items_id_2]][] = $data;
+        }
+        return $results;
+    }
+}

--- a/src/Glpi/Controller/VisibilityController.php
+++ b/src/Glpi/Controller/VisibilityController.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Glpi/Controller/VisibilityController.php
+++ b/src/Glpi/Controller/VisibilityController.php
@@ -7,7 +7,8 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -32,39 +33,40 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Controller\ItemType\Form;
+namespace Glpi\Controller;
 
-use Glpi\Controller\VisibilityController;
-use Glpi\Http\Firewall;
-use Glpi\Http\RedirectResponse;
-use Glpi\Routing\Attribute\ItemtypeFormRoute;
-use Glpi\Security\Attribute\SecurityStrategy;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
 use Html;
-use SavedSearch;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SavedSearchFormController extends VisibilityController
+class VisibilityController extends GenericFormController
 {
-    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
-    #[ItemtypeFormRoute(SavedSearch::class)]
     public function __invoke(Request $request): Response
     {
-        $request->attributes->set('class', SavedSearch::class);
-
-        if ($request->query->has('create_notif')) {
-            return $this->createNotif();
+        if ($request->request->has('addvisibility')) {
+            return $this->addVisibility($request);
         }
 
         return parent::__invoke($request);
     }
 
-    public function createNotif(): RedirectResponse
+    public function addVisibility(Request $request): RedirectResponse
     {
-        $savedsearch = new SavedSearch();
-        $savedsearch->check($_GET['id'], UPDATE);
-        $savedsearch->createNotif();
-
-        return new RedirectResponse(Html::getBackUrl());
+        $class = $request->attributes->get('class');
+        $item = getItemForItemtype($class);
+        $fk_field = getForeignKeyFieldForItemType($class);
+        if ($item instanceof \CommonDBVisible) {
+            if ($item->canEdit($request->request->get($fk_field))) {
+                $item->addVisibility($request->request->all());
+                return new RedirectResponse(Html::getBackUrl());
+            } else {
+                throw new AccessDeniedHttpException();
+            }
+        } else {
+            throw new BadRequestHttpException("Invalid class");
+        }
     }
 }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2638,6 +2638,16 @@ final class SQLProvider implements SearchProviderInterface
                 }
                 break;
 
+            case SavedSearch::class:
+                $criterias = \SavedSearch::getVisibilityCriteria(false);
+                if (isset($criterias['LEFT JOIN'])) {
+                    $out = ['LEFT JOIN' => $criterias['LEFT JOIN']];
+                    foreach ($criterias['LEFT JOIN'] as $table => $criteria) {
+                        $already_link_tables[] = $table;
+                    }
+                }
+                break;
+
             case ITILFollowup::class:
                 foreach ($CFG_GLPI['itil_types'] as $itil_itemtype) {
                     $out = array_merge_recursive($out, self::getLeftJoinCriteria(

--- a/src/Group_SavedSearch.php
+++ b/src/Group_SavedSearch.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/Group_SavedSearch.php
+++ b/src/Group_SavedSearch.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+class Group_SavedSearch extends CommonDBRelation
+{
+    // From CommonDBRelation
+    public static ?string $itemtype_1          = SavedSearch::class;
+    public static ?string $items_id_1          = 'savedsearches_id';
+    public static ?string $itemtype_2          = Group::class;
+    public static ?string $items_id_2          = 'groups_id';
+
+    public static int $checkItem_2_Rights  = self::DONT_CHECK_ITEM_RIGHTS;
+    public static bool $logs_for_item_2     = false;
+
+
+    /**
+     * Get groups for a saved search
+     *
+     * @param SavedSearch $savedSearch SavedSearch instance
+     *
+     * @return array of groups linked to a saved search
+     **/
+    public static function getGroups(SavedSearch $savedSearch)
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $results   = [];
+        $iterator = $DB->request([
+            'FROM'   => self::getTable(),
+            'WHERE'  => [
+                self::$items_id_1 => $savedSearch->getID(),
+            ],
+        ]);
+
+        foreach ($iterator as $data) {
+            $results[$data[self::$items_id_2]][] = $data;
+        }
+        return $results;
+    }
+}

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -48,13 +48,13 @@ use function Safe\parse_url;
  *
  * @since 9.2
  **/
-class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
+class SavedSearch extends CommonDBVisible implements ExtraVisibilityCriteria
 {
     /** @use Clonable<static> */
     use Clonable;
 
     public static string $rightname               = 'bookmark_public';
-
+    public static $types                   = [Group::class, User::class, Entity::class];
     public const SEARCH = 1; //SEARCH SYSTEM bookmark
     public const URI    = 2;
     public const ALERT  = 3; //SEARCH SYSTEM search alert
@@ -62,6 +62,10 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     public const COUNT_NO = 0;
     public const COUNT_YES = 1;
     public const COUNT_AUTO = 2;
+    protected $userClass = SavedSearch_UserTarget::class;
+    protected $groupClass = Group_SavedSearch::class;
+    protected $entityClass = Entity_SavedSearch::class;
+    protected $service = 'tools';
 
     public static function getForbiddenActionsForMenu()
     {
@@ -262,14 +266,28 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
     }
 
+    public function haveVisibilityAccess(): bool
+    {
+        if (!self::canView()) {
+            return false;
+        }
+
+        return parent::haveVisibilityAccess();
+    }
+
     public function canCreateItem(): bool
     {
 
-        if ($this->fields['is_private'] == 1) {
-            return (Session::haveRight('config', UPDATE)
-                 || $this->fields['users_id'] == Session::getLoginUserID());
+        if (isset($this->input['is_private']) && $this->input['is_private'] == 0) {
+            return self::canCreatePublic();
         }
         return parent::canCreateItem();
+    }
+
+    public static function canCreatePublic(): bool
+    {
+        return (Session::haveRight('config', UPDATE) ||
+            Session::haveRight(self::$rightname, CREATE));
     }
 
     public static function canView(): bool
@@ -280,19 +298,84 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
     public function canViewItem(): bool
     {
-        if ($this->fields['is_private'] == 1) {
-            return (Session::haveRight('config', READ)
-                 || $this->fields['users_id'] == Session::getLoginUserID());
+        if (
+            Session::haveRight('config', READ)
+            || $this->fields['users_id'] == Session::getLoginUserID()
+        ) {
+            return true;
         }
-        return parent::canViewItem();
+
+        if (array_key_exists($this->getID(), $this->getMine())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function post_getFromDB()
+    {
+        // Group
+        $this->groups = Group_SavedSearch::getGroups($this);
+
+        // Users
+        $this->users = SavedSearch_UserTarget::getUsers($this);
+
+        // Entities
+        $this->entities = Entity_SavedSearch::getEntities($this);
+    }
+
+    public function post_addItem()
+    {
+        // for search saved as public, automatically create a link with its entity
+        if (isset($this->input['is_private']) && !$this->input['is_private']) {
+            $item = new Entity_SavedSearch();
+            $item->add([
+                'savedsearches_id' => $this->getID(),
+                'entities_id' => $this->fields['entities_id'],
+                'is_recursive' => $this->fields['is_recursive'],
+            ]);
+        }
+        parent::post_addItem();
+    }
+
+    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        if (self::canView()
+            && $item::class == SavedSearch::class
+            && self::canCreatePublic()) {
+            $nb = 0;
+            if ($_SESSION['glpishow_count_on_tabs']) {
+                $nb = $item->countVisibilities();
+            }
+            return [
+                1 => self::createTabEntry(
+                    _n(
+                        'Target',
+                        'Targets',
+                        Session::getPluralNumber()
+                    ),
+                    $nb
+                ),
+            ];
+        }
+        return '';
     }
 
     public function defineTabs($options = [])
     {
         $ong = [];
-        $this->addDefaultFormTab($ong)
-           ->addStandardTab(SavedSearch_Alert::class, $ong, $options);
+        $this->addDefaultFormTab($ong);
+        $this->addStandardTab(SavedSearch::class, $ong, $options);
+        $this->addStandardTab(SavedSearch_Alert::class, $ong, $options);
         return $ong;
+    }
+
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
+    {
+        if ($item::class == SavedSearch::class) {
+            $item->showVisibility();
+        }
+        return false;
     }
 
     public function rawSearchOptions()
@@ -312,15 +395,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             'field'              => 'name',
             'name'               => User::getTypeName(1),
             'datatype'           => 'dropdown',
-        ];
-
-        $tab[] = [
-            'id'  => 4,
-            'table'           => $this->getTable(),
-            'field'           => 'is_private',
-            'name'            => __('Is private'),
-            'datatype'        => 'bool',
-            'massiveaction'   => false,
         ];
 
         $tab[] = ['id'                 => '8',
@@ -469,6 +543,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             [
                 SavedSearch_Alert::class,
                 SavedSearch_User::class,
+                SavedSearch_UserTarget::class,
+                Group_SavedSearch::class,
             ]
         );
     }
@@ -490,6 +566,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         TemplateRenderer::getInstance()->display('pages/tools/savedsearch/form.html.twig', [
             'item' => $this,
             'can_create' => self::canCreate(),
+            'can_create_public' => self::canCreatePublic(),
             'params' => $options,
         ]);
         return true;
@@ -681,6 +758,41 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     }
 
     /**
+     * Get relations for targets
+     * @return array[][] key 'LEFT JOIN' for request
+     */
+    public static function getDefaultJoin()
+    {
+        $table = self::getTable();
+        $user_table = SavedSearch_UserTarget::getTable();
+        $group_table = Group_SavedSearch::getTable();
+        $entity_table = Entity_SavedSearch::getTable();
+        return [
+            'LEFT JOIN' => [
+                // relations for targets
+                $user_table => [
+                    'ON' => [
+                        $user_table => 'savedsearches_id',
+                        $table => 'id',
+                    ],
+                ],
+                $group_table => [
+                    'ON' => [
+                        $group_table => 'savedsearches_id',
+                        $table => 'id',
+                    ],
+                ],
+                $entity_table => [
+                    'ON' => [
+                        $entity_table => 'savedsearches_id',
+                        $table => 'id',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
      * return an array of saved searches for a given itemtype
      *
      * @param string $itemtype if given filter saved search by only this one
@@ -696,6 +808,9 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
         $table = $this->getTable();
         $utable = 'glpi_savedsearches_users';
+        $user_table = SavedSearch_UserTarget::getTable();
+        $group_table = Group_SavedSearch::getTable();
+        $entity_table = Entity_SavedSearch::getTable();
         $criteria = [
             'SELECT'    => [
                 "$table.*",
@@ -704,19 +819,59 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                 ),
             ],
             'FROM'      => $table,
-            'LEFT JOIN' => [
-                $utable => [
-                    'ON' => [
-                        $utable  => 'savedsearches_id',
-                        $table   => 'id',
-                    ],
-                ],
-            ],
             'ORDERBY'   => [
                 'itemtype',
                 'name',
             ],
-        ] + self::getVisibilityCriteriaForMine();
+            ] + self::getDefaultJoin();
+
+        $criteria['LEFT JOIN'][$utable] = [
+            'ON' => [
+                $utable => 'savedsearches_id',
+                $table => 'id',
+            ],
+        ];
+        $owner_restrict = [
+            $table . '.users_id' => Session::getLoginUserID(),
+        ];
+        $entity_restrict = getEntitiesRestrictCriteria($table, '', '', true);
+        if (count($entity_restrict)) {
+            $owner_restrict += $entity_restrict;
+        }
+        $criteria['WHERE'] = [
+            'OR' => [
+                $owner_restrict,
+                [
+                    'OR' => [
+                        // directly targeted
+                        $user_table . '.users_id' => Session::getLoginUserID(),
+                        // targeted through groups
+                        [
+                            $group_table . '.groups_id' => count($_SESSION["glpigroups"])
+                                ? $_SESSION["glpigroups"]
+                                : [-1],
+                            'OR' => [
+                                [$group_table . '.no_entity_restriction' => 1],
+                                getEntitiesRestrictCriteria(
+                                    $group_table,
+                                    '',
+                                    $_SESSION['glpiactiveentities'],
+                                    true
+                                ),
+                            ],
+                        ],
+                        // targeted through entities
+                        getEntitiesRestrictCriteria(
+                            $entity_table,
+                            '',
+                            '',
+                            true,
+                            true
+                        ),
+                    ],
+                ],
+            ],
+        ];
 
         if ($itemtype != null) {
             if (!$inverse) {
@@ -809,6 +964,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     {
         TemplateRenderer::getInstance()->display('layout/parts/saved_searches_list.html.twig', [
             'active'         => $_SESSION['glpi_loaded_savedsearch'] ?? "",
+            'current_user'   => Session::getLoginUserID(),
             'saved_searches' => $this->getMine($itemtype, $inverse),
         ]);
     }
@@ -1140,7 +1296,7 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             $params = class_exists($this->fields['itemtype']) ? $query_tab : null;
 
             if (!$params) {
-                throw new RuntimeException('Saved search #' . $this->getID() . ' seems to be broken!');
+                throw new RuntimeException('Saved search #' . $this->getID() . ' seems to be broken!' . $this->getField('query') . 'test');
             } else {
                 $params['silent_validation'] = true;
                 $data                   = $search->prepareDatasForSearch(
@@ -1183,27 +1339,6 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         }
     }
 
-    private static function getVisibilityCriteriaForMine(): array
-    {
-        $criteria = ['WHERE' => []];
-        $restrict = [
-            self::getTable() . '.is_private' => 1,
-            self::getTable() . '.users_id'    => Session::getLoginUserID(),
-        ];
-
-        if (Session::haveRight(self::$rightname, READ)) {
-            $restrict = [
-                'OR' => [
-                    $restrict,
-                    [self::getTable() . '.is_private' => 0],
-                ],
-            ];
-        }
-
-        $criteria['WHERE'] = $restrict + getEntitiesRestrictCriteria(self::getTable(), '', '', true);
-        return $criteria;
-    }
-
     /**
      * Return visibility joins to add to DBIterator parameters
      *
@@ -1219,7 +1354,64 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
             return ['WHERE' => []];
         }
 
-        return self::getVisibilityCriteriaForMine();
+        if (!Session::haveRight(self::$rightname, READ)) {
+            return [
+                'WHERE' => ['glpi_savedsearches.users_id' => Session::getLoginUserID()],
+            ];
+        }
+
+        $table = self::getTable();
+        $user_table = SavedSearch_UserTarget::getTable();
+        $group_table = Group_SavedSearch::getTable();
+        $entity_table = Entity_SavedSearch::getTable();
+
+        $criteria = self::getDefaultJoin();
+
+        $owner_restrict = [
+            $table . '.users_id' => Session::getLoginUserID(),
+        ];
+        $entity_restrict = getEntitiesRestrictCriteria($table, '', '', true);
+        if (count($entity_restrict)) {
+            $owner_restrict += $entity_restrict;
+        }
+
+        $restrict = [
+            'OR' => [
+                $owner_restrict,
+                [
+                    'OR' => [
+                        // directly targeted
+                        $user_table . '.users_id' => Session::getLoginUserID(),
+                        // targeted through groups
+                        [
+                            $group_table . '.groups_id' => count($_SESSION["glpigroups"])
+                                ? $_SESSION["glpigroups"]
+                                : [-1],
+                            'OR' => [
+                                [$group_table . '.no_entity_restriction' => 1],
+                                getEntitiesRestrictCriteria(
+                                    $group_table,
+                                    '',
+                                    $_SESSION['glpiactiveentities'],
+                                    true
+                                ),
+                            ],
+                        ],
+                        // targeted through entities
+                        getEntitiesRestrictCriteria(
+                            $entity_table,
+                            '',
+                            '',
+                            true,
+                            true
+                        ),
+                    ],
+                ],
+            ],
+        ];
+        $criteria['WHERE'] = $restrict;
+
+        return $criteria;
     }
 
     public static function getIcon()
@@ -1241,5 +1433,14 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
     public function getCloneRelations(): array
     {
         return [];
+    }
+
+    /**
+     * No specific right needed to be a target
+     * @return string
+     */
+    public function getVisibilityRight()
+    {
+        return '';
     }
 }

--- a/src/SavedSearch_UserTarget.php
+++ b/src/SavedSearch_UserTarget.php
@@ -7,7 +7,7 @@
  *
  * http://glpi-project.org
  *
- * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2015-2026 Teclib' and contributors.
  * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *

--- a/src/SavedSearch_UserTarget.php
+++ b/src/SavedSearch_UserTarget.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2025 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+class SavedSearch_UserTarget extends CommonDBRelation
+{
+    public bool $auto_message_on_action = false;
+
+    public static ?string $itemtype_1          = SavedSearch::class;
+    public static ?string $items_id_1          = 'savedsearches_id';
+    public static ?string $itemtype_2          = User::class;
+    public static ?string $items_id_2          = 'users_id';
+
+    public static int $checkItem_2_Rights  = self::DONT_CHECK_ITEM_RIGHTS;
+    public static bool $logs_for_item_2     = false;
+
+    /**
+     * Get users for a saved search
+     *
+     * @param SavedSearch $savedSearch SavedSearch instance
+     *
+     * @return array of users linked to a saved search
+     **/
+    public static function getUsers(SavedSearch $savedSearch)
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $results   = [];
+        $iterator = $DB->request([
+            'FROM'   => self::getTable(),
+            'WHERE'  => [
+                self::$items_id_1 => $savedSearch->getID(),
+            ],
+        ]);
+
+        foreach ($iterator as $data) {
+            $results[$data[self::$items_id_2]][] = $data;
+        }
+        return $results;
+    }
+}

--- a/src/User.php
+++ b/src/User.php
@@ -514,14 +514,64 @@ class User extends CommonDBTM implements TreeBrowseInterface
         $reminder_translation = new ReminderTranslation();
         $reminder_translation->deleteByCriteria(['users_id' => $this->fields['id']]);
 
-        // Delete private bookmark
         $ss = new SavedSearch();
-        $ss->deleteByCriteria(
-            [
-                'users_id'   => $this->fields['id'],
-                'is_private' => 1,
-            ]
-        );
+        $search_table = SavedSearch::getTable();
+        $user_table = SavedSearch_UserTarget::getTable();
+        $group_table = Group_SavedSearch::getTable();
+        $entity_table = Entity_SavedSearch::getTable();
+        // Retrieve all bookmarks created by the user which have at least 1 target
+        $publics = $ss->find([
+            'id' => new QuerySubQuery([
+                'SELECT' => $search_table . '.id',
+                'FROM' => $ss->getTable(),
+                'LEFT JOIN' => [
+                    $user_table => [
+                        'ON' => [
+                            $user_table   => 'savedsearches_id',
+                            $search_table => 'id',
+                        ],
+                    ],
+                    $group_table => [
+                        'ON' => [
+                            $group_table  => 'savedsearches_id',
+                            $search_table => 'id',
+                        ],
+                    ],
+                    $entity_table => [
+                        'ON' => [
+                            $entity_table => 'savedsearches_id',
+                            $search_table => 'id',
+                        ],
+                    ],
+                ],
+                'WHERE' => [
+                    $search_table . '.users_id' => $this->fields['id'],
+                    'OR' => [
+                        ['NOT' => [$user_table . '.savedsearches_id'   => null]],
+                        ['NOT' => [$group_table . '.savedsearches_id'  => null]],
+                        ['NOT' => [$entity_table . '.savedsearches_id' => null]],
+                    ],
+                ],
+            ]),
+        ]);
+        if (count($publics)) {
+            $publics = array_map(fn($e) => $e['id'], $publics);
+            // Delete private bookmark
+            $ss->deleteByCriteria(
+                [
+                    'users_id' => $this->fields['id'],
+                    'NOT' => [
+                        'id' => $publics,
+                    ],
+                ]
+            );
+        } else {
+            $ss->deleteByCriteria(
+                [
+                    'users_id' => $this->fields['id'],
+                ]
+            );
+        }
 
         // Set no user to public bookmark
         $DB->update(
@@ -561,6 +611,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                 Reminder_User::class,
                 RSSFeed_User::class,
                 SavedSearch_User::class,
+                SavedSearch_UserTarget::class,
                 Ticket_User::class,
                 UserEmail::class,
             ]

--- a/templates/components/add_visibility_target.html.twig
+++ b/templates/components/add_visibility_target.html.twig
@@ -37,7 +37,7 @@
         {{ fields.csrfField() }}
         <div class="d-flex flex-wrap">
             {{ fields.dropdownItemTypes('_type', '', add_target_msg, {
-                types: ['Entity', 'Group', 'Profile', 'User'],
+                types: types,
                 rand: rand,
                 inline_add_field_html: true,
                 add_field_html: "<span id='visibility" ~ rand ~ "'></span>",

--- a/templates/pages/tools/savedsearch/form.html.twig
+++ b/templates/pages/tools/savedsearch/form.html.twig
@@ -60,15 +60,18 @@
             (constant('SavedSearch::COUNT_YES')): __('Yes'),
             (constant('SavedSearch::COUNT_NO')): __('No')
         }, __('Do count')) }}
-        {% if can_create %}
-            {{ fields.dropdownArrayField('is_private', item.fields['is_private'], {
-                1: __('Private'),
-                0: __('Public')
-            }, __('Visibility')) }}
+        {% if can_create and item.isNewItem() %}
+            {% if can_create_public %}
+                {{ fields.dropdownArrayField('is_private', item.fields['is_private'], {
+                    1: __('Private'),
+                    0: __('Public')
+                }, __('Visibility')) }}
+            {% endif %}
             {{ fields.dropdownField('Entity', 'entities_id', item.fields['entities_id'], 'Entity'|itemtype_name(1)) }}
             {{ fields.dropdownYesNo('is_recursive', item.fields['is_recursive'], __('Child entities')) }}
-        {% else %}
-            {{ fields.htmlField('', (item.fields['is_private']|default(1) ? __('Private') : __('Public'))|e, __('Visibility')) }}
+            {% if not can_create_public %}
+                {{ fields.hiddenField('is_private', 1) }}
+            {% endif %}
         {% endif %}
     {% endblock %}
 {% endblock %}

--- a/tests/functional/NotificationTargetSavedSearch_AlertTest.php
+++ b/tests/functional/NotificationTargetSavedSearch_AlertTest.php
@@ -50,6 +50,7 @@ class NotificationTargetSavedSearch_AlertTest extends DbTestCase
             'type' => \SavedSearch::SEARCH,
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
             'users_id' => \Session::getLoginUserID(),
+            'is_private' => 1,
             'itemtype' => 'Computer',
             'url' => 'http://localhost/front/computer.php?is_deleted=0&as_map=0&browse=0&criteria%5B0%5D%5Blink%5D=AND&criteria%5B0%5D%5Bfield%5D=view&criteria%5B0%5D%5Bsearchtype%5D=contains&criteria%5B0%5D%5Bvalue%5D=test&itemtype=Computer&start=0&_glpi_csrf_token=735e344f1f47545e5bea56aa4e75c15ca45d3628307937c3bf185e0a3bca39db&sort%5B%5D=1&order%5B%5D=ASC',
         ]);

--- a/tests/functional/SavedSearchTest.php
+++ b/tests/functional/SavedSearchTest.php
@@ -62,7 +62,8 @@ class SavedSearchTest extends DbTestCase
         global $DB;
 
         $root_entity_id  = getItemByTypeName(\Entity::class, '_test_root_entity', true);
-        $child_entity_id = getItemByTypeName(\Entity::class, '_test_child_1', true);
+
+        $test_group_1_id  = getItemByTypeName(\Group::class, '_test_group_1', true);
 
         // needs a user
         // let's use TU_USER
@@ -73,73 +74,87 @@ class SavedSearchTest extends DbTestCase
         // now add a bookmark on Ticket view
         $bk = new SavedSearch();
         $this->assertTrue(
-            (bool) $bk->add([
-                'name'         => 'public root recursive',
-                'type'         => 1,
-                'itemtype'     => 'Ticket',
-                'users_id'     => $tuuser_id,
-                'is_private'   => 0,
-                'entities_id'  => $root_entity_id,
-                'is_recursive' => 1,
-                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
-            ])
+            (bool) $bk->add(
+                [
+                    'name'         => 'private root recursive',
+                    'type'         => 1,
+                    'itemtype'     => 'Ticket',
+                    'users_id'     => $tuuser_id,
+                    'entities_id'  => 0,
+                    'is_recursive' => 1,
+                    'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
+                ]
+            )
         );
+        $bk_private_id = $bk->getID();
         $this->assertTrue(
-            (bool) $bk->add([
-                'name'         => 'public root NOT recursive',
-                'type'         => 1,
-                'itemtype'     => 'Ticket',
-                'users_id'     => $tuuser_id,
-                'is_private'   => 0,
-                'entities_id'  => $root_entity_id,
-                'is_recursive' => 0,
-                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
-            ])
+            (bool) $bk->add(
+                [
+                    'name'         => 'target user root recursive',
+                    'type'         => 1,
+                    'itemtype'     => 'Ticket',
+                    'users_id'     => $tuuser_id,
+                    'entities_id'  => 0,
+                    'is_recursive' => 1,
+                    'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
+                ]
+            )
         );
+        $bk_target_user_id = $bk->getID();
         $this->assertTrue(
-            (bool) $bk->add([
-                'name'         => 'public child 1 recursive',
-                'type'         => 1,
-                'itemtype'     => 'Ticket',
-                'users_id'     => $tuuser_id,
-                'is_private'   => 0,
-                'entities_id'  => $child_entity_id,
-                'is_recursive' => 1,
-                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
-            ])
+            (bool) $bk->add(
+                [
+                    'name'         => 'target group root recursive',
+                    'type'         => 1,
+                    'itemtype'     => 'Ticket',
+                    'users_id'     => $tuuser_id,
+                    'entities_id'  => 0,
+                    'is_recursive' => 1,
+                    'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
+                ]
+            )
         );
+        $bk_target_group_id = $bk->getID();
+        // has is_private => 0 in inputs, so a target will be automatically created for the bookmark's entity
+        $this->assertTrue(
+            (bool) $bk->add(
+                [
+                    'name'         => 'created public target entity root recursive',
+                    'type'         => 1,
+                    'itemtype'     => 'Ticket',
+                    'users_id'     => $tuuser_id,
+                    'is_private'   => 0,
+                    'entities_id'  => 0,
+                    'is_recursive' => 1,
+                    'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
+                ]
+            )
+        );
+        $bk_target_entity_id = $bk->getID();
+        $bk2 = new \SavedSearch();
+        $bk2->getFromDB($bk_target_entity_id);
+        $this->assertEquals(1, $bk2->countVisibilities());
 
         $this->assertTrue(
-            (bool) $bk->add([
-                'name'         => 'private TU_USER',
-                'type'         => 1,
-                'itemtype'     => 'Ticket',
-                'users_id'     => $tuuser_id,
-                'is_private'   => 1,
-                'entities_id'  => 0,
-                'is_recursive' => 1,
-                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
-            ])
+            (bool) $bk->add(
+                [
+                    'name'         => 'private normal user',
+                    'type'         => 1,
+                    'itemtype'     => 'Ticket',
+                    'users_id'     => $normal_id,
+                    'entities_id'  => 0,
+                    'is_recursive' => 1,
+                    'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
+                ]
+            )
         );
-
-        $this->assertTrue(
-            (bool) $bk->add([
-                'name'         => 'private normal user',
-                'type'         => 1,
-                'itemtype'     => 'Ticket',
-                'users_id'     => $normal_id,
-                'is_private'   => 1,
-                'entities_id'  => 0,
-                'is_recursive' => 1,
-                'url'          => 'front/ticket.php?itemtype=Ticket&sort=2&order=DESC&start=0&criteria[0][field]=5&criteria[0][searchtype]=equals&criteria[0][value]=' . $tuuser_id,
-            ])
-        );
-        // With UPDATE 'config' right, we still shouldn't see other user's private searches
+        $bk_private_normal_id = $bk->getID();
+        // With UPDATE 'config' right, we still shouldn't see other user's searches without targets
         $expected = [
-            'public root recursive',
-            'public root NOT recursive',
-            'public child 1 recursive',
-            'private TU_USER',
+            'private root recursive',
+            'target user root recursive',
+            'target group root recursive',
+            'created public target entity root recursive',
         ];
         $mine = $bk->getMine();
         $this->assertCount(count($expected), $mine);
@@ -154,77 +169,85 @@ class SavedSearchTest extends DbTestCase
             array_column($mine, 'name')
         );
 
-        // Normal user cannot see public saved searches by default
+        // test each type of targets so that normal will be able to see them
+        $bks_normal = [
+            'private normal user',
+            'created public target entity root recursive',
+        ];
+        // add normal to a group
+        $group_user = new \Group_User();
+        $group_user->add(
+            [
+                'users_id' => 5,
+                'groups_id' => $test_group_1_id,
+            ]
+        );
         $this->login('normal', 'normal');
 
         $mine = $bk->getMine();
-        $this->assertCount(1, $mine);
+        $this->assertCount(count($bks_normal), $mine);
         $this->assertEqualsCanonicalizing(
-            ['private normal user'],
+            $bks_normal,
             array_column($mine, 'name')
         );
 
-        //add public saved searches read right for normal profile
-        $DB->update(
-            'glpi_profilerights',
-            ['rights' => 1],
+        // add normal as target for another savedsearch
+        $DB->insert(
+            'glpi_savedsearches_usertargets',
             [
-                'profiles_id'  => 2,
-                'name'         => 'bookmark_public',
+                'users_id'  => 5,
+                'savedsearches_id' => $bk_target_user_id,
             ]
         );
-        $this->login('normal', 'normal'); // ACLs have changed: login again.
-        $expected = [
-            'public root recursive',
-            'public root NOT recursive',
-            'public child 1 recursive',
-            'private normal user',
-        ];
+        $bks_normal[] = 'target user root recursive';
         $mine = $bk->getMine('Ticket');
-        $this->assertCount(count($expected), $mine);
+        $this->assertCount(count($bks_normal), $mine);
         $this->assertEqualsCanonicalizing(
-            $expected,
+            $bks_normal,
             array_column($mine, 'name')
         );
 
-        // Check entity restrictions
-        $this->setEntity('_test_root_entity', false);
-        $expected = [
-            'public root recursive',
-            'public root NOT recursive',
-            'private normal user',
-        ];
+        // add the group as target for a bookmark
+        $DB->insert(
+            'glpi_groups_savedsearches',
+            [
+                'savedsearches_id'  => $bk_target_group_id,
+                'groups_id' => $test_group_1_id,
+                'entities_id' => 0,
+                'is_recursive' => 1,
+            ]
+        );
+
+        $bks_normal[] = 'target group root recursive';
         $mine = $bk->getMine('Ticket');
-        $this->assertCount(count($expected), $mine);
+        $this->assertCount(count($bks_normal), $mine);
         $this->assertEqualsCanonicalizing(
-            $expected,
+            $bks_normal,
             array_column($mine, 'name')
         );
 
-        $this->setEntity('_test_child_1', true);
-        $expected = [
-            'public root recursive',
-            'public child 1 recursive',
-            'private normal user',
-        ];
+        // add an entity target for an entity at a level below the current one
+        $DB->insert(
+            'glpi_entities_savedsearches',
+            [
+                'savedsearches_id'  => $bk_private_id,
+                'entities_id' => $root_entity_id,
+                'is_recursive' => 1,
+            ]
+        );
+        $bks_normal[] = 'private root recursive';
         $mine = $bk->getMine('Ticket');
-        $this->assertCount(count($expected), $mine);
+        $this->assertCount(count($bks_normal), $mine);
         $this->assertEqualsCanonicalizing(
-            $expected,
+            $bks_normal,
             array_column($mine, 'name')
         );
 
-        $this->setEntity('_test_child_1', false);
-        $expected = [
-            'public root recursive',
-            'public child 1 recursive',
-            'private normal user',
-        ];
-        $mine = $bk->getMine('Ticket');
-        $this->assertCount(count($expected), $mine);
-        $this->assertEqualsCanonicalizing(
-            $expected,
-            array_column($mine, 'name')
+        $DB->delete(
+            $group_user->getTable(),
+            [
+                'id' => $group_user->getID(),
+            ]
         );
     }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

This PR is to add a new feature on private saved search.
The goal is to be add target (user or group) on private saved search 
User and group dropdown take into account entity of the item when loading available targets.

## Screenshots :

See PR for screenshots

https://github.com/glpi-project/glpi/pull/17587
