### PR TITLE
Upgrade NodeJS requirement to v22 LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "description": "GLPI dependencies",
     "license": "GPL-3.0-or-later",
     "engines": {
-        "node": ">= 20.9"
+        "node": ">= 22.11"
     },
     "dependencies": {
         "@floating-ui/dom": "^1.7.6",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Not sure about this, but I think it can permit to unlock some dependencies upgrades not proposed by dependabot. Indeed, the following log lines makes me think that dependabot takes care of our versions constraint to proposed relevant dependencies versions:
```
INFO <job_1350830545> Command executed successfully: node -v
INFO <job_1350830545> Processing engine constraints for node
INFO <job_1350830545> Parsed constraints for node: >=20.9
```

It may explain why it did not yet proposed to upgrade to `eslint@^10.x`, since this version requires `node: ^20.19.0`, that is an higher version than the minimal version we are supposed to support.

Node v24 is not the latest LTS version, but since it is not yet available in some Linux distributions packages repositories, I think it is preferable to use the v22 for the moment.