### PR TITLE
fix: Plugin Controller should match declared HTTP methods

### DIFF
--- a/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
+++ b/src/Glpi/Kernel/Listener/RequestListener/PluginsRouterListener.php
@@ -100,6 +100,9 @@ final readonly class PluginsRouterListener implements EventSubscriberInterface
                 $server['REQUEST_URI'] = \str_replace($request->getPathInfo(), $request->getPathInfo() . '/', $server['REQUEST_URI']);
                 $request_to_match = $request->duplicate(server: $server);
             }
+            // Update the router's context from the actual request so that HTTP method constraints
+            // are evaluated against the real method, not the default 'GET' from RequestContext.
+            $router->getContext()->fromRequest($request_to_match);
             $matches = $router->matchRequest($request_to_match);
         } catch (ResourceNotFoundException) {
             // No route found, let Symfony do the rest of the work.

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -131,4 +131,5 @@ function plugin_tester_boot()
 {
     \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/$#');
     \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/StatelessURI$#');
+    \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/post-only$#');
 }

--- a/tests/fixtures/plugins/tester/src/Controller/TesterController.php
+++ b/tests/fixtures/plugins/tester/src/Controller/TesterController.php
@@ -52,4 +52,10 @@ final class TesterController extends AbstractController
     {
         return new Response('Greeting from tester plugin controller /Testuri route.');
     }
+
+    #[Route("/post-only", name: "testerplugin_post_only", methods: ['POST'])]
+    public function postOnly(Request $request): Response
+    {
+        return new Response('Greeting from tester plugin POST-only route.');
+    }
 }

--- a/tests/web/Glpi/RoutingTest.php
+++ b/tests/web/Glpi/RoutingTest.php
@@ -67,4 +67,12 @@ class RoutingTest extends FrontBaseClass
         $crawler = $this->http_client->request('GET', $this->base_uri . 'plugins/tester/Testuri');
         $this->assertSame('<body><p>Greeting from tester plugin controller /Testuri route.</p></body>', $crawler->html());
     }
+
+    public function testPluginPostOnlyRoute(): void
+    {
+        // Regression test: plugin POST-only routes must be matched by the plugin router.
+        // The route is stateless so no auth/CSRF token is needed.
+        $crawler = $this->http_client->request('POST', $this->base_uri . 'plugins/tester/post-only');
+        $this->assertSame('<body><p>Greeting from tester plugin POST-only route.</p></body>', $crawler->html());
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Before this fix, for plugin using the Symfony Controller syntax, declaring methods to only POST for example would not work and return a `Symfony\\Component\\Routing\\Exception\\MethodNotAllowedException`.

Changing it to `GET` and sending a `POST` on the browser would work :exploding_head: 

In my mind at first I though it was because before sending the POST payload the browser did a GET...

Something like that will work in GLPI < 11.0.7
```php
#[Route(
        "/save-related-match",
        name: "glpiai_save_related_match",
        methods: ["POST", "GET"],
    )]
    public function saveMatch(Request $request): JsonResponse
```

What it should be :
```php
#[Route(
        "/save-related-match",
        name: "glpiai_save_related_match",
        methods: ["POST"],
    )]
    public function saveMatch(Request $request): JsonResponse
```

The route cause was simple, the Plugin custom route loader/listener didn't load the request context and was so by default on a GET method context every time.