### PR TITLE
Add missing Import Information Tab

### DIFF
--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -49,6 +49,7 @@ use NetworkEquipment;
 use Override;
 use Printer;
 use RuleImportAsset;
+use RuleMatchedLog;
 use Session;
 
 class IsInventoriableCapacity extends AbstractCapacity
@@ -143,6 +144,7 @@ class IsInventoriableCapacity extends AbstractCapacity
 
         CommonGLPI::registerStandardTab($classname, Item_Environment::class, 85);
         CommonGLPI::registerStandardTab($classname, Item_Process::class, 85);
+        CommonGLPI::registerStandardTab($classname, RuleMatchedLog::class, 90);
     }
 
     public function onCapacityEnabled(string $classname, CapacityConfig $config): void


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43931
- Here is a brief description of what this PR does
The IsInventoriableCapacity::onClassBootstrap() method did not declare RuleMatchedLog as a standard tab for custom assets. Unlike NetworkEquipment, which calls addStandardTab(RuleMatchedLog::class) in its defineTabs() method, custom assets rely entirely on capabilities for tab registration.

## Screenshots (if appropriate):


