### PR TITLE
Fix helpdesk translations for zh_CN, zh_TW, zh_HK, ko_KR, ja_JP

### DIFF
--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -121,17 +121,6 @@ abstract class ItemTranslation extends CommonDBChild
     {
         if (isset($input['translations'])) {
             if (!is_string($input['translations'])) {
-                if (isset($input['language'], $input['translations']['one'])) {
-                    try {
-                        $actual_key = (new CldrLanguage($input['language']))->getPluralKey(1);
-                        if ($actual_key !== 'one') {
-                            $input['translations'][$actual_key] = $input['translations']['one'];
-                            unset($input['translations']['one']);
-                        }
-                    } catch (LogicException) {
-                        // Unknown language, keep 'one' as the default key
-                    }
-                }
                 $input['translations'] = json_encode($input['translations']);
             } elseif ($input['translations'] == "") {
                 $input['translations'] = "{}";

--- a/src/Glpi/ItemTranslation/ItemTranslation.php
+++ b/src/Glpi/ItemTranslation/ItemTranslation.php
@@ -121,6 +121,17 @@ abstract class ItemTranslation extends CommonDBChild
     {
         if (isset($input['translations'])) {
             if (!is_string($input['translations'])) {
+                if (isset($input['language'], $input['translations']['one'])) {
+                    try {
+                        $actual_key = (new CldrLanguage($input['language']))->getPluralKey(1);
+                        if ($actual_key !== 'one') {
+                            $input['translations'][$actual_key] = $input['translations']['one'];
+                            unset($input['translations']['one']);
+                        }
+                    } catch (LogicException) {
+                        // Unknown language, keep 'one' as the default key
+                    }
+                }
                 $input['translations'] = json_encode($input['translations']);
             } elseif ($input['translations'] == "") {
                 $input['translations'] = "{}";

--- a/templates/pages/admin/helpdesk_home_translation.html.twig
+++ b/templates/pages/admin/helpdesk_home_translation.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% macro getTranslationInput(handler, translation) %}
+{% macro getTranslationInput(handler, translation, plural_key) %}
     {% import 'components/form/fields_macros.html.twig' as fields %}
 
     {% set rand = random() %}
@@ -56,7 +56,7 @@
         {% endif %}
         {% if handler.isRichText() %}
             {{ fields.textareaField(
-                'translations[%s][translations][one]'|format(rand),
+                'translations[%s][translations][%s]'|format(rand, plural_key),
                 current_translation,
                 '',
                 {
@@ -75,7 +75,7 @@
         {% else %}
             <input
                 type="text"
-                name="translations[{{ rand }}][translations][one]"
+                name="translations[{{ rand }}][translations][{{ plural_key }}]"
                 class="form-control"
                 placeholder="{{ __('Enter translation') }}"
                 value="{{ current_translation }}"
@@ -106,7 +106,8 @@
                 'default': default_value,
                 'translation': _self.getTranslationInput(
                     handler,
-                    item_translation
+                    item_translation,
+                    helpdesk_translation.getCldrLanguage().getPluralKey(1)
                 ),
                 'type_aria_label': __('Translation name'),
                 'default_aria_label': __('Default value'),


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43700
- Here is a brief description of what this PR does

The helpdesk translation form always sends the singular value under the “one” key, but some languages (such as CJK languages: zh_CN, ko_KR, ja_JP, etc.) do not have the CLDR category ‘one’, their only category is “other”. The key must be remapped before saving so that the getTranslation() function can retrieve it using getPluralKey().

## Screenshots (if appropriate):


