### PR TITLE
fix(forms): Fixed SPECIFIC_ANSWERS strategy fallback when questions are empty or conditionally hidden

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -209,7 +209,10 @@ enum ITILActorFieldStrategy: string
             return null;
         }
 
-        return array_reduce($question_ids, function ($carry, $question_id) use ($itil_actor_field, $answers_set) {
+        $actors = [];
+        $answer_found = false;
+
+        foreach ($question_ids as $question_id) {
             $actors_ids = $this->getActorsForSpecificAnswer(
                 $question_id,
                 $itil_actor_field,
@@ -217,11 +220,21 @@ enum ITILActorFieldStrategy: string
             );
 
             if ($actors_ids === null) {
-                return $carry;
+                continue;
             }
 
-            return array_merge_recursive($carry, $actors_ids);
-        }, []);
+            $answer_found = true;
+            $actors = array_merge_recursive($actors, $actors_ids);
+        }
+
+        // When no answer was found for any of the specified questions (e.g. they
+        // were hidden by conditional visibility), return null so that subsequent
+        // strategies (such as FORM_FILLER) can act as a fallback.
+        if (!$answer_found) {
+            return null;
+        }
+
+        return $actors;
     }
 
     private function getActorsForSpecificAnswer(
@@ -325,7 +338,10 @@ enum ITILActorFieldStrategy: string
             return null;
         }
 
-        return array_reduce($question_ids, function ($carry, $question_id) use ($answers_set, $fk_field) {
+        $actors = [];
+        $answer_found = false;
+
+        foreach ($question_ids as $question_id) {
             $actors_ids = $this->getActorsFromObjectAnswer(
                 $question_id,
                 $answers_set,
@@ -333,11 +349,21 @@ enum ITILActorFieldStrategy: string
             );
 
             if ($actors_ids === null) {
-                return $carry;
+                continue;
             }
 
-            return array_merge_recursive($carry, $actors_ids);
-        }, []);
+            $answer_found = true;
+            $actors = array_merge_recursive($actors, $actors_ids);
+        }
+
+        // When no answer was found for any of the specified questions (e.g. they
+        // were hidden by conditional visibility), return null so that subsequent
+        // strategies can act as a fallback.
+        if (!$answer_found) {
+            return null;
+        }
+
+        return $actors;
     }
 
     private function getActorsFromObjectAnswer(

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -497,6 +497,41 @@ final class RequesterFieldTest extends AbstractActorFieldTest
         );
     }
 
+    public function testSpecificAnswersFallbackToFormFiller(): void
+    {
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $auth = $this->login();
+        $fallback_user = $this->createItem(User::class, ['name' => 'Fallback requester user']);
+
+        $config = new RequesterFieldConfig(
+            strategies: [
+                ITILActorFieldStrategy::SPECIFIC_ANSWERS,
+                ITILActorFieldStrategy::FORM_FILLER,
+            ],
+            specific_question_ids: [
+                $this->getQuestionId($form, "Requester 1"),
+            ]
+        );
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [],
+            expected_actors: [['items_id' => $auth->getUser()->getID()]]
+        );
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $config,
+            answers: [
+                "Requester 1" => [
+                    User::getForeignKeyField() . '-' . $fallback_user->getID(),
+                ],
+            ],
+            expected_actors: [['items_id' => $fallback_user->getID()]]
+        );
+    }
+
     #[Override]
     public static function provideConvertFieldConfigFromFormCreator(): iterable
     {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43205

When all questions specified in the SPECIFIC_ANSWERS strategy have no answer (e.g. because they were conditionally hidden), return null instead of [] so subsequent strategies like FORM_FILLER can act as fallback. Same fix applied to getActorsFromObjectAnswers.

Fixes: requester not set on ticket when form uses conditional visibility to hide the requester question and no fallback strategy is configured.