### PR TITLE
Fix eslint warning

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -191,7 +191,7 @@ export default [
             "playwright/no-force-option": "error",
             "playwright/no-raw-locators": "error",
             "playwright/expect-expect": [
-                "warn",
+                "error",
                 {
                     "assertFunctionPatterns": ["^expect.*", "^assert.*"]
                 }

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -190,6 +190,7 @@ for (const actor_type of actor_types) {
             }
         });
 
+        /* eslint-disable-next-line playwright/expect-expect -- expects are done in doAssertDropdownValueIsNotAvailable */
         test('Cannot select unauthorized actors with "Specific actors"', async () => {
             await form_page.doOpenDestinationAccordionItem('Actors');
 


### PR DESCRIPTION
Fix this warning:

<img width="704" height="209" alt="image" src="https://github.com/user-attachments/assets/adc72efd-4ba1-4d82-a9a3-cf50c20ed6a1" />

And set the rule as "error" so we don't miss it next time as we probably don't want to have some optional warnings like this polluting the results, might as well fix it immediately when it happens.