### PR TITLE
improve contributing flux

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -29,5 +29,15 @@ labels:
         body: |
             This issue has been closed because it appears your contribution comes (almost) verbatim from an IA agent.
             
-            We do not want to debate with IA bots; this is too much time consuming. Please read our contributions guidelines,
+            We do not want to debate with IA bots; this is too much time consuming. See CONTRIBUTING.md
         action: "close"
+  - name: needs-discussion
+    labeled:
+      pr:
+        body: |
+          This PR has been closed because no prior issue was opened to discuss the change.
+
+          Per [CONTRIBUTING.md](https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md), changes other than trivial fixes (typos, broken links) must start with a bug report or feature proposal so we can confirm the change is wanted, belongs in core rather than a plugin, and isn't a duplicate effort.
+
+          To proceed: open an issue, wait for confirmation, then submit the PR with the issue linked.
+        action: close

--- a/.github/workflows/commit-authorship.yml
+++ b/.github/workflows/commit-authorship.yml
@@ -1,0 +1,76 @@
+name: "Commit authorship gate"
+
+# Block PRs whose commits are authored by AI agents or LLM provider accounts.
+# Per CONTRIBUTING.md, commits must be authored under a human's name and email.
+#
+# Uses pull_request_target so the check fires even when the contributor's fork
+# has Actions disabled or is subject to the first-time contributor approval gate.
+# Safe because we only read commit metadata; PR code is never executed.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-authorship:
+    name: "Verify commit authorship"
+    runs-on: "ubuntu-latest"
+    steps:
+      # Checkout points at the fork (head.repo) — pull_request_target defaults
+      # to the base repo, where the PR's head SHA does not exist.
+      - name: "Checkout PR (metadata only)"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      # The fork doesn't contain the base SHA; fetch it so the diff range resolves.
+      - name: "Fetch base ref for diff range"
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.clone_url }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git remote add base "$BASE_REPO"
+          git fetch --no-tags --depth=1 base "$BASE_SHA"
+
+      # DENY list is matched (regex, case-insensitive) against author name and email
+      # of every commit in the PR. Extend conservatively as new agents appear.
+      - name: "Scan commit authors"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -e
+          DENY=(
+            '@anthropic\.com'
+            '@openai\.com'
+            '@cursor\.sh'
+            '@cursor\.so'
+            '@codeium\.com'
+            'copilot.*\[bot\]'
+            'copilot.*@.*users\.noreply\.github\.com'
+            '^claude([-_ ]|$)'
+            '^chatgpt([-_ ]|$)'
+            '^gpt-'
+          )
+          FAIL=0
+          while IFS=$'\t' read -r sha name email; do
+            for pattern in "${DENY[@]}"; do
+              if echo "$name" | grep -iqE "$pattern" || echo "$email" | grep -iqE "$pattern"; then
+                echo "::error title=AI-authored commit::${sha:0:12} — '$name <$email>' matches '$pattern'"
+                FAIL=1
+                break
+              fi
+            done
+          done < <(git log --format='%H%x09%an%x09%ae' "${BASE_SHA}..${HEAD_SHA}")
+          if [ "$FAIL" -ne 0 ]; then
+            echo ""
+            echo "PRs must be authored by humans. See CONTRIBUTING.md."
+            exit 1
+          fi
+          echo "All commits authored by human accounts."

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   issues:
-    types:
-      - "labeled"
-      - "unlabeled"
+    types: [labeled, unlabeled]
+  pull_request_target:
+    types: [labeled, unlabeled]
 
 jobs:
   comment:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,48 @@
 # Contributing to GLPI
 
-:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+Thank you for considering a contribution. Please read this document before opening an issue or pull request.
 
-Please note that current repository is about GLPI core only. All related plugins are the responsibility of their respective owners and all requests must be done on their own systems.
+## Scope
 
-**Please write only in English!**
+This repository covers **GLPI core only**. Third-party plugins are owned by their authors — report plugin issues and requests to the relevant plugin repository.
 
-## Security
+Issues, pull requests, commit messages, and code comments must be in **English**.
 
-**⚠️ Please never use standard issues to report security problems. See [security policy](https://github.com/glpi-project/glpi/security/policy) for more details. ⚠️**
+Issues are handled on a best-effort basis. For guaranteed support, see [GLPI Network](https://glpi-network.com) or our [official partners](https://glpi-project.org/partners/).
 
-## IA Agents
+> [!CAUTION]
+> ⚠️ For security vulnerabilities, see [SECURITY.md](SECURITY.md). Do not open public issues, pull requests, or discussions for security problems.
 
-Many people have the idea to propose code modifications from IA Agents, verbatim (or almost). We recently get lots of this kind of contributions. **That kind of IA only contribution will be refused.**
+## Where things go
 
-You can of course take help from any way you want (including IA agents), but a **human must** review and test the proposal; we do not want to debate with an AI bot.
+- **Bug report** — open an issue using the bug template. Reproducibility is the minimum bar; reports we cannot reproduce will be closed.
+- **Feature proposal** — open an issue using the "contribution request" template *before* writing code. We will tell you whether the change belongs in core, in a plugin, or not at all.
+- **Idea without implementation** — use [suggest.glpi-project.org](https://suggest.glpi-project.org) and upvote existing entries. Issues opened as "please add X" without a discussion or PR will be redirected there.
+- **Usage questions** — use the [forum](https://forum.glpi-project.org). Questions opened as issues will be closed.
 
-Another point: licensing around IA agents commit is currently quite uncertain. We prefer keeping things simple, so **we won't accept any code explicitely authored from any IA agent**.
+## Plugin-first
 
-## Bugs
+If a feature can live as a plugin, it should. Core accepts changes that touch shared infrastructure (data model, framework, security, accessibility) or that the majority of users need. Niche features become plugins — we will help you scope the API surface you need.
 
-Note that issues are handled on a best-effort basis. If you need a quick fix or any guarantee, take a look at **[profesional services](https://services.glpi-network.com/)** or [partners](https://glpi-project.org/partners/).
+## Pull requests
 
-If you found a bug, the first steps to do are:
-- check if you're using the latest version, and if not, upgrade to see if the problem remains unsolved,
-- search in already existing tickets to see if someone else already reported the issue.
+Trivial fixes (typos, broken links, small documentation corrections) may be submitted as PRs directly.
 
-If the last release does not solve the issue and there are no existing tickets, create one using the bug report template. Be sure you provide all requested details, log entries, and whatever may be useful to understand and reproduce the issue.
+For all other changes, a pull request is reviewed only after these conditions are met:
 
-If developers are not able to reproduce the issue, it may not be fixed.
+1. A linked issue exists and the change has been agreed.
+2. Tests cover the new behavior or the bug being fixed. PRs without tests are closed.
+3. CI passes — static analysis, code style, and the test suites.
+4. The PR description discloses whether AI tools were used and how.
 
-## Features
+Keep your branch up to date with the target branch. We rebase and squash on merge.
 
-If you want to work on a new feature, open a ticket using the feature template, so we can discuss on it.
+Coding standards and the local CI workflow are documented in the [GLPI developer documentation](https://glpi-developer-documentation.readthedocs.io).
 
-If you're just asking for something to be added without doing it yourself, please consider adding (or upvoting) an enhancement on the [suggestion website](https://suggest.glpi-project.org).
+## AI-assisted contributions
 
-## Support request
+AI tools are welcome when used by someone who understands the change. Disclose tool use in the PR description.
 
-You have a question on GLPI usage, or want to know what are the capabilities.
+Commits must be authored under your own name and email — not by an AI agent or LLM provider account. PRs containing commits owned by an AI service will be returned for re-authoring.
 
-Current repository is not the right place for that. You may try to ask your question on [the forums](https://forum.glpi-project.org), on the mailing lists, on telegram channels, ...
-
-## Coding
-
-If you want to contribute to the project code, please take a time to read the [project coding guidelines](https://glpi-developer-documentation.readthedocs.io).
+Contributions that reference functions, hooks, or APIs that do not exist in the codebase will be closed as hallucinations. Repeat offenders will be banned.


### PR DESCRIPTION
## Description

- Review CONTRIBUTING document
- add a yml to fail th CI when commit author is identified as a direct llm.
  It pull_request_target trigger that bypass workflow running protection. And so it will run also for newcomers and external contributors
- add new label commenter setup, to allow closing big PR opened without prior discussion.

