### PR TITLE
Fix - Content-Range header off-by-one error when no range parameter is provided

### DIFF
--- a/phpunit/APIBaseClass.php
+++ b/phpunit/APIBaseClass.php
@@ -1062,6 +1062,60 @@ abstract class APIBaseClass extends TestCase
     }
 
     /**
+     * Test that the Content-Range header uses a correct zero-based inclusive end index
+     * when no range parameter is provided.
+     *
+     * @tags    api
+     * @covers  API::getItems
+     */
+    public function testGetItemsDefaultRangeContentRangeHeader()
+    {
+        // Config always has more rows than the default list limit, ensuring a 206 response
+        $data = $this->query(
+            'getItems',
+            [
+                'itemtype' => 'Config',
+                'headers'  => ['Session-Token' => $this->session_token],
+            ],
+            206
+        );
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('headers', $data);
+
+        $headers = $data['headers'];
+        $this->assertArrayHasKey('Content-Range', $headers);
+
+        // Count only the item entries (exclude the 'headers' meta key)
+        $itemCount = count($data) - 1;
+        $this->assertGreaterThan(0, $itemCount);
+
+        // Parse Content-Range header: "start-end/total"
+        $contentRange = $headers['Content-Range'][0];
+        $this->assertMatchesRegularExpression('/^\d+-\d+\/\d+$/', $contentRange);
+
+        [$rangePart, $total] = explode('/', $contentRange);
+        [$start, $end] = explode('-', $rangePart);
+
+        $start = (int) $start;
+        $end   = (int) $end;
+        $total = (int) $total;
+
+        // Range is zero-based and inclusive: end must equal itemCount - 1, not itemCount
+        $this->assertSame(0, $start, 'Content-Range start should be 0');
+        $this->assertSame(
+            $itemCount - 1,
+            $end,
+            sprintf(
+                'Content-Range end should be %d (zero-based, inclusive) but got %d',
+                $itemCount - 1,
+                $end
+            )
+        );
+        $this->assertGreaterThan($itemCount, $total, 'Total should exceed returned item count for partial content');
+    }
+
+    /**
      * try to retrieve invalid range of users
      * We expect a http code 400
      *

--- a/src/Api/APIRest.php
+++ b/src/Api/APIRest.php
@@ -289,7 +289,7 @@ class APIRest extends API
                         $response = $this->getItems($itemtype, $this->parameters, $totalcount);
 
                         //add pagination headers
-                        $range = [0, $_SESSION['glpilist_limit']];
+                        $range = [0, $_SESSION['glpilist_limit'] - 1];
                         if (isset($this->parameters['range'])) {
                             $range = explode("-", $this->parameters['range']);
                         }

--- a/src/Api/APIXmlrpc.php
+++ b/src/Api/APIXmlrpc.php
@@ -180,7 +180,7 @@ class APIXmlrpc extends API
                 $response = $this->getItems($this->parameters['itemtype'], $this->parameters, $totalcount);
 
                 //add pagination headers
-                $range = [0, $_SESSION['glpilist_limit']];
+                $range = [0, $_SESSION['glpilist_limit'] - 1];
                 if (isset($this->parameters['range'])) {
                     $range = explode("-", $this->parameters['range']);
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43388
- Here is a brief description of what this PR does

When a GET request is sent to the REST API v1 endpoint for an itemtype without an explicit range parameter, the Content-Range response header reported an incorrect upper bound (e.g., 0-20/total instead of 0-19/total for a page of 
20 records). This is an off-by-one error: HTTP range indexing is zero-based and inclusive, so a page of N records starting at 0 must produce a range of 0 to N-1.

The fix corrects the default range initialization in APIRest.php to use `glpilist_limit - 1` as the upper bound, consistent with how getItems() already computes the SQL LIMIT internally.

A regression test (testGetItemsDefaultRangeContentRangeHeader) has been added to APIBaseClass.php to cover this scenario.

## Screenshots (if appropriate):

Before : 

<img width="374" height="83" alt="image" src="https://github.com/user-attachments/assets/eab7dd71-1414-47a9-b7e6-bbf5b5328668" />


After : 

<img width="374" height="83" alt="image" src="https://github.com/user-attachments/assets/cd8216e1-886e-4718-b65e-aac092c713ad" />
