### PR TITLE
fix: add child groups to actors list when creating a ticket with business rule

### DIFF
--- a/src/RuleTicket.php
+++ b/src/RuleTicket.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Toolbox\Sanitizer;
 
 class RuleTicket extends Rule
 {
@@ -468,9 +469,10 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::unsanitize($regexvalue);
                                 $group = new Group();
                                 if (
-                                    $group->getFromDBByCrit(["name" => $regexvalue,
+                                    $group->getFromDBByCrit(["completename" => $regexvalue,
                                         "is_requester" => true,
                                     ])
                                 ) {
@@ -483,9 +485,10 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::unsanitize($regexvalue);
                                 $group = new Group();
                                 if (
-                                    $group->getFromDBByCrit(["name" => $regexvalue,
+                                    $group->getFromDBByCrit(["completename" => $regexvalue,
                                         "is_watcher" => true,
                                     ])
                                 ) {
@@ -498,9 +501,10 @@ class RuleTicket extends Rule
                                     $action->fields["value"],
                                     $regex_result
                                 );
+                                $regexvalue = Sanitizer::unsanitize($regexvalue);
                                 $group = new Group();
                                 if (
-                                    $group->getFromDBByCrit(["name" => $regexvalue,
+                                    $group->getFromDBByCrit(["completename" => $regexvalue,
                                         "is_assign" => true,
                                     ])
                                 ) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes ticket 43709 (excluding SQL errors).

- Before this fix, when a business rule added groups to a ticket’s actors list using a regex, matching child groups were not added. This was due to two issues:
    - the resolved group name was HTML-escaped (e.g. "parent group > child group" became "parent group &#\62 child group"),
    - and the SQL query searched using the name field instead of the completename field in the database.
