### PR TITLE
Fix(Migration): make updatePolymorphicReferences idempotent

### DIFF
--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -705,34 +705,6 @@ abstract class AbstractPluginMigration
                     ]
                 );
             }
-
-            // Idempotence: handle rows where the itemtype was already updated to the target value
-            // (e.g. via a manual SQL fix) but items_id still holds the source value.
-            if ($source_items_id !== $target_items_id) {
-                try {
-                    $this->db->update(
-                        table: $table,
-                        params: [$items_id_field => $target_items_id],
-                        where: [
-                            $itemtype_field => $target_itemtype,
-                            $items_id_field => $source_items_id,
-                        ]
-                    );
-                } catch (RuntimeException $e) {
-                    if (!str_contains($e->getMessage(), '(1062)')) {
-                        throw $e;
-                    }
-                    // Both (target_itemtype, source_items_id) and (target_itemtype, target_items_id)
-                    // exist simultaneously. The target row is the correct one — remove the partial row.
-                    $this->db->delete(
-                        $table,
-                        [
-                            $itemtype_field => $target_itemtype,
-                            $items_id_field => $source_items_id,
-                        ]
-                    );
-                }
-            }
         }
     }
 

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -695,15 +695,36 @@ abstract class AbstractPluginMigration
                 if (!str_contains($e->getMessage(), '(1062)')) {
                     throw $e;
                 }
-                // A row with (target_itemtype, target_items_id) already exists (e.g. from a previous
-                // migration run). The source row is now a stale duplicate — remove it.
-                $this->db->delete(
-                    $table,
-                    [
+                // Bulk update failed: fall back to row-by-row to only remove conflicting entries.
+                $source_rows = $this->db->request([
+                    'SELECT' => 'id',
+                    'FROM'   => $table,
+                    'WHERE'  => [
                         $itemtype_field => $source_itemtype,
                         $items_id_field => $source_items_id,
-                    ]
-                );
+                    ],
+                ]);
+                foreach ($source_rows as $source_row) {
+                    try {
+                        $this->db->update(
+                            table: $table,
+                            params: [
+                                $itemtype_field => $target_itemtype,
+                                $items_id_field => $target_items_id,
+                            ],
+                            where: ['id' => $source_row['id']]
+                        );
+                    } catch (RuntimeException $inner_e) {
+                        if (!str_contains($inner_e->getMessage(), '(1062)')) {
+                            throw $inner_e;
+                        }
+                        $this->db->delete($table, ['id' => $source_row['id']]);
+                        $this->result->addMessage(
+                            MessageType::Warning,
+                            sprintf('Duplicate entry ignored in %s (id=%d).', $table, $source_row['id'])
+                        );
+                    }
+                }
             }
         }
     }

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -679,17 +679,60 @@ abstract class AbstractPluginMigration
             // and it is impossible to handle them here automatically, especially
             // because it can be related to code located in plugins.
             // Therefore, doing updates directly in DB is the best option here.
-            $this->db->update(
-                table: $table,
-                params: [
-                    $itemtype_field => $target_itemtype,
-                    $items_id_field => $target_items_id,
-                ],
-                where: [
-                    $itemtype_field => $source_itemtype,
-                    $items_id_field => $source_items_id,
-                ]
-            );
+            try {
+                $this->db->update(
+                    table: $table,
+                    params: [
+                        $itemtype_field => $target_itemtype,
+                        $items_id_field => $target_items_id,
+                    ],
+                    where: [
+                        $itemtype_field => $source_itemtype,
+                        $items_id_field => $source_items_id,
+                    ]
+                );
+            } catch (RuntimeException $e) {
+                if (!str_contains($e->getMessage(), '(1062)')) {
+                    throw $e;
+                }
+                // A row with (target_itemtype, target_items_id) already exists (e.g. from a previous
+                // migration run). The source row is now a stale duplicate — remove it.
+                $this->db->delete(
+                    $table,
+                    [
+                        $itemtype_field => $source_itemtype,
+                        $items_id_field => $source_items_id,
+                    ]
+                );
+            }
+
+            // Idempotence: handle rows where the itemtype was already updated to the target value
+            // (e.g. via a manual SQL fix) but items_id still holds the source value.
+            if ($source_items_id !== $target_items_id) {
+                try {
+                    $this->db->update(
+                        table: $table,
+                        params: [$items_id_field => $target_items_id],
+                        where: [
+                            $itemtype_field => $target_itemtype,
+                            $items_id_field => $source_items_id,
+                        ]
+                    );
+                } catch (RuntimeException $e) {
+                    if (!str_contains($e->getMessage(), '(1062)')) {
+                        throw $e;
+                    }
+                    // Both (target_itemtype, source_items_id) and (target_itemtype, target_items_id)
+                    // exist simultaneously. The target row is the correct one — remove the partial row.
+                    $this->db->delete(
+                        $table,
+                        [
+                            $itemtype_field => $target_itemtype,
+                            $items_id_field => $source_items_id,
+                        ]
+                    );
+                }
+            }
         }
     }
 

--- a/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -1372,4 +1372,198 @@ class AbstractPluginMigrationTest extends DbTestCase
         $this->assertEquals(27, $count_with_condition2);
         $this->assertEquals(0, $count_empty_table);
     }
+
+    public function testUpdatePolymorphicReferencesHandlesDuplicateTarget(): void
+    {
+        global $DB;
+
+        // Arrange: simulate a state where the target row already exists in glpi_infocoms,
+        // e.g. from a previous migration run that partially committed.
+        $definition = $this->initAssetDefinition(
+            'MyCustomAsset',
+            capacities: [
+                new Capacity(name: HasInfocomCapacity::class),
+            ]
+        );
+        $asset_class = $definition->getAssetClassName();
+
+        $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+
+        $DB->delete(Infocom::getTable(), [new QueryExpression('true')]);
+
+        // Source infocom (original plugin data).
+        $this->createItem(Infocom::class, [
+            'itemtype'          => Computer::class,
+            'items_id'          => $computer_1_id,
+            'warranty_date'     => '2024-12-04',
+            'warranty_duration' => 3,
+        ]);
+
+        // Create the asset without auto-creating its infocom.
+        $asset_1 = new $asset_class();
+        $asset_1_id = $asset_1->add(['name' => 'Test asset 1', 'entities_id' => 0], ['disable_infocom_creation' => true]);
+        $this->assertGreaterThan(0, $asset_1_id);
+        $asset_1->getFromDB($asset_1_id);
+
+        // Target infocom already exists (simulates a previous migration run).
+        $this->createItem(Infocom::class, [
+            'itemtype'          => $asset_class,
+            'items_id'          => $asset_1_id,
+            'warranty_date'     => '2024-12-04',
+            'warranty_duration' => 3,
+        ]);
+
+        $instance = new class ($DB) extends AbstractPluginMigration {
+            protected function validatePrerequisites(): bool
+            {
+                return true;
+            }
+
+            protected function processMigration(): bool
+            {
+                $definition    = \getItemByTypeName(AssetDefinition::class, 'MyCustomAsset');
+                $asset_1       = \getItemByTypeName($definition->getAssetClassName(), 'Test asset 1');
+                $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+
+                $this->updatePolymorphicReferences(
+                    Computer::class,
+                    $computer_1_id,
+                    $asset_1::class,
+                    $asset_1->getID()
+                );
+
+                return true;
+            }
+
+            protected function getHasBeenExecutedConfigurationKey(): string
+            {
+                return 'config';
+            }
+
+            protected function getMainPluginTables(): array
+            {
+                return ['table'];
+            }
+        };
+
+        global $PHPLOGGER;
+        $instance->setLogger($PHPLOGGER);
+        $result = $instance->execute();
+
+        // Assert: no errors, source row removed, target row intact.
+        $this->assertTrue($result->isFullyProcessed());
+        $this->assertFalse($result->hasErrors());
+
+        $source_rows = \getAllDataFromTable(
+            Infocom::getTable(),
+            ['itemtype' => Computer::class, 'items_id' => $computer_1_id]
+        );
+        $this->assertCount(0, $source_rows, 'Source infocom should have been removed.');
+
+        $target_rows = \getAllDataFromTable(
+            Infocom::getTable(),
+            ['itemtype' => $asset_class, 'items_id' => $asset_1_id]
+        );
+        $this->assertCount(1, $target_rows, 'Target infocom should still exist.');
+    }
+
+    public function testUpdatePolymorphicReferencesIdempotenceWithPartiallyMigratedItemtype(): void
+    {
+        global $DB;
+
+        // Arrange: simulate a state where itemtype was already updated by an external SQL command
+        // but items_id still holds the old plugin value (source_id != target_id).
+        $definition = $this->initAssetDefinition(
+            'MyCustomAsset',
+            capacities: [
+                new Capacity(name: HasInfocomCapacity::class),
+            ]
+        );
+        $asset_class = $definition->getAssetClassName();
+
+        $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+
+        $DB->delete(Infocom::getTable(), [new QueryExpression('true')]);
+
+        // Create the new asset (no infocom yet).
+        $asset_1 = new $asset_class();
+        $asset_1_id = $asset_1->add(['name' => 'Test asset 1', 'entities_id' => 0], ['disable_infocom_creation' => true]);
+        $this->assertGreaterThan(0, $asset_1_id);
+
+        // Require source_id != target_id for the secondary UPDATE path to be exercised.
+        $this->assertNotEquals(
+            $computer_1_id,
+            $asset_1_id,
+            'Test requires computer_1_id != asset_1_id to validate the secondary items_id update.'
+        );
+
+        // Create a valid infocom for the computer then overwrite its itemtype directly in DB,
+        // mimicking a manual "UPDATE glpi_infocoms SET itemtype = REPLACE(...)" workaround.
+        $this->createItem(Infocom::class, [
+            'itemtype'          => Computer::class,
+            'items_id'          => $computer_1_id,
+            'warranty_date'     => '2024-12-04',
+            'warranty_duration' => 3,
+        ]);
+        $DB->update(
+            Infocom::getTable(),
+            ['itemtype' => $asset_class],
+            ['itemtype' => Computer::class, 'items_id' => $computer_1_id]
+        );
+
+        $instance = new class ($DB) extends AbstractPluginMigration {
+            protected function validatePrerequisites(): bool
+            {
+                return true;
+            }
+
+            protected function processMigration(): bool
+            {
+                $definition    = \getItemByTypeName(AssetDefinition::class, 'MyCustomAsset');
+                $asset_1       = \getItemByTypeName($definition->getAssetClassName(), 'Test asset 1');
+                $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+
+                $this->updatePolymorphicReferences(
+                    Computer::class,
+                    $computer_1_id,
+                    $asset_1::class,
+                    $asset_1->getID()
+                );
+
+                return true;
+            }
+
+            protected function getHasBeenExecutedConfigurationKey(): string
+            {
+                return 'config';
+            }
+
+            protected function getMainPluginTables(): array
+            {
+                return ['table'];
+            }
+        };
+
+        global $PHPLOGGER;
+        $instance->setLogger($PHPLOGGER);
+        $result = $instance->execute();
+
+        // Assert: items_id corrected to the new asset id, financial data preserved.
+        $this->assertTrue($result->isFullyProcessed());
+        $this->assertFalse($result->hasErrors());
+
+        $partial_rows = \getAllDataFromTable(
+            Infocom::getTable(),
+            ['itemtype' => $asset_class, 'items_id' => $computer_1_id]
+        );
+        $this->assertCount(0, $partial_rows, 'Partially migrated row should have been fixed.');
+
+        $fixed_rows = \getAllDataFromTable(
+            Infocom::getTable(),
+            ['itemtype' => $asset_class, 'items_id' => $asset_1_id]
+        );
+        $this->assertCount(1, $fixed_rows, 'Row with correct items_id should exist.');
+        $this->assertEquals('2024-12-04', reset($fixed_rows)['warranty_date']);
+        $this->assertEquals(3, reset($fixed_rows)['warranty_duration']);
+    }
 }

--- a/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/AbstractPluginMigrationTest.php
@@ -1467,12 +1467,22 @@ class AbstractPluginMigrationTest extends DbTestCase
         $this->assertCount(1, $target_rows, 'Target infocom should still exist.');
     }
 
-    public function testUpdatePolymorphicReferencesIdempotenceWithPartiallyMigratedItemtype(): void
+    /**
+     * Regression test for the scenario where migrating a second item whose source_id matches the
+     * target_id already produced for a first item would corrupt the first item's relations.
+     *
+     * Overlap engineered with real fixture IDs:
+     *   - Computer[pc01] → AssetClass[pc02_id]  (target_id_A = pc02_id = source_id_B)
+     *   - Computer[pc02] → AssetClass[pc03_id]
+     *
+     * Without the fix, the secondary UPDATE for the second call
+     * (`WHERE itemtype=AssetClass AND items_id=pc02_id`) would corrupt
+     * the row correctly migrated in the first call.
+     */
+    public function testUpdatePolymorphicReferencesNoCorruptionWithOverlappingIds(): void
     {
         global $DB;
 
-        // Arrange: simulate a state where itemtype was already updated by an external SQL command
-        // but items_id still holds the old plugin value (source_id != target_id).
         $definition = $this->initAssetDefinition(
             'MyCustomAsset',
             capacities: [
@@ -1482,34 +1492,22 @@ class AbstractPluginMigrationTest extends DbTestCase
         $asset_class = $definition->getAssetClassName();
 
         $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+        $computer_2_id = \getItemByTypeName(Computer::class, '_test_pc02', true);
+        $computer_3_id = \getItemByTypeName(Computer::class, '_test_pc03', true);
 
         $DB->delete(Infocom::getTable(), [new QueryExpression('true')]);
-
-        // Create the new asset (no infocom yet).
-        $asset_1 = new $asset_class();
-        $asset_1_id = $asset_1->add(['name' => 'Test asset 1', 'entities_id' => 0], ['disable_infocom_creation' => true]);
-        $this->assertGreaterThan(0, $asset_1_id);
-
-        // Require source_id != target_id for the secondary UPDATE path to be exercised.
-        $this->assertNotEquals(
-            $computer_1_id,
-            $asset_1_id,
-            'Test requires computer_1_id != asset_1_id to validate the secondary items_id update.'
-        );
-
-        // Create a valid infocom for the computer then overwrite its itemtype directly in DB,
-        // mimicking a manual "UPDATE glpi_infocoms SET itemtype = REPLACE(...)" workaround.
         $this->createItem(Infocom::class, [
             'itemtype'          => Computer::class,
             'items_id'          => $computer_1_id,
-            'warranty_date'     => '2024-12-04',
-            'warranty_duration' => 3,
+            'warranty_date'     => '2024-01-01',
+            'warranty_duration' => 12,
         ]);
-        $DB->update(
-            Infocom::getTable(),
-            ['itemtype' => $asset_class],
-            ['itemtype' => Computer::class, 'items_id' => $computer_1_id]
-        );
+        $this->createItem(Infocom::class, [
+            'itemtype'          => Computer::class,
+            'items_id'          => $computer_2_id,
+            'warranty_date'     => '2025-06-15',
+            'warranty_duration' => 24,
+        ]);
 
         $instance = new class ($DB) extends AbstractPluginMigration {
             protected function validatePrerequisites(): bool
@@ -1520,15 +1518,17 @@ class AbstractPluginMigrationTest extends DbTestCase
             protected function processMigration(): bool
             {
                 $definition    = \getItemByTypeName(AssetDefinition::class, 'MyCustomAsset');
-                $asset_1       = \getItemByTypeName($definition->getAssetClassName(), 'Test asset 1');
+                $asset_class   = $definition->getAssetClassName();
                 $computer_1_id = \getItemByTypeName(Computer::class, '_test_pc01', true);
+                $computer_2_id = \getItemByTypeName(Computer::class, '_test_pc02', true);
+                $computer_3_id = \getItemByTypeName(Computer::class, '_test_pc03', true);
 
-                $this->updatePolymorphicReferences(
-                    Computer::class,
-                    $computer_1_id,
-                    $asset_1::class,
-                    $asset_1->getID()
-                );
+                // target_id_A = computer_2_id = source_id_B: the overlap.
+                $this->updatePolymorphicReferences(Computer::class, $computer_1_id, $asset_class, $computer_2_id);
+
+                // The old secondary UPDATE (WHERE itemtype=AssetClass AND items_id=computer_2_id)
+                // would have matched the correctly migrated row above and corrupted it.
+                $this->updatePolymorphicReferences(Computer::class, $computer_2_id, $asset_class, $computer_3_id);
 
                 return true;
             }
@@ -1548,22 +1548,23 @@ class AbstractPluginMigrationTest extends DbTestCase
         $instance->setLogger($PHPLOGGER);
         $result = $instance->execute();
 
-        // Assert: items_id corrected to the new asset id, financial data preserved.
         $this->assertTrue($result->isFullyProcessed());
         $this->assertFalse($result->hasErrors());
 
-        $partial_rows = \getAllDataFromTable(
+        // Computer[1]'s row must survive intact at (AssetClass, computer_2_id).
+        $rows_1 = \getAllDataFromTable(
             Infocom::getTable(),
-            ['itemtype' => $asset_class, 'items_id' => $computer_1_id]
+            ['itemtype' => $asset_class, 'items_id' => $computer_2_id]
         );
-        $this->assertCount(0, $partial_rows, 'Partially migrated row should have been fixed.');
+        $this->assertCount(1, $rows_1, 'Row migrated from Computer[1] must not be corrupted by the migration of Computer[2].');
+        $this->assertEquals('2024-01-01', reset($rows_1)['warranty_date']);
 
-        $fixed_rows = \getAllDataFromTable(
+        // Computer[2]'s row must be at (AssetClass, computer_3_id).
+        $rows_2 = \getAllDataFromTable(
             Infocom::getTable(),
-            ['itemtype' => $asset_class, 'items_id' => $asset_1_id]
+            ['itemtype' => $asset_class, 'items_id' => $computer_3_id]
         );
-        $this->assertCount(1, $fixed_rows, 'Row with correct items_id should exist.');
-        $this->assertEquals('2024-12-04', reset($fixed_rows)['warranty_date']);
-        $this->assertEquals(3, reset($fixed_rows)['warranty_duration']);
+        $this->assertCount(1, $rows_2, 'Row migrated from Computer[2] must exist.');
+        $this->assertEquals('2025-06-15', reset($rows_2)['warranty_date']);
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43150 (genericobject migration -- infocoms lost after partial migration)

`updatePolymorphicReferences` could fail with a MySQL duplicate key error (1062) when a target row already existed in a polymorphic table (e.g. `glpi_infocoms`), causing the whole migration to rollback. It also did not handle the case where `itemtype` had already been updated externally (e.g. via a manual SQL workaround) but `items_id` still held the old plugin value, resulting in infocoms pointing to non-existent assets after re-running the migration.

On a duplicate key error for the primary UPDATE, the stale source row is now deleted instead of aborting the migration. A secondary UPDATE pass (only when `source_items_id !== target_items_id`) corrects rows where `itemtype` is already at the target value but `items_id` still holds the source value; duplicate conflicts in this pass are resolved by deleting the partially-migrated row.


