### PR TITLE
force LTR dir for totp code input

### DIFF
--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -31,7 +31,7 @@
  #}
 
 {% macro tfa_code_input(digits = 6) %}
-   <div class="d-flex justify-content-center">
+   <div class="d-flex justify-content-center" dir="ltr">
       {% for i in 1..digits %}
          <input type="text" class="form-control text-center {{ i != 1 ? 'ms-2' : '' }} fw-bold" name="totp_code[]"
              maxlength="1" pattern="[0-9]" inputmode="numeric" required style="width: 2.5em; font-size: 1.5em"


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23232

As pointed out by the reporter, RTL languages still write numbers from left to right so the TOTP input should be forced in LTR mode.