### PR TITLE
KB : draggable article in category aside

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -799,7 +799,6 @@
 
     // Whole-row drag affordance: the row itself is the grab handle.
     .kb-aside-row {
-        padding: 0.25rem 0.5rem;
         transition: background-color 0.1s ease;
         border-radius: 4px;
     }

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -742,6 +742,7 @@
 [data-main-page-aside="knowbaseitem"] {
     display: flex;
     flex-direction: column;
+    
     // Bounded height aligned with .kb-article / .kb-sidepanel so the aside
     // scrolls internally instead of overflowing the viewport.
     max-height: calc(100vh - 150px);

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -795,6 +795,56 @@
         cursor: pointer;
     }
 
+    // Whole-row drag affordance: the row itself is the grab handle.
+    .kb-aside-row {
+        padding: 0.25rem 0.5rem;
+        transition: background-color 0.1s ease;
+        border-radius: 4px;
+    }
+
+    li[draggable="true"] > .kb-aside-row,
+    li[draggable="true"].kb-aside-row {
+        cursor: grab;
+
+        &:hover {
+            background-color: var(--tblr-info-bg-subtle);
+
+            // Override the yellow that .text-hover-link (Bootstrap) and the
+            // current-article rule apply on hover — yellow on pale-blue reads
+            // poorly. Use the matching deep info shade.
+            > a {
+                color: var(--tblr-info-text-emphasis) !important;
+            }
+        }
+    }
+
+    // Source element while it is being dragged: faded in place.
+    .kb-aside-source-dragging,
+    .kb-aside-source-dragging > .kb-aside-row,
+    .kb-aside-source-dragging > a,
+    .kb-aside-source-dragging > button {
+        opacity: 0.4;
+    }
+
+    // Cursor stays grabbing while a drag is in progress anywhere in the tree.
+    &.kb-aside-dragging,
+    &.kb-aside-dragging * {
+        cursor: grabbing !important;
+    }
+
+    // Active drop target: the title row of the destination category.
+    // Categories don't have a child <a>, but keep the override defensive in
+    // case the target structure changes.
+    .kb-aside-target {
+        background-color: var(--tblr-info);
+        box-shadow: inset 4px 0 0 var(--tblr-info-text-emphasis);
+        color: #fff;
+
+        a {
+            color: #fff !important;
+        }
+    }
+
     // KB aside tree hierarchy connector lines
     .kb-tree {
         list-style: none;
@@ -823,7 +873,7 @@
                     left: -1rem;
                     top: 0;
                     width: calc(1rem - #{$gap}); // leave a small gap before the content
-                    height: 0.625rem; // half of the 20px illustration = 10px
+                    height: 0.875rem; // .kb-aside-row padding-top 4px + half of the 20px illustration = 14px
                     border-left: 1px solid var(--tblr-border-color);
                     border-bottom: 1px solid var(--tblr-border-color);
                 }
@@ -832,7 +882,7 @@
                     content: '';
                     position: absolute;
                     left: -1rem;
-                    top: 0.625rem;
+                    top: 0.875rem;
                     bottom: 0;
                     width: 1px;
                     background-color: var(--tblr-border-color);

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -846,14 +846,11 @@
         }
     }
 
-    // Keyboard/touch fallback for drag-and-drop: a kebab "Move" button on each
-    // draggable row. Hidden on desktop until the row is hovered or anything
-    // inside it is focused (so keyboard tabbing into the article link reveals
-    // the kebab as the next tab stop). Always visible on touch devices where
-    // hover doesn't exist.
+    // Keyboard/touch-only fallback for drag-to-reparent (pointer users drag
+    // directly). display:none so its slot never shortens the category title.
     .kb-aside-move-btn {
-        visibility: hidden;
-        margin-left: auto;
+        display: none;
+        margin-left: 0.5rem;
         padding: 0 0.25rem;
         color: var(--tblr-secondary);
         line-height: 1;
@@ -864,16 +861,14 @@
         }
     }
 
-    li.article:hover > .kb-aside-move-btn,
     li.article:focus-within > .kb-aside-move-btn,
-    [data-glpi-kb-aside-category-title]:hover > .kb-aside-move-btn,
     [data-glpi-kb-aside-category-title]:focus-within > .kb-aside-move-btn {
-        visibility: visible;
+        display: inline-flex;
     }
 
     @media (hover: none) {
         .kb-aside-move-btn {
-            visibility: visible;
+            display: inline-flex;
         }
     }
 

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -740,8 +740,20 @@
 }
 
 [data-main-page-aside="knowbaseitem"] {
+    display: flex;
+    flex-direction: column;
+    // Bounded height aligned with .kb-article / .kb-sidepanel so the aside
+    // scrolls internally instead of overflowing the viewport.
+    max-height: calc(100vh - 150px);
     max-width: 300px;
     background-color: #fff;
+
+    // Only the tree scrolls; header and favorites stay fixed above it.
+    [data-glpi-kb-aside-tree] {
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow-y: auto;
+    }
 
     .node, .article {
         list-style: none;
@@ -844,6 +856,21 @@
         a {
             color: #fff !important;
         }
+    }
+
+    // "Top level" drop zone: hidden by default, revealed only while a category
+    // is being dragged so it can be dropped at the tree root.
+    .kb-aside-root-dropzone {
+        display: none;
+        margin: 0 0 0.25rem;
+        padding: 0.25rem 0.5rem;
+        border: 1px dashed var(--tblr-border-color);
+        border-radius: 4px;
+        color: var(--tblr-secondary);
+    }
+
+    &.kb-aside-dragging-category .kb-aside-root-dropzone {
+        display: block;
     }
 
     // Keyboard/touch-only fallback for drag-to-reparent (pointer users drag

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -845,9 +845,7 @@
         cursor: grabbing !important;
     }
 
-    // Active drop target: the title row of the destination category.
-    // Categories don't have a child <a>, but keep the override defensive in
-    // case the target structure changes.
+    // Drop target for the thin "Top level" root zone: solid fill.
     .kb-aside-target {
         background-color: var(--tblr-info);
         box-shadow: inset 4px 0 0 var(--tblr-info-text-emphasis);
@@ -856,6 +854,22 @@
         a {
             color: #fff !important;
         }
+    }
+
+    // Drop target for a whole category block: outline it (drop "into" it).
+    .kb-aside-target-block {
+        outline: 2px solid var(--tblr-info);
+        outline-offset: -2px;
+        border-radius: 4px;
+        background-color: var(--tblr-info-bg-subtle);
+    }
+
+    // Empty-state row: drop target + "no articles" hint for empty categories.
+    .kb-aside-empty {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.875rem;
+        font-style: italic;
+        color: var(--tblr-secondary);
     }
 
     // "Top level" drop zone: hidden by default, revealed only while a category

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -770,8 +770,9 @@
     }
 
     // Current article entry when it is not yet a favorite: hidden until the user favorites it.
+    // !important needed to override the Tabler `.d-flex` utility on the article <li>.
     [data-glpi-kb-favorite-current="pending"] {
-        display: none;
+        display: none !important;
     }
 
     // Favorites section hidden when there are no favorites to display (set server-side or by JS).
@@ -785,8 +786,9 @@
     }
 
     // Tree items hidden by the search filter.
+    // !important needed to override the Tabler `.d-flex` utility on the article <li>.
     [data-glpi-kb-search-hidden] {
-        display: none;
+        display: none !important;
     }
 
     // Clear button: interactive only when active (has text to clear).

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -847,6 +847,54 @@
         }
     }
 
+    // Keyboard/touch fallback for drag-and-drop: a kebab "Move" button on each
+    // draggable row. Hidden on desktop until the row is hovered or anything
+    // inside it is focused (so keyboard tabbing into the article link reveals
+    // the kebab as the next tab stop). Always visible on touch devices where
+    // hover doesn't exist.
+    .kb-aside-move-btn {
+        visibility: hidden;
+        margin-left: auto;
+        padding: 0 0.25rem;
+        color: var(--tblr-secondary);
+        line-height: 1;
+
+        &:hover,
+        &:focus-visible {
+            color: var(--tblr-primary);
+        }
+    }
+
+    li.article:hover > .kb-aside-move-btn,
+    li.article:focus-within > .kb-aside-move-btn,
+    [data-glpi-kb-aside-category-title]:hover > .kb-aside-move-btn,
+    [data-glpi-kb-aside-category-title]:focus-within > .kb-aside-move-btn {
+        visibility: visible;
+    }
+
+    @media (hover: none) {
+        .kb-aside-move-btn {
+            visibility: visible;
+        }
+    }
+
+    // "Move to" picker modal: a compact nested list of categories.
+    .kb-move-picker {
+        max-height: 50vh;
+        overflow-y: auto;
+    }
+
+    .kb-move-picker-list {
+        list-style: none;
+        padding-left: 1rem;
+        margin: 0;
+
+        // First level has no extra indent.
+        .kb-move-picker > & {
+            padding-left: 0;
+        }
+    }
+
     // KB aside tree hierarchy connector lines
     .kb-tree {
         list-style: none;

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -376,7 +376,13 @@ export class GlpiKnowbaseAsideController
 
         // Defer the class toggle so the browser captures the un-faded element
         // for the native drag image, then fades the source in place.
+        // Guard against a stale rAF: if dragend already fired before this frame
+        // (very fast drop), skip — otherwise the class would be applied with no
+        // dragend left to clean it up.
         requestAnimationFrame(() => {
+            if (this.#drag?.source !== li) {
+                return;
+            }
             li.classList.add('kb-aside-source-dragging');
             this.#aside.classList.add('kb-aside-dragging');
         });
@@ -479,8 +485,17 @@ export class GlpiKnowbaseAsideController
             this.#revertDrop();
             return;
         }
+
+        // Capture the revert state BEFORE awaiting the fetch: dragend fires
+        // synchronously after drop and nulls this.#drag before the await
+        // resolves, so #revertDrop() would silently no-op in either error
+        // branch below.
+        const source        = this.#drag.source;
+        const origin_parent = this.#drag.origin_parent;
+        const origin_next   = this.#drag.origin_next;
+
         // Optimistic move.
-        target_children.appendChild(this.#drag.source);
+        target_children.appendChild(source);
 
         let response;
         try {
@@ -498,7 +513,7 @@ export class GlpiKnowbaseAsideController
                 }),
             });
         } catch (e) {
-            this.#revertDrop();
+            origin_parent.insertBefore(source, origin_next);
             glpi_toast_error(__("An unexpected error occurred."));
             console.error(e);
             return;
@@ -507,7 +522,7 @@ export class GlpiKnowbaseAsideController
         if (response.ok) {
             return;
         }
-        this.#revertDrop();
+        origin_parent.insertBefore(source, origin_next);
         if (response.status === 409) {
             glpi_toast_error(__("This item can't be moved here."));
         } else {

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -30,9 +30,13 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _ */
+/* global _, glpi_toast_error */
 
 import { get } from "/js/modules/Ajax.js";
+
+const ITEMTYPE_ARTICLE   = "KnowbaseItem";
+const ITEMTYPE_CATEGORY  = "KnowbaseItemCategory";
+const AUTO_EXPAND_DELAY  = 800;
 
 export class GlpiKnowbaseAsideController
 {
@@ -55,6 +59,12 @@ export class GlpiKnowbaseAsideController
     #favorites_originally_hidden = false;
 
     /**
+     * Active drag operation state. Null when no drag is in progress.
+     * @type {?{source: HTMLElement, origin_parent: HTMLElement, origin_next: ?HTMLElement, current_target: ?HTMLElement, expand_timer: ?number, expand_target: ?HTMLElement}}
+     */
+    #drag = null;
+
+    /**
      * @param {HTMLElement} aside
      */
     constructor(aside)
@@ -62,6 +72,7 @@ export class GlpiKnowbaseAsideController
         this.#aside = aside;
         this.#initCategoryToggle();
         this.#initSearch();
+        this.#initDragAndDrop();
     }
 
     #initCategoryToggle()
@@ -309,5 +320,330 @@ export class GlpiKnowbaseAsideController
         }
 
         return has_visible;
+    }
+
+    /**
+     * Initialize native HTML5 drag-and-drop reparenting on the tree.
+     *
+     * The whole <li> is draggable (set server-side based on rights via the
+     * `draggable="true"` HTML attribute). Drop targets are category title rows
+     * ([data-glpi-kb-aside-category-title]). Dropping onto a category's title
+     * makes the dragged item a child of that category. Hovering on a collapsed
+     * category for AUTO_EXPAND_DELAY ms auto-expands it.
+     */
+    #initDragAndDrop()
+    {
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        if (!tree) {
+            return;
+        }
+        const can_reorder_articles   = tree.hasAttribute('data-glpi-kb-aside-can-reorder-articles');
+        const can_reorder_categories = tree.hasAttribute('data-glpi-kb-aside-can-reorder-categories');
+        if (!can_reorder_articles && !can_reorder_categories) {
+            return;
+        }
+
+        tree.addEventListener('dragstart', (e) => this.#onDragStart(e));
+        tree.addEventListener('dragover',  (e) => this.#onDragOver(e));
+        tree.addEventListener('dragenter', (e) => this.#onDragEnter(e));
+        tree.addEventListener('dragleave', (e) => this.#onDragLeave(e));
+        tree.addEventListener('drop',      (e) => this.#onDrop(e));
+        tree.addEventListener('dragend',   (e) => this.#onDragEnd(e));
+    }
+
+    /**
+     * @param {DragEvent} event
+     */
+    #onDragStart(event)
+    {
+        const li = event.target.closest('li[draggable="true"]');
+        if (!li) {
+            return;
+        }
+
+        this.#drag = {
+            source: li,
+            origin_parent: li.parentElement,
+            origin_next: li.nextElementSibling,
+            current_target: null,
+            expand_timer: null,
+            expand_target: null,
+        };
+
+        event.dataTransfer.effectAllowed = 'move';
+        // Required by Firefox; payload is unused (we keep state on `this`).
+        event.dataTransfer.setData('text/plain', '');
+
+        // Defer the class toggle so the browser captures the un-faded element
+        // for the native drag image, then fades the source in place.
+        requestAnimationFrame(() => {
+            li.classList.add('kb-aside-source-dragging');
+            this.#aside.classList.add('kb-aside-dragging');
+        });
+    }
+
+    /**
+     * @param {DragEvent} event
+     */
+    #onDragOver(event)
+    {
+        if (!this.#drag?.source) {
+            return;
+        }
+        // Required to allow a drop.
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+    }
+
+    /**
+     * @param {DragEvent} event
+     */
+    #onDragEnter(event)
+    {
+        if (!this.#drag?.source) {
+            return;
+        }
+        const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
+        if (!title) {
+            return;
+        }
+
+        const target_li = title.closest('[data-glpi-kb-aside-category]');
+        const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
+        const { itemtype, items_id } = this.#identifySource(this.#drag.source);
+
+        if (!this.#isDropAllowed(itemtype, items_id, target_li, target_id)) {
+            return;
+        }
+
+        this.#clearTargetHighlight();
+        title.classList.add('kb-aside-target');
+        this.#drag.current_target = title;
+
+        if (target_li.hasAttribute('data-glpi-kb-aside-category-collapsed')) {
+            this.#scheduleAutoExpand(target_li);
+        }
+    }
+
+    /**
+     * @param {DragEvent} event
+     */
+    #onDragLeave(event)
+    {
+        if (!this.#drag?.source) {
+            return;
+        }
+        const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
+        if (!title || title !== this.#drag.current_target) {
+            return;
+        }
+        // dragleave fires when entering a child node too — confirm we left the
+        // title row by checking relatedTarget.
+        const related_title = event.relatedTarget?.closest?.('[data-glpi-kb-aside-category-title]');
+        if (related_title === title) {
+            return;
+        }
+
+        this.#clearTargetHighlight();
+        this.#cancelAutoExpand();
+    }
+
+    /**
+     * @param {DragEvent} event
+     */
+    async #onDrop(event)
+    {
+        if (!this.#drag?.source) {
+            return;
+        }
+        event.preventDefault();
+
+        const target_title = this.#drag.current_target;
+        if (!target_title) {
+            this.#revertDrop();
+            return;
+        }
+
+        const target_li = target_title.closest('[data-glpi-kb-aside-category]');
+        const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
+        const { itemtype, items_id } = this.#identifySource(this.#drag.source);
+        const from_parent_id = this.#getCurrentParentId(this.#drag.source);
+
+        if (from_parent_id === target_id) {
+            this.#clearTargetHighlight();
+            return;
+        }
+
+        const target_children = target_li.querySelector(':scope > ul');
+        if (!target_children) {
+            this.#revertDrop();
+            return;
+        }
+        // Optimistic move.
+        target_children.appendChild(this.#drag.source);
+
+        let response;
+        try {
+            response = await fetch(`${CFG_GLPI.root_doc}/Knowbase/Aside/Reparent`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify({
+                    itemtype,
+                    items_id,
+                    from_parent_id,
+                    to_parent_id: target_id,
+                }),
+            });
+        } catch (e) {
+            this.#revertDrop();
+            glpi_toast_error(__("An unexpected error occurred."));
+            console.error(e);
+            return;
+        }
+
+        if (response.ok) {
+            return;
+        }
+        this.#revertDrop();
+        if (response.status === 409) {
+            glpi_toast_error(__("This item can't be moved here."));
+        } else {
+            glpi_toast_error(__("An unexpected error occurred."));
+        }
+    }
+
+    #onDragEnd()
+    {
+        this.#clearTargetHighlight();
+        this.#cancelAutoExpand();
+        if (this.#drag?.source) {
+            this.#drag.source.classList.remove('kb-aside-source-dragging');
+        }
+        this.#aside.classList.remove('kb-aside-dragging');
+        this.#drag = null;
+    }
+
+    #clearTargetHighlight()
+    {
+        if (this.#drag?.current_target) {
+            this.#drag.current_target.classList.remove('kb-aside-target');
+            this.#drag.current_target = null;
+        }
+    }
+
+    /**
+     * @param {HTMLElement} target_li
+     */
+    #scheduleAutoExpand(target_li)
+    {
+        if (this.#drag.expand_target === target_li) {
+            return;
+        }
+        this.#cancelAutoExpand();
+        this.#drag.expand_target = target_li;
+        this.#drag.expand_timer = window.setTimeout(() => {
+            target_li.removeAttribute('data-glpi-kb-aside-category-collapsed');
+            const toggle = target_li.querySelector('[data-glpi-kb-aside-category-toggle]');
+            toggle?.setAttribute('aria-expanded', 'true');
+            this.#drag.expand_timer = null;
+            this.#drag.expand_target = null;
+        }, AUTO_EXPAND_DELAY);
+    }
+
+    #cancelAutoExpand()
+    {
+        if (this.#drag?.expand_timer) {
+            window.clearTimeout(this.#drag.expand_timer);
+            this.#drag.expand_timer = null;
+            this.#drag.expand_target = null;
+        }
+    }
+
+    /**
+     * @param {HTMLElement} li
+     * @returns {{itemtype: ?string, items_id: ?number}}
+     */
+    #identifySource(li)
+    {
+        if (li.hasAttribute('data-glpi-kb-article-id')) {
+            return {
+                itemtype: ITEMTYPE_ARTICLE,
+                items_id: parseInt(li.dataset.glpiKbArticleId, 10),
+            };
+        }
+        if (li.hasAttribute('data-glpi-kb-aside-category')) {
+            return {
+                itemtype: ITEMTYPE_CATEGORY,
+                items_id: parseInt(li.dataset.glpiKbAsideCategoryId, 10),
+            };
+        }
+        return { itemtype: null, items_id: null };
+    }
+
+    /**
+     * Resolve the id of the category currently containing `li`.
+     * Returns 0 when the source's parent is the synthetic root.
+     *
+     * @param {HTMLElement} li
+     * @returns {number}
+     */
+    #getCurrentParentId(li)
+    {
+        const parent_li = li.parentElement?.closest('[data-glpi-kb-aside-category]');
+        if (!parent_li) {
+            return 0;
+        }
+        return parseInt(parent_li.dataset.glpiKbAsideCategoryId, 10);
+    }
+
+    /**
+     * @param {?string}     itemtype
+     * @param {?number}     items_id
+     * @param {HTMLElement} target_li
+     * @param {number}      target_id
+     * @returns {boolean}
+     */
+    #isDropAllowed(itemtype, items_id, target_li, target_id)
+    {
+        const is_uncategorized = target_li.hasAttribute('data-glpi-kb-aside-category-uncategorized');
+
+        if (itemtype === ITEMTYPE_ARTICLE) {
+            // Articles can go into any category including the uncategorized
+            // pseudo-bucket (id=0).
+            return true;
+        }
+
+        if (itemtype === ITEMTYPE_CATEGORY) {
+            if (is_uncategorized) {
+                return false;
+            }
+            if (target_id === items_id) {
+                return false;
+            }
+            // A category cannot be dropped onto one of its own descendants.
+            if (this.#drag.source.contains(target_li)) {
+                return false;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Put the source element back at its origin (optimistic UI revert).
+     */
+    #revertDrop()
+    {
+        if (!this.#drag?.source || !this.#drag?.origin_parent) {
+            return;
+        }
+        this.#drag.origin_parent.insertBefore(
+            this.#drag.source,
+            this.#drag.origin_next,
+        );
     }
 }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -30,7 +30,7 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _, glpi_toast_error */
+/* global _, glpi_toast_error, glpi_html_dialog */
 
 import { get } from "/js/modules/Ajax.js";
 
@@ -73,6 +73,7 @@ export class GlpiKnowbaseAsideController
         this.#initCategoryToggle();
         this.#initSearch();
         this.#initDragAndDrop();
+        this.#initMoveMenu();
     }
 
     #initCategoryToggle()
@@ -418,7 +419,7 @@ export class GlpiKnowbaseAsideController
         const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
         const { itemtype, items_id } = this.#identifySource(this.#drag.source);
 
-        if (!this.#isDropAllowed(itemtype, items_id, target_li, target_id)) {
+        if (!this.#isDropAllowed(this.#drag.source, itemtype, items_id, target_li, target_id)) {
             return;
         }
 
@@ -472,30 +473,49 @@ export class GlpiKnowbaseAsideController
 
         const target_li = target_title.closest('[data-glpi-kb-aside-category]');
         const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
-        const { itemtype, items_id } = this.#identifySource(this.#drag.source);
-        const from_parent_id = this.#getCurrentParentId(this.#drag.source);
-
-        if (from_parent_id === target_id) {
-            this.#clearTargetHighlight();
-            return;
-        }
-
-        const target_children = target_li.querySelector(':scope > ul');
-        if (!target_children) {
-            this.#revertDrop();
-            return;
-        }
 
         // Capture the revert state BEFORE awaiting the fetch: dragend fires
         // synchronously after drop and nulls this.#drag before the await
-        // resolves, so #revertDrop() would silently no-op in either error
-        // branch below.
+        // resolves, so a deferred revert would silently no-op otherwise.
         const source        = this.#drag.source;
         const origin_parent = this.#drag.origin_parent;
         const origin_next   = this.#drag.origin_next;
 
+        this.#clearTargetHighlight();
+        await this.#commitReparent(source, target_li, target_id, origin_parent, origin_next);
+    }
+
+    /**
+     * Move `source_li` under `target_li` in the DOM and persist the change.
+     * Optimistic: the move is applied first, then reverted if the server rejects.
+     *
+     * Shared between drag-drop (#onDrop) and the keyboard/touch fallback menu
+     * (#openMovePicker).
+     *
+     * @param {HTMLElement}  source_li
+     * @param {HTMLElement}  target_li
+     * @param {number}       target_id
+     * @param {HTMLElement}  origin_parent  Container `source_li` came from (for revert).
+     * @param {?HTMLElement} origin_next    Sibling that was after `source_li` (for revert).
+     * @returns {Promise<boolean>} true if the move was accepted by the server.
+     */
+    async #commitReparent(source_li, target_li, target_id, origin_parent, origin_next)
+    {
+        const { itemtype, items_id } = this.#identifySource(source_li);
+        const from_parent_id = this.#getCurrentParentId(source_li);
+
+        if (from_parent_id === target_id) {
+            return true;
+        }
+
+        const target_children = target_li.querySelector(':scope > ul');
+        if (!target_children) {
+            glpi_toast_error(__("An unexpected error occurred."));
+            return false;
+        }
+
         // Optimistic move.
-        target_children.appendChild(source);
+        target_children.appendChild(source_li);
 
         let response;
         try {
@@ -513,21 +533,22 @@ export class GlpiKnowbaseAsideController
                 }),
             });
         } catch (e) {
-            origin_parent.insertBefore(source, origin_next);
+            origin_parent.insertBefore(source_li, origin_next);
             glpi_toast_error(__("An unexpected error occurred."));
             console.error(e);
-            return;
+            return false;
         }
 
         if (response.ok) {
-            return;
+            return true;
         }
-        origin_parent.insertBefore(source, origin_next);
+        origin_parent.insertBefore(source_li, origin_next);
         if (response.status === 409) {
             glpi_toast_error(__("This item can't be moved here."));
         } else {
             glpi_toast_error(__("An unexpected error occurred."));
         }
+        return false;
     }
 
     #onDragEnd()
@@ -615,13 +636,14 @@ export class GlpiKnowbaseAsideController
     }
 
     /**
+     * @param {HTMLElement} source_li
      * @param {?string}     itemtype
      * @param {?number}     items_id
      * @param {HTMLElement} target_li
      * @param {number}      target_id
      * @returns {boolean}
      */
-    #isDropAllowed(itemtype, items_id, target_li, target_id)
+    #isDropAllowed(source_li, itemtype, items_id, target_li, target_id)
     {
         const is_uncategorized = target_li.hasAttribute('data-glpi-kb-aside-category-uncategorized');
 
@@ -639,7 +661,7 @@ export class GlpiKnowbaseAsideController
                 return false;
             }
             // A category cannot be dropped onto one of its own descendants.
-            if (this.#drag.source.contains(target_li)) {
+            if (source_li.contains(target_li)) {
                 return false;
             }
             return true;
@@ -660,5 +682,214 @@ export class GlpiKnowbaseAsideController
             this.#drag.source,
             this.#drag.origin_next,
         );
+    }
+
+    /**
+     * Initialize the keyboard/touch fallback for drag-and-drop: a kebab button
+     * on each draggable row opens a modal picker listing every category the
+     * item can be moved to. The same backend endpoint (Reparent) is used.
+     */
+    #initMoveMenu()
+    {
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        if (!tree) {
+            return;
+        }
+
+        tree.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-glpi-kb-aside-move]');
+            if (!button) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+
+            const source_li = button.closest('li[draggable="true"]');
+            if (!source_li) {
+                return;
+            }
+            this.#openMovePicker(source_li);
+        });
+    }
+
+    /**
+     * Open the "Move to" modal picker for `source_li`.
+     *
+     * @param {HTMLElement} source_li
+     */
+    #openMovePicker(source_li)
+    {
+        const { itemtype, items_id } = this.#identifySource(source_li);
+        if (!itemtype) {
+            return;
+        }
+
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        const root_ul = tree.querySelector(':scope > ul');
+        if (!root_ul) {
+            return;
+        }
+
+        const current_parent_id = this.#getCurrentParentId(source_li);
+        const source_title      = this.#getSourceTitle(source_li);
+        const picker_id         = `kb-move-picker-${Math.random().toString(36).slice(2, 8)}`;
+        const submit_id         = `${picker_id}-submit`;
+
+        const tree_html = this.#renderPickerLevel(
+            root_ul,
+            source_li,
+            itemtype,
+            items_id,
+            current_parent_id,
+            picker_id,
+        );
+
+        const body = `
+            <p class="text-muted mb-3">${_.escape(__("Pick a category as the new parent."))}</p>
+            <div class="kb-move-picker" data-glpi-kb-move-picker>${tree_html}</div>
+        `;
+
+        glpi_html_dialog({
+            title: _.escape(__("Move %s").replace('%s', source_title)),
+            body,
+            id: picker_id,
+            dialogclass: 'modal-lg',
+            buttons: [
+                {
+                    label: __("Cancel"),
+                    class: 'btn-outline-secondary',
+                },
+                {
+                    label: __("Move"),
+                    class: 'btn-primary',
+                    id: submit_id,
+                    click: () => {
+                        const modal = document.getElementById(picker_id);
+                        if (!modal) {
+                            return;
+                        }
+                        const selected = modal.querySelector('input[name="target"]:checked');
+                        if (!selected) {
+                            return;
+                        }
+                        const target_id = parseInt(selected.value, 10);
+                        const target_li = tree.querySelector(
+                            `[data-glpi-kb-aside-category][data-glpi-kb-aside-category-id="${target_id}"]`,
+                        );
+                        if (!target_li) {
+                            return;
+                        }
+                        this.#commitReparent(
+                            source_li,
+                            target_li,
+                            target_id,
+                            source_li.parentElement,
+                            source_li.nextElementSibling,
+                        );
+                    },
+                },
+            ],
+        });
+    }
+
+    /**
+     * Recursively render the picker's `<ul>` for one nesting level.
+     *
+     * Categories that the source cannot legally move into (self, descendants,
+     * uncategorized for categories) are rendered as disabled radios so the
+     * structure remains readable. The current parent is rendered checked.
+     *
+     * @param {HTMLElement} ul_el
+     * @param {HTMLElement} source_li
+     * @param {string}      itemtype
+     * @param {number}      items_id
+     * @param {number}      current_parent_id
+     * @param {string}      picker_id
+     * @returns {string}
+     */
+    #renderPickerLevel(ul_el, source_li, itemtype, items_id, current_parent_id, picker_id)
+    {
+        let html = '<ul class="kb-move-picker-list">';
+
+        for (const cat of ul_el.children) {
+            if (!cat.matches('[data-glpi-kb-aside-category]')) {
+                continue;
+            }
+
+            const cat_id           = parseInt(cat.dataset.glpiKbAsideCategoryId, 10);
+            const is_uncategorized = cat.hasAttribute('data-glpi-kb-aside-category-uncategorized');
+
+            // Categories cannot be moved into the uncategorized pseudo-bucket.
+            if (is_uncategorized && itemtype !== ITEMTYPE_ARTICLE) {
+                continue;
+            }
+
+            const allowed    = this.#isDropAllowed(source_li, itemtype, items_id, cat, cat_id);
+            const is_current = cat_id === current_parent_id;
+            const disabled   = !allowed || is_current;
+            const radio_id   = `${picker_id}-radio-${cat_id}`;
+            // The aria-label on the category <li> is rendered server-side from
+            // the (already translated) category title — including "Uncategorized"
+            // for the synthetic id=0 bucket.
+            const title      = cat.getAttribute('aria-label') ?? '';
+
+            const checked_attr  = is_current ? 'checked' : '';
+            const disabled_attr = disabled ? 'disabled' : '';
+            // aria-hidden keeps the badge out of the radio's accessible name so
+            // screen readers don't read "Réseau current" — the disabled state
+            // already conveys "this is where it is".
+            const current_badge = is_current
+                ? ` <span class="badge bg-info-lt ms-2" aria-hidden="true">${_.escape(__("current"))}</span>`
+                : '';
+
+            html += `
+                <li>
+                    <label class="form-check d-flex align-items-center mb-1" for="${radio_id}">
+                        <input type="radio"
+                               name="target"
+                               value="${cat_id}"
+                               id="${radio_id}"
+                               class="form-check-input me-2 mt-0"
+                               ${checked_attr}
+                               ${disabled_attr}>
+                        <span class="text-truncate">${_.escape(title)}</span>
+                        ${current_badge}
+                    </label>
+            `;
+
+            const sub_ul = cat.querySelector(':scope > ul');
+            if (sub_ul && sub_ul.children.length > 0) {
+                html += this.#renderPickerLevel(
+                    sub_ul,
+                    source_li,
+                    itemtype,
+                    items_id,
+                    current_parent_id,
+                    picker_id,
+                );
+            }
+
+            html += '</li>';
+        }
+
+        html += '</ul>';
+        return html;
+    }
+
+    /**
+     * Read the displayed title of `source_li` (article or category) for use in
+     * the picker's modal header.
+     *
+     * @param {HTMLElement} source_li
+     * @returns {string}
+     */
+    #getSourceTitle(source_li)
+    {
+        if (source_li.hasAttribute('data-glpi-kb-article-id')) {
+            // <a> contains the illustration (non-text) then the article title.
+            return source_li.querySelector(':scope > a')?.textContent.trim() ?? '';
+        }
+        // Categories have the clean title on aria-label of the <li>.
+        return source_li.getAttribute('aria-label') ?? '';
     }
 }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -428,12 +428,12 @@ export class GlpiKnowbaseAsideController
             return;
         }
 
-        const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
-        if (!title) {
+        // Whole category block is the drop target, so items drop "into" it.
+        const target_li = event.target.closest?.('[data-glpi-kb-aside-category]');
+        if (!target_li) {
             return;
         }
 
-        const target_li = title.closest('[data-glpi-kb-aside-category]');
         const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
         const { itemtype, items_id } = this.#identifySource(this.#drag.source);
 
@@ -442,8 +442,8 @@ export class GlpiKnowbaseAsideController
         }
 
         this.#clearTargetHighlight();
-        title.classList.add('kb-aside-target');
-        this.#drag.current_target = title;
+        target_li.classList.add('kb-aside-target-block');
+        this.#drag.current_target = target_li;
 
         if (target_li.hasAttribute('data-glpi-kb-aside-category-collapsed')) {
             this.#scheduleAutoExpand(target_li);
@@ -468,14 +468,13 @@ export class GlpiKnowbaseAsideController
             return;
         }
 
-        const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
-        if (!title || title !== this.#drag.current_target) {
+        const target_li = event.target.closest?.('[data-glpi-kb-aside-category]');
+        if (!target_li || target_li !== this.#drag.current_target) {
             return;
         }
-        // dragleave fires when entering a child node too — confirm we left the
-        // title row by checking relatedTarget.
-        const related_title = event.relatedTarget?.closest?.('[data-glpi-kb-aside-category-title]');
-        if (related_title === title) {
+        // dragleave also fires moving onto a descendant; only clear on real leave.
+        const related_li = event.relatedTarget?.closest?.('[data-glpi-kb-aside-category]');
+        if (related_li === target_li) {
             return;
         }
 
@@ -612,6 +611,9 @@ export class GlpiKnowbaseAsideController
      */
     async #postReparent(source_li, body, origin_parent, origin_next)
     {
+        // The optimistic move already happened in the caller.
+        this.#reconcileEmptyStates();
+
         let response;
         try {
             response = await fetch(`${CFG_GLPI.root_doc}/Knowbase/Aside/Reparent`, {
@@ -624,6 +626,7 @@ export class GlpiKnowbaseAsideController
             });
         } catch (e) {
             origin_parent.insertBefore(source_li, origin_next);
+            this.#reconcileEmptyStates();
             glpi_toast_error(__("An unexpected error occurred."));
             console.error(e);
             return false;
@@ -633,12 +636,47 @@ export class GlpiKnowbaseAsideController
             return true;
         }
         origin_parent.insertBefore(source_li, origin_next);
+        this.#reconcileEmptyStates();
         if (response.status === 409) {
             glpi_toast_error(__("This item can't be moved here."));
         } else {
             glpi_toast_error(__("An unexpected error occurred."));
         }
         return false;
+    }
+
+    /**
+     * Keep each category's "No articles" empty-state row accurate after an
+     * optimistic move (the server only renders it on a full reload).
+     */
+    #reconcileEmptyStates()
+    {
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        if (!tree) {
+            return;
+        }
+        const categories = tree.querySelectorAll(
+            '[data-glpi-kb-aside-category]:not([data-glpi-kb-aside-category-uncategorized])',
+        );
+        for (const cat of categories) {
+            const ul = cat.querySelector(':scope > ul');
+            if (!ul) {
+                continue;
+            }
+            const has_content = ul.querySelector(
+                ':scope > [data-glpi-kb-article-id], :scope > [data-glpi-kb-aside-category]',
+            );
+            const empty_row = ul.querySelector(':scope > .kb-aside-empty');
+            if (has_content && empty_row) {
+                empty_row.remove();
+            } else if (!has_content && !empty_row) {
+                const li = document.createElement('li');
+                li.className = 'kb-aside-empty';
+                li.setAttribute('aria-hidden', 'true');
+                li.textContent = __("No articles");
+                ul.appendChild(li);
+            }
+        }
     }
 
     #onDragEnd()
@@ -656,7 +694,7 @@ export class GlpiKnowbaseAsideController
     #clearTargetHighlight()
     {
         if (this.#drag?.current_target) {
-            this.#drag.current_target.classList.remove('kb-aside-target');
+            this.#drag.current_target.classList.remove('kb-aside-target', 'kb-aside-target-block');
             this.#drag.current_target = null;
         }
     }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -386,6 +386,9 @@ export class GlpiKnowbaseAsideController
             }
             li.classList.add('kb-aside-source-dragging');
             this.#aside.classList.add('kb-aside-dragging');
+            if (this.#identifySource(li).itemtype === ITEMTYPE_CATEGORY) {
+                this.#aside.classList.add('kb-aside-dragging-category');
+            }
         });
     }
 
@@ -410,6 +413,21 @@ export class GlpiKnowbaseAsideController
         if (!this.#drag?.source) {
             return;
         }
+
+        // Root drop zone: promote a category back to top level.
+        const root_zone = event.target.closest?.('[data-glpi-kb-aside-root-dropzone]');
+        if (root_zone) {
+            const { itemtype } = this.#identifySource(this.#drag.source);
+            if (itemtype !== ITEMTYPE_CATEGORY || this.#getCurrentParentId(this.#drag.source) === 0) {
+                return;
+            }
+            this.#clearTargetHighlight();
+            root_zone.classList.add('kb-aside-target');
+            this.#drag.current_target = root_zone;
+            this.#cancelAutoExpand();
+            return;
+        }
+
         const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
         if (!title) {
             return;
@@ -440,6 +458,16 @@ export class GlpiKnowbaseAsideController
         if (!this.#drag?.source) {
             return;
         }
+
+        const root_zone = event.target.closest?.('[data-glpi-kb-aside-root-dropzone]');
+        if (root_zone && root_zone === this.#drag.current_target) {
+            const related_zone = event.relatedTarget?.closest?.('[data-glpi-kb-aside-root-dropzone]');
+            if (related_zone !== root_zone) {
+                this.#clearTargetHighlight();
+            }
+            return;
+        }
+
         const title = event.target.closest?.('[data-glpi-kb-aside-category-title]');
         if (!title || title !== this.#drag.current_target) {
             return;
@@ -465,14 +493,11 @@ export class GlpiKnowbaseAsideController
         }
         event.preventDefault();
 
-        const target_title = this.#drag.current_target;
-        if (!target_title) {
+        const target = this.#drag.current_target;
+        if (!target) {
             this.#revertDrop();
             return;
         }
-
-        const target_li = target_title.closest('[data-glpi-kb-aside-category]');
-        const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
 
         // Capture the revert state BEFORE awaiting the fetch: dragend fires
         // synchronously after drop and nulls this.#drag before the await
@@ -482,6 +507,14 @@ export class GlpiKnowbaseAsideController
         const origin_next   = this.#drag.origin_next;
 
         this.#clearTargetHighlight();
+
+        if (target.matches('[data-glpi-kb-aside-root-dropzone]')) {
+            await this.#commitReparentToRoot(source, origin_parent, origin_next);
+            return;
+        }
+
+        const target_li = target.closest('[data-glpi-kb-aside-category]');
+        const target_id = parseInt(target_li.dataset.glpiKbAsideCategoryId, 10);
         await this.#commitReparent(source, target_li, target_id, origin_parent, origin_next);
     }
 
@@ -522,6 +555,63 @@ export class GlpiKnowbaseAsideController
             target_children.appendChild(source_li);
         }
 
+        return this.#postReparent(
+            source_li,
+            { itemtype, items_id, from_parent_id, to_parent_id: target_id },
+            origin_parent,
+            origin_next,
+        );
+    }
+
+    /**
+     * Promote a CATEGORY back to the top level (parent_id=0). Optimistic: the
+     * category <li> is appended to the tree's root <ul>, then reverted if the
+     * server rejects.
+     *
+     * @param {HTMLElement}  source_li
+     * @param {HTMLElement}  origin_parent  Container `source_li` came from (for revert).
+     * @param {?HTMLElement} origin_next    Sibling that was after `source_li` (for revert).
+     * @returns {Promise<boolean>} true if the move was accepted by the server.
+     */
+    async #commitReparentToRoot(source_li, origin_parent, origin_next)
+    {
+        const { itemtype, items_id } = this.#identifySource(source_li);
+        if (itemtype !== ITEMTYPE_CATEGORY) {
+            return false;
+        }
+        const from_parent_id = this.#getCurrentParentId(source_li);
+        if (from_parent_id === 0) {
+            return true;
+        }
+
+        const tree    = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        const root_ul = tree?.querySelector(':scope > ul');
+        if (!root_ul) {
+            glpi_toast_error(__("An unexpected error occurred."));
+            return false;
+        }
+
+        root_ul.appendChild(source_li);
+
+        return this.#postReparent(
+            source_li,
+            { itemtype, items_id, from_parent_id, to_parent_id: 0 },
+            origin_parent,
+            origin_next,
+        );
+    }
+
+    /**
+     * POST a reparent to the backend; revert the optimistic DOM move on failure.
+     *
+     * @param {HTMLElement}  source_li
+     * @param {{itemtype: string, items_id: number, from_parent_id: number, to_parent_id: number}} body
+     * @param {HTMLElement}  origin_parent
+     * @param {?HTMLElement} origin_next
+     * @returns {Promise<boolean>}
+     */
+    async #postReparent(source_li, body, origin_parent, origin_next)
+    {
         let response;
         try {
             response = await fetch(`${CFG_GLPI.root_doc}/Knowbase/Aside/Reparent`, {
@@ -530,12 +620,7 @@ export class GlpiKnowbaseAsideController
                     'Content-Type': 'application/json',
                     'X-Requested-With': 'XMLHttpRequest',
                 },
-                body: JSON.stringify({
-                    itemtype,
-                    items_id,
-                    from_parent_id,
-                    to_parent_id: target_id,
-                }),
+                body: JSON.stringify(body),
             });
         } catch (e) {
             origin_parent.insertBefore(source_li, origin_next);
@@ -564,6 +649,7 @@ export class GlpiKnowbaseAsideController
             this.#drag.source.classList.remove('kb-aside-source-dragging');
         }
         this.#aside.classList.remove('kb-aside-dragging');
+        this.#aside.classList.remove('kb-aside-dragging-category');
         this.#drag = null;
     }
 
@@ -740,6 +826,13 @@ export class GlpiKnowbaseAsideController
         const picker_id         = `kb-move-picker-${Math.random().toString(36).slice(2, 8)}`;
         const submit_id         = `${picker_id}-submit`;
 
+        // Categories get a synthetic "Top level" (root, value 0) option: the
+        // article picker reaches root through the real id=0 "Uncategorized" <li>,
+        // which is skipped for categories, so we prepend it explicitly.
+        const root_option = itemtype === ITEMTYPE_CATEGORY
+            ? this.#renderRootPickerOption(current_parent_id, picker_id)
+            : '';
+
         const tree_html = this.#renderPickerLevel(
             root_ul,
             source_li,
@@ -747,7 +840,7 @@ export class GlpiKnowbaseAsideController
             items_id,
             current_parent_id,
             picker_id,
-        );
+        ).replace('<ul class="kb-move-picker-list">', `<ul class="kb-move-picker-list">${root_option}`);
 
         const body = `
             <p class="text-muted mb-3">${_.escape(__("Pick a category as the new parent."))}</p>
@@ -778,6 +871,16 @@ export class GlpiKnowbaseAsideController
                             return;
                         }
                         const target_id = parseInt(selected.value, 10);
+                        // value 0 for a category means "Top level" (root); there
+                        // is no category <li> to find for it.
+                        if (target_id === 0 && itemtype === ITEMTYPE_CATEGORY) {
+                            this.#commitReparentToRoot(
+                                source_li,
+                                source_li.parentElement,
+                                source_li.nextElementSibling,
+                            );
+                            return;
+                        }
                         const target_li = tree.querySelector(
                             `[data-glpi-kb-aside-category][data-glpi-kb-aside-category-id="${target_id}"]`,
                         );
@@ -795,6 +898,41 @@ export class GlpiKnowbaseAsideController
                 },
             ],
         });
+    }
+
+    /**
+     * Render the synthetic "Top level" (root, value 0) radio for a category.
+     * Checked + disabled when the category is already at root.
+     *
+     * @param {number} current_parent_id
+     * @param {string} picker_id
+     * @returns {string}
+     */
+    #renderRootPickerOption(current_parent_id, picker_id)
+    {
+        const is_current    = current_parent_id === 0;
+        const radio_id      = `${picker_id}-radio-root`;
+        const checked_attr  = is_current ? 'checked' : '';
+        const disabled_attr = is_current ? 'disabled' : '';
+        const current_badge = is_current
+            ? ` <span class="badge bg-info-lt ms-2" aria-hidden="true">${_.escape(__("current"))}</span>`
+            : '';
+
+        return `
+            <li>
+                <label class="form-check d-flex align-items-center mb-1" for="${radio_id}">
+                    <input type="radio"
+                           name="target"
+                           value="0"
+                           id="${radio_id}"
+                           class="form-check-input me-2 mt-0"
+                           ${checked_attr}
+                           ${disabled_attr}>
+                    <span class="text-truncate">${_.escape(__("Top level"))}</span>
+                    ${current_badge}
+                </label>
+            </li>
+        `;
     }
 
     /**
@@ -891,8 +1029,11 @@ export class GlpiKnowbaseAsideController
     #getSourceTitle(source_li)
     {
         if (source_li.hasAttribute('data-glpi-kb-article-id')) {
-            // <a> contains the illustration (non-text) then the article title.
-            return source_li.querySelector(':scope > a')?.textContent.trim() ?? '';
+            // Clean title exposed server-side; fall back to <a> text (which also
+            // captures the illustration's accessible text) when absent.
+            return source_li.getAttribute('data-glpi-kb-article-title')
+                ?? source_li.querySelector(':scope > a')?.textContent.trim()
+                ?? '';
         }
         // Categories have the clean title on aria-label of the <li>.
         return source_li.getAttribute('aria-label') ?? '';

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -514,8 +514,13 @@ export class GlpiKnowbaseAsideController
             return false;
         }
 
-        // Optimistic move.
-        target_children.appendChild(source_li);
+        // Optimistic move: articles are grouped above subcategories
+        if (itemtype === 'KnowbaseItem') {
+            const first_subcategory = target_children.querySelector(':scope > [data-glpi-kb-aside-category]');
+            target_children.insertBefore(source_li, first_subcategory); // null → append
+        } else {
+            target_children.appendChild(source_li);
+        }
 
         let response;
         try {

--- a/src/Glpi/Controller/Knowbase/ReparentNodeController.php
+++ b/src/Glpi/Controller/Knowbase/ReparentNodeController.php
@@ -80,11 +80,17 @@ final class ReparentNodeController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        // The target category, if not the synthetic root, must exist.
+        // The target category, if not the synthetic root, must exist and be
+        // visible to the caller's active entity scope. canViewItem() enforces
+        // the entity restriction that getFromDB() alone would skip — without
+        // it, a user could drop items into a category from a foreign entity.
         if ($to_parent_id > 0) {
             $target_category = new KnowbaseItemCategory();
             if (!$target_category->getFromDB($to_parent_id)) {
                 throw new NotFoundHttpException();
+            }
+            if (!$target_category->canViewItem()) {
+                throw new AccessDeniedHttpException();
             }
         }
 

--- a/src/Glpi/Controller/Knowbase/ReparentNodeController.php
+++ b/src/Glpi/Controller/Knowbase/ReparentNodeController.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use KnowbaseItem;
+use KnowbaseItemCategory;
+use Safe\Exceptions\JsonException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+use function Safe\json_decode;
+
+final class ReparentNodeController extends AbstractController
+{
+    #[Route(
+        "/Knowbase/Aside/Reparent",
+        name: "knowbase_aside_reparent",
+        methods: 'POST',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        try {
+            $payload = json_decode($request->getContent(), true);
+        } catch (JsonException) {
+            throw new BadRequestHttpException();
+        }
+        if (!is_array($payload)) {
+            throw new BadRequestHttpException();
+        }
+        $this->validateInputHasExactKeys($payload, [
+            'itemtype',
+            'items_id',
+            'from_parent_id',
+            'to_parent_id',
+        ]);
+
+        $itemtype       = (string) $payload['itemtype'];
+        $items_id       = (int) $payload['items_id'];
+        $from_parent_id = (int) $payload['from_parent_id'];
+        $to_parent_id   = (int) $payload['to_parent_id'];
+
+        if ($items_id <= 0 || $from_parent_id < 0 || $to_parent_id < 0) {
+            throw new BadRequestHttpException();
+        }
+
+        // The target category, if not the synthetic root, must exist.
+        if ($to_parent_id > 0) {
+            $target_category = new KnowbaseItemCategory();
+            if (!$target_category->getFromDB($to_parent_id)) {
+                throw new NotFoundHttpException();
+            }
+        }
+
+        return match ($itemtype) {
+            KnowbaseItem::class         => $this->moveArticle($items_id, $from_parent_id, $to_parent_id),
+            KnowbaseItemCategory::class => $this->moveCategory($items_id, $to_parent_id),
+            default                     => throw new BadRequestHttpException(),
+        };
+    }
+
+    /**
+     * Move a KB article between categories by routing through
+     * `KnowbaseItem::update(['_categories' => …])` — the same path the form
+     * uses. Going through update() ensures that `post_updateItem` runs (which
+     * in turn invokes `update1NTableData` on the junction, raises the
+     * `update` notification event, fires `pre_item_update` plugin hook, and
+     * emits the `update` webhook).
+     *
+     * The same article can belong to multiple categories, so we compute the
+     * new set as `(current - from_parent_id) ∪ to_parent_id`. A parent_id of
+     * 0 represents the synthetic "Uncategorized" bucket — the absence of any
+     * junction row for the article.
+     */
+    private function moveArticle(int $article_id, int $from_parent_id, int $to_parent_id): Response
+    {
+        $article = new KnowbaseItem();
+        if (!$article->getFromDB($article_id)) {
+            throw new NotFoundHttpException();
+        }
+        if (!$article->can($article_id, UPDATE)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        if ($from_parent_id === $to_parent_id) {
+            // No-op (drop on same category).
+            return new Response('', Response::HTTP_NO_CONTENT);
+        }
+
+        // `post_getFromDB()` has already populated $article->fields['_categories']
+        // via `load1NTableData()` (see KnowbaseItem::post_getFromDB).
+        $current_ids = array_map('intval', $article->fields['_categories'] ?? []);
+
+        $new_ids = array_values(array_diff($current_ids, [$from_parent_id]));
+        if ($to_parent_id > 0 && !in_array($to_parent_id, $new_ids, true)) {
+            $new_ids[] = $to_parent_id;
+        }
+
+        // `__categories_defined = 1` is required so that `update1NTableData`
+        // treats an empty value as "clear all" rather than "untouched" (see
+        // CommonDBTM::update1NTableData and the dropdownField macro convention).
+        $ok = $article->update([
+            'id'                   => $article_id,
+            '_categories'          => $new_ids === [] ? '' : $new_ids,
+            '__categories_defined' => 1,
+        ]);
+        if (!$ok) {
+            return new Response('', Response::HTTP_CONFLICT);
+        }
+
+        // `update1NTableData` surfaces junction-mutation failures via
+        // `trigger_error(E_USER_WARNING)` only — `$article->update()` still
+        // returns true. Re-fetch and verify the *intended delta* applied:
+        // the removed category must no longer link, the added one must
+        // link. We don't compare the full set because external category
+        // additions (concurrent edits, side-effects) are not this drag's
+        // concern — we only verify what the drag itself attempted to do.
+        $article->getFromDB($article_id);
+        $current_after = array_map('intval', $article->fields['_categories'] ?? []);
+
+        $removal_pending = $from_parent_id > 0 && in_array($from_parent_id, $current_after, true);
+        $addition_pending = $to_parent_id > 0 && !in_array($to_parent_id, $current_after, true);
+
+        if ($removal_pending || $addition_pending) {
+            trigger_error(
+                sprintf(
+                    'ReparentNodeController: article %d reparent delta failed (from=%d, to=%d, observed=[%s]).',
+                    $article_id,
+                    $from_parent_id,
+                    $to_parent_id,
+                    implode(',', $current_after),
+                ),
+                E_USER_WARNING,
+            );
+            return new Response('', Response::HTTP_CONFLICT);
+        }
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Move a KB category to a new parent category. Cycle prevention is handled
+     * by CommonTreeDropdown::prepareInputForUpdate which returns false (and
+     * therefore makes update() return false) when the target is a descendant
+     * of the moved category.
+     */
+    private function moveCategory(int $category_id, int $to_parent_id): Response
+    {
+        if ($category_id === $to_parent_id) {
+            throw new BadRequestHttpException();
+        }
+
+        $category = new KnowbaseItemCategory();
+        if (!$category->getFromDB($category_id)) {
+            throw new NotFoundHttpException();
+        }
+
+        $input = [
+            'id'                        => $category_id,
+            'knowbaseitemcategories_id' => $to_parent_id,
+        ];
+        if (!$category->can($category_id, UPDATE, $input)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        if (!$category->update($input)) {
+            return new Response('', Response::HTTP_CONFLICT);
+        }
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -73,6 +73,7 @@ final class Builder
         ]);
         foreach ($categories as $cat_data) {
             $category = new Category(
+                id: (int) $cat_data['id'],
                 title: $cat_data['name'] ?? '',
                 illustration: $cat_data['illustration'] ?? '',
             );

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -68,8 +68,11 @@ final class Builder
             ));
         }
 
-        $categories = (new KnowbaseItemCategory())->find([
-            'knowbaseitemcategories_id' => $category_id,
+        $categories = $DB->request([
+            'FROM'  => KnowbaseItemCategory::getTable(),
+            'WHERE' => [
+                'knowbaseitemcategories_id' => $category_id,
+            ] + getEntitiesRestrictCriteria(KnowbaseItemCategory::getTable(), '', '', true),
         ]);
         foreach ($categories as $cat_data) {
             $category = new Category(

--- a/src/Glpi/Knowbase/Aside/Category.php
+++ b/src/Glpi/Knowbase/Aside/Category.php
@@ -43,6 +43,7 @@ final class Category implements Node
     protected array $categories = [];
 
     public function __construct(
+        public readonly int $id,
         public readonly string $title,
         public readonly string $illustration,
     ) {}

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2849,10 +2849,12 @@ TWIG, $twig_params);
         return TemplateRenderer::getInstance()->render(
             'pages/tools/kb/aside.html.twig',
             [
-                'tree'                => (new Builder($current_id))->buildTree(),
-                'favorites'           => $favorites,
-                'current_is_favorite' => $current_is_favorite,
-                'has_other_favorites' => $has_other_favorites,
+                'tree'                    => (new Builder($current_id))->buildTree(),
+                'favorites'               => $favorites,
+                'current_is_favorite'     => $current_is_favorite,
+                'has_other_favorites'     => $has_other_favorites,
+                'can_reorder_articles'    => Session::haveRightsOr(self::$rightname, [UPDATE, self::KNOWBASEADMIN]),
+                'can_reorder_categories'  => Session::haveRight(KnowbaseItemCategory::$rightname, UPDATE),
             ]
         );
     }

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -84,6 +84,7 @@
     {% import _self as macros %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
+        data-glpi-kb-article-title="{{ article.title }}"
         {% if draggable %}draggable="true"{% endif %}
         {% if favorite_state is not null %}
             data-glpi-kb-favorite-current="{{ favorite_state }}"
@@ -179,6 +180,15 @@
     {% if can_reorder_categories ?? false %}data-glpi-kb-aside-can-reorder-categories{% endif %}
 >
     <ul class="kb-tree ps-0">
+        {% if can_reorder_categories ?? false %}
+            <li class="kb-aside-root-dropzone" data-glpi-kb-aside-root-dropzone aria-hidden="true">
+                <div class="kb-aside-row d-flex align-items-center">
+                    <i class="ti ti-corner-left-up me-1 fs-4" aria-hidden="true"></i>
+                    <span class="ms-2 fw-bold text-truncate d-block">{{ __('Top level') }}</span>
+                </div>
+            </li>
+        {% endif %}
+
         {# Render root articles in a special "uncategorized" pseudo-category. #}
         {# The pseudo-category itself is never draggable (id=0), but its articles can be. #}
         {% if tree.articles|length %}

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -30,6 +30,18 @@
  # ---------------------------------------------------------------------
  #}
 
+{% macro move_button(label) %}
+    <button
+        type="button"
+        class="btn btn-sm btn-ghost-secondary p-0 border-0 bg-transparent kb-aside-move-btn"
+        draggable="false"
+        data-glpi-kb-aside-move
+        aria-label="{{ label }}"
+    >
+        <i class="ti ti-dots-vertical fs-4" aria-hidden="true"></i>
+    </button>
+{% endmacro %}
+
 {% macro render_category(category, draggable_articles = false, draggable_categories = false) %}
     {% import _self as macros %}
     <li
@@ -58,6 +70,9 @@
                 {% endif %}
                 <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
             </button>
+            {% if draggable_categories %}
+                {{ macros.move_button(__('Move %s')|format(category.title)) }}
+            {% endif %}
         </div>
         <ul>
             {{ macros.render_node(category, draggable_articles, draggable_categories) }}
@@ -66,6 +81,7 @@
 {% endmacro %}
 
 {% macro render_article(article, add_margin = false, favorite_state = null, draggable = false) %}
+    {% import _self as macros %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
         {% if draggable %}draggable="true"{% endif %}
@@ -88,6 +104,9 @@
             {% endif %}
             {{ article.title }}
         </a>
+        {% if draggable %}
+            {{ macros.move_button(__('Move %s')|format(article.title)) }}
+        {% endif %}
     </li>
 {% endmacro %}
 

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -30,31 +30,45 @@
  # ---------------------------------------------------------------------
  #}
 
-{% macro render_category(category) %}
+{% macro render_category(category, draggable_articles = false, draggable_categories = false) %}
     {% import _self as macros %}
-    <li class="node" data-glpi-kb-aside-category role="group" aria-label="{{ category.title }}">
-        <button
-            type="button"
-            class="d-flex align-items-center mb-2 p-0 w-100 text-start border-0 bg-transparent"
-            data-glpi-kb-aside-category-toggle
-            aria-label="{{ category.title }}"
-            aria-expanded="true"
+    <li
+        class="node"
+        data-glpi-kb-aside-category
+        data-glpi-kb-aside-category-id="{{ category.id }}"
+        {% if draggable_categories %}draggable="true"{% endif %}
+        role="group"
+        aria-label="{{ category.title }}"
+    >
+        <div
+            class="d-flex align-items-center mb-2 kb-aside-row"
+            data-glpi-kb-aside-category-title
         >
-            <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
-            {% if category.illustration %}
-                {{ render_illustration(category.illustration, 20) }}
-            {% endif %}
-            <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
-        </button>
+            <button
+                type="button"
+                class="d-flex align-items-center p-0 flex-grow-1 text-start border-0 bg-transparent"
+                draggable="false"
+                data-glpi-kb-aside-category-toggle
+                aria-label="{{ category.title }}"
+                aria-expanded="true"
+            >
+                <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
+                {% if category.illustration %}
+                    {{ render_illustration(category.illustration, 20) }}
+                {% endif %}
+                <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
+            </button>
+        </div>
         <ul>
-            {{ macros.render_node(category) }}
+            {{ macros.render_node(category, draggable_articles, draggable_categories) }}
         </ul>
     </li>
 {% endmacro %}
 
-{% macro render_article(article, add_margin = false, favorite_state = null) %}
+{% macro render_article(article, add_margin = false, favorite_state = null, draggable = false) %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
+        {% if draggable %}draggable="true"{% endif %}
         {% if favorite_state is not null %}
             data-glpi-kb-favorite-current="{{ favorite_state }}"
         {% endif %}
@@ -62,9 +76,13 @@
             data-glpi-kb-article-current
             aria-current="page"
         {% endif %}
-        class="article {{ add_margin ? 'mb-2' : '' }}"
+        class="article d-flex align-items-center kb-aside-row {{ add_margin ? 'mb-2' : '' }}"
     >
-        <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
+        <a
+            class="text-dark text-hover-link text-truncate d-block flex-grow-1"
+            href="{{ article.link }}"
+            draggable="false"
+        >
             {% if article.illustration %}
                 {{ render_illustration(article.illustration, 20) }}
             {% endif %}
@@ -73,13 +91,13 @@
     </li>
 {% endmacro %}
 
-{% macro render_node(node) %}
+{% macro render_node(node, draggable_articles = false, draggable_categories = false) %}
     {% import _self as macros %}
     {% for article in node.articles %}
-        {{ macros.render_article(article) }}
+        {{ macros.render_article(article, false, null, draggable_articles) }}
     {% endfor %}
     {% for category in node.categories %}
-        {{ macros.render_category(category) }}
+        {{ macros.render_category(category, draggable_articles, draggable_categories) }}
     {% endfor %}
 {% endmacro %}
 
@@ -135,21 +153,56 @@
         </ul>
 </div>
 
-<div class="card-body" data-glpi-kb-aside-tree>
+<div
+    class="card-body"
+    data-glpi-kb-aside-tree
+    {% if can_reorder_articles ?? false %}data-glpi-kb-aside-can-reorder-articles{% endif %}
+    {% if can_reorder_categories ?? false %}data-glpi-kb-aside-can-reorder-categories{% endif %}
+>
     <ul class="kb-tree ps-0">
-        {# Render root articles in a special "uncategorized" category #}
+        {# Render root articles in a special "uncategorized" pseudo-category. #}
+        {# The pseudo-category itself is never draggable (id=0), but its articles can be. #}
         {% if tree.articles|length %}
-            {{ macros.render_category({
-                title: __("Uncategorized"),
-                illustration: "",
-                articles: tree.articles,
-                categories: [],
-            }) }}
+            <li
+                class="node"
+                data-glpi-kb-aside-category
+                data-glpi-kb-aside-category-id="0"
+                data-glpi-kb-aside-category-uncategorized
+                role="group"
+                aria-label="{{ __('Uncategorized') }}"
+            >
+                <div
+                    class="d-flex align-items-center mb-2 kb-aside-row"
+                    data-glpi-kb-aside-category-title
+                >
+                    <button
+                        type="button"
+                        class="d-flex align-items-center p-0 flex-grow-1 text-start border-0 bg-transparent"
+                        draggable="false"
+                        data-glpi-kb-aside-category-toggle
+                        aria-label="{{ __('Uncategorized') }}"
+                        aria-expanded="true"
+                    >
+                        <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
+                        {{ render_illustration('kb-faq', 20) }}
+                        <span class="ms-2 fw-bold text-truncate d-block">{{ __('Uncategorized') }}</span>
+                    </button>
+                </div>
+                <ul>
+                    {% for article in tree.articles %}
+                        {{ macros.render_article(article, false, null, can_reorder_articles ?? false) }}
+                    {% endfor %}
+                </ul>
+            </li>
         {% endif %}
 
-        {# Render each categories #}
+        {# Render each top-level category. #}
         {% for category in tree.categories %}
-            {{ macros.render_category(category) }}
+            {{ macros.render_category(
+                category,
+                can_reorder_articles ?? false,
+                can_reorder_categories ?? false,
+            ) }}
         {% endfor %}
     </ul>
     <p class="text-muted" data-glpi-kb-aside-no-results hidden>

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -119,6 +119,10 @@
     {% for category in node.categories %}
         {{ macros.render_category(category, draggable_articles, draggable_categories) }}
     {% endfor %}
+    {# Empty-state keeps a drop target (and minimum height) in empty categories. #}
+    {% if node.articles is empty and node.categories is empty %}
+        <li class="kb-aside-empty" aria-hidden="true">{{ __('No articles') }}</li>
+    {% endif %}
 {% endmacro %}
 
 {% import _self as macros %}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -92,6 +92,15 @@ export class KnowbaseItemPage extends GlpiPage
         );
     }
 
+    public async gotoAndWait(id: number): Promise<void>
+    {
+        await this.goto(id);
+        // AsideController removes pe-none from the search input once it has
+        // attached all listeners (including drag handlers).
+        // eslint-disable-next-line playwright/no-raw-locators -- ready signal selector exposed by AsideController.js
+        await this.page.locator('[data-glpi-kb-aside-search-input]:not(.pe-none)').waitFor();
+    }
+
     public async doToggleFaqStatus(): Promise<void>
     {
         const faq_toggle = this.getButton('Add to FAQ');
@@ -355,6 +364,53 @@ export class KnowbaseItemPage extends GlpiPage
         }
 
         await name_input.press('Enter');
+    }
+
+    public getAsideCategoryById(category_id: number): Locator
+    {
+        return this.page.locator(`[data-glpi-kb-aside-category-id="${category_id}"]`);
+    }
+
+    public getAsideArticleById(article_id: number): Locator
+    {
+        return this.page.locator(`[data-glpi-kb-article-id="${article_id}"]`);
+    }
+
+    public getAsideArticleInCategoryById(category_id: number, article_title: string): Locator
+    {
+        return this.getAsideCategoryById(category_id).getByRole('link', { name: article_title });
+    }
+
+    public getAsideNestedCategoryById(parent_id: number, child_id: number): Locator
+    {
+        return this.getAsideCategoryById(parent_id).locator(
+            `[data-glpi-kb-aside-category-id="${child_id}"]`,
+        );
+    }
+
+    private getAsideCategoryTitleById(category_id: number): Locator
+    {
+        // eslint-disable-next-line playwright/no-raw-locators -- scoped child combinator on a server-rendered data attribute
+        return this.getAsideCategoryById(category_id).locator('> [data-glpi-kb-aside-category-title]');
+    }
+
+    public async doDragArticleToCategoryById(
+        article_id: number,
+        _from_category_id: number,
+        to_category_id: number,
+    ): Promise<void> {
+        await this.getAsideArticleById(article_id).dragTo(
+            this.getAsideCategoryTitleById(to_category_id),
+        );
+    }
+
+    public async doDragCategoryToCategoryById(
+        source_category_id: number,
+        target_category_id: number,
+    ): Promise<void> {
+        await this.getAsideCategoryById(source_category_id).dragTo(
+            this.getAsideCategoryTitleById(target_category_id),
+        );
     }
 }
 

--- a/tests/e2e/specs/Knowbase/kb-aside-drag.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-drag.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { KnowbaseItemPage } from '../../pages/KnowbaseItemPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test('Dragging an article onto a category title row reparents it and persists after reload', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = randomUUID().slice(0, 8);
+    const article_name = `E2E Article ${token}`;
+    const anchor_name  = `E2E Anchor ${token}`;
+
+    const from_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E From ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+    const to_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E To ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Body',
+        entities_id: getWorkerEntityId(),
+        _categories: [from_id],
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [to_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeVisible();
+    await expect(kb.getAsideArticleInCategoryById(to_id, article_name)).toBeHidden();
+
+    await kb.doDragArticleToCategoryById(article_id, from_id, to_id);
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(to_id, article_name)).toBeVisible();
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeHidden();
+});
+
+test('Dragging a category onto another category nests it and persists after reload', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = randomUUID().slice(0, 8);
+    const anchor_name = `E2E Anchor ${token}`;
+
+    const parent_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E Parent ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+    const child_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E Child ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [parent_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideCategoryById(parent_id)).toBeVisible();
+    await expect(kb.getAsideCategoryById(child_id)).toBeVisible();
+    await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toHaveCount(0);
+
+    await kb.doDragCategoryToCategoryById(child_id, parent_id);
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toBeVisible();
+});
+
+test('Dragging a category onto one of its own descendants is rejected and leaves the tree unchanged', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = randomUUID().slice(0, 8);
+    const anchor_name = `E2E Anchor ${token}`;
+
+    const parent_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E Parent ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+    const child_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E Child ${token}`,
+        entities_id: getWorkerEntityId(),
+        knowbaseitemcategories_id: parent_id,
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [parent_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+    await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toBeVisible();
+
+    await kb.doDragCategoryToCategoryById(parent_id, child_id);
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toBeVisible();
+    await expect(kb.getAsideNestedCategoryById(child_id, parent_id)).toHaveCount(0);
+});

--- a/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
@@ -188,3 +188,61 @@ test('In the move picker, a category cannot be moved into one of its descendants
     // The category itself is also disabled (it's the current selection).
     await expect(dialog.getByRole('radio', { name: parent_name })).toBeDisabled();
 });
+
+test('Moving a nested category to (Top level) makes it a root category', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token       = randomUUID().slice(0, 8);
+    const parent_name = `E2E Parent ${token}`;
+    const child_name  = `E2E Child ${token}`;
+    const anchor_name = `E2E Anchor ${token}`;
+
+    const parent_id = await api.createItem('KnowbaseItemCategory', {
+        name: parent_name,
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItemCategory', {
+        name: child_name,
+        entities_id: getWorkerEntityId(),
+        knowbaseitemcategories_id: parent_id,
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [parent_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    // The child category is nested inside the parent's group.
+    await expect(
+        page.getByRole('group', { name: parent_name })
+            .getByRole('group', { name: child_name }),
+    ).toBeVisible();
+
+    // Focus the child category's toggle so the row's :focus-within reveals the kebab.
+    await page
+        .getByRole('group', { name: child_name })
+        .getByRole('button', { name: child_name, exact: true })
+        .focus();
+    await page.getByRole('button', { name: `Move ${child_name}` }).click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('radio', { name: 'Top level' }).check();
+    await dialog.getByRole('button', { name: 'Move', exact: true }).click();
+
+    await kb.gotoAndWait(anchor_id);
+
+    // The child is still in the tree, but no longer nested under the parent.
+    await expect(page.getByRole('group', { name: child_name })).toBeVisible();
+    await expect(
+        page.getByRole('group', { name: parent_name })
+            .getByRole('group', { name: child_name }),
+    ).toHaveCount(0);
+});

--- a/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { KnowbaseItemPage } from '../../pages/KnowbaseItemPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test('Moving an article via the kebab menu reparents it and persists after reload', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const article_name = `E2E Article ${token}`;
+    const anchor_name  = `E2E Anchor ${token}`;
+    const from_name    = `E2E From ${token}`;
+    const to_name      = `E2E To ${token}`;
+
+    const from_id = await api.createItem('KnowbaseItemCategory', {
+        name: from_name,
+        entities_id: getWorkerEntityId(),
+    });
+    const to_id = await api.createItem('KnowbaseItemCategory', {
+        name: to_name,
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Body',
+        entities_id: getWorkerEntityId(),
+        _categories: [from_id],
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [to_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeVisible();
+    await expect(kb.getAsideArticleInCategoryById(to_id, article_name)).toBeHidden();
+
+    // Hover the row so the kebab button becomes visible, then click it.
+    await kb.getAsideArticleInCategoryById(from_id, article_name).hover();
+    await page.getByRole('button', { name: `Move ${article_name}` }).click();
+
+    // Pick the target category in the modal and submit.
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('radio', { name: to_name }).check();
+    await dialog.getByRole('button', { name: 'Move', exact: true }).click();
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(to_id, article_name)).toBeVisible();
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeHidden();
+});
+
+test('Moving an article to (Uncategorized) makes it a root article', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const article_name = `E2E Article ${token}`;
+    const anchor_name  = `E2E Anchor ${token}`;
+
+    const from_id = await api.createItem('KnowbaseItemCategory', {
+        name: `E2E From ${token}`,
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Body',
+        entities_id: getWorkerEntityId(),
+        _categories: [from_id],
+    });
+    // Anchor with no category so the page has an "Uncategorized" bucket already
+    // populated besides the moved article.
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeVisible();
+
+    await kb.getAsideArticleInCategoryById(from_id, article_name).hover();
+    await page.getByRole('button', { name: `Move ${article_name}` }).click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.getByRole('radio', { name: 'Uncategorized' }).check();
+    await dialog.getByRole('button', { name: 'Move', exact: true }).click();
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideArticleInCategoryById(0, article_name)).toBeVisible();
+    await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeHidden();
+});
+
+test('In the move picker, a category cannot be moved into one of its descendants', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token       = randomUUID().slice(0, 8);
+    const parent_name = `E2E Parent ${token}`;
+    const child_name  = `E2E Child ${token}`;
+    const anchor_name = `E2E Anchor ${token}`;
+
+    const parent_id = await api.createItem('KnowbaseItemCategory', {
+        name: parent_name,
+        entities_id: getWorkerEntityId(),
+    });
+    const child_id = await api.createItem('KnowbaseItemCategory', {
+        name: child_name,
+        entities_id: getWorkerEntityId(),
+        knowbaseitemcategories_id: parent_id,
+    });
+    const anchor_id = await api.createItem('KnowbaseItem', {
+        name: anchor_name,
+        answer: 'Anchor',
+        entities_id: getWorkerEntityId(),
+        _categories: [parent_id],
+    });
+
+    await kb.gotoAndWait(anchor_id);
+
+    await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toBeVisible();
+
+    // Hover the toggle button (which lives inside the category title row) so
+    // :hover propagates up to the row and reveals the kebab. Hovering the
+    // whole <li> would land on the children <ul> instead, leaving the title
+    // row untouched.
+    await kb
+        .getAsideCategoryById(parent_id)
+        .getByRole('button', { name: parent_name, exact: true })
+        .hover();
+    await page.getByRole('button', { name: `Move ${parent_name}` }).click();
+
+    const dialog = page.getByRole('dialog');
+
+    // The descendant category must be present but disabled (kept visible so the
+    // tree structure stays readable, but not selectable).
+    await expect(dialog.getByRole('radio', { name: child_name })).toBeDisabled();
+
+    // The category itself is also disabled (it's the current selection).
+    await expect(dialog.getByRole('radio', { name: parent_name })).toBeDisabled();
+});

--- a/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-move-menu.spec.ts
@@ -76,8 +76,8 @@ test('Moving an article via the kebab menu reparents it and persists after reloa
     await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeVisible();
     await expect(kb.getAsideArticleInCategoryById(to_id, article_name)).toBeHidden();
 
-    // Hover the row so the kebab button becomes visible, then click it.
-    await kb.getAsideArticleInCategoryById(from_id, article_name).hover();
+    // Focus the article link so the row's :focus-within reveals the kebab, then click it.
+    await kb.getAsideArticleInCategoryById(from_id, article_name).focus();
     await page.getByRole('button', { name: `Move ${article_name}` }).click();
 
     // Pick the target category in the modal and submit.
@@ -125,7 +125,7 @@ test('Moving an article to (Uncategorized) makes it a root article', async ({
 
     await expect(kb.getAsideArticleInCategoryById(from_id, article_name)).toBeVisible();
 
-    await kb.getAsideArticleInCategoryById(from_id, article_name).hover();
+    await kb.getAsideArticleInCategoryById(from_id, article_name).focus();
     await page.getByRole('button', { name: `Move ${article_name}` }).click();
 
     const dialog = page.getByRole('dialog');
@@ -171,14 +171,12 @@ test('In the move picker, a category cannot be moved into one of its descendants
 
     await expect(kb.getAsideNestedCategoryById(parent_id, child_id)).toBeVisible();
 
-    // Hover the toggle button (which lives inside the category title row) so
-    // :hover propagates up to the row and reveals the kebab. Hovering the
-    // whole <li> would land on the children <ul> instead, leaving the title
-    // row untouched.
+    // Focus the toggle button (inside the category title row) so the row's
+    // :focus-within reveals the kebab.
     await kb
         .getAsideCategoryById(parent_id)
         .getByRole('button', { name: parent_name, exact: true })
-        .hover();
+        .focus();
     await page.getByRole('button', { name: `Move ${parent_name}` }).click();
 
     const dialog = page.getByRole('dialog');

--- a/tests/functional/Glpi/Controller/Knowbase/ReparentNodeControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/ReparentNodeControllerTest.php
@@ -1,0 +1,481 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\Knowbase;
+
+use Glpi\Controller\Knowbase\ReparentNodeController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Plugin\Hooks;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+use KnowbaseItem_KnowbaseItemCategory;
+use KnowbaseItemCategory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ReparentNodeControllerTest extends DbTestCase
+{
+    private function callController(array $payload): Response
+    {
+        $controller = new ReparentNodeController();
+        $request = new Request(content: json_encode($payload));
+        return $controller->__invoke($request);
+    }
+
+    private function makeCategory(string $name, int $parent_id = 0): KnowbaseItemCategory
+    {
+        return $this->createItem(KnowbaseItemCategory::class, [
+            'name'                      => $name,
+            'knowbaseitemcategories_id' => $parent_id,
+            'entities_id'               => $this->getTestRootEntity(only_id: true),
+            'is_recursive'              => 1,
+        ]);
+    }
+
+    /**
+     * @param int[] $category_ids
+     */
+    private function makeArticle(string $name, array $category_ids = []): KnowbaseItem
+    {
+        return $this->createItem(KnowbaseItem::class, [
+            'name'        => $name,
+            'answer'      => '<p>Content</p>',
+            '_categories' => $category_ids,
+        ]);
+    }
+
+    private function hasJunction(int $article_id, int $category_id): bool
+    {
+        $junction = new KnowbaseItem_KnowbaseItemCategory();
+        return $junction->getFromDBByCrit([
+            'knowbaseitems_id'          => $article_id,
+            'knowbaseitemcategories_id' => $category_id,
+        ]);
+    }
+
+    public function testMoveArticleBetweenCategories(): void
+    {
+        $this->login();
+        $cat_from = $this->makeCategory('From');
+        $cat_to   = $this->makeCategory('To');
+        $article  = $this->makeArticle('A', [$cat_from->getID()]);
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_from->getID(),
+            'to_parent_id'   => $cat_to->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_from->getID()));
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_to->getID()));
+    }
+
+    public function testMoveArticleFromUncategorizedToCategory(): void
+    {
+        $this->login();
+        $cat_to  = $this->makeCategory('To');
+        $article = $this->makeArticle('A');
+
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_to->getID()));
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => $cat_to->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_to->getID()));
+    }
+
+    public function testMoveArticleToUncategorizedRemovesLink(): void
+    {
+        $this->login();
+        $cat_from = $this->makeCategory('From');
+        $article  = $this->makeArticle('A', [$cat_from->getID()]);
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_from->getID(),
+            'to_parent_id'   => 0,
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_from->getID()));
+    }
+
+    public function testMoveArticleOnlyAffectsOriginCategoryWhenInMultipleCategories(): void
+    {
+        $this->login();
+        $cat_a = $this->makeCategory('A');
+        $cat_b = $this->makeCategory('B');
+        $cat_c = $this->makeCategory('C');
+        $article = $this->makeArticle('Multi', [$cat_a->getID(), $cat_b->getID()]);
+
+        // Drag the (article, A) occurrence into C.
+        // The link to B must remain untouched.
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_a->getID(),
+            'to_parent_id'   => $cat_c->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_a->getID()));
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_b->getID()));
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_c->getID()));
+    }
+
+    public function testMoveArticleToCategoryItIsAlreadyInOnlyRemovesOrigin(): void
+    {
+        $this->login();
+        $cat_a = $this->makeCategory('A');
+        $cat_b = $this->makeCategory('B');
+        $article = $this->makeArticle('Multi', [$cat_a->getID(), $cat_b->getID()]);
+
+        // Drop the (article, A) occurrence on B (where the article already lives).
+        // Result: A link removed, B link still single (no duplicate row).
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_a->getID(),
+            'to_parent_id'   => $cat_b->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_a->getID()));
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_b->getID()));
+
+        global $DB;
+        $count = count($DB->request([
+            'FROM'  => KnowbaseItem_KnowbaseItemCategory::getTable(),
+            'WHERE' => [
+                'knowbaseitems_id'          => $article->getID(),
+                'knowbaseitemcategories_id' => $cat_b->getID(),
+            ],
+        ]));
+        $this->assertSame(1, $count);
+    }
+
+    public function testMoveCategoryToNewParent(): void
+    {
+        $this->login();
+        $parent = $this->makeCategory('Parent');
+        $child  = $this->makeCategory('Child');
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItemCategory::class,
+            'items_id'       => $child->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => $parent->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $reloaded = new KnowbaseItemCategory();
+        $reloaded->getFromDB($child->getID());
+        $this->assertSame($parent->getID(), (int) $reloaded->fields['knowbaseitemcategories_id']);
+    }
+
+    public function testMoveCategoryToRootSetsParentToZero(): void
+    {
+        $this->login();
+        $parent = $this->makeCategory('Parent');
+        $child  = $this->makeCategory('Child', $parent->getID());
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItemCategory::class,
+            'items_id'       => $child->getID(),
+            'from_parent_id' => $parent->getID(),
+            'to_parent_id'   => 0,
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $reloaded = new KnowbaseItemCategory();
+        $reloaded->getFromDB($child->getID());
+        $this->assertSame(0, (int) $reloaded->fields['knowbaseitemcategories_id']);
+    }
+
+    public function testMoveCategoryIntoOwnDescendantReturnsConflict(): void
+    {
+        $this->login();
+        $parent = $this->makeCategory('Parent');
+        $child  = $this->makeCategory('Child', $parent->getID());
+
+        // Attempt to move Parent under Child — would create a cycle.
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItemCategory::class,
+            'items_id'       => $parent->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => $child->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+
+        // Verify the parent was not moved.
+        $reloaded = new KnowbaseItemCategory();
+        $reloaded->getFromDB($parent->getID());
+        $this->assertSame(0, (int) $reloaded->fields['knowbaseitemcategories_id']);
+    }
+
+    public function testMoveCategoryIntoItselfIsRejected(): void
+    {
+        $this->login();
+        $category = $this->makeCategory('Self');
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController([
+            'itemtype'       => KnowbaseItemCategory::class,
+            'items_id'       => $category->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => $category->getID(),
+        ]);
+    }
+
+    public function testInvalidItemtypeIsRejected(): void
+    {
+        $this->login();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController([
+            'itemtype'       => 'NotARealClass',
+            'items_id'       => 1,
+            'from_parent_id' => 0,
+            'to_parent_id'   => 0,
+        ]);
+    }
+
+    public function testMissingKeysAreRejected(): void
+    {
+        $this->login();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController([
+            'itemtype' => KnowbaseItem::class,
+            'items_id' => 1,
+        ]);
+    }
+
+    public function testInvalidJsonIsRejected(): void
+    {
+        $this->login();
+
+        $controller = new ReparentNodeController();
+        $request = new Request(content: 'not json');
+
+        $this->expectException(BadRequestHttpException::class);
+        $controller->__invoke($request);
+    }
+
+    public function testUnknownTargetCategoryReturnsNotFound(): void
+    {
+        $this->login();
+        $article = $this->makeArticle('A');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => 99999,
+        ]);
+    }
+
+    public function testUnauthorizedUserCannotMoveArticle(): void
+    {
+        // Set up data as a privileged user.
+        $this->login();
+        $cat_from = $this->makeCategory('From');
+        $cat_to   = $this->makeCategory('To');
+        $article  = $this->makeArticle('A', [$cat_from->getID()]);
+
+        // Re-authenticate as a low-privilege user.
+        $this->login('normal', 'normal');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_from->getID(),
+            'to_parent_id'   => $cat_to->getID(),
+        ]);
+    }
+
+    public function testUnauthorizedUserCannotMoveCategory(): void
+    {
+        $this->login();
+        $parent = $this->makeCategory('Parent');
+        $child  = $this->makeCategory('Child');
+
+        $this->login('normal', 'normal');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->callController([
+            'itemtype'       => KnowbaseItemCategory::class,
+            'items_id'       => $child->getID(),
+            'from_parent_id' => 0,
+            'to_parent_id'   => $parent->getID(),
+        ]);
+    }
+
+    public function testNoOpDropOnSameCategoryReturnsSuccess(): void
+    {
+        $this->login();
+        $cat = $this->makeCategory('Same');
+        $article = $this->makeArticle('A', [$cat->getID()]);
+
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat->getID(),
+            'to_parent_id'   => $cat->getID(),
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertTrue($this->hasJunction($article->getID(), $cat->getID()));
+    }
+
+    public function testMoveArticleFromMultiCategoryToUncategorizedKeepsOtherCategories(): void
+    {
+        $this->login();
+        $cat_a = $this->makeCategory('Multi A');
+        $cat_b = $this->makeCategory('Multi B');
+        $article = $this->makeArticle('Multi', [$cat_a->getID(), $cat_b->getID()]);
+
+        // Drag the (article, A) occurrence to the synthetic "Uncategorized" bucket.
+        // The link to A must be removed; the link to B must remain.
+        $response = $this->callController([
+            'itemtype'       => KnowbaseItem::class,
+            'items_id'       => $article->getID(),
+            'from_parent_id' => $cat_a->getID(),
+            'to_parent_id'   => 0,
+        ]);
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertFalse($this->hasJunction($article->getID(), $cat_a->getID()));
+        $this->assertTrue($this->hasJunction($article->getID(), $cat_b->getID()));
+    }
+
+    public function testMoveArticleFiresKnowbaseItemUpdateHook(): void
+    {
+        global $PLUGIN_HOOKS;
+
+        $this->login();
+        $cat_from = $this->makeCategory('Hook From');
+        $cat_to   = $this->makeCategory('Hook To');
+        $article  = $this->makeArticle('Hook A', [$cat_from->getID()]);
+
+        // Register a spy on the unconditional CommonDBTM::update() hook to assert
+        // that the article reparent goes through $article->update() (rather than
+        // direct junction manipulation, which would bypass this hook).
+        // Uses the always-active "tester" plugin slot (see GLPITestCase::126-128).
+        $captured_ids = [];
+        $previous = $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tester'][KnowbaseItem::class] ?? null;
+        $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tester'][KnowbaseItem::class] = static function ($item) use (&$captured_ids) {
+            if ($item instanceof KnowbaseItem) {
+                $captured_ids[] = $item->getID();
+            }
+        };
+
+        try {
+            $response = $this->callController([
+                'itemtype'       => KnowbaseItem::class,
+                'items_id'       => $article->getID(),
+                'from_parent_id' => $cat_from->getID(),
+                'to_parent_id'   => $cat_to->getID(),
+            ]);
+        } finally {
+            if ($previous === null) {
+                unset($PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tester'][KnowbaseItem::class]);
+            } else {
+                $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tester'][KnowbaseItem::class] = $previous;
+            }
+        }
+
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertContains($article->getID(), $captured_ids);
+    }
+
+    public function testMoveArticleReturnsConflictWhenJunctionMutationFails(): void
+    {
+        global $PLUGIN_HOOKS;
+
+        $this->login();
+        $cat_from = $this->makeCategory('Fail From');
+        $cat_to   = $this->makeCategory('Fail To');
+        $article  = $this->makeArticle('Fail A', [$cat_from->getID()]);
+
+        // Veto every junction add() so update1NTableData warns but continues,
+        // simulating a constraint violation / plugin veto on add. Without the
+        // post-update verification, $article->update() returns true and the
+        // controller would silently report 204 to the client.
+        $previous = $PLUGIN_HOOKS[Hooks::PRE_ITEM_ADD]['tester'][KnowbaseItem_KnowbaseItemCategory::class] ?? null;
+        $PLUGIN_HOOKS[Hooks::PRE_ITEM_ADD]['tester'][KnowbaseItem_KnowbaseItemCategory::class] = static function ($item) {
+            $item->input = false;
+        };
+
+        try {
+            // E_USER_WARNING raised by update1NTableData on the vetoed add() must
+            // not bubble up as a PHPUnit failure for this scenario.
+            set_error_handler(static fn() => true, E_USER_WARNING);
+
+            try {
+                $response = $this->callController([
+                    'itemtype'       => KnowbaseItem::class,
+                    'items_id'       => $article->getID(),
+                    'from_parent_id' => $cat_from->getID(),
+                    'to_parent_id'   => $cat_to->getID(),
+                ]);
+
+                $this->assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+            } finally {
+                restore_error_handler();
+            }
+        } finally {
+            if ($previous === null) {
+                unset($PLUGIN_HOOKS[Hooks::PRE_ITEM_ADD]['tester'][KnowbaseItem_KnowbaseItemCategory::class]);
+            } else {
+                $PLUGIN_HOOKS[Hooks::PRE_ITEM_ADD]['tester'][KnowbaseItem_KnowbaseItemCategory::class] = $previous;
+            }
+        }
+    }
+}


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/276
- Here is a brief description of what this PR does : Drag to reorder categories and articles.

Note : html5sortable is built for flat-list reorder, which fits its other usages in GLPI but not the KB aside : that one is reparent-only, and making the library work here required disambiguation hacks, silent same-parent no-ops, and a drag-handle workaround :  combined, they produced erratic UX.

_Two post-review fixes : a silent revert after server rejection (the article stayed in the wrong category) and missing entity scoping on categories (the aside listed cross-entity categories, and the reparent endpoint accepted them as drop targets)._


## Screenshots :

<img width="373" height="432" alt="image" src="https://github.com/user-attachments/assets/0e30927a-2860-46b3-bde5-9cb632a457e6" />

