### PR TITLE
force mysql to use INSTANT algo when altering glpi_logs table

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/logs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/logs.php
@@ -58,7 +58,6 @@ $migration->addField(
 );
 
 // First migrate only column changes so MySQL/MariaDB can optimize the ALTER TABLE query to perform only metadata changes rather than a rebuild
-// (no AFTER clause).
 $migration->migrationOneTable("glpi_logs");
 
 // Then create indexes in a separate step to significantly reduce migration time on large tables

--- a/install/migrations/update_10.0.x_to_11.0.0/logs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/logs.php
@@ -57,5 +57,11 @@ $migration->addField(
     ]
 );
 
+// First migrate only column changes so MySQL can use ALTER TABLE with the INSTANT algorithm
+// (no AFTER clause).
+$migration->migrationOneTable('glpi_logs');
+
+// Then create indexes in a separate step to significantly reduce migration time on large tables
+// (about 2 minutes instead of 30 minutes for a 15 GB table).
 $migration->addKey("glpi_logs", "new_id");
 $migration->addKey("glpi_logs", "old_id");

--- a/install/migrations/update_10.0.x_to_11.0.0/logs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/logs.php
@@ -59,7 +59,7 @@ $migration->addField(
 
 // First migrate only column changes so MySQL can use ALTER TABLE with the INSTANT algorithm
 // (no AFTER clause).
-$migration->migrationOneTable('glpi_logs');
+$migration->migrationOneTable("glpi_logs");
 
 // Then create indexes in a separate step to significantly reduce migration time on large tables
 // (about 2 minutes instead of 30 minutes for a 15 GB table).

--- a/install/migrations/update_10.0.x_to_11.0.0/logs.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/logs.php
@@ -57,7 +57,7 @@ $migration->addField(
     ]
 );
 
-// First migrate only column changes so MySQL can use ALTER TABLE with the INSTANT algorithm
+// First migrate only column changes so MySQL/MariaDB can optimize the ALTER TABLE query to perform only metadata changes rather than a rebuild
 // (no AFTER clause).
 $migration->migrationOneTable("glpi_logs");
 


### PR DESCRIPTION
## Description

For a migration in progress done by @flegastelois, a glpi_logs table around 15 GB size took (and crashed) 30 min.
With the proposed changes, columns additions are instant.
The index part take ~2 min to do and don't imply copy of the full table (INPLACE algo).

Some documentation
- https://dev.mysql.com/blog-archive/mysql-8-0-innodb-now-supports-instant-add-column/
- https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-online-ddl/innodb-online-ddl-operations-with-the-instant-alter-algorithm


