### PR TITLE
add linked projects and tasks variables in itil notification templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 
-- Added variables for linked projects and tasks in ITIL notifications templates.
-
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The present file will list all changes made to the project; according to the
 
 ### Added
 
+- Added variables for linked projects and tasks in ITIL notifications templates.
+
 ### Changed
 
 ### Deprecated

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1570,7 +1570,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     ];
                 }
             }
-            $data['##ticket.numberoflinkedprojects##'] = count($data['linkedprojects']);
+            $data['##'. strtolower($item->getType()) . '.numberoflinkedprojects##'] = count($data['linkedprojects']);
 
             $show_private = $options['additionnaloption']['show_private'] ?? false;
             $followup_restrict = [];

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1545,6 +1545,33 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $data['##ticket.numberoflinkedchanges##'] = count($data['linkedchanges']);
             $data['##ticket.numberoflinkedproblems##'] = count($data['linkedproblems']);
 
+            $data['linkedprojects'] = [];
+            $itil_project = new Itil_Project();
+            $linked_projects = $itil_project->find([
+                'itemtype' => $item->getType(),
+                'items_id' => $item->getField('id'),
+            ]);
+            foreach ($linked_projects as $linked_project) {
+                $project = new Project();
+                if ($project->getFromDB($linked_project['projects_id'])) {
+                    $data['linkedprojects'][] = [
+                        '##linkedproject.id##'      => $linked_project['projects_id'],
+                        '##linkedproject.url##'     => $this->formatURL(
+                            $options['additionnaloption']['usertype'],
+                            'project_' . $linked_project['projects_id']
+                        ),
+                        '##linkedproject.name##'   => $project->getField('name'),
+                        '##linkedproject.content##' => $project->getField('content'),
+                        '##linkedproject.code##' => $project->getField('code'),
+                        '##linkedproject.planstartdate##' => $project->getField('plan_start_date'),
+                        '##linkedproject.planenddate##' => $project->getField('plan_end_date'),
+                        '##linkedproject.realstartdate##' => $project->getField('real_start_date'),
+                        '##linkedproject.realenddate##' => $project->getField('real_end_date'),
+                    ];
+                }
+            }
+            $data['##ticket.numberoflinkedprojects##'] = count($data['linkedprojects']);
+
             $show_private = $options['additionnaloption']['show_private'] ?? false;
             $followup_restrict = [];
             $followup_restrict['items_id'] = $item->getField('id');
@@ -2227,6 +2254,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.numberoflinkedtickets' => _x('quantity', 'Number of linked tickets'),
             $objettype . '.numberoflinkedchanges' => _x('quantity', 'Number of linked changes'),
             $objettype . '.numberoflinkedproblems' => _x('quantity', 'Number of linked problems'),
+            $objettype . '.numberoflinkedprojects' => _x('quantity', 'Number of linked projects'),
             $objettype . '.reminder.bumpcounter' => __('Number of sent reminders since status is pending'),
             $objettype . '.reminder.bumpremaining' => __('Number of remaining reminders before automatic resolution'),
             $objettype . '.reminder.bumptotal'  => __('Total number of reminders before automatic resolution'),
@@ -2255,6 +2283,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             'linkedtickets' => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
             'linkedchanges' => _n('Linked change', 'Linked changes', Session::getPluralNumber()),
             'linkedproblems' => _n('Linked problem', 'Linked problems', Session::getPluralNumber()),
+            'linkedprojects' => _n('Linked project', 'Linked projects', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -2278,6 +2307,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
             $objettype . '.linkedtickets'       => _n('Linked ticket', 'Linked tickets', Session::getPluralNumber()),
             $objettype . '.linkedchanges'       => _n('Linked change', 'Linked changes', Session::getPluralNumber()),
             $objettype . '.linkedproblems'      => _n('Linked problem', 'Linked problems', Session::getPluralNumber()),
+            $objettype . '.linkedprojects'      => _n('Linked project', 'Linked projects', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -2439,6 +2469,51 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                 __('%1$s: %2$s'),
                 _n('Linked problem', 'Linked problems', 1),
                 __('Description')
+            ),
+            'linkedproject.id'        => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('ID')
+            ),
+            'linkedproject.url'       => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('URL')
+            ),
+            'linkedproject.name'     => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Name')
+            ),
+            'linkedproject.content'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Description')
+            ),
+            'linkedproject.code'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Code')
+            ),
+            'linkedproject.planstartdate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Plan start date')
+            ),
+            'linkedproject.planenddate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Plan end date')
+            ),
+            'linkedproject.realstartdate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Plan start date')
+            ),
+            'linkedproject.realenddate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project', 'Linked projects', 1),
+                __('Plan start date')
             ),
         ];
 

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1570,7 +1570,7 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                     ];
                 }
             }
-            $data['##'. strtolower($item->getType()) . '.numberoflinkedprojects##'] = count($data['linkedprojects']);
+            $data['##' . strtolower($item->getType()) . '.numberoflinkedprojects##'] = count($data['linkedprojects']);
 
             $show_private = $options['additionnaloption']['show_private'] ?? false;
             $followup_restrict = [];

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1563,10 +1563,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                         '##linkedproject.name##'   => $project->getField('name'),
                         '##linkedproject.content##' => $project->getField('content'),
                         '##linkedproject.code##' => $project->getField('code'),
-                        '##linkedproject.planstartdate##' => Html::convDateTime($project->getField('plan_start_date'), with_seconds: true),
-                        '##linkedproject.planenddate##' => Html::convDateTime($project->getField('plan_end_date'), with_seconds: true),
-                        '##linkedproject.realstartdate##' => Html::convDateTime($project->getField('real_start_date'), with_seconds: true),
-                        '##linkedproject.realenddate##' => Html::convDateTime($project->getField('real_end_date'), with_seconds: true),
+                        '##linkedproject.planstartdate##' => Html::convDateTime($project->getField('plan_start_date')),
+                        '##linkedproject.planenddate##' => Html::convDateTime($project->getField('plan_end_date')),
+                        '##linkedproject.realstartdate##' => Html::convDateTime($project->getField('real_start_date')),
+                        '##linkedproject.realenddate##' => Html::convDateTime($project->getField('real_end_date')),
                     ];
                 }
             }

--- a/src/NotificationTargetCommonITILObject.php
+++ b/src/NotificationTargetCommonITILObject.php
@@ -1563,10 +1563,10 @@ abstract class NotificationTargetCommonITILObject extends NotificationTarget
                         '##linkedproject.name##'   => $project->getField('name'),
                         '##linkedproject.content##' => $project->getField('content'),
                         '##linkedproject.code##' => $project->getField('code'),
-                        '##linkedproject.planstartdate##' => $project->getField('plan_start_date'),
-                        '##linkedproject.planenddate##' => $project->getField('plan_end_date'),
-                        '##linkedproject.realstartdate##' => $project->getField('real_start_date'),
-                        '##linkedproject.realenddate##' => $project->getField('real_end_date'),
+                        '##linkedproject.planstartdate##' => Html::convDateTime($project->getField('plan_start_date'), with_seconds: true),
+                        '##linkedproject.planenddate##' => Html::convDateTime($project->getField('plan_end_date'), with_seconds: true),
+                        '##linkedproject.realstartdate##' => Html::convDateTime($project->getField('real_start_date'), with_seconds: true),
+                        '##linkedproject.realenddate##' => Html::convDateTime($project->getField('real_end_date'), with_seconds: true),
                     ];
                 }
             }

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -846,10 +846,10 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 _n('Linked project task', 'Linked project tasks', 1),
                 __('URL')
             ),
-            'linkedprojecttask.title'     => sprintf(
+            'linkedprojecttask.name'     => sprintf(
                 __('%1$s: %2$s'),
                 _n('Linked project task', 'Linked project tasks', 1),
-                __('Title')
+                __('Name')
             ),
             'linkedprojecttask.content'   => sprintf(
                 __('%1$s: %2$s'),

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -541,6 +541,30 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
 
                 $data['validations'][] = $tmp;
             }
+
+            // linked project tasks
+            $data['linkedprojecttasks'] = [];
+            $project_task_ticket = new ProjectTask_Ticket();
+            $linked_project_tasks = $project_task_ticket->find(['tickets_id' => $item->getField('id')]);
+            foreach ($linked_project_tasks as $linked_project_task) {
+                $project_task = new ProjectTask();
+                if ($project_task->getFromDB($linked_project_task['projecttasks_id'])) {
+                    $data['linkedprojecttasks'][] = [
+                        '##linkedprojecttask.id##'      => $linked_project_task['projecttasks_id'],
+                        '##linkedprojecttask.url##'     => $this->formatURL(
+                            $options['additionnaloption']['usertype'],
+                            'projecttask_' . $linked_project_task['projecttasks_id']
+                        ),
+                        '##linkedprojecttask.name##'   => $project_task->getField('name'),
+                        '##linkedprojecttask.content##' => $project_task->getField('content'),
+                        '##linkedprojecttask.planstartdate##' => $project_task->getField('plan_start_date'),
+                        '##linkedprojecttask.planenddate##' => $project_task->getField('plan_end_date'),
+                        '##linkedprojecttask.realstartdate##' => $project_task->getField('real_start_date'),
+                        '##linkedprojecttask.realenddate##' => $project_task->getField('real_end_date'),
+                    ];
+                }
+            }
+            $data['##ticket.numberoflinkedprojecttasks##'] = count($data['linkedprojecttasks']);
         }
 
         $data['##ticket.externalid##'] = $item->fields['externalid'];
@@ -652,6 +676,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'ticket.numberofproblems'      => _x('quantity', 'Number of problems'),
             'ticket.numberofchanges'       => _x('quantity', 'Number of changes'),
             'ticket.numberofitems'         => _x('quantity', 'Number of items'),
+            'ticket.numberoflinkedprojecttasks' => _x('quantity', 'Number of linked project tasks'),
             'ticket.autoclose'             => __('Automatic closing of solved tickets after'),
             'ticket.location'              => Location::getTypeName(1),
             'ticket.location.comment'      => __('Location comments'),
@@ -736,6 +761,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
             'changes'       => Change::getTypeName(Session::getPluralNumber()),
             'items'         => _n('Associated item', 'Associated items', Session::getPluralNumber()),
             'documents'     => Document::getTypeName(Session::getPluralNumber()),
+            'linkedprojecttasks' => _n('Linked project task', 'Linked project tasks', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -759,6 +785,7 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                          ),
                          '?'
                      ),
+            'ticket.linkedprojecttasks'  => _n('Linked project task', 'Linked project tasks', Session::getPluralNumber()),
         ];
 
         foreach ($tags as $tag => $label) {
@@ -808,6 +835,46 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                 __('%1$s: %2$s'),
                 Change::getTypeName(1),
                 __('Description')
+            ),
+            'linkedprojecttask.id'        => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('ID')
+            ),
+            'linkedprojecttask.url'       => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('URL')
+            ),
+            'linkedprojecttask.title'     => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Title')
+            ),
+            'linkedprojecttask.content'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Description')
+            ),
+            'linkedprojecttask.planstartdate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Plan start date')
+            ),
+            'linkedprojecttask.planenddate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Plan end date')
+            ),
+            'linkedprojecttask.realstartdate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Plan start date')
+            ),
+            'linkedprojecttask.realenddate'   => sprintf(
+                __('%1$s: %2$s'),
+                _n('Linked project task', 'Linked project tasks', 1),
+                __('Plan start date')
             ),
         ];
 

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -557,10 +557,10 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                         ),
                         '##linkedprojecttask.name##'   => $project_task->getField('name'),
                         '##linkedprojecttask.content##' => $project_task->getField('content'),
-                        '##linkedprojecttask.planstartdate##' => Html::convDateTime($project_task->getField('plan_start_date'), with_seconds: true),
-                        '##linkedprojecttask.planenddate##' => Html::convDateTime($project_task->getField('plan_end_date'), with_seconds: true),
-                        '##linkedprojecttask.realstartdate##' => Html::convDateTime($project_task->getField('real_start_date'), with_seconds: true),
-                        '##linkedprojecttask.realenddate##' => Html::convDateTime($project_task->getField('real_end_date'), with_seconds: true),
+                        '##linkedprojecttask.planstartdate##' => Html::convDateTime($project_task->getField('plan_start_date')),
+                        '##linkedprojecttask.planenddate##' => Html::convDateTime($project_task->getField('plan_end_date')),
+                        '##linkedprojecttask.realstartdate##' => Html::convDateTime($project_task->getField('real_start_date')),
+                        '##linkedprojecttask.realenddate##' => Html::convDateTime($project_task->getField('real_end_date')),
                     ];
                 }
             }

--- a/src/NotificationTargetTicket.php
+++ b/src/NotificationTargetTicket.php
@@ -557,10 +557,10 @@ class NotificationTargetTicket extends NotificationTargetCommonITILObject
                         ),
                         '##linkedprojecttask.name##'   => $project_task->getField('name'),
                         '##linkedprojecttask.content##' => $project_task->getField('content'),
-                        '##linkedprojecttask.planstartdate##' => $project_task->getField('plan_start_date'),
-                        '##linkedprojecttask.planenddate##' => $project_task->getField('plan_end_date'),
-                        '##linkedprojecttask.realstartdate##' => $project_task->getField('real_start_date'),
-                        '##linkedprojecttask.realenddate##' => $project_task->getField('real_end_date'),
+                        '##linkedprojecttask.planstartdate##' => Html::convDateTime($project_task->getField('plan_start_date'), with_seconds: true),
+                        '##linkedprojecttask.planenddate##' => Html::convDateTime($project_task->getField('plan_end_date'), with_seconds: true),
+                        '##linkedprojecttask.realstartdate##' => Html::convDateTime($project_task->getField('real_start_date'), with_seconds: true),
+                        '##linkedprojecttask.realenddate##' => Html::convDateTime($project_task->getField('real_end_date'), with_seconds: true),
                     ];
                 }
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes ticket 43722.
- Adds variables for linked projects and tasks in notification templates for ITIL notifications. 
- List of variables added for linked projects : 
  - [ItilObject].numberoflinkedprojects
  - linkedproject.id
  - linkedproject.url
  - linkedproject.name
  - linkedproject.content
  - linkedproject.code
  - linkedproject.planstartdate
  - linkedproject.planenddate
  - linkedproject.realstartdate
  - linkedproject.realenddate
- List of variables added for linked project tasks : 
  - ticket.numberoflinkedprojecttasks
  - linkedprojecttask.id
  - linkedprojecttask.url
  - linkedprojecttask.name
  - linkedprojecttask.content
  - linkedprojecttask.planstartdate
  - linkedprojecttask.planenddate
  - linkedprojecttask.realstartdate
  - linkedprojecttask.realenddate 

## Screenshots (if appropriate):


