### PR TITLE
Upgrade `uuid` to get latest security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17920,13 +17920,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "overrides": {
         "monaco-editor": {
             "dompurify": "^3.4.0"
-        }
+        },
+        "uuid": "^14.0.0"
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes the following issues.
```
# npm audit report

uuid  <14.0.0
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix --force`
Will install webpack-dev-server@1.16.5, which is a breaking change
node_modules/uuid
  @cypress/request  *
  Depends on vulnerable versions of uuid
  node_modules/@cypress/request
    cypress  >=4.3.0
    Depends on vulnerable versions of @cypress/request
    node_modules/cypress
  sockjs  >=0.3.17
  Depends on vulnerable versions of uuid
  node_modules/sockjs
    webpack-dev-server  >=2.0.0-beta
    Depends on vulnerable versions of sockjs
    node_modules/webpack-dev-server

5 moderate severity vulnerabilities
```