### PR TITLE
FIX / Ignore invalid inline image dimensions in emails

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -1623,6 +1623,10 @@ class Document extends CommonDBTM implements TreeBrowseInterface
      */
     public static function getResizedImagePath(string $path, int $width, int $height): string
     {
+        if ($width <= 0 || $height <= 0) {
+            return $path;
+        }
+
         // let's see if original image needs resize
         $img_infos  = getimagesize($path);
         if ($img_infos[0] <= $width && $img_infos[1] <= $height) {

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -339,6 +339,13 @@ class NotificationEventMailing extends NotificationEventAbstract
                                 $custom_height = intval($hmatches[1]);
                             }
 
+                            if ($custom_width !== null && $custom_width <= 0) {
+                                $custom_width = null;
+                            }
+                            if ($custom_height !== null && $custom_height <= 0) {
+                                $custom_height = null;
+                            }
+
                             if ($custom_height === null && $custom_width === null) {
                                 // no custom size, use original file
                                 $image_path = GLPI_DOC_DIR . "/" . $doc->fields['filepath'];
@@ -357,17 +364,27 @@ class NotificationEventMailing extends NotificationEventAbstract
                                     $initial_height = $img_infos[1];
 
                                     if ($custom_height === null) {
-                                        $custom_height = $initial_height * $custom_width / $initial_width;
+                                        $custom_height = max(
+                                            1,
+                                            (int) round($initial_height * $custom_width / $initial_width)
+                                        );
                                     } else {
-                                        $custom_width = $initial_width * $custom_height / $initial_height;
+                                        $custom_width = max(
+                                            1,
+                                            (int) round($initial_width * $custom_height / $initial_height)
+                                        );
                                     }
                                 }
 
-                                $image_path = Document::getResizedImagePath(
-                                    GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
-                                    $custom_width,
-                                    $custom_height
-                                );
+                                if ($custom_width <= 0 || $custom_height <= 0) {
+                                    $image_path = GLPI_DOC_DIR . "/" . $doc->fields['filepath'];
+                                } else {
+                                    $image_path = Document::getResizedImagePath(
+                                        GLPI_DOC_DIR . "/" . $doc->fields['filepath'],
+                                        $custom_width,
+                                        $custom_height
+                                    );
+                                }
                             }
 
                             $mail->embedFromPath($image_path, $doc->fields['filename']);


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43564
- This change prevents notification emails from failing when the HTML body contains inline images with invalid dimensions, such as width="0" or height="0". This can happen with signatures copied from Outlook or Word-generated HTML.