### PR TITLE
KB : add sharing to aside's history

### DIFF
--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -36,6 +36,7 @@ namespace Glpi\Knowbase\History;
 
 use Document;
 use Entity;
+use Glpi\ShareToken;
 use Glpi\UI\IllustrationManager;
 use Group;
 use KnowbaseItem;
@@ -69,6 +70,7 @@ final class HistoryBuilder
         $this->addCategoryChangesToHistory();
         $this->addDocumentChangesToHistory();
         $this->addPermissionChangesToHistory();
+        $this->addSharingChangesToHistory();
         $this->addNameChangesToHistory();
         $this->addIllustrationChangesToHistory();
 
@@ -258,6 +260,37 @@ final class HistoryBuilder
             $this->history->addEvent(new LogEvent(
                 label: __("Permissions updated"),
                 description: $description,
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
+    // TODO for next implementation (item agnostic): lift to a generic SharingHistorySource
+    // when a second itemtype implements ShareableInterface. The write side (ShareToken hooks) is already generic :
+    // only this read path is KnowbaseItem-specific.
+    private function addSharingChangesToHistory(): void
+    {
+        global $DB;
+
+        $logs = $DB->request([
+            'SELECT' => ['date_mod', 'user_name', 'linked_action'],
+            'FROM'   => Log::getTable(),
+            'WHERE'  => [
+                'itemtype'      => KnowbaseItem::class,
+                'items_id'      => $this->kb->getID(),
+                'itemtype_link' => ShareToken::class,
+                'linked_action' => [Log::HISTORY_ADD_RELATION, Log::HISTORY_DEL_RELATION],
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $enabled = (int) $row['linked_action'] === Log::HISTORY_ADD_RELATION;
+
+            $this->history->addEvent(new LogEvent(
+                label: $enabled ? __("Sharing enabled") : __("Sharing disabled"),
+                description: __("Updated by"),
                 date: $row['date_mod'],
                 author: $row['user_name'],
             ));

--- a/src/Glpi/ShareToken.php
+++ b/src/Glpi/ShareToken.php
@@ -37,7 +37,9 @@ namespace Glpi;
 use CommonDBChild;
 use Glpi\Security\ShareTokenManager;
 use GLPIKey;
+use Log;
 use Session;
+use Toolbox;
 
 /**
  * ShareToken - Generic sharing token system.
@@ -53,6 +55,8 @@ class ShareToken extends CommonDBChild
     public static int $checkParentRights = self::HAVE_SAME_RIGHT_ON_ITEM;
 
     public static array $undisclosedFields = ['token'];
+
+    private ?int $was_active_before_purge = null;
 
     public static function getTypeName($nb = 0): string
     {
@@ -72,5 +76,149 @@ class ShareToken extends CommonDBChild
         }
 
         return parent::prepareInputForAdd($input);
+    }
+
+    public function post_addItem()
+    {
+        parent::post_addItem();
+
+        if (!empty($this->input['_no_history'])) {
+            return;
+        }
+
+        if ((int) ($this->fields['is_active'] ?? 0) !== 1) {
+            return;
+        }
+
+        if ($this->countOtherActiveTokens() > 0) {
+            return;
+        }
+
+        $this->logSharingTransition(enabled: true);
+    }
+
+    public function post_updateItem($history = true)
+    {
+        parent::post_updateItem($history);
+
+        if (!empty($this->input['_no_history'])) {
+            return;
+        }
+
+        if (!in_array('is_active', $this->updates, true)) {
+            return;
+        }
+
+        $new_active = (int) $this->fields['is_active'];
+        $other_active = $this->countOtherActiveTokens();
+
+        if ($new_active === 1 && $other_active === 0) {
+            $this->logSharingTransition(enabled: true);
+        } elseif ($new_active === 0 && $other_active === 0) {
+            $this->logSharingTransition(enabled: false);
+        }
+    }
+
+    public function pre_deleteItem()
+    {
+        $this->was_active_before_purge = (int) ($this->fields['is_active'] ?? 0);
+
+        return parent::pre_deleteItem();
+    }
+
+    public function post_purgeItem()
+    {
+        parent::post_purgeItem();
+
+        if (!empty($this->input['_no_history'])) {
+            return;
+        }
+
+        if ($this->was_active_before_purge !== 1) {
+            return;
+        }
+
+        if ($this->countOtherActiveTokens() > 0) {
+            return;
+        }
+
+        $this->logSharingTransition(enabled: false);
+    }
+
+    /**
+     * Get all tokens for a given item.
+     *
+     * @param class-string<\CommonDBTM> $itemtype The item class name
+     * @param int $items_id The item ID
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function getTokensForItem(string $itemtype, int $items_id): array
+    {
+        global $DB;
+
+        $results = [];
+        $iterator = $DB->request([
+            'FROM'  => self::getTable(),
+            'WHERE' => [
+                'itemtype' => $itemtype,
+                'items_id' => $items_id,
+            ],
+            'ORDER' => 'date_creation DESC',
+        ]);
+
+        foreach ($iterator as $row) {
+            $results[] = $row;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Count active tokens for the same parent item, excluding the current one.
+     */
+    private function countOtherActiveTokens(): int
+    {
+        return (int) countElementsInTable(self::getTable(), [
+            'itemtype'  => $this->fields['itemtype'],
+            'items_id'  => $this->fields['items_id'],
+            'is_active' => 1,
+            ['NOT' => ['id' => $this->getID()]],
+        ]);
+    }
+
+    /**
+     * Write a sharing transition entry against the parent item.
+     *
+     * The transition is encoded with HISTORY_ADD_RELATION (enabled) or
+     * HISTORY_DEL_RELATION (disabled), combined with itemtype_link set to
+     * ShareToken::class so HistoryBuilder can pick it up unambiguously.
+     *
+     * Best-effort transition logging: a race window exists when two concurrent
+     * operations both observe countOtherActiveTokens() === 0 before either has
+     * committed. Result: duplicate "Sharing enabled" entries on simultaneous
+     * first-token creations (or symmetric on last-token deletions). Acceptable
+     * for V1; tighten with a transactional SELECT ... FOR UPDATE if needed.
+     */
+    private function logSharingTransition(bool $enabled): void
+    {
+        $parent = $this->getItem(getFromDB: true, getEmpty: false);
+        if (!$parent) {
+            Toolbox::logDebug(sprintf(
+                'ShareToken#%d: parent %s#%d not found, sharing transition log skipped.',
+                $this->getID(),
+                $this->fields['itemtype'] ?? '?',
+                $this->fields['items_id'] ?? 0,
+            ));
+            return;
+        }
+
+        Log::history(
+            $parent->getID(),
+            $parent::class,
+            [0, '', $enabled ? '1' : '0'],
+            self::class,
+            $enabled ? Log::HISTORY_ADD_RELATION : Log::HISTORY_DEL_RELATION,
+        );
     }
 }

--- a/src/Glpi/ShareToken.php
+++ b/src/Glpi/ShareToken.php
@@ -39,7 +39,6 @@ use Glpi\Security\ShareTokenManager;
 use GLPIKey;
 use Log;
 use Session;
-use Toolbox;
 
 /**
  * ShareToken - Generic sharing token system.
@@ -146,35 +145,6 @@ class ShareToken extends CommonDBChild
     }
 
     /**
-     * Get all tokens for a given item.
-     *
-     * @param class-string<\CommonDBTM> $itemtype The item class name
-     * @param int $items_id The item ID
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    public static function getTokensForItem(string $itemtype, int $items_id): array
-    {
-        global $DB;
-
-        $results = [];
-        $iterator = $DB->request([
-            'FROM'  => self::getTable(),
-            'WHERE' => [
-                'itemtype' => $itemtype,
-                'items_id' => $items_id,
-            ],
-            'ORDER' => 'date_creation DESC',
-        ]);
-
-        foreach ($iterator as $row) {
-            $results[] = $row;
-        }
-
-        return $results;
-    }
-
-    /**
      * Count active tokens for the same parent item, excluding the current one.
      */
     private function countOtherActiveTokens(): int
@@ -204,12 +174,6 @@ class ShareToken extends CommonDBChild
     {
         $parent = $this->getItem(getFromDB: true, getEmpty: false);
         if (!$parent) {
-            Toolbox::logDebug(sprintf(
-                'ShareToken#%d: parent %s#%d not found, sharing transition log skipped.',
-                $this->getID(),
-                $this->fields['itemtype'] ?? '?',
-                $this->fields['items_id'] ?? 0,
-            ));
             return;
         }
 

--- a/src/Glpi/ShareToken.php
+++ b/src/Glpi/ShareToken.php
@@ -55,7 +55,7 @@ class ShareToken extends CommonDBChild
 
     public static array $undisclosedFields = ['token'];
 
-    private ?int $was_active_before_purge = null;
+    private ?bool $was_active_before_purge = null;
 
     public static function getTypeName($nb = 0): string
     {
@@ -85,7 +85,7 @@ class ShareToken extends CommonDBChild
             return;
         }
 
-        if ((int) ($this->fields['is_active'] ?? 0) !== 1) {
+        if (!$this->isActive()) {
             return;
         }
 
@@ -108,19 +108,19 @@ class ShareToken extends CommonDBChild
             return;
         }
 
-        $new_active = (int) $this->fields['is_active'];
-        $other_active = $this->countOtherActiveTokens();
+        $new_active = $this->isActive();
+        $other_active = $this->countOtherActiveTokens() > 0;
 
-        if ($new_active === 1 && $other_active === 0) {
+        if ($new_active && !$other_active) {
             $this->logSharingTransition(enabled: true);
-        } elseif ($new_active === 0 && $other_active === 0) {
+        } elseif (!$new_active && !$other_active) {
             $this->logSharingTransition(enabled: false);
         }
     }
 
     public function pre_deleteItem()
     {
-        $this->was_active_before_purge = (int) ($this->fields['is_active'] ?? 0);
+        $this->was_active_before_purge = $this->isActive();
 
         return parent::pre_deleteItem();
     }
@@ -133,7 +133,7 @@ class ShareToken extends CommonDBChild
             return;
         }
 
-        if ($this->was_active_before_purge !== 1) {
+        if (!$this->was_active_before_purge) {
             return;
         }
 

--- a/tests/e2e/specs/Knowbase/history-sharing.spec.ts
+++ b/tests/e2e/specs/Knowbase/history-sharing.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from "../../fixtures/glpi_fixture";
+import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
+import { Profiles } from "../../utils/Profiles";
+import { getWorkerEntityId } from "../../utils/WorkerEntities";
+
+test('Enabling public sharing appears in the history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: `KB sharing history enable - ${crypto.randomUUID()}`,
+        entities_id: getWorkerEntityId(),
+        answer: 'Content for history-sharing enable',
+    });
+
+    await kb.goto(id);
+    const modal = await kb.doOpenSharingTab();
+    await kb.doCreateSharingLink(modal);
+    await expect(modal.getByRole('checkbox', { name: 'Link 1' })).toBeChecked();
+
+    await kb.goto(id);
+    await kb.doOpenHistoryPanel();
+    await expect(kb.getHistoryEventByText('Sharing enabled')).toBeVisible();
+});
+
+test('Disabling public sharing appears in the history', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: `KB sharing history disable - ${crypto.randomUUID()}`,
+        entities_id: getWorkerEntityId(),
+        answer: 'Content for history-sharing disable',
+    });
+
+    await kb.goto(id);
+    const modal = await kb.doOpenSharingTab();
+    await kb.doCreateSharingLink(modal);
+
+    const toggle = modal.getByRole('checkbox', { name: 'Link 1' });
+    await expect(toggle).toBeChecked();
+    await toggle.click();
+    await expect(toggle).not.toBeChecked();
+
+    await kb.goto(id);
+    await kb.doOpenHistoryPanel();
+    await expect(kb.getHistoryEventByText('Sharing enabled')).toBeVisible();
+    await expect(kb.getHistoryEventByText('Sharing disabled')).toBeVisible();
+});
+
+test('Creating a second active link does not duplicate the enable event', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: `KB sharing history second link - ${crypto.randomUUID()}`,
+        entities_id: getWorkerEntityId(),
+        answer: 'Content for history-sharing second-link',
+    });
+
+    await kb.goto(id);
+    const modal = await kb.doOpenSharingTab();
+    await kb.doCreateSharingLink(modal);
+    await kb.doCreateSharingLink(modal);
+    await expect(modal.getByRole('checkbox')).toHaveCount(2);
+
+    await kb.goto(id);
+    await kb.doOpenHistoryPanel();
+    await expect(kb.getHistoryEventByText('Sharing enabled')).toHaveCount(1);
+    await expect(kb.getHistoryEventByText('Sharing disabled')).toHaveCount(0);
+});

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -46,6 +46,7 @@ use Glpi\Knowbase\History\HistoryBuilder;
 use Glpi\Knowbase\History\LogEvent;
 use Glpi\Knowbase\History\RevisionEvent;
 use Glpi\Knowbase\History\TranslationRevisionEvent;
+use Glpi\ShareToken;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItem_Item;
@@ -549,6 +550,358 @@ final class HistoryBuilderTest extends DbTestCase
             ),
             new LogEvent(
                 label: "Added to the FAQ",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testSharingEnabledAppearsWhenFirstActiveTokenIsCreated(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testSharingDisabledAppearsWhenLastActiveTokenIsDeleted(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(ShareToken::class, $token->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing disabled",
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testSharingEnabledAppearsWhenInactiveTokenIsActivated(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 0,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(ShareToken::class, $token->getID(), [
+            'is_active' => 1,
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testSharingDisabledAppearsWhenActiveTokenIsDeactivated(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(ShareToken::class, $token->getID(), [
+            'is_active' => 0,
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing disabled",
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testNoSharingEventWhenAddingTokenWhileAnotherActiveExists(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        // Only the first token creation produces a "Sharing enabled" event.
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testNoSharingEventWhenDeletingInactiveToken(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 0,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(ShareToken::class, $token->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testNoSharingEventWhenDeletingActiveTokenButOthersRemainActive(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token_1 = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 13:00:00");
+        $this->deleteItem(ShareToken::class, $token_1->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        // Only one "Sharing enabled" event from the initial transition; no
+        // disable event since another active token remains.
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 11:00:00",
+                author: "_test_user (8)",
+            ),
+            new CreationEvent(
+                date: "2026-01-15 10:00:00",
+                author: 2,
+            ),
+        ], $events);
+    }
+
+    public function testMultipleSharingTransitionsAreOrderedDesc(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $token = $this->createItem(ShareToken::class, [
+            'itemtype'  => KnowbaseItem::class,
+            'items_id'  => $kb->getID(),
+            'is_active' => 1,
+        ], skip_fields: ['token']);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->updateItem(ShareToken::class, $token->getID(), [
+            'is_active' => 0,
+        ]);
+
+        $this->setCurrentTime("2026-01-15 13:00:00");
+        $this->updateItem(ShareToken::class, $token->getID(), [
+            'is_active' => 1,
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $events = (new HistoryBuilder($kb))->buildHistory()->getEvents();
+
+        $this->assertEquals([
+            new LogEvent(
+                label: "Sharing enabled",
+                description: "Updated by",
+                date: "2026-01-15 13:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: "Sharing disabled",
+                description: "Updated by",
+                date: "2026-01-15 12:00:00",
+                author: "_test_user (8)",
+            ),
+            new LogEvent(
+                label: "Sharing enabled",
                 description: "Updated by",
                 date: "2026-01-15 11:00:00",
                 author: "_test_user (8)",


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/112
- Here is a brief description of what this PR does : 

Builds on top of #23544 (KB public sharing via share tokens) to record sharing state changes in the article's History aside, matching the treatment already given to renames, FAQ status, permissions, etc.

Two events appear, scoped at the article level rather than per token:
- **Sharing enabled** : first active share token starts existing on the article
- **Sharing disabled** : last active share token is removed or deactivated

Operations that don't actually change the article's public exposure (creating an inactive token, deleting an inactive token, deleting one of several active tokens) are deliberately silent to keep the timeline readable.

## Screenshot :

<img width="412" height="656" alt="image" src="https://github.com/user-attachments/assets/d2621efd-a44e-4148-9030-1a32282488fd" />

