### PR TITLE
fix(generic-assets-migration): update itemtype references for asset types and models

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -13292,12 +13292,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Migration/GenericobjectPluginMigration.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\$source_itemtype of method Glpi\\\\Migration\\\\AbstractPluginMigration\\:\\:updateItemtypeReferences\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Migration/GenericobjectPluginMigration.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$identifier of method Glpi\\\\OAuth\\\\AccessToken\\:\\:setUserIdentifier\\(\\) expects non\\-empty\\-string, string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -561,7 +561,7 @@ abstract class AbstractPluginMigration
     /**
      * Update references to the given source itemtype and attach them to the given target itemtype.
      *
-     * @param class-string<CommonDBTM> $source_itemtype
+     * @param string $source_itemtype
      * @param class-string<CommonDBTM> $target_itemtype
      * @param class-string<CommonDBTM>[] $excluded_relations
      */

--- a/src/Glpi/Migration/GenericobjectPluginMigration.php
+++ b/src/Glpi/Migration/GenericobjectPluginMigration.php
@@ -571,18 +571,29 @@ class GenericobjectPluginMigration extends AbstractPluginMigration
             }
 
             // Update class references
+            $excluded_relations = [
+                // Ignore display preferences (some are created by default) and saved searches.
+                // These cannot be migrated this way, as a specific SO IDs mapping have to be applied.
+                DisplayPreference::class,
+                SavedSearch::class,
+
+                // Ignore self reference in the `genericobject` plugin table
+                PluginGenericobjectType::class,
+            ];
             $this->updateItemtypeReferences(
                 source_itemtype: $plugin_itemtype,
                 target_itemtype: $asset_definition->getAssetClassName(),
-                excluded_relations: [
-                    // Ignore display preferences (some are created by default) and saved searches.
-                    // These cannot be migrated this way, as a specific SO IDs mapping have to be applied.
-                    DisplayPreference::class,
-                    SavedSearch::class,
-
-                    // Ignore self reference in the `genericobject` plugin table
-                    PluginGenericobjectType::class,
-                ],
+                excluded_relations: $excluded_relations,
+            );
+            $this->updateItemtypeReferences(
+                source_itemtype: $plugin_itemtype . 'Type',
+                target_itemtype: $asset_definition->getAssetTypeClassName(),
+                excluded_relations: $excluded_relations,
+            );
+            $this->updateItemtypeReferences(
+                source_itemtype: $plugin_itemtype . 'Model',
+                target_itemtype: $asset_definition->getAssetModelClassName(),
+                excluded_relations: $excluded_relations,
             );
 
             // FIXME Copy history, display preferences and saved searches, for main definition, model and type ?

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\Form\Migration;
 use AbstractRightsDropdown;
 use Change;
 use Computer;
+use Dropdown;
 use Entity;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Form\AccessControl\ControlType\AllowList;
@@ -3654,6 +3655,54 @@ final class FormMigrationTest extends DbTestCase
         }
         $this->assertEquals(
             "Glpi\CustomAsset\smartphoneAsset",
+            $config->getItemtype()
+        );
+    }
+
+    public function testFormWithDropdownQuestionReferencingGenericObjectDropdown(): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        // Arrange: create a form with a "dropdown" question referencing a GenericObject
+        // custom dropdown type (PluginGenericobjectSmartphoneModel -> Glpi\CustomAsset\smartphoneAssetModel)
+        $this->createSimpleFormcreatorForm("With generic object custom dropdown", [
+            [
+                'name'      => 'Generic object dropdown',
+                'fieldtype' => 'dropdown',
+                'itemtype'  => 'PluginGenericobjectSmartphoneModel',
+                'values'    => json_encode([
+                    'show_ticket_categories' => '',
+                    'show_tree_depth'        => '0',
+                    'show_tree_root'         => '0',
+                    'selectable_tree_root'   => '0',
+                ]),
+            ],
+        ]);
+
+        // Run GenericObject migration first so that DropdownDefinition for "smartphoneAssetModel" is created
+        // and itemtype references should be updated
+        $asset_migration = new GenericobjectPluginMigration($DB);
+        $asset_migration->execute();
+
+        // Arrange: Reset the dropdown itemtypes static cache
+        Dropdown::resetItemtypesStaticCache();
+
+        // Act: run form migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $migration->execute();
+
+        // Assert: the question should have been migrated with the correct migrated itemtype
+        $form = getItemByTypeName(Form::class, "With generic object custom dropdown");
+        $question_id = $this->getQuestionId($form, "Generic object dropdown");
+        $question = Question::getById($question_id);
+
+        $config = $question->getExtraDataConfig();
+        if (!$config instanceof QuestionTypeItemDropdownExtraDataConfig) {
+            $this->fail("Unexpected config class: " . get_class($config));
+        }
+        $this->assertEquals(
+            "Glpi\\CustomAsset\\smartphoneAssetModel",
             $config->getItemtype()
         );
     }

--- a/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -864,6 +864,58 @@ class GenericobjectPluginMigrationTest extends DbTestCase
         }
     }
 
+    public function testItemtypeReferencesAreUpdatedForAssetTypeAndModel(): void
+    {
+        global $DB;
+
+        // Arrange: insert FieldUnicity records using Type and Model sub-itemtypes,
+        // which are not standalone custom dropdowns and have no explicit updateItemtypeReferences()
+        // call before this fix.
+        $DB->insert(FieldUnicity::getTable(), [
+            'name'         => 'Smartphone type uniqueness',
+            'itemtype'     => 'PluginGenericobjectSmartphoneType',
+            'fields'       => 'name',
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+            'is_active'    => 1,
+        ]);
+        $DB->insert(FieldUnicity::getTable(), [
+            'name'         => 'Smartphone model uniqueness',
+            'itemtype'     => 'PluginGenericobjectSmartphoneModel',
+            'fields'       => 'name',
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+            'is_active'    => 1,
+        ]);
+
+        // Act
+        $migration = new GenericobjectPluginMigration($DB);
+        $result    = new PluginMigrationResult();
+        $this->setPrivateProperty($migration, 'result', $result);
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Assert: references must be updated to the migrated class names
+        $smartphone_definition = getItemByTypeName(AssetDefinition::class, 'Smartphone');
+
+        $type_unicity = new FieldUnicity();
+        $this->assertTrue(
+            $type_unicity->getFromDBByCrit([
+                'name'     => 'Smartphone type uniqueness',
+                'itemtype' => $smartphone_definition->getAssetTypeClassName(),
+            ]),
+            'itemtype reference for SmartphoneType was not updated'
+        );
+
+        $model_unicity = new FieldUnicity();
+        $this->assertTrue(
+            $model_unicity->getFromDBByCrit([
+                'name'     => 'Smartphone model uniqueness',
+                'itemtype' => $smartphone_definition->getAssetModelClassName(),
+            ]),
+            'itemtype reference for SmartphoneModel was not updated'
+        );
+    }
+
     /**
      * Check that the expected items of the given class are present in DB and have the expected fields values.
      *


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43194

This PR improves the migration process for custom asset types and models in the GenericObject plugin by ensuring that itemtype references for both "Type" and "Model" sub-itemtypes are correctly updated during migration.