### PR TITLE
fix(Report.php):adding root_doc to the file path of reports list

### DIFF
--- a/src/Report.php
+++ b/src/Report.php
@@ -69,6 +69,8 @@ class Report extends CommonGLPI
     {
         global $CFG_GLPI, $PLUGIN_HOOKS;
 
+        $root_doc = $CFG_GLPI['root_doc'];
+
         // Report generation
         // Default Report included
         $report_list = [];
@@ -77,24 +79,24 @@ class Report extends CommonGLPI
 
         if (Contract::canView()) {
             $report_list["Contrats"]["name"] = __('By contract');
-            $report_list["Contrats"]["file"] = "/front/report.contract.php";
+            $report_list["Contrats"]["file"] = $root_doc . "/front/report.contract.php";
         }
         if (Infocom::canView()) {
             $report_list["Par_annee"]["name"] = __('By year');
-            $report_list["Par_annee"]["file"] = "/front/report.year.php";
+            $report_list["Par_annee"]["file"] = $root_doc . "/front/report.year.php";
             $report_list["Infocoms"]["name"]  = __('Hardware financial and administrative information');
-            $report_list["Infocoms"]["file"]  = "/front/report.infocom.php";
+            $report_list["Infocoms"]["file"]  = $root_doc . "/front/report.infocom.php";
             $report_list["Infocoms2"]["name"] = __('Other financial and administrative information (licenses, cartridges, consumables)');
-            $report_list["Infocoms2"]["file"] = "/front/report.infocom.conso.php";
+            $report_list["Infocoms2"]["file"] = $root_doc . "/front/report.infocom.conso.php";
         }
         if (Session::haveRight("networking", READ)) {
             // Network socket report
             $report_list["Rapport prises reseau"]["name"] = __('Network report');
-            $report_list["Rapport prises reseau"]["file"] = "/front/report.networking.php";
+            $report_list["Rapport prises reseau"]["file"] = $root_doc . "/front/report.networking.php";
         }
         if (Session::haveRight("reservation", READ)) {
             $report_list["reservation"]["name"] = __('Loan');
-            $report_list["reservation"]["file"] = "/front/report.reservation.php";
+            $report_list["reservation"]["file"] = $root_doc . "/front/report.reservation.php";
         }
         //TODO This should probably check all state_types
         if (
@@ -106,7 +108,7 @@ class Report extends CommonGLPI
             || Phone::canView()
         ) {
             $report_list["state"]["name"] = __('Status');
-            $report_list["state"]["file"] = "/front/report.state.php";
+            $report_list["state"]["file"] = $root_doc . "/front/report.state.php";
         }
 
         // Handle reports from plugins


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes ticket 43629 : the `root_doc` was not included in the file path of reports in the reports list, causing an error when choosing a report to generate if GLPI was installed in a subfolder of the Apache root directory, due to an incorrect redirection URL.

## screenshots : 

before the fix : 
- Before selecting a report : 
<img width="2224" height="643" alt="before_1" src="https://github.com/user-attachments/assets/31af0d37-b523-415d-b97c-c457774676dc" />

- After selecting a report : 
<img width="2458" height="643" alt="before_2" src="https://github.com/user-attachments/assets/b21d6cb2-4056-44ad-89d4-932f285c233e" />

After the fix : 
- After selecting a report : 
<img width="2221" height="641" alt="after_1" src="https://github.com/user-attachments/assets/2806855e-95bb-402e-8b86-6ce30ac129be" />

