### PR TITLE
Fix - Handle prepared actor answers format in condition comparisons

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -440,6 +440,23 @@ TWIG;
         if (is_string($value) && json_validate($value)) {
             $value = json_decode($value, true);
         } elseif (is_array($value)) {
+            // Handle "prepared end user answer" format: [['itemtype' => X, 'items_id' => Y], ...]
+            $first = reset($value);
+            if (is_array($first) && array_key_exists('itemtype', $first)) {
+                $normalized = ['users_ids' => [], 'groups_ids' => [], 'suppliers_ids' => []];
+                $fkey_map = [
+                    User::class     => 'users_ids',
+                    Group::class    => 'groups_ids',
+                    Supplier::class => 'suppliers_ids',
+                ];
+                foreach ($value as $actor) {
+                    $key = $fkey_map[$actor['itemtype']] ?? null;
+                    if ($key !== null) {
+                        $normalized[$key][] = (int) $actor['items_id'];
+                    }
+                }
+                $value = $normalized;
+            }
             $value = json_decode($this->formatDefaultValueForDB($value), true);
         }
 

--- a/tests/src/Glpi/Form/QuestionType/AbstractQuestionTypeActorsTest.php
+++ b/tests/src/Glpi/Form/QuestionType/AbstractQuestionTypeActorsTest.php
@@ -419,4 +419,36 @@ abstract class AbstractQuestionTypeActorsTest extends DbTestCase
         $this->assertArrayHasKey(QuestionTypeActorsExtraDataConfig::IS_MULTIPLE_ACTORS, $result);
         $this->assertFalse($result[QuestionTypeActorsExtraDataConfig::IS_MULTIPLE_ACTORS]);
     }
+
+    public function testTransformConditionValueForComparisonsWithPreparedAnswerFormat(): void
+    {
+        $glpi_id   = getItemByTypeName(User::class, 'glpi', true);
+        $tech_id   = getItemByTypeName(User::class, 'tech', true);
+        $group_id  = getItemByTypeName(Group::class, '_test_group_1', true);
+
+        $question_type = new (static::getQuestionType())();
+
+        // Single user — the format returned by prepareEndUserAnswer()
+        $result = $question_type->transformConditionValueForComparisons(
+            [['itemtype' => User::class, 'items_id' => $glpi_id]],
+            null
+        );
+        $this->assertContains('glpi', $result);
+
+        // Multiple actors of mixed types
+        $result = $question_type->transformConditionValueForComparisons(
+            [
+                ['itemtype' => User::class,  'items_id' => $glpi_id],
+                ['itemtype' => User::class,  'items_id' => $tech_id],
+                ['itemtype' => Group::class, 'items_id' => $group_id],
+            ],
+            null
+        );
+        $this->assertContains('glpi', $result);
+        $this->assertContains('tech', $result);
+        $this->assertContains('_test_group_1', $result);
+
+        // Empty array must return empty array without error
+        $this->assertSame([], $question_type->transformConditionValueForComparisons([], null));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43058
- Here is a brief description of what this PR does

### Context

When a form with an actor question is submitted and a condition references that question (e.g. a destination with a visibility condition), the condition engine calls `transformConditionValueForComparisons()` with the value returned by `prepareEndUserAnswer()`.

This produces a structure like:

```php
[
  ['itemtype' => 'User', 'items_id' => 2],
  ...
]
````

### Problem

This format was passed directly to `formatDefaultValueForDB()`, which expects either:

* `fkey-id` strings
* or keys like `users_ids`, `groups_ids`, `suppliers_ids`

As a result, `explode()` received an array instead of a string, leading to a `TypeError`.

### Solution

The fix detects this "prepared answer" format and normalizes it before passing it to `formatDefaultValueForDB()`.

### Tests

A regression test has been added to `AbstractQuestionTypeActorsTest`, covering:

* all actor types
* the empty case
