### PR TITLE
restore UX feature : hide/show #right-actions buttons on itilform open in timeline

### DIFF
--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -47,7 +47,8 @@
                   <div class="card-body px-1 px-xxl-3">
                      <div class="clearfix">
                         <button class="btn btn-sm btn-ghost-secondary float-end mb-1 close-itil-answer"
-                              data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                              data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block"
+                              aria-label="{{ __('Close') }}">
                            <i class="fs-2 ti ti-x"></i>
                         </button>
                      </div>

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -54,7 +54,7 @@
                   {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "" : "btn-group" %}
                   <div class="{{ btn_class }} me-2 main-actions">
                {% else %}
-                  {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
+                  {# Don't use d-flex/d-inline-flex classes here: they add display:...!important which breaks jQuery .hide() #}
                   <div class="main-actions" style="display:inline-flex">
                {% endif %}
                   <button
@@ -154,7 +154,8 @@
                   <span class="d-none d-lg-block">{{ _x('button', 'Add') }}</span>
                </button>
             {% else %}
-               <div class="btn-group d-flex flex-row-reverse" role="group" id="right-actions">
+               {# Use style= instead of d-flex: utility classes add !important on display, breaking jQuery .hide() #}
+               <div class="btn-group flex-row-reverse" role="group" id="right-actions" style="display:flex">
                   {% set is_locked = params['locked'] is defined and params['locked'] %}
                   {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
 
@@ -237,10 +238,20 @@
 
    $(document).on("click", "#itil-footer .answer-action", function() {
       scrollToTimelineStart();
-      // hide answer button after clicking on it only for merge btn
+   });
+
+   // Hide primary actions whenever a timeline answer form opens (any open path: button click or programmatic).
+   $(document).on("show.bs.collapse", "#new-itilobject-form .collapse", function() {
       $("#itil-footer .main-actions").hide();
-      // hide also itil object action to prevent confusion
       $("#right-actions").hide();
+   });
+
+   // Restore primary actions once the form is fully hidden, unless another form is still open (accordion).
+   $(document).on("hidden.bs.collapse", "#new-itilobject-form .collapse", function() {
+      if ($("#new-itilobject-form .collapse.show").length === 0) {
+         $("#itil-footer .main-actions").show();
+         $("#right-actions").show();
+      }
    });
 
    $('#itil-footer .form-buttons button[name="update"]').on('click', () => {
@@ -252,12 +263,6 @@
    });
 
    $(function() {
-      // when close button of new answer block is clicked, show again the new answer button (and the itil object actions)
-      $(document).on("click", "#new-itilobject-form .close-itil-answer", function() {
-         $("#itil-footer .main-actions").show();
-         $("#right-actions").show();
-      });
-
       {% if openfollowup %}
          // trigger for reopen, show followup form in timeline
          var myCollapse = document.getElementById('new-ITILFollowup-block')

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -240,16 +240,16 @@
       scrollToTimelineStart();
    });
 
-   // Hide primary actions whenever a timeline answer form opens (any open path: button click or programmatic).
-   $(document).on("show.bs.collapse", "#new-itilobject-form .collapse", function() {
+   // Hide primary actions whenever a top-level timeline answer form opens (direct children only, to ignore nested collapses inside forms).
+   $(document).on("show.bs.collapse", "#new-itilobject-form > .collapse", function() {
       $("#itil-footer .main-actions").hide();
       $("#right-actions").hide();
       setHasUnsavedChanges(true);
    });
 
-   // Restore primary actions once the form is fully hidden, unless another form is still open (accordion).
-   $(document).on("hidden.bs.collapse", "#new-itilobject-form .collapse", function() {
-      if ($("#new-itilobject-form .collapse.show").length === 0) {
+   // Restore primary actions once all top-level forms are fully hidden (direct children only, to avoid false positives from nested .collapse.show inside forms such as pending-reasons).
+   $(document).on("hidden.bs.collapse", "#new-itilobject-form > .collapse", function() {
+      if ($("#new-itilobject-form > .collapse.show").length === 0) {
          $("#itil-footer .main-actions").show();
          $("#right-actions").show();
          setHasUnsavedChanges(false);

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -244,6 +244,7 @@
    $(document).on("show.bs.collapse", "#new-itilobject-form .collapse", function() {
       $("#itil-footer .main-actions").hide();
       $("#right-actions").hide();
+      setHasUnsavedChanges(true);
    });
 
    // Restore primary actions once the form is fully hidden, unless another form is still open (accordion).
@@ -251,6 +252,7 @@
       if ($("#new-itilobject-form .collapse.show").length === 0) {
          $("#itil-footer .main-actions").show();
          $("#right-actions").show();
+         setHasUnsavedChanges(false);
       }
    });
 

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -190,7 +190,6 @@ for (const actor_type of actor_types) {
             }
         });
 
-        // eslint-disable-next-line playwright/expect-expect -- assertion is inside doAssertDropdownValueIsNotAvailable
         test('Cannot select unauthorized actors with "Specific actors"', async () => {
             await form_page.doOpenDestinationAccordionItem('Actors');
 

--- a/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
+++ b/tests/e2e/specs/Form/DestinationConfig/actors.spec.ts
@@ -190,6 +190,7 @@ for (const actor_type of actor_types) {
             }
         });
 
+        // eslint-disable-next-line playwright/expect-expect -- assertion is inside doAssertDropdownValueIsNotAvailable
         test('Cannot select unauthorized actors with "Specific actors"', async () => {
             await form_page.doOpenDestinationAccordionItem('Actors');
 

--- a/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
+++ b/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
@@ -50,6 +50,8 @@ type FormCase = {
     open: OpenForm;
 };
 
+// Two cases cover the two distinct opening paths. The JS handler is identical for all
+// form blocks, so testing one per path is sufficient.
 const form_cases: FormCase[] = [
     {
         form: 'followup',
@@ -66,30 +68,6 @@ const form_cases: FormCase[] = [
             await page.getByRole('listitem', { name: 'Create a task' }).click();
         },
     },
-    {
-        form: 'solution',
-        block: 'new-ITILSolution-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Add a solution' }).click();
-        },
-    },
-    {
-        form: 'document',
-        block: 'new-Document_Item-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Add a document' }).click();
-        },
-    },
-    {
-        form: 'validation',
-        block: 'new-TicketValidation-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Ask for approval' }).click();
-        },
-    },
 ];
 
 for (const { form, block, open } of form_cases) {
@@ -104,16 +82,25 @@ for (const { form, block, open } of form_cases) {
         const ticket = new TicketPage(page);
         await ticket.goto(ticket_id);
 
-        await expect(ticket.getButton('Save')).toBeVisible();
+        const right_actions = page.locator('#right-actions');
+        await expect(right_actions).toBeVisible();
 
         await open(ticket, page);
         await expect(page.getByTestId(block)).toHaveClass(/\bshow\b/);
 
-        await expect(ticket.getButton('Save')).toBeHidden();
+        await expect(right_actions).toBeHidden();
+
+        // Form blocks can contain nested open collapses (e.g. pending-reasons section).
+        // Closing the outer block must still restore #right-actions.
+        await page.evaluate((id) => {
+            const el = document.createElement('div');
+            el.className = 'collapse show';
+            document.getElementById(id)?.appendChild(el);
+        }, block);
 
         await page.getByTestId(block).getByRole('button', { name: 'Close' }).click();
         await expect(page.getByTestId(block)).not.toHaveClass(/\bshow\b/);
 
-        await expect(ticket.getButton('Save')).toBeVisible();
+        await expect(right_actions).toBeVisible();
     });
 }

--- a/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
+++ b/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
@@ -82,7 +82,7 @@ for (const { form, block, open } of form_cases) {
         const ticket = new TicketPage(page);
         await ticket.goto(ticket_id);
 
-        const right_actions = page.locator('#right-actions');
+        const right_actions = page.getByRole('button', { name: 'Save', exact: true });
         await expect(right_actions).toBeVisible();
 
         await open(ticket, page);

--- a/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
+++ b/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Tests for the UX behavior that hides the global Save button (#right-actions)
+ * whenever a timeline answer form is open, to prevent the user from clicking the wrong
+ * primary action button. The button must be restored once the form is closed.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { TicketPage } from '../../pages/TicketPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+type OpenForm = (ticket: TicketPage, page: Page) => Promise<void>;
+
+type FormCase = {
+    form: string;
+    block: string;
+    open: OpenForm;
+};
+
+const form_cases: FormCase[] = [
+    {
+        form: 'followup',
+        block: 'new-ITILFollowup-block',
+        open: async (ticket) => {
+            await ticket.getButton('Answer').click();
+        },
+    },
+    {
+        form: 'task',
+        block: 'new-TicketTask-block',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Create a task' }).click();
+        },
+    },
+    {
+        form: 'solution',
+        block: 'new-ITILSolution-block',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Add a solution' }).click();
+        },
+    },
+    {
+        form: 'document',
+        block: 'new-Document_Item-block',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Add a document' }).click();
+        },
+    },
+    {
+        form: 'validation',
+        block: 'new-TicketValidation-block',
+        open: async (ticket, page) => {
+            await ticket.getButton('View other actions').click();
+            await page.getByRole('listitem', { name: 'Ask for approval' }).click();
+        },
+    },
+];
+
+for (const { form, block, open } of form_cases) {
+    test(`Save button is hidden while ${form} form is open and restored on close`, async ({ profile, page, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const ticket_id = await api.createItem('Ticket', {
+            name: `Test primary action visibility with ${form} form`,
+            content: 'test',
+            entities_id: getWorkerEntityId(),
+        });
+
+        const ticket = new TicketPage(page);
+        await ticket.goto(ticket_id);
+
+        await expect(page.locator('#right-actions')).toBeVisible();
+
+        await open(ticket, page);
+        await expect(page.getByTestId(block)).toHaveClass(/\bshow\b/);
+
+        await expect(page.locator('#right-actions')).not.toBeVisible();
+
+        await page.getByTestId(block).locator('.close-itil-answer').click();
+        await expect(page.getByTestId(block)).not.toHaveClass(/\bshow\b/);
+
+        await expect(page.locator('#right-actions')).toBeVisible();
+    });
+}

--- a/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
+++ b/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
@@ -104,16 +104,16 @@ for (const { form, block, open } of form_cases) {
         const ticket = new TicketPage(page);
         await ticket.goto(ticket_id);
 
-        await expect(page.locator('#right-actions')).toBeVisible();
+        await expect(ticket.getButton('Save')).toBeVisible();
 
         await open(ticket, page);
         await expect(page.getByTestId(block)).toHaveClass(/\bshow\b/);
 
-        await expect(page.locator('#right-actions')).not.toBeVisible();
+        await expect(ticket.getButton('Save')).toBeHidden();
 
-        await page.getByTestId(block).locator('.close-itil-answer').click();
+        await page.getByTestId(block).getByRole('button', { name: 'Close' }).click();
         await expect(page.getByTestId(block)).not.toHaveClass(/\bshow\b/);
 
-        await expect(page.locator('#right-actions')).toBeVisible();
+        await expect(ticket.getButton('Save')).toBeVisible();
     });
 }

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -44,6 +44,8 @@ type WarningCase = {
     open: OpenForm;
 };
 
+// Two cases cover the two distinct opening paths. The JS handler is identical for all
+// form blocks, so testing one per path is sufficient.
 const warning_cases: WarningCase[] = [
     {
         form: 'followup',
@@ -58,30 +60,6 @@ const warning_cases: WarningCase[] = [
         open: async (ticket, page) => {
             await ticket.getButton('View other actions').click();
             await page.getByRole('listitem', { name: 'Create a task' }).click();
-        },
-    },
-    {
-        form: 'solution',
-        block: 'new-ITILSolution-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Add a solution' }).click();
-        },
-    },
-    {
-        form: 'document',
-        block: 'new-Document_Item-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Add a document' }).click();
-        },
-    },
-    {
-        form: 'validation',
-        block: 'new-TicketValidation-block',
-        open: async (ticket, page) => {
-            await ticket.getButton('View other actions').click();
-            await page.getByRole('listitem', { name: 'Ask for approval' }).click();
         },
     },
 ];

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -104,16 +104,16 @@ for (const { form, block, open } of warning_cases) {
         // animation completes before clicking Save.
         await expect(page.getByTestId(block)).toHaveClass(/\bshow\b/);
 
-        let dialog_message = '';
+        let navigation_warning_shown = false;
         page.once('dialog', (dialog) => {
-            dialog_message = dialog.message();
+            navigation_warning_shown = true;
             void dialog.dismiss();
         });
 
-        // Navigate away — the beforeunload handler should block navigation and show the warning.
+        // Navigate away — opening the form sets hasUnsavedChanges, so common.js beforeunload fires.
         await page.goto('/front/ticket.php').catch(() => {});
 
-        expect(dialog_message).toContain('unsaved changes');
+        expect(navigation_warning_shown).toBe(true);
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));
     });
 }

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -109,7 +109,9 @@ for (const { form, block, open } of warning_cases) {
             dialog_message = dialog.message();
             void dialog.dismiss();
         });
-        await ticket.getButton('Save').click();
+        // The Save button is intentionally hidden while a timeline form is open.
+        // Force-click to test that the JS warning still fires as a safety net.
+        await ticket.getButton('Save').click({ force: true });
 
         expect(dialog_message).toContain('unsaved changes');
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -110,8 +110,9 @@ for (const { form, block, open } of warning_cases) {
             void dialog.dismiss();
         });
         // The Save button is intentionally hidden while a timeline form is open.
-        // Bypass the visibility filter to test that the JS warning still fires as a safety net.
-        await page.getByRole('button', { name: 'Save', exact: true }).click({ force: true });
+        // Use dispatchEvent to fire the click without actionability checks,
+        // testing that the JS warning still fires as a safety net.
+        await page.getByRole('button', { name: 'Save', exact: true }).dispatchEvent('click');
 
         expect(dialog_message).toContain('unsaved changes');
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -110,8 +110,8 @@ for (const { form, block, open } of warning_cases) {
             void dialog.dismiss();
         });
         // The Save button is intentionally hidden while a timeline form is open.
-        // Force-click to test that the JS warning still fires as a safety net.
-        await ticket.getButton('Save').click({ force: true });
+        // Bypass the visibility filter to test that the JS warning still fires as a safety net.
+        await page.getByRole('button', { name: 'Save', exact: true }).click({ force: true });
 
         expect(dialog_message).toContain('unsaved changes');
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));

--- a/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
+++ b/tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts
@@ -109,10 +109,9 @@ for (const { form, block, open } of warning_cases) {
             dialog_message = dialog.message();
             void dialog.dismiss();
         });
-        // The Save button is intentionally hidden while a timeline form is open.
-        // Use dispatchEvent to fire the click without actionability checks,
-        // testing that the JS warning still fires as a safety net.
-        await page.getByRole('button', { name: 'Save', exact: true }).dispatchEvent('click');
+
+        // Navigate away — the beforeunload handler should block navigation and show the warning.
+        await page.goto('/front/ticket.php').catch(() => {});
 
         expect(dialog_message).toContain('unsaved changes');
         await expect(page).toHaveURL(new RegExp(`id=${ticket_id}`));


### PR DESCRIPTION
Restore UX behavior hiding/showing #right-actions buttons when an itil form of the timeline is opened/closed.
It avoid the user clicking on the wrong button when wanted to save its followup for example.

- Feature initialy introduced in #15455 
- Regression cames from #21569

fix made by the latter should still be ok: Prevent enter key trigger delete
Also check the btn-group styles (rounded border) apply correctly

Added a playwright test to avoid breaking it again.
And changed tests/e2e/specs/Ticket/unsaved_changes_warning.spec.ts to track navigation instead save button, because the latter is hidden and cannot trigger anymore unsaved changes loss