### PR TITLE
Use `hash_equals()` to validate webhook CRA challenge

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1119,10 +1119,10 @@ class Webhook extends CommonDBTM implements FilterableInterface
                 'query' => ['crc_token' => $secret_signature],
             ]);
 
-            if ($response->getStatusCode() == 200) {
+            if ($response->getStatusCode() === 200) {
                 $response_challenge = $response->getBody()->getContents();
                 //check response
-                if ($response_challenge == hash_hmac('sha256', $secret_signature, $decrypted_secret)) {
+                if (hash_equals(hash_hmac('sha256', $secret_signature, $decrypted_secret), $response_challenge)) {
                     $challenge_response = [
                         'status' => true,
                         'message' => __('Challenge–response authentication validated'),


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This replace a loose comparison by the usage of the dedicated `hash_equals()` method.