### PR TITLE
KB : add illustration on article creation

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -1105,6 +1105,14 @@ export class GlpiKnowbaseArticleController
             answer: answer,
         };
 
+        const illustration_input = this.#container.querySelector(
+            '[data-glpi-kb-illustration-container] [data-glpi-icon-picker-value]'
+        );
+        const illustration = illustration_input?.value ?? '';
+        if (illustration && illustration !== 'kb-faq') {
+            fields.illustration = illustration;
+        }
+
         for (const [key, value] of Object.entries(fields)) {
             const input = document.createElement('input');
             input.type = 'hidden';

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -52,6 +52,7 @@ use Glpi\Knowbase\History\HistoryBuilder;
 use Glpi\Knowbase\LastUpdateInfo;
 use Glpi\RichText\RichText;
 use Glpi\Search\Output\HTMLSearchOutput;
+use Glpi\UI\IllustrationManager;
 
 use function Safe\preg_match;
 use function Safe\preg_replace;
@@ -736,7 +737,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             $input["users_id"] = Session::getLoginUserID();
         }
 
-        return $input;
+        return $this->prepareIllustrationInput($input);
     }
 
     public function prepareInputForUpdate($input)
@@ -744,6 +745,43 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         // set title for question if empty
         if (isset($input["name"]) && empty($input["name"])) {
             $input["name"] = __('New item');
+        }
+
+        return $this->prepareIllustrationInput($input);
+    }
+
+    /**
+     * Drop the `illustration` field from $input when it is neither a known
+     * native icon nor an existing custom illustration file. The picker UI
+     * always submits valid values; this guards against direct POSTs.
+     *
+     * @param array<string, mixed> $input
+     * @return array<string, mixed>
+     */
+    private function prepareIllustrationInput(array $input): array
+    {
+        if (!array_key_exists('illustration', $input)) {
+            return $input;
+        }
+
+        $value = (string) $input['illustration'];
+        if ($value === '') {
+            return $input;
+        }
+
+        $manager = new IllustrationManager();
+        $prefix  = IllustrationManager::CUSTOM_ILLUSTRATION_PREFIX;
+
+        if (str_starts_with($value, $prefix)) {
+            $custom_id = substr($value, strlen($prefix));
+            if ($manager->getCustomIllustrationFile($custom_id) === null) {
+                unset($input['illustration']);
+            }
+            return $input;
+        }
+
+        if (!in_array($value, $manager->getAllIconsIds(), true)) {
+            unset($input['illustration']);
         }
 
         return $input;
@@ -832,7 +870,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         $this->updateCounter();
 
         $params = [
-            'item_id' => $this->fields['id'],
+            'item_id' => $mode === 'add' ? null : $this->fields['id'],
             'subject' => $this->fields['name'],
             'answer'  => $this->getAnswer(),
             'mode'    => $mode,
@@ -894,7 +932,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             // Add actions
             $params['actions'] = $this->getEditorActions();
         } elseif ($mode === "add") {
-            $params['can_edit'] = $this->can(-1, CREATE);
+            $params['can_edit']     = $this->can(-1, CREATE);
+            $params['illustration'] = 'kb-faq';
         }
 
         $out = TemplateRenderer::getInstance()->render(

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -84,7 +84,7 @@
         </div>
 
         <div class="d-flex align-items-center mb-3">
-            {% if mode == 'edit' or mode == 'view' %}
+            {% if mode == 'add' or mode == 'edit' or mode == 'view' %}
                 <div class="me-3 flex-shrink-0" data-glpi-kb-illustration-container>
                     {{ include('components/illustration/icon_picker.html.twig', {
                         'value': illustration,

--- a/tests/e2e/specs/Knowbase/illustration.spec.ts
+++ b/tests/e2e/specs/Knowbase/illustration.spec.ts
@@ -112,3 +112,60 @@ test('Can pick a custom illustration', async ({ page, profile, api }) => {
     const custom_preview = page.getByTestId('illustration-custom-preview');
     await expect(custom_preview).toBeVisible();
 });
+
+test('Can pick an illustration when creating an article', async ({ page, profile, entity }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await entity.resetToDefaultWorkerEntity();
+
+    await page.goto('/front/knowbaseitem.form.php', { waitUntil: 'domcontentloaded' });
+
+    // Pick a native icon before saving
+    await page.getByTestId('illustration-picker').click();
+    const modal = page.getByTestId('illustration-picker-modal');
+    await expect(modal).toBeVisible();
+    await modal.getByRole('img', { name: 'Antivirus', exact: true }).click();
+    await expect(modal).toBeHidden();
+
+    // Fill the title
+    const subject = page.getByTestId('subject');
+    await subject.click();
+    await subject.pressSequentially('KB created with custom icon');
+
+    // Submit the new article
+    await page.getByRole('button', { name: 'Add article' }).click();
+    await page.waitForURL(/knowbaseitem\.form\.php\?id=\d+/);
+
+    // Verify the chosen icon was persisted
+    await expect(page.getByTestId('illustration-input')).toHaveValue('antivirus');
+});
+
+test('Picking an illustration during creation does not trigger an UpdateIllustration AJAX call', async ({ page, profile, entity }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await entity.resetToDefaultWorkerEntity();
+
+    await page.goto('/front/knowbaseitem.form.php', { waitUntil: 'domcontentloaded' });
+
+    const ajax_calls: string[] = [];
+    page.on('request', (request) => {
+        if (request.url().includes('/UpdateIllustration')) {
+            ajax_calls.push(request.url());
+        }
+    });
+
+    await page.getByTestId('illustration-picker').click();
+    const modal = page.getByTestId('illustration-picker-modal');
+    await expect(modal).toBeVisible();
+    await modal.getByRole('img', { name: 'Antivirus', exact: true }).click();
+    await expect(modal).toBeHidden();
+
+    expect(ajax_calls).toHaveLength(0);
+
+    const subject = page.getByTestId('subject');
+    await subject.click();
+    await subject.pressSequentially('KB regression no AJAX on pick');
+
+    await page.getByRole('button', { name: 'Add article' }).click();
+    await page.waitForURL(/knowbaseitem\.form\.php\?id=\d+/);
+
+    await expect(page.getByTestId('illustration-input')).toHaveValue('antivirus');
+});


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/270
- Here is a brief description of what this PR does : 

The illustration picker is now rendered on the KB article creation form. The selected icon is sent with the create request and persisted alongside the rest of the article fields.
In addition, a server-side validation step rejects illustration values that are neither a known native icon nor an existing custom illustration file, on both create and update.

E2E coverage : a happy-path spec for picking an icon at creation, and a regression spec ensuring no stray UpdateIllustration AJAX call fires while picking before submit.

Features related to the illustration behavior contained in other PR aka https://github.com/glpi-project/glpi/pull/24024 for the hint and no possibility to edit only in edit mode will be harmonized after merge.


