### PR TITLE
KB: remove "@" prefix from user badges

### DIFF
--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -216,11 +216,11 @@
                                 class="badge bg-azure-lt ms-1"
                                 data-testid="author_link"
                             >
-                                @{{ last_update_author_name }}
+                                {{ last_update_author_name }}
                             </a>
                         {% else %}
                             <span class="badge bg-dark-lt ms-1">
-                                @{{ last_update_author_name }}
+                                {{ last_update_author_name }}
                             </span>
                         {% endif %}
                     </address>

--- a/templates/pages/tools/kb/sidepanel/revision_item.html.twig
+++ b/templates/pages/tools/kb/sidepanel/revision_item.html.twig
@@ -74,7 +74,7 @@
                 {% set user = users.getUser(event.getAuthor()) %}
                 {% if user %}
                     <a rel="author" href="{{ user.getLinkUrl() }}" class="badge bg-azure-lt ms-1">
-                        @{{ user.getFriendlyName() }}
+                        {{ user.getFriendlyName() }}
                     </a>
                 {% else %}
                     <span class="badge bg-secondary-lt ms-1">{{ __("Deleted user") }}</span>

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -1789,7 +1789,7 @@ HTML,
         $author_link = $html->filter('[data-testid=author_link]');
 
         // Assert: last update should be contain relative date + the author name
-        $this->assertEquals("Updated: 2 days ago by @_test_user", $last_update);
+        $this->assertEquals("Updated: 2 days ago by _test_user", $last_update);
         $this->assertCount(1, $author_link);
     }
 
@@ -1811,7 +1811,7 @@ HTML,
         $author_link = $html->filter('[data-testid=author_link]');
 
         // Assert: last update should be contain relative date + the author name
-        $this->assertEquals("Updated: 2 days ago by @Deleted user", $last_update);
+        $this->assertEquals("Updated: 2 days ago by Deleted user", $last_update);
         $this->assertCount(0, $author_link);
     }
 


### PR DESCRIPTION
Before:
<img width="560" height="139" alt="image" src="https://github.com/user-attachments/assets/4bfcbb51-3d7e-421f-880d-f62ca61b4f41" />


After:
<img width="559" height="136" alt="image" src="https://github.com/user-attachments/assets/b3a54d52-d43a-4701-a487-8112a95b8d19" />


