### PR TITLE
fix: Missing e2e-* command in make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ _ERROR := "\033[31m[%s]\033[0m %s\n" # Red text
 ## —— General ——————————————————————————————————————————————————————————————————
 .DEFAULT_GOAL := help
 help: ## Show this help message
-	@grep -hE '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-25s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+	@grep -hE '(^[0-9a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-25s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
 .PHONY: help
 
 install: init-override build up vendor db-install test-db-install ## Install the project


### PR DESCRIPTION
make help regex didn't support number.

make e2e-* wasn't listed