### PR TITLE
Never manually send active entities to getEntitiesRestrictCriteria

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3852,7 +3852,7 @@ HTML;
                 $multi = true;
             }
         } else {
-            $where += getEntitiesRestrictCriteria($table, '', $_SESSION['glpiactiveentities'], $multi);
+            $where += getEntitiesRestrictCriteria($table, '', '', $multi);
             if (count($_SESSION['glpiactiveentities']) > 1) {
                 $multi = true;
             }

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1320,7 +1320,7 @@ abstract class API
             // some CommonDBChild classes may not have entities_id fields and isEntityAssign still return true (like ITILTemplateMandatoryField)
             && array_key_exists('entities_id', $item->fields)
         ) {
-            $entity_restrict = getEntitiesRestrictCriteria($itemtype::getTable(), '', $_SESSION['glpiactiveentities'], $item->maybeRecursive(), true);
+            $entity_restrict = getEntitiesRestrictCriteria($itemtype::getTable(), '', '', $item->maybeRecursive(), true);
 
             if ($item instanceof SavedSearch) {
                 $criteria['WHERE'][] = [

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -206,7 +206,7 @@ class Infocom extends CommonDBChild
             [
                 'suppliers_id' => $item->getField('id'),
                 'NOT' => ['itemtype' => ['ConsumableItem', 'CartridgeItem', 'Software']],
-            ] + getEntitiesRestrictCriteria('glpi_infocoms', '', $_SESSION['glpiactiveentities'])
+            ] + getEntitiesRestrictCriteria('glpi_infocoms', '', '')
         );
     }
 

--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -515,7 +515,7 @@ TWIG, $avatar_params) . $username;
             'WHERE'           => [
                 "$putable.profiles_id"  => $ID,
                 "$utable.is_deleted"    => 0,
-            ] + getEntitiesRestrictCriteria($putable, 'entities_id', $_SESSION['glpiactiveentities'], true),
+            ] + getEntitiesRestrictCriteria($putable, 'entities_id', '', true),
             'ORDER'         => $sort_params,
             'START'         => $start,
             'LIMIT'         => $limit,

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -263,7 +263,7 @@ class Reminder extends CommonDBVisible implements
             $restrict = getEntitiesRestrictCriteria(
                 'glpi_groups_reminders',
                 '',
-                $_SESSION['glpiactiveentities'],
+                '',
                 true
             );
             if (count($restrict)) {
@@ -294,7 +294,7 @@ class Reminder extends CommonDBVisible implements
             $restrict = getEntitiesRestrictCriteria(
                 'glpi_profiles_reminders',
                 '',
-                $_SESSION['glpiactiveentities'],
+                '',
                 true
             );
             if (count($restrict)) {

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -442,7 +442,7 @@ TWIG, $twig_params);
             'FROM'            => 'glpi_reservationitems',
             'WHERE'           => [
                 'is_active' => 1,
-            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities'], true),
+            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', '', true),
         ]);
 
         foreach ($iterator as $data) {
@@ -476,7 +476,7 @@ TWIG, $twig_params);
                 'itemtype'           => Peripheral::class,
                 'is_active'          => 1,
                 'peripheraltypes_id' => ['>', 0],
-            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', $_SESSION['glpiactiveentities'], true),
+            ] + getEntitiesRestrictCriteria('glpi_reservationitems', 'entities_id', '', true),
             'ORDERBY'   => 'glpi_peripheraltypes.name',
         ]);
 
@@ -543,7 +543,7 @@ TWIG, $twig_params);
                 'WHERE'        => [
                     'glpi_reservationitems.is_active'   => 1,
                     "$itemtable.is_deleted"             => 0,
-                ] + getEntitiesRestrictCriteria($itemtable, '', $_SESSION['glpiactiveentities'], $item->maybeRecursive()),
+                ] + getEntitiesRestrictCriteria($itemtable, '', '', $item->maybeRecursive()),
                 'ORDERBY'      => [
                     "$itemtable.entities_id",
                     "$itemtable.$itemname",

--- a/tests/functional/ReminderTest.php
+++ b/tests/functional/ReminderTest.php
@@ -71,23 +71,29 @@ class ReminderTest extends DbTestCase
         );
 
         $this->login('normal', 'normal');
+        // 'normal' user has access to all entities in the test DB, so glpishowallentities=1
+        // and getEntitiesRestrictCriteria returns 'true' (no restriction needed) for the
+        // profiles block. glpi_entities_reminders uses $complete_request=true so it still
+        // returns the explicit IN list.
         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '5'
                OR `glpi_reminders_users`.`users_id` = '5'
                OR (`glpi_profiles_reminders`.`profiles_id` = '2'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
-                         OR (`glpi_profiles_reminders`.`entities_id` IN ($all_entities))))
+                         OR (true)))
                OR (`glpi_entities_reminders`.`entities_id` IN ($all_entities)))");
         $this->assertSame(
             $expected,
             trim(preg_replace('/\s+/', ' ', \Reminder::addVisibilityRestrict()))
         );
 
+        // Both 'tech' and 'normal' users have access to all entities in the test DB,
+        // so glpishowallentities=1 and the profiles/groups entity blocks get 'true'.
         $this->login('tech', 'tech');
         $expected = preg_replace('/\s+/', ' ', "(`glpi_reminders`.`users_id` = '4'
                OR `glpi_reminders_users`.`users_id` = '4'
                OR (`glpi_profiles_reminders`.`profiles_id` = '6'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
-                         OR (`glpi_profiles_reminders`.`entities_id` IN ($all_entities))))
+                         OR (true)))
                OR (`glpi_entities_reminders`.`entities_id` IN ($all_entities)))");
         $this->assertSame(
             $expected,
@@ -102,10 +108,10 @@ class ReminderTest extends DbTestCase
                OR `glpi_reminders_users`.`users_id` = '4'
                OR (`glpi_groups_reminders`.`groups_id` IN ('42', '1337')
                     AND (`glpi_groups_reminders`.`no_entity_restriction` = '1'
-                         OR (`glpi_groups_reminders`.`entities_id` IN ($all_entities))))
+                         OR (true)))
                OR (`glpi_profiles_reminders`.`profiles_id` = '6'
                     AND (`glpi_profiles_reminders`.`no_entity_restriction` = '1'
-                         OR (`glpi_profiles_reminders`.`entities_id` IN ($all_entities))))
+                         OR (true)))
                OR (`glpi_entities_reminders`.`entities_id` IN ($all_entities)))");
         $this->assertSame(
             $expected,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

https://github.com/glpi-project/glpi/pull/24059 brought an enormous performances increase to GLPI but some code doesn't benefit from it because they manually send the list of all entities instead of using the default empty parameter that does the same thing.

This mean that inside the function we can't know that the array contains only the active entities and thus we can't benefit from the `glpiparententities` or `glpishowallentities` shortcuts.

On the ajax/planning endpoint, this reduced the execution time from 4s to 1s on a client with ~1500 entities.


