### PR TITLE
Fix(Ticket): updating date_mod when add document

### DIFF
--- a/phpunit/functional/Document_ItemTest.php
+++ b/phpunit/functional/Document_ItemTest.php
@@ -208,7 +208,7 @@ class Document_ItemTest extends DbTestCase
 
         // Link the document to the ticket via Document_Item
         $this->createItem(
-            Document_Item::class,
+            \Document_Item::class,
             [
                 'users_id'      => $uid,
                 'items_id'      => $tickets_id,

--- a/phpunit/functional/Document_ItemTest.php
+++ b/phpunit/functional/Document_ItemTest.php
@@ -187,68 +187,41 @@ class Document_ItemTest extends DbTestCase
         $uid = getItemByTypeName('User', TU_USER, true);
 
         $ticket = new \Ticket();
-        $tickets_id = $ticket->add([
-            'name' => '',
-            'content' => 'Test modification date not updated from Document_Item',
-            'date_mod' => '2020-01-01',
-        ]);
-
-        $this->assertGreaterThan(0, $tickets_id);
+        $tickets_id = $this->createItem(
+            \Ticket::class,
+            [
+                'name' => 'Test modification date not updated from Document_Item',
+                'content' => 'Test modification date not updated from Document_Item',
+                'date_mod' => '2020-01-01 00:00:00',
+            ],
+        )->getID();
 
         // Document and Document_Item
-        $doc = new \Document();
-        $this->assertGreaterThan(
-            0,
-            $doc->add([
+        $doc_id = $this->createItem(
+            \Document::class,
+            [
                 'users_id'     => $uid,
                 'tickets_id'   => $tickets_id,
                 'name'         => 'A simple document object',
-            ])
-        );
+            ],
+        )->getID();
 
-        //do not change ticket modification date
-        $doc_item = new \Document_Item();
-        $this->assertGreaterThan(
-            0,
-            $doc_item->add([
+        // Link the document to the ticket via Document_Item
+        $this->createItem(
+            Document_Item::class,
+            [
                 'users_id'      => $uid,
                 'items_id'      => $tickets_id,
-                'itemtype'      => 'Ticket',
-                'documents_id'  => $doc->getID(),
-                '_do_update_ticket' => false,
-            ])
+                'itemtype'      => \Ticket::class,
+                'documents_id'  => $doc_id,
+            ],
         );
 
         $this->assertTrue($ticket->getFromDB($tickets_id));
-        $this->assertSame('2020-01-01 00:00:00', $ticket->fields['date_mod']);
-
-        //do change ticket modification date
-        $_SESSION["glpi_currenttime"] = '2021-01-01 00:00:01';
-        $doc = new \Document();
-        $this->assertGreaterThan(
-            0,
-            $doc->add([
-                'users_id'     => $uid,
-                'tickets_id'   => $tickets_id,
-                'name'         => 'A simple document object',
-            ])
-        );
-
-        $doc_item = new \Document_Item();
-        $this->assertGreaterThan(
-            0,
-            $doc_item->add([
-                'users_id'      => $uid,
-                'items_id'      => $tickets_id,
-                'itemtype'      => 'Ticket',
-                'documents_id'  => $doc->getID(),
-            ])
-        );
-
-        $this->assertTrue($ticket->getFromDB($tickets_id));
-        $this->assertNotEquals(
-            '2021-01-01 00:00:01',
-            $ticket->fields['date_mod']
+        $this->assertGreaterThan('2020-01-01 00:00:00', $ticket->fields['date_mod']);
+        $this->assertEquals(
+            $_SESSION["glpi_currenttime"],
+            $ticket->fields['date_mod'],
         );
     }
 }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1733,6 +1733,9 @@ abstract class CommonITILObject extends CommonDBTM
                     $allowed_fields[] = 'takeintoaccount_delay_stat';
                     $allowed_fields[] = 'takeintoaccountdate';
                 }
+                if (isset($input['_do_update_date_mod'])) {
+                    $allowed_fields[] = 'date_mod';
+                }
             }
 
             $ret = [];

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -216,6 +216,7 @@ class Document_Item extends CommonDBRelation
             $input  = [
                 'id'              => $this->fields['items_id'],
                 'date_mod'        => $_SESSION["glpi_currenttime"],
+                '_do_update_date_mod' => true,
             ];
 
             if (!isset($this->input['_do_notif']) || $this->input['_do_notif']) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43274

When a self-service user adds a document to a ticket, the ticket's modification date was not updated, whereas it is updated when using a standard interface profile.

- Backport of: #23819