### PR TITLE
Fix - getEntitiesRestrictCriteria() returns invalid SQL criterion when no session is active

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -52,7 +52,7 @@ use function Safe\realpath;
  *
  * @since 9.2
  */
-class DbUtils
+final class DbUtils
 {
     /**
      * Return foreign key field name for a table
@@ -891,16 +891,6 @@ class DbUtils
     }
 
     /**
-     * Check whether the current execution context is privileged (CLI or cron).
-     *
-     * @return bool
-     */
-    protected function isPrivilegedContext(): bool
-    {
-        return isCommandLine() || Session::isCron();
-    }
-
-    /**
      * Get criteria to restrict to current entities of the user
      *
      * @since 9.2
@@ -952,7 +942,7 @@ class DbUtils
                 $value = $_SESSION['glpiactiveentities'];
             } elseif (Session::isRightChecksDisabled()) {
                 return [new QueryExpression('true')];
-            } elseif ($this->isPrivilegedContext()) {
+            } elseif (isCommandLine() || Session::isCron()) {
                 $value = '0'; // If value is not set, fallback to root entity in cron / command line
             } else {
                 // No active session and no privileged context: deny all access to prevent

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -944,6 +944,10 @@ final class DbUtils
                 return [new QueryExpression('true')];
             } elseif (isCommandLine() || Session::isCron()) {
                 $value = '0'; // If value is not set, fallback to root entity in cron / command line
+            } else {
+                // No active session and no privileged context: deny all access to prevent
+                // invalid SQL criterion (entities_id = '' on integer column → MySQL warning 1292).
+                return [new QueryExpression('false')];
             }
         }
 

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -52,7 +52,7 @@ use function Safe\realpath;
  *
  * @since 9.2
  */
-final class DbUtils
+class DbUtils
 {
     /**
      * Return foreign key field name for a table
@@ -891,6 +891,16 @@ final class DbUtils
     }
 
     /**
+     * Check whether the current execution context is privileged (CLI or cron).
+     *
+     * @return bool
+     */
+    protected function isPrivilegedContext(): bool
+    {
+        return isCommandLine() || Session::isCron();
+    }
+
+    /**
      * Get criteria to restrict to current entities of the user
      *
      * @since 9.2
@@ -942,7 +952,7 @@ final class DbUtils
                 $value = $_SESSION['glpiactiveentities'];
             } elseif (Session::isRightChecksDisabled()) {
                 return [new QueryExpression('true')];
-            } elseif (isCommandLine() || Session::isCron()) {
+            } elseif ($this->isPrivilegedContext()) {
                 $value = '0'; // If value is not set, fallback to root entity in cron / command line
             } else {
                 // No active session and no privileged context: deny all access to prevent

--- a/src/autoload/misc-functions.php
+++ b/src/autoload/misc-functions.php
@@ -42,9 +42,10 @@ use function Safe\preg_match;
  *
  * @return bool
  */
-function isCommandLine()
+function isCommandLine(): bool
 {
-    return (PHP_SAPI == 'cli');
+    global $GLPI_IS_COMMAND_LINE;
+    return $GLPI_IS_COMMAND_LINE ?? (PHP_SAPI === 'cli');
 }
 
 /**

--- a/src/autoload/misc-functions.php
+++ b/src/autoload/misc-functions.php
@@ -44,6 +44,7 @@ use function Safe\preg_match;
  */
 function isCommandLine(): bool
 {
+    /** @var bool|null $GLPI_IS_COMMAND_LINE */
     global $GLPI_IS_COMMAND_LINE;
     return $GLPI_IS_COMMAND_LINE ?? (PHP_SAPI === 'cli');
 }

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -906,7 +906,7 @@ class DbUtilsTest extends DbTestCase
     {
         // Use a subclass that overrides isPrivilegedContext() to simulate a
         // non-CLI, non-cron context (unreachable in PHPUnit because PHP_SAPI === 'cli').
-        $instance = new class () extends \DbUtils {
+        $instance = new class extends \DbUtils {
             protected function isPrivilegedContext(): bool
             {
                 return false;

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -902,6 +902,29 @@ class DbUtilsTest extends DbTestCase
         );
     }
 
+    public function testGetEntitiesRestrictCriteriaWithNoSession()
+    {
+        // Use a subclass that overrides isPrivilegedContext() to simulate a
+        // non-CLI, non-cron context (unreachable in PHPUnit because PHP_SAPI === 'cli').
+        $instance = new class () extends \DbUtils {
+            protected function isPrivilegedContext(): bool
+            {
+                return false;
+            }
+        };
+
+        // Ensure no active session entities and no right-check bypass.
+        unset($_SESSION['glpiactiveentities']);
+        unset($_SESSION['glpishowallentities']);
+
+        $criteria = $instance->getEntitiesRestrictCriteria('glpi_computers');
+
+        $this->assertCount(1, $criteria);
+        $this->assertArrayHasKey(0, $criteria);
+        $this->assertInstanceOf(QueryExpression::class, $criteria[0]);
+        $this->assertSame('false', (string) $criteria[0]);
+    }
+
     /**
      * Run getAncestorsOf tests
      *

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -904,11 +904,9 @@ class DbUtilsTest extends DbTestCase
 
     public function testGetEntitiesRestrictCriteriaWithNoSession(): void
     {
-        global $GLPI_IS_COMMAND_LINE;
-
         // PHP_SAPI is always 'cli' in PHPUnit and cannot be changed at runtime.
         // Override via the global read by isCommandLine() to simulate a web context.
-        $GLPI_IS_COMMAND_LINE = false;
+        $GLOBALS['GLPI_IS_COMMAND_LINE'] = false;
 
         // Ensure no active session entities and no right-check bypass.
         unset($_SESSION['glpiactiveentities']);
@@ -926,7 +924,7 @@ class DbUtilsTest extends DbTestCase
         $this->assertInstanceOf(QueryExpression::class, $first[0]);
         $this->assertSame('false', (string) $first[0]);
 
-        unset($GLPI_IS_COMMAND_LINE);
+        unset($GLOBALS['GLPI_IS_COMMAND_LINE']);
     }
 
     /**

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -902,27 +902,31 @@ class DbUtilsTest extends DbTestCase
         );
     }
 
-    public function testGetEntitiesRestrictCriteriaWithNoSession()
+    public function testGetEntitiesRestrictCriteriaWithNoSession(): void
     {
-        // Use a subclass that overrides isPrivilegedContext() to simulate a
-        // non-CLI, non-cron context (unreachable in PHPUnit because PHP_SAPI === 'cli').
-        $instance = new class extends \DbUtils {
-            protected function isPrivilegedContext(): bool
-            {
-                return false;
-            }
-        };
+        global $GLPI_IS_COMMAND_LINE;
+
+        // PHP_SAPI is always 'cli' in PHPUnit and cannot be changed at runtime.
+        // Override via the global read by isCommandLine() to simulate a web context.
+        $GLPI_IS_COMMAND_LINE = false;
 
         // Ensure no active session entities and no right-check bypass.
         unset($_SESSION['glpiactiveentities']);
         unset($_SESSION['glpishowallentities']);
 
-        $criteria = $instance->getEntitiesRestrictCriteria('glpi_computers');
+        $this->assertFalse(isCommandLine());
+        $this->assertFalse(\Session::isCron());
+
+        $criteria = getEntitiesRestrictCriteria('glpi_computers');
+        $first = reset($criteria);
 
         $this->assertCount(1, $criteria);
-        $this->assertArrayHasKey(0, $criteria);
-        $this->assertInstanceOf(QueryExpression::class, $criteria[0]);
-        $this->assertSame('false', (string) $criteria[0]);
+        $this->assertIsArray($first);
+        $this->assertCount(1, $first);
+        $this->assertInstanceOf(QueryExpression::class, $first[0]);
+        $this->assertSame('false', (string) $first[0]);
+
+        unset($GLPI_IS_COMMAND_LINE);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43370 & https://github.com/pluginsGLPI/fields/pull/1179
- Here is a brief description of what this PR does

When `getEntitiesRestrictCriteria()` is called with no active session, no CLI context, and no cron context, the function falls through all conditions without an else branch. This leaves `$value` as an empty string `''`, producing the invalid SQL criterion `entities_id = ''` on an integer column and triggering MySQL warning 1292 (Truncated incorrect DECIMAL value).

This fix adds a missing else branch that returns `[new QueryExpression('false')]` when no valid context is available, denying all access instead of generating invalid SQL. If there is no session, no results should be returned.

Fixes all callers of `getEntitiesRestrictCriteria()` that are affected by this edge case (e.g. [pluginsGLPI/fields#1179](https://github.com/pluginsGLPI/fields/pull/1179)).