### PR TITLE
fix(forms): update urgency condition handler to filter enabled urgency levels

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -14990,12 +14990,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\UrgencyField\\:\\:getUrgencyLevels\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\UrgencyField\\:\\:getUrgencyQuestionsValuesForDropdown\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
@@ -16641,12 +16635,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Form\\\\QuestionType\\\\QuestionTypeUrgency\\:\\:getTargetQuestionType\\(\\) has parameter \\$rawData with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Form\\\\QuestionType\\\\QuestionTypeUrgency\\:\\:getUrgencyLevels\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php',
@@ -18498,12 +18486,6 @@ $ignoreErrors[] = [
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/UI/ThemeManager.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Urgency\\:\\:getUrgencyValuesForDropdown\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Urgency.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Group\\:\\:cleanCloneInput\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#',

--- a/src/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandler.php
+++ b/src/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandler.php
@@ -54,6 +54,6 @@ final class UrgencyConditionHandler extends NumberConditionHandler
     #[Override]
     public function getTemplateParameters(ConditionData $condition): array
     {
-        return ['values' => Urgency::getUrgencyValuesForDropdown()];
+        return ['values' => Urgency::getEnabledUrgencyValuesForDropdown()];
     }
 }

--- a/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/UrgencyField.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
-use CommonITILObject;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
@@ -47,6 +46,7 @@ use Glpi\Form\Migration\DestinationFieldConverterInterface;
 use Glpi\Form\Migration\FormMigration;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use Glpi\Urgency;
 use InvalidArgumentException;
 use Override;
 
@@ -96,7 +96,7 @@ final class UrgencyField extends AbstractConfigField implements DestinationField
                 'empty_label'     => __("Select an urgency level..."),
                 'value'           => $config->getSpecificUrgency(),
                 'input_name'      => $input_name . "[" . UrgencyFieldConfig::SPECIFIC_URGENCY_VALUE . "]",
-                'possible_values' => $this->getUrgencyLevels(),
+                'possible_values' => Urgency::getEnabledUrgencyValuesForDropdown(),
             ],
 
             // Specific additional config for SPECIFIC_ANSWER strategy
@@ -126,7 +126,7 @@ final class UrgencyField extends AbstractConfigField implements DestinationField
         $urgency = $strategy->computeUrgency($config, $answers_set);
 
         // Do not edit input if invalid value was found
-        $valid_values = array_keys($this->getUrgencyLevels());
+        $valid_values = array_keys(Urgency::getEnabledUrgencyValuesForDropdown());
         if (!in_array($urgency, $valid_values)) {
             return $input;
         }
@@ -172,31 +172,6 @@ final class UrgencyField extends AbstractConfigField implements DestinationField
         }
 
         return $this->getDefaultConfig($form);
-    }
-
-    /**
-     * Retrieve available urgency levels
-     *
-     * @return array
-     */
-    private function getUrgencyLevels(): array
-    {
-        global $CFG_GLPI;
-
-        // Get the urgency levels
-        $urgency_levels = array_combine(
-            range(1, 5),
-            array_map(fn($urgency) => CommonITILObject::getUrgencyName($urgency), range(1, 5))
-        );
-
-        // Filter out the urgency levels that are not enabled
-        $urgency_levels = array_filter(
-            $urgency_levels,
-            fn($key) => (($CFG_GLPI['urgency_mask'] & (1 << $key)) > 0),
-            ARRAY_FILTER_USE_KEY
-        );
-
-        return $urgency_levels;
     }
 
     public function getStrategiesForDropdown(): array

--- a/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeUrgency.php
@@ -43,6 +43,7 @@ use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\Condition\UsedAsCriteriaInterface;
 use Glpi\Form\Migration\FormQuestionDataConverterInterface;
 use Glpi\Form\Question;
+use Glpi\Urgency;
 use Override;
 
 final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCriteriaInterface, FormQuestionDataConverterInterface, ConditionValueTransformerInterface
@@ -69,31 +70,6 @@ final class QuestionTypeUrgency extends AbstractQuestionType implements UsedAsCr
         return 0;
     }
 
-    /**
-     * Retrieve available urgency levels
-     *
-     * @return array
-     */
-    private function getUrgencyLevels(): array
-    {
-        global $CFG_GLPI;
-
-        // Get the urgency levels
-        $urgency_levels = array_combine(
-            range(1, 5),
-            array_map(fn($urgency) => CommonITILObject::getUrgencyName($urgency), range(1, 5))
-        );
-
-        // Filter out the urgency levels that are not enabled
-        $urgency_levels = array_filter(
-            $urgency_levels,
-            fn($key) => (($CFG_GLPI['urgency_mask'] & (1 << $key)) > 0),
-            ARRAY_FILTER_USE_KEY
-        );
-
-        return $urgency_levels;
-    }
-
     #[Override]
     public function renderAdministrationTemplate(?Question $question): string
     {
@@ -118,7 +94,7 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'init'               => $question != null,
             'value'              => $this->getDefaultValue($question),
-            'urgency_levels'     => $this->getUrgencyLevels(),
+            'urgency_levels'     => Urgency::getEnabledUrgencyValuesForDropdown(),
         ]);
     }
 
@@ -146,7 +122,7 @@ TWIG;
         return $twig->renderFromStringTemplate($template, [
             'value'              => $this->getDefaultValue($question),
             'question'           => $question,
-            'urgency_levels'     => $this->getUrgencyLevels(),
+            'urgency_levels'     => Urgency::getEnabledUrgencyValuesForDropdown(),
             'label' => $question->fields['name'],
         ]);
     }

--- a/src/Glpi/Urgency.php
+++ b/src/Glpi/Urgency.php
@@ -43,6 +43,9 @@ enum Urgency: int
     case HIGH = 4;
     case VERY_HIGH = 5;
 
+    /**
+     * @return array<int, string>
+     */
     public static function getUrgencyValuesForDropdown(): array
     {
         return [
@@ -52,5 +55,22 @@ enum Urgency: int
             self::HIGH->value      => __('High'),
             self::VERY_HIGH->value => __('Very high'),
         ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getEnabledUrgencyValuesForDropdown(): array
+    {
+        global $CFG_GLPI;
+
+        return array_filter(
+            array_combine(
+                array_map(fn($case) => $case->value, self::cases()),
+                array_map(fn($case) => \CommonITILObject::getUrgencyName($case->value), self::cases()),
+            ),
+            fn($key) => (($CFG_GLPI['urgency_mask'] & (1 << $key)) > 0),
+            ARRAY_FILTER_USE_KEY
+        );
     }
 }

--- a/tests/functional/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandlerTest.php
+++ b/tests/functional/Glpi/Form/Condition/ConditionHandler/UrgencyConditionHandlerTest.php
@@ -34,6 +34,8 @@
 
 namespace Glpi\Form\Condition\ConditionHandler;
 
+use CommonITILObject;
+use Glpi\Form\Condition\ConditionData;
 use Glpi\Form\Condition\ValueOperator;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Tests\AbstractConditionHandlerTest;
@@ -189,5 +191,31 @@ final class UrgencyConditionHandlerTest extends AbstractConditionHandlerTest
             'submitted_answer'   => Urgency::MEDIUM->value,
             'expected_result'    => true,
         ];
+    }
+
+    public function testGetTemplateParametersFiltersDisabledUrgencies(): void
+    {
+        global $CFG_GLPI;
+
+        $original_mask = $CFG_GLPI['urgency_mask'];
+
+        try {
+            $CFG_GLPI['urgency_mask'] = (1 << 1) | (1 << 2) | (1 << 3);
+
+            $handler = new UrgencyConditionHandler();
+            $condition = new ConditionData('', '', null, null);
+            $params = $handler->getTemplateParameters($condition);
+
+            $this->assertEquals(
+                [
+                    1 => CommonITILObject::getUrgencyName(1),
+                    2 => CommonITILObject::getUrgencyName(2),
+                    3 => CommonITILObject::getUrgencyName(3),
+                ],
+                $params['values']
+            );
+        } finally {
+            $CFG_GLPI['urgency_mask'] = $original_mask;
+        }
     }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeUrgencyTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeUrgencyTest.php
@@ -39,6 +39,7 @@ use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Glpi\Urgency;
 
 final class QuestionTypeUrgencyTest extends DbTestCase
 {
@@ -64,7 +65,6 @@ final class QuestionTypeUrgencyTest extends DbTestCase
     {
         global $CFG_GLPI;
 
-        $questionType = new QuestionTypeUrgency();
         $urgency_levels = array_combine(
             range(1, 5),
             array_map(
@@ -75,13 +75,13 @@ final class QuestionTypeUrgencyTest extends DbTestCase
 
         // Allow all urgency levels
         $CFG_GLPI['urgency_mask'] = array_reduce(range(1, 5), fn($mask, $level) => $mask | (1 << $level), 0);
-        $this->assertEquals($urgency_levels, $this->callPrivateMethod($questionType, 'getUrgencyLevels'));
+        $this->assertEquals($urgency_levels, Urgency::getEnabledUrgencyValuesForDropdown());
 
         // Allow only the third urgency level (the third level can't be disabled)
         $CFG_GLPI['urgency_mask'] = 1 << 3;
         $this->assertEquals(
             [3 => $urgency_levels[3]],
-            $this->callPrivateMethod($questionType, 'getUrgencyLevels')
+            Urgency::getEnabledUrgencyValuesForDropdown()
         );
 
         // Allow the three first urgency levels
@@ -92,7 +92,7 @@ final class QuestionTypeUrgencyTest extends DbTestCase
                 2 => $urgency_levels[2],
                 3 => $urgency_levels[3],
             ],
-            $this->callPrivateMethod($questionType, 'getUrgencyLevels'),
+            Urgency::getEnabledUrgencyValuesForDropdown(),
         );
 
         // Allow the two last urgency levels
@@ -103,7 +103,7 @@ final class QuestionTypeUrgencyTest extends DbTestCase
                 4 => $urgency_levels[4],
                 5 => $urgency_levels[5],
             ],
-            $this->callPrivateMethod($questionType, 'getUrgencyLevels'),
+            Urgency::getEnabledUrgencyValuesForDropdown(),
         );
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !44013

Modification of the `UrgencyConditionHandler` class to ensure it properly accounts for GLPI's configuration regarding authorized urgency levels and those that have been disabled.
This filtering had already been implemented to filter the selectable urgency levels for `Urgency`-type issues, but it had not been reused to filter the selectable urgency levels in visibility and validation conditions.
This PR therefore resolves this issue and centralizes the retrieval of available urgency levels.