### PR TITLE
fix: prevent duplicate SLA level entry on ticket update

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -14774,12 +14774,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/LevelAgreement.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call static method getTable\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'staticMethod.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/LevelAgreement.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method LevelAgreement\\:\\:computeDate\\(\\) should return string\\|null but returns bool\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -966,8 +966,21 @@ TWIG, $twig_params);
                 $toadd['date']           = $date;
                 $toadd[$pre . 'levels_id'] = $levels_id;
                 $toadd['tickets_id']     = $ticket->fields["id"];
-                $levelticket             = getItemForItemtype(static::$levelticketclass);
-                $levelticket->add($toadd);
+                /** @var class-string<CommonDBTM> $levelticketclass */
+                $levelticketclass = static::$levelticketclass;
+                if (
+                    !countElementsInTable(
+                        $levelticketclass::getTable(),
+                        [
+                            $pre . 'levels_id' => $levels_id,
+                            'tickets_id'       => $ticket->fields["id"],
+                        ]
+                    )
+                ) {
+                    /** @var OlaLevel_Ticket|SlaLevel_Ticket $levelticket */
+                    $levelticket = getItemForItemtype($levelticketclass);
+                    $levelticket->add($toadd);
+                }
             }
         }
     }
@@ -986,14 +999,17 @@ TWIG, $twig_params);
         $ticketfield = static::$prefix . "levels_id_ttr";
 
         if ($ticket->fields[$ticketfield] > 0) {
-            $levelticket = getItemForItemtype(static::$levelticketclass);
+            /** @var class-string<CommonDBTM> $levelticketclass */
+            $levelticketclass = static::$levelticketclass;
             $iterator = $DB->request([
                 'SELECT' => 'id',
-                'FROM'   => $levelticket::getTable(),
+                'FROM'   => $levelticketclass::getTable(),
                 'WHERE'  => ['tickets_id' => $ticket->fields['id']],
             ]);
 
             foreach ($iterator as $data) {
+                /** @var OlaLevel_Ticket|SlaLevel_Ticket $levelticket */
+                $levelticket = getItemForItemtype($levelticketclass);
                 $levelticket->delete(['id' => $data['id']]);
             }
         }

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -966,7 +966,6 @@ TWIG, $twig_params);
                 $toadd['date']           = $date;
                 $toadd[$pre . 'levels_id'] = $levels_id;
                 $toadd['tickets_id']     = $ticket->fields["id"];
-                /** @var class-string<CommonDBTM> $levelticketclass */
                 $levelticketclass = static::$levelticketclass;
                 if (
                     !countElementsInTable(
@@ -977,7 +976,6 @@ TWIG, $twig_params);
                         ]
                     )
                 ) {
-                    /** @var OlaLevel_Ticket|SlaLevel_Ticket $levelticket */
                     $levelticket = getItemForItemtype($levelticketclass);
                     $levelticket->add($toadd);
                 }
@@ -999,7 +997,6 @@ TWIG, $twig_params);
         $ticketfield = static::$prefix . "levels_id_ttr";
 
         if ($ticket->fields[$ticketfield] > 0) {
-            /** @var class-string<CommonDBTM> $levelticketclass */
             $levelticketclass = static::$levelticketclass;
             $iterator = $DB->request([
                 'SELECT' => 'id',
@@ -1008,7 +1005,6 @@ TWIG, $twig_params);
             ]);
 
             foreach ($iterator as $data) {
-                /** @var OlaLevel_Ticket|SlaLevel_Ticket $levelticket */
                 $levelticket = getItemForItemtype($levelticketclass);
                 $levelticket->delete(['id' => $data['id']]);
             }

--- a/tests/functional/SlaLevel_TicketTest.php
+++ b/tests/functional/SlaLevel_TicketTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use CommonITILObject;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\Glpi\SLMTrait;
+use SLA;
 use SlaLevel;
 use SlaLevel_Ticket;
 use SLM;
@@ -134,7 +135,7 @@ class SlaLevel_TicketTest extends DbTestCase
         ];
 
         // add sla (TTO)
-        $sla    = new \SLA();
+        $sla    = new SLA();
         $sla1_id = $sla->add($sla1_in);
         $this->checkInput($sla, $sla1_id, $sla1_in);
 
@@ -257,7 +258,7 @@ class SlaLevel_TicketTest extends DbTestCase
         ];
 
         // add sla (TTO)
-        $sla    = new \SLA();
+        $sla    = new SLA();
         $sla1_id = $sla->add($sla1_in);
         $this->checkInput($sla, $sla1_id, $sla1_in);
 
@@ -354,4 +355,69 @@ class SlaLevel_TicketTest extends DbTestCase
             )
         );
     }
+
+    /**
+     * addLevelToDo must not insert a duplicate (tickets_id, slalevels_id) row
+     * when called twice for the same ticket and level.
+     */
+    public function testAddLevelToDoNoDuplicate(): void
+    {
+        $this->login();
+
+        ['sla' => $sla] = $this->createSLA(['definition_time' => 'hour', 'number_time' => 4], SLM::TTR);
+
+        $sla_level = $this->createItem(SlaLevel::class, [
+            'slas_id'        => $sla->getID(),
+            'execution_time' => -HOUR_TIMESTAMP,
+        ] + $this->getMinimalCreationInput(SlaLevel::class));
+
+        $ticket = $this->createItem(Ticket::class, [
+            'slas_id_ttr'      => $sla->getID(),
+            'slalevels_id_ttr' => $sla_level->getID(),
+        ] + $this->getMinimalCreationInput(Ticket::class));
+
+        $sla->getFromDB($sla->getID());
+
+        $sla->addLevelToDo($ticket, $sla_level->getID());
+        $sla->addLevelToDo($ticket, $sla_level->getID());
+
+        $this->assertSame(1, countElementsInTable(SlaLevel_Ticket::getTable(), [
+            'tickets_id'   => $ticket->getID(),
+            'slalevels_id' => $sla_level->getID(),
+        ]));
+    }
+
+    /**
+     * deleteLevelsToDo must remove all SlaLevel_Ticket rows for the ticket.
+     */
+    public function testDeleteLevelsToDo(): void
+    {
+        $this->login();
+
+        ['sla' => $sla] = $this->createSLA(['definition_time' => 'hour', 'number_time' => 4], SLM::TTR);
+
+        $sla_level = $this->createItem(SlaLevel::class, [
+            'slas_id'        => $sla->getID(),
+            'execution_time' => -HOUR_TIMESTAMP,
+        ] + $this->getMinimalCreationInput(SlaLevel::class));
+
+        $ticket = $this->createItem(Ticket::class, [
+            'slas_id_ttr'      => $sla->getID(),
+            'slalevels_id_ttr' => $sla_level->getID(),
+        ] + $this->getMinimalCreationInput(Ticket::class));
+
+        $sla->getFromDB($sla->getID());
+        $sla->addLevelToDo($ticket, $sla_level->getID());
+
+        $this->assertSame(1, countElementsInTable(SlaLevel_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+        ]));
+
+        SLA::deleteLevelsToDo($ticket);
+
+        $this->assertSame(0, countElementsInTable(SlaLevel_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+        ]));
+    }
+
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43778
- When updating a ticket, adding an SLA could cause a duplicate SQL error. A check for existing entries is now performed before insertion.

## Screenshots (if appropriate):


