### PR TITLE
fix: truncate title fields to 255 characters in CommonITILObject

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2967,7 +2967,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         // No name set name
-        $input["name"]    = ltrim($input["name"] ?? '');
+        $input["name"]    = Toolbox::substr(ltrim($input["name"] ?? ''), 0, 255);
         $input['content'] = ltrim($input['content'] ?? '');
         if (empty($input["name"])) {
             // Build name based on content

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -616,4 +616,17 @@ class ChangeTest extends DbTestCase
 
         $this->assertCount(1, $found);
     }
+
+    public function testTitleIsTruncatedTo255Characters(): void
+    {
+        $this->login();
+
+        $change = $this->createItem(Change::class, [
+            'name'        => str_repeat('a', 300),
+            'content'     => 'Hello world',
+            'entities_id' => $this->getTestRootEntity(true),
+        ], ['name']);
+
+        $this->assertSame(255, mb_strlen($change->fields['name']));
+    }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeShortTextTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeShortTextTest.php
@@ -34,7 +34,10 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
+use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
@@ -57,5 +60,28 @@ final class QuestionTypeShortTextTest extends DbTestCase
             "1) First name: John",
             strip_tags($ticket->fields['content']),
         );
+    }
+
+    public function testLongAnswerUsedAsTitleIsTruncatedTo255Characters(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("Title", QuestionTypeShortText::class);
+        $form = $this->createForm($builder);
+        $question = current($form->getQuestions());
+
+        // Configure the ticket title to be sourced from the form answer
+        $this->setDestinationFieldConfig(
+            form: $form,
+            key: TitleField::getKey(),
+            config: new SimpleValueConfig((new AnswerTagProvider())->getTagForQuestion($question)->html)
+        );
+
+        // Submit with an answer exceeding VARCHAR(255) — used to throw a DB exception
+        $long_answer = str_repeat('a', 300);
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Title" => $long_answer,
+        ]);
+
+        $this->assertSame(255, mb_strlen($ticket->fields['name']));
     }
 }

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -589,4 +589,16 @@ class ProblemTest extends DbTestCase
         $this->assertCount(1, $found);
     }
 
+    public function testTitleIsTruncatedTo255Characters(): void
+    {
+        $this->login();
+
+        $problem = $this->createItem(Problem::class, [
+            'name'        => str_repeat('a', 300),
+            'content'     => 'Hello world',
+            'entities_id' => $this->getTestRootEntity(true),
+        ], ['name']);
+
+        $this->assertSame(255, mb_strlen($problem->fields['name']));
+    }
 }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10412,4 +10412,17 @@ HTML,
 
         $this->assertCount(1, $found);
     }
+
+    public function testTitleIsTruncatedTo255Characters(): void
+    {
+        $this->login();
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'        => str_repeat('a', 300),
+            'content'     => 'Hello world',
+            'entities_id' => $this->getTestRootEntity(true),
+        ], ['name']);
+
+        $this->assertSame(255, mb_strlen($ticket->fields['name']));
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !43347

This PR addresses an important data integrity issue by ensuring that object names (titles) for tickets, changes, and problems are properly truncated to a maximum of 255 characters, preventing database exceptions when overly long strings are submitted.

Currently, the maximum size is enforced only on the frontend side and only in forms used to create the object.
This limitation can easily be circumvented by the user and does not account for all other ways of creating tickets/problems/changes (form submissions, APIs, etc.).