### PR TITLE
Clear tinymce/select2/flatpicker instances on modal close

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -150,6 +150,27 @@ var glpi_html_dialog = function({
             $('div.modal-backdrop').remove();
         }
 
+        // Destroy TinyMCE instances within the modal to prevent memory leaks
+        if (window.tinymce !== undefined) {
+            window.tinymce.get().forEach((editor) => {
+                if (myModalEl.contains(editor.getElement())) {
+                    editor.remove();
+                }
+            });
+        }
+
+        // Destroy Select2 instances within the modal to prevent memory leaks
+        $(myModalEl).find('.select2-hidden-accessible').each(function() {
+            $(this).select2('destroy');
+        });
+
+        // Destroy Flatpickr instances within the modal to prevent memory leaks
+        $(myModalEl).find('input').each(function() {
+            if (this._flatpickr) {
+                this._flatpickr.destroy();
+            }
+        });
+
         // remove html on modal close
         $(`#${CSS.escape(id)}`).remove();
     });


### PR DESCRIPTION
@cconard96 detected a memory leak due to tinymce/select2/flatpicker instances not being deleted when a modal is cleared (reopening the same modal would thus take more and more memory over time).

These changes try to fix the issue by manually clearing these instances before dropping the modal html.

