### PR TITLE
Restore creation date field and default on project creation

### DIFF
--- a/templates/pages/tools/project.html.twig
+++ b/templates/pages/tools/project.html.twig
@@ -43,11 +43,14 @@
 } %}
 
 {% block form_fields %}
+    {% set date = item.isNewItem() ? session('glpi_currenttime') : item.fields['date'] %}
+    {{ fields.datetimeField('date', date, __('Creation date'), field_options) }}
     {% if not item.isNewItem() and not is_template %}
-        {{ fields.datetimeField('date', item.fields['date'], __('Creation date'), field_options) }}
         {{ fields.htmlField('date_mod', item.fields['date_mod']|formatted_datetime|e, __('Last update')) }}
     {% elseif is_template and not item.isNewItem() and no_header %}
         {{ fields.autoNameField('template_name', item, __('Template name'), 0, field_options) }}
+        {{ fields.nullField() }}
+    {% elseif item.isNewItem() %}
         {{ fields.nullField() }}
     {% endif %}
     {{ fields.autoNameField('name', item, __('Name'), withtemplate, field_options) }}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23946

Restores the Creation Date `date` field to the new Project form as it was before #18959. When creating a new project, the field is populated with the current datetime but remains a customizable field like the Date field for Tickets to allow back-dating.