### PR TITLE
Fix(Validation step): Delete permanently even if linked items

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -30746,6 +30746,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/ValidationStep.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method ValidationStep\\:\\:getForbiddenStandardMassiveAction\\(\\) return type has no value type specified in iterable type array\\.$#',
+	'identifier' => 'missingType.iterableValue',
+	'count' => 1,
+	'path' => __DIR__ . '/src/ValidationStep.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method ValidatorSubstitute\\:\\:updateSubstitutes\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -703,7 +703,7 @@ class MassiveAction
                 } else {
                     $actions[$self_pref . 'purge'] = _sx('button', 'Delete permanently');
                 }
-                if ($item instanceof CommonDropdown) {
+                if ($item instanceof CommonDropdown && !$item instanceof ValidationStep) {
                     $actions[$self_pref . 'purge_but_item_linked']
                      = _sx('button', 'Delete permanently even if linked items');
                 }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -703,7 +703,7 @@ class MassiveAction
                 } else {
                     $actions[$self_pref . 'purge'] = _sx('button', 'Delete permanently');
                 }
-                if ($item instanceof CommonDropdown && !$item instanceof ValidationStep) {
+                if ($item instanceof CommonDropdown) {
                     $actions[$self_pref . 'purge_but_item_linked']
                      = _sx('button', 'Delete permanently even if linked items');
                 }

--- a/src/ValidationStep.php
+++ b/src/ValidationStep.php
@@ -219,4 +219,11 @@ class ValidationStep extends CommonDropdown
 
         return false;
     }
+
+    public function getForbiddenStandardMassiveAction()
+    {
+        $forbidden   = parent::getForbiddenStandardMassiveAction();
+        $forbidden[] = 'purge_but_item_linked';
+        return $forbidden;
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43322
- Since https://github.com/glpi-project/glpi/pull/19937, it has not been possible to delete a used validation step. Therefore, the "Delete permanently even if linked items" option in massive actions cannot function and is not relevant.

## Screenshots (if appropriate):


