### PR TITLE
Improve getEntitiesRestrictCriteria performances

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -937,9 +937,11 @@ final class DbUtils
             $field = "$table.$field";
         }
 
+        $value_is_session_default = false;
         if (!is_array($value) && strlen($value) == 0) {
             if (isset($_SESSION['glpiactiveentities'])) {
                 $value = $_SESSION['glpiactiveentities'];
+                $value_is_session_default = true;
             } elseif (Session::isRightChecksDisabled()) {
                 return [new QueryExpression('true')];
             } elseif (isCommandLine() || Session::isCron()) {
@@ -962,7 +964,10 @@ final class DbUtils
 
         if ($is_recursive) {
             $ancestors = [];
-            if (is_array($value)) {
+            if ($value_is_session_default) {
+                $ancestors = $_SESSION['glpiparententities'] ?? [];
+                $ancestors = array_diff($ancestors, $value);
+            } elseif (is_array($value)) {
                 $ancestors = $this->getAncestorsOf("glpi_entities", $value);
                 $ancestors = array_diff($ancestors, $value);
             } elseif (strlen($value) == 0) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.

## Description

While investigating potential performances issues, I found this timing for a simple operation of the news plugin:

<img width="1048" height="107" alt="image" src="https://github.com/user-attachments/assets/98efa373-996c-436e-83fb-d4b711fd23f2" />

Given we only have 16 entries in the relevant table, it seemed weird so I added a bit of debug and monitored one of the function used by this specific plugin hook: getEntitiesRestrictCriteria.

I got the following results:
```
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.183105ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.181913ms
getEntitiesRestrictCriteria(glpi_savedsearches) took 374.084949ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.192165ms
getEntitiesRestrictCriteria(glpi_savedsearches) took 375.653982ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.180960ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.181913ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.189066ms
getEntitiesRestrictCriteria(glpi_profiles_users) took 0.211954ms
```

As you can see, there is a huge slow down when checking the criteria for `glpi_savedsearches`.

Looking at the method, it accepts a `value` parameter:

<img width="965" height="383" alt="image" src="https://github.com/user-attachments/assets/64574b04-ccfe-4b2f-ae3a-034647e2ca91" />

When an empty value is supplied, it is replaced by the current entities:

<img width="485" height="138" alt="image" src="https://github.com/user-attachments/assets/ce469a9b-8c62-46e4-87b0-777d86930012" />

It is also taken into account when computing recursion:

<img width="634" height="233" alt="image" src="https://github.com/user-attachments/assets/1d2f870c-d3cb-4712-8e12-d4425d49c728" />

However, this condition seems unlikely to be true, as $value was already replaced with the current entities.

From my understanding, this mean we never use `$_SESSION['glpiparententities']` and instead we recompute the parent every time.

I've fixed it by setting a `value_is_session_default` flag to true when `value` is empty, which we check to see if we can safely bypass ancestors computation by using `$_SESSION['glpiparententities']` later.

This proved effective as the plugin hook time was instantly reduced:

<img width="843" height="87" alt="image" src="https://github.com/user-attachments/assets/b99a3eeb-69f2-4f32-bbc4-150dcc7d26e0" />


