### PR TITLE
fix double encrypt of snmp passwords

### DIFF
--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -209,18 +209,6 @@ class SNMPCredential extends CommonDBTM
         }
     }
 
-    public function post_getFromDB()
-    {
-        parent::post_getFromDB();
-        $key = new GLPIKey();
-        if (isset($this->fields['auth_passphrase'])) {
-            $this->fields['auth_passphrase'] = $key->decrypt($this->fields['auth_passphrase']);
-        }
-        if (isset($this->fields['priv_passphrase'])) {
-            $this->fields['priv_passphrase'] = $key->decrypt($this->fields['priv_passphrase']);
-        }
-    }
-
     protected function prepareInputs(array $input): array
     {
         $key = new GLPIKey();

--- a/src/SNMPCredential.php
+++ b/src/SNMPCredential.php
@@ -45,6 +45,11 @@ class SNMPCredential extends CommonDBTM
     public $dohistory                   = true;
     public static $rightname = 'snmpcredential';
 
+    public static $undisclosedFields = [
+        'auth_passphrase',
+        'priv_passphrase',
+    ];
+
     public static function getTypeName($nb = 0)
     {
         return _n('SNMP credential', 'SNMP credentials', $nb);
@@ -201,6 +206,18 @@ class SNMPCredential extends CommonDBTM
                 return 'CFB256-AES';
             default:
                 return '';
+        }
+    }
+
+    public function post_getFromDB()
+    {
+        parent::post_getFromDB();
+        $key = new GLPIKey();
+        if (isset($this->fields['auth_passphrase'])) {
+            $this->fields['auth_passphrase'] = $key->decrypt($this->fields['auth_passphrase']);
+        }
+        if (isset($this->fields['priv_passphrase'])) {
+            $this->fields['priv_passphrase'] = $key->decrypt($this->fields['priv_passphrase']);
         }
     }
 

--- a/templates/components/form/snmpcredential.html.twig
+++ b/templates/components/form/snmpcredential.html.twig
@@ -85,7 +85,7 @@
 
    {{ fields.passwordField(
       'auth_passphrase',
-      item.fields['auth_passphrase'],
+      item.fields['auth_passphrase']|decrypt,
       __('Password'),
       {
          add_field_attribs: {
@@ -112,7 +112,7 @@
 
    {{ fields.passwordField(
       'priv_passphrase',
-      item.fields['priv_passphrase'],
+      item.fields['priv_passphrase']|decrypt,
       __('Password'),
       {
          add_field_attribs: {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23843

UX of password fields isn't standardized in GLPI, so if this isn't how it is desired to handle them in this specific case, please let me know. The encrypted values were used in the form and saving the form caused them to get encrypted again. By the second save, the encrypted data becomes too long to store.
