### PR TITLE
[UI][ITILObject] Improve the button alignement in `splitted` mode

### DIFF
--- a/css/includes/components/itilobject/_footer.scss
+++ b/css/includes/components/itilobject/_footer.scss
@@ -43,6 +43,14 @@
         z-index: var(--glpi-zindex-fixed);
     }
 
+    .main-actions {
+        &.btn-splitted {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }
+    }
+
     .answer-action {
         &:hover {
             font-weight: bold;

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -51,7 +51,7 @@
             {% set default_action = main_actions_itemtypes|keys|first %}
             {% if item.isNotSolved() and default_action_data != false %}
                {% if main_actions_itemtypes|length > 1 %}
-                  {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "" : "btn-group" %}
+                  {% set btn_class = timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') ? "btn-splitted" : "btn-group" %}
                   <div class="{{ btn_class }} me-2 main-actions">
                {% else %}
                   {# Don't use d-inline-flex class as it add an '!important' tag that mess with our javascript that will hide this div #}
@@ -72,7 +72,7 @@
                      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') %}
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
                         {% if loop.index0 > 0 %}
-                              <button class="ms-2 btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                              <button class="btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
                                  <i class="{{ timeline_itemtype.icon }}"></i>
                                  <span>{{ timeline_itemtype.short_label }}</span>
                               </button>


### PR DESCRIPTION

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description
When plugin added more buttons, or on smaller screen, we could happen to have more than one line.

Currently the button are spaced with a margin-left, making the button with a weird left margin on new line and touching with parent line.

## Screenshots

### Before

<img width="1314" height="177" alt="Screenshot From 2026-05-11 10-59-18" src="https://github.com/user-attachments/assets/b9b69911-4b0c-4904-890c-a259c1ed1fc6" />

<img width="641" height="295" alt="Screenshot From 2026-05-11 10-59-58" src="https://github.com/user-attachments/assets/fd389ac2-1ce9-4a22-b336-24dd1fdd2e27" />

### After

<img width="1324" height="178" alt="Screenshot From 2026-05-11 11-24-30" src="https://github.com/user-attachments/assets/a153bd63-79f7-40b5-ab3e-08a356cce410" />

<img width="641" height="310" alt="Screenshot From 2026-05-11 11-24-18" src="https://github.com/user-attachments/assets/24dd85bc-b283-4fc3-9d1c-b9b76e19f1a5" />