### PR TITLE
do not store changed view when viewing planning from homepage

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -443,30 +443,31 @@ var GLPIPlanning  = {
                 var view_type = info.view.type;
 
                 GLPIPlanning.last_view = view_type;
-                // inform backend we changed view (to store it in session)
-                $.ajax({
-                    url:  `${CFG_GLPI.root_doc}/ajax/planning.php`,
-                    type: 'POST',
-                    data: {
-                        action: 'view_changed',
-                        view:   view_type
-                    }
-                }).done(function() {
-                    // indicate to central page we're done rendering
-                    if (!options.full_view) {
-                        // Observe changes in the DOM before triggering
-                        const observer = new MutationObserver((mutations, obs) => {
-                            if (document.readyState === 'complete') {
-                                obs.disconnect(); // Stop observation once the DOM is stable
-                                setTimeout(() => {
-                                    $(document).trigger('masonry_grid:layout');
-                                }, 100);
-                            }
-                        });
 
-                        observer.observe(document.body, { childList: true, subtree: true });
-                    }
-                });
+                if (options.full_view) {
+                    // inform backend we changed view (to store it in session)
+                    $.ajax({
+                        url: `${CFG_GLPI.root_doc}/ajax/planning.php`,
+                        type: 'POST',
+                        data: {
+                            action: 'view_changed',
+                            view: view_type,
+                            full_view: options?.full_view ? 1 : 0
+                        }
+                    });
+                } else {
+                    // Observe changes in the DOM before triggering
+                    const observer = new MutationObserver((mutations, obs) => {
+                        if (document.readyState === 'complete') {
+                            obs.disconnect(); // Stop observation once the DOM is stable
+                            setTimeout(() => {
+                                $(document).trigger('masonry_grid:layout');
+                            }, 100);
+                        }
+                    });
+
+                    observer.observe(document.body, {childList: true, subtree: true});
+                }
 
                 // set end of day markers for timeline
                 GLPIPlanning.setEndofDays(info.view);

--- a/js/planning.js
+++ b/js/planning.js
@@ -451,8 +451,7 @@ var GLPIPlanning  = {
                         type: 'POST',
                         data: {
                             action: 'view_changed',
-                            view: view_type,
-                            full_view: options?.full_view ? 1 : 0
+                            view: view_type
                         }
                     });
                 } else {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23383

Passes the `full_view` option along with the `view_changed` AJAX request and then the server skips updating the view in the session if it is not the full view. This keeps the widget on the homepage from always resetting the view back to the list view whil allowing the change to happen as expected in the full planning view.