### PR TITLE
Revert dir separator changes in scss methods

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -6668,8 +6668,6 @@ CSS;
     {
         $file = preg_replace('/\.scss$/', '', $file);
 
-        $file = str_replace(DIRECTORY_SEPARATOR, '/', $file);
-
         return self::getScssCompileDir($root_dir) . '/' . str_replace('/', '_', $file) . '.min.css';
     }
 
@@ -6682,7 +6680,7 @@ CSS;
      */
     public static function getScssCompileDir(string $root_dir = GLPI_ROOT)
     {
-        return str_replace(DIRECTORY_SEPARATOR, '/', $root_dir) . '/public/css_compiled';
+        return $root_dir . '/public/css_compiled';
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Partial revert of #23123.

I set up an IIS installation of GLPI on a Windows VM to test this fix.

There was indeed some bug with the SCSS compile command file paths but the changes in "src/Html.php" don't seem related and in fact caused the CSS to break on Windows installations.