### PR TITLE
Fix encoded char in ticket title

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/TitleField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/TitleField.php
@@ -134,10 +134,13 @@ TWIG;
         }
 
         $tag_manager = new FormTagsManager();
-        $input['name'] = $tag_manager->insertTagsContent(
+
+        $title = $tag_manager->insertTagsContent(
             $config->getValue(),
             $answers_set
         );
+
+        $input['name'] = html_entity_decode(strip_tags($title));
 
         return $input;
     }

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/TitleFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/TitleFieldTest.php
@@ -39,6 +39,7 @@ use Glpi\Form\Destination\CommonITILField\SimpleValueConfig;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
@@ -63,6 +64,26 @@ final class TitleFieldTest extends DbTestCase
             form: $this->createAndGetFormWithFirstAndLastNameQuestions(),
             config: new SimpleValueConfig("My custom ticket title"),
         );
+    }
+
+    public function testTitleWithApostropheIsNotHtmlEncoded(): void
+    {
+        $builder = new FormBuilder("My form name");
+        $builder->addQuestion("Subject", QuestionTypeShortText::class);
+        $form = $this->createForm($builder);
+
+        $question = current($form->getQuestions());
+        $this->setDestinationFieldConfig(
+            form: $form,
+            key: TitleField::getKey(),
+            config: new SimpleValueConfig((new AnswerTagProvider())->getTagForQuestion($question)->html),
+        );
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Subject" => "It's a ticket with an apostrophe",
+        ]);
+
+        $this->assertSame("It's a ticket with an apostrophe", $ticket->fields['name']);
     }
 
     private function sendFormAndAssertTicketTitle(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43784
- Here is a brief description of what this PR does
Apostrophes are encoded as &#039; when a ticket title corresponds to a form submission