### PR TITLE
fix first clic not registered

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3785,7 +3785,7 @@ JS;
                         // Close TinyMCE toolbar dropdowns and blur active buttons when clicking outside editor UI elements
                         $(document).on('click', function(e) {
                             const target = $(e.target);
-                            const isEditorElementClicked = target.closest('[class^="tox-"]');
+                            const isEditorElementClicked = target.closest('[class*="tox-"]').length > 0;
 
                             if (!isEditorElementClicked) {
                                 $('.tox-tbtn.tox-tbtn--enabled[data-mce-name="overflow-button"]').trigger('click').trigger('blur');

--- a/src/Html.php
+++ b/src/Html.php
@@ -3785,10 +3785,7 @@ JS;
                         // Close TinyMCE toolbar dropdowns and blur active buttons when clicking outside editor UI elements
                         $(document).on('click', function(e) {
                             const target = $(e.target);
-                            const isEditorElementClicked =
-                                target.closest('.tox-editor-header').length > 0 ||
-                                target.closest('.tox-toolbar__primary').length > 0 ||
-                                target.closest('.tox-menu').length > 0;
+                            const isEditorElementClicked = target.closest('[class^="tox-"]');
 
                             if (!isEditorElementClicked) {
                                 $('.tox-tbtn.tox-tbtn--enabled[data-mce-name="overflow-button"]').trigger('click').trigger('blur');


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43326
Fixes an issue where the first click on an editable field (e.g., width) in a table was not registered.

## Screenshots (if appropriate):
<img width="656" height="452" alt="image" src="https://github.com/user-attachments/assets/70ecf519-670c-4987-b073-72b9e87f8aa4" />


