### PR TITLE
Fix(Core): Fix false positive unsaved changes warning on ticket update

### DIFF
--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -244,7 +244,7 @@
    });
 
    $('#itil-footer .form-buttons button[name="update"]').on('click', () => {
-       const has_opened_new_form = $('#new-itilobject-form .collapse.show').length > 0
+       const has_opened_new_form = $('#new-itilobject-form > .collapse.show').length > 0
            || $('.timeline-item .edit-content').filter((i, c) => c.textContent.trim().length > 0).length > 0;
        if (has_opened_new_form) {
           return confirm('{{ __("You have unsaved changes in the timeline. Are you sure you want to continue?")|e('js') }}');

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { TicketPage } from '../../pages/TicketPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+type OpenForm = (ticket: TicketPage, page: Page) => Promise<void>;
+
+const warning_cases: { form: string; open: OpenForm }[] = [
+    {
+        form: 'followup',
+        open: async (ticket) => {
+            await ticket.getButton('Answer').click();
+        },
+    },
+    {
+        form: 'task',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Create a task' }).click();
+        },
+    },
+    {
+        form: 'solution',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Add a solution' }).click();
+        },
+    },
+    {
+        form: 'document',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Add a document' }).click();
+        },
+    },
+    {
+        form: 'validation',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Ask for approval' }).click();
+        },
+    },
+];
+
+for (const { form, open } of warning_cases) {
+    test(`warning appears and blocks save when ${form} form is open`, async ({ profile, page, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const ticket_id = await api.createItem('Ticket', {
+            name: `Test warning with open ${form} form`,
+            content: '',
+            entities_id: getWorkerEntityId(),
+        });
+
+        const ticket = new TicketPage(page);
+        await ticket.goto(ticket_id);
+        await open(ticket, page);
+
+        const dialog_promise = page.waitForEvent('dialog');
+        await ticket.getButton('Save').click();
+        const dialog = await dialog_promise;
+
+        expect(dialog.message()).toContain('unsaved changes');
+        await dialog.dismiss();
+
+        await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));
+    });
+}
+
+test('no warning when saving ticket without open timeline form', async ({ profile, page, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const ticket_id = await api.createItem('Ticket', {
+        name: 'Test no warning on save',
+        content: '',
+        entities_id: getWorkerEntityId(),
+    });
+
+    const ticket = new TicketPage(page);
+    await ticket.goto(ticket_id);
+
+    const save_response = page.waitForResponse(
+        (resp) => resp.url().includes('/front/ticket.form.php') && resp.request().method() === 'POST'
+    );
+    await ticket.getButton('Save').click();
+    await save_response;
+
+    await expect(page.getByRole('alert')).toContainText('Item successfully updated');
+});
+
+test('no warning when saving ticket in waiting status', async ({ profile, page, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const ticket_id = await api.createItem('Ticket', {
+        name: 'Test no warning on waiting ticket',
+        content: '',
+        status: 4,
+        entities_id: getWorkerEntityId(),
+    });
+
+    const ticket = new TicketPage(page);
+    await ticket.goto(ticket_id);
+
+    const save_response = page.waitForResponse(
+        (resp) => resp.url().includes('/front/ticket.form.php') && resp.request().method() === 'POST'
+    );
+    await ticket.getButton('Save').click();
+    await save_response;
+
+    await expect(page.getByRole('alert')).toContainText('Item successfully updated');
+});

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -38,15 +38,23 @@ import { getWorkerEntityId } from '../../utils/WorkerEntities';
 
 type OpenForm = (ticket: TicketPage, page: Page) => Promise<void>;
 
-const warning_cases: { form: string; open: OpenForm }[] = [
+type WarningCase = {
+    form: string;
+    block: string;
+    open: OpenForm;
+};
+
+const warning_cases: WarningCase[] = [
     {
         form: 'followup',
+        block: 'new-ITILFollowup-block',
         open: async (ticket) => {
             await ticket.getButton('Answer').click();
         },
     },
     {
         form: 'task',
+        block: 'new-TicketTask-block',
         open: async (ticket, page) => {
             await ticket.getButton('View other actions').click();
             await page.getByRole('listitem', { name: 'Create a task' }).click();
@@ -54,6 +62,7 @@ const warning_cases: { form: string; open: OpenForm }[] = [
     },
     {
         form: 'solution',
+        block: 'new-ITILSolution-block',
         open: async (ticket, page) => {
             await ticket.getButton('View other actions').click();
             await page.getByRole('listitem', { name: 'Add a solution' }).click();
@@ -61,6 +70,7 @@ const warning_cases: { form: string; open: OpenForm }[] = [
     },
     {
         form: 'document',
+        block: 'new-Document_Item-block',
         open: async (ticket, page) => {
             await ticket.getButton('View other actions').click();
             await page.getByRole('listitem', { name: 'Add a document' }).click();
@@ -68,6 +78,7 @@ const warning_cases: { form: string; open: OpenForm }[] = [
     },
     {
         form: 'validation',
+        block: 'new-TicketValidation-block',
         open: async (ticket, page) => {
             await ticket.getButton('View other actions').click();
             await page.getByRole('listitem', { name: 'Ask for approval' }).click();
@@ -75,7 +86,7 @@ const warning_cases: { form: string; open: OpenForm }[] = [
     },
 ];
 
-for (const { form, open } of warning_cases) {
+for (const { form, block, open } of warning_cases) {
     test(`warning appears and blocks save when ${form} form is open`, async ({ profile, page, api }) => {
         await profile.set(Profiles.SuperAdmin);
         const ticket_id = await api.createItem('Ticket', {
@@ -87,6 +98,11 @@ for (const { form, open } of warning_cases) {
         const ticket = new TicketPage(page);
         await ticket.goto(ticket_id);
         await open(ticket, page);
+
+        // Bootstrap Collapse goes: 'collapse' → 'collapsing' (350ms) → 'collapse show'.
+        // The JS condition checks for '.collapse.show', so we must wait until the
+        // animation completes before clicking Save.
+        await expect(page.getByTestId(block)).toHaveClass(/\bshow\b/);
 
         let dialog_message = '';
         page.once('dialog', (dialog) => {

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -80,7 +80,7 @@ for (const { form, open } of warning_cases) {
         await profile.set(Profiles.SuperAdmin);
         const ticket_id = await api.createItem('Ticket', {
             name: `Test warning with open ${form} form`,
-            content: '',
+            content: 'test',
             entities_id: getWorkerEntityId(),
         });
 
@@ -88,13 +88,14 @@ for (const { form, open } of warning_cases) {
         await ticket.goto(ticket_id);
         await open(ticket, page);
 
-        const dialog_promise = page.waitForEvent('dialog');
+        let dialog_message = '';
+        page.once('dialog', (dialog) => {
+            dialog_message = dialog.message();
+            void dialog.dismiss();
+        });
         await ticket.getButton('Save').click();
-        const dialog = await dialog_promise;
 
-        expect(dialog.message()).toContain('unsaved changes');
-        await dialog.dismiss();
-
+        expect(dialog_message).toContain('unsaved changes');
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));
     });
 }
@@ -103,7 +104,7 @@ test('no warning when saving ticket without open timeline form', async ({ profil
     await profile.set(Profiles.SuperAdmin);
     const ticket_id = await api.createItem('Ticket', {
         name: 'Test no warning on save',
-        content: '',
+        content: 'test',
         entities_id: getWorkerEntityId(),
     });
 
@@ -123,7 +124,7 @@ test('no warning when saving ticket in waiting status', async ({ profile, page, 
     await profile.set(Profiles.SuperAdmin);
     const ticket_id = await api.createItem('Ticket', {
         name: 'Test no warning on waiting ticket',
-        content: '',
+        content: 'test',
         status: 4,
         entities_id: getWorkerEntityId(),
     });


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes regression introduced by https://github.com/glpi-project/glpi/pull/23631

The bug originated from an overly broad jQuery selector.

* The `#new-itilobject-form` container includes multiple forms (such as follow-up and task forms), each wrapped inside a `.timeline-item.collapse` element.
* These forms embed templates like `form_followup.html.twig` and `form_task_main_form.html.twig`, which themselves contain *pending-reasons* sections with elements marked as `.collapse.show` (e.g., `#pending-reasons-setup-...` and `#pending-reasons-more_options_...`). See : `pending_reasons.html.twig` > L85
* As a result, the `.collapse.show` selector was traversing all descendants of `#new-itilobject-form`, matching these elements even when no form had been explicitly opened by the user.

<img width="1063" height="248" alt="image" src="https://github.com/user-attachments/assets/ba320dd6-d012-4146-a786-e3be517bd640" />


After the fix


<img width="602" height="134" alt="image" src="https://github.com/user-attachments/assets/1a8f9f6e-70ac-448f-9848-43623956fef0" />


If a timeline form is open


<img width="1284" height="189" alt="image" src="https://github.com/user-attachments/assets/7aed4562-4b8c-4580-84f7-b347540e5ba0" />


If no form opened but one field change (ex: category)


<img width="558" height="130" alt="image" src="https://github.com/user-attachments/assets/a3e3a272-c6df-4538-8009-fa216b162466" />

I am now working on setting up an end-to-end (E2E) test—fingers crossed it will work as expected.

## Screenshots (if appropriate):


