### PR TITLE
perf(search): prevent N x M cartesian product on User ticket counts

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -3727,57 +3727,43 @@ HTML;
 
         $tab[] = [
             'id'                 => '60',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of tickets as requester'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => 'glpi_tickets_users',
-                    'joinparams'         => [
-                        'jointype'           => 'child',
-                        'condition'          => ['NEWTABLE.type' => CommonITILActor::REQUESTER],
-                    ],
-                ],
-            ],
+            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
+                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
+                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::REQUESTER . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [
             'id'                 => '61',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of written tickets'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child',
-                'linkfield'          => 'users_id_recipient',
-            ],
+            'computation'        => '(SELECT COUNT(' . DBmysql::quoteName('t.id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets') . ' AS ' . DBmysql::quoteName('t') . ' 
+                                      WHERE ' . DBmysql::quoteName('t.users_id_recipient') . ' = ' . DBmysql::quoteName('TABLE.id') . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [
             'id'                 => '64',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of assigned tickets'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => 'glpi_tickets_users',
-                    'joinparams'         => [
-                        'jointype'           => 'child',
-                        'condition'          => ['NEWTABLE.type' => CommonITILActor::ASSIGN],
-                    ],
-                ],
-            ],
+            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
+                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
+                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::ASSIGN . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [


### PR DESCRIPTION
### 1. General information
* [ ] Bug fix
* [ ] New feature and improvement
* [x] Performance optimization
* [ ] Refactoring
* [ ] Documentation

### 2. Context
In large databases, displaying the Search Options `60` (Number of tickets as requester), `61` (Number of written tickets), and `64` (Number of assigned tickets) in the `User` itemtype routinely causes severe query delays (often exceeding 8-minute timeouts). 

This bottleneck occurs because multiple simultaneous `LEFT JOIN` operations via the `joinparams` configuration trigger a massive N x M cartesian product during the `SELECT` phase, which exhausts database memory before the `GROUP BY` clause can even be applied.

### 3. Solution
This PR replaces the implicit joins (`joinparams` + `forcegroupby` + `usehaving`) with explicit, correlated scalar subqueries utilizing the `computation` key. 

**Technical adjustments:**
- Implemented subqueries targeting `glpi_tickets_users` indices directly for highly efficient row-level evaluation.
- Altered the `datatype` from `count` to `number` to prevent the `Search` engine from wrapping the computation in a redundant `COUNT(DISTINCT ...)` which would incorrectly evaluate the ticket total to `1`.
- Added `'nosort' => true` to protect the database from attempting to order by a computed subquery over the entire user table (which causes massive temporary table creation and optimizer hangs).

This optimization reduces query evaluation times for the User list view from minutes to under ~2 seconds in high-volume instances.
