### PR TITLE
Render KB aside only if categories or article exists

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2829,6 +2829,12 @@ TWIG, $twig_params);
         $current_is_favorite = KnowbaseItem_Favorite::isFavoriteForCurrentUser($current_id);
         $has_other_favorites = array_filter($favorites, fn(Article $a) => !$a->is_current) !== [];
 
+        // Don't render the aside if we don't have any categories or article
+        $tree = (new Builder($current_id))->buildTree();
+        if ($tree->getArticles() === [] && $tree->getCategories() === []) {
+            return null;
+        }
+
         return TemplateRenderer::getInstance()->render(
             'pages/tools/kb/aside.html.twig',
             [


### PR DESCRIPTION
In this case, there won't be any data to display so the aside would be useless.
