### PR TITLE
Increase timeout when retrying playwright tests

### DIFF
--- a/tests/e2e/fixtures/glpi_fixture.ts
+++ b/tests/e2e/fixtures/glpi_fixture.ts
@@ -55,6 +55,7 @@ export const test = baseTest.extend<{
     formImporter: FormImporter,
     api: Api,
     debug: DebugModeSwitcher,
+    retryTimeout: void,
 }, {
     // Worker scoped fixtures, these objects will be created once per thread.
     workerSessionCache: WorkerSessionCache,
@@ -189,4 +190,16 @@ export const test = baseTest.extend<{
         await use(await context.newPage());
         await context.close();
     },
+
+    // Increase the timeout when retrying a test.
+    // This is needed because the first retry on the CI enable trace mode to
+    // debug the error, which slow the test down.
+    // This can cause the test to go over the 30 seconds timeout so this fixture
+    // add a bit a leeway to avoid this unfortunate side effect.
+    retryTimeout: [async ({}, use, testInfo) => {
+        if (testInfo.retry > 0) {
+            testInfo.setTimeout(testInfo.timeout * 2);
+        }
+        await use();
+    }, { auto: true, scope: 'test' }],
 });


### PR DESCRIPTION
When a test fail on the CI (flaky) it is restarted with debug trace enabled so we can understand why.

An unfortunate side effect is that it make the test slower (since we are collecting debug information) so it might push it over the 30s max timeout (making the debug worthless as the test don't finish).

To prevent that, I've added a mechanism that double the timeout when we detect a retry.