### PR TITLE
fix/ preserve task state when editing existing planning

### DIFF
--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -265,9 +265,11 @@
                 ) }}
 
                 <script type="text/javascript">
-                    function showPlanUpdate{{ rand }}(e) {
+                    function showPlanUpdate{{ rand }}(applyDefaultState = false) {
                         $('#plan{{ rand }}').hide();
-                        $('#dropdown_state{{ rand }}').trigger('setValue', {{ session('glpiplanned_task_state')|json_encode|raw }});
+                        if (applyDefaultState) {
+                            $('#dropdown_state{{ rand }}').trigger('setValue', {{ session('glpiplanned_task_state')|json_encode|raw }});
+                        }
                         $('#viewplan{{ rand }}').load(`${CFG_GLPI.root_doc}/ajax/planning.php`, {
                             action: "add_event_classic_form",
                             form: "followups", // Was followups for tasks before. Can't find where this is used.
@@ -295,7 +297,7 @@
                         <span>{{ __('Unplan') }}</span>
                     </button>
                 {% elseif item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) or constant('CommonITILObject::PLANNED') not in item.getAllStatusArray() %}
-                    <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}()" type="button">
+                    <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}(true)" type="button">
                         <i class="ti ti-calendar"></i>
                         <span>{{ __('Plan this task') }}</span>
                     </button>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43801
- When editing a task that already has planning, the status dropdown was being incorrectly reset to the default planned state value (glpiplanned_task_state from session).

  This happened because showPlanUpdate() was called automatically on page load to display the existing planning form, and it unconditionally triggered setValue on the status dropdown — overwriting the actual saved status.

  Tasks without planning were unaffected since showPlanUpdate() was never called automatically for them.
  
## Screenshots (if appropriate):

<img width="364" height="372" alt="image" src="https://github.com/user-attachments/assets/e1c57f8c-e51a-48bc-b5b1-69af8343668f" />


