### PR TITLE
Fix port_vlan tagging in web form

### DIFF
--- a/front/networkport_vlan.form.php
+++ b/front/networkport_vlan.form.php
@@ -47,7 +47,7 @@ if (isset($_POST["add"])) {
         $npv->assignVlan(
             $_POST["networkports_id"],
             $_POST["vlans_id"],
-            (isset($_POST['tagged']) ? 1 : 0)
+            (isset($_POST['tagged']) ? ((int) $_POST['tagged']) : 0)
         );
         Event::log(
             0,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #23951 

When adding a VLAN to a network port in the web form, a "0" would be sent to `front/networkport_vlan.php` for the `tagged` value. Since this value was set, the front file was considering it to be tagged.
