### PR TITLE
Fix networkdevice changed to customasset

### DIFF
--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -71,6 +71,8 @@ use Glpi\Inventory\Asset\Software;
 use Glpi\Inventory\Asset\SoundCard;
 use Glpi\Inventory\Asset\VirtualMachine;
 use Glpi\Inventory\Asset\Volume;
+use Glpi\Inventory\MainAsset\GenericAsset;
+use Glpi\Inventory\MainAsset\GenericNetworkAsset;
 use Glpi\Inventory\MainAsset\Itemtype;
 use Glpi\Inventory\MainAsset\MainAsset;
 use Glpi\Inventory\MainAsset\NetworkEquipment;
@@ -688,6 +690,14 @@ class Inventory
         if ($main_class === null || !class_exists($main_class)) {
             $main_class = $class_ns . 'GenericAsset';
         }
+
+        if (
+            ltrim($main_class, '\\') === ltrim(GenericAsset::class, '\\')
+            && isset($this->data['network_device'])
+        ) {
+            $main_class = GenericNetworkAsset::class;
+        }
+
         return $main_class;
     }
 

--- a/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
+++ b/tests/functional/Glpi/Inventory/GenericNetworkAssetInventoryTest.php
@@ -40,6 +40,7 @@ use Glpi\Asset\Capacity\HasDevicesCapacity;
 use Glpi\Asset\Capacity\HasNetworkPortCapacity;
 use Glpi\Asset\Capacity\IsInventoriableCapacity;
 use Glpi\Asset\CapacityConfig;
+use Glpi\Inventory\MainAsset\GenericAsset;
 use Glpi\Inventory\MainAsset\GenericNetworkAsset;
 use Glpi\Inventory\Request;
 use Glpi\Tests\InventoryTestCase;
@@ -703,5 +704,43 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $inventory = $this->doInventory($xml_source, true);
         $item = $inventory->getItem();
         $this->assertInstanceOf(NetworkEquipment::class, $item);
+    }
+
+    public function testImportNetworkEquipmentWithDefaultMainAsset(): void
+    {
+        global $DB;
+
+        // Create a custom asset with IsInventoriableCapacity using GenericAsset (the non-network
+        // default). The fix in Inventory::getMainClass() auto-upgrades to GenericNetworkAsset
+        // when network_device data is detected, preventing the "constraint (name)" rule failure.
+        $definition = $this->initAssetDefinition(
+            system_name: 'NetworkAssetDefault' . $this->getUniqueString(),
+            capacities: [
+                new Capacity(
+                    name: IsInventoriableCapacity::class,
+                    config: new CapacityConfig([
+                        'inventory_mainasset' => GenericAsset::class,
+                    ])
+                ),
+            ]
+        );
+        $classname = $definition->getAssetClassName();
+
+        $json = json_decode(file_get_contents(self::INV_FIXTURES . 'networkequipment_1.json'));
+        $json->itemtype = $classname;
+        $json->deviceid = 'a-network-deviceid-default';
+
+        $this->doInventory($json);
+
+        $refused = $DB->request(['FROM' => \RefusedEquipment::getTable()]);
+        $this->assertCount(0, $refused);
+
+        $equipments = $DB->request(['FROM' => $classname::getTable(), 'WHERE' => ['is_dynamic' => 1]]);
+        $this->assertCount(1, $equipments);
+
+        $equipment = new $classname();
+        $this->assertTrue($equipment->getFromDB($equipments->current()['id']));
+        $this->assertSame('ucs6248up-cluster-pa3-B', $equipment->fields['name']);
+        $this->assertSame('SSI1912014B', $equipment->fields['serial']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43132
- Here is a brief description of what this PR does
When a network device is converted to a Generic Asset via a rule, the import fails because the values are not saved

## Screenshots (if appropriate):


