### PR TITLE
Set use_notification when adding a user to a ITIlObject in UserMentio…

### DIFF
--- a/src/Glpi/RichText/UserMention.php
+++ b/src/Glpi/RichText/UserMention.php
@@ -166,7 +166,7 @@ final class UserMention
                     $current_actors_ids[] = $actor['users_id'];
                 }
             }
-            // Get notification setting 
+            // Get notification setting
             $defaults = $main_item::getDefaultValues($main_item->getEntityID());
             $default_use_notif = $defaults['_users_id_observer_notif']['use_notification'];
             if (is_array($default_use_notif)) {

--- a/src/Glpi/RichText/UserMention.php
+++ b/src/Glpi/RichText/UserMention.php
@@ -166,20 +166,12 @@ final class UserMention
                     $current_actors_ids[] = $actor['users_id'];
                 }
             }
-            // Get notification setting
-            $defaults = $main_item::getDefaultValues($main_item->getEntityID());
-            $default_use_notif = $defaults['_users_id_observer_notif']['use_notification'];
-            if (is_array($default_use_notif)) {
-                #Ticket return an array but change and problem return value directly
-                $default_use_notif = $default_use_notif[0];
-            }
-
+            $default_use_notif = \Entity::getUsedConfig('is_notif_enable_default', $main_item->getEntityID(), '', 1);
             // Add newly mentioned actors as observers
             foreach ($mentionned_actors_ids as $user_id) {
                 if (in_array($user_id, $current_actors_ids)) {
                     continue;
                 }
-
                 $input = [
                     'type'                            => CommonITILActor::OBSERVER,
                     'users_id'                        => $user_id,

--- a/src/Glpi/RichText/UserMention.php
+++ b/src/Glpi/RichText/UserMention.php
@@ -166,6 +166,13 @@ final class UserMention
                     $current_actors_ids[] = $actor['users_id'];
                 }
             }
+            // Get notification setting 
+            $defaults = $main_item::getDefaultValues($main_item->getEntityID());
+            $default_use_notif = $defaults['_users_id_observer_notif']['use_notification'];
+            if (is_array($default_use_notif)) {
+                #Ticket return an array but change and problem return value directly
+                $default_use_notif = $default_use_notif[0];
+            }
 
             // Add newly mentioned actors as observers
             foreach ($mentionned_actors_ids as $user_id) {
@@ -179,6 +186,7 @@ final class UserMention
                     $main_item->getForeignKeyField()  => $main_item->fields['id'],
                     '_do_not_compute_takeintoaccount' => true,
                     '_from_object'                    => true,
+                    'use_notification'                => $default_use_notif,
                 ];
                 $userlink->add($input);
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23975 
- It adds the use_notification parameter for ITILObjects in UserMention.php
However I'm not quite sure if how I get this value is correct. I noticed the getDefaultValue function 
differs slightly between change and problem and more substantially for tickets. Perhaps this part should should be unified in a common base function and only the needed extra values are adjusted. But I'm unsure if this to much for a bugfix.
