### PR TITLE
[GraphQL] Restore support for RSQL referencing outside main schema

### DIFF
--- a/src/Glpi/Api/HL/Doc/Schema.php
+++ b/src/Glpi/Api/HL/Doc/Schema.php
@@ -257,11 +257,17 @@ class Schema implements ArrayAccess
         };
         foreach ($props as $name => $prop) {
             if ($prop['type'] === self::TYPE_OBJECT && isset($prop['x-join'])) {
-                $new_join = $prop['x-join'] + ['parent_type' => self::TYPE_OBJECT];
+                $new_join = $prop['x-join'] + [
+                    'parent_type' => self::TYPE_OBJECT,
+                    'x-full-schema' => $prop['x-full-schema'] ?? null,
+                ];
                 $joins[$prefix . $name] = $fn_add_parent_hint($new_join, $prefix);
                 $joins += self::getJoins($prop['properties'], $prefix . $name . '.', $new_join);
             } elseif ($prop['type'] === self::TYPE_ARRAY && isset($prop['items']['x-join'])) {
-                $new_join = $prop['items']['x-join'] + ['parent_type' => self::TYPE_ARRAY];
+                $new_join = $prop['items']['x-join'] + [
+                    'parent_type' => self::TYPE_ARRAY,
+                    'x-full-schema' => $prop['items']['x-full-schema'] ?? null,
+                ];
                 $joins[$prefix . $name] = $fn_add_parent_hint($new_join, $prefix);
                 $joins += self::getJoins($prop['items']['properties'], $prefix . $name . '.', $new_join);
             } elseif ($prop['type'] === self::TYPE_OBJECT && isset($prop['properties'])) {

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -41,6 +41,7 @@ use Glpi\Api\HL\OpenAPIGenerator;
 use Glpi\Api\HL\RightConditionNotMetException;
 use Glpi\Api\HL\RSQL\RSQLException;
 use Glpi\Api\HL\Search;
+use Glpi\Api\HL\Search\SearchContext;
 use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
@@ -384,8 +385,8 @@ class DefaultResolvers
             }
         }
 
+        $search->addRSQLCriteria($criteria, fn(SearchContext $context, array $properties) => $this->resolveSchemaFromProperties($context, $properties));
         $search->addJoinsCriteria($criteria);
-        $search->addRSQLCriteria($criteria);
 
         if ($request_params['id'] ?? null) {
             if (!is_array($request_params['id'])) {
@@ -425,5 +426,37 @@ class DefaultResolvers
         $count_select = [QueryFunction::count("$table_alias.id", true, 'count')];
         $count_criteria['SELECT'] = $count_select;
         return $count_criteria;
+    }
+
+    /**
+     * @param SearchContext &$context
+     * @param string[] $properties
+     * @return void
+     */
+    private function resolveSchemaFromProperties(SearchContext $context, array $properties): void
+    {
+        $joins = $context->getJoins();
+        $new_schema = $context->getSchema();
+        foreach ($properties as $property) {
+            if (!str_contains($property, '.')) {
+                continue;
+            }
+            $parent_path = substr($property, 0, (int) strrpos($property, '.'));
+            $join_name = $context->getJoinNameForProperty($parent_path);
+            if (array_key_exists($join_name, $joins)) {
+                $join_schema_name = $joins[$join_name]['x-full-schema'] ?? null;
+                if ($join_schema_name !== null) {
+                    $join_schema = $this->getSchemaForObjectName($join_schema_name);
+                    if (($join_schema !== null)) {
+                        if (array_key_exists('items', $new_schema['properties'][$join_name])) {
+                            $new_schema['properties'][$join_name]['items']['properties'] = $join_schema['properties'];
+                        } else {
+                            $new_schema['properties'][$join_name]['properties'] = $join_schema['properties'];
+                        }
+                    }
+                }
+            }
+        }
+        $context->updateSchema($new_schema);
     }
 }

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -44,6 +44,7 @@ use DBmysqlIterator;
 use Entity;
 use ExtraVisibilityCriteria;
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\RSQL\Error;
 use Glpi\Api\HL\RSQL\Lexer;
 use Glpi\Api\HL\RSQL\Parser;
 use Glpi\Api\HL\RSQL\RSQLException;
@@ -402,17 +403,30 @@ final class Search
      * @return void
      * @throws RSQLException
      */
-    public function addRSQLCriteria(array &$criteria): void
+    public function addRSQLCriteria(array &$criteria, ?callable $schema_resolver = null): void
     {
         if (!empty($this->context->getRequestParameter('filter'))) {
             $filter_result = $this->rsql_parser->parse(Lexer::tokenize($this->context->getRequestParameter('filter')));
+            $unknown_properties = array_keys(
+                array: array_filter(
+                    array: $filter_result->getInvalidFilters(),
+                    callback: static fn($error) => $error === Error::UNKNOWN_PROPERTY
+                )
+            );
+            $other_invalid_filters = array_filter($filter_result->getInvalidFilters(), static fn($error) => $error !== Error::UNKNOWN_PROPERTY);
             // Fail the request if any of the filters are invalid
-            if (!empty($filter_result->getInvalidFilters())) {
+            if ($schema_resolver === null && $other_invalid_filters !== []) {
                 throw new RSQLException(
                     message: 'RSQL query has invalid filters',
                     details: array_map(static fn($rsql_error) => $rsql_error->getMessage(), $filter_result->getInvalidFilters())
                 );
+            } elseif ($schema_resolver !== null && $unknown_properties !== []) {
+                // Try to resolve the missing schema parts and retry parsing the RSQL filters
+                $schema_resolver($this->getContext(), $unknown_properties);
+                $this->addRSQLCriteria(criteria: $criteria, schema_resolver: null);
+                return;
             }
+
             $criteria['WHERE'] = [$filter_result->getSQLWhereCriteria()];
             $criteria['HAVING'] = [$filter_result->getSQLHavingCriteria()];
         }

--- a/src/Glpi/Api/HL/Search/SearchContext.php
+++ b/src/Glpi/Api/HL/Search/SearchContext.php
@@ -58,11 +58,21 @@ final class SearchContext
 
     public function __construct(array $schema, array $request_params)
     {
-        $this->schema = $schema;
         $this->request_params = $request_params;
+        $this->updateSchema($schema);
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @return void
+     */
+    public function updateSchema(array $schema): void
+    {
+        $this->schema = $schema;
         $this->flattened_properties = Doc\Schema::flattenProperties($schema['properties']);
         $this->joins = Doc\Schema::getJoins($schema['properties']);
         $this->union_table_schemas = $this->getUnionTables();
+        $this->clearFkeyTablesCache();
     }
 
     public function clearFkeyTablesCache(): void

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -38,6 +38,8 @@ use Glpi\Api\HL\Middleware\InternalAuthMiddleware;
 use Glpi\Api\HL\Router;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
+use Project;
+use ProjectTask;
 
 class GraphQLControllerTest extends HLAPITestCase
 {
@@ -465,5 +467,64 @@ GRAPHQL);
         }
 
         $this->assertEmpty($schemas_errors, "Schemas with errors when querying with GraphQL: \n" . implode("\n", $schemas_errors));
+    }
+
+    /**
+     * Tests a GraphQL query with filters that reference properties not directly in the main schema.
+     * @return void
+     */
+    public function testIndirectRSQLFilters(): void
+    {
+        $this->login();
+
+        $query = 'query { Project(filter: "name==_project01;entity.level==2") { id name } }';
+        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertCount(1, $content['data']);
+                    $this->assertCount(1, $content['data']['Project']);
+                    $this->assertEquals('_project01', $content['data']['Project'][0]['name']);
+                });
+        });
+
+        $projecttask = new ProjectTask();
+        $parent_task = $projecttask->add([
+            'name' => 'ParentTask',
+            'projects_id' => getItemByTypeName(Project::class, '_project01', true),
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $projecttask->add([
+            'name' => 'ChildTask',
+            'projects_id' => getItemByTypeName(Project::class, '_project01', true),
+            'projecttasks_id' => $parent_task,
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+
+        $query = 'query { Project(filter: "name==_project01;tasks.parent_task.name==test") { id name } }';
+        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertEmpty($content['data']['Project']);
+                });
+        });
+
+        $query = 'query { Project(filter: "name==_project01;tasks.parent_task.name==ParentTask") { id name } }';
+        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
+        $this->api->call($request, function ($call) {
+            /** @var \HLAPICallAsserter $call */
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertCount(1, $content['data']);
+                    $this->assertCount(1, $content['data']['Project']);
+                    $this->assertEquals('_project01', $content['data']['Project'][0]['name']);
+                });
+        });
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

In the original GraphQL implementation, RSQL filters referencing properties outside of the main schema were possible as a side-effect of the way a new schema was created based on the requested properties (partially why RSQL filters in GraphQL could only use properties that were asked for in the query).

Example GraphQL query with RSQL filters referencing properties "entity.level" and "tasks.parent_task.name" which are not in the main schema "Project":
```graphql
query {
    Project(filter: "id=gt=0;entity.level==1;tasks.parent_task.name==ParentTaskA") {
        id name
    }
}
```
Partial Response:
```json
{
    "data": {
        "Project": [
            {
                "id": 22,
                "name": "ProjectWithNestedTasks"
            }
        ]
    }
}
```

The new GraphQL implementation does not stitch schemas together as it was requiring the search code to take a lot of complexity into account, and instead properly resolves individual properties and lazily resolves types.

This PR adds a callable parameter to the `Glpi\Api\HL\Search::addRSQLCriteria()` method which allows the GraphQL resolver to dynamically expand the schema when the parser identifies unknown properties. The REST side of the HLAPI does not use this parameter so there is no change in behavior.