### PR TITLE
Fix(RichText): Remove TinyMCE (Ephox) editor artifacts

### DIFF
--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -236,6 +236,8 @@ final class RichText
                     '/' . $leading_spaces . '<head[^>]*>.*?<\/head[^>]*>' . $following_spaces . '/si',
                     '/' . $leading_spaces . '<script[^>]*>.*?<\/script[^>]*>' . $following_spaces . '/si',
                     '/' . $leading_spaces . '<style[^>]*>.*?<\/style[^>]*>' . $following_spaces . '/si',
+                    // Remove TinyMCE (Ephox) editor artifacts (e.g. drag-and-drop overlay blockers)
+                    '/<div[^>]+class=["\'][^"\']*\bephox-[^"\']*["\'][^>]*>\s*<\/div>/si',
                 ],
                 '',
                 $content

--- a/tests/functional/Glpi/RichText/RichTextTest.php
+++ b/tests/functional/Glpi/RichText/RichTextTest.php
@@ -337,6 +337,17 @@ HTML,
 HTML,
         ];
 
+        // TinyMCE (Ephox) editor artifacts should be stripped
+        // e.g. drag-and-drop overlay blocker that gets saved into content and renders as a full-screen overlay
+        yield 'TinyMCE ephox editor artifacts should be removed' => [
+            'content'                => <<<HTML
+<p>Some content</p>
+<div class="ephox-dragster-blocker" style="position: fixed; left: 0px; top: 0px; width: 100%; height: 100%;" role="presentation"> </div>
+HTML,
+            'encode_output_entities' => false,
+            'expected_result'        => '<p>Some content</p>',
+        ];
+
         // Deprecated html attributes should not be transformed into styles
         // see #11580
         yield [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43352

Remove TinyMCE (Ephox) editor artifacts, e.g. drag-and-drop overlay blocker that gets saved into content and renders as a full-screen overlay