### PR TITLE
log json decode type array error

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -243,22 +243,22 @@ class Log extends CommonDBTM
         $new_id           = $changes[4] ?? null;
 
         // Remove json values
-        if (is_array($old_value) || is_object($old_value)) {
-            $old_value = '';
-        } else {
+        if (!is_array($old_value) && !is_object($old_value)) {
             $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
                 $old_value = '';
             }
+        } else {
+            $old_value = '';
         }
 
-        if (is_array($new_value) || is_object($new_value)) {
-            $new_value = '';
-        } else {
+        if (!is_array($new_value) && !is_object($new_value)) {
             $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
                 $new_value = '';
             }
+        } else {
+            $new_value = '';
         }
 
         if ($uid = Session::getLoginUserID(false)) {

--- a/src/Log.php
+++ b/src/Log.php
@@ -243,13 +243,22 @@ class Log extends CommonDBTM
         $new_id           = $changes[4] ?? null;
 
         // Remove json values
-        $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
-        $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
-        if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
+        if (is_array($old_value) || is_object($old_value)) {
             $old_value = '';
+        } else {
+            $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
+            if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
+                $old_value = '';
+            }
         }
-        if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
+
+        if (is_array($new_value) || is_object($new_value)) {
             $new_value = '';
+        } else {
+            $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
+            if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
+                $new_value = '';
+            }
         }
 
         if ($uid = Session::getLoginUserID(false)) {

--- a/src/Log.php
+++ b/src/Log.php
@@ -37,9 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryParam;
 use Glpi\RichText\RichText;
 use Glpi\Search\SearchOption;
-use Safe\Exceptions\JsonException;
 
-use function Safe\json_decode;
 use function Safe\preg_match;
 
 /**
@@ -227,7 +225,6 @@ class Log extends CommonDBTM
      * @param int $linked_action (default 0)
      *
      * @return bool success
-     * @throws JsonException
      */
     public static function history($items_id, $itemtype, $changes, $itemtype_link = '', $linked_action = 0)
     {
@@ -247,7 +244,7 @@ class Log extends CommonDBTM
 
         // Remove json values
         if (is_string($old_value)) {
-            $decoded_old_value = json_decode($old_value);
+            $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
                 $old_value = '';
             }
@@ -256,7 +253,7 @@ class Log extends CommonDBTM
         }
 
         if (is_string($new_value)) {
-            $decoded_new_value = json_decode($new_value);
+            $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
                 $new_value = '';
             }

--- a/src/Log.php
+++ b/src/Log.php
@@ -37,7 +37,9 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryParam;
 use Glpi\RichText\RichText;
 use Glpi\Search\SearchOption;
+use Safe\Exceptions\JsonException;
 
+use function Safe\json_decode;
 use function Safe\preg_match;
 
 /**
@@ -246,7 +248,11 @@ class Log extends CommonDBTM
         if (is_array($old_value) || is_object($old_value)) {
             $old_value = '';
         } elseif (is_string($old_value)) {
-            $decoded_old_value = \json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
+            try {
+                $decoded_old_value = json_decode($old_value);
+            } catch (JsonException $e) {
+                $decoded_old_value = null;
+            }
             if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
                 $old_value = '';
             }
@@ -255,7 +261,11 @@ class Log extends CommonDBTM
         if (is_array($new_value) || is_object($new_value)) {
             $new_value = '';
         } elseif (is_string($new_value)) {
-            $decoded_new_value = \json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
+            try {
+                $decoded_new_value = json_decode($new_value);
+            } catch (JsonException $e) {
+                $decoded_new_value = null;
+            }
             if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
                 $new_value = '';
             }

--- a/src/Log.php
+++ b/src/Log.php
@@ -243,8 +243,8 @@ class Log extends CommonDBTM
         $new_id           = $changes[4] ?? null;
 
         // Remove json values
-        if (!is_array($old_value) && !is_object($old_value)) {
-            $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
+        if (is_string($old_value)) {
+            $decoded_old_value = json_decode($old_value);
             if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
                 $old_value = '';
             }
@@ -252,8 +252,8 @@ class Log extends CommonDBTM
             $old_value = '';
         }
 
-        if (!is_array($new_value) && !is_object($new_value)) {
-            $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
+        if (is_string($new_value)) {
+            $decoded_new_value = json_decode($new_value);
             if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
                 $new_value = '';
             }

--- a/src/Log.php
+++ b/src/Log.php
@@ -243,22 +243,22 @@ class Log extends CommonDBTM
         $new_id           = $changes[4] ?? null;
 
         // Remove json values
-        if (is_string($old_value)) {
-            $decoded_old_value = json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
+        if (is_array($old_value) || is_object($old_value)) {
+            $old_value = '';
+        } elseif (is_string($old_value)) {
+            $decoded_old_value = \json_decode($old_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_old_value) || is_object($decoded_old_value)) {
                 $old_value = '';
             }
-        } else {
-            $old_value = '';
         }
 
-        if (is_string($new_value)) {
-            $decoded_new_value = json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
+        if (is_array($new_value) || is_object($new_value)) {
+            $new_value = '';
+        } elseif (is_string($new_value)) {
+            $decoded_new_value = \json_decode($new_value); //@phpstan-ignore theCodingMachineSafe.function
             if (is_array($decoded_new_value) || is_object($decoded_new_value)) {
                 $new_value = '';
             }
-        } else {
-            $new_value = '';
         }
 
         if ($uid = Session::getLoginUserID(false)) {

--- a/src/Log.php
+++ b/src/Log.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryParam;
 use Glpi\RichText\RichText;
 use Glpi\Search\SearchOption;
+use Safe\Exceptions\JsonException;
 
 use function Safe\json_decode;
 use function Safe\preg_match;
@@ -226,7 +227,7 @@ class Log extends CommonDBTM
      * @param int $linked_action (default 0)
      *
      * @return bool success
-     * @throws \Safe\Exceptions\JsonException
+     * @throws JsonException
      */
     public static function history($items_id, $itemtype, $changes, $itemtype_link = '', $linked_action = 0)
     {

--- a/src/Log.php
+++ b/src/Log.php
@@ -38,6 +38,7 @@ use Glpi\DBAL\QueryParam;
 use Glpi\RichText\RichText;
 use Glpi\Search\SearchOption;
 
+use function Safe\json_decode;
 use function Safe\preg_match;
 
 /**
@@ -221,10 +222,11 @@ class Log extends CommonDBTM
      * @param int $items_id
      * @param class-string<CommonDBTM> $itemtype
      * @param array $changes
-     * @param int|string $itemtype_link   (default '')
-     * @param int $linked_action   (default 0)
+     * @param int|string $itemtype_link (default '')
+     * @param int $linked_action (default 0)
      *
      * @return bool success
+     * @throws \Safe\Exceptions\JsonException
      */
     public static function history($items_id, $itemtype, $changes, $itemtype_link = '', $linked_action = 0)
     {

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -1042,8 +1042,8 @@ class LogTest extends DbTestCase
                 'expected_new_value' => '',
             ],
             'objects in both values' => [
-                'input_old_value' => (object)['key1' => 'value1', 'key2' => 'value2'],
-                'input_new_value' => (object)['key3' => 'value3', 'key4' => 'value4'],
+                'input_old_value' => (object) ['key1' => 'value1', 'key2' => 'value2'],
+                'input_new_value' => (object) ['key3' => 'value3', 'key4' => 'value4'],
                 'expected_old_value' => '',
                 'expected_new_value' => '',
             ],

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -1023,4 +1023,35 @@ class LogTest extends DbTestCase
         $this->assertEquals(255, mb_strlen($log_entry['old_value']));
         $this->assertEquals(255, mb_strlen($log_entry['new_value']));
     }
+
+    /**
+     * Verify that Log::history can handle values in the form of arrays without generating a TypeError
+     * This occurs when fields with multiple values are passed as arrays
+     */
+    public function testHistoryWithArrayValues()
+    {
+        global $DB;
+
+        $computer_id = getItemByTypeName(Computer::class, '_test_pc01', true);
+
+        Log::history(
+            $computer_id,
+            Computer::class,
+            [0, ['value1', 'value2'], ['value3', 'value4']]
+        );
+
+        $log_entry = $DB->request([
+            'FROM'   => Log::getTable(),
+            'WHERE'  => [
+                'itemtype'  => Computer::class,
+                'items_id'  => $computer_id,
+            ],
+            'ORDER'  => 'id DESC',
+            'LIMIT'  => 1,
+        ])->current();
+
+        $this->assertNotNull($log_entry);
+        $this->assertEquals('', $log_entry['old_value']);
+        $this->assertEquals('', $log_entry['new_value']);
+    }
 }

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -1034,24 +1034,65 @@ class LogTest extends DbTestCase
 
         $computer_id = getItemByTypeName(Computer::class, '_test_pc01', true);
 
-        Log::history(
-            $computer_id,
-            Computer::class,
-            [0, ['value1', 'value2'], ['value3', 'value4']]
-        );
-
-        $log_entry = $DB->request([
-            'FROM'   => Log::getTable(),
-            'WHERE'  => [
-                'itemtype'  => Computer::class,
-                'items_id'  => $computer_id,
+        $test_cases = [
+            'arrays in both values' => [
+                'input_old_value' => ['value1', 'value2'],
+                'input_new_value' => ['value3', 'value4'],
+                'expected_old_value' => '',
+                'expected_new_value' => '',
             ],
-            'ORDER'  => 'id DESC',
-            'LIMIT'  => 1,
-        ])->current();
+            'objects in both values' => [
+                'input_old_value' => (object)['key1' => 'value1', 'key2' => 'value2'],
+                'input_new_value' => (object)['key3' => 'value3', 'key4' => 'value4'],
+                'expected_old_value' => '',
+                'expected_new_value' => '',
+            ],
+            'json encoded object in old value' => [
+                'input_old_value' => json_encode(['key1' => 'value1']),
+                'input_new_value' => 'string_value',
+                'expected_old_value' => '',
+                'expected_new_value' => 'string_value',
+            ],
+            'array in old value string in new value' => [
+                'input_old_value' => ['value1', 'value2'],
+                'input_new_value' => 'string_value',
+                'expected_old_value' => '',
+                'expected_new_value' => 'string_value',
+            ],
+            'string in old value and array in new value' => [
+                'input_old_value' => 'string_value',
+                'input_new_value' => ['value3', 'value4'],
+                'expected_old_value' => 'string_value',
+                'expected_new_value' => '',
+            ],
+            'string values' => [
+                'input_old_value' => 'simple string',
+                'input_new_value' => 'another string',
+                'expected_old_value' => 'simple string',
+                'expected_new_value' => 'another string',
+            ],
+        ];
 
-        $this->assertNotNull($log_entry);
-        $this->assertEquals('', $log_entry['old_value']);
-        $this->assertEquals('', $log_entry['new_value']);
+        foreach ($test_cases as $case_name => $test_data) {
+            Log::history(
+                $computer_id,
+                Computer::class,
+                [0, $test_data['input_old_value'], $test_data['input_new_value']]
+            );
+
+            $log_entry = $DB->request([
+                'FROM'   => Log::getTable(),
+                'WHERE'  => [
+                    'itemtype'  => Computer::class,
+                    'items_id'  => $computer_id,
+                ],
+                'ORDER'  => 'id DESC',
+                'LIMIT'  => 1,
+            ])->current();
+
+            $this->assertNotNull($log_entry, "Log entry should exist for case: $case_name");
+            $this->assertEquals($test_data['expected_old_value'], $log_entry['old_value'], "Old value mismatch for case: $case_name");
+            $this->assertEquals($test_data['expected_new_value'], $log_entry['new_value'], "New value mismatch for case: $case_name");
+        }
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43230
- The Fields plugin can pass arrays to the Log::history() function for multi-value fields. The code previously called json_decode() directly on these values, but json_decode() now only accepts strings, which caused an error. The fix first checks whether the value is already an array or object before calling json_decode().


