### PR TITLE
Fix(LDAP): reduce AD nested group sync from N to M queries

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -80,6 +80,9 @@ class AuthLDAP extends CommonDBTM
     public const GROUP_SEARCH_GROUP   = 1;
     public const GROUP_SEARCH_BOTH    = 2;
 
+    /** OID for the LDAP_MATCHING_RULE_IN_CHAIN extended match rule (AD nested groups). */
+    public const MATCHING_RULE_IN_CHAIN_OID = '1.2.840.113556.1.4.1941';
+
     /**
      * Deleted user strategy: preserve user.
      * @var int

--- a/src/User.php
+++ b/src/User.php
@@ -2180,6 +2180,22 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
+        // When the LDAP_MATCHING_RULE_IN_CHAIN OID is in use (AD nested groups), the
+        // per-user query `(group_member_field=user_dn)` forces the server to perform a
+        // recursive group-tree traversal for every user, resulting in N such traversals
+        // for N users being synced. Instead, precompute memberships once per GLPI group
+        // (M queries) and serve subsequent per-user lookups from a static cache.
+        if (
+            str_contains($ldap_method["group_member_field"], '1.2.840.113556.1.4.1941')
+            && !empty($ldap_method["group_field"])
+        ) {
+            return $this->getFromLDAPGroupDiscretCached(
+                $ldap_connection,
+                $ldap_method,
+                $userdn
+            );
+        }
+
         if ($ldap_method["use_dn"]) {
             $user_tmp = $userdn;
         } else {
@@ -2213,6 +2229,121 @@ class User extends CommonDBTM implements TreeBrowseInterface
                 }
             }
         }
+        return true;
+    }
+
+
+    /**
+     * Precompute a user_dn → group_ids mapping for all GLPI groups, then resolve
+     * the current user's memberships from cache.
+     *
+     * Called instead of the per-user LDAP query when LDAP_MATCHING_RULE_IN_CHAIN
+     * is configured, to reduce N recursive traversals to M (one per GLPI group).
+     *
+     * @param Connection $ldap_connection LDAP connection
+     * @param array      $ldap_method     LDAP method config
+     * @param string     $userdn          DN of the user to resolve
+     *
+     * @return bool
+     */
+    private function getFromLDAPGroupDiscretCached(
+        $ldap_connection,
+        array $ldap_method,
+        string $userdn
+    ): bool {
+        global $DB;
+
+        $auth_id = (int) ($ldap_method['id'] ?? 0);
+
+        // Static cache: [auth_id => [user_dn_lower => [group_id, ...]]]
+        // Populated once per auth server per process, then reused for all users.
+        static $cache = [];
+
+        if (!array_key_exists($auth_id, $cache)) {
+            $cache[$auth_id] = [];
+
+            // Extract the OID suffix from group_member_field so we can build the
+            // inverse attribute. e.g. 'member:1.2.840.113556.1.4.1941' → ':1.2.840.113556.1.4.1941'
+            $chain_suffix = '';
+            if (($colon = strpos($ldap_method['group_member_field'], ':')) !== false) {
+                $chain_suffix = substr($ldap_method['group_member_field'], $colon);
+            }
+
+            // Inverse attribute: group_field (e.g. 'memberof') + CHAIN OID suffix
+            // queries USER objects for transitive group membership.
+            $user_group_attr = $ldap_method['group_field'] . $chain_suffix;
+
+            $condition = !empty($ldap_method['condition'])
+                ? $ldap_method['condition']
+                : '(objectClass=*)';
+
+            // For each GLPI group that has an LDAP DN, fetch all transitive members.
+            $groups_iterator = $DB->request([
+                'SELECT' => ['id', 'ldap_group_dn'],
+                'FROM'   => 'glpi_groups',
+                'WHERE'  => ['NOT' => ['ldap_group_dn' => '']],
+            ]);
+
+            foreach ($groups_iterator as $group_row) {
+                $group_id = (int) $group_row['id'];
+                $group_dn = $group_row['ldap_group_dn'];
+                $escaped  = ldap_escape($group_dn, '', LDAP_ESCAPE_FILTER);
+                $filter   = "(& $condition ($user_group_attr=$escaped))";
+                $cookie   = '';
+
+                do {
+                    if (!empty($ldap_method['pagesize'])) {
+                        $controls = [[
+                            'oid'        => LDAP_CONTROL_PAGEDRESULTS,
+                            'iscritical' => true,
+                            'value'      => ['size' => (int) $ldap_method['pagesize'], 'cookie' => $cookie],
+                        ]];
+                        $sr = @ldap_search(
+                            $ldap_connection,
+                            $ldap_method['basedn'],
+                            $filter,
+                            ['dn'],
+                            0,
+                            -1,
+                            -1,
+                            LDAP_DEREF_NEVER,
+                            $controls
+                        );
+                        if (
+                            $sr !== false
+                            && @ldap_parse_result($ldap_connection, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls) !== false // @phpstan-ignore theCodingMachineSafe.function
+                            && isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])
+                        ) {
+                            $cookie = $controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'];
+                        } else {
+                            $cookie = '';
+                        }
+                    } else {
+                        $sr     = @ldap_search($ldap_connection, $ldap_method['basedn'], $filter, ['dn']);
+                        $cookie = '';
+                    }
+
+                    if ($sr === false) {
+                        break;
+                    }
+
+                    $info = AuthLDAP::get_entries_clean($ldap_connection, $sr);
+                    for ($i = 0; $i < ($info['count'] ?? 0); $i++) {
+                        if (!empty($info[$i]['dn'])) {
+                            $member_key = strtolower($info[$i]['dn']);
+                            $cache[$auth_id][$member_key][] = $group_id;
+                        }
+                    }
+                } while ($cookie !== '');
+            }
+        }
+
+        // Assign groups from cache — O(1) lookup, no LDAP round-trip.
+        $user_key = strtolower($userdn);
+        foreach ($cache[$auth_id][$user_key] ?? [] as $group_id) {
+            $this->fields["_groups"][] = $group_id;
+        }
+
         return true;
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -2181,11 +2181,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
-        // When the LDAP_MATCHING_RULE_IN_CHAIN OID is in use (AD nested groups), the
-        // per-user query `(group_member_field=user_dn)` forces the server to perform a
-        // recursive group-tree traversal for every user, resulting in N such traversals
-        // for N users being synced. Instead, precompute memberships once per GLPI group
-        // (M queries) and serve subsequent per-user lookups from a static cache.
+        // Use cached lookup when MATCHING_RULE_IN_CHAIN is set (AD nested groups).
         if (
             str_contains($ldap_method["group_member_field"], AuthLDAP::MATCHING_RULE_IN_CHAIN_OID)
             && !empty($ldap_method["group_field"])
@@ -2235,17 +2231,14 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
 
     /**
-     * Precompute a user_dn → group_ids mapping for all GLPI groups, then resolve
-     * the current user's memberships from cache.
+     * Variant of getFromLDAPGroupDiscret() for MATCHING_RULE_IN_CHAIN (AD nested groups).
+     * Fetches members per group (M queries) and caches results for subsequent users.
      *
-     * Called instead of the per-user LDAP query when LDAP_MATCHING_RULE_IN_CHAIN
-     * is configured, to reduce N recursive traversals to M (one per GLPI group).
+     * @param Connection $ldap_connection LDAP connection
+     * @param array<string, mixed> $ldap_method LDAP method config
+     * @param string $userdn DN of the user to resolve
      *
-     * @param Connection           $ldap_connection LDAP connection
-     * @param array<string, mixed> $ldap_method     LDAP method config
-     * @param string               $userdn          DN of the user to resolve
-     *
-     * @return bool
+     * @return bool true if groups were resolved, false on LDAP error
      */
     private function getFromLDAPGroupDiscretCached(
         $ldap_connection,
@@ -2256,34 +2249,31 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
         $auth_id = (int) ($ldap_method['id'] ?? 0);
 
-        // Static cache: [auth_id => [user_dn_lower => [group_id, ...]]]
-        // Populated once per auth server per process, then reused for all users.
+        // Keyed by auth_id then lowercase user DN; populated once per process.
         static $cache = [];
 
         if (!array_key_exists($auth_id, $cache)) {
             $cache[$auth_id] = [];
 
-            // Extract the OID suffix from group_member_field so we can build the
-            // inverse attribute. e.g. 'member:1.2.840.113556.1.4.1941' → ':1.2.840.113556.1.4.1941'
+            // Keep the OID suffix from group_member_field (e.g. ':1.2.840.113556.1.4.1941').
             $chain_suffix = '';
             if (($colon = strpos($ldap_method['group_member_field'], ':')) !== false) {
                 $chain_suffix = substr($ldap_method['group_member_field'], $colon);
             }
 
-            // Inverse attribute: group_field (e.g. 'memberof') + CHAIN OID suffix
-            // queries USER objects for transitive group membership.
             $user_group_attr = $ldap_method['group_field'] . $chain_suffix;
 
             $condition = !empty($ldap_method['condition'])
                 ? $ldap_method['condition']
                 : '(objectClass=*)';
 
-            // For each GLPI group that has an LDAP DN, fetch all transitive members.
             $groups_iterator = $DB->request([
                 'SELECT' => ['id', 'ldap_group_dn'],
                 'FROM'   => 'glpi_groups',
                 'WHERE'  => ['NOT' => ['ldap_group_dn' => '']],
             ]);
+
+            $ldap_error = false;
 
             foreach ($groups_iterator as $group_row) {
                 $group_id = (int) $group_row['id'];
@@ -2325,7 +2315,8 @@ class User extends CommonDBTM implements TreeBrowseInterface
                     }
 
                     if ($sr === false) {
-                        break;
+                        $ldap_error = true;
+                        break 2;
                     }
 
                     /** @var Result $sr */
@@ -2338,9 +2329,13 @@ class User extends CommonDBTM implements TreeBrowseInterface
                     }
                 } while ($cookie !== '');
             }
+
+            if ($ldap_error) {
+                unset($cache[$auth_id]);
+                return false;
+            }
         }
 
-        // Assign groups from cache — O(1) lookup, no LDAP round-trip.
         $user_key = strtolower($userdn);
         foreach ($cache[$auth_id][$user_key] ?? [] as $group_id) {
             $this->fields["_groups"][] = $group_id;

--- a/src/User.php
+++ b/src/User.php
@@ -47,6 +47,7 @@ use Glpi\Features\TreeBrowseInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\TOTPManager;
 use LDAP\Connection;
+use LDAP\Result;
 use Sabre\VObject\Component\VCard;
 use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
@@ -2186,7 +2187,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         // for N users being synced. Instead, precompute memberships once per GLPI group
         // (M queries) and serve subsequent per-user lookups from a static cache.
         if (
-            str_contains($ldap_method["group_member_field"], '1.2.840.113556.1.4.1941')
+            str_contains($ldap_method["group_member_field"], AuthLDAP::MATCHING_RULE_IN_CHAIN_OID)
             && !empty($ldap_method["group_field"])
         ) {
             return $this->getFromLDAPGroupDiscretCached(
@@ -2240,9 +2241,9 @@ class User extends CommonDBTM implements TreeBrowseInterface
      * Called instead of the per-user LDAP query when LDAP_MATCHING_RULE_IN_CHAIN
      * is configured, to reduce N recursive traversals to M (one per GLPI group).
      *
-     * @param Connection $ldap_connection LDAP connection
-     * @param array      $ldap_method     LDAP method config
-     * @param string     $userdn          DN of the user to resolve
+     * @param Connection           $ldap_connection LDAP connection
+     * @param array<string, mixed> $ldap_method     LDAP method config
+     * @param string               $userdn          DN of the user to resolve
      *
      * @return bool
      */
@@ -2310,7 +2311,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                             $controls
                         );
                         if (
-                            $sr !== false
+                            $sr instanceof Result
                             && @ldap_parse_result($ldap_connection, $sr, $errcode, $matcheddn, $errmsg, $referrals, $controls) !== false // @phpstan-ignore theCodingMachineSafe.function
                             && isset($controls[LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'])
                         ) {
@@ -2327,6 +2328,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                         break;
                     }
 
+                    /** @var Result $sr */
                     $info = AuthLDAP::get_entries_clean($ldap_connection, $sr);
                     for ($i = 0; $i < ($info['count'] ?? 0); $i++) {
                         if (!empty($info[$i]['dn'])) {

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2551,7 +2551,7 @@ class UserTest extends DbTestCase
      * LDAP_MATCHING_RULE_IN_CHAIN OID is present in group_member_field.
      *
      * The cached path queries GLPI groups from DB (no LDAP call when DB is empty)
-     * and always returns true, while the standard path returns false when
+     * and returns true, while the standard path returns false when
      * group_member_field is empty.
      */
     #[RequiresPhpExtension('ldap')]

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -34,12 +34,15 @@
 
 namespace tests\units;
 
+use AuthLDAP;
 use DateInterval;
 use DateTime;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Exception\ForgetPasswordException;
 use Glpi\Tests\DbTestCase;
+use Group;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Profile_User;
 use Psr\Log\LogLevel;
 use User;
@@ -2150,7 +2153,7 @@ class UserTest extends DbTestCase
         $user->getFromDB($_SESSION['glpiID']);
 
         // Create a group that will be used to add a profile
-        $group = new \Group();
+        $group = new Group();
         $groups_id = $group->add([
             'name' => __FUNCTION__,
             'entities_id' => $entities_id,
@@ -2541,5 +2544,135 @@ class UserTest extends DbTestCase
         $this->assertCount(3, $tree);
         $this->assertStringStartsWith(__FUNCTION__ . '_1', $tree[1]['title']);
         $this->assertStringStartsWith(__FUNCTION__ . '_2', $tree[0]['title']);
+    }
+
+    /**
+     * Verify that getFromLDAPGroupDiscret() routes to the cached path when the
+     * LDAP_MATCHING_RULE_IN_CHAIN OID is present in group_member_field.
+     *
+     * The cached path queries GLPI groups from DB (no LDAP call when DB is empty)
+     * and always returns true, while the standard path returns false when
+     * group_member_field is empty.
+     */
+    #[RequiresPhpExtension('ldap')]
+    public function testGetFromLDAPGroupDiscretChainOidRouting(): void
+    {
+        $this->login();
+
+        // Create an AuthLDAP entry to get a real, unique auth_id so the static
+        // cache inside getFromLDAPGroupDiscretCached stays isolated per test run.
+        $auth = $this->createItem(AuthLDAP::class, [
+            'name'    => $this->getUniqueString(),
+            'host'    => '127.0.0.1',
+            'basedn'  => 'dc=example,dc=com',
+        ]);
+
+        $ldap_method_base = [
+            'id'               => $auth->getID(),
+            'basedn'           => 'dc=example,dc=com',
+            'condition'        => '',
+            'pagesize'         => 0,
+            'group_field'      => 'member',
+            'use_dn'           => 1,
+            'group_condition'  => '',
+            'login_field'      => 'uid',
+        ];
+
+        $user = new User();
+
+        // Empty group_member_field → early false (no LDAP server needed).
+        $result = $this->callPrivateMethod(
+            $user,
+            'getFromLDAPGroupDiscret',
+            null,
+            array_merge($ldap_method_base, ['group_member_field' => '']),
+            'uid=testuser,dc=example,dc=com',
+            'testuser'
+        );
+        $this->assertFalse($result);
+
+        // CHAIN OID present + group_field set → cached path → true.
+        // No groups with ldap_group_dn exist in DB, so no ldap_search is fired.
+        $result = $this->callPrivateMethod(
+            $user,
+            'getFromLDAPGroupDiscret',
+            null,
+            array_merge($ldap_method_base, [
+                'group_member_field' => 'member:1.2.840.113556.1.4.1941',
+            ]),
+            'uid=testuser,dc=example,dc=com',
+            'testuser'
+        );
+        $this->assertTrue($result);
+        $this->assertEmpty($user->fields['_groups'] ?? []);
+    }
+
+    /**
+     * Verify that getFromLDAPGroupDiscretCached() reads group assignments from
+     * its static cache on subsequent calls, skipping DB and LDAP queries.
+     *
+     * Strategy: pre-seed the cache via the first call (DB empty → no ldap_search),
+     * then add a group to DB and call again — the cached path must ignore the new
+     * DB row and still return no groups, proving the static cache is effective.
+     */
+    #[RequiresPhpExtension('ldap')]
+    public function testGetFromLDAPGroupDiscretCachedUsesStaticCache(): void
+    {
+        $this->login();
+
+        $auth = $this->createItem(AuthLDAP::class, [
+            'name'    => $this->getUniqueString(),
+            'host'    => '127.0.0.1',
+            'basedn'  => 'dc=example,dc=com',
+        ]);
+
+        $ldap_method = [
+            'id'               => $auth->getID(),
+            'basedn'           => 'dc=example,dc=com',
+            'condition'        => '',
+            'pagesize'         => 0,
+            'group_field'      => 'member',
+            'group_member_field' => 'member:1.2.840.113556.1.4.1941',
+            'use_dn'           => 1,
+            'group_condition'  => '',
+            'login_field'      => 'uid',
+        ];
+
+        $userdn = 'uid=cachetest,dc=example,dc=com';
+
+        $user1 = new User();
+
+        // First call — DB has no groups with ldap_group_dn, cache is primed as empty.
+        $result = $this->callPrivateMethod(
+            $user1,
+            'getFromLDAPGroupDiscret',
+            null,
+            $ldap_method,
+            $userdn,
+            'cachetest'
+        );
+        $this->assertTrue($result);
+        $this->assertEmpty($user1->fields['_groups'] ?? []);
+
+        // Add a group to DB between the two calls.
+        $this->createItem(Group::class, [
+            'name'          => $this->getUniqueString(),
+            'entities_id'   => $this->getTestRootEntity(true),
+            'ldap_group_dn' => 'cn=admins,dc=example,dc=com',
+        ]);
+
+        $user2 = new User();
+
+        // Second call with same auth_id — cache hit, DB group is NOT picked up.
+        $result = $this->callPrivateMethod(
+            $user2,
+            'getFromLDAPGroupDiscret',
+            null,
+            $ldap_method,
+            $userdn,
+            'cachetest'
+        );
+        $this->assertTrue($result);
+        $this->assertEmpty($user2->fields['_groups'] ?? []);
     }
 }

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2598,7 +2598,7 @@ class UserTest extends DbTestCase
             'getFromLDAPGroupDiscret',
             null,
             array_merge($ldap_method_base, [
-                'group_member_field' => 'member:1.2.840.113556.1.4.1941',
+                'group_member_field' => 'member:' . AuthLDAP::MATCHING_RULE_IN_CHAIN_OID,
             ]),
             'uid=testuser,dc=example,dc=com',
             'testuser'
@@ -2632,7 +2632,7 @@ class UserTest extends DbTestCase
             'condition'        => '',
             'pagesize'         => 0,
             'group_field'      => 'member',
-            'group_member_field' => 'member:1.2.840.113556.1.4.1941',
+            'group_member_field' => 'member:' . AuthLDAP::MATCHING_RULE_IN_CHAIN_OID,
             'use_dn'           => 1,
             'group_condition'  => '',
             'login_field'      => 'uid',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43252

When `group_member_field` is configured with the `LDAP_MATCHING_RULE_IN_CHAIN` OID (`1.2.840.113556.1.4.1941`), GLPI was issuing one recursive LDAP query per user during group synchronization, causing N recursive traversals on the AD/Samba server for N users being synced.

The fix introduces `getFromLDAPGroupDiscretCached()`: when the OID is detected, GLPI precomputes group memberships once per GLPI group (M queries) and stores the result in a static cache. Subsequent per-user lookups are served from the cache with no LDAP round-trip.

- _https://help.glpi-project.org/faq/glpi/ldap#is-it-possible-to-use-nested-groups_

## Screenshots (if appropriate):


