### PR TITLE
fix(inventory): optimize lockfields

### DIFF
--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -40,7 +40,6 @@ use Glpi\Features\AssignableItem;
 use Glpi\Inventory\Inventory;
 use Glpi\Search\SearchOption;
 
-
 /**
  *  Locked fields for inventory
  **/

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -34,11 +34,12 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QuerySubQuery;
+use Glpi\DBAL\QueryUnion;
 use Glpi\Features\AssignableItem;
 use Glpi\Inventory\Inventory;
 use Glpi\Search\SearchOption;
-use Glpi\DBAL\QuerySubQuery;
-use Glpi\DBAL\QueryUnion;
+
 
 /**
  *  Locked fields for inventory

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -37,6 +37,8 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\AssignableItem;
 use Glpi\Inventory\Inventory;
 use Glpi\Search\SearchOption;
+use Glpi\DBAL\QuerySubQuery;
+use Glpi\DBAL\QueryUnion;
 
 /**
  *  Locked fields for inventory
@@ -258,18 +260,21 @@ class Lockedfield extends CommonDBTM
     {
         global $DB;
 
-        $iterator = $DB->request([
-            'FROM'   => $this->getTable(),
-            'WHERE'  => [
-                'itemtype'  => $itemtype,
-                [
-                    'OR' => [
-                        'items_id'  => $items_id,
-                        'is_global' => 1,
-                    ],
-                ],
+        $query_item = new QuerySubQuery([
+            'FROM'  => $this->getTable(),
+            'WHERE' => [
+                'itemtype' => $itemtype,
+                'items_id' => $items_id,
             ],
         ]);
+        $query_global = new QuerySubQuery([
+            'FROM'  => $this->getTable(),
+            'WHERE' => [
+                'itemtype'  => $itemtype,
+                'is_global' => 1,
+            ],
+        ]);
+        $iterator = $DB->request(['FROM' => new QueryUnion([$query_item, $query_global])]);
 
         $locks = [];
         foreach ($iterator as $row) {
@@ -291,18 +296,21 @@ class Lockedfield extends CommonDBTM
     {
         global $DB;
 
-        $iterator = $DB->request([
-            'FROM'   => $this->getTable(),
-            'WHERE'  => [
-                'itemtype'  => $itemtype,
-                [
-                    'OR' => [
-                        'items_id'  => $items_id,
-                        'is_global' => 1,
-                    ],
-                ],
+        $query_item = new QuerySubQuery([
+            'FROM'  => $this->getTable(),
+            'WHERE' => [
+                'itemtype' => $itemtype,
+                'items_id' => $items_id,
             ],
         ]);
+        $query_global = new QuerySubQuery([
+            'FROM'  => $this->getTable(),
+            'WHERE' => [
+                'itemtype'  => $itemtype,
+                'is_global' => 1,
+            ],
+        ]);
+        $iterator = $DB->request(['FROM' => new QueryUnion([$query_item, $query_global])]);
 
         $locks = [];
         foreach ($iterator as $row) {

--- a/tests/functional/LockedfieldTest.php
+++ b/tests/functional/LockedfieldTest.php
@@ -798,7 +798,7 @@ class LockedfieldTest extends DbTestCase
         $this->assertGreaterThan(0, $global_lockedfield_id);
 
         $this->assertTrue($computer->getFromDB($cid));
-        $this->assertSame(['manufacturers_id' => null, 'otherserial' => null], $lockedfield->getLockedValues($computer->getType(), $cid));
+        $this->assertSame(['otherserial' => null, 'manufacturers_id' => null], $lockedfield->getLockedValues($computer->getType(), $cid));
 
         // change to child entity
         $entities_id_child = getItemByTypeName(\Entity::class, '_test_child_1', true);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I hope I haven't broken the tests.

## Description

On a Cloud instance with 15k Computers, and about 300k lockedfields (mainly status, and location), inventory updates during peak hours can reach up to 250 agents per minute.

We then always notice the same type of SQL query in the processlist of mysql, which leads to a full CPU.

```sql
SELECT * 
FROM glpi_lockedfields
WHERE itemtype = 'Item_DeviceControl'
  AND (items_id = ? OR is_global = 1)
```

Because of the OR, MySQL is unable to efficiently use indexes and ends up scanning a very large part of the table for each request.

I propose switching to UNION: in production we observe a processing time of approximately 120 seconds per agent before the patch and full MySQL CPU usage (which inevitably leads to an unusable server), compared to 24 seconds after the patch and no significant CPU load.

Same fix can be done for GLPI 10.