### PR TITLE
Remove fileupload tooltip

### DIFF
--- a/templates/components/form/file_uploader.html.twig
+++ b/templates/components/form/file_uploader.html.twig
@@ -41,10 +41,6 @@
     <div class="file-uploader-dropzone-content">
         <i class="ti ti-cloud-upload file-uploader-dropzone-icon"></i>
         <p class="file-uploader-dropzone-title">{{ __('Drop files here or click to browse') }}</p>
-        <span class="form-help"
-              data-bs-toggle="tooltip"
-              data-bs-placement="top"
-              data-bs-title="{{ __('Allowed file types are configured by your administrator') }}">?</span>
         <span class="btn btn-outline-primary btn-sm mt-2">
             <i class="ti ti-folder-open me-1"></i>{{ __('Browse Files') }}
         </span>


### PR DESCRIPTION
## Description

<img width="574" height="497" alt="image" src="https://github.com/user-attachments/assets/0f28d7ba-1fff-4d5e-8815-760f20179c47" />

This tooltip seems useless because it provides no informations about the types that are allowed to be uploaded (and listing all types would be too long anyway).