### PR TITLE
Full Implementation of TacticalRMM and Meshcentral in remote management

### DIFF
--- a/src/Item_RemoteManagement.php
+++ b/src/Item_RemoteManagement.php
@@ -46,6 +46,7 @@ class Item_RemoteManagement extends CommonDBChild
     public const MESHCENTRAL = 'meshcentral';
     public const SUPREMO = 'supremo';
     public const RUSTDESK = 'rustdesk';
+    public const TACTICALRMM = 'tacticalrmm';
 
 
     public static function getTypeName($nb = 0)
@@ -177,6 +178,12 @@ class Item_RemoteManagement extends CommonDBChild
             case self::RUSTDESK:
                 $href = "rustdesk://$id";
                 break;
+            case self::MESHCENTRAL:
+                $href = "https://meshcentral.exemple.com/?viewmode=11&gotonode=$id";
+                break;
+            case self::TACTICALRMM:
+                $href = "https://trmm.exemple.com/agents/$id";
+                break;
         }
 
         if ($href === null) {
@@ -306,6 +313,7 @@ class Item_RemoteManagement extends CommonDBChild
             self::MESHCENTRAL => 'MeshCentral',
             self::SUPREMO => 'SupRemo',
             self::RUSTDESK => 'RustDesk',
+            self::TACTICALRMM => 'TacticalRMM',
         ];
 
         $options['canedit'] = Session::haveRight($itemtype::$rightname, UPDATE);


### PR DESCRIPTION
The purpose is to find a solution to fully implement TacticalRMM and Meshcentral on remote management (Open in new tab directly to the computer/server when click on link).

For the moment, with this implementation, is there is to hardcode the destination fqdn.

Anyone know how to set it fynamically per glpi instance for exemple ?

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


