### PR TITLE
fix(Entity): default entity list sort by completename

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -43,6 +43,7 @@ use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
 use Glpi\ItemTranslation\Context\TranslationHandler;
+use Glpi\Search\DefaultSearchRequestInterface;
 use Glpi\UI\IllustrationManager;
 use Ramsey\Uuid\Uuid;
 
@@ -53,7 +54,10 @@ use function Safe\realpath;
 /**
  * Entity class
  */
-class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, ProvideTranslationsInterface
+class Entity extends CommonTreeDropdown implements
+    LinkableToTilesInterface,
+    ProvideTranslationsInterface,
+    DefaultSearchRequestInterface
 {
     /** @use Clonable<static> */
     use Clonable;
@@ -258,6 +262,15 @@ class Entity extends CommonTreeDropdown implements LinkableToTilesInterface, Pro
         $GLPI_CACHE->delete($ckey);
 
         return true;
+    }
+
+
+    public static function getDefaultSearchRequest(): array
+    {
+        return [
+            'sort'  => 1,
+            'order' => 'ASC',
+        ];
     }
 
     public static function getTypeName($nb = 0)

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -264,11 +264,14 @@ class Entity extends CommonTreeDropdown implements
         return true;
     }
 
-
+    /**
+     * @return array<string, mixed>
+     */
+    #[Override]
     public static function getDefaultSearchRequest(): array
     {
         return [
-            'sort'  => 1,
+            'sort'  => 1, //completename SO
             'order' => 'ASC',
         ];
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43182
- In GLPI 10, the list of entities was sorted by “completename” by default, but this sorting option was removed in GLPI 11. This fix adds the option to sort entities in ascending alphabetical order by “completename.”

## Screenshots (if appropriate):

GLPI 10 view:
<img width="1403" height="168" alt="image" src="https://github.com/user-attachments/assets/4558707e-20c0-4d75-90d9-8fc1f06460ab" />

GLPI 11 view:
<img width="1425" height="199" alt="image" src="https://github.com/user-attachments/assets/52c9f164-bff8-4825-bcac-9ada3860480f" />



