### PR TITLE
Fix(Ticket): redirect pending approval link to main tab

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -4329,7 +4329,7 @@ JAVASCRIPT;
                         $options['criteria'][3]['searchtype'] = 'equals';
                         $options['criteria'][3]['value']      = CommonITILValidation::WAITING;
                         $options['criteria'][3]['link']       = 'AND';
-                        $forcetab                         = 'TicketValidation$1';
+                        $forcetab                             = 'Ticket$main';
 
                         $main_header = "<a href=\"" . htmlescape(Ticket::getSearchURL() . "?" . Toolbox::append_params($options)) . "\">"
                             . Html::makeTitle(__('Your tickets to approve'), $displayed_row_count, $total_row_count) . "</a>";

--- a/tests/cypress/e2e/dropdown.cy.js
+++ b/tests/cypress/e2e/dropdown.cy.js
@@ -38,7 +38,7 @@ describe('setupAjaxDropdown()', () => {
             content: "My ticket content",
         }).then((ticket_id) => {
             // open Ticket view on Approval tab
-            cy.visit(`/front/ticket.form.php?id=${ticket_id}&forcetab=TicketValidation$1`);
+            cy.visit(`/front/ticket.form.php?id=${ticket_id}&forcetab=Ticket$main`);
             // prepare to intercept the ajax call to getDropdownValue
             cy.intercept('/ajax/getDropdownValue.php').as('getDropdownValue');
             // click on "Send an approval request" button
@@ -55,6 +55,3 @@ describe('setupAjaxDropdown()', () => {
         });
     });
 });
-
-
-

--- a/tests/cypress/e2e/dropdown.cy.js
+++ b/tests/cypress/e2e/dropdown.cy.js
@@ -38,7 +38,7 @@ describe('setupAjaxDropdown()', () => {
             content: "My ticket content",
         }).then((ticket_id) => {
             // open Ticket view on Approval tab
-            cy.visit(`/front/ticket.form.php?id=${ticket_id}&forcetab=Ticket$main`);
+            cy.visit(`/front/ticket.form.php?id=${ticket_id}&forcetab=TicketValidation$1`);
             // prepare to intercept the ajax call to getDropdownValue
             cy.intercept('/ajax/getDropdownValue.php').as('getDropdownValue');
             // click on "Send an approval request" button


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

In the personal view, clicking a ticket from the "Tickets waiting for your approval" block was opening the Validation tab, which only shows approval status and does not allow the user to validate or refuse the ticket. The link now opens the main Ticket tab so the user can directly act on the approval.

## Screenshots (if appropriate):

<img width="696" height="290" alt="image" src="https://github.com/user-attachments/assets/fdd0b718-706c-46b1-891c-601466f3608d" />
