### PR TITLE
dashboard, widget - display group name instead of ID

### DIFF
--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1576,7 +1576,7 @@ class Provider
             ),
             'reset' => 'reset',
         ];
-        $is_group = str_starts_with($case, 'group');
+        $is_group = ($ug_table === Group::getTable());
         $data = [];
         foreach ($iterator as $result) {
             $s_params['criteria'][0]['value'] = $result['actor_id'];

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1576,12 +1576,15 @@ class Provider
             ),
             'reset' => 'reset',
         ];
+        $is_group = str_starts_with($case, 'group');
         $data = [];
         foreach ($iterator as $result) {
             $s_params['criteria'][0]['value'] = $result['actor_id'];
             $data[] = [
                 'number' => $result['nb_tickets'],
-                'label'  => $case_array[0] === 'user' ? formatUserName($result['actor_id'], $result['username'], $result['second'], $result['first']) : $result['name'],
+                'label'  => $is_group
+                    ? ($result['first'] ?? '')
+                    : formatUserName($result['actor_id'], $result['username'] ?? '', $result['second'] ?? '', $result['first'] ?? ''),
                 'url'    => Ticket::getSearchURL() . "?" . Toolbox::append_params($s_params),
             ];
         }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43440
- When a dashboard widget displays the number of tickets per group, the query selects the completename field first, rather than username or second. The code unconditionally called the formatUserName( function with these missing keys, which triggered “array key not defined” warnings and caused the ID to be displayed.
Fix: Detect the group and use completename as the label. Keep formatUserName for user cases.

## Screenshots (if appropriate):

<img width="404" height="382" alt="image" src="https://github.com/user-attachments/assets/a2273a81-edb5-4aea-a7e8-c000b55a0959" />

