### PR TITLE
No longer reload the page when adding a document to the KB

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -215,6 +215,11 @@ export class GlpiKnowbaseArticleController
                 this.#unlinkItem(button);
             }
         });
+
+        // Handle documents uploaded without page reload
+        this.#container.addEventListener('documents:uploaded', (e) => {
+            this.#onDocumentsUploaded(e.detail.documents ?? []);
+        });
     }
 
     #initDiffListeners()
@@ -540,14 +545,35 @@ export class GlpiKnowbaseArticleController
         if (meta_link) {
             const current = parseInt(meta_link.textContent, 10) || 0;
             const updated = Math.max(0, current + delta);
+            const meta_container = meta_link.closest('[data-kb-documents-count-container]');
             if (updated === 0) {
-                // Hide the entire metadata entry when no documents remain
-                meta_link.closest('.d-flex')?.remove();
+                meta_container.classList.add('d-none');
             } else {
+                meta_container.classList.remove('d-none');
                 const label = _n('%s document', '%s documents', updated).replace('%s', updated);
                 meta_link.textContent = label;
             }
         }
+    }
+
+    /**
+     * @param {Array<html: string}>} documents
+     */
+    #onDocumentsUploaded(documents)
+    {
+        if (documents.length === 0) {
+            return;
+        }
+
+        // Insert new badges to show linked documents
+        const badges_container = this.#container.querySelector('[data-glpi-kb-documents-list]');
+        for (const doc of documents) {
+            badges_container.insertAdjacentHTML('beforeend', doc.html);
+        }
+        badges_container.classList.remove('d-none');
+
+        // Update counters
+        this.#updateDocumentCount(documents.length);
     }
 
     /**

--- a/js/modules/Knowbase/UploadController.js
+++ b/js/modules/Knowbase/UploadController.js
@@ -32,6 +32,7 @@
 
 /* global getAjaxCsrfToken, bootstrap, glpi_toast_error, glpi_toast_info */
 
+import { post } from '/js/modules/Ajax.js';
 import { FileUploader } from '/js/modules/FileUploader.js';
 
 /**
@@ -130,11 +131,11 @@ export class DocumentUploadController
         this.#setLoading(true);
 
         try {
-            await this.#createDocuments(successEntries);
-            this.#onSuccess();
+            const documents = await this.#createDocuments(successEntries);
+            this.#onSuccess(documents);
         } catch (error) {
-            console.error('Document creation failed:', error);
-            glpi_toast_error(__('Upload failed: %s').replace('%s', error.message));
+            glpi_toast_error(__('Upload failed'));
+            throw error;
         } finally {
             this.#setLoading(false);
         }
@@ -163,55 +164,35 @@ export class DocumentUploadController
 
     /**
      * @param {{ file: File, status: string, result: Object|null }[]} successEntries
+     * @returns {Promise<Array>}
      */
     async #createDocuments(successEntries)
     {
         const description = this.#form.querySelector('#kb-document-description')?.value || '';
-        const itemtype = this.#form.querySelector('[name="itemtype"]')?.value;
         const items_id = this.#form.querySelector('[name="items_id"]')?.value;
 
-        for (const entry of successEntries) {
-            const uploadedFile = entry.result;
-            const formData = new FormData();
-            const fullTempName = uploadedFile.name || '';
-            const displayName = uploadedFile.display || '';
-            const filePrefix = uploadedFile.prefix || '';
-            const fileTag = uploadedFile.id || '';
+        const files = successEntries.map((entry) => {
+            const uploaded_file = entry.result;
+            return {
+                name:             (uploaded_file.display || '').replace(/\.[^.]+$/, ''),
+                comment:          description,
+                _filename:        uploaded_file.name    || '',
+                _prefix_filename: uploaded_file.prefix  || '',
+                _tag_filename:    uploaded_file.id      || '',
+            };
+        });
 
-            formData.append('_filename[0]', fullTempName);
-            formData.append('_prefix_filename[0]', filePrefix);
-            formData.append('_tag_filename[0]', fileTag);
-            formData.append('name', displayName.replace(/\.[^.]+$/, ''));
-            formData.append('comment', description);
-
-            if (itemtype && items_id) {
-                formData.append('itemtype', itemtype);
-                formData.append('items_id', items_id);
-            }
-
-            formData.append('add', '1');
-
-            const response = await fetch(
-                `${CFG_GLPI.root_doc}/front/document.form.php`,
-                {
-                    method: 'POST',
-                    body: formData,
-                    headers: {
-                        'X-Requested-With': 'XMLHttpRequest',
-                        'X-Glpi-Csrf-Token': getAjaxCsrfToken(),
-                    },
-                }
-            );
-
-            if (!response.ok) {
-                throw new Error(`Failed to create document for ${displayName}`);
-            }
-        }
+        const response = await post(`Knowbase/${items_id}/UploadDocuments`, { files });
+        const body = await response.json();
+        return body.documents ?? [];
     }
 
-    #onSuccess()
+    /**
+     * @param {Array} documents
+     */
+    #onSuccess(documents)
     {
-        const count = this.#uploader.getSuccessfulEntries().length;
+        const count = documents.length;
 
         if (this.#modal) {
             const modalInstance = bootstrap.Modal.getInstance(this.#modal);
@@ -228,9 +209,7 @@ export class DocumentUploadController
 
         this.#container.dispatchEvent(new CustomEvent('documents:uploaded', {
             bubbles: true,
-            detail: { count: count }
+            detail: { count, documents },
         }));
-
-        window.location.reload();
     }
 }

--- a/src/Glpi/Controller/AbstractDocumentUploadController.php
+++ b/src/Glpi/Controller/AbstractDocumentUploadController.php
@@ -64,8 +64,8 @@ abstract class AbstractDocumentUploadController extends AbstractController
         array $files,
         string $itemtype,
         int $items_id,
-        ?int $entities_id = null,
-        ?bool $is_recursive = null,
+        int $entities_id,
+        bool $is_recursive,
     ): array {
         $created = [];
 
@@ -91,13 +91,9 @@ abstract class AbstractDocumentUploadController extends AbstractController
                 '_tag_filename'    => [$tag],
                 'itemtype'         => $itemtype,
                 'items_id'         => $items_id,
+                'entities_id'      => $entities_id,
+                'is_recursive'     => $is_recursive,
             ];
-            if ($entities_id !== null) {
-                $input['entities_id'] = $entities_id;
-            }
-            if ($is_recursive !== null) {
-                $input['is_recursive'] = $is_recursive;
-            }
             $document = $this->add(Document::class, $input);
 
             // Fetch document item link

--- a/src/Glpi/Controller/AbstractDocumentUploadController.php
+++ b/src/Glpi/Controller/AbstractDocumentUploadController.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller;
+
+use CommonDBTM;
+use Document;
+use Document_Item;
+use Glpi\Exception\Http\BadRequestHttpException;
+
+abstract class AbstractDocumentUploadController extends AbstractController
+{
+    use CrudControllerTrait;
+
+    /**
+     * Process a list of uploaded file entries and create Document + Document_Item records.
+     *
+     * Each entry in $files must contain:
+     *   - _filename        : temp filename
+     *   - _prefix_filename : temp filename prefix
+     *   - _tag_filename    : file tag UUID
+     *   - name             : document display name (optional)
+     *   - comment          : document description (optional)
+     *
+     * Returns an array of successfully created document data:
+     *   ['assoc_id', 'id', 'filename', 'download_url', 'extension']
+     *
+     * @param array<array<string,string>> $files
+     * @param class-string<CommonDBTM> $itemtype
+     * @return array<array{assoc_id: int, filename: string, download_url: string, extension: string}>
+     */
+    final protected function createDocuments(
+        array $files,
+        string $itemtype,
+        int $items_id
+    ): array {
+        $created = [];
+
+        foreach ($files as $file_data) {
+            // Read inputs
+            $temp_name = $file_data['_filename']        ?? '';
+            $prefix    = $file_data['_prefix_filename'] ?? '';
+            $tag       = $file_data['_tag_filename']    ?? '';
+            $name      = $file_data['name']             ?? '';
+            $comment   = $file_data['comment']          ?? '';
+
+            // Validate mandatory parameters
+            if (empty($temp_name) || empty($prefix) || empty($tag)) {
+                throw new BadRequestHttpException();
+            }
+
+            // Add document
+            $document = $this->add(Document::class, [
+                'name'             => $name,
+                'comment'          => $comment,
+                '_filename'        => [$temp_name],
+                '_prefix_filename' => [$prefix],
+                '_tag_filename'    => [$tag],
+                'itemtype'         => $itemtype,
+                'items_id'         => $items_id,
+            ]);
+
+            // Fetch document item link
+            $doc_id   = $document->getID();
+            $doc_item = new Document_Item();
+            if (!$doc_item->getFromDBByCrit([
+                'documents_id' => $doc_id,
+                'itemtype'     => $itemtype,
+                'items_id'     => $items_id,
+            ])) {
+                continue;
+            }
+
+            // Compute file extension
+            $filename  = (string) ($document->fields['filename'] ?? '');
+            $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+            $created[] = [
+                'assoc_id'     => $doc_item->getID(),
+                'filename'     => $filename,
+                'download_url' => $document->getDownloadUrl(),
+                'extension'    => $extension,
+            ];
+        }
+
+        return $created;
+    }
+}

--- a/src/Glpi/Controller/AbstractDocumentUploadController.php
+++ b/src/Glpi/Controller/AbstractDocumentUploadController.php
@@ -63,7 +63,9 @@ abstract class AbstractDocumentUploadController extends AbstractController
     final protected function createDocuments(
         array $files,
         string $itemtype,
-        int $items_id
+        int $items_id,
+        ?int $entities_id = null,
+        ?bool $is_recursive = null,
     ): array {
         $created = [];
 
@@ -81,7 +83,7 @@ abstract class AbstractDocumentUploadController extends AbstractController
             }
 
             // Add document
-            $document = $this->add(Document::class, [
+            $input = [
                 'name'             => $name,
                 'comment'          => $comment,
                 '_filename'        => [$temp_name],
@@ -89,7 +91,14 @@ abstract class AbstractDocumentUploadController extends AbstractController
                 '_tag_filename'    => [$tag],
                 'itemtype'         => $itemtype,
                 'items_id'         => $items_id,
-            ]);
+            ];
+            if ($entities_id !== null) {
+                $input['entities_id'] = $entities_id;
+            }
+            if ($is_recursive !== null) {
+                $input['is_recursive'] = $is_recursive;
+            }
+            $document = $this->add(Document::class, $input);
 
             // Fetch document item link
             $doc_id   = $document->getID();

--- a/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
+++ b/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
@@ -38,7 +38,6 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractDocumentUploadController;
 use Glpi\Exception\Http\BadRequestHttpException;
 use KnowbaseItem;
-use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
+++ b/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
@@ -75,8 +75,8 @@ final class UploadDocumentsController extends AbstractDocumentUploadController
             files: $files,
             itemtype: KnowbaseItem::class,
             items_id: $id,
-            entities_id: Session::getActiveEntity(),
-            is_recursive: true,
+            entities_id: $kb->getEntityID(),
+            is_recursive: $kb->isRecursive(),
         ) as $doc) {
             // Compute dynamic styles based on file extension
             $styles = KnowbaseItem::getDocumentIconAndColor($doc['extension']);

--- a/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
+++ b/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
@@ -38,6 +38,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractDocumentUploadController;
 use Glpi\Exception\Http\BadRequestHttpException;
 use KnowbaseItem;
+use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -70,7 +71,13 @@ final class UploadDocumentsController extends AbstractDocumentUploadController
         $result = [];
         $twig = TemplateRenderer::getInstance();
 
-        foreach ($this->createDocuments($files, KnowbaseItem::class, $id) as $doc) {
+        foreach ($this->createDocuments(
+            files: $files,
+            itemtype: KnowbaseItem::class,
+            items_id: $id,
+            entities_id: Session::getActiveEntity(),
+            is_recursive: true,
+        ) as $doc) {
             // Compute dynamic styles based on file extension
             $styles = KnowbaseItem::getDocumentIconAndColor($doc['extension']);
             $doc['icon_class']  = $styles['icon_class'];

--- a/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
+++ b/src/Glpi/Controller/Knowbase/UploadDocumentsController.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\Controller\AbstractDocumentUploadController;
+use Glpi\Exception\Http\BadRequestHttpException;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+use function Safe\json_decode;
+
+final class UploadDocumentsController extends AbstractDocumentUploadController
+{
+    #[Route(
+        "/Knowbase/{id}/UploadDocuments",
+        name: "knowbase_upload_documents",
+        methods: ["POST"],
+        requirements: ['id' => '\d+']
+    )]
+    public function __invoke(int $id, Request $request): JsonResponse
+    {
+        // Load target KB item
+        $kb = KnowbaseItem::getById($id);
+        if (!$kb) {
+            throw new BadRequestHttpException();
+        }
+
+        // Read parameters
+        $data  = json_decode($request->getContent(), true);
+        $files = $data['files'] ?? [];
+        if (!is_array($files) || count($files) === 0) {
+            throw new BadRequestHttpException();
+        }
+
+        $result = [];
+        $twig = TemplateRenderer::getInstance();
+
+        foreach ($this->createDocuments($files, KnowbaseItem::class, $id) as $doc) {
+            // Compute dynamic styles based on file extension
+            $styles = KnowbaseItem::getDocumentIconAndColor($doc['extension']);
+            $doc['icon_class']  = $styles['icon_class'];
+            $doc['color_class'] = $styles['color_class'];
+
+            // Render badge
+            $result[] = [
+                'html' => $twig->render('pages/tools/kb/document_badge.html.twig', [
+                    'doc'      => $doc,
+                    'can_edit' => true,
+                ]),
+            ];
+        }
+
+        return new JsonResponse(['documents' => $result]);
+    }
+}

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1131,7 +1131,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
      * @param string $extension File extension (lowercase, without dot)
      * @return array{icon_class: string, color_class: string}
      */
-    private static function getDocumentIconAndColor(string $extension): array
+    public static function getDocumentIconAndColor(string $extension): array
     {
         return match ($extension) {
             'pdf' => [

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -252,14 +252,12 @@
                 </div>
 
                 {# Documents count #}
-                {% if documents_count > 0 %}
-                <div class="d-flex align-items-center">
+                <div class="d-flex align-items-center {{ documents_count == 0 ? 'd-none' : '' }}" data-kb-documents-count-container>
                     <i class="ti ti-paperclip me-1 fs-3"></i>
                     <a href="#kb-documents" class="text-muted" data-kb-documents-count  data-testid="documents-count">
                         {{ _n("%s document", "%s documents", documents_count)|format(documents_count) }}
                     </a>
                 </div>
-                {% endif %}
 
                 {% if related_items_count > 0 %}
                     <div class="d-flex align-items-center">
@@ -391,36 +389,14 @@
                 {# Tab content #}
                 <div class="tab-content">
                     <div class="tab-pane fade show active" id="kb-documents-tab" role="tabpanel">
-                        {% if documents|length > 0 %}
-                            <div class="d-flex flex-wrap gap-2 mb-2">
-                                {% for doc in documents %}
-                                    <span
-                                        class="kb-item-badge badge bg-light text-dark d-flex align-items-center gap-2"
-                                        data-glpi-document-assoc-id="{{ doc.assoc_id }}"
-                                        data-testid="document-chip"
-                                    >
-                                        <a
-                                            href="{{ doc.download_url }}"
-                                            class="d-flex align-items-center gap-2 text-decoration-none"
-                                            target="_blank"
-                                        >
-                                            <i class="ti {{ doc.icon_class }} {{ doc.color_class }}"></i>
-                                            <span>{{ doc.filename }}</span>
-                                        </a>
-
-                                        {% if can_edit %}
-                                            <button
-                                                type="button"
-                                                class="kb-unlink-item btn-close btn-close-white"
-                                                data-glpi-kb-unlink-document="{{ doc.assoc_id }}"
-                                                title="{{ __('Unlink document') }}"
-                                                aria-label="{{ __('Unlink document') }}"
-                                            ></button>
-                                        {% endif %}
-                                    </span>
-                                {% endfor %}
-                            </div>
-                        {% endif %}
+                        <div class="d-flex flex-wrap gap-2 mb-2 {{ documents|length == 0 ? 'd-none' : '' }}" data-glpi-kb-documents-list>
+                            {% for doc in documents %}
+                                {{ include('pages/tools/kb/document_badge.html.twig', {
+                                    doc: doc,
+                                    can_edit: can_edit,
+                                }, with_context = false) }}
+                            {% endfor %}
+                        </div>
 
                         {% if can_add_documents %}
                             <button

--- a/templates/pages/tools/kb/document_badge.html.twig
+++ b/templates/pages/tools/kb/document_badge.html.twig
@@ -1,0 +1,56 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<span
+    class="kb-item-badge badge bg-light text-dark d-flex align-items-center gap-2"
+    data-glpi-document-assoc-id="{{ doc.assoc_id }}"
+    data-testid="document-chip"
+>
+    <a
+        href="{{ doc.download_url }}"
+        class="d-flex align-items-center gap-2 text-decoration-none"
+        target="_blank"
+    >
+        <i class="ti {{ doc.icon_class }} {{ doc.color_class }}"></i>
+        <span>{{ doc.filename }}</span>
+    </a>
+
+    {% if can_edit %}
+        <button
+            type="button"
+            class="kb-unlink-item btn-close btn-close-white"
+            data-glpi-kb-unlink-document="{{ doc.assoc_id }}"
+            title="{{ __('Unlink document') }}"
+            aria-label="{{ __('Unlink document') }}"
+        ></button>
+    {% endif %}
+</span>

--- a/tests/e2e/specs/Knowbase/document_upload.spec.ts
+++ b/tests/e2e/specs/Knowbase/document_upload.spec.ts
@@ -61,41 +61,6 @@ test('Can open document upload modal', async ({ page, profile, api }) => {
     await expect(modal.getByRole('tab', { name: 'Upload a file' })).toHaveAttribute('aria-selected', 'true');
 });
 
-test('Can select files and upload via modal', async ({ page, profile, api }) => {
-    await profile.set(Profiles.SuperAdmin);
-    const kb = new KnowbaseItemPage(page);
-
-    const id = await api.createItem('KnowbaseItem', {
-        name: 'KB entry for document upload test',
-        entities_id: getWorkerEntityId(),
-        answer: "Article content",
-    });
-
-    await kb.goto(id);
-
-    // Open the document upload modal
-    await page.getByRole('button', { name: 'Add Document' }).click();
-    const modal = page.getByRole('dialog');
-    await expect(modal).toBeVisible();
-
-    // Select a file - verify it appears in preview
-    await kb.doSelectFilesForKbUpload(['uploads/foo.png'], modal);
-
-    // Verify file is shown in preview
-    await expect(modal.getByRole('listitem')).toHaveCount(1);
-    await expect(modal.getByRole('listitem')).toContainText('foo.png');
-
-    // Verify upload button is enabled
-    await expect(modal.getByRole('button', { name: 'Upload Documents' })).toBeEnabled();
-
-    // Click upload and verify modal closes
-    await modal.getByRole('button', { name: 'Upload Documents' }).click();
-    await expect(modal).toBeHidden();
-
-    // Wait for page reload
-    await page.waitForLoadState('load');
-});
-
 test('Can select multiple files for upload', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
@@ -124,7 +89,13 @@ test('Can select multiple files for upload', async ({ page, profile, api }) => {
     await expect(modal).toBeHidden();
 
     // Wait for page reload
-    await page.waitForLoadState('load');
+    await expect(kb.getAlert('2 documents uploaded successfully')).toBeVisible();
+    await expect(page.getByTestId('document-chip').filter({
+        hasText: "foo.png",
+    })).toBeVisible();
+    await expect(page.getByTestId('document-chip').filter({
+        hasText: "bar.png",
+    })).toBeVisible();
 });
 
 test('Can remove a file from selection', async ({ page, profile, api }) => {
@@ -190,7 +161,10 @@ test('Can add description before upload', async ({ page, profile, api }) => {
     await expect(modal).toBeHidden();
 
     // Wait for page reload
-    await page.waitForLoadState('load');
+    await expect(kb.getAlert('Document uploaded successfully')).toBeVisible();
+    await expect(page.getByTestId('document-chip').filter({
+        hasText: "foo.png",
+    })).toBeVisible();
 });
 
 test('Shows error for disallowed file type', async ({ page, profile, api }) => {

--- a/tests/e2e/specs/Knowbase/kb-unlink-document.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-unlink-document.spec.ts
@@ -100,5 +100,5 @@ test('Document count updates after unlinking', async ({ page, profile, api }) =>
     const modal = kb.getDialog('Unlink document');
     await modal.getByRole('button', { name: 'Unlink' }).click();
 
-    await expect(page.getByTestId('documents-count')).not.toBeAttached();
+    await expect(page.getByTestId('documents-count')).toBeHidden();
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

Adding a document would trigger a reload of the kb article page.
This is not in line with others action so I have modified this behavior to ensure it does not require a reload.

