### PR TITLE
Fix KB article missing scroll in edit mode

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -78,15 +78,9 @@
 }
 
 .kb-article {
+    position: relative;
     max-height: calc(100vh - 150px);
     overflow: auto;
-
-    // Allow bubble menu to overflow when editor is active
-    &:has(.is-editing) {
-        overflow: visible;
-        max-height: none;
-    }
-
     transition: width 0.35s ease-in-out;
 }
 

--- a/js/modules/KnowbaseEditor.js
+++ b/js/modules/KnowbaseEditor.js
@@ -126,12 +126,11 @@ class KnowbaseEditor {
             }),
             TiptapBubbleMenu.configure({
                 element: this.#bubbleMenuElement,
-                appendTo: () => document.body,
+                appendTo: () => this.#element.closest('.kb-article') ?? document.body,
                 shouldShow: ({ editor, state }) => !state.selection.empty && !editor.isActive('image'),
                 options: {
                     placement: 'top',
                     offset: 8,
-                    shift: {boundary: this.#element},
                 },
             }),
             TiptapTable.configure({


### PR DESCRIPTION
When entering edit mode, the KB container was expanding over his defined max height, which de-synchronized it from the side bar (see the blank space at the bottom right corner in the image below):

<img width="1938" height="1239" alt="image" src="https://github.com/user-attachments/assets/889cc647-0632-4331-bef6-41f8238a3559" />

It turns out to be caused by some css instructions that were meant to deal with the bubble menu overflow.

After removing them, the menu was out of sync with its target element after a scroll so I had to do a few more tweaks (mainly attaching it the KB container so it scrolls with it, previously it was attached to the top level body tag).