### PR TITLE
cache timezone list

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1942,7 +1942,10 @@ class DBmysql
                 $now->setTimezone(new DateTimeZone($row['name']));
                 $list[$row['name']] = $row['name'] . $now->format(" (T P)");
             }
-            $GLPI_CACHE->set('timezones', $list);
+            if (!empty($list)) {
+                // Only cache if there are some timezones. This method may be called before timezones are properly setup, and we don't want to cache an empty list.
+                $GLPI_CACHE->set('timezones', $list);
+            }
         } else {
             $list = $GLPI_CACHE->get('timezones');
         }

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1908,36 +1908,43 @@ class DBmysql
      */
     public function getTimezones()
     {
+        global $GLPI_CACHE;
+
         $list = [];
 
-        $timezones = DateTimeZone::listIdentifiers();
-        $results_queries = [];
-        foreach ($timezones as $index => $timezone) {
-            $results_queries[] =  new QuerySubQuery([
-                'SELECT' => ['name', 'value'],
-                'FROM' => new QueryExpression(
-                    sprintf(
-                        '(SELECT %1$s as %2$s, CONVERT_TZ(%3$s, %4$s, %5$s) as %6$s) as %7$s',
-                        self::quoteValue($timezone),
-                        self::quoteName('name'),
-                        self::quoteValue('2000-01-01 00:00:00'),
-                        self::quoteValue('GMT'),
-                        self::quoteValue($timezone),
-                        self::quoteName('value'),
-                        self::quoteName(sprintf('timezone_%d', $index)),
-                    )
-                ),
-                'WHERE' => [
-                    ['NOT' => ['value' => null]],
-                ],
-            ]);
-        }
+        if (!$GLPI_CACHE->has('timezones')) {
+            $timezones = DateTimeZone::listIdentifiers();
+            $results_queries = [];
+            foreach ($timezones as $index => $timezone) {
+                $results_queries[] =  new QuerySubQuery([
+                    'SELECT' => ['name', 'value'],
+                    'FROM' => new QueryExpression(
+                        sprintf(
+                            '(SELECT %1$s as %2$s, CONVERT_TZ(%3$s, %4$s, %5$s) as %6$s) as %7$s',
+                            self::quoteValue($timezone),
+                            self::quoteName('name'),
+                            self::quoteValue('2000-01-01 00:00:00'),
+                            self::quoteValue('GMT'),
+                            self::quoteValue($timezone),
+                            self::quoteName('value'),
+                            self::quoteName(sprintf('timezone_%d', $index)),
+                        )
+                    ),
+                    'WHERE' => [
+                        ['NOT' => ['value' => null]],
+                    ],
+                ]);
+            }
 
-        $iterator = $this->request(['FROM' => new QueryUnion($results_queries)]);
-        foreach ($iterator as $row) {
-            $now = new DateTime();
-            $now->setTimezone(new DateTimeZone($row['name']));
-            $list[$row['name']] = $row['name'] . $now->format(" (T P)");
+            $iterator = $this->request(['FROM' => new QueryUnion($results_queries)]);
+            foreach ($iterator as $row) {
+                $now = new DateTime();
+                $now->setTimezone(new DateTimeZone($row['name']));
+                $list[$row['name']] = $row['name'] . $now->format(" (T P)");
+            }
+            $GLPI_CACHE->set('timezones', $list);
+        } else {
+            $list = $GLPI_CACHE->get('timezones');
         }
 
         return $list;

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1942,7 +1942,7 @@ class DBmysql
                 $now->setTimezone(new DateTimeZone($row['name']));
                 $list[$row['name']] = $row['name'] . $now->format(" (T P)");
             }
-            if (!empty($list)) {
+            if ($list !== []) {
                 // Only cache if there are some timezones. This method may be called before timezones are properly setup, and we don't want to cache an empty list.
                 $GLPI_CACHE->set('timezones', $list);
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Finding the list of supported timezones is an expensive operation since the replacement of the logic that checked the "mysql.time_zone_name" table to avoid needing permission on the table. Now, it makes a query composed of over 400 subqueries that do a timezone conversion and checks if the result is not null to validate the timezone is supported.

Normally, this is around 30-40ms for me but I have seen it spike occasionally to 300-350ms.

This isn't expected to change once the timezones are loaded in the database, so this could be safely cached.

This biggest improvement by doing this currently is with the GraphQL part of the HLAPI as `DBmysql::getTimezones()` is called when generating the API schema info which is a prerequisite of creating the GraphQL types. The GraphQL type info is not able to be cached at this time with the recent rework as it uses lazy type resolution (and there is a performance improvement by using lazy resolution vs caching anyways).