### PR TITLE
PHP 8.1 no longer receives security fixes

### DIFF
--- a/phpunit/functional/Glpi/System/Requirement/PhpSupportedVersionTest.php
+++ b/phpunit/functional/Glpi/System/Requirement/PhpSupportedVersionTest.php
@@ -92,14 +92,22 @@ class PhpSupportedVersionTest extends \GLPITestCase
 
         yield [
             'phpversion' => '8.1.0-rc1',
-            'validated'  => true,
-            'messages'   => [],
+            'validated'  => false,
+            'messages'   => [
+                'PHP 8.1 is no longer maintained by its community.',
+                'Even if GLPI still supports this PHP version, an upgrade to a more recent PHP version is recommended.',
+                'Indeed, this PHP version may contain unpatched security vulnerabilities.',
+            ],
         ];
 
         yield [
             'phpversion' => '8.1.7',
-            'validated'  => true,
-            'messages'   => [],
+            'validated'  => false,
+            'messages'   => [
+                'PHP 8.1 is no longer maintained by its community.',
+                'Even if GLPI still supports this PHP version, an upgrade to a more recent PHP version is recommended.',
+                'Indeed, this PHP version may contain unpatched security vulnerabilities.',
+            ],
         ];
 
         yield [
@@ -122,6 +130,30 @@ class PhpSupportedVersionTest extends \GLPITestCase
 
         yield [
             'phpversion' => '8.3.1',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.4.0-dev',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.4.3',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.5.0-dev',
+            'validated'  => true,
+            'messages'   => [],
+        ];
+
+        yield [
+            'phpversion' => '8.5.5',
             'validated'  => true,
             'messages'   => [],
         ];

--- a/src/System/Requirement/PhpSupportedVersion.php
+++ b/src/System/Requirement/PhpSupportedVersion.php
@@ -46,7 +46,7 @@ class PhpSupportedVersion extends AbstractRequirement
      * @var string
      * @see https://www.php.net/supported-versions
      */
-    private const MIN_SECURITY_SUPPORTED_VERSION = '8.1';
+    private const MIN_SECURITY_SUPPORTED_VERSION = '8.2';
 
     public function __construct()
     {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

PHP 8.1 is no longer supported, since 31 Dec 2025.