### PR TITLE
Switch to whitelist system for Twig autoload

### DIFF
--- a/.github/workflows/docker_rebuild.yml
+++ b/.github/workflows/docker_rebuild.yml
@@ -148,8 +148,8 @@ jobs:
       GHCR_ACCESS_TOKEN: ${{ secrets.GHCR_ACCESS_TOKEN }}
     with:
       push: true
-      glpi-version: ${{ matrix.glpi-version }}
       glpi-repo: ${{ vars.GLPI_REPO || 'glpi-project/glpi' }}
+      glpi-version: ${{ matrix.glpi-version }}
       image-tag: ${{ matrix.image-tag }}
       no-cache: ${{ matrix.no-cache }}
       use-legacy-marketplace-path: ${{ matrix.use-legacy-marketplace-path }}

--- a/.github/workflows/docker_rebuild.yml
+++ b/.github/workflows/docker_rebuild.yml
@@ -149,6 +149,7 @@ jobs:
     with:
       push: true
       glpi-version: ${{ matrix.glpi-version }}
+      glpi-repo: ${{ vars.GLPI_REPO || 'glpi-project/glpi' }}
       image-tag: ${{ matrix.image-tag }}
       no-cache: ${{ matrix.no-cache }}
       use-legacy-marketplace-path: ${{ matrix.use-legacy-marketplace-path }}

--- a/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
+++ b/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Unregister Twig extensions that Symfony TwigBundle auto-registers but that
+ * GLPI does not want to activate yet.
+ *
+ * Some Symfony-provided extensions collide with GLPI extensions.
+ * i.g. `twig.extension.routing` exposes `path` and `url` Twig functions,
+ * which conflict with `Glpi\Application\View\Extension\RoutingExtension`.
+ *
+ */
+final class RemoveUnwantedTwigExtensionsPass implements CompilerPassInterface
+{
+    /**
+     * Twig extension tag to unload.
+     * Can be listed by doing `bin/console symfony:debug:container --tag=twig.extension`
+     */
+    private const UNWANTED_EXTENSION_IDS = [
+        'twig.extension.routing',       // conflicts with Glpi\Application\View\Extension\RoutingExtension (path/url)
+        'twig.extension.httpfoundation',
+        'twig.extension.httpkernel',
+        'twig.extension.assets',
+        'twig.extension.form',
+        'twig.extension.weblink',
+        'twig.extension.serializer',
+        'twig.extension.yaml',
+        'twig.extension.expression',
+        'twig.extension.emoji',
+        'twig.extension.htmlsanitizer',
+        'twig.extension.debug.stopwatch',
+        'twig.extension.debug',
+        'twig.extension.profiler',
+        'workflow.twig_extension',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::UNWANTED_EXTENSION_IDS as $id) {
+            if ($container->hasDefinition($id)) {
+                $container->getDefinition($id)->clearTag('twig.extension');
+            }
+        }
+    }
+}

--- a/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
+++ b/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\DependencyInjection\Compiler;
 
+use Glpi\Application\Environment;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -73,6 +74,13 @@ final class RemoveUnwantedTwigExtensionsPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         foreach (self::UNWANTED_EXTENSION_IDS as $id) {
+            // We allow debug extensions in dev env
+            if (Environment::get()->shouldEnableExtraDevAndDebugTools()) {
+                if (in_array($id, ['twig.extension.debug', 'twig.extension.debug.stopwatch', 'twig.extension.profiler'])) {
+                    continue;
+                }
+            }
+
             if ($container->hasDefinition($id)) {
                 $container->getDefinition($id)->clearTag('twig.extension');
             }

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -36,6 +36,7 @@ namespace Glpi\Kernel;
 
 use Glpi\Application\Environment;
 use Glpi\Application\SystemConfigurator;
+use Glpi\DependencyInjection\Compiler\RemoveUnwantedTwigExtensionsPass;
 use Override;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -44,6 +45,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -195,6 +197,21 @@ final class Kernel extends BaseKernel
         }
 
         return parent::buildContainer();
+    }
+
+    #[Override()]
+    protected function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        // Must run AFTER Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExtensionPass,
+        // which is registered at TYPE_BEFORE_OPTIMIZATION with priority 10
+        // In Symfony\Bundle\TwigBundle\TwigBundle
+        $container->addCompilerPass(
+            new RemoveUnwantedTwigExtensionsPass(),
+            PassConfig::TYPE_BEFORE_OPTIMIZATION,
+            0
+        );
     }
 
     protected function configureContainer(ContainerConfigurator $container): void

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -210,7 +210,7 @@ final class Kernel extends BaseKernel
         $container->addCompilerPass(
             new RemoveUnwantedTwigExtensionsPass(),
             PassConfig::TYPE_BEFORE_OPTIMIZATION,
-            0
+            9
         );
     }
 

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -110,7 +110,7 @@ do
 done
 
 echo "Clearing Symfony cache compiled with dev dependencies..."
-rm -rf $WORKING_DIR/files/_cache
+rm -rf $WORKING_DIR/files/_cache/*
 
 echo "Generating file manifest..."
 $WORKING_DIR/bin/console build:generate_code_manifest -a crc32c

--- a/tools/build_glpi.sh
+++ b/tools/build_glpi.sh
@@ -109,6 +109,9 @@ do
     rm -rf $WORKING_DIR/$node
 done
 
+echo "Clearing Symfony cache compiled with dev dependencies..."
+rm -rf $WORKING_DIR/files/_cache
+
 echo "Generating file manifest..."
 $WORKING_DIR/bin/console build:generate_code_manifest -a crc32c
 


### PR DESCRIPTION
Add a whitelist logic so we don't expose twig function that in the future we could overload or remove.

That could lead to plugin dev to have then broken plugin if they used them.

Also add a new CI action var `GLPI_REPO` so we can run build/image download on another glpi project (useful when debugging on a fork) --> For this to be working, it will need https://github.com/glpi-project/docker-images/pull/294 to be merged (build on it fail for now as glpi@main build fail - waiting for this PR)

Tested on my fork, build are ok : https://github.com/froozeify/glpi/actions/runs/24446791883