### PR TITLE
Fix(Marketplace): fix plugin update process V2

### DIFF
--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -231,7 +231,29 @@ class Controller extends CommonGLPI
         }
 
         // clean dir in case of update
-        Toolbox::deleteDir(GLPI_MARKETPLACE_DIR . "/{$this->plugin_key}");
+        $plugin_dir = GLPI_MARKETPLACE_DIR . "/{$this->plugin_key}";
+        $opcache_files = [];
+
+        // If OPCache is enabled, we must invalidate the cache for the affected plugin files before deleting them.
+        // Otherwise, a removed file may remain cached between the deletion and extraction steps,
+        // causing the application to execute an outdated version of the code.
+        if (function_exists('opcache_invalidate') && is_dir($plugin_dir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($plugin_dir, \RecursiveDirectoryIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $file) {
+                if ($file->isFile() && $file->getExtension() === 'php') {
+                    $opcache_files[] = $file->getRealPath();
+                }
+            }
+        }
+
+        Toolbox::deleteDir($plugin_dir);
+
+        // Invalidate the cache for the affected files.
+        foreach ($opcache_files as $cached_file) {
+            opcache_invalidate($cached_file, true);
+        }
 
         $archive = new $driver($dest, $format);
         try {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Another proposal for:

https://github.com/glpi-project/glpi/pull/24189

After several tests, OPCache appears to be involved in the plugin update process.

Once the plugin archive is downloaded and the existing files are removed, an outdated version of the code may still remain in the OPCache.

For some reason, this stale cache is not automatically invalidated when the file timestamps change (the exact cause is still under investigation).

## Screenshots (if appropriate):


