### PR TITLE
Prevent sorting on virtual 2FA search field

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -3689,6 +3689,7 @@ HTML;
             'datatype'          => 'specific',
             'additionalfields'  => ['2fa'],
             'nosearch'          => true, // Searching virtual fields is not supported currently
+            'nosort'            => true, // Same as above
         ];
 
         // add objectlock search options


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #24080

The 2FA status search option for User is virtual, so it cannot properly support searching or sorting but only searching was blocked before. This PR blocks sorting to prevent confusion and prevent an error being shown.