### PR TITLE
FIX / Prevent division by zero in software license progress bar

### DIFF
--- a/templates/pages/management/license_progressbar.html.twig
+++ b/templates/pages/management/license_progressbar.html.twig
@@ -35,7 +35,7 @@
     {% set is_unlimited = total == -1 %}
     {% set license_contexts = {
         'valid': {
-            'progress' : (100 * licences_assigned / total)|round(2),
+            'progress' : (total > 0 ? (100 * licences_assigned / total) : 0)|round(2),
             'icon' : 'ti ti-circle-check text-success',
             'color': 'bg-success',
             'remaining': remaining|number_format,


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43598
- This PR fixes a division by zero error when rendering the software license progress bar in search results and trashbin lists. Some legacy software licenses can still have `number = 0` in database records. When the `Affected items` column is displayed, the progress bar template computes the percentage using `licences_assigned / total`, which raises a runtime exception when `total` is zero.