### PR TITLE
listing imap folder can only be done with saved receiver

### DIFF
--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -55,9 +55,7 @@ if (isset($_REQUEST['action'])) {
                 !array_key_exists('id', $_REQUEST)
                 || !$mailcollector->getFromDB($_REQUEST['id'])
             ) {
-                $exception = new AccessDeniedHttpException();
-                $exception->setMessageToDisplay(__('Mail collector must be saved before browsing folders.'));
-                throw $exception;
+                Html::displayErrorAndDie(__('Mail collector must be saved before browsing folders.'));
             }
 
             $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -50,43 +50,17 @@ $mailcollector = new MailCollector();
 if (isset($_REQUEST['action'])) {
     switch ($_REQUEST['action']) {
         case "getFoldersList":
-            // Load config if already exists
-            // Necessary if password is not updated
-            if (array_key_exists('id', $_REQUEST)) {
-                $mailcollector->getFromDB($_REQUEST['id']);
+            // The collector must already exist in database.
+            if (
+                !array_key_exists('id', $_REQUEST)
+                || !$mailcollector->getFromDB($_REQUEST['id'])
+            ) {
+                $exception = new AccessDeniedHttpException();
+                $exception->setMessageToDisplay(__('Mail collector must be saved before browsing folders.'));
+                throw $exception;
             }
 
-            // Update fields with input values
-            $input = $_REQUEST;
-            if (array_key_exists('passwd', $input)) {
-                // Password must not be altered, it will be encrypted and never displayed, so sanitize is not necessary.
-                $input['passwd'] = $_UREQUEST['passwd'];
-            }
-            $input['login'] = stripslashes($input['login']);
-
-            if (isset($input["passwd"])) {
-                if (empty($input["passwd"])) {
-                    unset($input["passwd"]);
-                } else {
-                    $input["passwd"] = (new GLPIKey())->encrypt($input["passwd"]);
-                }
-            }
-
-            if (!empty($input['mail_server'])) {
-                $input["host"] = Toolbox::constructMailServerConfig($input);
-                if (!isset($input['passwd'])) {
-                    throw new \RuntimeException(
-                        __('Password is required to list mail folders.')
-                    );
-                }
-            }
-
-            if (!isset($input['errors'])) {
-                $input['errors'] = 0;
-            }
-
-            $mailcollector->fields = array_merge($mailcollector->fields, $input);
-            $mailcollector->displayFoldersList($_REQUEST['input_id']);
+            $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
             break;
     }
 }

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -33,9 +33,6 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var array $_UREQUEST */
-global $_UREQUEST;
-
 $AJAX_INCLUDE = 1;
 include('../inc/includes.php');
 
@@ -47,18 +44,13 @@ Session::checkRight("config", UPDATE);
 
 $mailcollector = new MailCollector();
 
-if (isset($_REQUEST['action'])) {
-    switch ($_REQUEST['action']) {
-        case "getFoldersList":
-            // The collector must already exist in database.
-            if (
-                !array_key_exists('id', $_REQUEST)
-                || !$mailcollector->getFromDB($_REQUEST['id'])
-            ) {
-                Html::displayErrorAndDie(__('Mail collector must be saved before browsing folders.'));
-            }
-
-            $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
-            break;
+if ($_REQUEST['action'] === "getFoldersList") {
+    if (
+        !array_key_exists('id', $_REQUEST)
+        || !$mailcollector->getFromDB($_REQUEST['id'])
+    ) {
+        Html::displayErrorAndDie(__('Mail collector must be saved before browsing folders.'));
     }
+
+    $mailcollector->displayFoldersList($_REQUEST['input_id'] ?? '');
 }

--- a/ajax/mailcollector.php
+++ b/ajax/mailcollector.php
@@ -43,7 +43,7 @@ include('../inc/includes.php');
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
-Session::checkRight("config", READ);
+Session::checkRight("config", UPDATE);
 
 $mailcollector = new MailCollector();
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -378,7 +378,7 @@ class MailCollector extends CommonDBTM
         if ($type != 'pop') {
             echo Html::scriptBlock("$(function() {
 
-            var isNewItem = (" . (int)$ID . " <= 0);
+            var isNewItem = (" . (int) $ID . " <= 0);
             var serverFieldNames = ['mail_server', 'server_type', 'server_ssl', 'server_tls', 'server_cert', 'server_rsh', 'server_secure', 'server_debug', 'server_mailbox', 'server_port'];
             var form = $('input[name=\"mail_server\"]').closest('form');
             var initialValues = {};
@@ -425,7 +425,7 @@ class MailCollector extends CommonDBTM
 
                const data = {
                         action: 'getFoldersList',
-                        id: " . (int)$ID . ",
+                        id: " . (int) $ID . ",
                         input_id: input.attr('id')
                     };
 

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -378,20 +378,61 @@ class MailCollector extends CommonDBTM
         if ($type != 'pop') {
             echo Html::scriptBlock("$(function() {
 
-            $(document).on('click', '.get-imap-folder', function() {
+            var isNewItem = (" . (int)$ID . " <= 0);
+            var serverFieldNames = ['mail_server', 'server_type', 'server_ssl', 'server_tls', 'server_cert', 'server_rsh', 'server_secure', 'server_debug', 'server_mailbox', 'server_port'];
+            var form = $('input[name=\"mail_server\"]').closest('form');
+            var initialValues = {};
+
+            serverFieldNames.forEach(function(name) {
+               var el = form.find('[name=\"' + name + '\"]');
+               if (el.length) {
+                  initialValues[name] = el.val();
+               }
+            });
+
+            function hasServerFieldsChanged() {
+               for (var i = 0; i < serverFieldNames.length; i++) {
+                  var el = form.find('[name=\"' + serverFieldNames[i] + '\"]');
+                  if (el.length && el.val() !== initialValues[serverFieldNames[i]]) {
+                     return true;
+                  }
+               }
+               return false;
+            }
+
+            function updateFolderButtonsState() {
+               if (isNewItem || hasServerFieldsChanged()) {
+                  $('.get-imap-folder').addClass('disabled').attr('aria-disabled', 'true').css('pointer-events', 'none');
+               } else {
+                  $('.get-imap-folder').removeClass('disabled').removeAttr('aria-disabled').css('pointer-events', '');
+               }
+            }
+
+            updateFolderButtonsState();
+
+            serverFieldNames.forEach(function(name) {
+               form.on('change input', '[name=\"' + name + '\"]', updateFolderButtonsState);
+            });
+
+            $(document).on('click', '.get-imap-folder', function(e) {
+               if ($(this).hasClass('disabled')) {
+                  e.preventDefault();
+                  e.stopImmediatePropagation();
+                  return false;
+               }
+
                var input = $(this).prev('input');
 
-               var data = 'action=getFoldersList';
-               data += '&input_id=' + input.attr('id');
-               // Get form values without server_mailbox value to prevent filtering
-               data += '&' + $(this).closest('form').find(':not([name=\"server_mailbox\"])').serialize();
-               // Force empty value for server_mailbox
-               data += '&server_mailbox=';
+               const data = {
+                        action: 'getFoldersList',
+                        id: " . (int)$ID . ",
+                        input_id: input.attr('id')
+                    };
 
                // Ask for password if missing
                if ($(this).closest('form').find('input[name=\"passwd\"]').val() == '') {
                   var passwd = prompt(__('Please enter password to list folders'));
-                  data += '&passwd=' + encodeURIComponent(passwd);
+                  data.passwd = passwd;
                }
 
                glpi_ajax_dialog({

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -429,12 +429,6 @@ class MailCollector extends CommonDBTM
                         input_id: input.attr('id')
                     };
 
-               // Ask for password if missing
-               if ($(this).closest('form').find('input[name=\"passwd\"]').val() == '') {
-                  var passwd = prompt(__('Please enter password to list folders'));
-                  data.passwd = passwd;
-               }
-
                glpi_ajax_dialog({
                   title: __('Select a folder'),
                   url: '" . $CFG_GLPI['root_doc'] . "/ajax/mailcollector.php',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Avoid probing external imap without having receiver saved.

js updated : choice of imap folder button can only be clicked if server is unchanged (because request is done with data from database, not form the form).

