### PR TITLE
Define global docker name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-name: glpi_main
-
 services:
   app:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,6 @@ services:
       - "3306"
 
   mailpit:
-    container_name: "glpi-mailpit"
     image: "axllent/mailpit"
     restart: "unless-stopped"
     expose:
@@ -44,7 +43,6 @@ services:
       - "8025:8025"
 
   dbgate:
-    container_name: "glpi-dbgate"
     image: "dbgate/dbgate:latest"
     restart: "unless-stopped"
     ports:
@@ -61,7 +59,6 @@ services:
 
   # To create a preconfigured LDAP object in GLPI, run `make console c='tools:generate_dev_ldap'`
   openldap:
-    container_name: "glpi-openldap"
     image: "osixia/openldap:latest"
     restart: "unless-stopped"
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
+name: glpi_main
+
 services:
   app:
-    container_name: "glpi-app"
     build:
       context: ".docker/app"
       args:
@@ -22,7 +23,6 @@ services:
       - "host.docker.internal:host-gateway"
 
   db:
-    container_name: "glpi-db"
     image: "mariadb:11.8"
     restart: "unless-stopped"
     volumes:


### PR DESCRIPTION
The goal is to unify and simplify the container naming

To avoid breaking too much dev database I made the PR only on main.

To active this current effect we have to override the container name with `container_name: !reset null`

Example of my current override:
```yaml
name: glpi_main

services:
  app:
    container_name: !reset null
    ports: !override
      - "8012:80"
      - "8092:8080"
      # - "9637:9637" # Webpack dev container
    environment:
      - GLPI_URI=http://localhost:8080 # Local test uri env var
    post_start:
      - command: >
          bash -c "sudo mkdir -p /opt/phpstorm-coverage && sudo chmod a+rw /opt/phpstorm-coverage"

  db:
    container_name: !reset null
    expose:
      - "3306"
    ports:
      - "3312:3306"

  dbgate: !reset null
  openldap: !reset null
  mailpit: !reset null
```

<img width="732" height="539" alt="image" src="https://github.com/user-attachments/assets/65037e14-50ea-456a-8f5e-c66fee035df0" />

---
If you have custom script you can run them using something like:
```bash
docker compose exec app sh -c 'bin/console symfony:cache:clear'
```