### PR TITLE
KB: always show add comment button, use required state instead

### DIFF
--- a/js/modules/Knowbase/CommentsPanelController.js
+++ b/js/modules/Knowbase/CommentsPanelController.js
@@ -69,14 +69,6 @@ export class GlpiKnowbaseCommentsPanelController
 
     #initEventListeners()
     {
-        this.#container.addEventListener('input', (e) => {
-            // Show submit button when typing a new comment
-            const textarea = e.target.closest(content_selector);
-            if (textarea) {
-                this.#toggleSubmitButtonVisibility(textarea);
-            }
-        });
-
         this.#container.addEventListener('click', (e) => {
             // Submit new comment
             const submit = e.target.closest(submit_selector);
@@ -237,17 +229,12 @@ export class GlpiKnowbaseCommentsPanelController
         this.#showEmptyStateIfNoComments();
     }
 
-    #toggleSubmitButtonVisibility(textarea)
-    {
-        if (textarea.value !== '') {
-            this.#getSubmitButton().classList.remove('d-none');
-        } else {
-            this.#getSubmitButton().classList.add('d-none');
-        }
-    }
-
     async #submitComment()
     {
+        if (!this.#getContentTextarea().reportValidity()) {
+            return;
+        }
+
         // Show loading state
         this.#getSubmitButton().classList.add('pointer-events-none');
         this.#getSubmitButton()
@@ -268,7 +255,6 @@ export class GlpiKnowbaseCommentsPanelController
         // Clear input/UI
         this.#getContentTextarea().value = "";
         this.#getSubmitButton().classList.remove('pointer-events-none');
-        this.#getSubmitButton().classList.add('d-none');
         this.#getSubmitButton()
             .querySelector('[data-glpi-icon]')
             .classList

--- a/templates/pages/tools/kb/sidepanel/comments.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments.html.twig
@@ -70,6 +70,7 @@
             rows="1"
             placeholder="{{ __('Add a comment...') }}"
             name="new_comment"
+            required
             data-glpi-add-comments-content
         ></textarea>
     </div>
@@ -77,7 +78,7 @@
     <div class="d-flex mt-3">
         <button
             type="button"
-            class="btn btn-sm btn-primary ms-auto d-none"
+            class="btn btn-sm btn-primary ms-auto"
             data-glpi-add-comments-submit
             aria-label="{{ __('Add comment') }}"
         >

--- a/tests/e2e/specs/Knowbase/comments.spec.ts
+++ b/tests/e2e/specs/Knowbase/comments.spec.ts
@@ -64,14 +64,17 @@ test('Can view and add comments', async ({ page, profile, api }) => {
     await expect(page.getByText('E2E API account · Just now')).toBeVisible();
     await expect(kb.getCommentByContent('My first comment')).toBeVisible();
 
-    // Add a new comment
-    await expect(kb.getButton("Add comment")).toBeHidden();
+    // Add a new comment without text (should fail due to required attribute)
+    await expect(kb.getNewCommentTextarea()).toHaveJSProperty('validity.valueMissing', true);
+    await kb.getButton("Add comment").click();
+    await expect(kb.getCommentsCounter()).toHaveText("1");
+
+    // Add a new comment with text
     await kb.getNewCommentTextarea().fill("My second comment");
-    await expect(kb.getButton("Add comment")).toBeVisible();
+    await expect(kb.getNewCommentTextarea()).toHaveJSProperty('validity.valueMissing', false);
     await kb.getButton("Add comment").click();
 
     // New comment should be added
-    await expect(kb.getButton("Add comment")).toBeHidden();
     await expect(kb.getNewCommentTextarea()).toBeEmpty();
     await expect(page.getByText(/E2E worker account \d+\s+·\s+Now/)).toBeVisible();
     await expect(kb.getCommentByContent('My second comment')).toBeVisible();


### PR DESCRIPTION
Before:
<img width="522" height="130" alt="commentbefore" src="https://github.com/user-attachments/assets/9f801657-c04b-4997-90e2-4b9b3de7d3a4" />

After:
<img width="520" height="168" alt="commentafter" src="https://github.com/user-attachments/assets/46a16762-c91c-4ec1-bbf1-37884c8ed4bd" />
