### PR TITLE
Avoid docker port warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ PLAYWRIGHT = docker run \
 	--user=$(shell id -u):$(shell id -g) \
 	-v .:/app \
 	-w /app \
-	-p 9323:9323 \
 	-e E2E_BASE_URL=$(E2E_BASE_URL) \
 	--network host \
 	mcr.microsoft.com/playwright:v$(PLAYWRIGHT_VERSION)-noble \


### PR DESCRIPTION
Followup to #23859.

Prevent this warning:

<img width="714" height="85" alt="image" src="https://github.com/user-attachments/assets/681f6412-924c-41d1-aa13-d94b6726b324" />


