### PR TITLE
prevent pending reason autoresolve with no solution template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 
+- Pending reason UI and save logic changed to prevent auto-resolve without selection of a solution template.
+  Any existing pending reasons with "Follow-ups before automatic resolution" set without a solution template
+  will be automatically updated to set the "Follow-ups before automatic resolution" to "Automatic resolution disabled"
+  to prevent the "Failed to load SolutionTemplate" PHP warnings that were raised previously.
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The present file will list all changes made to the project; according to the
   Any existing pending reasons with "Follow-ups before automatic resolution" set without a solution template
   will be automatically updated to set the "Follow-ups before automatic resolution" to "Automatic resolution disabled"
   to prevent the "Failed to load SolutionTemplate" PHP warnings that were raised previously.
+  The pending reason UI in followups and tasks will only show the "Automatic follow-up" and "Automatic resolution" options when a followup template and solution template respectively are set for the pending reason.
 
 ### Deprecated
 

--- a/ajax/pendingreason.php
+++ b/ajax/pendingreason.php
@@ -56,4 +56,6 @@ if (!$pending_reason) {
 echo json_encode([
     'followup_frequency'          => $pending_reason->fields['followup_frequency'],
     'followups_before_resolution' => $pending_reason->fields['followups_before_resolution'],
+    'itilfollowuptemplates_id' => $pending_reason->fields['itilfollowuptemplates_id'],
+    'solutiontemplates_id' => $pending_reason->fields['solutiontemplates_id'],
 ]);

--- a/install/migrations/update_11.0.6_to_11.0.7.php
+++ b/install/migrations/update_11.0.6_to_11.0.7.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+use function Safe\preg_match;
+use function Safe\scandir;
+
+/**
+ * Update from 11.0.6 to 11.0.7
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update1106to1107()
+{
+    /**
+     * @var DBmysql $DB
+     * @var Migration $migration
+     */
+    global $DB, $migration;
+
+    $updateresult       = true;
+    $ADDTODISPLAYPREF   = [];
+    $DELFROMDISPLAYPREF = [];
+    $update_dir = __DIR__ . '/update_11.0.6_to_11.0.7/';
+
+    $migration->setVersion('11.0.7');
+
+    $update_scripts = scandir($update_dir);
+    foreach ($update_scripts as $update_script) {
+        if (preg_match('/\.php$/', $update_script) !== 1) {
+            continue;
+        }
+        require $update_dir . $update_script;
+    }
+
+    // ************ Keep it at the end **************
+    $migration->updateDisplayPrefs($ADDTODISPLAYPREF, $DELFROMDISPLAYPREF);
+
+    $migration->executeMigration();
+
+    return $updateresult;
+}

--- a/install/migrations/update_11.0.6_to_11.0.7/pendingreason.php
+++ b/install/migrations/update_11.0.6_to_11.0.7/pendingreason.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+$DB->update(
+    'glpi_pendingreasons',
+    ['followups_before_resolution' => 0],
+    ['solutiontemplates_id' => 0]
+);

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -439,5 +439,6 @@ class PendingReason extends CommonDropdown
             'params' => $options,
             'additional_fields' => $fields,
         ]);
+        return true;
     }
 }

--- a/src/PendingReason.php
+++ b/src/PendingReason.php
@@ -404,6 +404,12 @@ class PendingReason extends CommonDropdown
         $input['is_pending_per_default'] = isset($input['is_default']) && $input['is_default']
             ? ($input['is_pending_per_default'] ?? 0) : 0;
 
+        // Prevent auto-solve without a solution template as it raises a PHP warning in PendingReasonCron
+        $solution_template_id = $input['solutiontemplates_id'] ?? $this->fields['solutiontemplates_id'] ?? 0;
+        if ((int) $solution_template_id <= 0) {
+            $input['followups_before_resolution'] = 0;
+        }
+
         return $input;
     }
 
@@ -415,5 +421,23 @@ class PendingReason extends CommonDropdown
     public function prepareInputForUpdate($input)
     {
         return $this->prepareInput($input);
+    }
+
+    public function showForm($ID, array $options = [])
+    {
+        if (!self::isNewID($ID)) {
+            $this->check($ID, READ);
+        } else {
+            // Create item
+            $this->check(-1, CREATE);
+        }
+
+        $fields = $this->getAdditionalFields();
+
+        echo TemplateRenderer::getInstance()->render('pages/setup/pendingreason_form.html.twig', [
+            'item'   => $this,
+            'params' => $options,
+            'additional_fields' => $fields,
+        ]);
     }
 }

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -33,143 +33,156 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% if call('PendingReason_Item::canDisplayPendingReasonForItem', [subitem]) %}
-   {% set default_pending = call('PendingReason::getDefault') %}
-   {% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
-   {% set pending_item_parent = call('PendingReason_Item::getForItem', [item, true]) %}
-   {% set pendingreasons_id = pending_item.fields['pendingreasons_id'] ?? pending_item_parent.fields['pendingreasons_id'] ?? default_pending.fields['id'] ?? 0 %}
+    {% set default_pending = call('PendingReason::getDefault') %}
+    {% set pending_item = call('PendingReason_Item::getForItem', [subitem, true]) %}
+    {% set pending_item_parent = call('PendingReason_Item::getForItem', [item, true]) %}
+    {% set pendingreasons_id = pending_item.fields['pendingreasons_id'] ?? pending_item_parent.fields['pendingreasons_id'] ?? default_pending.fields['id'] ?? 0 %}
 
-   <div class="row">
-      <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
-           data-bs-toggle="tooltip" data-bs-placement="top">
-         {% set pendingreasons_lbl %}
-            <i class="ti ti-tags"></i>
-         {% endset %}
-         {% set pending_reasons_id_script %}
-            <script>
-               var myCollapsible = $('#pending-reasons-setup-{{ rand }}')[0];
-               myCollapsible.addEventListener('show.bs.collapse', function () {
-                  $('#pending-reasons-control-{{ rand }}').addClass('flex-fill');
-               });
-               myCollapsible.addEventListener('hide.bs.collapse', function () {
-                  $('#pending-reasons-control-{{ rand }}').removeClass('flex-fill');
-               });
+    <div class="row">
+        <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
+             data-bs-toggle="tooltip" data-bs-placement="top">
+            {% set pendingreasons_lbl %}
+                <i class="ti ti-tags"></i>
+            {% endset %}
+            {% set pending_reasons_id_script %}
+                <script>
+                    var myCollapsible = $('#pending-reasons-setup-{{ rand }}')[0];
+                    myCollapsible.addEventListener('show.bs.collapse', function () {
+                        $('#pending-reasons-control-{{ rand }}').addClass('flex-fill');
+                    });
+                    myCollapsible.addEventListener('hide.bs.collapse', function () {
+                        $('#pending-reasons-control-{{ rand }}').removeClass('flex-fill');
+                    });
+                </script>
+            {% endset %}
+            {{ fields.dropdownField(
+                'PendingReason',
+                'pendingreasons_id',
+                pendingreasons_id,
+                pendingreasons_lbl,
+                {
+                    'label_class': 'col-1',
+                    'input_class': 'col-10 ms-1',
+                    'rand': rand,
+                    'mb': '',
+                    'hide_if_no_elements': true,
+                    'addicon': false,
+                    'comments': false,
+                    'width': '95%',
+                    'field_class': 'flex-nowrap',
+                    'add_field_html': pending_reasons_id_script,
+                    'aria_label': _n('Pending reason', 'Pending reasons', 1),
+                }
+            ) }}
+            <script type="module">
+                // Initialize a flag to check if the pending reasons dropdown has been initialized
+                let pendingReasonsInitalized{{ rand }} = false;
+
+                let handlePendingReasonsChange{{ rand }} = async () => {
+                    let pending_val = $('#dropdown_pendingreasons_id{{ rand }}').val();
+
+                    if (pending_val > 0) {
+                        $('#pending-reasons-more_options_{{ rand }}').addClass('show');
+                        let data = await $.ajax({
+                            url: '{{ path("ajax/pendingreason.php") }}',
+                            type: 'POST',
+                            data: {
+                                pendingreasons_id: pending_val
+                            }
+                        });
+
+                        if (data.itilfollowuptemplates_id) {
+                            $('#dropdown_followup_frequency{{ rand }}')
+                                .val(data.followup_frequency)
+                                .trigger('change');
+                            $('#dropdown_followup_frequency{{ rand }}').closest('.form-field').parent().removeClass('d-none');
+                        } else {
+                            $('#dropdown_followup_frequency{{ rand }}')
+                                .closest('.form-field').parent().addClass('d-none');
+                        }
+                        if (data.solutiontemplates_id) {
+                            $('#dropdown_followups_before_resolution{{ rand }}')
+                                .val(data.followups_before_resolution)
+                                .removeClass('d-none')
+                                .trigger('change');
+                            $('#dropdown_followups_before_resolution{{ rand }}').closest('.form-field').parent().removeClass('d-none');
+                        } else {
+                            $('#dropdown_followups_before_resolution{{ rand }}')
+                                .closest('.form-field').parent().addClass('d-none');
+                        }
+                    } else {
+                        $('#pending-reasons-more_options_{{ rand }}').removeClass('show');
+                    }
+                }
+
+                await handlePendingReasonsChange{{ rand }}();
+
+                // If this is the first time the dropdown is being initialized
+                // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
+                if (!pendingReasonsInitalized{{ rand }}) {
+                    pendingReasonsInitalized{{ rand }} = true;
+                    setHasUnsavedChanges(false);
+                }
+
+                $('#dropdown_pendingreasons_id{{ rand }}').change(handlePendingReasonsChange{{ rand }});
             </script>
-         {% endset %}
-         {{ fields.dropdownField(
-            'PendingReason',
-            'pendingreasons_id',
-            pendingreasons_id,
-            pendingreasons_lbl,
-            {
-               'label_class': 'col-1',
-               'input_class': 'col-10 ms-1',
-               'rand': rand,
-               'mb': '',
-               'hide_if_no_elements': true,
-               'addicon': false,
-               'comments': false,
-               'width': '95%',
-               'field_class': 'flex-nowrap',
-               'add_field_html': pending_reasons_id_script,
-               'aria_label': _n('Pending reason', 'Pending reasons', 1),
-            }
-         ) }}
-         <script type="module">
-            // Initialize a flag to check if the pending reasons dropdown has been initialized
-            let pendingReasonsInitalized{{ rand }} = false;
+        </div>
 
-            let handlePendingReasonsChange{{ rand }} = async () => {
-               let pending_val = $('#dropdown_pendingreasons_id{{ rand }}').val();
-
-               if (pending_val > 0) {
-                  $('#pending-reasons-more_options_{{ rand }}').addClass('show');
-                  let data = await $.ajax({
-                     url: '{{ path("ajax/pendingreason.php") }}',
-                     type: 'POST',
-                     data: {
-                        pendingreasons_id: pending_val
-                     }
-                  });
-
-                  $('#dropdown_followup_frequency{{ rand }}')
-                     .val(data.followup_frequency)
-                     .trigger('change');
-                  $('#dropdown_followups_before_resolution{{ rand }}')
-                     .val(data.followups_before_resolution)
-                     .trigger('change');
-               } else {
-                  $('#pending-reasons-more_options_{{ rand }}').removeClass('show');
-               }
-            }
-
-            await handlePendingReasonsChange{{ rand }}();
-
-            // If this is the first time the dropdown is being initialized
-            // Mark the dropdown as initialized and reset the form modification flag to avoid triggering the unsaved changes warning
-            if (!pendingReasonsInitalized{{ rand }}) {
-               pendingReasonsInitalized{{ rand }} = true;
-               setHasUnsavedChanges(false);
-            }
-
-            $('#dropdown_pendingreasons_id{{ rand }}').change(handlePendingReasonsChange{{ rand }});
-         </script>
-      </div>
-
-      <div class="collapse col-12 col-sm-8 {{ pendingreasons_id ? "show" : "" }}" id="pending-reasons-more_options_{{ rand }}">
-         <div class="row">
-            <div class="col-12 col-sm-6" title="{{ __('Automatic follow-up') }}"
-                  data-bs-toggle="tooltip" data-bs-placement="top">
-               {% set pendingreasons_frequency_field = call('PendingReason::displayFollowupFrequencyfield', [
-                  pending_item ? pending_item.fields['followup_frequency'] : pending_item_parent ? pending_item_parent.fields['followup_frequency'] : null,
-                  "",
-                  {
-                     'rand': rand
-                  },
-                  false
-               ]) %}
-               {% set pendingreasons_frequency_lbl %}
-                  <i class="ti ti-reload"></i>
-               {% endset %}
-               {{ fields.field(
-                  'followup_frequency',
-                  pendingreasons_frequency_field,
-                  pendingreasons_frequency_lbl,
-                  {
-                     'field_class': '',
-                     'label_class': 'col-1',
-                     'input_class': 'col-10 ms-1',
-                     'rand': rand,
-                     'mb': '',
-                  }
-               ) }}
+        <div class="collapse col-12 col-sm-8 {{ pendingreasons_id ? "show" : "" }}" id="pending-reasons-more_options_{{ rand }}">
+            <div class="row">
+                <div class="col-12 col-sm-6" title="{{ __('Automatic follow-up') }}"
+                     data-bs-toggle="tooltip" data-bs-placement="top">
+                    {% set pendingreasons_frequency_field = call('PendingReason::displayFollowupFrequencyfield', [
+                        pending_item ? pending_item.fields['followup_frequency'] : pending_item_parent ? pending_item_parent.fields['followup_frequency'] : null,
+                        "",
+                        {
+                            'rand': rand
+                        },
+                        false
+                    ]) %}
+                    {% set pendingreasons_frequency_lbl %}
+                        <i class="ti ti-reload"></i>
+                    {% endset %}
+                    {{ fields.field(
+                        'followup_frequency',
+                        pendingreasons_frequency_field,
+                        pendingreasons_frequency_lbl,
+                        {
+                            'field_class': '',
+                            'label_class': 'col-1',
+                            'input_class': 'col-10 ms-1',
+                            'rand': rand,
+                            'mb': '',
+                        }
+                    ) }}
+                </div>
+                <div class="col-12 col-sm-6" title="{{ __('Automatic resolution') }}"
+                     data-bs-toggle="tooltip" data-bs-placement="top">
+                    {% set pendingreasons_resolution_field = call('PendingReason::displayFollowupsNumberBeforeResolutionField', [
+                        pending_item ? pending_item.fields['followups_before_resolution'] : pending_item_parent ? pending_item_parent.fields['followups_before_resolution'] : null,
+                        "",
+                        {
+                            'rand': rand
+                        },
+                        false
+                    ]) %}
+                    {% set pendingreasons_resolution_lbl %}
+                        <i class="ti ti-check"></i>
+                    {% endset %}
+                    {{ fields.field(
+                        'followups_before_resolution',
+                        pendingreasons_resolution_field,
+                        pendingreasons_resolution_lbl,
+                        {
+                            'field_class': '',
+                            'label_class': 'col-1',
+                            'input_class': 'col-10 ms-1',
+                            'rand': rand,
+                            'mb': '',
+                        }
+                    ) }}
+                </div>
             </div>
-            <div class="col-12 col-sm-6" title="{{ __('Automatic resolution') }}"
-                 data-bs-toggle="tooltip" data-bs-placement="top">
-               {% set pendingreasons_resolution_field = call('PendingReason::displayFollowupsNumberBeforeResolutionField', [
-                     pending_item ? pending_item.fields['followups_before_resolution'] : pending_item_parent ? pending_item_parent.fields['followups_before_resolution'] : null,
-                     "",
-                     {
-                        'rand': rand
-                     },
-                     false
-               ]) %}
-               {% set pendingreasons_resolution_lbl %}
-                  <i class="ti ti-check"></i>
-               {% endset %}
-               {{ fields.field(
-                  'followups_before_resolution',
-                  pendingreasons_resolution_field,
-                  pendingreasons_resolution_lbl,
-                  {
-                     'field_class': '',
-                     'label_class': 'col-1',
-                     'input_class': 'col-10 ms-1',
-                     'rand': rand,
-                     'mb': '',
-                  }
-               ) }}
-            </div>
-         </div>
-      </div>
-   </div>
+        </div>
+    </div>
 {% endif %}

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -98,6 +98,7 @@
                             $('#dropdown_followup_frequency{{ rand }}').closest('.form-field').parent().removeClass('d-none');
                         } else {
                             $('#dropdown_followup_frequency{{ rand }}')
+                                .val('0')
                                 .closest('.form-field').parent().addClass('d-none');
                         }
                         if (data.solutiontemplates_id) {
@@ -108,6 +109,7 @@
                             $('#dropdown_followups_before_resolution{{ rand }}').closest('.form-field').parent().removeClass('d-none');
                         } else {
                             $('#dropdown_followups_before_resolution{{ rand }}')
+                                .val('0')
                                 .closest('.form-field').parent().addClass('d-none');
                         }
                     } else {

--- a/templates/pages/setup/pendingreason_form.html.twig
+++ b/templates/pages/setup/pendingreason_form.html.twig
@@ -1,0 +1,66 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "dropdown_form.html.twig" %}
+
+{% block more_fields %}
+    <script>
+        const followup_frequency = $('select[name="followup_frequency"]');
+        const followups_before_resolution = $('select[name="followups_before_resolution"]');
+        const itilfollowuptemplates_id = $('select[name="itilfollowuptemplates_id"]');
+        const solutiontemplates_id = $('select[name="solutiontemplates_id"]');
+
+        function updateFieldVisibility() {
+            console.log('Updating field visibility');
+            if (followup_frequency.val() === '0') {
+                followups_before_resolution.closest('.form-field').addClass('d-none');
+                itilfollowuptemplates_id.closest('.form-field').addClass('d-none');
+                solutiontemplates_id.closest('.form-field').addClass('d-none');
+            } else {
+                followups_before_resolution.closest('.form-field').removeClass('d-none');
+                itilfollowuptemplates_id.closest('.form-field').removeClass('d-none');
+                solutiontemplates_id.closest('.form-field').removeClass('d-none');
+            }
+
+            if (parseInt(followups_before_resolution.val()) <= 0) {
+                solutiontemplates_id.closest('.form-field').addClass('d-none');
+            } else {
+                solutiontemplates_id.closest('.form-field').removeClass('d-none');
+            }
+        }
+        updateFieldVisibility();
+
+        {# Select2 uses jQuery and native change event listeners are not functional here #}
+        $(followup_frequency).on('change', updateFieldVisibility);
+        $(followups_before_resolution).on('change', updateFieldVisibility);
+    </script>
+{% endblock %}

--- a/templates/pages/setup/pendingreason_form.html.twig
+++ b/templates/pages/setup/pendingreason_form.html.twig
@@ -47,13 +47,11 @@
             } else {
                 followups_before_resolution.closest('.form-field').removeClass('d-none');
                 itilfollowuptemplates_id.closest('.form-field').removeClass('d-none');
-                solutiontemplates_id.closest('.form-field').removeClass('d-none');
-            }
-
-            if (parseInt(followups_before_resolution.val()) <= 0) {
-                solutiontemplates_id.closest('.form-field').addClass('d-none');
-            } else {
-                solutiontemplates_id.closest('.form-field').removeClass('d-none');
+                if (parseInt(followups_before_resolution.val()) <= 0) {
+                    solutiontemplates_id.closest('.form-field').addClass('d-none');
+                } else {
+                    solutiontemplates_id.closest('.form-field').removeClass('d-none');
+                }
             }
         }
         updateFieldVisibility();

--- a/templates/pages/setup/pendingreason_form.html.twig
+++ b/templates/pages/setup/pendingreason_form.html.twig
@@ -40,7 +40,6 @@
         const solutiontemplates_id = $('select[name="solutiontemplates_id"]');
 
         function updateFieldVisibility() {
-            console.log('Updating field visibility');
             if (followup_frequency.val() === '0') {
                 followups_before_resolution.closest('.form-field').addClass('d-none');
                 itilfollowuptemplates_id.closest('.form-field').addClass('d-none');

--- a/tests/functional/PendingReasonTest.php
+++ b/tests/functional/PendingReasonTest.php
@@ -1612,4 +1612,79 @@ class PendingReasonTest extends DbTestCase
         }
         $this->assertTrue($warning_found, 'Expected warning about missing pending reason not found');
     }
+
+    public function testPrepareInputForAdd()
+    {
+        $pr = new PendingReason();
+
+        // Normal case
+        $this->assertEquals([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'followup_frequency' => 1,
+            'followups_before_resolution' => 2,
+            'itilfollowuptemplates_id' => 3,
+            'solutiontemplates_id' => 4,
+            'is_pending_per_default' => 0,
+        ], $pr->prepareInputForAdd([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'followup_frequency' => 1,
+            'followups_before_resolution' => 2,
+            'itilfollowuptemplates_id' => 3,
+            'solutiontemplates_id' => 4,
+        ]));
+
+        // No solution template = no auto resolve
+        $this->assertEquals([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'followup_frequency' => 1,
+            'followups_before_resolution' => 0,
+            'itilfollowuptemplates_id' => 3,
+            'solutiontemplates_id' => 0,
+            'is_pending_per_default' => 0,
+        ], $pr->prepareInputForAdd([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'followup_frequency' => 1,
+            'followups_before_resolution' => 2,
+            'itilfollowuptemplates_id' => 3,
+            'solutiontemplates_id' => 0,
+        ]));
+
+        // Is pending per default
+        $this->assertEquals([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'is_default' => 0,
+            'is_pending_per_default' => 0,
+            'followups_before_resolution' => 0,
+        ], $pr->prepareInputForAdd([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'is_default' => 0,
+            'is_pending_per_default' => 1,
+        ]));
+        $this->assertEquals([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'is_default' => 1,
+            'is_pending_per_default' => 1,
+            'followups_before_resolution' => 0,
+        ], $pr->prepareInputForAdd([
+            'name' => 'Test',
+            'entities_id' => 1,
+            'is_recursive' => 1,
+            'is_default' => 1,
+            'is_pending_per_default' => 1,
+        ]));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

This aims to improve user experience and prevent a PHP warning when automatic resolution is configured but no solution template is selected.

The main pending reason form UI will dynamically show dependent fields.
If no "Automatic follow-up/solution frequency" is selected, the followup template and resolution/solution fields will be hidden.
If No "Follow-ups before automatic resolution" is selected, the solution template field will be hidden.

If a user saves a pending reason with a "Follow-ups before automatic resolution" value except disabled but no template, the "Follow-ups before automatic resolution" value will be forced to Disabled.

Any existing pending reasons with "Follow-ups before automatic resolution" set without a solution template will be automatically updated to set the "Follow-ups before automatic resolution" to "Automatic resolution disabled" to prevent the "Failed to load SolutionTemplate" PHP warnings that were raised previously.

The pending reason UI in followups and tasks will only show the "Automatic follow-up" and "Automatic resolution" options when a followup template and solution template respectively are set for the pending reason.

fixes #23190

Review with whitespace changes ignored as the "templates/components/itilobject/timeline/pending_reasons.html.twig" was re-indented following GLPI's code standards.