### PR TITLE
FIX / Knowbaseitem FaQ image relink

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -300,6 +300,13 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             ]
         );
 
+        $answer = $this->relinkEmbeddedDocumentsFromLinkedItemContext($this->fields['answer'] ?? null);
+        if ($answer !== null && $answer !== ($this->fields['answer'] ?? null)) {
+            $this->fields['answer'] = $answer;
+            $this->input['answer'] = $answer;
+            $this->updateInDB(['answer']);
+        }
+
         if (isset($this->input["_visibility"]['_type']) && !empty($this->input["_visibility"]["_type"])) {
             $this->input["_visibility"]['knowbaseitems_id'] = $this->getID();
             $item                                           = null;
@@ -371,6 +378,130 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, "_categories");
 
         NotificationEvent::raiseEvent('new', $this);
+    }
+
+    /**
+     * Recontextualize embedded document URLs from source item to current KnowbaseItem.
+     *
+     * @param ?string $answer
+     *
+     * @return ?string
+     */
+    private function relinkEmbeddedDocumentsFromLinkedItemContext(?string $answer): ?string
+    {
+        global $DB;
+
+        if ($answer === null || $answer === '') {
+            return $answer;
+        }
+
+        $source_itemtype = $this->input['_itemtype'] ?? null;
+        $source_items_id = $this->input['_items_id'] ?? null;
+        if (
+            !is_string($source_itemtype)
+            || !is_a($source_itemtype, CommonDBTM::class, true)
+            || !is_numeric($source_items_id)
+            || (int) $source_items_id <= 0
+        ) {
+            return $answer;
+        }
+        $source_items_id = (int) $source_items_id;
+
+        $matches = [];
+        preg_match_all('/(?:https?:\/\/[^"\'\s<>]+)?\/front\/document\.send\.php\?[^"\'\s<>]+/i', $answer, $matches);
+        if (!isset($matches[0]) || count($matches[0]) === 0) {
+            return $answer;
+        }
+
+        $document_item = new Document_Item();
+        foreach (array_unique($matches[0]) as $document_url) {
+            if (!is_string($document_url) || $document_url === '') {
+                continue;
+            }
+
+            $decoded_url = html_entity_decode($document_url, ENT_QUOTES | ENT_HTML5);
+            $query = parse_url($decoded_url, PHP_URL_QUERY);
+            if (!is_string($query) || $query === '') {
+                continue;
+            }
+
+            parse_str($query, $params);
+            $document_id = (int) ($params['docid'] ?? 0);
+            if (
+                $document_id <= 0
+                || ($params['itemtype'] ?? null) !== $source_itemtype
+                || (int) ($params['items_id'] ?? 0) !== $source_items_id
+            ) {
+                continue;
+            }
+
+            if (!$this->canRelinkEmbeddedDocumentFromSourceContext($document_id, $source_itemtype, $source_items_id)) {
+                continue;
+            }
+
+            $target_link = [
+                'documents_id' => $document_id,
+                'itemtype'     => self::class,
+                'items_id'     => $this->getID(),
+            ];
+            if (!$document_item->alreadyExists($target_link)) {
+                $document_item->add($target_link);
+            }
+
+            $params['itemtype'] = self::class;
+            $params['items_id'] = $this->getID();
+            $base_url = strtok($decoded_url, '?');
+            if (!is_string($base_url) || $base_url === '') {
+                continue;
+            }
+            $updated_url = htmlescape($base_url . '?' . http_build_query($params, '', '&amp;', PHP_QUERY_RFC3986));
+            $answer = str_replace($document_url, $updated_url, $answer);
+        }
+
+        return $answer;
+    }
+
+    /**
+     * Ensure a document can be safely re-linked from a source context.
+     *
+     * @param int    $document_id
+     * @param string $source_itemtype
+     * @param int    $source_items_id
+     *
+     * @return bool
+     */
+    private function canRelinkEmbeddedDocumentFromSourceContext(
+        int $document_id,
+        string $source_itemtype,
+        int $source_items_id
+    ): bool {
+        global $DB;
+
+        $source_link = $DB->request([
+            'FROM'  => Document_Item::getTable(),
+            'COUNT' => 'cpt',
+            'WHERE' => [
+                'documents_id' => $document_id,
+                'itemtype'     => $source_itemtype,
+                'items_id'     => $source_items_id,
+            ],
+            'LIMIT' => 1,
+        ])->current();
+
+        if ((int) ($source_link['cpt'] ?? 0) > 0) {
+            return true;
+        }
+
+        if (!is_a($source_itemtype, CommonITILObject::class, true)) {
+            return false;
+        }
+
+        $document = new Document();
+        return $document->getFromDB($document_id)
+            && $document->canViewFile([
+                'itemtype' => $source_itemtype,
+                'items_id' => $source_items_id,
+            ]);
     }
 
     public function post_getFromDB()

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -45,9 +45,9 @@ use Glpi\Form\ServiceCatalog\ServiceCatalogLeafInterface;
 use Glpi\RichText\RichText;
 use Glpi\Search\Output\HTMLSearchOutput;
 
+use function Safe\parse_url;
 use function Safe\preg_match;
 use function Safe\preg_match_all;
-use function Safe\parse_url;
 use function Safe\preg_replace;
 use function Safe\preg_replace_callback;
 

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -46,6 +46,8 @@ use Glpi\RichText\RichText;
 use Glpi\Search\Output\HTMLSearchOutput;
 
 use function Safe\preg_match;
+use function Safe\preg_match_all;
+use function Safe\parse_url;
 use function Safe\preg_replace;
 use function Safe\preg_replace_callback;
 
@@ -409,7 +411,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
         $matches = [];
         preg_match_all('/(?:https?:\/\/[^"\'\s<>]+)?\/front\/document\.send\.php\?[^"\'\s<>]+/i', $answer, $matches);
-        if (!isset($matches[0]) || count($matches[0]) === 0) {
+        if (count($matches[0]) === 0) {
             return $answer;
         }
 
@@ -421,7 +423,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
             $decoded_url = html_entity_decode($document_url, ENT_QUOTES | ENT_HTML5);
             $query = parse_url($decoded_url, PHP_URL_QUERY);
-            if (!is_string($query) || $query === '') {
+            if ($query === '') {
                 continue;
             }
 
@@ -451,7 +453,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             $params['itemtype'] = self::class;
             $params['items_id'] = $this->getID();
             $base_url = strtok($decoded_url, '?');
-            if (!is_string($base_url) || $base_url === '') {
+            if ($base_url === false) {
                 continue;
             }
             $updated_url = htmlescape($base_url . '?' . http_build_query($params, '', '&amp;', PHP_QUERY_RFC3986));

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -423,7 +423,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
             $decoded_url = html_entity_decode($document_url, ENT_QUOTES | ENT_HTML5);
             $query = parse_url($decoded_url, PHP_URL_QUERY);
-            if ($query === '') {
+            if (!is_string($query)) {
                 continue;
             }
 

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -490,11 +490,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             'LIMIT' => 1,
         ])->current();
 
-        if ((int) ($source_link['cpt'] ?? 0) > 0) {
-            return true;
-        }
-
-        if (!is_a($source_itemtype, CommonITILObject::class, true)) {
+        if (
+            (int) ($source_link['cpt'] ?? 0) <= 0
+            && !is_a($source_itemtype, CommonITILObject::class, true)
+        ) {
             return false;
         }
 

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -1748,4 +1748,118 @@ HTML,
         ]);
         $this->assertTrue($fn_can_tech_see_kb());
     }
+
+    public function testRelinkEmbeddedDocumentsFromTicketSolution(): void
+    {
+        $this->login();
+
+        $ticket = $this->createItem(\Ticket::class, [
+            'name'    => __FUNCTION__,
+            'content' => __FUNCTION__,
+        ]);
+
+        $document = $this->createItem(\Document::class, [
+            'name'     => __FUNCTION__,
+            'filename' => 'test.txt',
+        ]);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \Ticket::class,
+            'items_id'     => $ticket->getID(),
+        ]);
+
+        $doc_url = '/front/document.send.php?docid=' . $document->getID()
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
+
+        $kb = $this->createItem(\KnowbaseItem::class, [
+            'name'       => __FUNCTION__,
+            'answer'     => '<p><a href="' . $doc_url . '">doc</a></p>',
+            'is_faq'     => 0,
+            'users_id'   => \Session::getLoginUserID(),
+            '_itemtype'  => \Ticket::class,
+            '_items_id'  => $ticket->getID(),
+            '_do_item_link' => false,
+        ]);
+
+        $this->assertTrue($kb->getFromDB($kb->getID()));
+
+        $this->assertStringContainsString('itemtype=KnowbaseItem', $kb->fields['answer']);
+        $this->assertStringContainsString('items_id=' . $kb->getID(), $kb->fields['answer']);
+        $this->assertStringNotContainsString('itemtype=Ticket', $kb->fields['answer']);
+
+        $this->assertEquals(
+            1,
+            countElementsInTable(\Document_Item::getTable(), [
+                'documents_id' => $document->getID(),
+                'itemtype'     => \KnowbaseItem::class,
+                'items_id'     => $kb->getID(),
+            ])
+        );
+    }
+
+    public function testRelinkEmbeddedDocumentsBlockedWithoutSourceAccess(): void
+    {
+        $this->login();
+
+        $ticket = $this->createItem(\Ticket::class, [
+            'name'    => __FUNCTION__,
+            'content' => __FUNCTION__,
+        ]);
+
+        $document = $this->createItem(\Document::class, [
+            'name'     => __FUNCTION__,
+            'filename' => 'test.txt',
+        ]);
+
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \Ticket::class,
+            'items_id'     => $ticket->getID(),
+        ]);
+
+        $profile = $this->createItem(\Profile::class, [
+            'name'      => __FUNCTION__,
+            'interface' => 'central',
+            'knowbase'  => \KnowbaseItem::PUBLISHFAQ | CREATE,
+            'ticket'    => 0,
+        ]);
+
+        $user = $this->createItem(\User::class, [
+            'name'         => __FUNCTION__,
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => $profile->getID(),
+            '_entities_id' => 0,
+        ]);
+
+        $this->login($user->fields['name'], 'testpassword');
+
+        $doc_url = '/front/document.send.php?docid=' . $document->getID()
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
+
+        $kb = $this->createItem(\KnowbaseItem::class, [
+            'name'          => __FUNCTION__,
+            'answer'        => '<p><a href="' . $doc_url . '">doc</a></p>',
+            'is_faq'        => 1,
+            'users_id'      => $user->getID(),
+            '_itemtype'     => \Ticket::class,
+            '_items_id'     => $ticket->getID(),
+            '_do_item_link' => false,
+        ]);
+
+        $this->assertTrue($kb->getFromDB($kb->getID()));
+
+        $this->assertStringNotContainsString('itemtype=KnowbaseItem', $kb->fields['answer']);
+        $this->assertStringContainsString('itemtype=Ticket', $kb->fields['answer']);
+
+        $this->assertEquals(
+            0,
+            countElementsInTable(\Document_Item::getTable(), [
+                'documents_id' => $document->getID(),
+                'itemtype'     => \KnowbaseItem::class,
+                'items_id'     => $kb->getID(),
+            ])
+        );
+    }
 }

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -1780,7 +1780,7 @@ HTML,
             '_itemtype'  => \Ticket::class,
             '_items_id'  => $ticket->getID(),
             '_do_item_link' => false,
-        ]);
+        ], ['answer']);
 
         $this->assertTrue($kb->getFromDB($kb->getID()));
 
@@ -1831,7 +1831,7 @@ HTML,
             'password2'    => 'testpassword',
             '_profiles_id' => $profile->getID(),
             '_entities_id' => 0,
-        ]);
+        ], ['password', 'password2']);
 
         $this->login($user->fields['name'], 'testpassword');
 
@@ -1846,7 +1846,7 @@ HTML,
             '_itemtype'     => \Ticket::class,
             '_items_id'     => $ticket->getID(),
             '_do_item_link' => false,
-        ]);
+        ], ['answer']);
 
         $this->assertTrue($kb->getFromDB($kb->getID()));
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43385
- This PR fixes an issue where images embedded in a ticket solution remain linked to the Ticket context after creating a Knowledge Base article from that solution. As a result, FAQ-only users (without Ticket read permissions) cannot see those images, because document access is still evaluated against the Ticket context.

The fix adds a post-processing step when creating a Knowledge Base article to re-link embedded document URLs from the source ITIL context (like Ticket) to the new KnowbaseItem context.
It detects inline `document.send.php` links in the article content, validates each referenced document against the source context, creates missing `Document_Item` links to the KB article, and rewrites URLs to `itemtype=KnowbaseItem`.

From a security perspective, ACL behavior is unchanged: no access bypass was added, `document.send.php` authorization remains intact, and re-linking only applies to documents that are explicitly validated as legitimate from the source context.

## Screenshots :

Before fix : 

<img width="1544" height="898" alt="solution_w_embedded_image 2026-04-22" src="https://github.com/user-attachments/assets/a48b4ce2-2414-43e9-aad1-6fb1750369ff" />
<img width="1544" height="898" alt="broken_image_for_user 2026-04-22" src="https://github.com/user-attachments/assets/b7b17189-0f30-4a87-bb33-e624c48fdfa4" />
<img width="584" height="29" alt="link_ticket_item 2026-04-22" src="https://github.com/user-attachments/assets/041119d3-a0b5-4bc4-9f14-a346fc83333a" />


After fix : 

<img width="1429" height="810" alt="user_faq_access_image 2026-04-22" src="https://github.com/user-attachments/assets/e7312fc5-6cfb-4341-ab0f-0421cccc76ca" />
<img width="696" height="46" alt="link_knowbase_item 2026-04-22" src="https://github.com/user-attachments/assets/2a36df09-1611-4f8e-9cb1-8955d7b2a973" />



