### PR TITLE
Mark "Can use all possible configuration options" test as slow

### DIFF
--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -102,6 +102,8 @@ for (const actor_type of actor_types) {
         });
 
         test('Can use all possible configuration options', async () => {
+            test.slow();
+
             await form_page.doOpenDestinationAccordionItem('Actors');
 
             const config = form_page.getRegion(`${actor_type.name}s configuration`);


### PR DESCRIPTION
Fix a failure detected in https://github.com/glpi-project/glpi/actions/runs/24337365908/attempts/1?pr=23836.

The test is very close to the 30s limit so if we get a slow runner it might go over and fail.

Marking it with `test.slow()` increase the timeout to 90s, fixing the issue.