### PR TITLE
Add Service Catalog plugin hook to display partner-facing News alerts

### DIFF
--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -123,6 +123,11 @@ class Hooks
     public const DISPLAY_CENTRAL             = 'display_central';
 
     /**
+     * Register a function to output some content on the service catalog page.
+     */
+    public const DISPLAY_SERVICE_CATALOG     = 'display_service_catalog';
+
+    /**
      * Register a function to output some content before the network port list.
      */
     public const DISPLAY_NETPORT_LIST_BEFORE = 'display_netport_list_before';
@@ -1359,6 +1364,7 @@ class Hooks
             self::DISPLAY_LOCKED_FIELDS,
             self::DISPLAY_LOGIN,
             self::DISPLAY_CENTRAL,
+            self::DISPLAY_SERVICE_CATALOG,
             self::INIT_SESSION,
             self::POST_KANBAN_CONTENT,
             self::PRE_KANBAN_CONTENT,

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -93,6 +93,8 @@
 {% endblock content_title %}
 
 {% block content_body %}
+    {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::DISPLAY_SERVICE_CATALOG')) }}
+
     <section
         aria-label="{{ __("Forms") }}"
         class="row mb-5"


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR adds a dedicated plugin hook on the Service Catalog page so plugins can inject contextual content directly in this entry point.
This request was raised by @PierreTeclib to help partners quickly see important recent GLPI fixes through News alerts displayed on the Service Catalog page.

This PR is designed to work together with the News plugin PR that adds a dedicated display target for Service Catalog alerts.
Related plugin PR: https://github.com/pluginsGLPI/news/pull/206
