### PR TITLE
Fixed ProjectTask visibility (filter issue)

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1867,7 +1867,7 @@ TWIG, $twig_params);
             ];
         }
 
-        if ($options['state_done']) {
+        if (!$options['state_done']) {
             $ADDWHERE['glpi_projecttasks.percent_done'] = ['<', 100];
             $ADDWHERE[] = [
                 'OR' => [

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -288,7 +288,8 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
                 Planning::checkAlreadyPlanned(
                     $user,
                     $this->fields['plan_start_date'],
-                    $this->fields['plan_end_date']
+                    $this->fields['plan_end_date'],
+                    [self::class => [$this->fields['id']]],
                 );
             }
         }


### PR DESCRIPTION
Added exclamation mark where it belongs

- It fixes visibility issue for completed projectTasks. 
- Adds an exclamation mark

## Screenshots (if appropriate):
How it was before:
<img width="1608" height="708" alt="image" src="https://github.com/user-attachments/assets/fdee728d-766e-4420-8a9a-cebd5407bab7" />
<img width="1604" height="641" alt="image" src="https://github.com/user-attachments/assets/426495d7-edd6-4ad7-ab80-c1b3d4e3ec20" />

How it is now (with tat simple PR)
<img width="1590" height="625" alt="image" src="https://github.com/user-attachments/assets/4c14100e-602c-42cc-a327-66d33360f173" />
<img width="1659" height="524" alt="image" src="https://github.com/user-attachments/assets/ba66dba5-d863-4b47-bfe6-2545f82feab4" />

I checked. This issue was only for project tasks, tickets works fine!
