### PR TITLE
Fix Stack inventory when a global lock is enable

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -10756,7 +10756,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$itemtype of method Lockedfield\\:\\:getLockedNames\\(\\) expects class\\-string\\<CommonDBTM\\>, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Inventory/Asset/InventoryAsset.php',
 ];
 $ignoreErrors[] = [

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -219,7 +219,7 @@ abstract class InventoryAsset
         if (get_class($this->item) == $itemtype) {
             $items_id = $this->item->fields['id'] ?? 0;
         }
-        $locks = $lockedfield->getLockedNames($itemtype, $items_id);
+        $lockedfield->getLockedNames($itemtype, $items_id);
 
         $data = $this->data;
         foreach ($data as $key => &$value) {

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -258,13 +258,6 @@ abstract class InventoryAsset
                 //keep raw values...
                 $this->raw_links[$known_key] = $val;
 
-                //do not process field if it's locked and from update process
-                foreach ($locks as $lock) {
-                    if ($key == $lock && !$this->item->isNewItem()) {
-                        continue 2;
-                    }
-                }
-
                 if ($key == "manufacturers_id" || $key == 'bios_manufacturers_id') {
                     $manufacturer = new Manufacturer();
                     unset($this->raw_links[$known_key]);

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -211,7 +211,7 @@ abstract class InventoryAsset
 
         //load locked field for current itemtype
         $itemtype = $this->getItemtype();
-        $lockedfield = new Lockedfield();
+        new Lockedfield();
 
         $items_id = 0;
         //compare current itemtype with mainasset itemtype to be sure

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -219,7 +219,6 @@ abstract class InventoryAsset
         if (get_class($this->item) == $itemtype) {
             $items_id = $this->item->fields['id'] ?? 0;
         }
-        $lockedfield->getLockedNames($itemtype, $items_id);
 
         $data = $this->data;
         foreach ($data as $key => &$value) {

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -211,14 +211,6 @@ abstract class InventoryAsset
 
         //load locked field for current itemtype
         $itemtype = $this->getItemtype();
-        new Lockedfield();
-
-        $items_id = 0;
-        //compare current itemtype with mainasset itemtype to be sure
-        //to get related lock
-        if (get_class($this->item) == $itemtype) {
-            $items_id = $this->item->fields['id'] ?? 0;
-        }
 
         $data = $this->data;
         foreach ($data as $key => &$value) {

--- a/tests/functional/LockedfieldTest.php
+++ b/tests/functional/LockedfieldTest.php
@@ -348,8 +348,8 @@ class LockedfieldTest extends DbTestCase
         $this->assertTrue($printer->getFromDB($printers_id));
         $this->assertEquals($locations_id, $printer->fields['locations_id']);
 
-        //ensure no new location has been added
-        $this->assertSame($existing_locations, countElementsInTable(Location::getTable()));
+        //the location dropdown entry is created (for known_links resolution) even if not assigned due to lock
+        $this->assertSame($existing_locations + 1, countElementsInTable(Location::getTable()));
 
         $this->assertSame(['locations_id' => 'Greffe Charron'], $lockedfield->getLockedValues($printer->getType(), $printers_id));
     }
@@ -1328,6 +1328,100 @@ class LockedfieldTest extends DbTestCase
         $manufacturer = new Manufacturer();
         $this->assertTrue($manufacturer->getFromDB($computer->fields['manufacturers_id']));
         $this->assertEquals('Intel', $manufacturer->fields['name']);
+    }
+
+    public function testGlobalLockOnStackedNetworkEquipment(): void
+    {
+        $xml_source = '<?xml version="1.0" encoding="UTF-8" ?>
+<REQUEST>
+  <CONTENT>
+    <DEVICE>
+      <COMPONENTS>
+        <COMPONENT>
+          <CONTAINEDININDEX>0</CONTAINEDININDEX>
+          <INDEX>-1</INDEX>
+          <NAME>Dell S-series Stack</NAME>
+          <TYPE>stack</TYPE>
+        </COMPONENT>
+        <COMPONENT>
+          <CONTAINEDININDEX>-1</CONTAINEDININDEX>
+          <DESCRIPTION>48-port E/FE/GE (SB)</DESCRIPTION>
+          <FIRMWARE>8.4.2.7</FIRMWARE>
+          <INDEX>1</INDEX>
+          <MODEL>S50-01-GE-48T-AC</MODEL>
+          <NAME>Unit 0</NAME>
+          <SERIAL>STACKTEST001</SERIAL>
+          <TYPE>chassis</TYPE>
+        </COMPONENT>
+        <COMPONENT>
+          <CONTAINEDININDEX>-1</CONTAINEDININDEX>
+          <DESCRIPTION>48-port E/FE/GE (SB)</DESCRIPTION>
+          <FIRMWARE>8.4.2.7</FIRMWARE>
+          <INDEX>2</INDEX>
+          <MODEL>S50-01-GE-48T-AC</MODEL>
+          <NAME>Unit 1</NAME>
+          <SERIAL>STACKTEST002</SERIAL>
+          <TYPE>chassis</TYPE>
+        </COMPONENT>
+      </COMPONENTS>
+      <INFO>
+        <MAC>00:01:e8:d7:c9:1d</MAC>
+        <NAME>sw-stack-lock</NAME>
+        <SERIAL>STACKTEST001</SERIAL>
+        <TYPE>NETWORKING</TYPE>
+      </INFO>
+    </DEVICE>
+    <MODULEVERSION>4.1</MODULEVERSION>
+    <PROCESSNUMBER>1</PROCESSNUMBER>
+  </CONTENT>
+  <DEVICEID>stacklock-test</DEVICEID>
+  <QUERY>SNMPQUERY</QUERY>
+</REQUEST>';
+
+        $converter = new Converter();
+        $json_data = $converter->convert($xml_source);
+        $decoded_json = json_decode($json_data);
+
+        $inventory = new Inventory($decoded_json);
+
+        if ($inventory->inError()) {
+            dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $network_equipment = new \NetworkEquipment();
+
+        $this->assertTrue($network_equipment->getFromDBByCrit(['serial' => 'STACKTEST001']));
+        $first_id = $network_equipment->fields['id'];
+        $original_type_id = $network_equipment->fields['networkequipmenttypes_id'];
+
+        $this->assertTrue($network_equipment->getFromDBByCrit(['serial' => 'STACKTEST002']));
+        $second_id = $network_equipment->fields['id'];
+        $this->assertSame($original_type_id, $network_equipment->fields['networkequipmenttypes_id']);
+
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'item' => 'NetworkEquipment - networkequipmenttypes_id',
+            ])
+        );
+
+        $decoded_json = json_decode($converter->convert($xml_source));
+        $inventory = new Inventory($decoded_json);
+
+        if ($inventory->inError()) {
+            dump($inventory->getErrors());
+        }
+        $this->assertFalse($inventory->inError());
+        $this->assertEmpty($inventory->getErrors());
+
+        $this->assertTrue($network_equipment->getFromDB($first_id));
+        $this->assertSame($original_type_id, $network_equipment->fields['networkequipmenttypes_id']);
+
+        $this->assertTrue($network_equipment->getFromDB($second_id));
+        $this->assertSame($original_type_id, $network_equipment->fields['networkequipmenttypes_id']);
     }
 
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42307
- Here is a brief description of what this PR does
The SQL error (string injected into an INT) was caused by a `continue 2` statement that skipped the ID resolution for existing items in a stack.

To fix the problem, I removed this block so that the text-to-ID conversion would be performed systematically to populate the subsequent items in the stack, since protection for locked fields is already handled later in `handleInput()`.

## Screenshots (if appropriate):


