### PR TITLE
Prevent conflicts between legacy API auth methods

### DIFF
--- a/apirest.md
+++ b/apirest.md
@@ -1748,6 +1748,10 @@ One of theses parameter(s) is missing:
 The GLPI setup forbid the login with credentials, you must login with your user_token instead.
 See your personal preferences page or setup API access in GLPI main interface.
 
+### ERROR_LOGIN_WITH_TOKEN_DISABLED
+
+The GLPI setup forbid the login with user token, you must login with your login/password instead.
+
 ### ERROR_GLPI_LOGIN_USER_TOKEN
 
 The provided user_token seems invalid.

--- a/phpunit/APIBaseClass.php
+++ b/phpunit/APIBaseClass.php
@@ -52,13 +52,6 @@ abstract class APIBaseClass extends TestCase
         global $GLPI_CACHE;
         $GLPI_CACHE->clear();
 
-        $this->initSessionCredentials();
-    }
-
-    abstract public function initSessionCredentials();
-
-    public static function setUpBeforeClass(): void
-    {
         // To bypass various right checks
         // This is mandatory to create/update/delete some items during tests.
         $_SESSION['glpishowallentities'] = 1;
@@ -70,14 +63,19 @@ abstract class APIBaseClass extends TestCase
         $_SESSION['glpicronuserrunning'] = "cron_phpunit";
 
         // enable api config
-        $config = new Config();
-        $config->update([
-            'id'                              => 1,
-            'enable_api'                      => true,
-            'enable_api_login_credentials'    => true,
-            'enable_api_login_external_token' => true,
-        ]);
+        Config::setConfigurationValues(
+            'core',
+            [
+                'enable_api'                      => true,
+                'enable_api_login_credentials'    => true,
+                'enable_api_login_external_token' => true,
+            ]
+        );
+
+        $this->initSessionCredentials();
     }
+
+    abstract public function initSessionCredentials();
 
     /**
      * @tags   api
@@ -95,6 +93,68 @@ abstract class APIBaseClass extends TestCase
             'initSession',
             ['query' => ['user_token' => $token]]
         );
+        $this->assertNotFalse($data);
+        $this->assertArrayHasKey('session_token', $data);
+    }
+
+    /**
+     * @tags   api
+     * @covers API::initSession
+     */
+    public function testInitSessionUserTokenFailIfNotEnabled()
+    {
+        Config::setConfigurationValues(
+            'core',
+            [
+                'enable_api_login_external_token' => false,
+            ]
+        );
+
+        $user = new User();
+        $uid = getItemByTypeName('User', TU_USER, true);
+        $this->assertTrue($user->getFromDB($uid));
+        $token = $user->getAuthToken('api_token');
+
+        $this->query(
+            'initSession',
+            ['query' => ['user_token' => $token]],
+            400,
+            'ERROR_LOGIN_WITH_TOKEN_DISABLED'
+        );
+    }
+
+    /**
+     * @tags   api
+     * @covers API::initSession
+     */
+    public function testInitSessionCredentialsFailIfNotEnabled()
+    {
+        Config::setConfigurationValues(
+            'core',
+            [
+                'enable_api_login_credentials' => false,
+            ]
+        );
+
+        $this->query(
+            'initSession',
+            ['query' => ['login' => TU_USER, 'password' => TU_PASS]],
+            400,
+            'ERROR_LOGIN_WITH_CREDENTIALS_DISABLED'
+        );
+    }
+
+    /**
+     * @tags   api
+     * @covers API::initSession
+     */
+    public function testInitSessionFallbackToCredentials()
+    {
+        $data = $this->query(
+            'initSession',
+            ['query' => ['user_token' => 'notvalid', 'login' => TU_USER, 'password' => TU_PASS]],
+        );
+
         $this->assertNotFalse($data);
         $this->assertArrayHasKey('session_token', $data);
     }

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -263,36 +263,11 @@ abstract class API
         $this->checkAppToken();
         $this->logEndpointUsage(__FUNCTION__);
 
-        if (
-            (!isset($params['login'])
-            || empty($params['login'])
-            || !isset($params['password'])
-            || empty($params['password']))
-            && (!isset($params['user_token'])
-             || empty($params['user_token']))
-        ) {
-            $this->returnError(
-                __("parameter(s) login, password or user_token are missing"),
-                400,
-                "ERROR_LOGIN_PARAMETERS_MISSING"
-            );
-        }
+        $login    = $params['login'] ?? '';
+        $password = $params['password'] ?? '';
+        $token    = $params['user_token'] ?? '';
 
-        $auth = new Auth();
-
-        // fill missing params (in case of user_token)
-        if (!isset($params['login'])) {
-            $params['login'] = '';
-        }
-        if (!isset($params['password'])) {
-            $params['password'] = '';
-        }
-
-        $noAuto = true;
-        if (isset($params['user_token']) && !empty($params['user_token'])) {
-            $_REQUEST['user_token'] = Sanitizer::dbEscape($params['user_token']);
-            $noAuto = false;
-        } elseif (!$CFG_GLPI['enable_api_login_credentials']) {
+        if (($login !== '' || $password !== '') && !$CFG_GLPI['enable_api_login_credentials']) {
             $this->returnError(
                 __("usage of initSession resource with credentials is disabled"),
                 400,
@@ -300,21 +275,65 @@ abstract class API
                 false
             );
         }
-
-        if (!isset($params['auth'])) {
-            $params['auth'] = '';
+        if ($token !== '' && !$CFG_GLPI['enable_api_login_external_token']) {
+            $this->returnError(
+                __("usage of initSession resource with user token is disabled"),
+                400,
+                "ERROR_LOGIN_WITH_TOKEN_DISABLED",
+                false
+            );
         }
 
-        // login on glpi
-        if (!$auth->login($params['login'], $params['password'], $noAuto, false, $params['auth'])) {
-            $err = implode(' ', $auth->getErrors());
-            if (
-                isset($params['user_token'])
-                && !empty($params['user_token'])
-            ) {
-                $this->returnError(__("parameter user_token seems invalid"), 401, "ERROR_GLPI_LOGIN_USER_TOKEN", false);
+        if (
+            (!$CFG_GLPI['enable_api_login_credentials'] || $login === '' || $password === '')
+            && (!$CFG_GLPI['enable_api_login_external_token'] || $token === '')
+        ) {
+            if ($CFG_GLPI['enable_api_login_credentials'] && $CFG_GLPI['enable_api_login_external_token']) {
+                $this->returnError(
+                    __("parameter(s) login, password or user_token are missing"),
+                    400,
+                    "ERROR_LOGIN_PARAMETERS_MISSING"
+                );
+            } elseif ($CFG_GLPI['enable_api_login_credentials']) {
+                $this->returnError(
+                    __("parameter(s) login, password are missing"),
+                    400,
+                    "ERROR_LOGIN_PARAMETERS_MISSING"
+                );
+            } else {
+                $this->returnError(
+                    __("parameter user_token is missing"),
+                    400,
+                    "ERROR_LOGIN_PARAMETERS_MISSING"
+                );
             }
-            $this->returnError($err, 401, "ERROR_GLPI_LOGIN", false);
+        }
+
+        $authenticated  = false;
+        $error_msg      = '';
+        $error_code     = '';
+        $use_token_auth = $CFG_GLPI['enable_api_login_external_token'] && $token !== '';
+        $use_login_auth = $CFG_GLPI['enable_api_login_credentials'] && $login !== '' && $password !== '';
+
+        if ($use_token_auth) {
+            $_REQUEST['user_token'] = $token;
+
+            $auth = new Auth();
+            $authenticated = $auth->login('', '', false, false, $params['auth'] ?? '');
+            $error_code    = 'ERROR_GLPI_LOGIN_USER_TOKEN';
+            $error_msg     = __("parameter user_token seems invalid");
+        }
+        if (!$authenticated && $use_login_auth) {
+            unset($_REQUEST['user_token']);
+
+            $auth = new Auth();
+            $authenticated = $auth->login($login, $password, true, false, $params['auth'] ?? '');
+            $error_code    = 'ERROR_GLPI_LOGIN';
+            $error_msg     = implode(' ', $auth->getErrors());
+        }
+
+        if (!$authenticated) {
+            $this->returnError($error_msg, 401, $error_code, false);
         }
 
         // stop session and return session key


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Under certain circumstances, the `Enable login with credentials` and `Enable login with external token` configuration options were not correctly applied, resulting in being able to somehow bypass these settings. With the proposed change, both will correctly be applied and if both are active and used at the same time, each authentication method will be tested sequentially.