### PR TITLE
Balance e2e shards with new env parameter

### DIFF
--- a/.github/actions/docker-compose-app.yml
+++ b/.github/actions/docker-compose-app.yml
@@ -10,6 +10,7 @@ services:
       # E2E env is exposed on the 8090 port
       # See: https://github.com/glpi-project/docker-images/blob/main/githubactions-php-apache/files/etc/apache2/sites-available/000-default.conf
       E2E_BASE_URL: http://localhost:8090
+      PWTEST_SHARD_WEIGHTS: "40:60"
     volumes:
       - type: "bind"
         source: "${APPLICATION_ROOT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         if: ${{ !cancelled() }}
         run:  |
           docker compose exec -T app bin/console config:set url_base http://localhost:8090 --env=e2e_testing
-          docker compose exec -T app npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+          docker compose exec -T app PWTEST_SHARD_WEIGHTS=40:60 npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Check for PHP errors
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         if: ${{ !cancelled() }}
         run:  |
           docker compose exec -T app bin/console config:set url_base http://localhost:8090 --env=e2e_testing
-          docker compose exec -T app PWTEST_SHARD_WEIGHTS=40:60 npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+          docker compose exec -T app npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Check for PHP errors
         if: ${{ !cancelled() }}
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
                 "@babel/preset-env": "^7.28.6",
                 "@eslint/eslintrc": "^3.3.5",
                 "@eslint/js": "^9.31.0",
-                "@playwright/test": "^1.56.1",
+                "@playwright/test": "^1.59.1",
                 "@testing-library/cypress": "^10.0.3",
                 "@testing-library/jest-dom": "^6.6.4",
                 "@types/node": "^24.10.15",
@@ -4517,13 +4517,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-            "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.56.1"
+                "playwright": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14844,13 +14844,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-            "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.56.1"
+                "playwright-core": "1.59.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14863,9 +14863,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.56.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-            "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "@babel/preset-env": "^7.28.6",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.31.0",
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "^1.59.1",
         "@testing-library/cypress": "^10.0.3",
         "@testing-library/jest-dom": "^6.6.4",
         "@types/node": "^24.10.15",


### PR DESCRIPTION
The 1.59.1 version add the ability to balance shards: https://github.com/microsoft/playwright/pull/38624

Our shards are pretty uneven due to having a lot of slow tests in the first half of the suite so it seems a good idea to use it.

Before:
<img width="497" height="68" alt="image" src="https://github.com/user-attachments/assets/8c3b5343-2e36-49c2-a253-d07ba4d783da" />

After:
<img width="457" height="72" alt="image" src="https://github.com/user-attachments/assets/cdbf5cde-f04d-42c4-966d-a867eb012dd2" />
