### PR TITLE
display satisfaction survey in ticket / change timeline for standard interface

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -19882,7 +19882,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/Ticket.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2014,7 +2014,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$form_itemtype of static method CommonGLPI\\:\\:createTabEntry\\(\\) expects class\\-string\\<CommonGLPI\\>\\|null, string given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 3,
+	'count' => 2,
 	'path' => __DIR__ . '/src/Change.php',
 ];
 $ignoreErrors[] = [

--- a/src/Change.php
+++ b/src/Change.php
@@ -229,13 +229,6 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                     if ($item->canUpdate()) {
                         $ong[1] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
                     }
-                    $satisfaction = new ChangeSatisfaction();
-                    if (
-                        $satisfaction->getFromDB($item->getID())
-                        && in_array($item->fields['status'], self::getClosedStatusArray())
-                    ) {
-                        $ong[3] = ChangeSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
-                    }
 
                     return $ong;
 
@@ -282,9 +275,6 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                 switch ($tabnum) {
                     case 1:
                         $item->showStats();
-                        break;
-                    case 3:
-                        self::showSatisfactionTabContent($item);
                         break;
                 }
                 break;

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -689,6 +689,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'canassign'               => $canupdate,
             'can_requester'           => $this->canRequesterUpdateItem(),
             'has_pending_reason'      => PendingReason_Item::getForItem($this) !== false,
+            'survey'                  => $this->getSatisfactionSurvey(),
         ]);
 
         return true;
@@ -11057,6 +11058,24 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         return ($tot > 0 ? 1 : 0);
+    }
+
+    /**
+     * Returns the satisfaction survey instance for the current item if it exists, null otherwise.
+     *
+     * @return CommonITILSatisfaction|null
+     */
+    public function getSatisfactionSurvey(): ?CommonITILSatisfaction
+    {
+        $satisfaction = static::getSatisfactionClassInstance();
+        if ($satisfaction === null) {
+            return null;
+        }
+        $survey_exist = $satisfaction->getFromDBByCrit([
+            static::getForeignKeyField() => $this->getID(),
+        ]);
+
+        return $survey_exist ? $satisfaction : null;
     }
 
     /**

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -11065,7 +11065,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      *
      * @return CommonITILSatisfaction|null
      */
-    public function getSatisfactionSurvey(): ?CommonITILSatisfaction
+    protected function getSatisfactionSurvey(): ?CommonITILSatisfaction
     {
         $satisfaction = static::getSatisfactionClassInstance();
         if ($satisfaction === null) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -11097,6 +11097,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      * @param CommonITILObject $item The ITIL Object
      * @return void
      * @since 11.0.0
+     * @TODO Remove this unused method in GLPI 12.0.
      */
     final protected static function showSatisfactionTabContent(CommonITILObject $item): void
     {

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6399,16 +6399,4 @@ JAVASCRIPT;
         return $restrict;
     }
 
-    private function getSatisfactionSurvey(): ?TicketSatisfaction
-    {
-        $satisfaction = static::getSatisfactionClassInstance();
-        if (!$satisfaction instanceof TicketSatisfaction) {
-            return null;
-        }
-        $survey_exist = $satisfaction->getFromDBByCrit([
-            self::getForeignKeyField() => $this->getID(),
-        ]);
-
-        return $survey_exist ? $satisfaction : null;
-    }
 }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -797,14 +797,6 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         if ($item instanceof self) {
             $ong    = [];
 
-            // enquete si statut clos
-            $satisfaction = new TicketSatisfaction();
-            if (
-                $satisfaction->getFromDB($item->getID())
-                && $item->fields['status'] == self::CLOSED
-            ) {
-                $ong[3] = TicketSatisfaction::createTabEntry(__('Satisfaction'), 0, static::getType());
-            }
             if ($item->canView()) {
                 $ong[4] = static::createTabEntry(__('Statistics'), 0, null, 'ti ti-chart-pie');
             }
@@ -821,10 +813,6 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         switch (get_class($item)) {
             case self::class:
                 switch ($tabnum) {
-                    case 3:
-                        self::showSatisfactionTabContent($item);
-                        break;
-
                     case 4:
                         $item->showStats();
                         break;
@@ -3842,7 +3830,7 @@ JAVASCRIPT;
                 'show_tickets_properties_on_helpdesk',
                 Session::getActiveEntity(),
             ),
-            'survey'                    => $this->getSatisfactionSurveyForHelpdesk(),
+            'survey'                    => $this->getSatisfactionSurvey(),
         ]);
 
         return true;
@@ -6411,18 +6399,11 @@ JAVASCRIPT;
         return $restrict;
     }
 
-    private function getSatisfactionSurveyForHelpdesk(): ?TicketSatisfaction
+    private function getSatisfactionSurvey(): ?TicketSatisfaction
     {
-        // On the "central" interface, the survey will be available in a
-        // dedicated tab
-        if (Session::getCurrentInterface() !== "helpdesk") {
-            return null;
-        }
-
-        // Try to find a satisfaction survey for this ticket
         $satisfaction = static::getSatisfactionClassInstance();
         if (!$satisfaction instanceof TicketSatisfaction) {
-            return null; // Can't happen
+            return null;
         }
         $survey_exist = $satisfaction->getFromDBByCrit([
             self::getForeignKeyField() => $this->getID(),

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -247,7 +247,7 @@
         data-testid="survey"
         class="mt-5 w-100 hide-form-button-separator"
         method="POST"
-        action="{{ "TicketSatisfaction"|itemtype_form_path }}"
+        action="{{ survey.getType()|itemtype_form_path }}"
     >
         <div>
             {{ survey.showSatisactionForm(item, false) }}

--- a/templates/components/itilobject/timeline/timeline.html.twig
+++ b/templates/components/itilobject/timeline/timeline.html.twig
@@ -247,7 +247,7 @@
         data-testid="survey"
         class="mt-5 w-100 hide-form-button-separator"
         method="POST"
-        action="{{ survey.getType()|itemtype_form_path }}"
+        action="{{ get_class(survey)|itemtype_form_path }}"
     >
         <div>
             {{ survey.showSatisactionForm(item, false) }}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- The satisfaction survey was only accessible via a dedicated tab in the standard interface, while the helpdesk interface already displayed it directly in the timeline. This change removes the restriction in getSatisfactionSurvey() so the survey is injected into the timeline for both interfaces. The Satisfaction tab is removed from getTabNameForItem() and displayTabContentForItem().

## Screenshots (if appropriate):

<img width="422" height="441" alt="image" src="https://github.com/user-attachments/assets/e35b5f0e-9332-4be9-ac64-bc435cbbf191" />


