### PR TITLE
fix wrong position of BubbleMenu on first text selection

### DIFF
--- a/js/modules/KnowbaseEditor.js
+++ b/js/modules/KnowbaseEditor.js
@@ -208,6 +208,8 @@ class KnowbaseEditor {
     #createBubbleMenu() {
         const menu = document.createElement('div');
         menu.classList.add('bubble-menu');
+        menu.style.position = 'absolute';
+        menu.style.width = 'max-content';
 
         const buttons = [
             { command: 'toggleBold', icon: 'ti ti-bold', title: __('Bold') },


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes [# (issue number, if applicable)](https://github.com/glpi-project/roadmap/issues/222)
- Here is a brief description of what this PR does : fix positioning on load by JS



