### PR TITLE
fix(forms): Implement HTML escaping for non-HTML raw answers

### DIFF
--- a/src/Glpi/Form/Answer.php
+++ b/src/Glpi/Form/Answer.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form;
 
 use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Glpi\Form\QuestionType\RawAnswerIsHtmlInterface;
 use InvalidArgumentException;
 use JsonSerializable;
 
@@ -96,7 +97,14 @@ final readonly class Answer implements JsonSerializable
         if ($question === false) {
             return null;
         }
-        return $type->formatRawAnswer($this->getRawAnswer(), $question);
+
+        $formatted = $type->formatRawAnswer($this->getRawAnswer(), $question);
+
+        if (!$type instanceof RawAnswerIsHtmlInterface) {
+            $formatted = \htmlescape($formatted);
+        }
+
+        return $formatted;
     }
 
     public function getQuestionLabel(): string

--- a/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeLongText.php
@@ -55,7 +55,8 @@ final class QuestionTypeLongText extends AbstractQuestionType implements
     FormQuestionDataConverterInterface,
     UsedAsCriteriaInterface,
     TranslationAwareQuestionType,
-    ConditionValueTransformerInterface
+    ConditionValueTransformerInterface,
+    RawAnswerIsHtmlInterface
 {
     #[Override]
     public function getFormEditorJsOptions(): string

--- a/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeShortText.php
@@ -78,14 +78,6 @@ final class QuestionTypeShortText extends AbstractQuestionTypeShortAnswer implem
     }
 
     #[Override]
-    public function formatRawAnswer(mixed $answer, Question $question): string
-    {
-        $formatted_answer = parent::formatRawAnswer($answer, $question);
-
-        return \htmlescape($formatted_answer);
-    }
-
-    #[Override]
     public function listTranslationsHandlers(Question $question): array
     {
         return [

--- a/src/Glpi/Form/QuestionType/RawAnswerIsHtmlInterface.php
+++ b/src/Glpi/Form/QuestionType/RawAnswerIsHtmlInterface.php
@@ -42,6 +42,4 @@ namespace Glpi\Form\QuestionType;
  * Question types that do NOT implement this interface will have their
  * formatted answer automatically HTML-escaped by Answer::getFormattedAnswer().
  */
-interface RawAnswerIsHtmlInterface
-{
-}
+interface RawAnswerIsHtmlInterface {}

--- a/src/Glpi/Form/QuestionType/RawAnswerIsHtmlInterface.php
+++ b/src/Glpi/Form/QuestionType/RawAnswerIsHtmlInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\QuestionType;
+
+/**
+ * Marker interface for question types whose formatRawAnswer() returns
+ * already-safe HTML that must NOT be automatically escaped.
+ *
+ * Question types that do NOT implement this interface will have their
+ * formatted answer automatically HTML-escaped by Answer::getFormattedAnswer().
+ */
+interface RawAnswerIsHtmlInterface
+{
+}

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ContentFieldTest.php
@@ -38,6 +38,9 @@ use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\ContentField;
 use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeLongText;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
@@ -115,6 +118,45 @@ final class ContentFieldTest extends DbTestCase
         $this->assertNotFalse($output);
         $this->assertStringContainsString('<b>1) First name</b>: John &lt;john&#64;doe.fr&gt;', $output);
         $this->assertStringContainsString("<b>2) Last name</b>: Doe", $output);
+    }
+
+    public function testRadioAnswerWithAngleBracketsIsEscaped(): void
+    {
+        $form = $this->createForm(
+            (new FormBuilder("Radio form"))
+                ->addQuestion(
+                    name: "Pick one",
+                    type: QuestionTypeRadio::class,
+                    extra_data: json_encode(new QuestionTypeSelectableExtraDataConfig([
+                        'opt1' => 'Option <br>test',
+                        'opt2' => 'Normal option',
+                    ]))
+                )
+        );
+
+        $this->sendFormAndAssertTicketContentContains(
+            expected_content: ["Option &lt;br&gt;test"],
+            form: $form,
+            answers: ["Pick one" => "opt1"],
+            config: null,
+        );
+    }
+
+    public function testLongTextAnswerHtmlIsPreserved(): void
+    {
+        $form = $this->createForm(
+            (new FormBuilder("Long text form"))
+                ->addQuestion("Description", QuestionTypeLongText::class)
+        );
+
+        $html_answer = "<p>Bold <strong>text</strong></p>";
+
+        $this->sendFormAndAssertTicketContentContains(
+            expected_content: [$html_answer],
+            form: $form,
+            answers: ["Description" => $html_answer],
+            config: null,
+        );
     }
 
     public function testSpecificContent(): void


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Following #23750, but for all question types except `QuestionTypeLongText`