### PR TITLE
Fix(Marketplace): fix plugin update process

### DIFF
--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -249,17 +249,14 @@ class Controller extends CommonGLPI
 
         if ($plugin_inst->getFromDBbyDir($this->plugin_key)) {
             // Plugin exists, update its version/state
-            $update_input = [
-                'id'      => $plugin_inst->fields['id'],
-                'version' => $version,
-            ];
             if (!in_array($plugin_inst->fields['state'], [Plugin::ANEW, Plugin::NOTINSTALLED, Plugin::NOTUPDATED])) {
                 // Plugin was already existing, make it "not updated" before checking its state
                 // to prevent message like 'Plugin "xxx" version changed. It has been deactivated as its update process has to be launched.'.
-                $update_input['state'] = Plugin::NOTUPDATED;
+                $plugin_inst->update([
+                    'id'    => $plugin_inst->fields['id'],
+                    'state' => Plugin::NOTUPDATED,
+                ]);
             }
-
-            $plugin_inst->update($update_input);
         } else {
             // Plugin does not exist, initialize it with known information
             $plugin_inst->add([


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since GLPI pull request [https://github.com/glpi-project/glpi/pull/21504](https://github.com/glpi-project/glpi/pull/21504), any plugin updated from the marketplace that includes a database schema change is no longer properly updated.

When a plugin is downloaded from the marketplace, its version is updated in the database (table `glpi_plugins`) via the `Controller.php` class and `downloadPlugin` function.

However, in the `CheckPluginState` function  of the `Plugin` class (call right after via `setPluginState`) , the update mechanism specifically checks that the stored version must differ from the installed version in order to trigger the update process.

```php
        if (
            $information['version'] != $plugin->fields['version']
            || $plugin_key != $plugin->fields['directory']
        ) {
            // Plugin known version differs from information or plugin has been renamed,
            // update information in database
            $input              = $information;
            $input['directory'] = $plugin_key;
            if (!in_array($plugin->fields['state'], [self::ANEW, self::NOTINSTALLED, self::NOTUPDATED])) {
                // mark it as 'updatable' unless it was not installed
                trigger_error(
                    sprintf(
                        'Plugin "%s" version changed. It has been deactivated as its update process has to be launched.',
                        $plugin_key
                    ),
                    E_USER_WARNING
                );

                $input['state']     = self::NOTUPDATED;

                Event::log(
                    '',
                    Plugin::class,
                    3,
                    "setup",
                    sprintf(
                        __('Plugin %1$s version changed. It has been deactivated as its update process has to be launched.'),
                        $plugin_key
                    )
                );
            }

            $DB->update(
                self::getTable(),
                $input,
                [
                    'id' => $plugin->fields['id'],
                ]
            );

            $this->unload($plugin_key);

            return;
        }
```

As a result, plugins with schema changes are not being updated as expected, even though their version is modified in the database.

I am currently looking into setting up a unit test.

## Screenshots (if appropriate):


