### PR TITLE
fix(forms): translate tag content using end user's language when creating items

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -10160,12 +10160,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/ServiceCatalog/ServiceCatalogManager.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Form\\\\Tag\\\\AnswerTagProvider\\:\\:getTagContentForValue\\(\\) should return string but returns string\\|null\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Tag/AnswerTagProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Offset 1 might not exist on array\\{0\\: string, 1\\?\\: non\\-empty\\-string\\}\\.$#',
 	'identifier' => 'offsetAccess.notFound',
 	'count' => 4,

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\QuestionType;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Condition\ConditionValueTransformerInterface;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
 use Glpi\ItemTranslation\Context\TranslationHandler;
@@ -515,10 +516,13 @@ TWIG;
             $answer = [$answer];
         }
 
-        // Replace uuids by labels
+        // Replace uuids by translated labels
         $options = $this->getOptions($question);
         $answer = array_map(
-            fn($uuid) => $options[$uuid] ?? '',
+            function ($uuid) use ($question, $options) {
+                $key = sprintf('%s-%s', self::TRANSLATION_KEY_OPTION, $uuid);
+                return FormTranslation::translate($question, $key) ?? ($options[$uuid] ?? '');
+            },
             $answer
         );
 

--- a/src/Glpi/Form/Tag/AnswerTagProvider.php
+++ b/src/Glpi/Form/Tag/AnswerTagProvider.php
@@ -77,7 +77,7 @@ final class AnswerTagProvider implements TagProviderInterface, TagWithIdValueInt
         }
 
         $answer = array_pop($answers);
-        return $answer->getFormattedAnswer();
+        return $answer->getFormattedAnswer() ?? '';
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentDescriptionTagProvider.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\Tag;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Comment;
 use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
 use Override;
 
 final class CommentDescriptionTagProvider implements TagProviderInterface, TagWithIdValueInterface
@@ -70,7 +71,7 @@ final class CommentDescriptionTagProvider implements TagProviderInterface, TagWi
         if ($comment === false) {
             return '';
         }
-        return $comment->fields['description'];
+        return FormTranslation::translate($comment, Comment::TRANSLATION_KEY_DESCRIPTION) ?? $comment->fields['description'];
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/CommentTitleTagProvider.php
+++ b/src/Glpi/Form/Tag/CommentTitleTagProvider.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\Tag;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Comment;
 use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
 use Override;
 
 final class CommentTitleTagProvider implements TagProviderInterface, TagWithIdValueInterface
@@ -70,7 +71,7 @@ final class CommentTitleTagProvider implements TagProviderInterface, TagWithIdVa
         if ($comment === false) {
             return '';
         }
-        return $comment->fields['name'];
+        return FormTranslation::translate($comment, Comment::TRANSLATION_KEY_NAME) ?? $comment->fields['name'];
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/FormTagProvider.php
+++ b/src/Glpi/Form/Tag/FormTagProvider.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
 use Override;
 
 final class FormTagProvider implements TagProviderInterface, TagWithIdValueInterface
@@ -64,7 +65,7 @@ final class FormTagProvider implements TagProviderInterface, TagWithIdValueInter
         if ($form === false) {
             return '';
         }
-        return $form->fields['name'];
+        return FormTranslation::translate($form, Form::TRANSLATION_KEY_NAME) ?? $form->fields['name'];
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/QuestionTagProvider.php
+++ b/src/Glpi/Form/Tag/QuestionTagProvider.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Question;
 use Override;
 
@@ -70,7 +71,7 @@ final class QuestionTagProvider implements TagProviderInterface, TagWithIdValueI
         if (!$question) {
             return '';
         }
-        return $question->fields['name'];
+        return FormTranslation::translate($question, Question::TRANSLATION_KEY_NAME) ?? $question->fields['name'];
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/SectionTagProvider.php
+++ b/src/Glpi/Form/Tag/SectionTagProvider.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
 use Glpi\Form\Section;
 use Override;
 
@@ -70,7 +71,7 @@ final class SectionTagProvider implements TagProviderInterface, TagWithIdValueIn
         if (!$section) {
             return '';
         }
-        return $section->fields['name'];
+        return FormTranslation::translate($section, Section::TRANSLATION_KEY_NAME) ?? $section->fields['name'];
     }
 
     #[Override]

--- a/tests/functional/Glpi/Form/Tag/AnswerTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/AnswerTagProviderTest.php
@@ -37,12 +37,18 @@ namespace tests\units\Glpi\Form\Tag;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\Tag;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+
+use function Safe\json_encode;
 
 final class AnswerTagProviderTest extends DbTestCase
 {
@@ -119,6 +125,52 @@ final class AnswerTagProviderTest extends DbTestCase
             $answers_set,
         );
         $this->assertEquals($expected_content, $computed_content);
+    }
+
+    public function testGetTagContentForValueTranslatesSelectableOptionLabels(): void
+    {
+        $option_uuid = 'test-uuid-option-1';
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: 'Favorite color',
+                type: QuestionTypeRadio::class,
+                extra_data: json_encode((new QuestionTypeSelectableExtraDataConfig(
+                    options: [$option_uuid => 'Red']
+                ))->jsonSerialize()),
+            )
+        );
+
+        $question = Question::getById($this->getQuestionId($form, 'Favorite color'));
+        $translation_key = sprintf(
+            '%s-%s',
+            AbstractQuestionTypeSelectable::TRANSLATION_KEY_OPTION,
+            $option_uuid
+        );
+        $this->addTranslationToForm($question, 'fr_FR', $translation_key, 'Rouge');
+
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers($form, [
+            $this->getQuestionId($form, 'Favorite color') => $option_uuid,
+        ], 0);
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue(
+                value: $this->getQuestionId($form, 'Favorite color'),
+                answers_set: $answers,
+                expected_content: 'Rouge',
+            );
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue(
+                value: $this->getQuestionId($form, 'Favorite color'),
+                answers_set: $answers,
+                expected_content: 'Red',
+            );
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
     }
 
     private function createAndGetFormWithFirstAndLastNameQuestions(): Form

--- a/tests/functional/Glpi/Form/Tag/CommentDescriptionTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/CommentDescriptionTagProviderTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Comment;
 use Glpi\Form\Form;
 use Glpi\Form\Tag\CommentDescriptionTagProvider;
 use Glpi\Form\Tag\Tag;
@@ -92,6 +93,35 @@ final class CommentDescriptionTagProviderTest extends DbTestCase
             $this->getCommentId($form, 'Second comment title'),
             'Second comment description'
         );
+    }
+
+    public function testGetTagContentForValueUsingTranslation(): void
+    {
+        $form = $this->getFormWithComments();
+        $comment = Comment::getById($this->getCommentId($form, 'First comment title'));
+        $this->addTranslationToForm(
+            $comment,
+            'fr_FR',
+            Comment::TRANSLATION_KEY_DESCRIPTION,
+            'Description du premier commentaire'
+        );
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue(
+                $this->getCommentId($form, 'First comment title'),
+                'Description du premier commentaire'
+            );
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue(
+                $this->getCommentId($form, 'First comment title'),
+                'First comment description'
+            );
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
     }
 
     private function checkGetTagContentForValue(

--- a/tests/functional/Glpi/Form/Tag/CommentTitleTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/CommentTitleTagProviderTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Comment;
 use Glpi\Form\Form;
 use Glpi\Form\Tag\CommentTitleTagProvider;
 use Glpi\Form\Tag\Tag;
@@ -92,6 +93,35 @@ final class CommentTitleTagProviderTest extends DbTestCase
             $this->getCommentId($form, 'Second comment title'),
             'Second comment title'
         );
+    }
+
+    public function testGetTagContentForValueUsingTranslation(): void
+    {
+        $form = $this->getFormWithComments();
+        $comment = Comment::getById($this->getCommentId($form, 'First comment title'));
+        $this->addTranslationToForm(
+            $comment,
+            'fr_FR',
+            Comment::TRANSLATION_KEY_NAME,
+            'Titre du premier commentaire'
+        );
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue(
+                $this->getCommentId($form, 'First comment title'),
+                'Titre du premier commentaire'
+            );
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue(
+                $this->getCommentId($form, 'First comment title'),
+                'First comment title'
+            );
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
     }
 
     private function checkGetTagContentForValue(

--- a/tests/functional/Glpi/Form/Tag/FormTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/FormTagProviderTest.php
@@ -91,6 +91,23 @@ final class FormTagProviderTest extends DbTestCase
         );
     }
 
+    public function testGetTagContentForValueUsingTranslation(): void
+    {
+        $form = $this->createForm((new FormBuilder())->setName('My form'));
+        $this->addTranslationToForm($form, 'fr_FR', Form::TRANSLATION_KEY_NAME, 'Mon formulaire');
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue($form->getId(), 'Mon formulaire');
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue($form->getId(), 'My form');
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
+    }
+
     private function checkGetTagContentForValue(
         string $value,
         string $expected_content

--- a/tests/functional/Glpi/Form/Tag/QuestionTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/QuestionTagProviderTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\Tag\QuestionTagProvider;
 use Glpi\Form\Tag\Tag;
@@ -93,6 +94,35 @@ final class QuestionTagProviderTest extends DbTestCase
             $this->getQuestionId($form, 'Last name'),
             'Last name'
         );
+    }
+
+    public function testGetTagContentForValueUsingTranslation(): void
+    {
+        $form = $this->getFormWithFirstAndLastNameQuestions();
+        $question = Question::getById($this->getQuestionId($form, 'First name'));
+        $this->addTranslationToForm(
+            $question,
+            'fr_FR',
+            Question::TRANSLATION_KEY_NAME,
+            'Prénom'
+        );
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue(
+                $this->getQuestionId($form, 'First name'),
+                'Prénom'
+            );
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue(
+                $this->getQuestionId($form, 'First name'),
+                'First name'
+            );
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
     }
 
     private function checkGetTagContentForValue(

--- a/tests/functional/Glpi/Form/Tag/SectionTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/SectionTagProviderTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Form\Tag;
 
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
+use Glpi\Form\Section;
 use Glpi\Form\Tag\SectionTagProvider;
 use Glpi\Form\Tag\Tag;
 use Glpi\Tests\DbTestCase;
@@ -92,6 +93,35 @@ final class SectionTagProviderTest extends DbTestCase
             $this->getSectionId($form, 'Professional information'),
             'Professional information'
         );
+    }
+
+    public function testGetTagContentForValueUsingTranslation(): void
+    {
+        $form = $this->getFormWithSections();
+        $section = Section::getById($this->getSectionId($form, 'Personal information'));
+        $this->addTranslationToForm(
+            $section,
+            'fr_FR',
+            Section::TRANSLATION_KEY_NAME,
+            'Informations personnelles'
+        );
+
+        $original_language = $_SESSION['glpilanguage'];
+        try {
+            $_SESSION['glpilanguage'] = 'fr_FR';
+            $this->checkGetTagContentForValue(
+                $this->getSectionId($form, 'Personal information'),
+                'Informations personnelles'
+            );
+
+            $_SESSION['glpilanguage'] = 'de_DE'; // No translation, falls back to original
+            $this->checkGetTagContentForValue(
+                $this->getSectionId($form, 'Personal information'),
+                'Personal information'
+            );
+        } finally {
+            $_SESSION['glpilanguage'] = $original_language;
+        }
     }
 
     private function checkGetTagContentForValue(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43077

When a form is submitted and creates a ticket, the title and content fields support tags (form name, section names, question names, comment titles/descriptions, and selectable answer labels). These tags were resolved using the raw database values, ignoring any translations defined on the form.                                                                              
                                                                                                                                                                                                                                                                                                                                                                                      
Tags are now resolved in the end user's session language, using the same translation mechanism as the form renderer. If no translation exists for the current language, the original value is used as fallback.


