### PR TITLE
Fix - Missing login name in event log for external authentication (SSO)

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1129,6 +1129,12 @@ class Auth extends CommonGLPI
             // GET THE IP OF THE CLIENT
             $ip = getenv("HTTP_X_FORWARDED_FOR") ?: getenv("REMOTE_ADDR");
 
+            // For external auth (e.g. OAuth SSO), $login_name is empty because
+            // it is resolved inside validateLogin(). Use the resolved user name.
+            if (empty($login_name) && !empty($this->user->fields['name'])) {
+                $login_name = $this->user->fields['name'];
+            }
+
             if ($this->auth_succeded) {
                 //TRANS: %1$s is the login of the user and %2$s its IP address
                 Event::log(0, "system", 3, "login", sprintf(

--- a/tests/functional/AuthTest.php
+++ b/tests/functional/AuthTest.php
@@ -328,4 +328,63 @@ class AuthTest extends DbTestCase
         $this->assertTrue($user->getFromDB($user->getID()));
         $this->assertNotNull($user->fields['last_login']);
     }
+
+    /**
+     * Non-regression test: when logging in via external auth (e.g. OAuth SSO),
+     * the login() method receives an empty $login_name because the actual username
+     * is resolved inside validateLogin(). The event log must still record the
+     * resolved login name instead of an empty string.
+     *
+     */
+    public function testExternalAuthLoginNameInEventLog(): void
+    {
+        global $CFG_GLPI, $DB;
+
+        $this->login();
+
+        $username = 'sso_test_' . mt_rand();
+        $this->createItem(
+            User::class,
+            [
+                'name'         => $username,
+                '_profiles_id' => 1,
+                'authtype'     => Auth::EXTERNAL,
+            ]
+        );
+
+        $ssovariable_row = $DB->request([
+            'FROM'  => 'glpi_ssovariables',
+            'WHERE' => ['name' => 'HTTP_AUTH_USER'],
+        ])->current();
+        $this->assertNotEmpty($ssovariable_row);
+
+        $cfg_backup = $CFG_GLPI;
+        $CFG_GLPI['ssovariables_id'] = $ssovariable_row['id'];
+        $CFG_GLPI['existing_auth_server_field_clean_domain'] = 0;
+
+        // Simulate what the oauthsso plugin (or any external auth) does:
+        // it sets the SSO server variable and calls login() with an empty login_name.
+        $_SERVER['HTTP_AUTH_USER'] = $username;
+
+        $auth = new Auth();
+        $logged_in = $auth->login('', '', false);
+
+        $CFG_GLPI = $cfg_backup;
+        unset($_SERVER['HTTP_AUTH_USER']);
+
+        $this->assertTrue($logged_in);
+
+        $events = getAllDataFromTable('glpi_events', [
+            'service'  => 'login',
+            'type'     => 'system',
+            'items_id' => 0,
+        ]);
+        $this->assertNotEmpty(
+            array_filter(
+                $events,
+                static fn($event) => str_starts_with($event['message'], "{$username} log in from IP ")
+            ),
+            "Event log must contain the resolved login name '{$username}', not an empty string"
+        );
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43951
- Here is a brief description of what this PR does

When logging in via an external authentication method (e.g. OAuth SSO), the `$login_name` parameter passed to `Auth::login()` is empty because the actual username is resolved internally inside `Auth::validateLogin()`. Since PHP passes parameters by value, the resolved value never propagates back to `login()`, resulting in an empty login name in the event log entry.

Fix: before writing the login event, fall back to `$this->user->fields['name']` when `$login_name` is empty.

Introduced in dcc2a90830 (2FA Login) when `validateLogin()` was extracted from `login()`.

## Screenshots (if appropriate):

<img width="749" height="330" alt="image" src="https://github.com/user-attachments/assets/7a8b327c-37ba-462d-be24-238fd40dee8f" />

