### PR TITLE
Makefile: only set -it flag if supported for playwright command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ include tests/e2e/.env
 -include tests/e2e/.env.local
 
 # See: https://playwright.dev/docs/docker
+DOCKER_TTY_FLAGS = $(shell [ -t 0 ] && echo "-it")
 PLAYWRIGHT = docker run \
-	-it \
+	$(DOCKER_TTY_FLAGS) \
 	--rm \
 	--ipc=host \
 	--user=$(shell id -u):$(shell id -g) \


### PR DESCRIPTION
The `-it` option require a valid tty, which is not always the case (for example, when running the command from a bash script).