### PR TITLE
Fix auth form saving on MariaDB Galera cluster

### DIFF
--- a/front/auth.others.php
+++ b/front/auth.others.php
@@ -43,7 +43,7 @@ $config = new Config();
 
 //Update CAS configuration
 if (isset($_POST["update"])) {
-    $_POST['id'] = 1;
+    $_POST['id'] = Config::getConfigIDForContext('core');
     $config->update($_POST);
     Html::redirect($CFG_GLPI["root_doc"] . "/front/auth.others.php");
 }


### PR DESCRIPTION
Don't Hardcode ID as 1 because it could be other ID in galera cluster environments.

This as been resolved in https://github.com/glpi-project/glpi/pull/12295 for other parts of the code, but in this one is still hardcoded as 1.

@cedric-anne not an expert in GLPI code, since you solved the orignal issue in other parts of the code, i followed your changes.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Fixes similiar to #12267 but in another file (Others Authentication)
- Here is a brief description of what this PR does

This happen because the id 1 in "glpi_configs" table does not exists in galera cluster scenario. Because the first id of that table in this scenario is "2".

See #12267 for further explanation of the same issue

## Screenshots (if appropriate):

Not applicable
