### PR TITLE
Enforce IDs integer type in API response headers

### DIFF
--- a/src/Glpi/Api/APIRest.php
+++ b/src/Glpi/Api/APIRest.php
@@ -348,14 +348,14 @@ class APIRest extends API
                     $code     = 201;
                     if (isset($response['id'])) {
                         // add a location targetting created element
-                        $additionalheaders['location'] = self::$api_url . "/$itemtype/" . $response['id'];
+                        $additionalheaders['location'] = self::$api_url . "/$itemtype/" . ((int) $response['id']);
                     } else {
                         // add a link header targetting created elements
                         $additionalheaders['link'] = "";
                         foreach ($response as $created_item) {
                             if ($created_item['id']) {
                                 $additionalheaders['link'] .= self::$api_url . "/$itemtype/"
-                                                     . $created_item['id'] . ",";
+                                                     . ((int) $created_item['id']) . ",";
                             }
                         }
                         // remove last comma


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Psalm is a tools that tries to execute all possible paths to detect potential security issues. It means that issues are not detected when Pslam does not understand that a specific path exists to trigger them.

The #21618 PR test suite failure is a good example of this. A modification in the `Consumable` class resulted in the detection of an issue in the API, throught the massive action feature.
https://github.com/glpi-project/glpi/actions/runs/25109688457/job/73580063067?pr=21618

```
ERROR: TaintedHeader - src/Glpi/Api/APIRest.php:658:20 - Detected tainted header (see https://psalm.dev/256)
  $_POST
    <no known location>

  call to MassiveAction::__construct - front/massiveaction.php:44:29
    $ma = new MassiveAction($_POST, $_GET, 'process');

  MassiveAction::__construct#1 - src/MassiveAction.php:159:39
    public function __construct(array $POST, array $GET, $stage, ?int $items_id = null)

  $POST - src/MassiveAction.php:159:39
    public function __construct(array $POST, array $GET, $stage, ?int $items_id = null)

  $this->POST - src/MassiveAction.php:341:17
                $this->POST = $POST;

  MassiveAction::$POST
    <no known location>

  $this->POST - src/MassiveAction.php:399:16
        return $this->POST;

  MassiveAction::getInput - src/MassiveAction.php:397:21
    public function getInput()

  $input - src/Consumable.php:310:17
                $input = $ma->getInput();

  $input['give_itemtype'] - src/Consumable.php:317:50
                            if ($item->out($key, $input['give_itemtype'], $input["give_items_id"])) {

  call to Consumable::out - src/Consumable.php:317:50
                            if ($item->out($key, $input['give_itemtype'], $input["give_items_id"])) {

  Consumable::out#2 - src/Consumable.php:186:30
    public function out($ID, $itemtype = '', $items_id = 0)

  $itemtype - src/Consumable.php:186:30
    public function out($ID, $itemtype = '', $items_id = 0)

  call to __ - src/Consumable.php:220:36
                                __($itemtype),

  __#1 - src/autoload/i18n.php:57:13
function __($str, $domain = 'glpi')

  $str - src/autoload/i18n.php:57:13
function __($str, $domain = 'glpi')

  coalesce - src/autoload/i18n.php:75:12
    return $trans ?? $str;

  __ - src/autoload/i18n.php:57:10
function __($str, $domain = 'glpi')

  array['message'] - src/Glpi/Api/API.php:1911:25
                        'message' => __("You don't have permission to perform this action."),

  $current_res - src/Glpi/Api/API.php:1910:21
                    $current_res = ['id'      => false,

  $idCollection - src/Glpi/Api/API.php:1952:17
                $idCollection[] = $current_res;

  Glpi\Api\API::createItems - src/Glpi/Api/API.php:1880:24
    protected function createItems($itemtype, $params = [])

  Glpi\Api\APIRest::createItems
    <no known location>

  $response - src/Glpi/Api/APIRest.php:347:21
                    $response = $this->createItems($itemtype, $this->parameters);

  $response['id'] - src/Glpi/Api/APIRest.php:351:91
                        $additionalheaders['Location'] = self::$api_url . "/$itemtype/" . $response['id'];

  concat - src/Glpi/Api/APIRest.php:351:58
                        $additionalheaders['Location'] = self::$api_url . "/$itemtype/" . $response['id'];

  $additionalheaders - src/Glpi/Api/APIRest.php:351:25
                        $additionalheaders['Location'] = self::$api_url . "/$itemtype/" . $response['id'];

  call to Glpi\Api\APIRest::returnResponse - src/Glpi/Api/APIRest.php:393:53
            $this->returnResponse($response, $code, $additionalheaders);

  Glpi\Api\APIRest::returnResponse#3 - src/Glpi/Api/APIRest.php:650:64
    public function returnResponse($response, $httpcode = 200, $additionalheaders = [])

  $additionalheaders - src/Glpi/Api/APIRest.php:650:64
    public function returnResponse($response, $httpcode = 200, $additionalheaders = [])

  arrayvalue-fetch - src/Glpi/Api/APIRest.php:657:18
        foreach ($additionalheaders as $key => $value) {

  $value - src/Glpi/Api/APIRest.php:657:48
        foreach ($additionalheaders as $key => $value) {

  concat - src/Glpi/Api/APIRest.php:658:27
            header("$key: $value");

  call to header - src/Glpi/Api/APIRest.php:658:20
            header("$key: $value");



------------------------------
1 errors found
------------------------------
```

Enforcing integer type for IDs in API response headers fixes this.