### PR TITLE
chore(phpcsfixer): Add filter to exclude paratest "files" folders

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,6 +46,19 @@ $finder = (new PhpCsFixer\Finder())
         'tests/e2e/',
         'vendor/',
     ])
+    ->filter(static function (\SplFileInfo $file): bool {
+        $tests_path = realpath(__DIR__ . '/tests');
+        if ($tests_path === false) {
+            return true;
+        }
+
+        $file_path = $file->getRealPath();
+        if ($file_path === false) {
+            return true;
+        }
+
+        return !str_starts_with($file_path, $tests_path . '/files-');
+    })
 ;
 
 return (new PhpCsFixer\Config())

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,19 +46,9 @@ $finder = (new PhpCsFixer\Finder())
         'tests/e2e/',
         'vendor/',
     ])
-    ->filter(static function (\SplFileInfo $file): bool {
-        $tests_path = realpath(__DIR__ . '/tests');
-        if ($tests_path === false) {
-            return true;
-        }
-
-        $file_path = $file->getRealPath();
-        if ($file_path === false) {
-            return true;
-        }
-
-        return !str_starts_with($file_path, $tests_path . '/files-');
-    })
+    ->notPath([
+        '/^tests\/files-/'
+    ])
 ;
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Since the addition of `paratest`, as many `tests/files-n` directories are created as there are workers.
These directories are not deleted and are not excluded from the `phpcsfixer` configuration, which reduces the effectiveness of the linter in development environments.

This PR therefore modifies the configuration to ignore these directories.
