### PR TITLE
fix(service_catalog): limit card height in service catalog

### DIFF
--- a/templates/components/helpdesk_forms/service_catalog_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_item.html.twig
@@ -66,7 +66,8 @@
                         {% endif %}
                     </div>
                     <div
-                        class="text-secondary remove-last-tinymce-margin"
+                        class="text-secondary remove-last-tinymce-margin overflow-hidden"
+                        style="max-height: 300px"
                         data-testid="service-catalog-description"
                     >
                         {{ item.getServiceCatalogItemDescription()|safe_html }}

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -55,7 +55,7 @@
                             <h2 id="{{ unique_dom_id }}" class="mb-0 fs-2">
                                 {{ item.getServiceCatalogItemTitle() }}
                             </h2>
-                            <div class="card-subtitle ms-2 remove-last-tinymce-margin">
+                            <div class="card-subtitle mt-1 remove-last-tinymce-margin overflow-hidden" style="max-height: 300px">
                                 {{ item.getServiceCatalogItemDescription()|safe_html }}
                             </div>
                         </div>

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -55,7 +55,7 @@
                             <h2 id="{{ unique_dom_id }}" class="mb-0 fs-2">
                                 {{ item.getServiceCatalogItemTitle() }}
                             </h2>
-                            <div class="card-subtitle mt-1 remove-last-tinymce-margin overflow-hidden" style="max-height: 300px">
+                            <div class="card-subtitle ms-2 remove-last-tinymce-margin overflow-hidden" style="max-height: 300px">
                                 {{ item.getServiceCatalogItemDescription()|safe_html }}
                             </div>
                         </div>

--- a/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_nested_item.html.twig
@@ -59,7 +59,7 @@
                     >
                         {{ child.getServiceCatalogItemTitle() }}
                     </h2>
-                    <div class="text-secondary remove-last-tinymce-margin">
+                    <div class="text-secondary remove-last-tinymce-margin overflow-hidden" style="max-height: 300px">
                         {{ child.getServiceCatalogItemDescription()|safe_html }}
                     </div>
                 </div>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43331
- This fix limits the height of the cards to prevent the service catalog from becoming unreadable 

## Screenshots (if appropriate):
After:
<img width="1303" height="495" alt="image" src="https://github.com/user-attachments/assets/f04a908a-e64d-481c-b354-48924132b301" />

Before:
<img width="1308" height="873" alt="image" src="https://github.com/user-attachments/assets/02a2fc96-3335-4198-8a5e-c323a3621a18" />



