### PR TITLE
Fix(Form): load large form dropdown options via AJAX (> 50 items)

### DIFF
--- a/src/Glpi/Controller/Form/QuestionDropdownValuesController.php
+++ b/src/Glpi/Controller/Form/QuestionDropdownValuesController.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Form;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Form\AccessControl\FormAccessControlManager;
+use Glpi\Form\AccessControl\FormAccessParameters;
+use Glpi\Form\Form;
+use Glpi\Form\FormTranslation;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class QuestionDropdownValuesController extends AbstractController
+{
+    private const DEFAULT_PAGE_SIZE = 50;
+
+    #[Route(
+        "/Form/Question/DropdownValues",
+        name: "glpi_form_question_dropdown_values",
+        methods: "POST"
+    )]
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
+    public function __invoke(Request $request): Response
+    {
+        $this->checkFormAccessPolicies($request);
+
+        $question = $this->loadQuestion($request);
+
+        if (!$question->getQuestionType() instanceof QuestionTypeDropdown) {
+            throw new BadRequestHttpException();
+        }
+
+        $search_text = $request->request->getString('searchText', '');
+        $page        = max(1, $request->request->getInt('page', 1));
+        $page_size   = max(1, $request->request->getInt('page_limit', self::DEFAULT_PAGE_SIZE));
+
+        $question_type = new QuestionTypeDropdown();
+        $options       = $question_type->getOptions($question);
+
+        $results = [];
+        foreach ($options as $uuid => $option) {
+            $key   = sprintf('%s-%s', AbstractQuestionTypeSelectable::TRANSLATION_KEY_OPTION, $uuid);
+            $label = FormTranslation::translate($question, $key) ?? $option;
+
+            if ($search_text !== '' && stripos($label, $search_text) === false) {
+                continue;
+            }
+
+            $results[] = ['id' => $uuid, 'text' => $label];
+        }
+
+        $total        = count($results);
+        $offset       = ($page - 1) * $page_size;
+        $page_results = array_slice($results, $offset, $page_size);
+
+        return new JsonResponse([
+            'results'    => $page_results,
+            'count'      => $total,
+            'pagination' => ['more' => $offset + $page_size < $total],
+        ]);
+    }
+
+    private function loadQuestion(Request $request): Question
+    {
+        $question_id = $request->request->getInt('question_id');
+        if (!$question_id) {
+            throw new BadRequestHttpException();
+        }
+
+        $question = Question::getById($question_id);
+        if (!$question instanceof Question) {
+            throw new NotFoundHttpException();
+        }
+
+        return $question;
+    }
+
+    private function checkFormAccessPolicies(Request $request): void
+    {
+        if (Session::haveRight(Form::$rightname, READ)) {
+            return;
+        }
+
+        $forms_id = $request->request->getInt('form_id');
+        if (!$forms_id) {
+            throw new BadRequestHttpException();
+        }
+
+        $form = Form::getById($forms_id);
+        if (!$form instanceof Form) {
+            throw new NotFoundHttpException();
+        }
+
+        $parameters = new FormAccessParameters(
+            session_info: Session::getCurrentSessionInfo(),
+            url_parameters: $request->query->all(),
+        );
+
+        if (!FormAccessControlManager::getInstance()->canAnswerForm($form, $parameters)) {
+            throw new AccessDeniedHttpException();
+        }
+    }
+}

--- a/src/Glpi/Controller/Form/QuestionDropdownValuesController.php
+++ b/src/Glpi/Controller/Form/QuestionDropdownValuesController.php
@@ -35,19 +35,15 @@
 namespace Glpi\Controller\Form;
 
 use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Glpi\Form\AccessControl\FormAccessControlManager;
-use Glpi\Form\AccessControl\FormAccessParameters;
-use Glpi\Form\Form;
 use Glpi\Form\FormTranslation;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeDropdown;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
-use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -55,6 +51,7 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class QuestionDropdownValuesController extends AbstractController
 {
+    use CanCheckAccessPolicies;
     private const DEFAULT_PAGE_SIZE = 50;
 
     #[Route(
@@ -65,9 +62,9 @@ final class QuestionDropdownValuesController extends AbstractController
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(Request $request): Response
     {
-        $this->checkFormAccessPolicies($request);
-
         $question = $this->loadQuestion($request);
+
+        $this->checkFormAccessPolicies($question->getForm(), $request);
 
         if (!$question->getQuestionType() instanceof QuestionTypeDropdown) {
             throw new BadRequestHttpException();
@@ -118,29 +115,5 @@ final class QuestionDropdownValuesController extends AbstractController
         return $question;
     }
 
-    private function checkFormAccessPolicies(Request $request): void
-    {
-        if (Session::haveRight(Form::$rightname, READ)) {
-            return;
-        }
 
-        $forms_id = $request->request->getInt('form_id');
-        if (!$forms_id) {
-            throw new BadRequestHttpException();
-        }
-
-        $form = Form::getById($forms_id);
-        if (!$form instanceof Form) {
-            throw new NotFoundHttpException();
-        }
-
-        $parameters = new FormAccessParameters(
-            session_info: Session::getCurrentSessionInfo(),
-            url_parameters: $request->query->all(),
-        );
-
-        if (!FormAccessControlManager::getInstance()->canAnswerForm($form, $parameters)) {
-            throw new AccessDeniedHttpException();
-        }
-    }
 }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -279,6 +279,10 @@ TWIG;
         );
 
         $options = $this->getOptions($question);
+        if (count($options) > 50) {
+            return $this->renderEndUserTemplateAjax($question, $options, $checked_values);
+        }
+
         $translated_options = [];
         foreach ($options as $uuid => $option) {
             $key = sprintf('%s-%s', self::TRANSLATION_KEY_OPTION, $uuid);
@@ -290,6 +294,86 @@ TWIG;
             'label'          => $question->fields['name'],
             'values'         => $translated_options,
             'checked_values' => $checked_values,
+            'is_multiple'    => $this->isMultipleDropdown($question),
+        ]);
+    }
+
+    /**
+     * Render end-user template for large option lists (> 50) using AJAX-backed Select2.
+     *
+     * @param array<string, string> $options        All available options (uuid → label)
+     * @param list<string>          $checked_values UUIDs of pre-selected options
+     */
+    private function renderEndUserTemplateAjax(
+        Question $question,
+        array $options,
+        array $checked_values,
+    ): string {
+        global $CFG_GLPI;
+
+        $template = <<<TWIG
+            {% set rand = random() %}
+
+            <div class="col-12 mb-0">
+                <select
+                    id="dropdown_{{ rand }}"
+                    name="{{ input_name }}"
+                    class="form-select select2"
+                    aria-label="{{ label|e }}"
+                    {{ is_multiple ? 'multiple' : '' }}
+                >
+                    {% for uuid, text in initial_values %}
+                        <option value="{{ uuid }}" selected>{{ text|e }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <script>
+            (function() {
+                var el = $('#dropdown_{{ rand }}');
+                el.select2({
+                    ajax: {
+                        url:      '{{ ajax_url }}',
+                        type:     'POST',
+                        dataType: 'json',
+                        delay:    250,
+                        data: function(params) {
+                            return {
+                                searchText:  params.term || '',
+                                page:        params.page || 1,
+                                page_limit:  50,
+                                form_id:     {{ form_id }},
+                                question_id: {{ question_id }},
+                            };
+                        },
+                        processResults: function(data) {
+                            return { results: data.results, pagination: data.pagination };
+                        },
+                    },
+                    allowClear:  true,
+                    placeholder: '',
+                    width:       '100%',
+                    multiple:    {{ is_multiple ? 'true' : 'false' }},
+                });
+            })();
+            </script>
+TWIG;
+
+        $initial_values = [];
+        foreach ($checked_values as $uuid) {
+            if (isset($options[$uuid])) {
+                $key = sprintf('%s-%s', self::TRANSLATION_KEY_OPTION, $uuid);
+                $initial_values[$uuid] = FormTranslation::translate($question, $key) ?? $options[$uuid];
+            }
+        }
+
+        return TemplateRenderer::getInstance()->renderFromStringTemplate($template, [
+            'label'          => $question->fields['name'],
+            'input_name'     => $question->getEndUserInputName(),
+            'form_id'        => $question->getForm()->getID(),
+            'question_id'    => $question->fields['id'],
+            'ajax_url'       => $CFG_GLPI['root_doc'] . '/Form/Question/DropdownValues',
+            'initial_values' => $initial_values,
             'is_multiple'    => $this->isMultipleDropdown($question),
         ]);
     }

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -319,11 +319,11 @@ TWIG;
                     id="dropdown_{{ rand }}"
                     name="{{ input_name }}"
                     class="form-select select2"
-                    aria-label="{{ label|e }}"
+                    aria-label="{{ label }}"
                     {{ is_multiple ? 'multiple' : '' }}
                 >
                     {% for uuid, text in initial_values %}
-                        <option value="{{ uuid }}" selected>{{ text|e }}</option>
+                        <option value="{{ uuid }}" selected>{{ text }}</option>
                     {% endfor %}
                 </select>
             </div>
@@ -333,7 +333,7 @@ TWIG;
                 var el = $('#dropdown_{{ rand }}');
                 el.select2({
                     ajax: {
-                        url:      '{{ ajax_url }}',
+                        url:      '{{ ajax_url|e('js') }}',
                         type:     'POST',
                         dataType: 'json',
                         delay:    250,
@@ -342,7 +342,7 @@ TWIG;
                                 searchText:  params.term || '',
                                 page:        params.page || 1,
                                 page_limit:  50,
-                                question_id: {{ question_id }},
+                                question_id: '{{ question_id|e('js') }}',
                             };
                         },
                         processResults: function(data) {

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -342,7 +342,6 @@ TWIG;
                                 searchText:  params.term || '',
                                 page:        params.page || 1,
                                 page_limit:  50,
-                                form_id:     {{ form_id }},
                                 question_id: {{ question_id }},
                             };
                         },
@@ -370,7 +369,6 @@ TWIG;
         return TemplateRenderer::getInstance()->renderFromStringTemplate($template, [
             'label'          => $question->fields['name'],
             'input_name'     => $question->getEndUserInputName(),
-            'form_id'        => $question->getForm()->getID(),
             'question_id'    => $question->fields['id'],
             'ajax_url'       => $CFG_GLPI['root_doc'] . '/Form/Question/DropdownValues',
             'initial_values' => $initial_values,

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -301,8 +301,8 @@ TWIG;
     /**
      * Render end-user template for large option lists (> 50) using AJAX-backed Select2.
      *
-     * @param array<string, string> $options        All available options (uuid → label)
-     * @param list<string>          $checked_values UUIDs of pre-selected options
+     * @param array<string, string> $options        All available options (uuid -> label)
+     * @param array<string>         $checked_values UUIDs of pre-selected options
      */
     private function renderEndUserTemplateAjax(
         Question $question,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43313

A form with many dropdown values can take a long time to load for the user (11 seconds in my example). 
_With these modifications, the loading time is reduced to 1 second_.
