### PR TITLE
Fix - Software dictionary not merging duplicates that already have the final name

### DIFF
--- a/src/RuleDictionnarySoftwareCollection.php
+++ b/src/RuleDictionnarySoftwareCollection.php
@@ -133,8 +133,24 @@ TWIG, $twig_params);
                 //Replay software dictionary rules
                 $res_rule = $this->processAllRules($input, [], []);
 
+                $IDs = [];
+                //Find all the software in the database with the same name and manufacturer
+                $same_iterator = $DB->request([
+                    'SELECT' => 'id',
+                    'FROM'   => 'glpi_softwares',
+                    'WHERE'  => [
+                        'name'               => $input['name'],
+                        'manufacturers_id'   => $input['manufacturers_id'],
+                    ],
+                ]);
+
+                foreach ($same_iterator as $result) {
+                    $IDs[] = $result["id"];
+                }
+
                 if (
-                    (isset($res_rule["name"]) && (strtolower($res_rule["name"]) != strtolower($input["name"])))
+                    count($IDs) > 1
+                    || (isset($res_rule["name"]) && (strtolower($res_rule["name"]) != strtolower($input["name"])))
                     || (isset($res_rule["version"]) && ($res_rule["version"] != ''))
                     || (isset($res_rule['new_entities_id'])
                     && ($res_rule['new_entities_id'] != $input['entities_id']))
@@ -145,22 +161,7 @@ TWIG, $twig_params);
                     || (isset($res_rule['softwarecategories_id'])
                     && ($res_rule['softwarecategories_id'] != $input['softwarecategories_id']))
                 ) {
-                    $IDs = [];
-                    //Find all the software in the database with the same name and manufacturer
-                    $same_iterator = $DB->request([
-                        'SELECT' => 'id',
-                        'FROM'   => 'glpi_softwares',
-                        'WHERE'  => [
-                            'name'               => $input['name'],
-                            'manufacturers_id'   => $input['manufacturers_id'],
-                        ],
-                    ]);
-
-                    if (count($same_iterator)) {
-                        //Store all the software's IDs in an array
-                        foreach ($same_iterator as $result) {
-                            $IDs[] = $result["id"];
-                        }
+                    if (count($IDs)) {
                         //Replay dictionary on all the software
                         $this->replayDictionnaryOnSoftwaresByID($IDs, $res_rule);
                     }
@@ -346,16 +347,24 @@ TWIG, $twig_params);
             // Move licenses to new software
             $this->moveLicenses($ID, $new_software_id);
         } else {
-            $new_software_id = $ID;
-            $res_rule["id"]  = $ID;
-            if (isset($res_rule["manufacturer"]) && $res_rule["manufacturer"]) {
-                $res_rule["manufacturers_id"] = Dropdown::importExternal(
-                    'Manufacturer',
-                    $res_rule["manufacturer"]
-                );
-                unset($res_rule["manufacturer"]);
+            if (!isset($new_softs[$entity][$name])) {
+                // This is the canonical software entry for this name/entity
+                $new_softs[$entity][$name] = $ID;
+                $new_software_id = $ID;
+                $res_rule["id"]  = $ID;
+                if (isset($res_rule["manufacturer"]) && $res_rule["manufacturer"]) {
+                    $res_rule["manufacturers_id"] = Dropdown::importExternal(
+                        'Manufacturer',
+                        $res_rule["manufacturer"]
+                    );
+                    unset($res_rule["manufacturer"]);
+                }
+                $soft->update($res_rule);
+            } else {
+                // A canonical software for this name/entity already exists — merge this duplicate into it
+                $new_software_id = $new_softs[$entity][$name];
+                $this->moveLicenses($ID, $new_software_id);
             }
-            $soft->update($res_rule);
         }
 
         // Add to software to deleted list

--- a/tests/functional/RuleDictionnarySoftwareCollectionTest.php
+++ b/tests/functional/RuleDictionnarySoftwareCollectionTest.php
@@ -523,4 +523,134 @@ class RuleDictionnarySoftwareCollectionTest extends DbTestCase
         $expected = ['version_append' => 'else', 'version' => 'else', '_ruleid' => $rules_id];
         $this->assertSame($expected, $result);
     }
+
+    public function testReplayDictionnaryMergesMultipleDuplicatesWithSameName(): void
+    {
+        $this->login();
+
+        $collection = new \RuleDictionnarySoftwareCollection();
+        $manufacturer = new \Manufacturer();
+
+        $manufacturers_id = $manufacturer->importExternal('Microsoft');
+
+        $rule = $this->createItem(\Rule::class, [
+            'name'        => 'Test duplicate merge - replayDictionnary',
+            'is_active'   => 1,
+            'entities_id' => 0,
+            'sub_type'    => 'RuleDictionnarySoftware',
+            'match'       => \Rule::AND_MATCHING,
+            'condition'   => 0,
+            'description' => '',
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'name',
+            'condition' => \Rule::PATTERN_IS,
+            'pattern'   => 'Microsoft .NET Host',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'assign',
+            'field'       => 'name',
+            'value'       => 'Microsoft .NET Host',
+        ]);
+
+        $ids = [];
+        for ($i = 0; $i < 3; $i++) {
+            $soft = $this->createItem(\Software::class, [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'entities_id'      => 0,
+                'is_deleted'       => 0,
+                'is_template'      => 0,
+            ]);
+            $ids[] = $soft->getID();
+        }
+
+        $this->assertSame(
+            3,
+            countElementsInTable('glpi_softwares', [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'is_deleted'       => 0,
+            ])
+        );
+
+        $collection->replayDictionnaryOnSoftwaresByID($ids);
+
+        $this->assertSame(
+            1,
+            countElementsInTable('glpi_softwares', [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'is_deleted'       => 0,
+            ])
+        );
+    }
+
+    public function testReplayRulesOnExistingDBMergesDuplicatesAlreadyWithFinalName(): void
+    {
+        $this->login();
+
+        $collection = new \RuleDictionnarySoftwareCollection();
+        $manufacturer = new \Manufacturer();
+
+        $manufacturers_id = $manufacturer->importExternal('Microsoft');
+
+        $rule = $this->createItem(\Rule::class, [
+            'name'        => 'Test duplicate merge - replayRulesOnExistingDB',
+            'is_active'   => 1,
+            'entities_id' => 0,
+            'sub_type'    => 'RuleDictionnarySoftware',
+            'match'       => \Rule::AND_MATCHING,
+            'condition'   => 0,
+            'description' => '',
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'name',
+            'condition' => \Rule::PATTERN_IS,
+            'pattern'   => 'Microsoft .NET Host',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'assign',
+            'field'       => 'name',
+            'value'       => 'Microsoft .NET Host',
+        ]);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->createItem(\Software::class, [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'entities_id'      => 0,
+                'is_deleted'       => 0,
+                'is_template'      => 0,
+            ]);
+        }
+
+        $this->assertSame(
+            3,
+            countElementsInTable('glpi_softwares', [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'is_deleted'       => 0,
+            ])
+        );
+
+        $collection->replayRulesOnExistingDB();
+
+        $this->assertSame(
+            1,
+            countElementsInTable('glpi_softwares', [
+                'name'             => 'Microsoft .NET Host',
+                'manufacturers_id' => $manufacturers_id,
+                'is_deleted'       => 0,
+            ])
+        );
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43648
- Here is a brief description of what this PR does

When replaying the software dictionary rules, duplicates that already had the target name (e.g. multiple "Microsoft .NET Host" entries) were never merged because the merge logic only triggered when the rule changed the software name.

This fix also triggers the merge when multiple entries share the same name and manufacturer, and ensures that within a single replay pass, duplicate entries with an unchanged name are consolidated into the first occurrence rather than 
updated independently.