### PR TITLE
FIX / Ticket list visibility for approval substitutes

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -894,20 +894,7 @@ final class SQLProvider implements SearchProviderInterface
                             ]
                         )
                     ) {
-                        $criteria['OR'][] = [
-                            'AND' => [
-                                "`glpi_ticketvalidations`.`itemtype_target`" => User::class,
-                                "`glpi_ticketvalidations`.`items_id_target`" => Session::getLoginUserID(),
-                            ],
-                        ];
-                        if (count($_SESSION['glpigroups'])) {
-                            $criteria['OR'][] = [
-                                'AND' => [
-                                    "`glpi_ticketvalidations`.`itemtype_target`" => Group::class,
-                                    "`glpi_ticketvalidations`.`items_id_target`" => $_SESSION['glpigroups'],
-                                ],
-                            ];
-                        }
+                        $criteria['OR'][] = TicketValidation::getTargetCriteriaForUser(Session::getLoginUserID());
                     }
                 }
                 break;

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -894,7 +894,7 @@ final class SQLProvider implements SearchProviderInterface
                             ]
                         )
                     ) {
-                        $criteria['OR'][] = TicketValidation::getTargetCriteriaForUser(Session::getLoginUserID());
+                        $criteria['OR'][] = TicketValidation::getTargetCriteriaForUser((int) Session::getLoginUserID());
                     }
                 }
                 break;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43617
- When a user had ticket validation rights but did not have the `See all tickets` permission, tickets delegated to them through the approval substitute mechanism were visible from the home page approval widgets and could still be opened and validated directly, but they were missing from `Assistance > Tickets`. 
The ticket search visibility criteria now reuse `TicketValidation::getTargetCriteriaForUser(Session::getLoginUserID())` instead of rebuilding a partial condition for direct approvers only.
This aligns the ticket list behavior with the existing validation logic and ensures that approval substitutes are handled the same way as direct approvers.