### PR TITLE
Fix CalDAV export timezone for planning dates

### DIFF
--- a/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
+++ b/src/Glpi/CalDAV/Traits/VobjectConverterTrait.php
@@ -77,7 +77,7 @@ trait VobjectConverterTrait
      */
     protected function getVCalendarForItem(CommonDBTM $item, $component_type): VCalendar
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
 
         if (!array_key_exists($component_type, VCalendar::$componentMap)) {
             throw new InvalidArgumentException(sprintf('Invalid component type "%s"', $component_type));
@@ -113,8 +113,9 @@ trait VobjectConverterTrait
             $vcomp = $vcalendar->add($component_type);
         }
 
-        $fields = $item->fields;
-        $utc_tz = new DateTimeZone('UTC');
+        $fields  = $item->fields;
+        $utc_tz  = new DateTimeZone('UTC');
+        $user_tz = new DateTimeZone($DB->guessTimezone());
 
         if (array_key_exists('uuid', $fields)) {
             $vcomp->UID = $fields['uuid'];
@@ -149,11 +150,14 @@ trait VobjectConverterTrait
         $vcomp->URL = $CFG_GLPI['url_base'] . $this->getFormURLWithID($fields['id'], false);
 
         if (array_key_exists('begin', $fields) && !empty($fields['begin'])) {
-            $vcomp->DTSTART = (new SafeDateTime($fields['begin']))->setTimeZone($utc_tz);
+            // Planning dates are stored as local wall-times in the GLPI/user timezone.
+            // Export them with an explicit TZID instead of converting them to UTC,
+            // otherwise CalDAV clients may shift events by the local UTC offset.
+            $vcomp->DTSTART = new SafeDateTime($fields['begin'], $user_tz);
         }
 
         if (array_key_exists('end', $fields) && !empty($fields['end'])) {
-            $end_date = (new SafeDateTime($fields['end']))->setTimeZone($utc_tz);
+            $end_date = new SafeDateTime($fields['end'], $user_tz);
             if ('VTODO' === $component_type) {
                 $vcomp->DUE = $end_date;
             } else {
@@ -173,7 +177,7 @@ trait VobjectConverterTrait
                 }
                 if (array_key_exists('exceptions', $rrule_specs) && $vcomp instanceof Component) {
                     foreach ($rrule_specs['exceptions'] as $exdate) {
-                        $vcomp->add('EXDATE', (new SafeDateTime($exdate))->setTimeZone($utc_tz));
+                        $vcomp->add('EXDATE', new SafeDateTime($exdate, $user_tz));
                     }
                     unset($rrule_specs['exceptions']);
                 }


### PR DESCRIPTION
## Summary

This changes the CalDAV export for planning dates so GLPI local/user wall-times are emitted with the GLPI/user timezone instead of being converted to UTC.

The affected fields are:

- `DTSTART`
- `DTEND` / `DUE`
- recurrence `EXDATE`

## Problem

The current export converts planning dates to UTC with `setTimeZone($utc_tz)`. For dates stored as GLPI/user local wall-times, this can make CalDAV clients such as Outlook display events shifted by the local UTC offset.

## Change

Use `$DB->guessTimezone()` to build a timezone-aware `SafeDateTime` directly from the stored planning date values. This keeps the intended local wall-time and exports an explicit timezone instead of shifting the event to UTC.

Fixes #24219.

## Testing

- Not run locally: PHP CLI is not installed in this environment.
- The patch has been tested manually in a GLPI 11 setup with timezone `Europe/Brussels` and Outlook CalDAV consumption, where it prevents the observed time shift.
