### PR TITLE
Add custom template cache dir config

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
@@ -35,6 +35,7 @@
 namespace Glpi\Kernel\Listener\PostBootListener;
 
 use Glpi\Application\Environment as GLPIEnvironment;
+use Glpi\Kernel\Kernel;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
 use Plugin;
@@ -88,6 +89,17 @@ final readonly class InitializeTwigEnvironment implements EventSubscriberInterfa
         if (GLPI_STRICT_ENV) {
             $this->twig_environment->enableStrictVariables();
         }
+
+        $cachedir = Kernel::getCacheRootDir();
+        $tpl_cachedir = $cachedir . '/templates';
+        if (
+            (file_exists($tpl_cachedir) && !is_writable($tpl_cachedir))
+            || (!file_exists($tpl_cachedir) && !is_writable($cachedir))
+        ) {
+            trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cachedir), E_USER_WARNING);
+        }
+
+         $this->twig_environment->setCache($tpl_cachedir);
     }
 
     /**

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
@@ -97,6 +97,7 @@ final readonly class InitializeTwigEnvironment implements EventSubscriberInterfa
             || (!file_exists($tpl_cachedir) && !is_writable($cachedir))
         ) {
             trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cachedir), E_USER_WARNING);
+            $this->twig_environment->setCache(false);
         } else {
             $this->twig_environment->setCache($tpl_cachedir);
         }

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializeTwigEnvironment.php
@@ -97,9 +97,9 @@ final readonly class InitializeTwigEnvironment implements EventSubscriberInterfa
             || (!file_exists($tpl_cachedir) && !is_writable($cachedir))
         ) {
             trigger_error(sprintf('Cache directory "%s" is not writeable.', $tpl_cachedir), E_USER_WARNING);
+        } else {
+            $this->twig_environment->setCache($tpl_cachedir);
         }
-
-         $this->twig_environment->setCache($tpl_cachedir);
     }
 
     /**


### PR DESCRIPTION
In 11.0 we had a constructor param to set the cache dir (default to null)

But was never used as the getInstance didn't set any constructor params.

So always setting it based on config from `Kernel::getCacheRootDir`

<img width="601" height="327" alt="image" src="https://github.com/user-attachments/assets/74d41139-ffb8-49bd-8424-657fd5daa9df" />