### PR TITLE
Change KB document/linked items button to outline secondary

### DIFF
--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -399,7 +399,7 @@
                         {% if can_add_documents %}
                             <button
                                 type="button"
-                                class="btn btn-sm btn-primary mt-2"
+                                class="btn btn-sm btn-outline-secondary mt-2"
                                 data-bs-toggle="modal"
                                 data-bs-target="#kb-add-document-modal"
                             >
@@ -552,7 +552,7 @@
                     </div>
 
                     {% if can_link_items %}
-                    <button type="button" class="btn btn-sm btn-primary mt-2"
+                    <button type="button" class="btn btn-sm btn-outline-secondary mt-2"
                             data-glpi-kb-action="OPEN_MODAL"
                             data-glpi-kb-action-param-id="{{ item_id }}"
                             data-glpi-kb-action-param-key="LinkItemModal"


### PR DESCRIPTION
Before:

<img width="476" height="270" alt="image" src="https://github.com/user-attachments/assets/a488a226-fe47-4d38-8280-87e21ba2a087" />


After:

<img width="308" height="277" alt="image" src="https://github.com/user-attachments/assets/401792bc-10a4-4283-a082-05852a2aa703" />
