### PR TITLE
Fix 'tester plugin is not active' errors

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
+use Glpi\Application\Environment;
 use Glpi\Debug\Profiler;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
@@ -65,6 +66,10 @@ final readonly class BootPlugins implements EventSubscriberInterface
 
         Profiler::getInstance()->start('BootPlugins::execute', Profiler::CATEGORY_BOOT);
 
+        if (Environment::get()->shouldSetupTesterPlugin()) {
+            $this->setupTesterPlugin();
+        }
+
         $plugin = new Plugin();
 
         if (!$plugin->isPluginsExecutionSuspended()) {
@@ -72,5 +77,16 @@ final readonly class BootPlugins implements EventSubscriberInterface
         }
 
         Profiler::getInstance()->stop('BootPlugins::execute');
+    }
+
+    private function setupTesterPlugin(): void
+    {
+        global $DB;
+        $DB->updateOrInsert(table: Plugin::getTable(), params: [
+            'directory' => 'tester',
+            'name'      => 'tester',
+            'state'     => 1,
+            'version'   => '1.0.0',
+        ], where: ['directory' => 'tester']);
     }
 }

--- a/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/InitializePlugins.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
-use Glpi\Application\Environment;
 use Glpi\Debug\Profiler;
 use Glpi\DependencyInjection\PluginContainer;
 use Glpi\Kernel\KernelListenerTrait;
@@ -68,26 +67,11 @@ final readonly class InitializePlugins implements EventSubscriberInterface
         $plugin = new Plugin();
 
         if (!$plugin->isPluginsExecutionSuspended()) {
-            if (Environment::get()->shouldSetupTesterPlugin()) {
-                $this->setupTesterPlugin();
-            }
-
             $plugin->init();
         }
 
         $this->pluginContainer->initializeContainer();
 
         Profiler::getInstance()->stop('InitializePlugins::execute');
-    }
-
-    private function setupTesterPlugin(): void
-    {
-        global $DB;
-        $DB->updateOrInsert(table: Plugin::getTable(), params: [
-            'directory' => 'tester',
-            'name'      => 'tester',
-            'state'     => 1,
-            'version'   => '1.0.0',
-        ], where: ['directory' => 'tester']);
     }
 }


### PR DESCRIPTION
For a while now, all tests would fail right after installing the database with the following error:

<img width="1229" height="150" alt="image" src="https://github.com/user-attachments/assets/7fe2ea26-d9f3-4b6f-b8af-575c4a2d8a09" />

Then on the second run it would go back to normal.

This was caused 9 months ago by https://github.com/glpi-project/glpi/pull/20189, which add a new plugin related step in the kernel post boot process before the existing `InitializePlugins` step.

This new step boot the plugins so we need our tester plugin to be loaded before it.
Fixed by moving the setup code inside this step.