### PR TITLE
Fix(Password): properly encode token in password reset URL

### DIFF
--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -178,12 +178,10 @@ class NotificationTargetUser extends NotificationTarget
                     ],
                 ];
 
-                $this->data[$routes[$event]['key']] = urldecode(
-                    $this->getUrlBase()
+                $this->data[$routes[$event]['key']] = $this->getUrlBase()
                     . $routes[$event]['path']
                     . '?password_forget_token='
-                    . $token
-                );
+                    . rawurlencode($token);
                 break;
         }
 

--- a/src/NotificationTargetUser.php
+++ b/src/NotificationTargetUser.php
@@ -181,7 +181,7 @@ class NotificationTargetUser extends NotificationTarget
                 $this->data[$routes[$event]['key']] = $this->getUrlBase()
                     . $routes[$event]['path']
                     . '?password_forget_token='
-                    . rawurlencode($token);
+                    . rawurlencode((string) $token);
                 break;
         }
 

--- a/tests/functional/NotificationTargetUserTest.php
+++ b/tests/functional/NotificationTargetUserTest.php
@@ -120,6 +120,65 @@ class NotificationTargetUserTest extends DbTestCase
         $this->checkTemplateData($target->data, $expected);
     }
 
+    public static function passwordTokenUrlProvider(): array
+    {
+        $cases = [
+            // Normal sha1 hex token (happy path) — no special chars, rawurlencode is a no-op
+            'sha1 hex token'              => ['a3f4b2c1d5e6789012345678901234567890abcd'],
+            // Base64 chars: + must become %2B, not a space (urldecode regression)
+            'token with +'                => ['abc+def+ghi'],
+            // Base64 chars: / must become %2F
+            'token with /'                => ['abc/def/ghi'],
+            // Base64 chars: = (padding) must become %3D
+            'token with ='                => ['abc='],
+            // All base64 special chars combined
+            'token with +, / and ='       => ['aB3+cd/ef=='],
+        ];
+
+        $events = [
+            'passwordinit'   => [
+                'passwordinit',
+                '##user.passwordiniturl##',
+            ],
+            'passwordforget' => [
+                'passwordforget',
+                '##user.passwordforgeturl##',
+            ],
+        ];
+
+        $result = [];
+        foreach ($events as $event_label => [$event, $url_tag]) {
+            foreach ($cases as $token_label => [$raw_token]) {
+                $result["$event_label / $token_label"] = [$event, $url_tag, $raw_token];
+            }
+        }
+        return $result;
+    }
+
+    #[DataProvider('passwordTokenUrlProvider')]
+    public function testPasswordTokenUrlIsProperlyEncoded(
+        string $event,
+        string $url_tag,
+        string $raw_token
+    ): void {
+        $encrypted_token = (new \GLPIKey())->encrypt($raw_token);
+
+        $user = new \User();
+        $user->fields = ['password_forget_token' => $encrypted_token];
+
+        $target = new \NotificationTargetUser(
+            getItemByTypeName('Entity', '_test_root_entity', true),
+            $event,
+            $user
+        );
+        $target->addDataForTemplate($event);
+
+        $url = $target->data[$url_tag];
+
+        $this->assertStringNotContainsString(' ', $url, 'URL must not contain spaces');
+        $this->assertStringContainsString('password_forget_token=' . rawurlencode($raw_token), $url);
+    }
+
     private function checkTemplateData(array $data, array $expected)
     {
         foreach ($expected as $key => $value) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43500

The password reset and initialization URLs generated in email notifications contained unencoded special characters in the token query parameter. A spurious urldecode() call converted any + character in the token to a space, producing an invalid URL that GLPI immediately rejected as expired or invalid.
