### PR TITLE
Use host network for the "make playwright" commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PLAYWRIGHT = docker run \
 	-w /app \
 	-p 9323:9323 \
 	-e E2E_BASE_URL=$(E2E_BASE_URL) \
-	--add-host host.docker.internal:host-gateway \
+	--network host \
 	mcr.microsoft.com/playwright:v$(PLAYWRIGHT_VERSION)-noble \
 	npx playwright
 

--- a/tests/e2e/.env
+++ b/tests/e2e/.env
@@ -1,4 +1,4 @@
 # Copy this file as .env.local and set your own values if needed.
 
 # Should be an url leading to a GLPI server running in the "e2e_testing" environment
-E2E_BASE_URL="http://host.docker.internal:8090"
+E2E_BASE_URL="http://localhost:8090"


### PR DESCRIPTION
Share the host network directly instead of using `host.docker.internal`.

This solves some issues of styles not being loaded when running playwright UI:

<img width="2180" height="1009" alt="image" src="https://github.com/user-attachments/assets/d970bbd9-a6b4-4b9a-953a-0c5984d7bf78" />

It seems it was trying to fetch the requests directly from `host.docker.internal` when viewing the trace. Now it will use localhost instead as the default URL so it will work.

Unsure if it is the correct solution as playwright should be able to serve styles properly when viewing a trace even if the url on which the test were executed is not reachable from the current machine (it stores the http requests in the trace so they can be replayed) but I've spent a few hours on the subject already and I can't find anything better right now. This didn't happen before but I can't find why.

At least it work locally now for docker users (I think non docker users don't have this issue since they already are on the same url).