### PR TITLE
fix: parent entity inherited values not displayed in Entity form

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2992,7 +2992,8 @@ class Entity extends CommonTreeDropdown implements
             if ($strategy_field === null) {
                 $strategy_field = $field;
             }
-            $inherited_strategy = self::getUsedConfig($strategy_field, $this->fields['entities_id']);
+            $get_used_config_default = is_numeric($inherit_parent_value) ? $default_value : '';
+            $inherited_strategy = self::getUsedConfig($strategy_field, $this->fields['entities_id'], '', $get_used_config_default);
             $inherited_value    = $inherited_strategy === 0
                 ? self::getUsedConfig($strategy_field, $this->fields['entities_id'], $field, $default_value)
                 : $inherited_strategy;

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2994,12 +2994,7 @@ class Entity extends CommonTreeDropdown implements
             if ($strategy_field === null) {
                 $strategy_field = $field;
             }
-            // getUsedConfig() uses different logic to detect "inherit" depending on whether $default_value
-            // is numeric (checks $ref == CONFIG_PARENT) or non-numeric (checks !$ref).
-            // For text/null fields ($inherit_parent_value === null), we must pass a non-numeric default ('')
-            // so that null values in ancestor entities are also recognized as "keep walking up the tree".
-            // Without this, a direct parent storing null would stop the traversal prematurely and no
-            // resolved value would ever be found from grandparents or higher ancestors.
+            // pass a non-numeric default ('') For text/null fields to recognize inherited values in ancestor entities.
             $get_used_config_default = is_numeric($inherit_parent_value) ? $default_value : '';
             $inherited_strategy = self::getUsedConfig($strategy_field, $this->fields['entities_id'], '', $get_used_config_default);
             $inherited_value    = $inherited_strategy === 0

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2980,6 +2980,8 @@ class Entity extends CommonTreeDropdown implements
      * @param string $field The field name
      * @param string|null $strategy_field The field name of the strategy
      * @param mixed $default_value
+     * @param mixed $inherit_parent_value The sentinel value stored in the field when it inherits from its parent.
+     *                                    Use CONFIG_PARENT (-2) for numeric fields, or null for text/email/URL fields.
      * @return string|null The badge HTML or null if the field is not inherited
      */
     public function getInheritedValueBadge(string $field, ?string $strategy_field = null, mixed $default_value = self::CONFIG_PARENT, mixed $inherit_parent_value = self::CONFIG_PARENT): ?string
@@ -2992,6 +2994,12 @@ class Entity extends CommonTreeDropdown implements
             if ($strategy_field === null) {
                 $strategy_field = $field;
             }
+            // getUsedConfig() uses different logic to detect "inherit" depending on whether $default_value
+            // is numeric (checks $ref == CONFIG_PARENT) or non-numeric (checks !$ref).
+            // For text/null fields ($inherit_parent_value === null), we must pass a non-numeric default ('')
+            // so that null values in ancestor entities are also recognized as "keep walking up the tree".
+            // Without this, a direct parent storing null would stop the traversal prematurely and no
+            // resolved value would ever be found from grandparents or higher ancestors.
             $get_used_config_default = is_numeric($inherit_parent_value) ? $default_value : '';
             $inherited_strategy = self::getUsedConfig($strategy_field, $this->fields['entities_id'], '', $get_used_config_default);
             $inherited_value    = $inherited_strategy === 0

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -706,6 +706,93 @@ class EntityTest extends DbTestCase
         $this->assertEquals($expected_result, call_user_func_array([Entity::class, 'getUsedConfig'], $params));
     }
 
+    public static function getInheritedValueBadgeProvider(): iterable
+    {
+        getItemByTypeName('Entity', '_test_child_1', true);
+
+        // Numeric sentinel (CONFIG_PARENT = -2): auto_assign_mode
+        yield 'numeric: not inheriting returns null' => [
+            'root_values'       => ['auto_assign_mode' => Entity::AUTO_ASSIGN_HARDWARE_CATEGORY],
+            'child_values'      => ['auto_assign_mode' => Entity::AUTO_ASSIGN_CATEGORY_HARDWARE],
+            'grandchild_values' => ['auto_assign_mode' => Entity::AUTO_ASSIGN_CATEGORY_HARDWARE],
+            'field'             => 'auto_assign_mode',
+            'expected_result'     => null,
+            'inherit_parent_value' => Entity::CONFIG_PARENT,
+        ];
+        yield 'numeric: inherits from direct parent' => [
+            'root_values'       => ['auto_assign_mode' => Entity::AUTO_ASSIGN_HARDWARE_CATEGORY],
+            'child_values'      => ['auto_assign_mode' => Entity::AUTO_ASSIGN_CATEGORY_HARDWARE],
+            'grandchild_values' => ['auto_assign_mode' => Entity::CONFIG_PARENT],
+            'field'             => 'auto_assign_mode',
+            'expected_result'   => 'Based on the category then the item',
+            'inherit_parent_value' => Entity::CONFIG_PARENT,
+        ];
+        yield 'numeric: inherits from grandparent when parent also inherits' => [
+            'root_values'       => ['auto_assign_mode' => Entity::AUTO_ASSIGN_HARDWARE_CATEGORY],
+            'child_values'      => ['auto_assign_mode' => Entity::CONFIG_PARENT],
+            'grandchild_values' => ['auto_assign_mode' => Entity::CONFIG_PARENT],
+            'field'             => 'auto_assign_mode',
+            'expected_result'   => 'Based on the item then the category',
+            'inherit_parent_value' => Entity::CONFIG_PARENT,
+        ];
+
+        // Null sentinel (text fields): admin_email
+        yield 'text: not inheriting returns null' => [
+            'root_values'          => ['admin_email' => 'root@example.com'],
+            'child_values'         => ['admin_email' => 'child@example.com'],
+            'grandchild_values'    => ['admin_email' => 'grand@example.com'],
+            'field'                => 'admin_email',
+            'expected_result'      => null,
+            'inherit_parent_value' => null,
+        ];
+        yield 'text: inherits from direct parent' => [
+            'root_values'          => ['admin_email' => 'root@example.com'],
+            'child_values'         => ['admin_email' => 'child@example.com'],
+            'grandchild_values'    => ['admin_email' => null],
+            'field'                => 'admin_email',
+            'expected_result'      => 'child@example.com',
+            'inherit_parent_value' => null,
+        ];
+        yield 'text: inherits from grandparent when parent also inherits' => [
+            'root_values'       => ['admin_email' => 'root@example.com'],
+            'child_values'      => ['admin_email' => null],
+            'grandchild_values' => ['admin_email' => null],
+            'field'             => 'admin_email',
+            'expected_result' => 'root@example.com',
+            'inherit_parent_value' => null,
+        ];
+    }
+
+    #[DataProvider('getInheritedValueBadgeProvider')]
+    public function testGetInheritedValueBadge(
+        array $root_values,
+        array $child_values,
+        array $grandchild_values,
+        string $field,
+        ?string $expected_result,
+        ?int $inherit_parent_value,
+    ): void {
+        $this->login();
+
+        $root_id       = getItemByTypeName('Entity', 'Root entity', true);
+        $child_id      = getItemByTypeName('Entity', '_test_root_entity', true);
+        $grandchild_id = getItemByTypeName('Entity', '_test_child_1', true);
+
+        $entity = new Entity();
+        $this->assertTrue($entity->update(['id' => $root_id] + $root_values));
+        $this->assertTrue($entity->update(['id' => $child_id] + $child_values));
+        $this->assertTrue($entity->update(['id' => $grandchild_id] + $grandchild_values));
+
+        $this->assertTrue($entity->getFromDB($grandchild_id));
+        $badge = $entity->getInheritedValueBadge(field: $field, inherit_parent_value: $inherit_parent_value);
+
+        if ($expected_result === null) {
+            $this->assertNull($badge);
+        } else {
+            $this->assertNotNull($badge);
+            $this->assertStringContainsString($expected_result, $badge);
+        }
+    }
 
     public static function customCssProvider()
     {

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -708,8 +708,6 @@ class EntityTest extends DbTestCase
 
     public static function getInheritedValueBadgeProvider(): iterable
     {
-        getItemByTypeName('Entity', '_test_child_1', true);
-
         // Numeric sentinel (CONFIG_PARENT = -2): auto_assign_mode
         yield 'numeric: not inheriting returns null' => [
             'root_values'       => ['auto_assign_mode' => Entity::AUTO_ASSIGN_HARDWARE_CATEGORY],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes ticket !43840
- Before this fix, the badge showing the inherited value in entity form only appears when the direct parent has an actual value set. If the direct parent also inherits (from a grandparent or higher), the badge is silently hidden.
- this is due to the fact that getInheritedValueBadge() method calls getUsedConfig() without passing the correct default value for non numeric fields (text/email/URL fields like admin_email, url_base, etc.). Instead, -2 is always passed. 
- Because of that, inside getUsedConfig(), the inheritance check for non numeric fields fails when the direct parent doesn't have an actual value.
- fix : In getInheritedValueBadge(), detect when $inherit_parent_value is null (text-field case) and pass a non-numeric default (empty string '') to getUsedConfig() so that the inheritance check succeed. 

## Screenshots (if appropriate):
before the fix : 

<img width="1402" height="499" alt="before" src="https://github.com/user-attachments/assets/62d69755-020d-4c09-836d-0a0fb41b1729" />

After the fix : 

<img width="2834" height="652" alt="after" src="https://github.com/user-attachments/assets/66556c0e-c798-403f-a979-79f5c7fff919" />
