### PR TITLE
Fix: cast size to float in Toolbox::getSize() for PHP 8 compatibility

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -867,7 +867,7 @@ class Toolbox
             }
         }
         //TRANS: %1$s is a number maybe float or string and %2$s the unit
-        return sprintf(__('%1$s %2$s'), round((float)$size, 2), $val);
+        return sprintf(__('%1$s %2$s'), round((float) $size, 2), $val);
     }
 
 

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -867,7 +867,7 @@ class Toolbox
             }
         }
         //TRANS: %1$s is a number maybe float or string and %2$s the unit
-        return sprintf(__('%1$s %2$s'), round($size, 2), $val);
+        return sprintf(__('%1$s %2$s'), round((float)$size, 2), $val);
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43493
Fixes a document display error via the URL /front/document.php, with the following error in php-errors.log:


```
 ==> php-errors.log <==

[2026-04-17 08:41:53] glpi.CRITICAL:   *** Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("round(): Argument #1 ($num) must be of type int|float, string given") in "pages/generic_list.html.twig" at line 37." at generic_list.html.twig line 37

  Backtrace :

  ./templates/pages/generic_list.html.twig:37

  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()

  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()

  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()

  .../Glpi/Application/View/TemplateRenderer.php:170 Twig\TemplateWrapper->render()

  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()

  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()

  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()

  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()

  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()

  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()

  Previous: round(): Argument #1 ($num) must be of type int|float, string given

  ./src/Toolbox.php:878

  ./src/Toolbox.php:878                              round()

  ./src/Document.php:1025                            Toolbox::getSize()

  ./src/Glpi/Search/Provider/SQLProvider.php:6877    Document::getSpecificValueToDisplay()

  ./src/Glpi/Search/Provider/SQLProvider.php:5265    Glpi\Search\Provider\SQLProvider::giveItem()

  ./src/Glpi/Search/SearchEngine.php:678             Glpi\Search\Provider\SQLProvider::constructData()

  ./src/Glpi/Search/SearchEngine.php:693             Glpi\Search\SearchEngine::getData()

  ./src/Glpi/Search/SearchEngine.php:650             Glpi\Search\SearchEngine::showOutput()

  :                                                  Glpi\Search\SearchEngine::show()

  ...Application/View/Extension/PhpExtension.php:105 call_user_func_array()

  ...ates/cd/cd3b54daa8e3cb9a2428d9d242841be3.php:55 Glpi\Application\View\Extension\PhpExtension->call()

  ./vendor/twig/twig/src/Template.php:402            __TwigTemplate_03549c4d60673a362d3db9922d392dca->doDisplay()

  ./vendor/twig/twig/src/Template.php:358            Twig\Template->yield()

  ./vendor/twig/twig/src/Template.php:373            Twig\Template->display()

  ./vendor/twig/twig/src/TemplateWrapper.php:51      Twig\Template->render()

  .../Glpi/Application/View/TemplateRenderer.php:170 Twig\TemplateWrapper->render()

  ./src/Glpi/Controller/AbstractController.php:68    Glpi\Application\View\TemplateRenderer->render()

  ./src/Glpi/Controller/GenericListController.php:51 Glpi\Controller\AbstractController->render()

  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\GenericListController->__invoke()

  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()

  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle() 
```

