### PR TITLE
Improve client IP detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 - Sessions tab for OAuth Clients to display non-expired sessions associated with the client and allow revoking them.
+- Improved client IP detection.
+  If your GLPI instance is behind a reverse proxy, you should add its IP(s) the new `GLPI_TRUSTED_REVERSE_PROXIES` constant and modify the new `GLPI_REVERSE_PROXY_HEADERS` constant to include the headers your proxy uses to forward the client IP.
+  Only the required HTTP headers should be listed for better security as any header not handled by the proxy could be spoofed by the client.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -56,6 +56,7 @@ parameters:
         - GLPI_PICTURE_DIR
         - GLPI_PLUGIN_DOC_DIR
         - GLPI_PLUGINS_DIRECTORIES
+        - GLPI_REVERSE_PROXY_HEADERS
         - GLPI_RSS_DIR
         - GLPI_SERVERSIDE_URL_ALLOWLIST
         - GLPI_SESSION_DIR
@@ -66,6 +67,7 @@ parameters:
         - GLPI_TEXT_MAXSIZE
         - GLPI_THEMES_DIR
         - GLPI_TMP_DIR
+        - GLPI_TRUSTED_REVERSE_PROXIES
         - GLPI_UPLOAD_DIR
         - GLPI_USER_AGENT_EXTRA_COMMENTS
         - GLPI_VAR_DIR

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -40,6 +40,7 @@ use Glpi\Error\ErrorHandler;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\Inventory;
 use Glpi\Plugin\Hooks;
+use Glpi\Toolbox\IPUtilities;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
 use Safe\DateTime;
@@ -446,18 +447,7 @@ class Agent extends CommonDBTM
             $input['use_module_collect_data']         = in_array("collect", $metadata['enabled-tasks']) ? 1 : 0;
         }
 
-        $remote_ip = "";
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            //Managing IP through a PROXY
-            $remote_ip = explode(', ', $_SERVER['HTTP_X_FORWARDED_FOR'])[0];
-        } elseif (isset($_SERVER['HTTP_X_REAL_IP'])) {
-            //try with X-Real-IP
-            $remote_ip = $_SERVER['HTTP_X_REAL_IP'];
-        } elseif (isset($_SERVER['REMOTE_ADDR'])) {
-            //then get connected IP
-            $remote_ip = $_SERVER['REMOTE_ADDR'];
-        }
-
+        $remote_ip = IPUtilities::getClientIP() ?? '';
         $remote_ip = new IPAddress($remote_ip);
         if ($remote_ip->is_valid()) {
             $input['remote_addr'] = $remote_ip->getTextual();

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -39,6 +39,7 @@ use Glpi\Error\ErrorHandler;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\TOTPManager;
+use Glpi\Toolbox\IPUtilities;
 use Safe\Exceptions\LdapException;
 
 use function Safe\ini_get;
@@ -1108,7 +1109,7 @@ class Auth extends CommonGLPI
         // Log Event (if possible)
         if (!$DB->isReplica()) {
             // GET THE IP OF THE CLIENT
-            $ip = getenv("HTTP_X_FORWARDED_FOR") ?: getenv("REMOTE_ADDR");
+            $ip = IPUtilities::getClientIP();
 
             if ($this->auth_succeded) {
                 //TRANS: %1$s is the login of the user and %2$s its IP address

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -61,6 +61,7 @@ use Glpi\Exception\ForgetPasswordException;
 use Glpi\Exception\PasswordTooWeakException;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\Search\SearchOption;
+use Glpi\Toolbox\IPUtilities;
 use Glpi\Toolbox\MarkdownRenderer;
 use GLPIKey;
 use Html;
@@ -189,7 +190,7 @@ abstract class API
         }
 
         // retrieve ip of client
-        $this->iptxt = Toolbox::getRemoteIpAddress();
+        $this->iptxt = IPUtilities::getClientIP() ?? '';
         $this->ipnum = (!str_contains($this->iptxt, ':') ? ip2long($this->iptxt) : '');
 
         // check ip access

--- a/src/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
+++ b/src/Glpi/Api/HL/Middleware/IPRestrictionRequestMiddleware.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\Middleware;
 
 use Glpi\Api\HL\Router;
 use Glpi\Http\JSONResponse;
+use Glpi\Toolbox\IPUtilities;
 use League\OAuth2\Server\Exception\OAuthServerException;
 
 use function Safe\inet_pton;
@@ -50,6 +51,8 @@ class IPRestrictionRequestMiddleware extends AbstractMiddleware implements Reque
             $next($input);
             return;
         }
+
+        $client_ip = IPUtilities::getClientIP();
 
         // Determine client_id from current route or request parameters
         $client = Router::getInstance()->getCurrentClient();
@@ -67,7 +70,7 @@ class IPRestrictionRequestMiddleware extends AbstractMiddleware implements Reque
         }
 
         // Check if client is allowed for the remote IP
-        if (!$this->isClientIPAllowed((string) $client_id, $_SERVER['REMOTE_ADDR'])) {
+        if ($client_ip === null || !$this->isClientIPAllowed((string) $client_id, $client_ip)) {
             $input->response = OAuthServerException::accessDenied(
                 'Your IP address is not allowed to use this OAuth client.'
             )->generateHttpResponse(new JSONResponse());

--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -150,6 +150,8 @@ final class SystemConfigurator
                     $~ixuD',
                 ],
                 'GLPI_DISALLOWED_UPLOADS_PATTERN' => '/\.(php\d*|phar)$/i', // Prevent upload of any PHP file / PHP archive; can be set to an empty value to allow every files
+                'GLPI_TRUSTED_REVERSE_PROXIES' => [], // List of known/trusted reverse proxies IP addresses (used for correct client IP detection)
+                'GLPI_REVERSE_PROXY_HEADERS' => ['Forwarded', 'X-Forwarded-For'], // Headers to check to get client IP from reverse proxy in order left to right.
 
                 // Constants related to GLPI Project / GLPI Network external services
                 'GLPI_TELEMETRY_URI'                => 'https://telemetry.glpi-project.org', // Telemetry project URL

--- a/src/Glpi/Toolbox/IPUtilities.php
+++ b/src/Glpi/Toolbox/IPUtilities.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Toolbox;
+
+final class IPUtilities
+{
+    public static function isTrustedReverseProxy(?string $ip): bool
+    {
+        if ($ip === null) {
+            return false;
+        }
+        return in_array($ip, GLPI_TRUSTED_REVERSE_PROXIES, true);
+    }
+
+    public static function getClientIP(): ?string
+    {
+        $remote_addr = $_SERVER['REMOTE_ADDR'] ?? null;
+        if ($remote_addr === null) {
+            return null;
+        }
+        if (!self::isTrustedReverseProxy($remote_addr)) {
+            return $remote_addr;
+        }
+        $proxy_ip_headers = GLPI_REVERSE_PROXY_HEADERS;
+        foreach ($proxy_ip_headers as $header) {
+            $server_header = 'HTTP_' . str_replace('-', '_', strtoupper($header));
+            if (isset($_SERVER[$server_header])) {
+                if ($server_header === 'HTTP_FORWARDED') {
+                    $forwarded_header = $_SERVER[$server_header];
+                    $forwarded_header_parts = explode(';', $forwarded_header);
+                    foreach ($forwarded_header_parts as $part) {
+                        $part = trim($part);
+                        if (str_starts_with($part, 'for=')) {
+                            $ip = substr($part, 4);
+                            // IP may be quoted and IPv6 IPs are supposed to be enclosed in square brackets.
+                            return trim($ip, '"[]');
+                        }
+                    }
+                }
+                // handle standard headers (X-Forwarded-For, etc.)
+                $ip_list = explode(',', $_SERVER[$server_header]);
+                $ip_list = array_map('trim', $ip_list);
+                // return the first IP in the list, which should be the original client IP
+                return $ip_list[0];
+            }
+        }
+
+        // At this point, the remote address is a trusted proxy but none of the expected headers were found, so we return the remote address as a fallback
+        return $remote_addr;
+    }
+}

--- a/src/Glpi/Toolbox/IPUtilities.php
+++ b/src/Glpi/Toolbox/IPUtilities.php
@@ -34,14 +34,27 @@
 
 namespace Glpi\Toolbox;
 
-final class IPUtilities
+/**
+ * @final Only open for extension for use within tests.
+ */
+class IPUtilities
 {
+    protected static function getTrustedReverseProxies(): array
+    {
+        return GLPI_TRUSTED_REVERSE_PROXIES;
+    }
+
+    protected static function getTrustedReverseProxyHeaders(): array
+    {
+        return GLPI_REVERSE_PROXY_HEADERS;
+    }
+
     public static function isTrustedReverseProxy(?string $ip): bool
     {
         if ($ip === null) {
             return false;
         }
-        return in_array($ip, GLPI_TRUSTED_REVERSE_PROXIES, true); // @phpstan-ignore function.impossibleType
+        return in_array($ip, static::getTrustedReverseProxies(), true); // @phpstan-ignore function.impossibleType
     }
 
     public static function getClientIP(): ?string
@@ -50,10 +63,10 @@ final class IPUtilities
         if ($remote_addr === null) {
             return null;
         }
-        if (!self::isTrustedReverseProxy($remote_addr)) {
+        if (!static::isTrustedReverseProxy($remote_addr)) {
             return $remote_addr;
         }
-        $proxy_ip_headers = GLPI_REVERSE_PROXY_HEADERS;
+        $proxy_ip_headers = static::getTrustedReverseProxyHeaders();
         foreach ($proxy_ip_headers as $header) {
             $server_header = 'HTTP_' . str_replace('-', '_', strtoupper($header));
             if (isset($_SERVER[$server_header])) {

--- a/src/Glpi/Toolbox/IPUtilities.php
+++ b/src/Glpi/Toolbox/IPUtilities.php
@@ -39,11 +39,17 @@ namespace Glpi\Toolbox;
  */
 class IPUtilities
 {
+    /**
+     * @return string[]
+     */
     protected static function getTrustedReverseProxies(): array
     {
         return GLPI_TRUSTED_REVERSE_PROXIES;
     }
 
+    /**
+     * @return string[]
+     */
     protected static function getTrustedReverseProxyHeaders(): array
     {
         return GLPI_REVERSE_PROXY_HEADERS;

--- a/src/Glpi/Toolbox/IPUtilities.php
+++ b/src/Glpi/Toolbox/IPUtilities.php
@@ -41,7 +41,7 @@ final class IPUtilities
         if ($ip === null) {
             return false;
         }
-        return in_array($ip, GLPI_TRUSTED_REVERSE_PROXIES, true);
+        return in_array($ip, GLPI_TRUSTED_REVERSE_PROXIES, true); // @phpstan-ignore function.impossibleType
     }
 
     public static function getClientIP(): ?string

--- a/src/Glpi/Toolbox/IPUtilities.php
+++ b/src/Glpi/Toolbox/IPUtilities.php
@@ -60,7 +60,7 @@ class IPUtilities
         if ($ip === null) {
             return false;
         }
-        return in_array($ip, static::getTrustedReverseProxies(), true); // @phpstan-ignore function.impossibleType
+        return in_array($ip, static::getTrustedReverseProxies(), true);
     }
 
     public static function getClientIP(): ?string

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2722,9 +2722,11 @@ class Toolbox
      * @since 9.2
      *
      * @return string the IP address
+     * @deprecated 12.0.0
      */
     public static function getRemoteIpAddress()
     {
+        self::deprecated('Use Glpi\\Toolbox\\IPUtilities::getClientIP() instead for better handling of reverse proxies.');
         return $_SERVER["REMOTE_ADDR"];
     }
 

--- a/stubs/glpi_constants.php
+++ b/stubs/glpi_constants.php
@@ -92,6 +92,8 @@
     define('GLPI_SYSTEM_CRON', $random_val([false, true]));
     define('GLPI_TELEMETRY_URI', 'https://telemetry.glpi-project.org');
     define('GLPI_TEXT_MAXSIZE', $random_val([1000, 2000, 3000, 4000]));
+    define('GLPI_TRUSTED_REVERSE_PROXIES', $random_val([[], ['10.10.3.4']]));
+    define('GLPI_REVERSE_PROXY_HEADERS', $random_val([['X-Forwarded-For'], ['Forwarded']]));
     define('GLPI_USER_AGENT_EXTRA_COMMENTS', $random_val(['', 'app-version:5']));
     define('GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING', $random_val([false, true]));
     define('GLPI_WEBHOOK_CRA_MANDATORY', $random_val([false, true]));

--- a/tests/functional/Glpi/Toolbox/IPUtilitiesTest.php
+++ b/tests/functional/Glpi/Toolbox/IPUtilitiesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Toolbox;
+
+use Glpi\Tests\GLPITestCase;
+use Glpi\Toolbox\IPUtilities;
+
+class IPUtilitiesTest extends GLPITestCase
+{
+    public function testIsTrustedReverseProxy()
+    {
+        $ipUtilities = new class extends IPUtilities {
+            public static function getTrustedReverseProxies(): array
+            {
+                return ['10.10.1.3', 'fd79:a3b1:c4d2:1::1'];
+            }
+        };
+
+        // Test with a trusted reverse proxy IP
+        $this->assertTrue($ipUtilities::isTrustedReverseProxy('10.10.1.3'));
+        $this->assertTrue($ipUtilities::isTrustedReverseProxy('fd79:a3b1:c4d2:1::1'));
+        $this->assertFalse($ipUtilities::isTrustedReverseProxy('10.9.1.3'));
+    }
+
+    public function testGetClientIP()
+    {
+        $ipUtilities = new class extends IPUtilities {
+            public static function getTrustedReverseProxies(): array
+            {
+                return ['10.10.1.3', 'fd79:a3b1:c4d2:1::1'];
+            }
+
+            protected static function getTrustedReverseProxyHeaders(): array
+            {
+                return ['X-Forwarded-For'];
+            }
+        };
+
+        // Not trusted proxy
+        $_SERVER['REMOTE_ADDR'] = '10.8.4.5';
+        $this->assertEquals('10.8.4.5', $ipUtilities::getClientIP());
+
+        // Trusted proxy but no trusted header
+        $_SERVER['REMOTE_ADDR'] = '10.10.1.3';
+        $this->assertEquals('10.10.1.3', $ipUtilities::getClientIP());
+
+        // Trusted proxy with trusted header
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.8.4.5';
+        $this->assertEquals('10.8.4.5', $ipUtilities::getClientIP());
+
+        // Not trusted header
+        unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+        $_SERVER['HTTP_FORWARDED'] = 'for=10.8.4.5;proto=http';
+        $this->assertEquals('10.10.1.3', $ipUtilities::getClientIP());
+
+        $ipUtilities = new class extends IPUtilities {
+            public static function getTrustedReverseProxies(): array
+            {
+                return ['10.10.1.3', 'fd79:a3b1:c4d2:1::1'];
+            }
+
+            protected static function getTrustedReverseProxyHeaders(): array
+            {
+                return ['Forwarded', 'X-Forwarded-For'];
+            }
+        };
+
+        // First header has priority over the second. Also tests Ipv6 format in Forwarded
+        $_SERVER['HTTP_FORWARDED'] = 'for=[fd79:a3b1:c4d2:1::5];proto=http';
+        $this->assertEquals('fd79:a3b1:c4d2:1::5', $ipUtilities::getClientIP());
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '10.10.4.4';
+        $this->assertEquals('fd79:a3b1:c4d2:1::5', $ipUtilities::getClientIP());
+        unset($_SERVER['HTTP_FORWARDED']);
+        $this->assertEquals('10.10.4.4', $ipUtilities::getClientIP());
+    }
+}

--- a/tests/functional/ToolboxTest.php
+++ b/tests/functional/ToolboxTest.php
@@ -163,7 +163,7 @@ class ToolboxTest extends DbTestCase
 
         // Test REMOTE_ADDR
         $_SERVER['REMOTE_ADDR'] = '123.123.123.123';
-        $ip = \Toolbox::getRemoteIpAddress();
+        $ip = @\Toolbox::getRemoteIpAddress();
         $this->assertEquals('123.123.123.123', $ip);
 
         // Restore values


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Adds a new method of determining the client's IP address.

Soft requirement/enhancement for #24000

Currently, GLPI checks for some proxy-related headers first in some cases and then fall back to `REMOTE_ADDR`.

This pull request adds a more secure determination and HTTP headers could be spoofed by the client.
1. If GLPI is behind a reverse proxy (or several), the GLPI admin should add those IPs to the new `GLPI_TRUSTED_REVERSE_PROXIES` constant. They should additionally modify the new `GLPI_REVERSE_PROXY_HEADERS` constant to include the header used by their proxy(s) and only those headers.
2. GLPI will check `REMOTE_ADDR` against the trusted proxy IPs.
3. If the `REMOTE_ADDR` is a trusted proxy, only then will GLPI check the `GLPI_REVERSE_PROXY_HEADERS` in the order they were defined.
4. If the `REMOTE_ADDR` is not a trusted proxy, that value is assumed to be the client IP.
