### PR TITLE
fix duplicate root_doc in asset qrcode link

### DIFF
--- a/src/BarcodeManager.php
+++ b/src/BarcodeManager.php
@@ -55,7 +55,7 @@ class BarcodeManager
         $barcode = new Barcode();
         $qrcode = $barcode->getBarcodeObj(
             'QRCODE,H',
-            $CFG_GLPI["url_base"] . $item->getLinkURL(),
+            $CFG_GLPI["url_base"] . $item::getFormURLWithID($item->getID(), false),
             200,
             200,
             'black',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

`url_base` already contains the complete URL including the subfolder (if applicable) while `CommonDBTM::getLink` always returns the URL with the `root_doc` (subfolder).

fixes: https://forum.glpi-project.org/viewtopic.php?id=294450

Old fix in barcode plugin:
https://github.com/pluginsGLPI/barcode/commit/1b6019d1eb04a01a123e76f1e464e7b843676d73