### PR TITLE
Disable optional warmers (so twig bundle don't warm all templates)

### DIFF
--- a/src/Glpi/Cache/CacheManager.php
+++ b/src/Glpi/Cache/CacheManager.php
@@ -606,6 +606,11 @@ PHP;
         // This command will clear the Symfony cache gracefully.
         $app = new Application($localKernel);
         $app->setAutoExit(false);
-        $app->run(new ArrayInput(['command' => 'cache:clear']), new NullOutput());
+        // Skip optional cache warmers (e.g. Twig templates, more than 400 to cache so cause memory exception - default 128M).
+        // Templates are compiled lazily on first render.
+        $app->run(
+            new ArrayInput(['command' => 'cache:clear', '--no-optional-warmers' => true]),
+            new NullOutput()
+        );
     }
 }

--- a/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
+++ b/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
@@ -53,8 +53,10 @@ final class RemoveUnwantedTwigExtensionsPass implements CompilerPassInterface
      * Twig extension tag to unload.
      * Can be listed by doing `bin/console symfony:debug:container --tag=twig.extension`
      */
-    private const UNWANTED_EXTENSION_IDS = [
+    private const array UNWANTED_EXTENSION_IDS = [
         'twig.extension.routing',       // conflicts with Glpi\Application\View\Extension\RoutingExtension (path/url)
+        'twig.extension.httpfoundation',
+        'twig.extension.httpkernel',
         'twig.extension.assets',
         'twig.extension.form',
         'twig.extension.weblink',
@@ -69,12 +71,19 @@ final class RemoveUnwantedTwigExtensionsPass implements CompilerPassInterface
         'workflow.twig_extension',
     ];
 
+    private const array ALLOWED_IN_DEV = [
+        'twig.extension.debug',
+        'twig.extension.debug.stopwatch',
+        'twig.extension.profiler',
+        'twig.extension.httpkernel', // Required by the SF Profiler
+    ];
+
     public function process(ContainerBuilder $container): void
     {
         foreach (self::UNWANTED_EXTENSION_IDS as $id) {
             // We allow debug extensions in dev env
             if (Environment::get()->shouldEnableExtraDevAndDebugTools()) {
-                if (in_array($id, ['twig.extension.debug', 'twig.extension.debug.stopwatch', 'twig.extension.profiler'])) {
+                if (in_array($id, self::ALLOWED_IN_DEV)) {
                     continue;
                 }
             }

--- a/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
+++ b/src/Glpi/DependencyInjection/Compiler/RemoveUnwantedTwigExtensionsPass.php
@@ -55,8 +55,6 @@ final class RemoveUnwantedTwigExtensionsPass implements CompilerPassInterface
      */
     private const UNWANTED_EXTENSION_IDS = [
         'twig.extension.routing',       // conflicts with Glpi\Application\View\Extension\RoutingExtension (path/url)
-        'twig.extension.httpfoundation',
-        'twig.extension.httpkernel',
         'twig.extension.assets',
         'twig.extension.form',
         'twig.extension.weblink',


### PR DESCRIPTION
Running `make test-db-install` will crash when it was reloading the symfony cache.

`make cc` didn't had any issue.

This was cause because now that twig is autoloaded, TwigBundle warm the templates (so more than 400 files) exceeding the 128M memoy_limit.

The `--no-optional-warmers` disable thoses optional cache warmup (so same behavior as before twig autoload)

Template will be lazy cached on first page display.


---

Fix also the blacklist to also autoload `twig.extension.httpfoundation` and `twig.extension.httpkernel` (used by the sf debug toolbar) and provides useful twig method like `absolute_url(), relative_path()` and `controller(), render(), fragment_uri()` and don't collide with any GLPI overrides