### PR TITLE
fix searchoption group in global

### DIFF
--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -253,6 +253,19 @@ final class SearchOption implements ArrayAccess
                 $search[$itemtype][71]['table']         = 'glpi_groups';
                 $search[$itemtype][71]['field']         = 'completename';
                 $search[$itemtype][71]['name']          = Group::getTypeName(1);
+                $search[$itemtype][71]['condition']     = ['is_itemgroup' => 1];
+                $search[$itemtype][71]['joinparams']    = [
+                    'beforejoin'         => [
+                        'table'              => 'glpi_groups_items',
+                        'joinparams'         => [
+                            'jointype'           => 'itemtype_item',
+                            'condition'          => ['NEWTABLE.type' => Group_Item::GROUP_TYPE_NORMAL],
+                        ],
+                    ],
+                ];
+                $search[$itemtype][71]['forcegroupby']  = true;
+                $search[$itemtype][71]['massiveaction'] = false;
+                $search[$itemtype][71]['datatype']      = 'dropdown';
 
                 $search[$itemtype][19]['table']         = 'asset_types';
                 $search[$itemtype][19]['field']         = 'date_mod';

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -239,7 +239,5 @@ class SearchOptionTest extends DbTestCase
         $this->assertArrayHasKey('data', $result2);
         $this->assertArrayHasKey('rows', $result2['data']);
         $this->assertGreaterThan(0, $result2['data']['totalcount']);
-
-        $this->assertTrue(true, 'ok');
     }
 }

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -161,4 +161,85 @@ class SearchOptionTest extends DbTestCase
         // If we reach this point, the SQL was successful
         $this->assertTrue(true, 'Search completed without SQL error - fix is working');
     }
+
+    public function testAllAssetsGroupSearchResults(): void
+    {
+        $this->login();
+
+        $group = $this->createItem(
+            \Group::class,
+            [
+                'name'          => 'Test Normal Group ' . __FUNCTION__,
+                'is_itemgroup'  => 1,
+                'entities_id'   => $this->getTestRootEntity(true),
+            ]
+        );
+
+        $computer = $this->createItem(
+            \Computer::class,
+            [
+                'name'        => 'Test Computer ' . __FUNCTION__,
+                'entities_id' => $this->getTestRootEntity(true),
+            ]
+        );
+
+        $this->createItem(
+            \Group_Item::class,
+            [
+                'groups_id'   => $group->getID(),
+                'itemtype'    => \Computer::class,
+                'items_id'    => $computer->getID(),
+                'type'        => \Group_Item::GROUP_TYPE_NORMAL,
+            ]
+        );
+
+        $result = \Search::getDatas(
+            \AllAssets::class,
+            [
+                'criteria' => [
+                    [
+                        'field'      => 71,
+                        'searchtype' => 'equals',
+                        'value'      => $group->getID(),
+                    ],
+                ],
+                'forcetoview' => [1, 71],
+            ]
+        );
+
+        $this->assertArrayHasKey('data', $result);
+        $this->assertArrayHasKey('rows', $result['data']);
+        $this->assertEquals(1, $result['data']['totalcount'], '1 pc found');
+
+        $row = $result['data']['rows'][0];
+
+        $this->assertArrayHasKey('AllAssets_1', $row);
+        $this->assertStringContainsString('Test Computer ' . __FUNCTION__, $row['AllAssets_1']['displayname']);
+
+        $this->assertArrayHasKey('AllAssets_71', $row);
+        $this->assertStringContainsString(
+            'Test Normal Group ' . __FUNCTION__,
+            $row['AllAssets_71']['displayname']
+        );
+
+        $result2 = \Search::getDatas(
+            \AllAssets::class,
+            [
+                'criteria' => [
+                    [
+                        'field'      => 71,
+                        'searchtype' => 'contains',
+                        'value'      => 'Test Normal Group ' . __FUNCTION__,
+                    ],
+                ],
+                'forcetoview' => [1, 71],
+            ]
+        );
+
+        $this->assertArrayHasKey('data', $result2);
+        $this->assertArrayHasKey('rows', $result2['data']);
+        $this->assertGreaterThan(0, $result2['data']['totalcount']);
+
+        $this->assertTrue(true, 'ok');
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43439
- The search option group in the AllAssets view was missing join parameters to link items with groups through the glpi_groups_items table, causing the column to remain empty even when items were associated with groups.



