### PR TITLE
Encrypt API session tokens

### DIFF
--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -317,9 +317,12 @@ abstract class API
             $this->returnError($err, 401, "ERROR_GLPI_LOGIN", false);
         }
 
+        $session_token = \base64_encode((new GLPIKey())->encrypt($_SESSION['valid_id']));
+        unset($_SESSION['valid_id']); // this is not needed for the API, unsetting it prevents any unexpected exposure
+
         // stop session and return session key
         session_write_close();
-        $data = ['session_token' => $_SESSION['valid_id']];
+        $data = ['session_token' => $session_token];
 
         // Insert session data if requested
         $get_full_session = $params['get_full_session'] ?? false;

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -40,6 +40,7 @@
 namespace Glpi\Api;
 
 use AllAssets;
+use GLPIKey;
 use GLPIUploadHandler;
 use stdClass;
 use Toolbox;
@@ -601,7 +602,7 @@ class APIRest extends API
 
         // try to retrieve session_token in header
         if (isset($headers['Session-Token'])) {
-            $parameters['session_token'] = $headers['Session-Token'];
+            $parameters['session_token'] = (new GLPIKey())->decrypt(\base64_decode(trim($headers['Session-Token'])));
         }
 
         // try to retrieve app_token in header

--- a/src/Api/APIXmlrpc.php
+++ b/src/Api/APIXmlrpc.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Api;
 
+use GLPIKey;
 use Toolbox;
 
 class APIXmlrpc extends API
@@ -268,6 +269,11 @@ class APIXmlrpc extends API
         $this->parameters = (isset($parameters[0]) && is_array($parameters[0])
                           ? $parameters[0]
                           : []);
+
+        // decrypt session token
+        if (\array_key_exists('session_token', $this->parameters)) {
+            $this->parameters['session_token'] = (new GLPIKey())->decrypt(\base64_decode($this->parameters['session_token']));
+        }
 
         // transform input from array to object
         if (


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Currently, the session token of the API corresponds to the ID of the PHP session. Although it is not an issue, using distinct tokens for both may prevent an unexpected reusage of this token in an unexpected context.

I used the base64 encoding to ensure to have no special chars to handle in API request headers. The token will now be about 130 chars, whereas it was about 30 chars before.