### PR TITLE
FIX / Dispose pagination tooltip before refreshing paginated results

### DIFF
--- a/js/modules/Search/Table.js
+++ b/js/modules/Search/Table.js
@@ -168,6 +168,16 @@ window.GLPI.Search.Table = class Table extends GenericView {
 
     onPageChange(target) {
         const page_link = $(target);
+
+        if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip) {
+            page_link.closest('.pagination').find('[data-bs-toggle="tooltip"]').each((index, node) => {
+                const tooltip = bootstrap.Tooltip.getInstance(node);
+                if (tooltip !== null) {
+                    tooltip.dispose();
+                }
+            });
+        }
+
         page_link.closest('.pagination').find('.page-item').removeClass('selected');
         page_link.closest('.page-item').addClass('selected');
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43729
- Next/Previous tooltips could remain visible after hover and page navigation when pagination is displayed above the results. This PR dispose existing Bootstrap tooltip instances on pagination controls before triggering the results refresh.

## Screenshots :

<img width="1859" height="246" alt="Capture d’écran du 2026-05-04 15-18-33" src="https://github.com/user-attachments/assets/0565f19d-894c-4dfb-bb92-d3f4170177cb" />

