### PR TITLE
listing imap folder can only be done with saved receiver.

### DIFF
--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
 
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");
@@ -43,21 +43,14 @@ Session::checkRight("config", UPDATE);
 
 $mailcollector = new MailCollector();
 
-if (isset($_REQUEST['action'])) {
-    switch ($_REQUEST['action']) {
-        case "getFoldersList":
-            // The collector must already exist in database.
-            if (
-                !array_key_exists('id', $_REQUEST)
-                || !$mailcollector->getFromDB($_REQUEST['id'])
-            ) {
-                $exception = new AccessDeniedHttpException();
-                $exception->setMessageToDisplay(__('Mail collector must be saved before browsing folders.'));
-                throw $exception;
-            }
-
-            // Update fields with input values
-            $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
-            break;
+if (isset($_REQUEST['action']) && $_REQUEST['action'] === 'getFoldersList') {
+    // The collector must already exist in database.
+    if (
+        !array_key_exists('id', $_REQUEST)
+        || !$mailcollector->getFromDB($_REQUEST['id'])
+    ) {
+        throw new NotFoundHttpException();
     }
+
+    $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
 }

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -39,48 +39,25 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkRight("config", READ);
+Session::checkRight("config", UPDATE);
 
 $mailcollector = new MailCollector();
 
 if (isset($_REQUEST['action'])) {
     switch ($_REQUEST['action']) {
         case "getFoldersList":
-            // Load config if already exists
-            // Necessary if password is not updated
-            if (array_key_exists('id', $_REQUEST)) {
-                $mailcollector->getFromDB($_REQUEST['id']);
+            // The collector must already exist in database.
+            if (
+                !array_key_exists('id', $_REQUEST)
+                || !$mailcollector->getFromDB($_REQUEST['id'])
+            ) {
+                $exception = new AccessDeniedHttpException();
+                $exception->setMessageToDisplay(__('Mail collector must be saved before browsing folders.'));
+                throw $exception;
             }
 
             // Update fields with input values
-            $input = $_REQUEST;
-
-            if (isset($input["passwd"])) {
-                if (empty($input["passwd"])) {
-                    unset($input["passwd"]);
-                } else {
-                    $input["passwd"] = (new GLPIKey())->encrypt($input["passwd"]);
-                }
-            }
-
-            if (!empty($input['mail_server'])) {
-                $input["host"] = Toolbox::constructMailServerConfig($input);
-                // In some case (like oauth imap) provide password is not possible
-                // So, ask for password only if there is one stored in database and it's not an OAuth connection
-                $is_oauth = !empty($input['server_type']) && str_contains($input['server_type'], 'oauth');
-                if (!$is_oauth && !isset($input['passwd']) && !empty($mailcollector->fields['passwd'])) {
-                    $exception = new AccessDeniedHttpException();
-                    $exception->setMessageToDisplay(__('Password is required to list mail folders.'));
-                    throw $exception;
-                }
-            }
-
-            if (!isset($input['errors'])) {
-                $input['errors'] = 0;
-            }
-
-            $mailcollector->fields = array_merge($mailcollector->fields, $input);
-            $mailcollector->displayFoldersList($_REQUEST['input_id']);
+            $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
             break;
     }
 }

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -1,34 +1,34 @@
 {#
-# ---------------------------------------------------------------------
-#
-# GLPI - Gestionnaire Libre de Parc Informatique
-#
-# http://glpi-project.org
-#
-# @copyright 2015-2026 Teclib' and contributors.
-# @licence   https://www.gnu.org/licenses/gpl-3.0.html
-#
-# ---------------------------------------------------------------------
-#
-# LICENSE
-#
-# This file is part of GLPI.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-# ---------------------------------------------------------------------
-#}
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -116,7 +116,7 @@
     {% if connect_opts['type'] != 'pop' %}
         {{ fields.smallTitle(__('Folders setup')) }}
         {% set get_imap_folder_btn %}
-            <div class="btn btn-outline-secondary get-imap-folder cursor-pointer{% if item.isNewItem %} disabled{% endif %}"
+            <div class="btn btn-outline-secondary get-imap-folder cursor-pointer{% if item.isNewItem() %} disabled{% endif %}"
                  {% if item.isNewItem %}style="pointer-events: none;"{% endif %}>
                 <i class="ti ti-list"></i>
             </div>
@@ -259,7 +259,7 @@
 
                 const data = {
                     action: 'getFoldersList',
-                    id: {{ item.fields['id']|default(0) }},
+                    id: '{{ item.fields['id']|default(0)|e('js') }}',
                         input_id: input.attr('id')
                     };
 

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -287,3 +287,4 @@
             });
         </script>
     {% endif %}
+{% endblock %}

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -106,7 +106,7 @@
         'passwd',
         '',
         __('Password'), {
-            clearable: not item.isNewItem,
+            clearable: not item.isNewItem(),
             'additional_attributes': {
                 'autocomplete': 'new-password',
             }
@@ -117,12 +117,12 @@
         {{ fields.smallTitle(__('Folders setup')) }}
         {% set get_imap_folder_btn %}
             <div class="btn btn-outline-secondary get-imap-folder cursor-pointer{% if item.isNewItem() %} disabled{% endif %}"
-                 {% if item.isNewItem %}style="pointer-events: none;"{% endif %}>
+                 {% if item.isNewItem() %}style="pointer-events: none;"{% endif %}>
                 <i class="ti ti-list"></i>
             </div>
         {% endset %}
         {# warning message when config is changed, choosing imap/folder is disabled #}
-        <div class="alert alert-warning{% if not item.isNewItem %} d-none{% endif %}" id="server-changed-warning">
+        <div class="alert alert-warning{% if not item.isNewItem() %} d-none{% endif %}" id="server-changed-warning">
             <i class="ti ti-info-circle"></i>
             {{ __('Server configuration has changed. Please save the collector before browsing folders.') }}
         </div>
@@ -217,7 +217,7 @@
                     'login', 'passwd'
                 ];
                 const form = $('.get-imap-folder').closest('form');
-            {% if item.isNewItem %}
+            {% if item.isNewItem() %}
                 // New collector: always disabled until first save
                 {% else %}
                 const savedValues = {};

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -1,34 +1,34 @@
 {#
- # ---------------------------------------------------------------------
- #
- # GLPI - Gestionnaire Libre de Parc Informatique
- #
- # http://glpi-project.org
- #
- # @copyright 2015-2026 Teclib' and contributors.
- # @licence   https://www.gnu.org/licenses/gpl-3.0.html
- #
- # ---------------------------------------------------------------------
- #
- # LICENSE
- #
- # This file is part of GLPI.
- #
- # This program is free software: you can redistribute it and/or modify
- # it under the terms of the GNU General Public License as published by
- # the Free Software Foundation, either version 3 of the License, or
- # (at your option) any later version.
- #
- # This program is distributed in the hope that it will be useful,
- # but WITHOUT ANY WARRANTY; without even the implied warranty of
- # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- # GNU General Public License for more details.
- #
- # You should have received a copy of the GNU General Public License
- # along with this program.  If not, see <https://www.gnu.org/licenses/>.
- #
- # ---------------------------------------------------------------------
- #}
+# ---------------------------------------------------------------------
+#
+# GLPI - Gestionnaire Libre de Parc Informatique
+#
+# http://glpi-project.org
+#
+# @copyright 2015-2026 Teclib' and contributors.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#}
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
@@ -47,211 +47,243 @@
 }) %}
 
 {% block form_fields %}
-   {% if item.fields['errors'] %}
-      <div class="alert alert-danger">
-         {{ __('%1$s: %2$s')|format(
-               _n('Error', 'Errors', get_plural_number()),
-               item.fields['errors']
-         ) }}
-      </div>
-   {% endif %}
+{% if item.fields['errors'] %}
+    <div class="alert alert-danger">
+        {{ __('%1$s: %2$s')|format(
+            _n('Error', 'Errors', get_plural_number()),
+            item.fields['errors']
+        ) }}
+    </div>
+{% endif %}
 
-   {{ fields.textField(
-      'name',
-      item.fields['name'],
-      __('Name'), {
-         helper: __('If the name is a valid email address, it will be automatically added to blacklisted senders.')
-      }
-   ) }}
+    {{ fields.textField(
+        'name',
+        item.fields['name'],
+        __('Name'), {
+            helper: __('If the name is a valid email address, it will be automatically added to blacklisted senders.')
+        }
+    ) }}
 
-   {{ fields.textareaField(
-      'comment',
-      item.fields['comment'],
-      __('Comments')
-   ) }}
+    {{ fields.textareaField(
+        'comment',
+        item.fields['comment'],
+        __('Comments')
+    ) }}
 
-   {{ fields.dropdownYesNo(
-      'is_active',
-      item.fields['is_active'],
-      __('Active')
-   ) }}
+    {{ fields.dropdownYesNo(
+        'is_active',
+        item.fields['is_active'],
+        __('Active')
+    ) }}
 
-   {{ fields.nullField() }}
+    {{ fields.nullField() }}
 
-   {{ fields.smallTitle(__('Server configuration')) }}
+    {{ fields.smallTitle(__('Server configuration')) }}
 
-   {% set host = item.fields['host'] %}
-   {% set connect_opts = call(
-      'Toolbox::parseMailServerConnectString',
-      [host]
-   ) %}
+    {% set host = item.fields['host'] %}
+    {% set connect_opts = call(
+        'Toolbox::parseMailServerConnectString',
+        [host]
+    ) %}
 
-   {{ include('pages/setup/mailcollector/server_config_fields.html.twig', {
-      'connect_opts': connect_opts,
-      'connect_string': host,
-      'protocol_choices': protocol_choices,
-   }) }}
+    {{ include('pages/setup/mailcollector/server_config_fields.html.twig', {
+        'connect_opts': connect_opts,
+        'connect_string': host,
+        'protocol_choices': protocol_choices,
+    }) }}
 
-   {{ fields.smallTitle(__('Authentication')) }}
+    {{ fields.smallTitle(__('Authentication')) }}
 
-   {{ fields.textField(
-      'login',
-      item.fields['login'],
-      __('Login')
-   ) }}
+    {{ fields.textField(
+        'login',
+        item.fields['login'],
+        __('Login')
+    ) }}
 
-   {{ fields.nullField() }}
+    {{ fields.nullField() }}
 
-   {{ fields.passwordField(
-      'passwd',
-      '',
-      __('Password'), {
-         clearable: not item.isNewItem,
-         'additional_attributes': {
-            'autocomplete': 'new-password',
-         }
-      }
-   ) }}
+    {{ fields.passwordField(
+        'passwd',
+        '',
+        __('Password'), {
+            clearable: not item.isNewItem,
+            'additional_attributes': {
+                'autocomplete': 'new-password',
+            }
+        }
+    ) }}
 
-   {% if connect_opts['type'] != 'pop' %}
-      {{ fields.smallTitle(__('Folders setup')) }}
-      {% set get_imap_folder_btn %}
-         <div class="btn btn-outline-secondary get-imap-folder cursor-pointer">
-            <i class="ti ti-list"></i>
-         </div>
-      {% endset %}
-      {{ fields.textField(
-         'server_mailbox',
-         connect_opts['mailbox'],
-         __('Incoming mail folder (optional, often INBOX)'), {
-            add_field_html: get_imap_folder_btn,
-            input_class: 'btn-group btn-group-sm col-xxl-7 d-flex',
-            input_addclass: 'rounded-end-0'
-         }
-      ) }}
-      {{ fields.nullField() }}
-      {{ fields.textField(
-         'accepted',
-         item.fields['accepted'],
-         __('Accepted mail archive folder (optional)'), {
-            add_field_html: get_imap_folder_btn,
-            input_class: 'btn-group btn-group-sm col-xxl-7 d-flex',
-            input_addclass: 'rounded-end-0'
-         }
-      ) }}
-      {{ fields.textField(
-         'refused',
-         item.fields['refused'],
-         __('Refused mail archive folder (optional)'), {
-            add_field_html: get_imap_folder_btn,
-            input_class: 'btn-group btn-group-sm col-xxl-7 d-flex',
-            input_addclass: 'rounded-end-0'
-         }
-      ) }}
-   {% endif %}
+    {% if connect_opts['type'] != 'pop' %}
+        {{ fields.smallTitle(__('Folders setup')) }}
+        {% set get_imap_folder_btn %}
+            <div class="btn btn-outline-secondary get-imap-folder cursor-pointer{% if item.isNewItem %} disabled{% endif %}"
+                 {% if item.isNewItem %}style="pointer-events: none;"{% endif %}>
+                <i class="ti ti-list"></i>
+            </div>
+        {% endset %}
+        {# warning message when config is changed, choosing imap/folder is disabled #}
+        <div class="alert alert-warning{% if not item.isNewItem %} d-none{% endif %}" id="server-changed-warning">
+            <i class="ti ti-info-circle"></i>
+            {{ __('Server configuration has changed. Please save the collector before browsing folders.') }}
+        </div>
+        {{ fields.textField(
+            'server_mailbox',
+            connect_opts['mailbox'],
+            __('Incoming mail folder (optional, often INBOX)'), {
+                add_field_html: get_imap_folder_btn,
+                input_class: 'col-xxl-7 d-flex'
+            }
+        ) }}
+        {{ fields.textField(
+            'accepted',
+            item.fields['accepted'],
+            __('Accepted mail archive folder (optional)'), {
+                add_field_html: get_imap_folder_btn,
+                input_class: 'col-xxl-7 d-flex'
+            }
+        ) }}
+        {{ fields.textField(
+            'refused',
+            item.fields['refused'],
+            __('Refused mail archive folder (optional)'), {
+                add_field_html: get_imap_folder_btn,
+                input_class: 'col-xxl-7 d-flex'
+            }
+        ) }}
+    {% endif %}
 
-   {{ fields.smallTitle(__('Collection options')) }}
-   {% set max_filesize_dropdown %}
-      {% do call('MailCollector::showMaxFilesize', ['filesize_max', item.fields['filesize_max']]) %}
-   {% endset %}
-   {{ fields.htmlField(
-      '',
-      max_filesize_dropdown,
-      __('Maximum size of each file imported by the mails receiver'),
-      field_options
-   ) }}
-   {{ fields.dropdownYesNo(
-      'use_mail_date',
-      item.fields['use_mail_date'],
-      __('Use mail date, instead of collect one')
-   ) }}
-   {{ fields.dropdownArrayField(
-      'requester_field',
-      item.fields['requester_field'], {
-         (constant('MailCollector::REQUESTER_FIELD_FROM')): __('No'),
-         (constant('MailCollector::REQUESTER_FIELD_REPLY_TO')): __('Yes'),
-      },
-      __('Use Reply-To as requester (when available)')
-   ) }}
-   {{ fields.dropdownYesNo(
-      'add_to_to_observer',
-      item.fields['add_to_to_observer'],
-      __('Add TO users as observer')
-   ) }}
-   {{ fields.dropdownYesNo(
-      'add_cc_to_observer',
-      item.fields['add_cc_to_observer'],
-      __('Add CC users as observer')
-   ) }}
-   {{ fields.dropdownYesNo(
-      'collect_only_unread',
-      item.fields['collect_only_unread'],
-      __('Collect only unread mail')
-   ) }}
+    {{ fields.smallTitle(__('Collection options')) }}
+    {% set max_filesize_dropdown %}
+        {% do call('MailCollector::showMaxFilesize', ['filesize_max', item.fields['filesize_max']]) %}
+    {% endset %}
+    {{ fields.htmlField(
+        '',
+        max_filesize_dropdown,
+        __('Maximum size of each file imported by the mails receiver'),
+        field_options
+    ) }}
+    {{ fields.dropdownYesNo(
+        'use_mail_date',
+        item.fields['use_mail_date'],
+        __('Use mail date, instead of collect one')
+    ) }}
+    {{ fields.dropdownArrayField(
+        'requester_field',
+        item.fields['requester_field'], {
+            (constant('MailCollector::REQUESTER_FIELD_FROM')): __('No'),
+            (constant('MailCollector::REQUESTER_FIELD_REPLY_TO')): __('Yes'),
+        },
+        __('Use Reply-To as requester (when available)')
+    ) }}
+    {{ fields.dropdownYesNo(
+        'add_to_to_observer',
+        item.fields['add_to_to_observer'],
+        __('Add TO users as observer')
+    ) }}
+    {{ fields.dropdownYesNo(
+        'add_cc_to_observer',
+        item.fields['add_cc_to_observer'],
+        __('Add CC users as observer')
+    ) }}
+    {{ fields.dropdownYesNo(
+        'collect_only_unread',
+        item.fields['collect_only_unread'],
+        __('Collect only unread mail')
+    ) }}
 
-   {% set create_user_helper %}
-      {% if not config('is_users_auto_add') %}
-         {{ __('If you use this option, and this collector is likely to receive requests from users authenticating via LDAP, we advise you to activate the option "Automatically add users from an external authentication source", in the Authentication settings in order to avoid the generation of duplicate users.') }}
-      {% endif %}
-   {% endset %}
+    {% set create_user_helper %}
+        {% if not config('is_users_auto_add') %}
+            {{ __('If you use this option, and this collector is likely to receive requests from users authenticating via LDAP, we advise you to activate the option "Automatically add users from an external authentication source", in the Authentication settings in order to avoid the generation of duplicate users.') }}
+        {% endif %}
+    {% endset %}
 
-   {{ fields.dropdownYesNo(
-      'create_user_from_email',
-      item.fields['create_user_from_email'],
-      __('Automatically create user from email'), {
-         helper: create_user_helper|trim|default(null)
-      }
-   ) }}
+    {{ fields.dropdownYesNo(
+        'create_user_from_email',
+        item.fields['create_user_from_email'],
+        __('Automatically create user from email'), {
+            helper: create_user_helper|trim|default(null)
+        }
+    ) }}
 
-   {% if connect_opts['type'] != 'pop' %}
-      <script>
-          $(function() {
-              $(document).on('click', '.get-imap-folder', function() {
-                  const input = $(this).prev('input');
+    {% if connect_opts['type'] != 'pop' %}
+        <script>
+            $(function() {
+                // Track all fields used to establish the IMAP connection
+                const connectionFields = [
+                    // Server configuration
+                    'mail_server', 'server_port', 'server_type', 'server_ssl',
+                    'server_tls', 'server_cert', 'server_rsh', 'server_secure', 'server_debug',
+                    // Authentication
+                    'login', 'passwd'
+                ];
+                const form = $('.get-imap-folder').closest('form');
+            {% if item.isNewItem %}
+                // New collector: always disabled until first save
+                {% else %}
+                const savedValues = {};
+                connectionFields.forEach(function(name) {
+                    const field = form.find('[name="' + name + '"]');
+                    if (field.length) {
+                        savedValues[name] = field.val();
+                    }
+                });
 
-                  let data = 'action=getFoldersList';
-                  data += '&input_id=' + input.attr('id');
-                  // Get form values without server_mailbox value to prevent filtering
-                  data += '&' + $(this).closest('form').find(':not([name=\"server_mailbox\"])').serialize();
-                  // Force empty value for server_mailbox
-                  data += '&server_mailbox=';
+                function checkConnectionChanged() {
+                    let changed = false;
+                    connectionFields.forEach(function(name) {
+                        const field = form.find('[name="' + name + '"]');
+                        if (field.length && field.val() !== savedValues[name]) {
+                            changed = true;
+                        }
+                    });
+                    const warning = $('#server-changed-warning');
+                    const buttons = form.find('.get-imap-folder');
+                    if (changed) {
+                        warning.removeClass('d-none');
+                        buttons.addClass('disabled').css('pointer-events', 'none');
+                    } else {
+                        warning.addClass('d-none');
+                        buttons.removeClass('disabled').css('pointer-events', '');
+                    }
+                }
 
-                  // In some case (like oauth imap) provide password is not possible
-                  // So, ask for password only if there is one stored in database and it's not an OAuth connection
-                  var passwdField = $(this).closest('form').find('input[name="passwd"]');
-                  var hasStoredPassword = {{ (item.fields['passwd'] is defined and item.fields['passwd']) ? 'true' : 'false' }};
-                  var isOAuth = {{ ('oauth' in (item.fields['server_type'] ?? '')) ? 'true' : 'false' }};
-                  if (hasStoredPassword && !isOAuth && passwdField.val() == '') {
-                     var passwd = prompt(__('Please enter password to list folders'));
-                     if (passwd === null) {
-                        // User cancelled the prompt
-                        return;
-                     }
-                     data += '&passwd=' + encodeURIComponent(passwd);
-                  }
+                form.on(
+                    'change input',
+                    connectionFields.map(n => '[name="' + n + '"]').join(', '),
+                    checkConnectionChanged
+                );
+                {% endif %}
 
-                  glpi_ajax_dialog({
-                      title: __('Select a folder'),
-                      url: '{{ path('/ajax/mailcollector.php') }}',
-                      params: data,
-                      id: input.attr('id') + '_modal'
-                  });
-              });
+            $(document).on('click', '.get-imap-folder', function() {
+                const input = $(this).prev('input');
 
-              $(document).on('click', '.select_folder li', function(event) {
-                  event.stopPropagation();
+                const data = {
+                    action: 'getFoldersList',
+                    id: {{ item.fields['id']|default(0) }},
+                        input_id: input.attr('id')
+                    };
 
-                  const li       = $(this);
-                  const input_id = li.data('input-id');
-                  const folder   = li.children('.folder-name').data('globalname');
+                    glpi_ajax_dialog({
+                        title: __('Select a folder'),
+                        url: '{{ path('/ajax/mailcollector.php') }}',
+                        params: data,
+                        id: input.attr('id') + '_modal'
+                    });
+                });
 
-                  $('#'+input_id).val(folder);
+                $(document).on('click', '.select_folder li', function(event) {
+                    event.stopPropagation();
 
-                  const modalEl = $('#'+input_id+'_modal')[0];
-                  const modal = bootstrap.Modal.getInstance(modalEl);
-                  modal.hide();
-              })
-          });
-      </script>
-   {% endif %}
-{% endblock %}
+                    const li       = $(this);
+                    const input_id = li.data('input-id');
+                    const folder   = li.children('.folder-name').data('globalname');
+
+                    $('#'+input_id).val(folder);
+
+                    const modalEl = $('#'+input_id+'_modal')[0];
+                    const modal = bootstrap.Modal.getInstance(modalEl);
+                    modal.hide();
+                })
+            });
+        </script>
+    {% endif %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Avoid probing external imap without having receiver saved.

+ added modification right since this ajax call can be done only when editing a receiver.
