### PR TITLE
Remove name header for KB articles

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1228,6 +1228,17 @@ class CommonGLPI implements CommonGLPIInterface
     }
 
     /**
+     * Whether to display the type icon and name title in the form header.
+     *
+     * Override this method and return false to hide the icon ribbon and type/name title
+     * from the form header (e.g. for items that render their own title inside the form body).
+     */
+    public function showFriendlyNameBadgeInForm(): bool
+    {
+        return true;
+    }
+
+    /**
      * Compute the name to be used in the main header of this item.
      *
      * @return string

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2430,6 +2430,12 @@ TWIG, $twig_params);
         return "ti ti-lifebuoy";
     }
 
+    #[Override]
+    public function showFriendlyNameBadgeInForm(): bool
+    {
+        return false;
+    }
+
     /**
      * @param array $params
      *

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -79,28 +79,30 @@
              value="{{ template_name }}" />
    {% endif %}
    <h3 class="card-title d-flex align-items-center ps-0 {{ in_navheader ? "ps-sm-5" : "ps-sm-4" }}">
-      {% set icon = item.getIcon() %}
-      {% if not in_navheader and icon|length > 0 %}
-         <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-            <i class="{{ icon }} fa-2x"></i>
-         </div>
-      {% endif %}
-      <span {% if in_navheader %} class="status rounded-1 me-1" {% endif %}>
-         {% if in_navheader %}
-            <i class="{{ icon }}"></i>
+      {% if item.showFriendlyNameBadgeInForm() %}
+         {% set icon = item.getIcon() %}
+         {% if not in_navheader and icon|length > 0 %}
+            <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
+               <i class="{{ icon }} fa-2x"></i>
+            </div>
          {% endif %}
-         {% if withtemplate == 1 and item.id > 0 %}
-            {{ _n('Template', 'Templates', 1) }} - {{ nametype }} - {{ template_name }}
-         {% elseif not item.isNewItem() %}
-            {{ nametype }} - <span id="header-friendlyname"> {{ friendlyname }} </span>
-         {% else %}
-            {{ nametype }}
+         <span {% if in_navheader %} class="status rounded-1 me-1" {% endif %}>
+            {% if in_navheader %}
+               <i class="{{ icon }}"></i>
+            {% endif %}
+            {% if withtemplate == 1 and item.id > 0 %}
+               {{ _n('Template', 'Templates', 1) }} - {{ nametype }} - {{ template_name }}
+            {% elseif not item.isNewItem() %}
+               {{ nametype }} - <span id="header-friendlyname"> {{ friendlyname }} </span>
+            {% else %}
+               {{ nametype }}
+            {% endif %}
+         </span>
+         {% if in_navheader and item.isField('is_dynamic') and item.fields['is_dynamic'] %}
+            <span class="mx-1 status rounded-1" title="{{ __('Automatic Inventory') }}" data-bs-toggle="tooltip">
+               <i class="{{ call('Agent::getIcon') }}"></i>
+            </span>
          {% endif %}
-      </span>
-      {% if in_navheader and item.isField('is_dynamic') and item.fields['is_dynamic'] %}
-      <span class="mx-1 status rounded-1" title="{{ __('Automatic Inventory') }}" data-bs-toggle="tooltip">
-         <i class="{{ call('Agent::getIcon') }}"></i>
-      </span>
       {% endif %}
       {% if in_navheader and item.isField('is_deleted') %}
       {% set title = item.isField('date_mod') ? __('Item has been deleted on %s')|format(item.fields['date_mod']) : __('Deleted') %}

--- a/tests/functional/CommonGLPITest.php
+++ b/tests/functional/CommonGLPITest.php
@@ -38,7 +38,9 @@ use Computer;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Crawler;
 
 class CommonGLPITest extends DbTestCase
 {
@@ -106,5 +108,41 @@ class CommonGLPITest extends DbTestCase
 
         $item = new $itemtype();
         $item->display(['id' => $items_id]);
+    }
+
+    public function testShowFriendlyNameBadgeInFormIsDisplayedByDefault(): void
+    {
+        $this->login();
+
+        $computer_id = getItemByTypeName(Computer::class, '_test_pc01', true);
+        $_SERVER['REQUEST_URI'] = Computer::getFormURLWithID($computer_id);
+        $_GET['id'] = $computer_id;
+
+        $computer = new Computer();
+        ob_start();
+        $computer->display(['id' => $computer_id]);
+        $html = ob_get_clean();
+
+        $crawler = new Crawler($html);
+        $this->assertCount(1, $crawler->filter('#header-friendlyname'));
+    }
+
+    public function testShowFriendlyNameBadgeInFormIsHiddenForKnowbaseItem(): void
+    {
+        $this->login();
+
+        $kb_item = $this->createItem(KnowbaseItem::class, [
+            'name'   => "Test article",
+            'answer' => 'Test answer',
+        ]);
+        $_SERVER['REQUEST_URI'] = KnowbaseItem::getFormURLWithID($kb_item->getID());
+        $_GET['id'] = $kb_item->getID();
+
+        ob_start();
+        $kb_item->display(['id' => $kb_item->getID()]);
+        $html = ob_get_clean();
+
+        $crawler = new Crawler($html);
+        $this->assertCount(0, $crawler->filter('#header-friendlyname'));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

The name of an article was displayed twice, which is unnecessary.

Before:
<img width="1664" height="314" alt="image" src="https://github.com/user-attachments/assets/c8be7691-475f-4642-8303-d0a60c9e62ec" />

After:
<img width="1654" height="253" alt="image" src="https://github.com/user-attachments/assets/8ad91380-56a3-497f-8928-fbdf4f317368" />


