### PR TITLE
Fix(Log): Remove error when No-Reply address is not defined

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1941,8 +1941,6 @@ class Config extends CommonDBTM
             $sender = Config::getNoReplyEmailSender($entities_id);
             if ($sender['email'] !== null) {
                 return $sender;
-            } else {
-                trigger_error('No-Reply address is not defined in configuration.', E_USER_NOTICE);
             }
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -1942,7 +1942,7 @@ class Config extends CommonDBTM
             if ($sender['email'] !== null) {
                 return $sender;
             } else {
-                trigger_error('No-Reply address is not defined in configuration.', E_USER_WARNING);
+                trigger_error('No-Reply address is not defined in configuration.', E_USER_NOTICE);
             }
         }
 

--- a/tests/functional/NotificationTargetTest.php
+++ b/tests/functional/NotificationTargetTest.php
@@ -323,7 +323,6 @@ class NotificationTargetTest extends DbTestCase
             'allow_response' => false,
             'email'          => "admsys@localhost",
             'name'           => "",
-            'warning'        => 'No-Reply address is not defined in configuration.',
         ];
 
         // Case 2: no reply with global config


### PR DESCRIPTION
…n configuration.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

When the "No-Reply" address is not defined in the configuration, it triggers a warning in the logs, even though this field is not required for the system to function, and it quickly clutters the logs with unnecessary warnings. I therefore propose lowering its severity level.
