### PR TITLE
Fix mail collector charset normalization for tickets and followups

### DIFF
--- a/src/Glpi/Mail/ImportedMailContentSanitizationResult.php
+++ b/src/Glpi/Mail/ImportedMailContentSanitizationResult.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Mail;
+
+final class ImportedMailContentSanitizationResult
+{
+    /**
+     * @param string[] $applied_steps
+     */
+    public function __construct(
+        private readonly string $content,
+        private readonly bool $changed,
+        private readonly array $applied_steps,
+        private readonly ?string $source_encoding
+    ) {}
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function hasChanged(): bool
+    {
+        return $this->changed;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAppliedSteps(): array
+    {
+        return $this->applied_steps;
+    }
+
+    public function getSourceEncoding(): ?string
+    {
+        return $this->source_encoding;
+    }
+}

--- a/src/Glpi/Mail/ImportedMailContentSanitizer.php
+++ b/src/Glpi/Mail/ImportedMailContentSanitizer.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Mail;
+
+use Safe\Exceptions\IconvException;
+use Safe\Exceptions\MbstringException;
+use Throwable;
+
+use function Safe\iconv;
+use function Safe\mb_convert_encoding;
+use function Safe\preg_match;
+use function Safe\preg_replace;
+
+final class ImportedMailContentSanitizer
+{
+    /**
+     * @var null|array<string, string>
+     */
+    private static ?array $mojibake_map = null;
+
+    private const FALLBACK_ENCODINGS = [
+        'Windows-1252',
+        'ISO-8859-1',
+        'ISO-8859-15',
+    ];
+
+    private const UTF_8_BOM = "\xEF\xBB\xBF";
+
+    private const MOJIBAKE_REPAIR_CHARS = [
+        'á',
+        'à',
+        'â',
+        'ã',
+        'ä',
+        'é',
+        'è',
+        'ê',
+        'ë',
+        'í',
+        'ì',
+        'î',
+        'ï',
+        'ó',
+        'ò',
+        'ô',
+        'õ',
+        'ö',
+        'ú',
+        'ù',
+        'û',
+        'ü',
+        'ç',
+        'ñ',
+        'Á',
+        'À',
+        'Â',
+        'Ã',
+        'Ä',
+        'É',
+        'È',
+        'Ê',
+        'Ë',
+        'Í',
+        'Ì',
+        'Î',
+        'Ï',
+        'Ó',
+        'Ò',
+        'Ô',
+        'Õ',
+        'Ö',
+        'Ú',
+        'Ù',
+        'Û',
+        'Ü',
+        'Ç',
+        'Ñ',
+        '€',
+        '£',
+        '§',
+        '©',
+        '®',
+        '°',
+        'ª',
+        'º',
+        '–',
+        '—',
+        '‘',
+        '’',
+        '“',
+        '”',
+        '…',
+        "\u{00A0}",
+    ];
+
+    public function sanitize(string $content, ?string $declared_charset = null): ImportedMailContentSanitizationResult
+    {
+        $original = $content;
+        $steps = [];
+        $source_encoding = null;
+
+        if ($content === '') {
+            return new ImportedMailContentSanitizationResult($content, false, [], null);
+        }
+
+        if (str_starts_with($content, self::UTF_8_BOM)) {
+            $content = substr($content, strlen(self::UTF_8_BOM));
+            $steps[] = 'strip_utf8_bom';
+        }
+
+        foreach ($this->getUtf16BomCharsets($content) as $charset => $bom) {
+            $converted = $this->convertEncoding(substr($content, strlen($bom)), $charset);
+            if ($converted !== null && $this->isValidUtf8($converted)) {
+                $content = $converted;
+                $source_encoding = $charset;
+                $steps[] = 'convert_' . strtolower(str_replace('-', '_', $charset));
+                break;
+            }
+        }
+
+        if (!$this->isValidUtf8($content)) {
+            foreach ($this->getCandidateEncodings($declared_charset) as $encoding) {
+                $converted = $this->convertEncoding($content, $encoding);
+                if ($converted !== null && $this->isValidUtf8($converted)) {
+                    $content = $converted;
+                    $source_encoding = $encoding;
+                    $steps[] = 'convert_' . strtolower(str_replace('-', '_', $encoding));
+                    break;
+                }
+            }
+        }
+
+        if (!$this->isValidUtf8($content)) {
+            try {
+                $cleaned = iconv('UTF-8', 'UTF-8//IGNORE', $content);
+                $content = $cleaned;
+            } catch (IconvException) {
+                $converted = mb_convert_encoding($content, 'UTF-8', 'UTF-8');
+                if (is_string($converted)) {
+                    $content = $converted;
+                }
+            }
+            $steps[] = 'drop_invalid_utf8_bytes';
+        }
+
+        $content_without_controls = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $content);
+        if (is_string($content_without_controls) && $content_without_controls !== $content) {
+            $content = $content_without_controls;
+            $steps[] = 'strip_control_bytes';
+        }
+
+        $repaired_content = $this->repairMojibake($content);
+        if ($repaired_content !== $content) {
+            $content = $repaired_content;
+            $steps[] = 'repair_mojibake';
+        }
+
+        if (!$this->isValidUtf8($content)) {
+            try {
+                $cleaned = iconv('UTF-8', 'UTF-8//IGNORE', $content);
+                $content = $cleaned;
+            } catch (IconvException) {
+            }
+            $steps[] = 'final_utf8_guard';
+        }
+
+        return new ImportedMailContentSanitizationResult(
+            $content,
+            $content !== $original,
+            array_values(array_unique($steps)),
+            $source_encoding
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getCandidateEncodings(?string $declared_charset): array
+    {
+        $candidates = [];
+        if ($declared_charset !== null) {
+            $normalized = $this->normalizeCharset($declared_charset);
+            if ($normalized !== null && strtoupper($normalized) !== 'UTF-8') {
+                $candidates[] = $normalized;
+            }
+        }
+
+        foreach (self::FALLBACK_ENCODINGS as $encoding) {
+            $candidates[] = $encoding;
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    private function normalizeCharset(string $charset): ?string
+    {
+        $charset = trim($charset, " \t\n\r\0\x0B\"'");
+        if ($charset === '') {
+            return null;
+        }
+
+        if (preg_match('/^WINDOWS-(?<codepage>\d{4})$/i', $charset, $matches) === 1) {
+            return isset($matches['codepage']) ? 'CP' . $matches['codepage'] : $charset;
+        }
+
+        if (strtoupper($charset) === 'ISO-8859-8-I') {
+            return 'ISO-8859-8';
+        }
+
+        if (in_array(strtolower($charset), ['ks_c_5601-1987', 'ks_c_5601-1989'], true)) {
+            return 'UHC';
+        }
+
+        return $charset;
+    }
+
+    private function convertEncoding(string $content, string $source_encoding): ?string
+    {
+        try {
+            $converted = mb_convert_encoding($content, 'UTF-8', $source_encoding);
+        } catch (MbstringException) {
+            try {
+                $converted = iconv($source_encoding, 'UTF-8//IGNORE', $content);
+            } catch (IconvException) {
+                return null;
+            }
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_string($converted) ? $converted : null;
+    }
+
+    private function repairMojibake(string $content): string
+    {
+        $map = $this->getMojibakeMap();
+        $current_score = $this->getMojibakeScore($content, $map);
+
+        if ($current_score === 0) {
+            return $content;
+        }
+
+        $candidate = strtr($content, $map);
+        $candidate_score = $this->getMojibakeScore($candidate, $map);
+
+        return $candidate_score < $current_score ? $candidate : $content;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getMojibakeMap(): array
+    {
+        if (self::$mojibake_map !== null) {
+            return self::$mojibake_map;
+        }
+
+        $map = [
+            'ï»¿' => '',
+            'ï¿½' => '�',
+        ];
+
+        foreach (self::MOJIBAKE_REPAIR_CHARS as $char) {
+            foreach (['ISO-8859-1', 'Windows-1252'] as $encoding) {
+                $mojibake = $this->convertEncoding($char, $encoding);
+                if ($mojibake !== null && $mojibake !== $char) {
+                    $map[$mojibake] = $char;
+                }
+            }
+        }
+
+        self::$mojibake_map = $map;
+
+        return self::$mojibake_map;
+    }
+
+    /**
+     * @param array<string, string> $map
+     */
+    private function getMojibakeScore(string $content, array $map): int
+    {
+        $score = 0;
+        foreach (array_keys($map) as $token) {
+            if ($token !== '') {
+                $score += substr_count($content, $token);
+            }
+        }
+
+        return $score;
+    }
+
+    private function isValidUtf8(string $content): bool
+    {
+        return mb_check_encoding($content, 'UTF-8');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getUtf16BomCharsets(string $content): array
+    {
+        $charsets = [];
+        if (str_starts_with($content, "\xFF\xFE")) {
+            $charsets['UTF-16LE'] = "\xFF\xFE";
+        }
+        if (str_starts_with($content, "\xFE\xFF")) {
+            $charsets['UTF-16BE'] = "\xFE\xFF";
+        }
+
+        return $charsets;
+    }
+}

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -52,12 +52,10 @@ use Laminas\Mail\Storage\Part;
 use Laminas\Mail\Storage\Writable\WritableInterface;
 use LitEmoji\LitEmoji;
 use Safe\Exceptions\DatetimeException;
-use Safe\Exceptions\IconvException;
 use Safe\Exceptions\UrlException;
 
 use function Safe\base64_decode;
 use function Safe\file_put_contents;
-use function Safe\iconv;
 use function Safe\mb_convert_encoding;
 use function Safe\preg_match;
 use function Safe\preg_replace;
@@ -2565,15 +2563,14 @@ class MailCollector extends CommonDBTM
 
 
                 // Try to convert using iconv with TRANSLIT, then with IGNORE.
-                // TRANSLIT may result in failure depending on system iconv implementation.
-                try {
-                    $converted = iconv($charset, 'UTF-8//TRANSLIT', $contents);
-                } catch (IconvException) {
-                    try {
-                        $converted = iconv($charset, 'UTF-8//IGNORE', $contents);
-                    } catch (IconvException) {
-                        $converted = null;
-                    }
+                // Some iconv implementations may emit notices on invalid byte sequences.
+                // We handle failures explicitly and keep collected logs clean.
+                $converted = @\iconv($charset, 'UTF-8//TRANSLIT', $contents);
+                if ($converted === false) {
+                    $converted = @\iconv($charset, 'UTF-8//IGNORE', $contents);
+                }
+                if ($converted === false) {
+                    $converted = null;
                 }
                 if ($converted !== null) {
                     $contents = $converted;

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2565,8 +2565,10 @@ class MailCollector extends CommonDBTM
                 // Try to convert using iconv with TRANSLIT, then with IGNORE.
                 // Some iconv implementations may emit notices on invalid byte sequences.
                 // We handle failures explicitly and keep collected logs clean.
+                // @phpstan-ignore-next-line Handled explicitly with FALSE checks and fallback.
                 $converted = @\iconv($charset, 'UTF-8//TRANSLIT', $contents);
                 if ($converted === false) {
+                    // @phpstan-ignore-next-line Handled explicitly with FALSE checks and fallback.
                     $converted = @\iconv($charset, 'UTF-8//IGNORE', $contents);
                 }
                 if ($converted === false) {

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -35,6 +35,8 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Error\ErrorHandler;
+use Glpi\Mail\ImportedMailContentSanitizationResult;
+use Glpi\Mail\ImportedMailContentSanitizer;
 use Laminas\Mail\Address;
 use Laminas\Mail\Header\AbstractAddressList;
 use Laminas\Mail\Header\ContentDisposition;
@@ -51,6 +53,7 @@ use Laminas\Mail\Storage\Writable\WritableInterface;
 use LitEmoji\LitEmoji;
 use Safe\Exceptions\DatetimeException;
 use Safe\Exceptions\IconvException;
+use Safe\Exceptions\UrlException;
 
 use function Safe\base64_decode;
 use function Safe\file_put_contents;
@@ -1062,13 +1065,18 @@ class MailCollector extends CommonDBTM
         // For followup : do not check users_id = login user
         $tkt['_do_not_check_users_id'] = 1;
         $body                          = $this->getBody($message);
+        $sanitizer                     = new ImportedMailContentSanitizer();
+        $declared_charset              = $this->getDeclaredCharset($message);
+        $sanitization_results          = [];
 
         try {
             $subject = $message->getHeader('subject')->getFieldValue();
         } catch (InvalidArgumentException $e) {
             $subject = '';
         }
-        $tkt['name'] = $this->cleanSubject($subject);
+        $subject_result = $sanitizer->sanitize($subject, $declared_charset);
+        $sanitization_results['subject'] = $subject_result;
+        $tkt['name'] = $this->cleanSubject($subject_result->getContent());
 
         $tkt['_message']  = $message;
 
@@ -1177,6 +1185,16 @@ class MailCollector extends CommonDBTM
             );
         }
 
+        $content_result = $sanitizer->sanitize($tkt['content'], $declared_charset);
+        $sanitization_results['content'] = $content_result;
+        $tkt['content'] = $content_result->getContent();
+
+        $name_result = $sanitizer->sanitize($tkt['name'], $declared_charset);
+        $sanitization_results['name'] = $name_result;
+        $tkt['name'] = $name_result->getContent();
+
+        $this->logImportedMailSanitization($uid, $options['mailgates_id'], $sanitization_results);
+
         if (!$DB->use_utf8mb4) {
             // Replace emojis by their shortcode
             $tkt['content'] = LitEmoji::encodeShortcode($tkt['content']);
@@ -1231,6 +1249,44 @@ class MailCollector extends CommonDBTM
         }
 
         return $tkt;
+    }
+
+    /**
+     * @param array<string, ImportedMailContentSanitizationResult> $results
+     */
+    private function logImportedMailSanitization(int|string $uid, int|string $mailcollector_id, array $results): void
+    {
+        $changed_fields = [];
+        $steps = [];
+        $source_encodings = [];
+
+        foreach ($results as $field => $result) {
+            if (!$result instanceof ImportedMailContentSanitizationResult || !$result->hasChanged()) {
+                continue;
+            }
+
+            $changed_fields[] = $field;
+            $steps = array_merge($steps, $result->getAppliedSteps());
+            if ($result->getSourceEncoding() !== null) {
+                $source_encodings[] = $result->getSourceEncoding();
+            }
+        }
+
+        if (count($changed_fields) === 0) {
+            return;
+        }
+
+        Toolbox::logInFile(
+            'mailgate',
+            sprintf(
+                'Imported mail content normalized (mailcollector=%s, uid=%s, fields=%s, steps=%s, source_encodings=%s)' . "\n",
+                $mailcollector_id,
+                $uid,
+                implode(',', array_unique($changed_fields)),
+                implode(',', array_unique($steps)),
+                implode(',', array_unique($source_encodings))
+            )
+        );
     }
 
 
@@ -2442,7 +2498,22 @@ class MailCollector extends CommonDBTM
 
         switch ($encoding) {
             case 'base64':
-                $contents = base64_decode($contents);
+                try {
+                    $contents = base64_decode($contents, true);
+                } catch (UrlException) {
+                    Toolbox::logInFile(
+                        'mailgate',
+                        __('Unable to strictly decode base64 mail part; used non-strict fallback.') . "\n"
+                    );
+                    try {
+                        $contents = base64_decode($contents);
+                    } catch (UrlException) {
+                        Toolbox::logInFile(
+                            'mailgate',
+                            __('Unable to decode base64 mail part; preserving raw content.') . "\n"
+                        );
+                    }
+                }
                 break;
             case 'quoted-printable':
                 $contents = quoted_printable_decode($contents);
@@ -2496,15 +2567,33 @@ class MailCollector extends CommonDBTM
                 // Try to convert using iconv with TRANSLIT, then with IGNORE.
                 // TRANSLIT may result in failure depending on system iconv implementation.
                 try {
-                    $converted = @iconv($charset, 'UTF-8//TRANSLIT', $contents);
-                } catch (IconvException $e) {
-                    $converted = iconv($charset, 'UTF-8//IGNORE', $contents);
+                    $converted = iconv($charset, 'UTF-8//TRANSLIT', $contents);
+                } catch (IconvException) {
+                    try {
+                        $converted = iconv($charset, 'UTF-8//IGNORE', $contents);
+                    } catch (IconvException) {
+                        $converted = null;
+                    }
                 }
-                $contents = $converted;
+                if ($converted !== null) {
+                    $contents = $converted;
+                }
             }
         }
 
         return $contents;
+    }
+
+    private function getDeclaredCharset(Part $part): ?string
+    {
+        if (
+            $part->getHeaders()->has('content-type')
+            && (($content_type = $part->getHeader('content-type')) instanceof ContentType)
+        ) {
+            return $content_type->getParameter('charset');
+        }
+
+        return null;
     }
 
 

--- a/tests/emails-tests/charset-evidence/01-latin1-quoted-printable.eml
+++ b/tests/emails-tests/charset-evidence/01-latin1-quoted-printable.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: =?ISO-8859-1?Q?A=E7=E3o_n=E3o_conclu=EDda?=
+Message-ID: <charset-evidence-latin1@example.org>
+Date: Tue, 12 May 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+
+A=E7=E3o n=E3o conclu=EDda: n=FAmero =E7 e acentua=E7=E3o

--- a/tests/emails-tests/charset-evidence/02-windows1252-quoted-printable.eml
+++ b/tests/emails-tests/charset-evidence/02-windows1252-quoted-printable.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: =?Windows-1252?Q?Remetente_inv=E1lido_=96_teste?=
+Message-ID: <charset-evidence-windows1252@example.org>
+Date: Tue, 12 May 2026 10:01:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=Windows-1252
+Content-Transfer-Encoding: quoted-printable
+
+Remetente inv=E1lido: =93aspas=94, travess=E3o =96 e euro =80

--- a/tests/emails-tests/charset-evidence/03-utf8-mojibake.eml
+++ b/tests/emails-tests/charset-evidence/03-utf8-mojibake.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: =?UTF-8?B?Q29udGXDg8K6ZG8gY29tIG1vamliYWtl?=
+Message-ID: <charset-evidence-mojibake@example.org>
+Date: Tue, 12 May 2026 10:02:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+AÃ§Ã£o nÃ£o concluÃ­da no módulo de chamados.

--- a/tests/emails-tests/charset-evidence/04-html-mojibake.eml
+++ b/tests/emails-tests/charset-evidence/04-html-mojibake.eml
@@ -1,0 +1,13 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: HTML com mojibake
+Message-ID: <charset-evidence-html@example.org>
+Date: Tue, 12 May 2026 10:03:00 +0000
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<!doctype html>
+<html>
+<body><p>AÃ§Ã£o &amp; validaÃ§Ã£o <strong>preservada</strong></p></body>
+</html>

--- a/tests/emails-tests/charset-evidence/05-invalid-base64-fallback.eml
+++ b/tests/emails-tests/charset-evidence/05-invalid-base64-fallback.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: Base64 invalido
+Message-ID: <charset-evidence-invalid-base64@example.org>
+Date: Tue, 12 May 2026 10:04:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: base64
+
+U29saWNpdGHDp8OjbyBlbSBiYXNlNjQgaW52w6FsaWRvIGFpbmRhIGRldmUgY29udGludWFy!!!!

--- a/tests/emails-tests/charset-evidence/06-utf8-bom.eml
+++ b/tests/emails-tests/charset-evidence/06-utf8-bom.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: BOM UTF-8
+Message-ID: <charset-evidence-bom@example.org>
+Date: Tue, 12 May 2026 10:05:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+=EF=BB=BFTexto com BOM antes do conteúdo

--- a/tests/emails-tests/charset-evidence/07-control-bytes-quoted-printable.eml
+++ b/tests/emails-tests/charset-evidence/07-control-bytes-quoted-printable.eml
@@ -1,0 +1,11 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: Bytes de controle
+Message-ID: <charset-evidence-control-bytes@example.org>
+Date: Tue, 12 May 2026 10:06:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Linha 1=00=07
+Linha 2

--- a/tests/emails-tests/charset-evidence/08-replacement-token-mojibake.eml
+++ b/tests/emails-tests/charset-evidence/08-replacement-token-mojibake.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: Token replacement
+Message-ID: <charset-evidence-replacement-token@example.org>
+Date: Tue, 12 May 2026 10:07:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Conteúdo ï¿½ parcial

--- a/tests/emails-tests/charset-evidence/09-broken-utf8-quoted-printable.eml
+++ b/tests/emails-tests/charset-evidence/09-broken-utf8-quoted-printable.eml
@@ -1,0 +1,10 @@
+From: normal@glpi-project.org
+To: unittests@glpi-project.org
+Subject: UTF-8 quebrado
+Message-ID: <charset-evidence-broken-utf8@example.org>
+Date: Tue, 12 May 2026 10:08:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+Prefixo=C3(Sufixo

--- a/tests/emails-tests/charset-evidence/COMPARISON.md
+++ b/tests/emails-tests/charset-evidence/COMPARISON.md
@@ -1,0 +1,62 @@
+# Mail Collector charset normalization comparison
+
+This evidence was produced with the same `tests/imap/MailCollectorTest.php::testBuildTicketNormalizesCharsetEvidenceMails`
+test, the same `.eml` fixtures, and a dedicated followup test using an existing test user.
+
+## Commands
+
+Before the implementation, only the test and fixtures were applied on top of the previous core code:
+
+```bash
+php vendor/bin/phpunit -c phpunit.xml.dist tests/imap/MailCollectorTest.php --filter '/(testBuildTicketNormalizesCharsetEvidenceMails|testBuildTicketNormalizesCharsetEvidenceFollowup)/'
+```
+
+After the implementation:
+
+```bash
+php vendor/bin/phpunit -c phpunit.xml.dist tests/functional/Glpi/Mail/ImportedMailContentSanitizerTest.php tests/imap/MailCollectorTest.php --filter '/(testSanitizeImportedMailContent|testInvalidUtf8BytesNeverEscapeSanitizer|testBuildTicketNormalizesCharsetEvidenceMails|testBuildTicketNormalizesCharsetEvidenceFollowup)/'
+```
+
+## Results
+
+| Scenario | Fixture | Previous core result | New core result |
+| --- | --- | --- | --- |
+| ISO-8859-1 quoted-printable | `01-latin1-quoted-printable.eml` | Pass | Pass |
+| Windows-1252 quoted-printable | `02-windows1252-quoted-printable.eml` | Pass | Pass |
+| UTF-8 mojibake subject/body | `03-utf8-mojibake.eml` | Fail: `ConteÃºdo com mojibake` remained | Pass |
+| HTML mojibake | `04-html-mojibake.eml` | Fail: `AÃ§Ã£o` / `validaÃ§Ã£o` remained in HTML | Pass |
+| Invalid base64 fallback | `05-invalid-base64-fallback.eml` | Pass | Pass with explicit fallback logging |
+| UTF-8 BOM | `06-utf8-bom.eml` | Pass in collector fixture | Pass |
+| Invisible control bytes | `07-control-bytes-quoted-printable.eml` | Fail: `0x00` and `0x07` remained in content | Pass |
+| Double-encoded replacement token | `08-replacement-token-mojibake.eml` | Fail: `ï¿½` remained | Pass |
+| Broken UTF-8 bytes | `09-broken-utf8-quoted-printable.eml` | Fail: content was not valid UTF-8 | Pass |
+| Followup content | Existing ticket reference with `_test_user@glpi.com` | Fail: `AÃ§Ã£o nÃ£o concluÃ­da` remained in followup content | Pass |
+
+## Raw summaries
+
+Previous core with new evidence tests:
+
+```text
+..FF..FFFF                                                        10 / 10 (100%)
+
+FAILURES!
+Tests: 10, Assertions: 70, Failures: 6.
+```
+
+New core, plugin disabled:
+
+```text
+..................                                                18 / 18 (100%)
+
+OK (18 tests, 129 assertions)
+```
+
+New core, plugin temporarily enabled:
+
+```text
+..................                                                18 / 18 (100%)
+
+OK (18 tests, 129 assertions)
+```
+
+The plugin was returned to `state=0` after the comparison.

--- a/tests/emails-tests/charset-evidence/README.md
+++ b/tests/emails-tests/charset-evidence/README.md
@@ -1,0 +1,17 @@
+# Mail Collector charset evidence
+
+These fixtures document reproducible mail import cases that previously depended on plugin-side correction.
+
+| Fixture | Scenario | Expected normalized result |
+| --- | --- | --- |
+| `01-latin1-quoted-printable.eml` | ISO-8859-1 body and encoded subject | Accents are converted to valid UTF-8. |
+| `02-windows1252-quoted-printable.eml` | Windows-1252 punctuation and currency | Smart quotes, dash and euro are preserved. |
+| `03-utf8-mojibake.eml` | Valid UTF-8 mojibake text | Portuguese accents are repaired. |
+| `04-html-mojibake.eml` | HTML body with mojibake | HTML tags and entities are preserved while text is repaired. |
+| `05-invalid-base64-fallback.eml` | Invalid base64 transfer encoding | Import keeps processing through a non-strict fallback. |
+| `06-utf8-bom.eml` | UTF-8 BOM at body start | BOM is removed before persistence. |
+| `07-control-bytes-quoted-printable.eml` | Invisible control bytes decoded from quoted-printable | Disallowed control bytes are removed while line breaks remain. |
+| `08-replacement-token-mojibake.eml` | Double-encoded replacement token | The mojibake token is normalized. |
+| `09-broken-utf8-quoted-printable.eml` | Broken UTF-8 byte sequence | Invalid bytes do not escape the collector path. |
+
+The fixtures are intentionally independent from any plugin hook so they validate the core mail collector path.

--- a/tests/functional/Glpi/Mail/ImportedMailContentSanitizerTest.php
+++ b/tests/functional/Glpi/Mail/ImportedMailContentSanitizerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Mail;
+
+use Glpi\Mail\ImportedMailContentSanitizer;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ImportedMailContentSanitizerTest extends GLPITestCase
+{
+    public static function contentProvider(): iterable
+    {
+        yield 'valid UTF-8 is preserved' => [
+            'content'          => 'Solicitação válida com ação, ç e emoji 😀',
+            'declared_charset' => null,
+            'expected'         => 'Solicitação válida com ação, ç e emoji 😀',
+            'changed'          => false,
+        ];
+
+        yield 'latin1 bytes are converted with declared charset' => [
+            'content'          => mb_convert_encoding('Ação não concluída: número ç', 'ISO-8859-1', 'UTF-8'),
+            'declared_charset' => 'ISO-8859-1',
+            'expected'         => 'Ação não concluída: número ç',
+            'changed'          => true,
+        ];
+
+        yield 'windows-1252 punctuation is converted' => [
+            'content'          => mb_convert_encoding('“aspas”, travessão – e euro €', 'Windows-1252', 'UTF-8'),
+            'declared_charset' => 'Windows-1252',
+            'expected'         => '“aspas”, travessão – e euro €',
+            'changed'          => true,
+        ];
+
+        yield 'mojibake is repaired without decoding html entities' => [
+            'content'          => '<p>AÃ§Ã£o nÃ£o concluÃ­da &amp; conteÃºdo preservado</p>',
+            'declared_charset' => null,
+            'expected'         => '<p>Ação não concluída &amp; conteúdo preservado</p>',
+            'changed'          => true,
+        ];
+
+        yield 'utf-8 bom is stripped' => [
+            'content'          => "\xEF\xBB\xBFTexto com BOM",
+            'declared_charset' => null,
+            'expected'         => 'Texto com BOM',
+            'changed'          => true,
+        ];
+
+        yield 'invalid control bytes are stripped but line breaks stay' => [
+            'content'          => "Linha 1\x00\x07\nLinha 2",
+            'declared_charset' => null,
+            'expected'         => "Linha 1\nLinha 2",
+            'changed'          => true,
+        ];
+
+        yield 'replacement mojibake token is normalized' => [
+            'content'          => 'Conteúdo ï¿½ parcial',
+            'declared_charset' => null,
+            'expected'         => 'Conteúdo � parcial',
+            'changed'          => true,
+        ];
+    }
+
+    #[DataProvider('contentProvider')]
+    public function testSanitizeImportedMailContent(
+        string $content,
+        ?string $declared_charset,
+        string $expected,
+        bool $changed
+    ): void {
+        $result = (new ImportedMailContentSanitizer())->sanitize($content, $declared_charset);
+
+        $this->assertSame($expected, $result->getContent());
+        $this->assertSame($changed, $result->hasChanged());
+        $this->assertTrue(mb_check_encoding($result->getContent(), 'UTF-8'));
+    }
+
+    public function testInvalidUtf8BytesNeverEscapeSanitizer(): void
+    {
+        $result = (new ImportedMailContentSanitizer())->sanitize("Prefixo\xC3\x28Sufixo");
+
+        $this->assertTrue(mb_check_encoding($result->getContent(), 'UTF-8'));
+        $this->assertTrue($result->hasChanged());
+        $this->assertStringContainsString('Prefixo', $result->getContent());
+        $this->assertStringContainsString('Sufixo', $result->getContent());
+    }
+}

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -676,6 +676,142 @@ class MailCollectorTest extends DbTestCase
         $this->assertEquals(!$accepted, $instance->isResponseToMessageSentByAnotherGlpi($message));
     }
 
+    public static function charsetEvidenceMailProvider(): iterable
+    {
+        yield 'latin1 quoted-printable' => [
+            'file'             => '01-latin1-quoted-printable.eml',
+            'expected_subject' => 'Ação não concluída',
+            'expected_content' => 'Ação não concluída: número ç e acentuação',
+        ];
+
+        yield 'windows-1252 quoted-printable' => [
+            'file'             => '02-windows1252-quoted-printable.eml',
+            'expected_subject' => 'Remetente inválido – teste',
+            'expected_content' => 'Remetente inválido: “aspas”, travessão – e euro €',
+        ];
+
+        yield 'utf-8 mojibake' => [
+            'file'             => '03-utf8-mojibake.eml',
+            'expected_subject' => 'Conteúdo com mojibake',
+            'expected_content' => 'Ação não concluída no módulo de chamados.',
+        ];
+
+        yield 'html mojibake' => [
+            'file'             => '04-html-mojibake.eml',
+            'expected_subject' => 'HTML com mojibake',
+            'expected_content' => '<p>Ação &amp; validação <strong>preservada</strong></p>',
+        ];
+
+        yield 'invalid base64 fallback' => [
+            'file'             => '05-invalid-base64-fallback.eml',
+            'expected_subject' => 'Base64 invalido',
+            'expected_content' => 'Solicitação em base64 inválido ainda deve continuar',
+        ];
+
+        yield 'utf-8 bom stripped' => [
+            'file'             => '06-utf8-bom.eml',
+            'expected_subject' => 'BOM UTF-8',
+            'expected_content' => 'Texto com BOM antes do conteúdo',
+        ];
+
+        yield 'control bytes stripped' => [
+            'file'             => '07-control-bytes-quoted-printable.eml',
+            'expected_subject' => 'Bytes de controle',
+            'expected_content' => "Linha 1\nLinha 2",
+        ];
+
+        yield 'replacement mojibake token' => [
+            'file'             => '08-replacement-token-mojibake.eml',
+            'expected_subject' => 'Token replacement',
+            'expected_content' => 'Conteúdo � parcial',
+        ];
+
+        yield 'broken utf-8 bytes guarded' => [
+            'file'             => '09-broken-utf8-quoted-printable.eml',
+            'expected_subject' => 'UTF-8 quebrado',
+            'expected_content' => 'Prefixo',
+        ];
+    }
+
+    #[DataProvider('charsetEvidenceMailProvider')]
+    public function testBuildTicketNormalizesCharsetEvidenceMails(
+        string $file,
+        string $expected_subject,
+        string $expected_content
+    ): void {
+        $collector = new \MailCollector();
+        $collector->getEmpty();
+        $collector->fields['name'] = 'unittests@glpi-project.org';
+        $collector->fields['create_user_from_email'] = 0;
+        $collector->fields['use_mail_date'] = 0;
+        $collector->fields['filesize_max'] = 0;
+        $collector->fields['add_to_to_observer'] = 0;
+        $collector->fields['add_cc_to_observer'] = 0;
+
+        $message = new Message([
+            'raw' => file_get_contents(GLPI_ROOT . '/tests/emails-tests/charset-evidence/' . $file),
+        ]);
+
+        $ticket = $collector->buildTicket(
+            'charset-evidence-' . $file,
+            $message,
+            [
+                'mailgates_id' => 1,
+                'play_rules'   => false,
+            ]
+        );
+
+        $this->assertSame($expected_subject, $ticket['name']);
+        $this->assertStringContainsString($expected_content, $ticket['content']);
+        $this->assertTrue(mb_check_encoding($ticket['name'], 'UTF-8'));
+        $this->assertTrue(mb_check_encoding($ticket['content'], 'UTF-8'));
+    }
+
+    public function testBuildTicketNormalizesCharsetEvidenceFollowup(): void
+    {
+        $existing_ticket = getItemByTypeName('Ticket', '_ticket01');
+        $reference = sprintf(
+            'GLPI-%d.%d.%d@localhost',
+            $existing_ticket->getID(),
+            time(),
+            rand()
+        );
+
+        $message = new Message([
+            'headers' => [
+                'from'       => '_test_user@glpi.com',
+                'to'         => 'unittests@glpi-project.org',
+                'subject'    => sprintf('[GLPI #%d] Acompanhamento com mojibake', $existing_ticket->getID()),
+                'references' => $reference,
+                'date'       => 'Tue, 12 May 2026 10:09:00 +0000',
+            ],
+            'content' => 'AÃ§Ã£o nÃ£o concluÃ­da no followup.',
+        ]);
+
+        $collector = new \MailCollector();
+        $collector->getEmpty();
+        $collector->fields['name'] = 'unittests@glpi-project.org';
+        $collector->fields['create_user_from_email'] = 0;
+        $collector->fields['use_mail_date'] = 0;
+        $collector->fields['filesize_max'] = 0;
+        $collector->fields['add_to_to_observer'] = 0;
+        $collector->fields['add_cc_to_observer'] = 0;
+
+        $ticket = $collector->buildTicket(
+            'charset-evidence-followup',
+            $message,
+            [
+                'mailgates_id' => 1,
+                'play_rules'   => false,
+            ]
+        );
+
+        $this->assertSame((int) $existing_ticket->getID(), $ticket['tickets_id']);
+        $this->assertSame(sprintf('[GLPI #%d] Acompanhamento com mojibake', $existing_ticket->getID()), $ticket['name']);
+        $this->assertSame('Ação não concluída no followup.', $ticket['content']);
+        $this->assertTrue(mb_check_encoding($ticket['content'], 'UTF-8'));
+    }
+
     private function doConnect()
     {
         if (null === $this->collector) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that this feature works.

## Description

This PR improves the MailCollector import path by normalizing imported email subjects and bodies before tickets or followups are persisted.

It addresses malformed or mixed email encodings that may be accepted by the MIME parser but still leave corrupted, invalid, or unsafe text in the ticket/followup payload.

The goal is to make the core MailCollector path defensive enough to handle these cases without requiring plugin-side charset correction hooks.

### Problem

Some real-world emails contain malformed or mixed encodings, such as:

- UTF-8 mojibake, for example `AÃ§Ã£o` instead of `Ação`
- HTML bodies containing mojibake while valid HTML tags/entities must be preserved
- invisible control bytes decoded from quoted-printable payloads
- double-encoded replacement tokens such as `ï¿½`
- broken UTF-8 byte sequences
- UTF-8 BOM markers
- invalid base64 transfer payloads

Without normalization in the core collector flow, these values may remain corrupted in imported content, fail UTF-8 validation, or risk persistence errors depending on the database charset and malformed payload.

### Solution

This PR adds a dedicated core sanitizer:

- `Glpi\Mail\ImportedMailContentSanitizer`
- `Glpi\Mail\ImportedMailContentSanitizationResult`

The sanitizer is applied in `MailCollector::buildTicket()` before persistence, covering both new tickets and followups.

It performs conservative normalization:

- preserves valid UTF-8 unchanged
- converts invalid text using declared charset when available
- falls back to common mail encodings such as Windows-1252, ISO-8859-1 and ISO-8859-15
- strips UTF-8 BOM markers
- removes invalid control bytes while preserving regular line breaks
- repairs known mojibake sequences only when the result improves the text
- keeps HTML markup and entities intact
- prevents invalid UTF-8 bytes from escaping the collector path
- records applied sanitization steps for troubleshooting logs

Base64 decoding was also made more defensive: strict decoding is attempted first, then a non-strict fallback is used and logged when needed.

### Evidence

New reproducible `.eml` fixtures were added under:

`tests/emails-tests/charset-evidence/`

The evidence covers:

- ISO-8859-1 quoted-printable
- Windows-1252 quoted-printable
- UTF-8 mojibake in subject/body
- HTML body with mojibake
- invalid base64 fallback
- UTF-8 BOM
- invisible control bytes
- double-encoded replacement token
- broken UTF-8 bytes
- followup content normalization on an existing ticket

The before/after comparison is documented in:

`tests/emails-tests/charset-evidence/COMPARISON.md`

Using the same evidence tests against the previous core behavior produced:

```text
..FF..FFFF                                                        10 / 10 (100%)

FAILURES!
Tests: 10, Assertions: 70, Failures: 6.
