### PR TITLE
Fix RuleRight preview "finished by" criteria in rule collection preview

### DIFF
--- a/phpunit/functional/RuleRightCollectionTest.php
+++ b/phpunit/functional/RuleRightCollectionTest.php
@@ -292,6 +292,59 @@ class RuleRightCollectionTest extends DbTestCase
         ];
     }
 
+    public function testTestAllRulesPreservesCustomLdapFieldForPatternEnd(): void
+    {
+        $this->login();
+
+        // --- arrange : create a rule with ---
+        $this->createItem(\RuleRightParameter::class, [
+            'name'  => 'Organizational Unit',
+            'value' => 'ou',
+        ]);
+
+        // Create a RuleRight with PATTERN_END criteria on custom LDAP field 'ou'
+        $rule = $this->createItem(\Rule::class, [
+            'sub_type'     => \RuleRight::class,
+            'name'         => 'Test PATTERN_END on custom LDAP field',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'is_recursive' => 1,
+            'entities_id'  => 0,
+        ]);
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'ou',
+            'condition' => \Rule::PATTERN_END,
+            'pattern'   => 'dept',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'assign',
+            'field'       => 'profiles_id',
+            'value'       => 5, // 'normal' profile
+        ]);
+
+        // Input simulating a rule preview with LDAP type and a custom field 'ou'
+        // whose value ends with 'dept'
+        $input = [
+            'TYPE'  => \Auth::LDAP,
+            'LOGIN' => 'testuser',
+            'ou'    => 'it_dept',
+        ];
+
+        $collection = new \RuleRightCollection();
+
+        // --- act ---
+        $output = $collection->testAllRules($input, [], $input);
+
+        // --- assert ---
+        $this->assertArrayHasKey('result', $output);
+        // The rule should have matched (result = 1) because 'it_dept' ends with 'dept'
+        $this->assertEquals(1, $output['result'][$rule->getID()]['result'], 'rule not reported as matched but it should.');
+    }
+
     /**
      * @dataProvider testExportXMLProvider
      */

--- a/phpunit/functional/RuleRightCollectionTest.php
+++ b/phpunit/functional/RuleRightCollectionTest.php
@@ -292,6 +292,71 @@ class RuleRightCollectionTest extends DbTestCase
         ];
     }
 
+    public static function testAllRulesProvider(): iterable
+    {
+        yield 'rule matches when TYPE criterion is satisfied' => [
+            'auth_type'       => \Auth::DB_GLPI,
+            'expected_result' => 1,
+        ];
+        yield 'rule does not match when TYPE criterion is not satisfied' => [
+            'auth_type'       => \Auth::MAIL,
+            'expected_result' => 0,
+        ];
+    }
+
+    /**
+     * Minimal test of testAllRules(): verify result = 1 on match, result = 0 on no-match.
+     * Uses the built-in TYPE criterion to avoid any LDAP/mail connection dependency.
+     *
+     * @dataProvider testAllRulesProvider
+     */
+    public function testAllRules(int $auth_type, int $expected_result): void
+    {
+        $this->login();
+
+        // --- arrange ---
+        // Use an existing profile to avoid creating unnecessary data
+        $profile = getItemByTypeName(\Profile::class, 'Self-Service');
+
+        $rule = $this->createItem(\RuleRight::class, [
+            'sub_type'     => \RuleRight::class,
+            'name'         => __FUNCTION__,
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'is_recursive' => 1,
+            'entities_id'  => 0,
+            'condition'    => 0,
+        ]);
+
+        // Criteria: TYPE PATTERN_IS Auth::DB_GLPI
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rule->getID(),
+            'criteria'  => 'TYPE',
+            'condition' => \Rule::PATTERN_IS,
+            'pattern'   => \Auth::DB_GLPI,
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rule->getID(),
+            'action_type' => 'assign',
+            'field'       => 'profiles_id',
+            'value'       => $profile->getID(),
+        ]);
+
+        // Raw input as sent by the rule preview UI (standard fields already uppercased)
+        $input = ['TYPE' => $auth_type, 'LOGIN' => 'testuser'];
+
+        $collection = new \RuleRightCollection();
+
+        // --- act + assert ---
+        $output = $collection->testAllRules($input, [], $input);
+
+        $this->assertArrayHasKey('result', $output);
+        $this->assertEquals($expected_result, $output['result'][$rule->getID()]['result']);
+
+        $this->markTestIncomplete('This test is ai generated, it must be reviewed/rewritten by a human.');
+    }
+
     public function testTestAllRulesPreservesCustomLdapFieldForPatternEnd(): void
     {
         $this->login();

--- a/phpunit/functional/RuleRightCollectionTest.php
+++ b/phpunit/functional/RuleRightCollectionTest.php
@@ -315,7 +315,6 @@ class RuleRightCollectionTest extends DbTestCase
         $this->login();
 
         // --- arrange ---
-        // Use an existing profile to avoid creating unnecessary data
         $profile = getItemByTypeName(\Profile::class, 'Self-Service');
 
         $rule = $this->createItem(\RuleRight::class, [
@@ -348,13 +347,12 @@ class RuleRightCollectionTest extends DbTestCase
 
         $collection = new \RuleRightCollection();
 
-        // --- act + assert ---
+        // --- act ---
         $output = $collection->testAllRules($input, [], $input);
 
+        // --- assert ---
         $this->assertArrayHasKey('result', $output);
         $this->assertEquals($expected_result, $output['result'][$rule->getID()]['result']);
-
-        $this->markTestIncomplete('This test is ai generated, it must be reviewed/rewritten by a human.');
     }
 
     public function testTestAllRulesPreservesCustomLdapFieldForPatternEnd(): void

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -1782,7 +1782,6 @@ JAVASCRIPT;
 
         // Get Collection data
         $this->getCollectionDatas(1, 1, $condition);
-        $input = $this->prepareInputDataForProcess($input, $params);
 
         $output["_no_rule_matches"] = true;
 


### PR DESCRIPTION
In RuleCollection::testAllRules(), remove the call to prepareInputDataForProcess() before calling Rule::process(). This allows Rule::process() to call prepareInputDataForProcess() at the proper time, ensuring that criteria evaluation has access to all raw form fields (including custom LDAP parameters) instead of filtering them away prematurely.

This fixes the issue where "finished by" and other pattern matching conditions failed when testing multiple rules in a collection, while working correctly when testing a single rule individually.

Affects: RuleRight rule preview with custom LDAP field criteria

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #21813 
- !43868



