### PR TITLE
fix: remove mini dashboard from default dashboards for menus different than mini_tickets

### DIFF
--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -201,7 +201,10 @@ class Dashboard extends CommonDBTM
     public function canViewCurrent(): bool
     {
         Profiler::getInstance()->start(__METHOD__);
-        $this->load();
+
+        if (!$this->load()) {
+            return false;
+        };
 
         if ($this->fields['users_id'] === Session::getLoginUserID()) {
             // User is always allowed to view its own dashboards.

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -204,7 +204,7 @@ class Dashboard extends CommonDBTM
 
         if (!$this->load()) {
             return false;
-        };
+        }
 
         if ($this->fields['users_id'] === Session::getLoginUserID()) {
             // User is always allowed to view its own dashboards.

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1629,17 +1629,11 @@ HTML;
         // if default not found, return first dashboard
         if (!$strict) {
             self::loadAllDashboards();
-            $possible_dashboards = self::$all_dashboards;
+            $dashboards = $menu === 'mini_ticket'
+                ? self::$all_dashboards
+                : array_filter(self::$all_dashboards, static fn($d) => $d['key'] !== 'mini_tickets');
 
-            //if the menu is not mini_ticket, remove the mini dashboard from the possible dashboards
-            if ($menu !== "mini_ticket") {
-                $possible_dashboards = array_filter($possible_dashboards, static fn($dashboard) => $dashboard['key'] !== 'mini_tickets');
-            }
-
-            $first_dashboard = array_shift($possible_dashboards);
-            if (isset($first_dashboard['key'])) {
-                return $first_dashboard['key'];
-            }
+            return array_shift($dashboards)['key'] ?? "";
         }
 
         return "";

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1629,7 +1629,14 @@ HTML;
         // if default not found, return first dashboard
         if (!$strict) {
             self::loadAllDashboards();
-            $first_dashboard = array_shift(self::$all_dashboards);
+            $possible_dashboards = self::$all_dashboards;
+
+            //if the menu is not mini_ticket, remove the mini dashboard from the possible dashboards
+            if ($menu !== "mini_ticket") {
+                $possible_dashboards = array_filter($possible_dashboards, static fn($dashboard) => $dashboard['key'] !== 'mini_tickets');
+            }
+
+            $first_dashboard = array_shift($possible_dashboards);
             if (isset($first_dashboard['key'])) {
                 return $first_dashboard['key'];
             }

--- a/tests/functional/Glpi/Dashboard/GridTest.php
+++ b/tests/functional/Glpi/Dashboard/GridTest.php
@@ -63,7 +63,7 @@ class GridTest extends DbTestCase
     {
         foreach (array_keys($_SESSION) as $key) {
             if (str_starts_with($key, 'glpidefault_dashboard_')) {
-                unset($_SESSION[$key]);
+                $_SESSION[$key] = '';
             }
         }
         unset($_SESSION['last_dashboards']);
@@ -76,7 +76,7 @@ class GridTest extends DbTestCase
 
         foreach ($CFG_GLPI as $key => $value) {
             if (str_starts_with($key, 'default_dashboard_')) {
-                unset($CFG_GLPI[$key]);
+                $CFG_GLPI[$key] = '';
             }
         }
     }

--- a/tests/functional/Glpi/Dashboard/GridTest.php
+++ b/tests/functional/Glpi/Dashboard/GridTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Dashboard;
+
+use Glpi\Dashboard\Dashboard;
+use Glpi\Dashboard\Grid;
+use Glpi\Dashboard\Item;
+use Glpi\Dashboard\Right;
+use Glpi\Tests\DbTestCase;
+
+class GridTest extends DbTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->login();
+        Grid::$all_dashboards = [];
+        $this->clearDashboardSession();
+        $this->clearDashboardConfig();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Grid::$all_dashboards = [];
+        $this->clearDashboardSession();
+        $this->clearDashboardConfig();
+    }
+
+    private function clearDashboardSession(): void
+    {
+        foreach (array_keys($_SESSION) as $key) {
+            if (str_starts_with($key, 'glpidefault_dashboard_')) {
+                unset($_SESSION[$key]);
+            }
+        }
+        unset($_SESSION['last_dashboards']);
+        unset($_REQUEST['_target']);
+    }
+
+    private function clearDashboardConfig(): void
+    {
+        global $CFG_GLPI;
+
+        foreach ($CFG_GLPI as $key => $value) {
+            if (str_starts_with($key, 'default_dashboard_')) {
+                unset($CFG_GLPI[$key]);
+            }
+        }
+    }
+
+    private function clearAllDashboardsFromDB(): void
+    {
+        global $DB;
+
+        $DB->delete(Right::getTable(), ['NOT' => ['id' => 0] ]);
+        $DB->delete(Item::getTable(), ['NOT' => ['id' => 0] ]);
+        $DB->delete(Dashboard::getTable(), ['NOT' => ['id' => 0] ]);
+        Dashboard::$all_dashboards = [];
+        Grid::$all_dashboards = [];
+    }
+
+    public function testGetDefaultDashboardForMenuStrictWithNoDefaultValue(): void
+    {
+        Grid::$all_dashboards = [
+            'test_dashboard' => ['key' => 'test_dashboard', 'name' => 'Test', 'context' => 'core'],
+        ];
+
+        $result = Grid::getDefaultDashboardForMenu('central', true);
+        $this->assertSame('', $result);
+    }
+
+    public function testGetDefaultDashboardForMenutWithSessionDefaultValue(): void
+    {
+        global $CFG_GLPI;
+
+        $_SESSION['glpidefault_dashboard_central'] = 'test_dashboard';
+        $CFG_GLPI['default_dashboard_central'] = 'test_dashboard2';
+
+        $result = Grid::getDefaultDashboardForMenu('central', true);
+        $this->assertSame('test_dashboard', $result);
+    }
+
+    public function testGetDefaultDashboardForMenuWithSessionDisabled(): void
+    {
+        global $CFG_GLPI;
+
+        $_SESSION['glpidefault_dashboard_central'] = 'disabled';
+        $CFG_GLPI['default_dashboard_central'] = 'test_dashboard';
+
+        $result = Grid::getDefaultDashboardForMenu('central', true);
+        $this->assertSame('', $result);
+    }
+
+    public function testGetDefaultDashboardForMenuUsesConfigValue(): void
+    {
+        global $CFG_GLPI;
+
+        $CFG_GLPI['default_dashboard_central'] = 'test_dashboard';
+
+        $result = Grid::getDefaultDashboardForMenu('central', true);
+        $this->assertSame('test_dashboard', $result);
+    }
+
+    public function testGetDefaultDashboardForMenuNotStrictWithNoDefaultValue(): void
+    {
+        $this->clearAllDashboardsFromDB();
+
+        $this->createItem(Dashboard::class, [
+            'key'     => 'mini_tickets',
+            'name'    => 'Mini Tickets',
+            'context' => 'mini_core',
+        ]);
+        $this->createItem(Dashboard::class, [
+            'key'     => 'test_dashboard',
+            'name'    => 'Test Dashboard',
+            'context' => 'core',
+        ]);
+        Dashboard::$all_dashboards = [];
+
+        $result = Grid::getDefaultDashboardForMenu('central', false);
+        $this->assertNotSame('mini_tickets', $result);
+        $this->assertSame('test_dashboard', $result);
+
+        $this->clearAllDashboardsFromDB();
+        $this->createItem(Dashboard::class, [
+            'key'     => 'mini_tickets',
+            'name'    => 'Mini Tickets',
+            'context' => 'mini_core',
+        ]);
+        Dashboard::$all_dashboards = [];
+
+        $result = Grid::getDefaultDashboardForMenu('central', false);
+        $this->assertSame('', $result);
+    }
+
+    public function testGetDefaultDashboardWithNoStrictForMenuMiniTicket(): void
+    {
+        $this->clearAllDashboardsFromDB();
+
+        $this->createItem(Dashboard::class, [
+            'key'     => 'mini_tickets',
+            'name'    => 'Mini Tickets',
+            'context' => 'mini_core',
+        ]);
+        Dashboard::$all_dashboards = [];
+
+        $result = Grid::getDefaultDashboardForMenu('mini_ticket', false);
+        $this->assertSame('mini_tickets', $result);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Fixes ticket 43824.
- Before this fix, when the default dashboard defined in the general configuration was not accessible to the current user, and no default dashboard was set in their personal configuration, GLPI displayed the first accessible dashboard found in the database. This was often the mini ticket dashboard, regardless of the current menu. This behavior was incorrect for menus such as "Assets" and "Helpdesk", where this dashboard is not intended to be displayed.
- This fix removes the mini ticket dashboard from the default dashboards when the current menu is not "mini_tickets".
- It also returns false in Dashboard::canViewCurrent() when the dashboard is not loaded, preventing the error shown in the following image when no default dashboard is accessible to the current user:

<img width="2387" height="397" alt="dashboard_error" src="https://github.com/user-attachments/assets/926fc76a-0898-4030-a8d4-45875a5f495c" />