### PR TITLE
fix(form-migration): handle empty default values in actor questions

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -229,7 +229,12 @@ abstract class AbstractQuestionTypeActors extends AbstractQuestionType implement
     #[Override]
     public function convertDefaultValue(array $rawData): mixed
     {
-        $users_ids = json_decode($rawData['default_values'] ?? "[]");
+        $users_ids = [];
+        $raw_default_values = $rawData['default_values'] ?? null;
+        if (!empty($raw_default_values)) {
+            $users_ids = json_decode($raw_default_values, true);
+        }
+
         return ['users_ids' => $users_ids];
     }
 

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -3911,4 +3911,25 @@ final class FormMigrationTest extends DbTestCase
         // Assert: migration should be done without error
         $this->assertTrue($result->isFullyProcessed());
     }
+
+    public function testFormMigrationActorsWithEmptyDefaultValue(): void
+    {
+        global $DB;
+
+        // Arrange: create a form with an actor question with an empty default value
+        $this->createSimpleFormcreatorForm('Actor test with empty default value', [
+            [
+                'name'           => 'Actor',
+                'fieldtype'      => 'actor',
+                'default_values' => '',
+            ],
+        ]);
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $result = $migration->execute();
+
+        // Assert: migration should be done without error
+        $this->assertTrue($result->isFullyProcessed());
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43194

This PR improves how empty or null default values are handled for actor-type questions in forms, ensuring that migrations work correctly even when these values are missing or empty. It also adds a new test to verify this behavior.