### PR TITLE
Fix(Ticket): updating date_mod when add document

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1811,7 +1811,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             // Closed tickets
             || in_array($this->fields['status'], static::getClosedStatusArray()))
         ) {
-            $allowed_fields                    = ['id', 'date_mod'];
+            $allowed_fields                    = ['id'];
             $check_allowed_fields_for_template = true;
 
             if (in_array($this->fields['status'], static::getClosedStatusArray())) {
@@ -1870,6 +1870,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     $allowed_fields[] = '_prefix_content';
                     $allowed_fields[] = 'takeintoaccount_delay_stat';
                     $allowed_fields[] = 'takeintoaccountdate';
+                }
+                if (isset($input['_do_update_date_mod'])) {
+                    $allowed_fields[] = 'date_mod';
                 }
             }
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1811,7 +1811,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             // Closed tickets
             || in_array($this->fields['status'], static::getClosedStatusArray()))
         ) {
-            $allowed_fields                    = ['id'];
+            $allowed_fields                    = ['id', 'date_mod'];
             $check_allowed_fields_for_template = true;
 
             if (in_array($this->fields['status'], static::getClosedStatusArray())) {

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -203,6 +203,7 @@ class Document_Item extends CommonDBRelation
             $input  = [
                 'id'              => $this->fields['items_id'],
                 'date_mod'        => $_SESSION["glpi_currenttime"],
+                '_do_update_date_mod' => true,
             ];
 
             if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {

--- a/tests/functional/Document_ItemTest.php
+++ b/tests/functional/Document_ItemTest.php
@@ -261,32 +261,5 @@ class Document_ItemTest extends DbTestCase
             $_SESSION["glpi_currenttime"],
             $ticket->fields['date_mod'],
         );
-
-        // Now test that if we set the current time before adding the Document_Item, the ticket modification date is updated with this time
-        $_SESSION["glpi_currenttime"] = '2021-01-01 00:00:01';
-        $doc_id = $this->createItem(
-            \Document::class,
-            [
-                'users_id'     => $uid,
-                'tickets_id'   => $tickets_id,
-                'name'         => 'A simple document object',
-            ],
-        )->getID();
-
-        $this->createItem(
-            Document_Item::class,
-            [
-                'users_id'      => $uid,
-                'items_id'      => $tickets_id,
-                'itemtype'      => \Ticket::class,
-                'documents_id'  => $doc_id,
-            ],
-        );
-
-        $this->assertTrue($ticket->getFromDB($tickets_id));
-        $this->assertEquals(
-            '2021-01-01 00:00:01',
-            $ticket->fields['date_mod']
-        );
     }
 }

--- a/tests/functional/Document_ItemTest.php
+++ b/tests/functional/Document_ItemTest.php
@@ -225,66 +225,66 @@ class Document_ItemTest extends DbTestCase
         $uid = getItemByTypeName('User', TU_USER, true);
 
         $ticket = new \Ticket();
-        $tickets_id = $ticket->add([
-            'name' => '',
-            'content' => 'Test modification date not updated from Document_Item',
-            'date_mod' => '2020-01-01',
-        ]);
-
-        $this->assertGreaterThan(0, $tickets_id);
+        $tickets_id = $this->createItem(
+            \Ticket::class,
+            [
+                'name' => 'Test modification date not updated from Document_Item',
+                'content' => 'Test modification date not updated from Document_Item',
+                'date_mod' => '2020-01-01 00:00:00',
+            ],
+        )->getID();
 
         // Document and Document_Item
-        $doc = new \Document();
-        $this->assertGreaterThan(
-            0,
-            $doc->add([
+        $doc_id = $this->createItem(
+            \Document::class,
+            [
                 'users_id'     => $uid,
                 'tickets_id'   => $tickets_id,
                 'name'         => 'A simple document object',
-            ])
-        );
+            ],
+        )->getID();
 
-        //do not change ticket modification date
-        $doc_item = new Document_Item();
-        $this->assertGreaterThan(
-            0,
-            $doc_item->add([
+        // Link the document to the ticket via Document_Item, which should not update the ticket modification date
+        $this->createItem(
+            Document_Item::class,
+            [
                 'users_id'      => $uid,
                 'items_id'      => $tickets_id,
-                'itemtype'      => 'Ticket',
-                'documents_id'  => $doc->getID(),
-                '_do_update_ticket' => false,
-            ])
+                'itemtype'      => \Ticket::class,
+                'documents_id'  => $doc_id,
+            ],
         );
 
         $this->assertTrue($ticket->getFromDB($tickets_id));
-        $this->assertSame('2020-01-01 00:00:00', $ticket->fields['date_mod']);
+        $this->assertGreaterThan('2020-01-01 00:00:00', $ticket->fields['date_mod']);
+        $this->assertEquals(
+            $_SESSION["glpi_currenttime"],
+            $ticket->fields['date_mod'],
+        );
 
-        //do change ticket modification date
+        // Now test that if we set the current time before adding the Document_Item, the ticket modification date is updated with this time
         $_SESSION["glpi_currenttime"] = '2021-01-01 00:00:01';
-        $doc = new \Document();
-        $this->assertGreaterThan(
-            0,
-            $doc->add([
+        $doc_id = $this->createItem(
+            \Document::class,
+            [
                 'users_id'     => $uid,
                 'tickets_id'   => $tickets_id,
                 'name'         => 'A simple document object',
-            ])
-        );
+            ],
+        )->getID();
 
-        $doc_item = new Document_Item();
-        $this->assertGreaterThan(
-            0,
-            $doc_item->add([
+        $this->createItem(
+            Document_Item::class,
+            [
                 'users_id'      => $uid,
                 'items_id'      => $tickets_id,
-                'itemtype'      => 'Ticket',
-                'documents_id'  => $doc->getID(),
-            ])
+                'itemtype'      => \Ticket::class,
+                'documents_id'  => $doc_id,
+            ],
         );
 
         $this->assertTrue($ticket->getFromDB($tickets_id));
-        $this->assertNotEquals(
+        $this->assertEquals(
             '2021-01-01 00:00:01',
             $ticket->fields['date_mod']
         );

--- a/tests/functional/Document_ItemTest.php
+++ b/tests/functional/Document_ItemTest.php
@@ -244,7 +244,7 @@ class Document_ItemTest extends DbTestCase
             ],
         )->getID();
 
-        // Link the document to the ticket via Document_Item, which should not update the ticket modification date
+        // Link the document to the ticket via Document_Item
         $this->createItem(
             Document_Item::class,
             [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43274

When a self-service user adds a document to a ticket, the ticket's modification date was not updated, whereas it is updated when using a standard interface profile.

## Screenshots (if appropriate):


