### PR TITLE
Improve Twig Alert Component and replace all depracted macro call

### DIFF
--- a/src/RuleDictionnarySoftwareCollection.php
+++ b/src/RuleDictionnarySoftwareCollection.php
@@ -79,11 +79,13 @@ class RuleDictionnarySoftwareCollection extends RuleCollection
         // language=Twig
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% import 'components/form/fields_macros.html.twig' as fields %}
-            {% import 'components/alerts_macros.html.twig' as alerts %}
             <form name="testrule_form" id="softdictionnary_confirmation" method="post" action="{{ target }}">
                 <div class="card">
                     <div class="card-body">
-                        {{ alerts.alert_warning(warning_title, warning_message) }}
+                        <twig:Alert:Warning
+                            :title="warning_title"
+                            :message="warning_message"
+                        />
                         <div>
                             {{ fields.dropdownField('Manufacturer', 'manufacturer', 0, manufacturer_label, {
                                 emptylabel: emptylabel,

--- a/src/Twig/Components/Alert/AbstractAlert.php
+++ b/src/Twig/Components/Alert/AbstractAlert.php
@@ -56,7 +56,7 @@ abstract class AbstractAlert
 
     public ?string $link_text = null;
 
-    public ?string $link_target = '_blank';
+    public bool $link_blank = true;
 
     public function getResolvedIcon(): string
     {

--- a/src/Twig/Components/Alert/AbstractAlert.php
+++ b/src/Twig/Components/Alert/AbstractAlert.php
@@ -56,7 +56,7 @@ abstract class AbstractAlert
 
     public ?string $link_text = null;
 
-    public bool $link_blank = true;
+    public bool $link_blank = false;
 
     public function getResolvedIcon(): string
     {

--- a/src/Twig/Components/Alert/AbstractAlert.php
+++ b/src/Twig/Components/Alert/AbstractAlert.php
@@ -46,14 +46,17 @@ abstract class AbstractAlert
 
     public string $title = '';
 
-    /**
-     * @var iterable<mixed>|string
-     */
-    public iterable|string $messages = [];
+    public string $message = '';
 
     public string $icon = '';
 
     public bool $important = false;
+
+    public ?string $link_url = null;
+
+    public ?string $link_text = null;
+
+    public ?string $link_target = '_blank';
 
     public function getResolvedIcon(): string
     {

--- a/templates/components/alerts_macros.html.twig
+++ b/templates/components/alerts_macros.html.twig
@@ -31,14 +31,27 @@
  #}
 
 {% macro alert(alert_type = "", title = "", messages = [], icon = "", important = false) %}
-   {#{% do call('Toolbox::deprecated', ['Twig alert macros are deprecated. Use the Alert Twig component instead.']) %}#}
-   {{ component('Alert', {
-      type: alert_type,
-      title: title,
-      messages: messages,
-      icon: icon,
-      important: important,
-   }) }}
+    {% do call('Toolbox::deprecated', ['Twig alert macros are deprecated. Use the Alert Twig component instead.']) %}
+    {% set _message = '' %}
+    {% if messages is iterable %}
+        {% for message in messages %}
+            {% if _message %}
+                {% set _message = _message ~ "\n" %}
+            {% endif %}
+
+            {% set _message = _message ~ message %}
+        {% endfor %}
+    {% else %}
+        {% set _message = messages %}
+    {% endif %}
+
+    {{ component('Alert', {
+        type: alert_type,
+        title: title,
+        message: _message,
+        icon: icon,
+        important: important,
+    }) }}
 {% endmacro %}
 
 {% macro alert_success(title = "", messages = [], important = false) %}

--- a/templates/components/dashboard/reset.html.twig
+++ b/templates/components/dashboard/reset.html.twig
@@ -31,12 +31,13 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <div class="dashboard-reset-container">
     {% if dashboard.fields['context'] == 'core' or dashboard.fields['context'] == 'mini_core' %}
         <div>
-            {{ alerts.alert_danger(__('This will reset all filters, cards, and sharing options in this dashboard with the one selected!')) }}
+            <twig:Alert:Danger
+                :title="__('This will reset all filters, cards, and sharing options in this dashboard with the one selected!')"
+            />
             {{ fields.dropdownArrayField('default_dashboard_key', null, default_dashboards, __('Default dashboard to reset to'), {
                 full_width: true,
                 is_horizontal: false,
@@ -49,6 +50,8 @@
             </button>
         </div>
     {% else %}
-        {{ alerts.alert_danger(__('Resetting this dashboard is not currently supported.')) }}
+        <twig:Alert:Danger
+            :title="__('Resetting this dashboard is not currently supported.')"
+        />
     {% endif %}
 </div>

--- a/templates/components/dashboard/reset.html.twig
+++ b/templates/components/dashboard/reset.html.twig
@@ -36,7 +36,7 @@
     {% if dashboard.fields['context'] == 'core' or dashboard.fields['context'] == 'mini_core' %}
         <div>
             <twig:Alert:Danger
-                :title="__('This will reset all filters, cards, and sharing options in this dashboard with the one selected!')"
+                :message="__('This will reset all filters, cards, and sharing options in this dashboard with the one selected!')"
             />
             {{ fields.dropdownArrayField('default_dashboard_key', null, default_dashboards, __('Default dashboard to reset to'), {
                 full_width: true,
@@ -51,7 +51,7 @@
         </div>
     {% else %}
         <twig:Alert:Danger
-            :title="__('Resetting this dashboard is not currently supported.')"
+            :message="__('Resetting this dashboard is not currently supported.')"
         />
     {% endif %}
 </div>

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -84,8 +84,6 @@
  */
 #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
-
 {% set datatable_id = datatable_id|default('datatable' ~ random()) %}
 {% set filters = filters|default([]) %}
 {% set additional_params = additional_params|default('') %}
@@ -386,7 +384,9 @@
                 {% else %}
                     <tr>
                         <td colspan="{{ total_cols }}">
-                            {{ alerts.alert_info(__('No results found')) }}
+                            <twig:Alert
+                                :message="__('No results found')"
+                            />
                         </td>
                     </tr>
                 {% endif %}

--- a/templates/components/form/item_remotemanagement_list.html.twig
+++ b/templates/components/form/item_remotemanagement_list.html.twig
@@ -54,7 +54,7 @@
     }, with_context = false) }}
 {% else %}
     <twig:Alert
-        :title="__('No results found')"
+        :message="__('No results found')"
     />
 {% endif %}
 

--- a/templates/components/form/item_remotemanagement_list.html.twig
+++ b/templates/components/form/item_remotemanagement_list.html.twig
@@ -30,8 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
-
 {% if canedit %}
     {% include 'components/tab/addlink_block.html.twig' with {'add_link': form_url, 'button_label': __('Add a remote management')} %}
 {% endif %}
@@ -55,8 +53,8 @@
         'massiveactionparams': massiveactionparams,
     }, with_context = false) }}
 {% else %}
-    {{ alerts.alert_info(
-        __('No results found')
-    ) }}
+    <twig:Alert
+        :title="__('No results found')"
+    />
 {% endif %}
 

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -51,7 +51,7 @@
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
         {% endif %}
         <twig:Alert
-            :title="message"
+            :message="message"
         />
         {% if item.fields['date_answered'] is empty and expired %}
             {{ fields.htmlField(

--- a/templates/components/itilobject/itilsatisfaction.html.twig
+++ b/templates/components/itilobject/itilsatisfaction.html.twig
@@ -30,7 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import "components/alerts_macros.html.twig" as alerts %}
 {% import "components/form/fields_macros.html.twig" as fields %}
 
 {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {"item": item, 'options': params}) }}
@@ -51,7 +50,9 @@
         {% else %}
             {% set message = __('After 12 hours, you can no longer modify your response.') %}
         {% endif %}
-        {{ alerts.alert_info(message) }}
+        <twig:Alert
+            :title="message"
+        />
         {% if item.fields['date_answered'] is empty and expired %}
             {{ fields.htmlField(
                 '',

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -88,7 +88,7 @@
                 />
             {% else %}
                 <twig:Alert
-                    :title="__('No results found')"
+                    :message="__('No results found')"
                 />
             {% endif %}
         {% endif %}

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -30,7 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set is_ajax = data['searchform_id'] is defined and data['searchform_id'] is not null %}
 {% set fluid_search = fluid_search|default(true) %}
 {% if not is_ajax %}
@@ -83,9 +82,14 @@
             {% endif %}
         {% elseif as_map %}
             {% if search_error %}
-                {{ alerts.alert_danger(__('An error occurred during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+                <twig:Alert:Danger
+                    :title="__('An error occurred during the search')"
+                    :message="__('Consider changing the search criteria or adjusting the displayed columns.')"
+                />
             {% else %}
-                {{ alerts.alert_info(__('No results found')) }}
+                <twig:Alert
+                    :title="__('No results found')"
+                />
             {% endif %}
         {% endif %}
     </form>

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -118,7 +118,7 @@
                          />
                      {% else %}
                          <twig:Alert
-                             :title="__('No results found')"
+                             :message="__('No results found')"
                          />
                      {% endif %}
                   </td>

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -30,7 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
 {% set searchform_id = data['searchform_id']|default('search_' ~ rand) %}
 {% set massive_action_form_id = massive_action_form_id ?? "" %}
 {% set is_trashbin = data['search']['is_deleted'] %}
@@ -113,9 +112,14 @@
                <tr>
                   <td colspan="{{ data['data']['cols']|length }}">
                      {% if search_error %}
-                        {{ alerts.alert_danger(__('An error occurred during the search'), __('Consider changing the search criteria or adjusting the displayed columns.')) }}
+                         <twig:Alert:Danger
+                             :title="__('An error occurred during the search')"
+                             :message="__('Consider changing the search criteria or adjusting the displayed columns.')"
+                         />
                      {% else %}
-                        {{ alerts.alert_info(__('No results found')) }}
+                         <twig:Alert
+                             :title="__('No results found')"
+                         />
                      {% endif %}
                   </td>
                </tr>

--- a/templates/install/step0.html.twig
+++ b/templates/install/step0.html.twig
@@ -34,7 +34,7 @@
    <div class="text-start">
        <twig:Alert
            :title="__('Installation or update of GLPI')"
-            :message:"__('Choose \'Install\' for a completely new installation of GLPI, or select \'Upgrade\' to update your version of GLPI from an earlier version.')"
+            :message="__('Choose \'Install\' for a completely new installation of GLPI, or select \'Upgrade\' to update your version of GLPI from an earlier version.')"
        >
        </twig:Alert>
    </div>

--- a/templates/install/step0.html.twig
+++ b/templates/install/step0.html.twig
@@ -30,19 +30,14 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
-
 <div class="container text-center">
    <div class="text-start">
-      {% set alert_messages %}
-         {{ __("Choose 'Install' for a completely new installation of GLPI.") }}<br>
-         {{ __("Select 'Upgrade' to update your version of GLPI from an earlier version") }}
-      {% endset %}
-
-      {{ alerts.alert_info(
-         __('Installation or update of GLPI'),
-         alert_messages
-      ) }}
+       <twig:Alert
+           :title="__('Installation or update of GLPI')"
+       >
+           {{ __("Choose 'Install' for a completely new installation of GLPI.") }}<br>
+           {{ __("Select 'Upgrade' to update your version of GLPI from an earlier version") }}
+       </twig:Alert>
    </div>
 
    <form action="install.php" method="post" class="d-inline" data-submit-once>

--- a/templates/install/step0.html.twig
+++ b/templates/install/step0.html.twig
@@ -34,9 +34,8 @@
    <div class="text-start">
        <twig:Alert
            :title="__('Installation or update of GLPI')"
+            :message:"__('Choose \'Install\' for a completely new installation of GLPI, or select \'Upgrade\' to update your version of GLPI from an earlier version.')"
        >
-           {{ __("Choose 'Install' for a completely new installation of GLPI.") }}<br>
-           {{ __("Select 'Upgrade' to update your version of GLPI from an earlier version") }}
        </twig:Alert>
    </div>
 

--- a/templates/install/step3.html.twig
+++ b/templates/install/step3.html.twig
@@ -50,7 +50,7 @@
    </form>
 {% else %}
     <twig:Alert:Success
-        :title="__('Database connection successful')"
+        :message="__('Database connection successful')"
     />
 
    {% if not engine_requirement.isValidated() %}

--- a/templates/install/step3.html.twig
+++ b/templates/install/step3.html.twig
@@ -30,16 +30,14 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/alerts_macros.html.twig' as alerts %}
-
 <h3>{{ __('Test of the connection at the database') }}</h3>
 
 {% if host|length == 0 or user|length == 0 or link.connect_error %}
 
-   {{ alerts.alert_danger(
-      __("Can't connect to the database"),
-      __('The server answered: %s')|format(link.connect_error)
-   ) }}
+    <twig:Alert:Danger
+        :title="__('Can\'t connect to the database')"
+        :message="__('The server answered: %s')|format(link.connect_error)"
+    />
 
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-warning">
@@ -51,22 +49,22 @@
       <input type="hidden" name="install" value="Etape_1">
    </form>
 {% else %}
-   {{ alerts.alert_success(
-      __('Database connection successful'),
-   ) }}
+    <twig:Alert:Success
+        :title="__('Database connection successful')"
+    />
 
    {% if not engine_requirement.isValidated() %}
-      {{ alerts.alert_danger(
-         __('Database engine is not supported.'),
-         engine_requirement.getValidationMessages()
-      ) }}
+       <twig:Alert:Danger
+           :title="__('Database engine is not supported.')"
+           :message="engine_requirement.getValidationMessages()"
+       />
    {% endif %}
 
    {% if not config_requirement.isValidated() %}
-      {{ alerts.alert_danger(
-         __('Database configuration is not supported.'),
-         config_requirement.getValidationMessages()
-      ) }}
+       <twig:Alert:Danger
+           :title="__('Database configuration is not supported.')"
+           :message="config_requirement.getValidationMessages()"
+       />
    {% endif %}
 
    {% if engine_requirement.isValidated() and config_requirement.isValidated() %}

--- a/templates/pages/2fa/2fa_status.html.twig
+++ b/templates/pages/2fa/2fa_status.html.twig
@@ -31,7 +31,6 @@
  #}
 
 {% import 'pages/2fa/macros.html.twig' as tfa %}
-{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <form method="post" action="#" data-submit-once>
     {% set status_message %}
@@ -43,7 +42,10 @@
             {{ __('Optional') }}
         {% endif %}
     {% endset %}
-    {{ alerts.alert_info(__('2FA enabled'), [status_message]) }}
+    <twig:Alert
+        :title="__('2FA enabled')"
+        :message="status_message"
+    />
    {{ tfa.tfa_backup_codes_container() }}
    <div>
       {% if enforcement != constant('Glpi\\Security\\TOTPManager::ENFORCEMENT_MANDATORY') %}

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -32,7 +32,7 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set params  = params ?? [] %}
 
 {% set customobj_ns = item.getCustomObjectNamespace() %}
@@ -40,7 +40,9 @@
 
 {% block form_fields %}
     {% if not item.isNewItem() and item.isActive() and not has_rights_enabled %}
-        {{ alerts.alert_warning(__('There is currently no profile with access to items with current definition.')) }}
+        <twig:Alert:Warning
+            :title="__('There is currently no profile with access to items with current definition.')"
+        />
     {% endif %}
 
     {% set helper %}

--- a/templates/pages/admin/customobjects/main.html.twig
+++ b/templates/pages/admin/customobjects/main.html.twig
@@ -41,7 +41,7 @@
 {% block form_fields %}
     {% if not item.isNewItem() and item.isActive() and not has_rights_enabled %}
         <twig:Alert:Warning
-            :title="__('There is currently no profile with access to items with current definition.')"
+            :message="__('There is currently no profile with access to items with current definition.')"
         />
     {% endif %}
 

--- a/templates/pages/admin/transfer.html.twig
+++ b/templates/pages/admin/transfer.html.twig
@@ -33,7 +33,7 @@
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
-{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set params  = params ?? [] %}
 {% set edit_mode = edit_mode|default(false) %}
 {% set no_header = not edit_mode %}
@@ -77,7 +77,9 @@
       } %}
 
       {{ fields.smallTitle(__('General')) }}
-      {{ alerts.alert('warning', '', __('Child locations will not be transferred with the parent to avoid visibility and hierarchy issues.')) }}
+       <twig:Alert:Warning
+           :message="__('Child locations will not be transferred with the parent to avoid visibility and hierarchy issues.')"
+       />
       {{ fields.dropdownArrayField('keep_history', item.fields['keep_history'], keep_options, __('Historical'), {
          readonly: not can_change_options,
       }) }}

--- a/templates/pages/setup/webhook/webhook_security.html.twig
+++ b/templates/pages/setup/webhook/webhook_security.html.twig
@@ -32,7 +32,7 @@
 
 {% extends "generic_show_form.html.twig" %}
 {% import 'components/form/fields_macros.html.twig' as fields %}
-{% import 'components/alerts_macros.html.twig' as alerts %}
+
 {% set params  = params ?? [] %}
 {% set rand_field = rand|default(random()) %}
 
@@ -81,7 +81,10 @@
         {% set cra_tooltip = __('Challenge–response authentication can be used to validate the identity of the target server before any data is sent from GLPI. This uses the shared secret that was generated in the above section.') %}
 
         {% if constant('GLPI_WEBHOOK_CRA_MANDATORY') %}
-            {{ alerts.alert_info(__('CRA is mandatory due to GLPI configuration'), [cra_tooltip]) }}
+            <twig:Alert
+                :title="__('CRA is mandatory due to GLPI configuration')"
+                :message="cra_tooltip"
+            />
             <input type="hidden" name="use_cra_challenge" value="1" />
         {% else %}
             {{ fields.checkboxField(

--- a/templates/twig_components/Alert/Info.html.twig
+++ b/templates/twig_components/Alert/Info.html.twig
@@ -60,7 +60,7 @@
             <div>
                 <a class="alert-link"
                    href="{{ link_url }}"
-                   target="{{ link_target }}"
+                   target="{{ link_blank ? '_blank' : '_self' }}"
                 >
                     {{ link_text ? link_text : link_url }}
                 </a>

--- a/templates/twig_components/Alert/Info.html.twig
+++ b/templates/twig_components/Alert/Info.html.twig
@@ -31,7 +31,7 @@
  #}
 
 {% set _classes = 'alert alert-' ~ this.type %}
-{% if important|default(false) %}
+{% if this.important %}
     {% set _classes = _classes ~ ' alert-important' %}
 {% endif %}
 
@@ -42,27 +42,27 @@
         </div>
         <div class="flex-grow-1">
             {% block title %}
-                {% if title|length %}
+                {% if this.title|length %}
                     <h4 class="alert-title">
-                        {{ title }}
+                        {{ this.title }}
                     </h4>
                 {% endif %}
             {% endblock %}
             {% block content %}
-                {% if message %}
+                {% if this.message %}
                     <div class="text-muted">
-                        {{ message }}
+                        {{ this.message }}
                     </div>
                 {% endif %}
             {% endblock %}
         </div>
-        {% if link_url %}
+        {% if this.link_url %}
             <div>
                 <a class="alert-link"
-                   href="{{ link_url }}"
-                   target="{{ link_blank ? '_blank' : '_self' }}"
+                   href="{{ this.link_url }}"
+                   target="{{ this.link_blank ? '_blank' : '_self' }}"
                 >
-                    {{ link_text ? link_text : link_url }}
+                    {{ this.link_text ? this.link_text : this.link_url }}
                 </a>
             </div>
         {% endif %}

--- a/templates/twig_components/Alert/Info.html.twig
+++ b/templates/twig_components/Alert/Info.html.twig
@@ -35,12 +35,12 @@
     {% set _classes = _classes ~ ' alert-important' %}
 {% endif %}
 
-<div class="{{ _classes }}" role="alert">
-    <div class="d-flex">
-        <div class="me-2">
+<div class="{{ _classes }}">
+    <div class="d-flex gap-2 w-full">
+        <div>
             <i class="{{ this.resolvedIcon }} fs-2x alert-icon"></i>
         </div>
-        <div>
+        <div class="flex-grow-1">
             {% block title %}
                 {% if title|length %}
                     <h4 class="alert-title">
@@ -49,19 +49,22 @@
                 {% endif %}
             {% endblock %}
             {% block content %}
-                {% if messages|length > 0 %}
+                {% if message %}
                     <div class="text-muted">
-                        {% if messages is iterable %}
-                            {% for message in messages %}
-                                {{ message }}
-                                {% if loop.last %}<br/>{% endif %}
-                            {% endfor %}
-                        {% else %}
-                            {{ messages }}
-                        {% endif %}
+                        {{ message }}
                     </div>
                 {% endif %}
             {% endblock %}
         </div>
+        {% if link_url %}
+            <div>
+                <a class="alert-link"
+                   href="{{ link_url }}"
+                   target="{{ link_target }}"
+                >
+                    {{ link_text ? link_text : link_url }}
+                </a>
+            </div>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
* Remove the `role=alert`  for a better a11y.
* Simplify the usage by supporting only one message and adding link support.
* Deprecate macro usage + replace all existing core usage for the Alert component

[Roadmap](https://github.com/glpi-project/roadmap/issues/158)

[Documentation PR](https://github.com/glpi-project/docdev/pull/201)