### PR TITLE
(planning) revers order event in list to show most recent first

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -424,6 +424,38 @@ var GLPIPlanning  = {
 
                     // hide control buttons
                     $('#planning .fc-left .fc-button-group').hide();
+
+                    // Reverse event order inlist to show most recent first
+                    setTimeout(function() {
+                        var $table = $(`#${CSS.escape(GLPIPlanning.dom_id)} .fc-list-table tbody`);
+                        if ($table.length) {
+                            var rows = [];
+                            var currentGroup = [];
+
+                            $table.children('tr').each(function() {
+                                var $row = $(this);
+                                if ($row.hasClass('fc-list-heading')) {
+                                    if (currentGroup.length > 0) {
+                                        rows.push(currentGroup);
+                                    }
+                                    currentGroup = [$row];
+                                } else {
+                                    currentGroup.push($row);
+                                }
+                            });
+
+                            if (currentGroup.length > 0) {
+                                rows.push(currentGroup);
+                            }
+
+                            $table.empty();
+                            for (var i = rows.length - 1; i >= 0; i--) {
+                                for (var j = 0; j < rows[i].length; j++) {
+                                    $table.append(rows[i][j]);
+                                }
+                            }
+                        }
+                    }, 0);
                 } else {
                     // reinit datepicker
                     $('#planning_datepicker').show();
@@ -658,6 +690,41 @@ var GLPIPlanning  = {
             success: function (data) {
                 if (!options.full_view && data.length === 0) {
                     GLPIPlanning.calendar.setOption('height', 0);
+                }
+                // Reverse order for listFull view after events load
+                if (GLPIPlanning.calendar && GLPIPlanning.calendar.state.viewType === 'listFull') {
+                    setTimeout(function() {
+                        var $table = $(`#${CSS.escape(GLPIPlanning.dom_id)} .fc-list-table tbody`);
+                        if ($table.length) {
+                            var rows = [];
+                            var currentGroup = [];
+
+                            $table.children('tr').each(function() {
+                                var $row = $(this);
+                                if ($row.hasClass('fc-list-heading')) {
+                                    if (currentGroup.length > 0) {
+                                        rows.push(currentGroup);
+                                    }
+                                    currentGroup = [$row];
+                                } else {
+                                    currentGroup.push($row);
+                                }
+                            });
+
+                            if (currentGroup.length > 0) {
+                                rows.push(currentGroup);
+                            }
+
+                            if (rows.length > 0) {
+                                $table.empty();
+                                for (var i = rows.length - 1; i >= 0; i--) {
+                                    for (var j = 0; j < rows[i].length; j++) {
+                                        $table.append(rows[i][j]);
+                                    }
+                                }
+                            }
+                        }
+                    }, 0);
                 }
             },
             failure: function (error) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43415
- (planning) revers order event in list to show most recent first

## Screenshots (if appropriate):
<img width="353" height="187" alt="image" src="https://github.com/user-attachments/assets/93b359b1-2503-4ba0-9ecd-8c847bf3cb21" />


