### PR TITLE
fix(forms): fix specific ticket template not being applied

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1892,6 +1892,11 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             }
         }
 
+        // If category, entity, or type fields are not updated, the template is not changed.
+        if (empty($input['itilcategories_id']) && empty($input['entities_id']) && empty($input['type'])) {
+            return $input;
+        }
+
         // First get ticket template associated: entity and type/category
         $tt = $this->getITILTemplateFromInput($input);
 

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
@@ -215,6 +215,7 @@ final class TemplateFieldTest extends AbstractDestinationFieldTest
         TemplateFieldConfig $config,
         int $expected_tickettemplates_id
     ): Ticket {
+        $this->login();
 
         // Insert config
         $destinations = $form->getDestinations();


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43787
- If a template is specified in the form's destination settings, the generated ticket will use the ticket template from the category associated with the ticket, not the specified template.

## Screenshots (if appropriate):
<img width="1004" height="193" alt="image" src="https://github.com/user-attachments/assets/16f733bf-f658-4125-a07d-7450e3b6e1dd" />


