### PR TITLE
fix(html): correct flatpickr layout and button grouping in showDateField

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -2659,7 +2659,7 @@ TWIG,
         $placeholder = htmlescape($p['placeholder']);
 
         $output = <<<HTML
-      <div class="button-group flex-grow-1 flatpickr d-flex align-items-center" id="showdate{$rand}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{$calendar_tooltip}">
+      <div class="btn-group flex-grow-1 flatpickr" id="showdate{$rand}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{$calendar_tooltip}">
          <input type="text" name="{$name}" size="{$size}"
                 {$required} {$disabled} data-input placeholder="{$placeholder}" class="form-control rounded-start ps-2">
          $calendar_btn


### PR DESCRIPTION
## Checklist before requesting a review
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.
## Description
- It fixes a layout bug where the `Html::showDateField()` inputs and action buttons are visually separated.
- **Here is a brief description of what this PR does:**
This PR fixes a layout issue where the text input and the flatpickr action buttons (calendar and clear buttons) were visually separated with an unwanted gap. The invalid `button-group` class along with `d-flex align-items-center` were overriding standard Bootstrap `btn-group` inline-flex properties. This caused the right-side border-radius of the input field to render incorrectly.
This change replaces those classes with `btn-group flex-grow-1 flatpickr`, aligning the layout with standard Bootstrap 5 behaviors and standardizing it with how `Html::showDateTimeField()` is structured. It fixes the layout across multiple UI areas, such as Project Costs, Dashboard Date Filters, and Reservations.
## Screenshots (if appropriate):
**Before:**
<img width="1331" height="592" alt="image" src="https://github.com/user-attachments/assets/b92d328a-3355-430b-9827-cfc48d6acce4" />

**After:**
<img width="1339" height="725" alt="image" src="https://github.com/user-attachments/assets/d608a911-1004-4d23-91af-599bf9519846" />
