### PR TITLE
fix(service-catalog): Make default sort strategy configurable for entities

### DIFF
--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2574,6 +2574,7 @@ $empty_data_builder = new class {
                 'enable_helpdesk_home_search_bar' => 1,
                 'enable_helpdesk_service_catalog' => 1,
                 'expand_service_catalog' => 0,
+                'service_catalog_default_sort_strategy' => 'popularity',
             ],
         ];
 

--- a/install/migrations/update_11.0.6_to_11.0.7/service_catalog.php
+++ b/install/migrations/update_11.0.6_to_11.0.7/service_catalog.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+if (!$DB->fieldExists('glpi_entities', 'service_catalog_default_sort_strategy')) {
+    $migration->addField(
+        'glpi_entities',
+        'service_catalog_default_sort_strategy',
+        "varchar(255) NOT NULL DEFAULT '-2'"
+    );
+    $migration->addPostQuery(
+        $DB->buildUpdate(
+            'glpi_entities',
+            ['service_catalog_default_sort_strategy' => 'popularity'],
+            ['id' => 0]
+        )
+    );
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2852,6 +2852,7 @@ CREATE TABLE `glpi_entities` (
   `enable_helpdesk_home_search_bar` tinyint NOT NULL DEFAULT '-2',
   `enable_helpdesk_service_catalog` tinyint NOT NULL DEFAULT '-2',
   `expand_service_catalog` tinyint NOT NULL DEFAULT '-2',
+  `service_catalog_default_sort_strategy` varchar(255) NOT NULL DEFAULT '-2',
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`entities_id`,`name`),
   KEY `name` (`name`),

--- a/js/modules/Forms/ServiceCatalogController.js
+++ b/js/modules/Forms/ServiceCatalogController.js
@@ -35,16 +35,22 @@
 export class GlpiFormServiceCatalogController
 {
     /** @type {string} */
-    #sort_strategy = 'popularity';
+    #sort_strategy;
+
+    /** @type {string} */
+    #default_sort_strategy;
 
     /**
      * @constructor
      * @param {Object} sort_icons - Icons for sorting
+     * @param {string} default_sort_strategy - Server-configured default sort strategy
      */
-    constructor(sort_icons)
+    constructor(sort_icons, default_sort_strategy = 'popularity')
     {
         this.breadcrumb = [];
         this.sort_icons = sort_icons;
+        this.#default_sort_strategy = default_sort_strategy;
+        this.#sort_strategy = default_sort_strategy;
 
         const input = this.#getFilterInput();
         const filterFormsDebounced = _.debounce(
@@ -70,7 +76,7 @@ export class GlpiFormServiceCatalogController
                     this.breadcrumb = event.state.breadcrumb;
                 }
                 const params = new URLSearchParams(event.state.url_params);
-                this.#sort_strategy = params.get('sort_strategy') || 'popularity';
+                this.#sort_strategy = params.get('sort_strategy') || this.#default_sort_strategy;
                 this.#syncSortDropdown(this.#sort_strategy);
             }
         });
@@ -116,8 +122,8 @@ export class GlpiFormServiceCatalogController
                     this.#applySortStrategy(sort_strategy);
                 });
 
-            // Sync dropdown to URL-provided sort strategy
-            if (this.#sort_strategy !== 'popularity') {
+            // Sync dropdown to current sort strategy when it differs from the select2 initial value
+            if (this.#sort_strategy !== this.#default_sort_strategy) {
                 $select.val(this.#sort_strategy).trigger('change');
             }
         }, 0);

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -38,6 +38,7 @@ use Glpi\Debug\Profiler;
 use Glpi\Event;
 use Glpi\Features\Clonable;
 use Glpi\Form\FormTranslation;
+use Glpi\Form\ServiceCatalog\SortStrategy\SortStrategyEnum;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
@@ -186,7 +187,7 @@ class Entity extends CommonTreeDropdown implements
             'contracts_strategy_default', 'contracts_id_default', 'show_tickets_properties_on_helpdesk',
             'custom_helpdesk_home_scene_left', 'custom_helpdesk_home_scene_right',
             'custom_helpdesk_home_title', 'enable_helpdesk_home_search_bar', 'enable_helpdesk_service_catalog',
-            'expand_service_catalog',
+            'expand_service_catalog', 'service_catalog_default_sort_strategy',
         ],
         // Configuration
         'config' => ['enable_custom_css', 'custom_css_code'],
@@ -3319,9 +3320,16 @@ class Entity extends CommonTreeDropdown implements
             $tiles_manager->showConfigFormForItem($this);
         }
 
+        $sort_strategy_options = array_map(
+            fn($strategy) => $strategy->getLabel(),
+            SortStrategyEnum::getAvailableStrategies()
+        );
         $twig->display(
             'pages/admin/helpdesk_home_config_for_entity.html.twig',
-            ['entity' => $this],
+            [
+                'entity'                  => $this,
+                'sort_strategy_options'   => $sort_strategy_options,
+            ],
         );
 
         return true;
@@ -3441,6 +3449,21 @@ class Entity extends CommonTreeDropdown implements
         }
 
         return $value === 1;
+    }
+
+    public function getServiceCatalogDefaultSortStrategy(): SortStrategyEnum
+    {
+        $value = $this->fields['service_catalog_default_sort_strategy'] ?? '';
+
+        // Load from parent if needed
+        if ($value == self::CONFIG_PARENT) {
+            $value = self::getUsedConfig(
+                'service_catalog_default_sort_strategy',
+                $this->fields['entities_id']
+            );
+        }
+
+        return SortStrategyEnum::tryFrom((string) $value) ?? SortStrategyEnum::getDefault();
     }
 
     public function getDefaultHelpdeskHomeTitle(): string

--- a/src/Glpi/Controller/ServiceCatalog/IndexController.php
+++ b/src/Glpi/Controller/ServiceCatalog/IndexController.php
@@ -102,7 +102,7 @@ final class IndexController extends AbstractController
                 : ["create_ticket"],
             'items' => $items,
             'sort_strategies' => SortStrategyEnum::getAvailableStrategies(),
-            'default_sort_strategy' => SortStrategyEnum::getDefault()->value,
+            'default_sort_strategy' => $entity->getServiceCatalogDefaultSortStrategy()->value,
             'expand_categories' => $entity->shouldExpandCategoriesInServiceCatalog(),
         ]);
     }

--- a/src/Glpi/Controller/ServiceCatalog/ItemsController.php
+++ b/src/Glpi/Controller/ServiceCatalog/ItemsController.php
@@ -90,12 +90,6 @@ final class ItemsController extends AbstractController
         $page = max(1, $request->query->getInt('page', 1));
         $items_per_page = ServiceCatalogManager::ITEMS_PER_PAGE;
 
-        // Read sort strategy
-        $sort_strategy = $request->query->getEnum(
-            'sort_strategy',
-            SortStrategyEnum::class,
-        ) ?? SortStrategyEnum::getDefault();
-
         // Build session + url params
         $session = Session::getCurrentSessionInfo();
         $parameters = new FormAccessParameters(
@@ -108,6 +102,12 @@ final class ItemsController extends AbstractController
         if (!$entity) {
             throw new LogicException();
         }
+
+        // Read sort strategy — explicit URL param wins, otherwise use the entity-configured default
+        $sort_strategy = $request->query->getEnum(
+            'sort_strategy',
+            SortStrategyEnum::class,
+        ) ?? $entity->getServiceCatalogDefaultSortStrategy();
 
         // If we have a filter, we search in all categories
         if (!empty($filter)) {
@@ -131,16 +131,17 @@ final class ItemsController extends AbstractController
         return $this->render(
             'components/helpdesk_forms/service_catalog_items.html.twig',
             [
-                'category_id'       => $category_id,
-                'filter'            => $filter,
-                'sort_strategy'     => $sort_strategy->value,
-                'ancestors'         => $ancestors,
-                'items'             => $result['items'],
-                'total'             => $result['total'],
-                'current_page'      => $page,
-                'items_per_page'    => $items_per_page,
-                'is_default_search' => false,
-                'expand_categories' => $entity->shouldExpandCategoriesInServiceCatalog(),
+                'category_id'            => $category_id,
+                'filter'                 => $filter,
+                'sort_strategy'          => $sort_strategy->value,
+                'default_sort_strategy'  => $entity->getServiceCatalogDefaultSortStrategy()->value,
+                'ancestors'              => $ancestors,
+                'items'                  => $result['items'],
+                'total'                  => $result['total'],
+                'current_page'           => $page,
+                'items_per_page'         => $items_per_page,
+                'is_default_search'      => false,
+                'expand_categories'      => $entity->shouldExpandCategoriesInServiceCatalog(),
             ]
         );
     }

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -100,7 +100,7 @@
 {% endfor %}
 
 {# Add pagination if there are more items than items_per_page #}
-{% set sort_strategy = sort_strategy|default('popularity') %}
+{% set sort_strategy = sort_strategy|default(default_sort_strategy)|default('popularity') %}
 {% if total > items_per_page %}
     {% set total_pages = ((total + items_per_page - 1) / items_per_page)|round(0, 'floor') %}
     {% set adjacents = 2 %}

--- a/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
@@ -354,6 +354,32 @@
             </div>
         </div>
 
+        <div class="row mb-3">
+            <div class="col-6">
+                {% if is_root_entity %}
+                    {% set sort_strategy_dropdown_options = sort_strategy_options %}
+                {% else %}
+                    {% set resolved_sort_label = entity.getServiceCatalogDefaultSortStrategy().getStrategy().getLabel() %}
+                    {% set sort_strategy_dropdown_options = sort_strategy_options|merge({
+                        (constant("Entity::CONFIG_PARENT")): __("Inherited from parent entity (%1$s)")|format(resolved_sort_label),
+                    }) %}
+                {% endif %}
+
+                <h3 class="mb-2 mt-1">{{ __("Default sort order in the service catalog") }}</h3>
+                <div class="mb-2">
+                    {% do call('Dropdown::showFromArray', [
+                        'service_catalog_default_sort_strategy',
+                        sort_strategy_dropdown_options,
+                        {
+                            value: entity.fields.service_catalog_default_sort_strategy,
+                            width: "100%",
+                            aria_label: __('Default sort order in the service catalog'),
+                        }
+                    ]) %}
+                </div>
+            </div>
+        </div>
+
         {# Form actions #}
         <div class="d-flex mb-1">
             <button

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -111,6 +111,7 @@
                 'items_per_page': constant('Glpi\\Form\\ServiceCatalog\\ServiceCatalogManager::ITEMS_PER_PAGE'),
                 'is_default_search': true,
                 'expand_categories': expand_categories,
+                'default_sort_strategy': default_sort_strategy,
             },
             with_context = false
         ) }}
@@ -124,7 +125,7 @@
             {% for key, icon in icons %}
                 icons["{{ key|escape('js') }}"] = "{{ icon|escape('js') }}";
             {% endfor %}
-            window.GlpiServiceCatalog = new module.GlpiFormServiceCatalogController(icons);
+            window.GlpiServiceCatalog = new module.GlpiFormServiceCatalogController(icons, "{{ default_sort_strategy|escape('js') }}");
         })();
     </script>
 {% endblock content_body %}

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -42,6 +42,7 @@ use Glpi\Controller\ServiceCatalog\IndexController;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Form\Category;
 use Glpi\Form\Form;
+use Glpi\Form\ServiceCatalog\SortStrategy\SortStrategyEnum;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\Helpdesk\HomePageTabs;
 use Glpi\Tests\DbTestCase;
@@ -2076,5 +2077,94 @@ class EntityTest extends DbTestCase
             $should_be_expanded ? 1 : 0,
             $request_form
         );
+    }
+
+    public static function serviceCatalogDefaultSortStrategyProvider(): iterable
+    {
+        yield 'Entity without config inherits popularity from root' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => '-2'],
+            ],
+            'entity' => 'entity_a',
+            'expected_strategy' => SortStrategyEnum::POPULARITY,
+        ];
+
+        yield 'Entity with explicit alphabetical value' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 'alphabetical'],
+            ],
+            'entity' => 'entity_a',
+            'expected_strategy' => SortStrategyEnum::ALPHABETICAL,
+        ];
+
+        yield 'Entity with explicit reverse_alphabetical value' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 'reverse_alphabetical'],
+            ],
+            'entity' => 'entity_a',
+            'expected_strategy' => SortStrategyEnum::REVERSE_ALPHABETICAL,
+        ];
+
+        yield 'Entity inherits alphabetical from parent' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 'alphabetical'],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => '-2'],
+            ],
+            'entity' => 'entity_aa',
+            'expected_strategy' => SortStrategyEnum::ALPHABETICAL,
+        ];
+
+        yield 'Child overrides parent alphabetical with popularity' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 'alphabetical'],
+                ['name' => 'entity_aa', 'parent' => 'entity_a', 'config' => 'popularity'],
+            ],
+            'entity' => 'entity_aa',
+            'expected_strategy' => SortStrategyEnum::POPULARITY,
+        ];
+
+        yield 'Invalid stored value falls back to default' => [
+            'entities' => [
+                ['name' => 'entity_a', 'config' => 'unknown_value'],
+            ],
+            'entity' => 'entity_a',
+            'expected_strategy' => SortStrategyEnum::POPULARITY,
+        ];
+    }
+
+    #[DataProvider('serviceCatalogDefaultSortStrategyProvider')]
+    public function testServiceCatalogDefaultSortStrategy(
+        array $entities,
+        string $entity,
+        SortStrategyEnum $expected_strategy,
+    ): void {
+        $this->login();
+
+        // Arrange: create requested entities
+        $root = $this->getTestRootEntity(only_id: true);
+        foreach ($entities as $to_create) {
+            if (isset($to_create['parent'])) {
+                $parent = getItemByTypeName(
+                    Entity::class,
+                    $to_create['parent'],
+                    onlyid: true,
+                );
+            } else {
+                $parent = $root;
+            }
+
+            $this->createItem(Entity::class, [
+                'name'                                  => $to_create['name'],
+                'entities_id'                           => $parent,
+                'service_catalog_default_sort_strategy' => $to_create['config'],
+            ]);
+        }
+
+        // Act
+        $entity = getItemByTypeName(Entity::class, $entity);
+        $actual_strategy = $entity->getServiceCatalogDefaultSortStrategy();
+
+        // Assert
+        $this->assertEquals($expected_strategy, $actual_strategy);
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description

- It fixes !43245

This PR introduces a new configurable default sort strategy for the service catalog, allowing each entity to define how service catalog items are sorted (e.g., by popularity or alphabetically).

## Screenshots (if appropriate):

<img width="1187" height="445" alt="image" src="https://github.com/user-attachments/assets/ffb58b35-bc5a-47d1-ae1c-5f7b0c48b73a" />
<img width="591" height="165" alt="image" src="https://github.com/user-attachments/assets/f7ceb9da-4112-4ef5-b743-36d7c0bb6a67" />
