### PR TITLE
Add cancel buttons for all KB modals (with similar ghost-secondary style)

### DIFF
--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -437,7 +437,7 @@
 
                                                         {# Actions #}
                                                         <div class="d-flex justify-content-end gap-2 mt-4">
-                                                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                                                            <button type="button" class="btn btn-ghost-secondary" data-bs-dismiss="modal">
                                                                 {{ __('Cancel') }}
                                                             </button>
                                                             <button type="submit" class="btn btn-primary"
@@ -476,7 +476,7 @@
 
                                                     {# Actions #}
                                                     <div class="d-flex justify-content-end gap-2 mt-4">
-                                                        <button type="button" class="btn btn-secondary"
+                                                        <button type="button" class="btn btn-ghost-secondary"
                                                                 data-bs-dismiss="modal">
                                                             {{ __('Cancel') }}
                                                         </button>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -58,6 +58,11 @@
     {% endif %}
 
     <div class="kb-link-item-footer">
+        <button
+            class="btn btn-ghost-secondary me-2"
+            type="button"
+            data-bs-dismiss="modal"
+        >{{ __('Cancel') }}</button>
         {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary', 'icon': 'ti ti-link'}) }}
     </div>
 </form>

--- a/templates/pages/tools/kb/modal/schedule_visibility.html.twig
+++ b/templates/pages/tools/kb/modal/schedule_visibility.html.twig
@@ -59,8 +59,13 @@
     </div>
     <div class="d-flex">
         <button
+            class="btn btn-ghost-secondary ms-auto me-2"
             type="button"
-            class="btn btn-primary ms-auto"
+            data-bs-dismiss="modal"
+        >{{ __('Cancel') }}</button>
+        <button
+            type="button"
+            class="btn btn-primary"
             data-glpi-kb-schedule-apply
             data-testid="schedule-apply-btn"
         >{{ __('Apply') }}</button>

--- a/templates/pages/tools/kb/modal/service_catalog.html.twig
+++ b/templates/pages/tools/kb/modal/service_catalog.html.twig
@@ -105,8 +105,13 @@
 
     <div class="d-flex mt-3">
         <button
+            class="btn btn-ghost-secondary ms-auto me-2"
+            type="button"
+            data-bs-dismiss="modal"
+        >{{ __('Cancel') }}</button>
+        <button
             type="submit"
-            class="btn btn-primary ms-auto"
+            class="btn btn-primary"
             data-glpi-service-catalog-submit
         >
             <i class="ti ti-device-floppy" data-glpi-icon aria-hidden="true"></i>


### PR DESCRIPTION
There is already a button to close the modal at the top right corner.

