### PR TITLE
Update contact us url

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -12,7 +12,7 @@ labels:
             This issue has been closed as we only track bugs here.
             
             You can get community support on [forums](https://forum.glpi-project.org/) or you can consider [taking a subscription](https://glpi-project.org/subscriptions/) to get professional support.
-            You can also [contact GLPI editor team](https://www.glpi-project.org/fr/contact/) directly.
+            You can also [contact GLPI editor team](https://www.glpi-project.org/contact/) directly.
         action: close
   - name: "feature suggestion"
     labeled:
@@ -21,7 +21,7 @@ labels:
             This issue has been closed as we only track bugs here.
             
             You can open a topic to discuss with community about this enhancement on [suggestion website](https://glpi.userecho.com/).
-            You can also [contact GLPI editor team](https://www.glpi-project.org/fr/contact/) directly if you are willing to sponsor this feature.
+            You can also [contact GLPI editor team](https://www.glpi-project.org/contact/) directly if you are willing to sponsor this feature.
         action: close
   - name: "IA only"
     labeled:

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -12,7 +12,7 @@ labels:
             This issue has been closed as we only track bugs here.
             
             You can get community support on [forums](https://forum.glpi-project.org/) or you can consider [taking a subscription](https://glpi-project.org/subscriptions/) to get professional support.
-            You can also [contact GLPI editor team](https://portal.glpi-network.com/contact-us) directly.
+            You can also [contact GLPI editor team](https://www.glpi-project.org/fr/contact/) directly.
         action: close
   - name: "feature suggestion"
     labeled:
@@ -21,7 +21,7 @@ labels:
             This issue has been closed as we only track bugs here.
             
             You can open a topic to discuss with community about this enhancement on [suggestion website](https://glpi.userecho.com/).
-            You can also [contact GLPI editor team](https://portal.glpi-network.com/contact-us) directly if you are willing to sponsor this feature.
+            You can also [contact GLPI editor team](https://www.glpi-project.org/fr/contact/) directly if you are willing to sponsor this feature.
         action: close
   - name: "IA only"
     labeled:


### PR DESCRIPTION
Update the contact us link that github-action will post.

For example in https://github.com/glpi-project/glpi/issues/24166#issuecomment-4413450729 `contact glpi editor team` redirect to a broken link.