### PR TITLE
Stream document responses

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5810,12 +5810,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$body of class Glpi\\\\Http\\\\Response constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string\\|null, string\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\$itemtypes of static method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getUnionSchemaForItemtypes\\(\\) expects non\\-empty\\-array\\<string, class\\-string\\<CommonGLPI\\>\\>, array given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -5841,12 +5835,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$headers of class Glpi\\\\Http\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, list\\<string\\|null\\>\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$body of class Glpi\\\\Http\\\\Response constructor expects Psr\\\\Http\\\\Message\\\\StreamInterface\\|resource\\|string\\|null, string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5804,12 +5804,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$headers of class Glpi\\\\Http\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, list\\<string\\|null\\>\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AdministrationController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\$itemtypes of static method Glpi\\\\Api\\\\HL\\\\Doc\\\\Schema\\:\\:getUnionSchemaForItemtypes\\(\\) expects non\\-empty\\-array\\<string, class\\-string\\<CommonGLPI\\>\\>, array given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -5832,12 +5826,6 @@ $ignoreErrors[] = [
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ITILController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$headers of class Glpi\\\\Http\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, list\\<string\\|null\\>\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/ManagementController.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot access offset mixed on array\\|void\\.$#',
@@ -20628,6 +20616,18 @@ $ignoreErrors[] = [
 	'identifier' => 'offsetAccess.nonOffsetAccessible',
 	'count' => 1,
 	'path' => __DIR__ . '/src/autoload/legacy-autoloader.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
+    'identifier' => 'argument.type',
+    'count' => 2,
+    'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
+    'identifier' => 'argument.type',
+    'count' => 1,
+    'path' => __DIR__ . '/src/Glpi/Api/HL/StreamedResponseWrapper.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -36,10 +36,12 @@
 namespace Glpi\Api\HL\Controller;
 
 use CommonDBTM;
+use Document;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\RoutePath;
 use Glpi\Api\HL\Router;
+use Glpi\Api\HL\StreamedResponseWrapper;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -47,6 +49,8 @@ use Glpi\Plugin\Hooks;
 use Plugin;
 use RuntimeException;
 use Session;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Toolbox;
 
 /**
  * @phpstan-type AdditionalErrorMessage array{priority: string, message: string}
@@ -350,5 +354,38 @@ abstract class AbstractController
             return $path;
         }
         return '/';
+    }
+
+    /**
+     * Download a file using streaming.
+     *
+     * This method does not check permissions or validate the document in any way.
+     *
+     * If this method actually sends the file content (not a 304 FOUND or similar), the underlying {@link Toolbox::getFileAsResponse()} response would be a Symfony StreamedResponse, which is not PSR-7 compatible and cannot be processed by the HLAPI.
+     * To ensure it can be processed and the headers do not get sent too early, the StreamedResponse is wrapped with {@link StreamedResponseWrapper} which allows it to be treated as a normal PSR-7 Response until the HLAPI is ready to send the response.
+     * As the HLAPI ultimately converts PSR-7 responses to Symfony responses before sending, the underlying Symfony response will be sent directly instead of creating in a new Symfony Response.
+     *
+     * @param Request $request The request object
+     * @param string $filepath The file path
+     * @param string $filename The name of the file to be downloaded (used in the Content-Disposition header)
+     * @param string|null $mime The mime type of the file if known. If null, the mime type will be determined based on the file content.
+     * @return Response
+     * @internal This method is not intended to be overriden and should not be relied on too much. It should be replaced in GLPI 12 as part of a switch to Symfony requests/responses (if possible).
+     */
+    protected function downloadFile(Request $request, string $filepath, string $filename, ?string $mime = null): Response
+    {
+        $is_head_request = $request->getMethod() === 'HEAD';
+        $symfony_response = Toolbox::getFileAsResponse($filepath, $filename, $mime);
+
+        if ($symfony_response instanceof StreamedResponse) {
+            if ($is_head_request) {
+                // we can return a normal PSR-7 response with the headers and status code, but without content
+                return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all());
+            }
+            return new StreamedResponseWrapper($symfony_response);
+        } else {
+            $content = $is_head_request ? null : $symfony_response->getContent();
+            return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
+        }
     }
 }

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -384,7 +384,7 @@ abstract class AbstractController
             }
             return new StreamedResponseWrapper($symfony_response);
         } else {
-            $content = $is_head_request ? null : $symfony_response->getContent();
+            $content = $is_head_request ? null : (string) $symfony_response->getContent();
             return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
         }
     }

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -60,6 +60,9 @@ use UserEmail;
 use UserTitle;
 use ValidatorSubstitute;
 
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+
 /**
  * @phpstan-type EmailData = array{id: int, email: string, is_default: int, _links: array{'self': array{href: non-empty-string}}}
  */
@@ -1357,7 +1360,11 @@ EOT,
         }
         $symfony_response = Toolbox::getFileAsResponse($picture_path, $username);
 
-        return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $symfony_response->getContent());
+        ob_start();
+        $symfony_response->sendContent();
+        $content = ob_get_clean();
+
+        return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
     }
 
     #[Route(path: '/User/Me/Picture', methods: ['GET'], scopes: ['user'])]

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -60,9 +60,6 @@ use UserEmail;
 use UserTitle;
 use ValidatorSubstitute;
 
-use function Safe\ob_get_clean;
-use function Safe\ob_start;
-
 /**
  * @phpstan-type EmailData = array{id: int, email: string, is_default: int, _links: array{'self': array{href: non-empty-string}}}
  */
@@ -1351,20 +1348,14 @@ EOT,
      * @param string|null $picture_path The path to the picture from the user's "picture" field.
      * @return Response A response with the picture as binary content (or the placeholder user picture if the user has no picture).
      */
-    private function getUserPictureResponse(string $username, ?string $picture_path): Response
+    private function getUserPictureResponse(Request $request, string $username, ?string $picture_path): Response
     {
         if ($picture_path !== null) {
             $picture_path = GLPI_PICTURE_DIR . '/' . $picture_path;
         } else {
-            $picture_path = 'public/pics/picture.png';
+            $picture_path = GLPI_ROOT . '/public/pics/picture.png';
         }
-        $symfony_response = Toolbox::getFileAsResponse($picture_path, $username);
-
-        ob_start();
-        $symfony_response->sendContent();
-        $content = ob_get_clean();
-
-        return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
+        return $this->downloadFile($request, $picture_path, $username);
     }
 
     #[Route(path: '/User/Me/Picture', methods: ['GET'], scopes: ['user'])]
@@ -1383,7 +1374,7 @@ EOT,
             ],
         ]);
         $data = $it->current();
-        return $this->getUserPictureResponse($data['name'], $data['picture']);
+        return $this->getUserPictureResponse($request, $data['name'], $data['picture']);
     }
 
     #[Route(path: '/User', methods: ['POST'])]
@@ -1426,7 +1417,7 @@ EOT,
             ],
         ]);
         $data = $it->current();
-        return $this->getUserPictureResponse($data['name'], $data['picture']);
+        return $this->getUserPictureResponse($request, $data['name'], $data['picture']);
     }
 
     #[Route(path: '/User/username/{username}/Picture', methods: ['GET'], requirements: ['username' => '[a-zA-Z0-9_]+'])]
@@ -1445,7 +1436,7 @@ EOT,
             ],
         ]);
         $data = $it->current();
-        return $this->getUserPictureResponse($data['name'], $data['picture']);
+        return $this->getUserPictureResponse($request, $data['name'], $data['picture']);
     }
 
     #[Route(path: '/User/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]

--- a/src/Glpi/Api/HL/Controller/ManagementController.php
+++ b/src/Glpi/Api/HL/Controller/ManagementController.php
@@ -87,6 +87,9 @@ use Supplier;
 use SupplierType;
 use User;
 
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+
 #[Route(path: '/Management', tags: ['Management'])]
 final class ManagementController extends AbstractController
 {
@@ -1186,7 +1189,11 @@ EOT,
         if ($document->getFromDB($request->getAttribute('id'))) {
             if ($document->canViewFile()) {
                 $symfony_response = $document->getAsResponse();
-                return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $symfony_response->getContent());
+                ob_start();
+                $symfony_response->sendContent();
+                $content = ob_get_clean();
+
+                return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
             }
             return self::getAccessDeniedErrorResponse();
         }

--- a/src/Glpi/Api/HL/Controller/ManagementController.php
+++ b/src/Glpi/Api/HL/Controller/ManagementController.php
@@ -87,9 +87,6 @@ use Supplier;
 use SupplierType;
 use User;
 
-use function Safe\ob_get_clean;
-use function Safe\ob_start;
-
 #[Route(path: '/Management', tags: ['Management'])]
 final class ManagementController extends AbstractController
 {
@@ -1188,12 +1185,7 @@ EOT,
         $document = new Document();
         if ($document->getFromDB($request->getAttribute('id'))) {
             if ($document->canViewFile()) {
-                $symfony_response = $document->getAsResponse();
-                ob_start();
-                $symfony_response->sendContent();
-                $content = ob_get_clean();
-
-                return new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
+                return $this->downloadFile($request, GLPI_DOC_DIR . "/" . $document->fields['filepath'], $document->fields['filename'], $document->fields['mime']);
             }
             return self::getAccessDeniedErrorResponse();
         }

--- a/src/Glpi/Api/HL/StreamedResponseWrapper.php
+++ b/src/Glpi/Api/HL/StreamedResponseWrapper.php
@@ -50,7 +50,7 @@ final class StreamedResponseWrapper extends Response
         parent::__construct(
             $symfony_response->getStatusCode(),
             $symfony_response->headers->all(),
-            $symfony_response->getContent()
+            '', // The content is always returned as 'false' in a StreamedResponse, so we set it to an empty string here.
         );
     }
 

--- a/src/Glpi/Api/HL/StreamedResponseWrapper.php
+++ b/src/Glpi/Api/HL/StreamedResponseWrapper.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+use Glpi\Http\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * This class wraps a Symfony {@link StreamedResponse} to allow it to be used in the API, which expects a PSR-7 response.
+ *
+ * @internal Intended to be removed in the future, when the API requests/responses use Symfony's classes which aren't PSR-7 compatible.
+ */
+final class StreamedResponseWrapper extends Response
+{
+    public function __construct(
+        private StreamedResponse $symfony_response
+    ) {
+        parent::__construct(
+            $symfony_response->getStatusCode(),
+            $symfony_response->headers->all(),
+            $symfony_response->getContent()
+        );
+    }
+
+    /**
+     * Get the underlying Symfony StreamedResponse with some of its data synced with the PSR-7 response.
+     * @return StreamedResponse
+     */
+    public function getSymfonyResponse(): StreamedResponse
+    {
+        $this->symfony_response->setStatusCode($this->getStatusCode());
+        foreach ($this->getHeaders() as $header => $values) {
+            foreach ($values as $value) {
+                $this->symfony_response->headers->set($header, $value);
+            }
+        }
+        return $this->symfony_response;
+    }
+}

--- a/src/Glpi/Controller/ApiController.php
+++ b/src/Glpi/Controller/ApiController.php
@@ -37,6 +37,7 @@ namespace Glpi\Controller;
 use Glpi\Api\APIRest;
 use Glpi\Api\HL\Controller\AbstractController as ApiAbstractController;
 use Glpi\Api\HL\Router;
+use Glpi\Api\HL\StreamedResponseWrapper;
 use Glpi\Error\ErrorHandler;
 use Glpi\Http\HeaderlessStreamedResponse;
 use Glpi\Http\JSONResponse;
@@ -107,6 +108,10 @@ final class ApiController extends AbstractController
         } catch (Throwable $e) {
             ErrorHandler::logCaughtException($e);
             $response = new JSONResponse(null, 500);
+        }
+
+        if ($response instanceof StreamedResponseWrapper) {
+            return $response->getSymfonyResponse();
         }
 
         return new SymfonyResponse(

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -68,6 +68,7 @@ use Safe\Exceptions\PcreException;
 use Safe\Exceptions\UrlException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use function Safe\base64_decode;
@@ -79,10 +80,10 @@ use function Safe\curl_getinfo;
 use function Safe\curl_init;
 use function Safe\error_log;
 use function Safe\fclose;
-use function Safe\file_get_contents;
 use function Safe\filemtime;
 use function Safe\finfo_open;
 use function Safe\fopen;
+use function Safe\fread;
 use function Safe\fwrite;
 use function Safe\getimagesize;
 use function Safe\gzcompress;
@@ -661,14 +662,18 @@ class Toolbox
             );
         }
 
-        try {
-            $content = file_get_contents($path);
-        } catch (FilesystemException $e) {
-            throw new HttpException(500, $e->getMessage(), $e);
-        }
+        return new StreamedResponse(
+            function () use ($path) {
+                $file_stream = fopen($path, 'r');
 
-        return new Response(
-            content: $content,
+                // Flush the response into small chunks to prevent loading the whole file contents into the memory.
+                // This is mandatory to prevent memory exhaustion when sending huge files.
+                while (!feof($file_stream)) {
+                    echo fread($file_stream, 8192);
+                    flush();
+                }
+                fclose($file_stream);
+            },
             status: 200,
             headers: $headers
         );

--- a/tests/src/HLAPITestCase.php
+++ b/tests/src/HLAPITestCase.php
@@ -44,6 +44,7 @@ use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\RoutePath;
 use Glpi\Api\HL\Router;
+use Glpi\Api\HL\StreamedResponseWrapper;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -299,6 +300,13 @@ final class HLAPIHelper
         }
         $request = $request->withHeader('GLPI-API-Version', $this->api_version);
         $response = $this->router->handleRequest($request);
+        if ($response instanceof StreamedResponseWrapper) {
+            $symfony_response = $response->getSymfonyResponse();
+            ob_start();
+            $symfony_response->sendContent();
+            $content = ob_get_clean();
+            $response = new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
+        }
         $fn(new HLAPICallAsserter($this->test, $this->router, $response));
         return $this;
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Done as a continuation of #24139 to change document downloads back to streamed responses to avoid loading the entire file into memory. For non-API calls, the logic remains the same as the original PR. For HLAPI, there was an issue with the call to `sendContent` on the StreamedResponse as it didn't send any headers like the `Content-Type` which was set so the first `echo` call set the Content-Type as the default `text/html`. It also meant that the response middleware, like for CORS, could not add new headers either.

For HLAPI calls I added a wrapper class that wraps the Symfony StreamedResponse in the PSR-7 compatible response the HLAPI expects. Then, when the response gets back to the ApiController it is checked if it is a `StreamedResponseWrapper` and if so the underlying Symfony response is returned as-is instead of a new response being created. This way, the content is not streamed until the HLAPI is done setting the headers like the CORS headers. When the underlying StreamedResponse is fetched, the headers and status code are synced with the PSR-7 information.

I also added logic to handle HEAD requests which will take the status and headers from the StreamedResponse from `Toolbox::getFileAsResponse` and return a normal PSR-7 response with no content.

This can be cleaned up more if/when all HLAPI code is changed to use Symfony request/response classes instead of the PSR-7 compatible ones.