### PR TITLE
Update tooltip titles for download and delete actions in log list template

### DIFF
--- a/templates/pages/admin/logs_list.html.twig
+++ b/templates/pages/admin/logs_list.html.twig
@@ -122,6 +122,8 @@
                                             <ul class="dropdown-menu">
                                                 <li>
                                                     <a href="{{ path('/front/logviewer.php') }}?action=download_log_file&amp;filepath={{ log['filepath']|url_encode }}"
+                                                       title="{{ __("Download file") }}"
+                                                       data-bs-toggle="tooltip" data-bs-placement="bottom"
                                                        class="dropdown-item">
                                                         <i class="ti ti-file-download" aria-hidden="true"></i>
                                                         <span>{{ __("Download file") }}</span>
@@ -143,7 +145,7 @@
                                                     <li>
                                                         <button type="submit" name="action" value="delete"
                                                                      class="dropdown-item"
-                                                                     title="{{ __("Empty file") }}"
+                                                                     title="{{ __("Delete file") }}"
                                                                      onclick="return confirm('{{ __("Are you sure you want to delete this file?")|e('js') }}')"
                                                                      data-bs-toggle="tooltip" data-bs-placement="bottom">
                                                             <i class="ti ti-trash-x" aria-hidden="true"></i>


### PR DESCRIPTION
New Download tooltip and fixed Delete file tooltip in log list template

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [] This change requires a documentation update.

## Description

- It fixes #24066
- Fixes the incorrect Delete file tooltip and missing Download tooltip

## Reference
https://github.com/glpi-project/roadmap/discussions/199

## Screenshots (if appropriate):
Delete
<img width="724" height="465" alt="image" src="https://github.com/user-attachments/assets/02c93128-3d99-4caa-9040-f508ae9bca9b" />
Download
<img width="708" height="428" alt="image" src="https://github.com/user-attachments/assets/32f08bd0-e676-4da0-8486-e1b54aa644f2" />


