### PR TITLE
fix(ServiceCatalog): ensure sort strategy persistence across navigation

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -8804,12 +8804,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Controller/ServiceCatalog/ItemsController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\$sort_strategy of class Glpi\\\\Form\\\\ServiceCatalog\\\\ItemRequest constructor expects Glpi\\\\Form\\\\ServiceCatalog\\\\SortStrategy\\\\SortStrategyEnum, Glpi\\\\Form\\\\ServiceCatalog\\\\SortStrategy\\\\SortStrategyEnum\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Controller/ServiceCatalog/ItemsController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$url of class Glpi\\\\Http\\\\RedirectResponse constructor expects string, string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/js/modules/Forms/ServiceCatalogController.js
+++ b/js/modules/Forms/ServiceCatalogController.js
@@ -34,6 +34,9 @@
 
 export class GlpiFormServiceCatalogController
 {
+    /** @type {string} */
+    #sort_strategy = 'popularity';
+
     /**
      * @constructor
      * @param {Object} sort_icons - Icons for sorting
@@ -52,6 +55,9 @@ export class GlpiFormServiceCatalogController
         input.addEventListener('input', filterFormsDebounced);
         // Handle page load with URL parameters
         const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('sort_strategy')) {
+            this.#sort_strategy = urlParams.get('sort_strategy');
+        }
         if (urlParams.size > 0) {
             this.#loadItems(urlParams.toString());
         }
@@ -63,6 +69,9 @@ export class GlpiFormServiceCatalogController
                 if (event.state.breadcrumb) {
                     this.breadcrumb = event.state.breadcrumb;
                 }
+                const params = new URLSearchParams(event.state.url_params);
+                this.#sort_strategy = params.get('sort_strategy') || 'popularity';
+                this.#syncSortDropdown(this.#sort_strategy);
             }
         });
 
@@ -83,8 +92,10 @@ export class GlpiFormServiceCatalogController
 
                 const index = this.breadcrumb.findIndex(item => item.params === breadcrumbItem.data('childrenUrlParameters'));
                 this.breadcrumb = this.breadcrumb.slice(0, index + 1);
-                this.#loadItems(breadcrumbItem.data('childrenUrlParameters'));
-                this.#updateHistory(breadcrumbItem.data('childrenUrlParameters'));
+                const url_params = new URLSearchParams(breadcrumbItem.data('childrenUrlParameters'));
+                url_params.set('sort_strategy', this.#sort_strategy);
+                this.#loadItems(url_params.toString());
+                this.#updateHistory(url_params.toString());
             }
 
             const pageLink = $(e.target).closest('[data-pagination-item]');
@@ -99,11 +110,16 @@ export class GlpiFormServiceCatalogController
         // Initialize the sort select after the DOM is ready
         const sortSelect = document.querySelector('[data-glpi-service-catalog-sort-strategy]');
         setTimeout(() => {
-            setupAdaptDropdown(window.select2_configs[sortSelect.id])
+            const $select = setupAdaptDropdown(window.select2_configs[sortSelect.id])
                 .on('select2:select', (e) => {
                     const sort_strategy = e.params.data.id;
                     this.#applySortStrategy(sort_strategy);
                 });
+
+            // Sync dropdown to URL-provided sort strategy
+            if (this.#sort_strategy !== 'popularity') {
+                $select.val(this.#sort_strategy).trigger('change');
+            }
         }, 0);
     }
 
@@ -113,6 +129,7 @@ export class GlpiFormServiceCatalogController
         const url_params = new URLSearchParams({
             filter: input.value,
             page: 1, // Reset to first page when filtering
+            sort_strategy: this.#sort_strategy,
         });
         this.#loadItems(url_params);
     }
@@ -123,11 +140,12 @@ export class GlpiFormServiceCatalogController
         const search_input = this.#getFilterInput();
         search_input.value = '';
 
-        const url_params = element.dataset['childrenUrlParameters'];
+        const url_params = new URLSearchParams(element.dataset['childrenUrlParameters']);
+        url_params.set('sort_strategy', this.#sort_strategy);
 
         // Get children items from backend
-        this.#loadItems(url_params);
-        this.#updateHistory(url_params);
+        this.#loadItems(url_params.toString());
+        this.#updateHistory(url_params.toString());
     }
 
     async #loadItems(url_params)
@@ -144,21 +162,48 @@ export class GlpiFormServiceCatalogController
     }
 
     async #loadPage(element) {
-        const url_params = element.dataset.childrenUrlParameters;
+        const url_params = new URLSearchParams(element.dataset.childrenUrlParameters);
+        url_params.set('sort_strategy', this.#sort_strategy);
 
         // Get children items from backend
-        this.#loadItems(url_params);
+        this.#loadItems(url_params.toString());
 
         // Push state to history with breadcrumb
-        this.#updateHistory(url_params);
+        this.#updateHistory(url_params.toString());
     }
 
     async #applySortStrategy(sort_strategy) {
+        this.#sort_strategy = sort_strategy;
+
         const url_params = new URLSearchParams();
         url_params.set('sort_strategy', sort_strategy);
         url_params.set('filter', this.#getFilterInput().value); // Keep the current filter
         url_params.set('page', 1); // Reset to first page when sorting
+
+        // Stay in the current category instead of returning to root
+        const current_category = this.#getCurrentCategoryFromBreadcrumb();
+        if (current_category !== null) {
+            url_params.set('category', current_category);
+        }
+
         this.#loadItems(url_params);
+        this.#updateHistory(url_params.toString());
+    }
+
+    #getCurrentCategoryFromBreadcrumb() {
+        if (this.breadcrumb.length === 0) {
+            return null;
+        }
+        const lastItem = this.breadcrumb[this.breadcrumb.length - 1];
+        const params = new URLSearchParams(lastItem.params);
+        return params.get('category');
+    }
+
+    #syncSortDropdown(value) {
+        const sortSelect = document.querySelector('[data-glpi-service-catalog-sort-strategy]');
+        if (sortSelect) {
+            $(sortSelect).val(value).trigger('change');
+        }
     }
 
     #updateBreadcrumb() {

--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -94,8 +94,7 @@ final class ItemsController extends AbstractController
         $sort_strategy = $request->query->getEnum(
             'sort_strategy',
             SortStrategyEnum::class,
-            SortStrategyEnum::getDefault()
-        );
+        ) ?? SortStrategyEnum::getDefault();
 
         // Build session + url params
         $session = Session::getCurrentSessionInfo();
@@ -134,6 +133,7 @@ final class ItemsController extends AbstractController
             [
                 'category_id'       => $category_id,
                 'filter'            => $filter,
+                'sort_strategy'     => $sort_strategy->value,
                 'ancestors'         => $ancestors,
                 'items'             => $result['items'],
                 'total'             => $result['total'],

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -100,6 +100,7 @@
 {% endfor %}
 
 {# Add pagination if there are more items than items_per_page #}
+{% set sort_strategy = sort_strategy|default('popularity') %}
 {% if total > items_per_page %}
     {% set total_pages = ((total + items_per_page - 1) / items_per_page)|round(0, 'floor') %}
     {% set adjacents = 2 %}
@@ -111,8 +112,8 @@
             <li class="page-item {{ current_page <= 1 ? 'disabled' : '' }}">
                 <a
                     class="page-link d-flex justify-content-center"
-                    href="?{{ {'category': category_id, 'filter': filter, 'page': 1}|url_encode }}"
-                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': 1}|url_encode }}"
+                    href="?{{ {'category': category_id, 'filter': filter, 'page': 1, 'sort_strategy': sort_strategy}|url_encode }}"
+                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': 1, 'sort_strategy': sort_strategy}|url_encode }}"
                     data-pagination-item
                     aria-label="{{ __('First page') }}"
                     {{ current_page <= 1 ? 'aria-disabled="true"' : '' }}
@@ -123,8 +124,8 @@
             <li class="page-item {{ current_page <= 1 ? 'disabled' : '' }}">
                 <a
                     class="page-link d-flex justify-content-center"
-                    href="?{{ {'category': category_id, 'filter': filter, 'page': current_page - 1}|url_encode }}"
-                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': current_page - 1}|url_encode }}"
+                    href="?{{ {'category': category_id, 'filter': filter, 'page': current_page - 1, 'sort_strategy': sort_strategy}|url_encode }}"
+                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': current_page - 1, 'sort_strategy': sort_strategy}|url_encode }}"
                     data-pagination-item
                     aria-label="{{ __('Previous page') }}"
                     {{ current_page <= 1 ? 'aria-disabled="true"' : '' }}
@@ -139,8 +140,8 @@
                     <li class="d-none d-sm-block page-item {{ page == current_page ? 'active selected' : '' }}">
                         <a
                             class="page-link d-flex justify-content-center"
-                            href="?{{ {'category': category_id, 'filter': filter, 'page': page}|url_encode }}"
-                            data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': page}|url_encode }}"
+                            href="?{{ {'category': category_id, 'filter': filter, 'page': page, 'sort_strategy': sort_strategy}|url_encode }}"
+                            data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': page, 'sort_strategy': sort_strategy}|url_encode }}"
                             data-pagination-item
                             {{ page == current_page ? 'aria-current="page"' : '' }}
                         >
@@ -162,8 +163,8 @@
             <li class="page-item {{ current_page >= total_pages ? 'disabled' : '' }}">
                 <a
                     class="page-link d-flex justify-content-center"
-                    href="?{{ {'category': category_id, 'filter': filter, 'page': current_page + 1}|url_encode }}"
-                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': current_page + 1}|url_encode }}"
+                    href="?{{ {'category': category_id, 'filter': filter, 'page': current_page + 1, 'sort_strategy': sort_strategy}|url_encode }}"
+                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': current_page + 1, 'sort_strategy': sort_strategy}|url_encode }}"
                     data-pagination-item
                     aria-label="{{ __('Next page') }}"
                     {{ current_page >= total_pages ? 'aria-disabled="true"' : '' }}
@@ -174,8 +175,8 @@
             <li class="page-item {{ current_page >= total_pages ? 'disabled' : '' }}">
                 <a
                     class="page-link d-flex justify-content-center"
-                    href="?{{ {'category': category_id, 'filter': filter, 'page': total_pages}|url_encode }}"
-                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': total_pages}|url_encode }}"
+                    href="?{{ {'category': category_id, 'filter': filter, 'page': total_pages, 'sort_strategy': sort_strategy}|url_encode }}"
+                    data-children-url-parameters="{{ {'category': category_id, 'filter': filter, 'page': total_pages, 'sort_strategy': sort_strategy}|url_encode }}"
                     data-pagination-item
                     aria-label="{{ __('Last page') }}"
                     {{ current_page >= total_pages ? 'aria-disabled="true"' : '' }}

--- a/tests/e2e/specs/Helpdesk/service_catalog.spec.ts
+++ b/tests/e2e/specs/Helpdesk/service_catalog.spec.ts
@@ -573,4 +573,91 @@ test.describe('Service Catalog Page - Isolated', () => {
         }
         await expect(service_catalog.getItemRegion(`Form ${String.fromCharCode(65 + forms_per_page)} ${uuid}`)).toBeHidden();
     });
+
+    test(`Sort order is preserved when navigating into a category`, async ({page, profile, api, entity}) => {
+        const uuid = randomUUID();
+
+        // Disable expanded service catalog to ensure we are testing the sort order persistence when navigating, not the sort order of the category tree
+        await api.updateItem('Entity', entity_id, {'expand_service_catalog': false});
+
+        // Create a category with forms A, B, C
+        const category_id = await createCategory(api, `Sort test category ${uuid}`);
+        await createActiveForm(api, `A form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+        await createActiveForm(api, `B form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+        await createActiveForm(api, `C form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+
+        // Go to service catalog
+        await profile.set(Profiles.SelfService);
+        await entity.switchToWithoutRecursion(entity_id);
+        const service_catalog = new ServiceCatalogPage(page);
+        await service_catalog.goto();
+
+        // Change sort order to reverse alphabetical
+        await service_catalog.doChangeSortOrder('Reverse alphabetical');
+        await expect(page.getByRole('textbox', {name: 'Reverse alphabetical'})).toBeVisible();
+
+        // Navigate into the category
+        const items_response = service_catalog.waitForItemsResponse();
+        await service_catalog.doGoToItem(`Sort test category ${uuid}`);
+        await items_response;
+
+        // Verify sort order is still reverse alphabetical after navigation
+        await expect(page.getByRole('textbox', {name: 'Reverse alphabetical'})).toBeVisible();
+        const links = service_catalog.getFormsRegion().getByRole('link');
+        await expect(links.nth(0).getByRole('heading')).toContainText(`C form ${uuid}`);
+        await expect(links.nth(1).getByRole('heading')).toContainText(`B form ${uuid}`);
+        await expect(links.nth(2).getByRole('heading')).toContainText(`A form ${uuid}`);
+    });
+
+    test(`Changing sort order stays in the current subcategory`, async ({page, profile, api, entity}) => {
+        const uuid = randomUUID();
+
+        // Disable expanded service catalog to ensure we are testing the sort order persistence when navigating, not the sort order of the category tree
+        await api.updateItem('Entity', entity_id, {'expand_service_catalog': false});
+
+        // Create a category with forms A, B, C
+        const category_id = await createCategory(api, `Sort stay category ${uuid}`);
+        await createActiveForm(api, `A form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+        await createActiveForm(api, `B form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+        await createActiveForm(api, `C form ${uuid}`, entity_id, {
+            'forms_categories_id': category_id,
+        });
+
+        // Go to service catalog
+        await profile.set(Profiles.SelfService);
+        await entity.switchToWithoutRecursion(entity_id);
+        const service_catalog = new ServiceCatalogPage(page);
+        await service_catalog.goto();
+
+        // Navigate into the category first
+        const items_response = service_catalog.waitForItemsResponse();
+        await service_catalog.doGoToItem(`Sort stay category ${uuid}`);
+        await items_response;
+
+        // Verify we are inside the category (breadcrumb shows it)
+        const breadcrumb_nav = service_catalog.getCategoryBreadcrumbNav();
+        await expect(breadcrumb_nav.getByRole('link', {name: 'Service catalog'})).toBeVisible();
+
+        // Change sort order while inside the category
+        await service_catalog.doChangeSortOrder('Alphabetical');
+
+        // Verify we are still inside the category (breadcrumb must still show "Service catalog" link)
+        await expect(breadcrumb_nav.getByRole('link', {name: 'Service catalog'})).toBeVisible();
+
+        // Verify items are sorted alphabetically inside the category
+        const links = service_catalog.getFormsRegion().getByRole('link');
+        await expect(links.nth(0).getByRole('heading')).toContainText(`A form ${uuid}`);
+        await expect(links.nth(1).getByRole('heading')).toContainText(`B form ${uuid}`);
+        await expect(links.nth(2).getByRole('heading')).toContainText(`C form ${uuid}`);
+    });
 });


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #23653 and !43382

This PR improves the Service Catalog's sort order handling, ensuring that the user's selected sort strategy is consistently preserved during navigation and when changing categories or pages. The changes affect both the frontend JavaScript logic and the backend/template handling, and add end-to-end tests to verify the new behavior.