### PR TITLE
accept UTF-8 characters in email addresses for ticket actors

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -39,6 +39,7 @@ use Glpi\Form\AnswersSet;
 use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeItem;
+use GLPIMailer;
 use Group;
 use Session;
 use Ticket;
@@ -256,7 +257,7 @@ enum ITILActorFieldStrategy: string
             }, []);
         } elseif ($answer->getType() instanceof QuestionTypeEmail) {
             $value = $answer->getRawAnswer();
-            if (filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            if (GLPIMailer::validateAddress($value)) {
                 return [
                     [
                         'itemtype' => User::class,

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -124,6 +124,13 @@ use function Safe\unpack;
 class Toolbox
 {
     /**
+     * Regular expression pattern for validating email addresses in ITIL actor fields.
+     * Supports UTF-8 characters and special characters as per RFC 6531.
+     * @var string
+     */
+    public const ACTOR_EMAIL_VALIDATION_REGEX = '/^[\p{L}\p{N}\p{M}._%+\'-]+@([\p{L}\p{N}\p{M}._-]+\.)+[\p{L}\p{N}]{2,63}$/u';
+
+    /**
      * Wrapper for max_input_vars
      *
      * @since 0.84

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -264,7 +264,8 @@
                 }
 
                 // Don't offset to create a tag if it's not an email
-                if (!new RegExp(/^[\w-\.]+@([\w-]+\.)+[\w-]{2,63}$/).test(term)) {
+                // Support UTF-8 characters and special chars in email addresses (RFC 6531)
+                if (!new RegExp(/^[\p{L}\p{N}\p{M}._%+'-]+@([\p{L}\p{N}\p{M}._-]+\.)+[\p{L}\p{N}]{2,63}$/u).test(term)) {
                     // Return null to disable tag creation
                     return null;
                 }

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -264,8 +264,7 @@
                 }
 
                 // Don't offset to create a tag if it's not an email
-                // Support UTF-8 characters and special chars in email addresses (RFC 6531)
-                if (!new RegExp(/^[\p{L}\p{N}\p{M}._%+'-]+@([\p{L}\p{N}\p{M}._-]+\.)+[\p{L}\p{N}]{2,63}$/u).test(term)) {
+                if (!new RegExp({{ constant('Toolbox::ACTOR_EMAIL_VALIDATION_REGEX')|slice(1, -2)|json_encode|raw }}, 'u').test(term)) {
                     // Return null to disable tag creation
                     return null;
                 }

--- a/tests/functional/ActorEmailValidationTest.php
+++ b/tests/functional/ActorEmailValidationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function Safe\preg_match;
+
+class ActorEmailValidationTest extends DbTestCase
+{
+    /**
+     * @return iterable<array{string, int}>
+     */
+    public static function emailValidationProvider()
+    {
+        yield ['josé@example.com', 1];
+        yield ['françois@example.fr', 1];
+        yield ['müller@example.de', 1];
+        yield ['andré.garcía@example.es', 1];
+        yield ['jürgen_øvergård@example.no', 1];
+        yield ['andré+tag@example.com', 1];
+        yield ['søren@example.dk', 1];
+        yield ['björk@example.is', 1];
+        yield ['déjà-vu@example.com', 1];
+        yield ['naïve@example.com', 1];
+        yield ['user_123@mötörhead.com', 1];
+        yield ['test.user+tag@café.fr', 1];
+        yield ['FRANÇOIS@EXAMPLE.FR', 1];
+        yield ['José.García@Example.COM', 1];
+        yield ['test_user-123@münchen.de', 1];
+        yield ["o'brien@example.com", 1];
+        yield ['nëñö_123@example.com', 1];
+        yield ['test.user%tag@example.com', 1];
+        yield ['user+test@localhost.domain.com', 1];
+        yield ['test@example.com', 1];
+        yield ['user.name@example.com', 1];
+        yield ['user+tag@example.com', 1];
+        yield ['user_name@example.com', 1];
+        yield ['user-name@example.com', 1];
+        yield ['user%name@example.com', 1];
+        yield ['test.user+tag@sub.example.com', 1];
+        yield ['a@b.co', 1];
+        yield ['123@example.com', 1];
+        yield ['user123@example.com', 1];
+        yield ['user@sub1.sub2.example.com', 1];
+        yield ['user@example123.com', 1];
+        yield ['user@ex-ample.com', 1];
+        yield ['user@josé.example.com', 1];
+        yield ['user@münchen.de', 1];
+        yield ['user@café.fr', 1];
+        yield ['user@ñoño.es', 1];
+        yield ['user@例え.jp', 1];
+        yield ['test@José.com', 1];
+        yield [str_repeat('a', 63) . '@example.' . str_repeat('a', 63), 1];
+        yield ['', 0];
+        yield ['notanemail', 0];
+        yield ['@example.com', 0];
+        yield ['user@', 0];
+        yield ['user@@example.com', 0];
+        yield ['user@example', 0];
+        yield ['user @example.com', 0];
+        yield ['user@exam ple.com', 0];
+        yield ['user@example.c', 0];
+        yield ['user name@example.com', 0];
+        yield ['user@example .com', 0];
+        yield ['user@example.' . str_repeat('a', 64), 0];
+    }
+
+    #[DataProvider('emailValidationProvider')]
+    public function testActorEmailValidation(string $email, int $expected): void
+    {
+        // Tests the JavaScript regex used in templates/components/itilobject/actors/field.html.twig
+        // for validating email addresses in the Select2 tag creation
+        $pattern = '/^[\p{L}\p{N}\p{M}._%+\'-]+@([\p{L}\p{N}\p{M}._-]+\.)+[\p{L}\p{N}]{2,63}$/u';
+
+        $is_valid = preg_match($pattern, $email);
+
+        $this->assertSame(
+            $expected,
+            $is_valid,
+            sprintf('Email "%s" should be %s', $email, $expected ? 'valid' : 'invalid')
+        );
+    }
+}

--- a/tests/functional/ActorEmailValidationTest.php
+++ b/tests/functional/ActorEmailValidationTest.php
@@ -102,11 +102,9 @@ class ActorEmailValidationTest extends DbTestCase
     #[DataProvider('emailValidationProvider')]
     public function testActorEmailValidation(string $email, int $expected): void
     {
-        // Tests the JavaScript regex used in templates/components/itilobject/actors/field.html.twig
+        // Tests the regex used in templates/components/itilobject/actors/field.html.twig
         // for validating email addresses in the Select2 tag creation
-        $pattern = '/^[\p{L}\p{N}\p{M}._%+\'-]+@([\p{L}\p{N}\p{M}._-]+\.)+[\p{L}\p{N}]{2,63}$/u';
-
-        $is_valid = preg_match($pattern, $email);
+        $is_valid = preg_match(\Toolbox::ACTOR_EMAIL_VALIDATION_REGEX, $email);
 
         $this->assertSame(
             $expected,

--- a/tests/functional/GLPIMailerTest.php
+++ b/tests/functional/GLPIMailerTest.php
@@ -68,6 +68,27 @@ class GLPIMailerTest extends DbTestCase
             ["test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.dot", false],
             ["test@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false],
             ["abcd'efgh@example.com", true],
+
+            // Test UTF-8 characters (RFC 6531)
+            ["josé@example.com", true],
+            ["françois@example.fr", true],
+            ["müller@example.de", true],
+            ["andré.garcía@example.es", true],
+            ["jürgen_øvergård@example.no", true],
+            ["andré+tag@example.com", true],
+            ["user@josé.example.com", true],
+            ["user@münchen.de", true],
+            ["user@café.fr", true],
+            ["test@ñoño.es", true],
+            ["naïve@example.com", true],
+            ["søren@example.dk", true],
+            ["björk@example.is", true],
+            ["déjà-vu@example.com", true],
+            ["user_123@mötörhead.com", true],
+            ["用户@example.com", true],
+            ["тест@example.ru", true],
+            ["משתמש@example.com", true],
+            ["user@例え.jp", true],
         ];
     }
 

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/MailFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/MailFieldTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use CommonITILActor;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILActorFieldStrategy;
+use Glpi\Form\Destination\CommonITILField\RequesterField;
+use Glpi\Form\Destination\CommonITILField\RequesterFieldConfig;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Session;
+use Ticket;
+use Ticket_User;
+
+class MailFieldTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function emailProvider()
+    {
+        yield ['josé@example.com'];
+        yield ['françois@example.fr'];
+        yield ['müller@example.de'];
+        yield ['andré.garcía@example.es'];
+        yield ['jürgen.øvergård@example.no'];
+        yield ['søren@example.dk'];
+        yield ['björk@example.is'];
+        yield ['naïve@example.com'];
+        yield ['user+tag@example.com'];
+        yield ['user.name+tag@example.com'];
+        yield ['test.user%tag@example.com'];
+        yield ["o'brien@example.com"];
+        yield ['user_name@example.com'];
+        yield ['user-name@example.com'];
+        yield ['test@example.com'];
+        yield ['user.name@example.com'];
+        yield ['admin@sub.example.com'];
+        yield ['contact@example123.com'];
+    }
+
+    #[DataProvider('emailProvider')]
+    public function testFormSubmissionWithEmailRequester(string $email): void
+    {
+        $this->login();
+
+        $builder = new FormBuilder();
+        $builder->addQuestion("Requester email", QuestionTypeEmail::class);
+        $form = $this->createForm($builder);
+
+        $requester_config = new RequesterFieldConfig(
+            [ITILActorFieldStrategy::LAST_VALID_ANSWER]
+        );
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->assertNotFalse($destination);
+        $this->updateItem(
+            $destination::class,
+            $destination->getId(),
+            ['config' => [
+                (new RequesterField())->getKey() => $requester_config->jsonSerialize(),
+            ],
+            ],
+            ["config"],
+        );
+
+        $answers_handler = AnswersHandler::getInstance();
+
+        $users_id = Session::getLoginUserID();
+        $this->assertIsInt($users_id);
+
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            [
+                $this->getQuestionId($form, 'Requester email') => $email,
+            ],
+            $users_id
+        );
+
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items, 'One ticket should be created');
+
+        $ticket = current($created_items);
+        $this->assertInstanceOf(Ticket::class, $ticket);
+
+        $ticket_users = (new Ticket_User())->find([
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::REQUESTER,
+        ]);
+        $this->assertCount(
+            1,
+            $ticket_users,
+            sprintf('One requester should be associated with ticket for email "%s"', $email)
+        );
+
+        $ticket_user = array_shift($ticket_users);
+        $this->assertSame(
+            $email,
+            $ticket_user['alternative_email'],
+            sprintf('Alternative email should be "%s"', $email)
+        );
+    }
+}

--- a/tests/web/TicketTest.php
+++ b/tests/web/TicketTest.php
@@ -36,6 +36,8 @@ namespace tests\units;
 
 use Glpi\Tests\FrontBaseClass;
 
+use function Safe\json_encode;
+
 class TicketTest extends FrontBaseClass
 {
     public function testTicketCreate()
@@ -46,7 +48,7 @@ class TicketTest extends FrontBaseClass
         //load computer form
         $crawler = $this->http_client->request('GET', $this->base_uri . 'front/ticket.form.php');
 
-        $crawler = $this->http_client->request(
+        $this->http_client->request(
             'POST',
             $this->base_uri . 'front/ticket.form.php',
             [
@@ -63,5 +65,66 @@ class TicketTest extends FrontBaseClass
             'A \'test\' > "ticket" & name thetestuuidtoremove',
             $ticket->fields['name']
         );
+    }
+
+    public function testTicketCreateWithUtf8EmailRequester()
+    {
+        $this->logIn();
+        $this->addToCleanup(\Ticket::class, ['name' => ['LIKE', 'Test ticket with UTF-8 email requester%']]);
+
+        $utf8_emails = [
+            'josé@example.com',
+            'françois@example.fr',
+            'müller@example.de',
+            'andré.garcía@example.es',
+            'jürgen_øvergård@example.no',
+        ];
+
+        foreach ($utf8_emails as $index => $email) {
+            $ticket_name = 'Test ticket with UTF-8 email requester ' . $index;
+
+            $crawler = $this->http_client->request('GET', $this->base_uri . 'front/ticket.form.php');
+            $csrf_token = $crawler->filter('input[name=_glpi_csrf_token]')->attr('value');
+
+            $crawler = $this->http_client->request(
+                'POST',
+                $this->base_uri . 'front/ticket.form.php',
+                [
+                    'add' => true,
+                    'name' => $ticket_name,
+                    'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+                    '_glpi_csrf_token' => $csrf_token,
+                    '_actors' => json_encode([
+                        'requester' => [
+                            [
+                                'itemtype' => 'User',
+                                'items_id' => 0,
+                                'use_notification' => 1,
+                                'alternative_email' => $email,
+                            ],
+                        ],
+                    ]),
+                ]
+            );
+
+            $ticket = new \Ticket();
+            $this->assertTrue(
+                $ticket->getFromDBByCrit(['name' => $ticket_name]),
+                sprintf('Ticket with UTF-8 email requester "%s" should be created', $email)
+            );
+
+            $ticket_users = (new \Ticket_User())->find([
+                'tickets_id' => $ticket->fields['id'],
+                'type' => \CommonITILActor::REQUESTER,
+            ]);
+            $this->assertCount(1, $ticket_users, sprintf('One requester should be associated with ticket for email "%s"', $email));
+
+            $ticket_user = array_shift($ticket_users);
+            $this->assertSame(
+                $email,
+                $ticket_user['alternative_email'],
+                sprintf('Alternative email should be "%s"', $email)
+            );
+        }
     }
 }


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Fixes ticket 43563.

- Before this fix, email addresses containing UTF-8 characters (such as é) were accepted when submitting a form, but were not included in the requesters list when the ticket created from that form was generated.

- The validation of actor email addresses performed when submitting form answers was not consistent with the validation applied when creating a ticket from those answers. This fix replaces the validation logic in ITILActorFieldStrategy with GLPIMailer::validateAddress(), which is already used during form submission, ensuring consistent behavior throughout the process.

- This change also updates the JavaScript validation when adding an email address directly to the actor list in the ticket form, allowing UTF-8 and special characters (such as é and +). This ensures that frontend validation is aligned with backend validation.

- UTF-8 characters in email addresses are supported as defined in RFC 6532 : https://datatracker.ietf.org/doc/html/rfc6532#section-1.

- Additionally, UTF-8 and special characters are already accepted when adding an email address to a user. This change ensures consistent behavior across the application.

