### PR TITLE
KB : add illustration field to categories

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+$migration->addField(
+    'glpi_knowbaseitemcategories',
+    'illustration',
+    'varchar(255) DEFAULT NULL',
+    ['after' => 'comment']
+);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -4085,6 +4085,7 @@ CREATE TABLE `glpi_knowbaseitemcategories` (
   `name` varchar(255) DEFAULT NULL,
   `completename` text,
   `comment` text,
+  `illustration` varchar(255) DEFAULT NULL,
   `level` int NOT NULL DEFAULT '0',
   `sons_cache` longtext,
   `ancestors_cache` longtext,

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -70,7 +70,7 @@ final class Builder
         foreach ($categories as $cat_data) {
             $category = new Category(
                 title: $cat_data['name'] ?? '',
-                illustration: 'kb-faq',
+                illustration: $cat_data['illustration'] ?: 'kb-faq',
             );
             $this->populateNode($category, (int) $cat_data['id']);
             $node->addCategory($category);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2582,6 +2582,17 @@ TWIG, $twig_params);
         }
     }
 
+    public static function getAdditionalMenuLinks(): array
+    {
+        $links = [];
+
+        if (KnowbaseItemCategory::canView()) {
+            $links['view_kb_categories'] = KnowbaseItemCategory::getSearchURL(false);
+        }
+
+        return $links;
+    }
+
     #[Override]
     protected function getLeftSideContent(): ?string
     {

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -63,6 +63,22 @@ class KnowbaseItemCategory extends CommonTreeDropdown
         return KnowbaseItem::getIcon();
     }
 
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAdditionalFields()
+    {
+        $fields = parent::getAdditionalFields();
+
+        $fields[] = [
+            'name'  => 'illustration',
+            'type'  => 'illustration',
+            'label' => __('Illustration'),
+        ];
+
+        return $fields;
+    }
+
     public function cleanDBonPurge()
     {
         $this->deleteChildrenAndRelationsFromDb(

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -103,6 +103,13 @@
             <span class="d-none d-xxl-block">{{ 'Glpi\\Form\\Category'|itemtype_name(get_plural_number()) }}</span>
          </a>
       </li>
+   {% elseif type == 'view_kb_categories' %}
+      <li class="nav-item">
+         <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ 'KnowbaseItemCategory'|itemtype_name(get_plural_number()) }}">
+            <i class="ti ti-folder"></i>
+            <span class="d-none d-xxl-block">{{ 'KnowbaseItemCategory'|itemtype_name(get_plural_number()) }}</span>
+         </a>
+      </li>
    {% elseif type == 'import_forms' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Import forms') }}">

--- a/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
@@ -35,7 +35,6 @@
 namespace tests\unit\Glpi\Knowbase\Aside;
 
 use Glpi\Knowbase\Aside\Builder;
-use Glpi\Knowbase\Aside\Category;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItemCategory;
@@ -105,6 +104,30 @@ final class BuilderTest extends DbTestCase
             array_column($plants_node->getArticles(), 'title'),
         );
         $this->assertEmpty($plants_node->getCategories());
+    }
+
+    public function testCategoryIllustrationIsPropagatedFromDb(): void
+    {
+        $this->login();
+
+        $this->createItem(KnowbaseItemCategory::class, [
+            'name'                      => 'Custom illustrated',
+            'knowbaseitemcategories_id' => 0,
+            'entities_id'               => $this->getTestRootEntity(only_id: true),
+            'is_recursive'              => 1,
+            'illustration'              => 'kb-graduation',
+        ]);
+        $this->makeCategory('Default illustrated');
+
+        $tree = (new Builder())->buildTree();
+
+        $by_title = [];
+        foreach ($tree->getCategories() as $node) {
+            $by_title[$node->title] = $node;
+        }
+
+        $this->assertSame('kb-graduation', $by_title['Custom illustrated']->illustration);
+        $this->assertSame('kb-faq', $by_title['Default illustrated']->illustration);
     }
 
     private function makeCategory(string $name, int $parent_id = 0): KnowbaseItemCategory


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- https://github.com/glpi-project/roadmap/issues/267
- Here is a brief description of what this PR does : add the illustration support, new link is added pointing to KB categories administration on top bar, next to breadcrumbs.

Provides also the migration needed and a functional test.

As for now in the KB project we cannot associate an article to a category, no e2e test can be provided. For testing an article / category association, use SQL : 

```
INSERT INTO glpi_knowbaseitems_knowbaseitemcategories
      (knowbaseitems_id, knowbaseitemcategories_id)
  VALUES (2, 2);

  SELECT * FROM glpi_knowbaseitemcategories WHERE id = 2;
```


## Screenshot : 

<img width="1686" height="817" alt="image" src="https://github.com/user-attachments/assets/d9bde992-9b5c-473d-b09b-cb536aab9c94" />



