### PR TITLE
Feat(Profile): add per-profile ticket search option restrictions

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/profile_search_list.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/profile_search_list.php
@@ -34,11 +34,11 @@
 
 /** @var Migration $migration */
 
-$migration->addField('glpi_profiles', 'excluded_ticket_searchoptions', 'text', [
+$migration->addField('glpi_profiles', 'excluded_searchoptions', 'text', [
     'value'   => null,
     'after'   => 'managed_domainrecordtypes',
 ]);
 $migration->addField('glpi_profiles', 'show_map', 'boolean', [
     'value' => '1',
-    'after' => 'excluded_ticket_searchoptions',
+    'after' => 'excluded_searchoptions',
 ]);

--- a/install/migrations/update_11.0.x_to_12.0.0/profile_search_list.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/profile_search_list.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/** @var Migration $migration */
+
+$migration->addField('glpi_profiles', 'excluded_ticket_searchoptions', 'text', [
+    'value'   => null,
+    'after'   => 'managed_domainrecordtypes',
+]);
+$migration->addField('glpi_profiles', 'show_map', 'boolean', [
+    'value' => '1',
+    'after' => 'excluded_ticket_searchoptions',
+]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6046,7 +6046,7 @@ CREATE TABLE `glpi_profiles` (
   `problemtemplates_id` int unsigned NOT NULL DEFAULT '0',
   `change_status` text,
   `managed_domainrecordtypes` text,
-  `excluded_ticket_searchoptions` text DEFAULT NULL,
+  `excluded_searchoptions` text DEFAULT NULL,
   `show_map` tinyint NOT NULL DEFAULT '1',
   `date_creation` timestamp NULL DEFAULT NULL,
   `2fa_enforced` tinyint NOT NULL DEFAULT '0',

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -6046,6 +6046,8 @@ CREATE TABLE `glpi_profiles` (
   `problemtemplates_id` int unsigned NOT NULL DEFAULT '0',
   `change_status` text,
   `managed_domainrecordtypes` text,
+  `excluded_ticket_searchoptions` text DEFAULT NULL,
+  `show_map` tinyint NOT NULL DEFAULT '1',
   `date_creation` timestamp NULL DEFAULT NULL,
   `2fa_enforced` tinyint NOT NULL DEFAULT '0',
   `last_rights_update` timestamp NULL DEFAULT NULL,

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -247,7 +247,9 @@ class HTMLSearchOutput extends AbstractSearchOutput
                 DisplayPreference::GENERAL,
             ]),
             'may_be_deleted'      => $item instanceof CommonDBTM && $item->maybeDeleted() && !$item->useDeletedToLockIfDynamic(),
-            'may_be_located'      => $item instanceof CommonDBTM && $item->maybeLocated(),
+            'may_be_located'      => $item instanceof CommonDBTM
+                && $item->maybeLocated()
+                && (bool) ($_SESSION['glpiactiveprofile']['show_map'] ?? true),
             'may_be_browsed'      => $item !== null && Toolbox::hasTrait($item, TreeBrowse::class),
             'may_be_unpublished'  => $itemtype == 'KnowbaseItem' && $item->canUpdate(),
             'original_params'     => $params,

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -446,17 +446,22 @@ final class SearchOption implements ArrayAccess
      */
     private static function applyProfileRestrictions(string $itemtype, array &$options): void
     {
-        if ($itemtype !== Ticket::class || Session::isCron()) {
+        if (Session::isCron()) {
             return;
         }
 
-        $excluded = $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] ?? null;
+        $all_excluded = $_SESSION['glpiactiveprofile']['excluded_searchoptions'] ?? null;
+        if (empty($all_excluded)) {
+            return;
+        }
+
+        if (!is_array($all_excluded)) {
+            $all_excluded = json_decode($all_excluded, true) ?? [];
+        }
+
+        $excluded = $all_excluded[$itemtype] ?? [];
         if (empty($excluded)) {
             return;
-        }
-
-        if (!is_array($excluded)) {
-            $excluded = json_decode($excluded, true) ?? [];
         }
 
         foreach ($excluded as $num) {

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -150,7 +150,7 @@ final class SearchOption implements ArrayAccess
      *
      * @return array The reference to the array of search options for the given item type
      **/
-    public static function getOptionsForItemtype($itemtype, $withplugins = true): array
+    public static function getOptionsForItemtype($itemtype, $withplugins = true, bool $apply_profile_restrictions = true): array
     {
         global $CFG_GLPI;
 
@@ -158,7 +158,11 @@ final class SearchOption implements ArrayAccess
 
         $cache_key = $itemtype . '_' . ($withplugins ? 1 : 0);
         if (isset(self::$search_options_cache[$cache_key])) {
-            return self::$search_options_cache[$cache_key];
+            $options = self::$search_options_cache[$cache_key];
+            if ($apply_profile_restrictions) {
+                self::applyProfileRestrictions($itemtype, $options);
+            }
+            return $options;
         }
 
         $fn_append_options = static function ($new_options) use (&$search, $itemtype) {
@@ -427,7 +431,38 @@ final class SearchOption implements ArrayAccess
         }
 
         self::$search_options_cache[$cache_key] = $search[$itemtype];
-        return $search[$itemtype];
+        $options = $search[$itemtype];
+        if ($apply_profile_restrictions) {
+            self::applyProfileRestrictions($itemtype, $options);
+        }
+        return $options;
+    }
+
+    /**
+     * @param string $itemtype
+     * @param array<int|string, mixed> $options Options array (modified in place)
+     */
+    private static function applyProfileRestrictions(string $itemtype, array &$options): void
+    {
+        if ($itemtype !== Ticket::class || Session::isCron()) {
+            return;
+        }
+
+        $excluded = $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] ?? null;
+        if (empty($excluded)) {
+            return;
+        }
+
+        if (!is_array($excluded)) {
+            $excluded = json_decode($excluded, true) ?? [];
+        }
+
+        foreach ($excluded as $num) {
+            if (isset($options[$num]) && is_array($options[$num])) {
+                $options[$num]['nosearch'] = true;
+                $options[$num]['nodisplay'] = true;
+            }
+        }
     }
 
     /**

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -64,6 +64,8 @@ use Session;
 use Ticket;
 use User;
 
+use function Safe\json_decode;
+
 /**
  * Object representing a search option.
  *

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -94,7 +94,10 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
      * Common fields used for all profiles type
      * @var string[]
      */
-    public static array $common_fields  = ['id', 'interface', 'is_default', 'name', '2fa_enforced', 'excluded_ticket_searchoptions', 'show_map'];
+    public static array $common_fields  = ['id', 'interface', 'is_default', 'name', '2fa_enforced', 'excluded_searchoptions', 'show_map'];
+
+    /** @var list<class-string> Itemtypes whose search options can be restricted per profile */
+    public const SEARCHOPTION_RESTRICTED_ITEMTYPES = [Ticket::class];
 
     public bool $dohistory             = true;
 
@@ -292,9 +295,9 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                 $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] = importArrayFromDB($this->input['managed_domainrecordtypes']);
             }
 
-            if (in_array('excluded_ticket_searchoptions', $this->updates, true)) {
-                $raw = $this->input['excluded_ticket_searchoptions'];
-                $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = $raw !== null
+            if (in_array('excluded_searchoptions', $this->updates, true)) {
+                $raw = $this->input['excluded_searchoptions'];
+                $_SESSION['glpiactiveprofile']['excluded_searchoptions'] = $raw !== null
                     ? (json_decode($raw, true) ?? [])
                     : [];
             }
@@ -383,10 +386,10 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             );
         }
 
-        if (isset($input['excluded_ticket_searchoptions'])) {
-            $values = is_array($input['excluded_ticket_searchoptions']) ? $input['excluded_ticket_searchoptions'] : [];
-            $values = array_values(array_unique(array_filter(array_map('intval', $values))));
-            $input['excluded_ticket_searchoptions'] = $values !== [] ? json_encode($values) : null;
+        if (isset($input['excluded_searchoptions'])) {
+            $input['excluded_searchoptions'] = self::normalizeExcludedSearchoptions(
+                is_array($input['excluded_searchoptions']) ? $input['excluded_searchoptions'] : []
+            );
         }
 
         if (isset($input['helpdesk_hardware']) && is_array($input['helpdesk_hardware'])) {
@@ -608,13 +611,29 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             }
         }
 
-        if (isset($input['excluded_ticket_searchoptions'])) {
-            $values = is_array($input['excluded_ticket_searchoptions']) ? $input['excluded_ticket_searchoptions'] : [];
-            $values = array_values(array_unique(array_filter(array_map('intval', $values))));
-            $input['excluded_ticket_searchoptions'] = $values !== [] ? json_encode($values) : null;
+        if (isset($input['excluded_searchoptions'])) {
+            $input['excluded_searchoptions'] = self::normalizeExcludedSearchoptions(
+                is_array($input['excluded_searchoptions']) ? $input['excluded_searchoptions'] : []
+            );
         }
 
         return $input;
+    }
+
+    /**
+     * @param array<string, list<int>> $input Keyed by itemtype short name
+     */
+    private static function normalizeExcludedSearchoptions(array $input): ?string
+    {
+        $result = [];
+        foreach (self::SEARCHOPTION_RESTRICTED_ITEMTYPES as $itemtype) {
+            $values = is_array($input[$itemtype] ?? null) ? $input[$itemtype] : [];
+            $values = array_values(array_unique(array_filter(array_map('intval', $values))));
+            if ($values !== []) {
+                $result[$itemtype] = $values;
+            }
+        }
+        return $result !== [] ? json_encode($result) : null;
     }
 
     /**
@@ -696,13 +715,13 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
         }
 
         if (
-            isset($this->fields['excluded_ticket_searchoptions'])
-            && !is_array($this->fields['excluded_ticket_searchoptions'])
+            isset($this->fields['excluded_searchoptions'])
+            && !is_array($this->fields['excluded_searchoptions'])
         ) {
-            $this->fields['excluded_ticket_searchoptions'] = json_decode($this->fields['excluded_ticket_searchoptions'], true) ?? [];
+            $this->fields['excluded_searchoptions'] = json_decode($this->fields['excluded_searchoptions'], true) ?? [];
         }
-        if (!isset($this->fields['excluded_ticket_searchoptions'])) {
-            $this->fields['excluded_ticket_searchoptions'] = [];
+        if (!isset($this->fields['excluded_searchoptions'])) {
+            $this->fields['excluded_searchoptions'] = [];
         }
     }
 
@@ -1529,26 +1548,34 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             return;
         }
 
-        $ticket_search_options = [];
-        $group = '';
-        foreach (SearchOption::getOptionsForItemtype(Ticket::class, true, false) as $key => $val) {
-            if (!is_array($val)) {
-                $group = $val;
-                continue;
+        $itemtypes_data = [];
+        foreach (self::SEARCHOPTION_RESTRICTED_ITEMTYPES as $itemtype) {
+            $options = [];
+            $group = '';
+            foreach (SearchOption::getOptionsForItemtype($itemtype, true, false) as $key => $val) {
+                if (!is_array($val)) {
+                    $group = $val;
+                    continue;
+                }
+                if (count($val) === 1) {
+                    $group = $val['name'];
+                    continue;
+                }
+                if (isset($val['nodisplay']) && $val['nodisplay']) {
+                    continue;
+                }
+                $options[$group][$key] = $val['name'];
             }
-            if (count($val) === 1) {
-                $group = $val['name'];
-                continue;
-            }
-            if (isset($val['nodisplay']) && $val['nodisplay']) {
-                continue;
-            }
-            $ticket_search_options[$group][$key] = $val['name'];
+            $itemtypes_data[] = [
+                'key'     => $itemtype,
+                'label'   => $itemtype::getTypeName(Session::getPluralNumber()),
+                'options' => $options,
+            ];
         }
 
         TemplateRenderer::getInstance()->display('pages/admin/profile/search_list.html.twig', [
-            'item'                    => $this,
-            'ticket_search_options'   => $ticket_search_options,
+            'item'           => $this,
+            'itemtypes_data' => $itemtypes_data,
         ]);
     }
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -44,6 +44,7 @@ use Glpi\Form\Form;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\Inventory\Conf;
+use Glpi\Search\SearchOption;
 use Glpi\Toolbox\ArrayNormalizer;
 
 /**
@@ -90,7 +91,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
      * Common fields used for all profiles type
      * @var string[]
      */
-    public static array $common_fields  = ['id', 'interface', 'is_default', 'name', '2fa_enforced'];
+    public static array $common_fields  = ['id', 'interface', 'is_default', 'name', '2fa_enforced', 'excluded_ticket_searchoptions', 'show_map'];
 
     public bool $dohistory             = true;
 
@@ -189,6 +190,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                         $ong[6] = self::createTabEntry(__('Tools'), 0, $item::class, 'ti ti-briefcase');
                         $ong[7] = self::createTabEntry(__('Setup'), 0, $item::class, 'ti ti-settings');
                         $ong[8] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                        $ong[9] = self::createTabEntry(__('Search / list'), 0, $item::class, 'ti ti-search');
                     } else {
                         $ong[2] = self::createTabEntry(_n('Asset', 'Assets', Session::getPluralNumber()), 0, $item::class, 'ti ti-package');
                         $ong[3] = self::createTabEntry(__('Assistance'), 0, $item::class, 'ti ti-headset');
@@ -198,6 +200,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                         $ong[7] = self::createTabEntry(__('Administration'), 0, $item::class, 'ti ti-shield-check');
                         $ong[8] = self::createTabEntry(__('Setup'), 0, $item::class, 'ti ti-settings');
                         $ong[9] = self::createTabEntry(__('Security'), 0, $item::class, 'ti ti-shield-lock');
+                        $ong[10] = self::createTabEntry(__('Search / list'), 0, $item::class, 'ti ti-search');
                     }
                     return $ong;
             }
@@ -218,6 +221,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                     6 => $item->showFormToolsHelpdesk(),
                     7 => $item->showFormSetupHelpdesk(),
                     8 => $item->showFormSecurity(),
+                    9 => $item->showFormSearchList(),
                     default => false,
                 };
             } else {
@@ -230,6 +234,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                     7 => $item->showFormAdmin(),
                     8 => $item->showFormSetup(),
                     9 => $item->showFormSecurity(),
+                    10 => $item->showFormSearchList(),
                     default => false,
                 };
             }
@@ -284,7 +289,16 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                 $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] = importArrayFromDB($this->input['managed_domainrecordtypes']);
             }
 
-            ///TODO other needed fields
+            if (in_array('excluded_ticket_searchoptions', $this->updates, true)) {
+                $raw = $this->input['excluded_ticket_searchoptions'];
+                $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = $raw !== null
+                    ? (json_decode($raw, true) ?? [])
+                    : [];
+            }
+
+            if (in_array('show_map', $this->updates, true)) {
+                $_SESSION['glpiactiveprofile']['show_map'] = (int) $this->input['show_map'];
+            }
         }
     }
 
@@ -364,6 +378,12 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             $input["managed_domainrecordtypes"] = exportArrayToDB(
                 ArrayNormalizer::normalizeValues($input["managed_domainrecordtypes"] ?: [], 'intval')
             );
+        }
+
+        if (isset($input['excluded_ticket_searchoptions'])) {
+            $values = is_array($input['excluded_ticket_searchoptions']) ? $input['excluded_ticket_searchoptions'] : [];
+            $values = array_values(array_unique(array_filter(array_map('intval', $values))));
+            $input['excluded_ticket_searchoptions'] = $values !== [] ? json_encode($values) : null;
         }
 
         if (isset($input['helpdesk_hardware']) && is_array($input['helpdesk_hardware'])) {
@@ -585,6 +605,12 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             }
         }
 
+        if (isset($input['excluded_ticket_searchoptions'])) {
+            $values = is_array($input['excluded_ticket_searchoptions']) ? $input['excluded_ticket_searchoptions'] : [];
+            $values = array_values(array_unique(array_filter(array_map('intval', $values))));
+            $input['excluded_ticket_searchoptions'] = $values !== [] ? json_encode($values) : null;
+        }
+
         return $input;
     }
 
@@ -664,6 +690,18 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                     $this->fields[$val] = [];
                 }
             }
+        }
+
+        if (
+            isset($this->fields['excluded_ticket_searchoptions'])
+            && !is_array($this->fields['excluded_ticket_searchoptions'])
+        ) {
+            $this->fields['excluded_ticket_searchoptions'] = $this->fields['excluded_ticket_searchoptions'] !== null
+                ? (json_decode($this->fields['excluded_ticket_searchoptions'], true) ?? [])
+                : [];
+        }
+        if (!isset($this->fields['excluded_ticket_searchoptions'])) {
+            $this->fields['excluded_ticket_searchoptions'] = [];
         }
     }
 
@@ -1478,6 +1516,38 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             'canedit' => $canedit,
             'item'   => $this,
             'action' => Toolbox::getItemTypeFormURL(self::class),
+        ]);
+    }
+
+    /**
+     * Print the Search / list settings form for a profile.
+     */
+    private function showFormSearchList(): void
+    {
+        if (!self::canView()) {
+            return;
+        }
+
+        $ticket_search_options = [];
+        $group = '';
+        foreach (SearchOption::getOptionsForItemtype(Ticket::class, true, false) as $key => $val) {
+            if (!is_array($val)) {
+                $group = $val;
+                continue;
+            }
+            if (count($val) === 1) {
+                $group = $val['name'];
+                continue;
+            }
+            if (isset($val['nodisplay']) && $val['nodisplay']) {
+                continue;
+            }
+            $ticket_search_options[$group][$key] = $val['name'];
+        }
+
+        TemplateRenderer::getInstance()->display('pages/admin/profile/search_list.html.twig', [
+            'item'                    => $this,
+            'ticket_search_options'   => $ticket_search_options,
         ]);
     }
 

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -47,6 +47,9 @@ use Glpi\Inventory\Conf;
 use Glpi\Search\SearchOption;
 use Glpi\Toolbox\ArrayNormalizer;
 
+use function Safe\json_decode;
+use function Safe\json_encode;
+
 /**
  * Profile class
  *
@@ -696,9 +699,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             isset($this->fields['excluded_ticket_searchoptions'])
             && !is_array($this->fields['excluded_ticket_searchoptions'])
         ) {
-            $this->fields['excluded_ticket_searchoptions'] = $this->fields['excluded_ticket_searchoptions'] !== null
-                ? (json_decode($this->fields['excluded_ticket_searchoptions'], true) ?? [])
-                : [];
+            $this->fields['excluded_ticket_searchoptions'] = json_decode($this->fields['excluded_ticket_searchoptions'], true) ?? [];
         }
         if (!isset($this->fields['excluded_ticket_searchoptions'])) {
             $this->fields['excluded_ticket_searchoptions'] = [];

--- a/templates/pages/admin/profile/search_list.html.twig
+++ b/templates/pages/admin/profile/search_list.html.twig
@@ -1,0 +1,62 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends 'pages/admin/profile/base_tab.html.twig' %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% block content %}
+    {{ fields.smallTitle(__('Tickets')) }}
+
+    {% set excluded_field %}
+        {% do call('Dropdown::showFromArray', ['excluded_ticket_searchoptions', ticket_search_options|merge({}), {
+            values: item.fields['excluded_ticket_searchoptions'],
+            multiple: true,
+            width: '100%',
+            rand: random(),
+        }]) %}
+    {% endset %}
+    {{ fields.htmlField(
+        'excluded_ticket_searchoptions',
+        excluded_field,
+        __('Hidden fields in search and column selection'),
+        { full_width: true }
+    ) }}
+
+    {{ fields.smallTitle(__('Map')) }}
+
+    {{ fields.checkboxField(
+        'show_map',
+        item.fields['show_map'],
+        __('Show map button in lists'),
+        { full_width: true }
+    ) }}
+{% endblock %}

--- a/templates/pages/admin/profile/search_list.html.twig
+++ b/templates/pages/admin/profile/search_list.html.twig
@@ -34,22 +34,26 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block content %}
-    {{ fields.smallTitle(__('Tickets')) }}
+    {% for data in itemtypes_data %}
+        {{ fields.smallTitle(data.label) }}
 
-    {% set excluded_field %}
-        {% do call('Dropdown::showFromArray', ['excluded_ticket_searchoptions', ticket_search_options|merge({}), {
-            values: item.fields['excluded_ticket_searchoptions'],
-            multiple: true,
-            width: '100%',
-            rand: random(),
-        }]) %}
-    {% endset %}
-    {{ fields.htmlField(
-        'excluded_ticket_searchoptions',
-        excluded_field,
-        __('Hidden fields in search and column selection'),
-        {full_width: true}
-    ) }}
+        {% set field_name = 'excluded_searchoptions[' ~ data.key ~ ']' %}
+        {% set current_values = item.fields['excluded_searchoptions'][data.key] ?? [] %}
+        {% set excluded_field %}
+            {% do call('Dropdown::showFromArray', [field_name, data.options|merge({}), {
+                values: current_values,
+                multiple: true,
+                width: '100%',
+                rand: random(),
+            }]) %}
+        {% endset %}
+        {{ fields.htmlField(
+            field_name,
+            excluded_field,
+            __('Hidden fields in search and column selection'),
+            {full_width: true}
+        ) }}
+    {% endfor %}
 
     {{ fields.smallTitle(__('Map')) }}
 

--- a/templates/pages/admin/profile/search_list.html.twig
+++ b/templates/pages/admin/profile/search_list.html.twig
@@ -48,7 +48,7 @@
         'excluded_ticket_searchoptions',
         excluded_field,
         __('Hidden fields in search and column selection'),
-        { full_width: true }
+        {full_width: true}
     ) }}
 
     {{ fields.smallTitle(__('Map')) }}
@@ -57,6 +57,6 @@
         'show_map',
         item.fields['show_map'],
         __('Show map button in lists'),
-        { full_width: true }
+        {full_width: true}
     ) }}
 {% endblock %}

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -251,7 +251,7 @@ class SearchOptionTest extends DbTestCase
 
         $excluded_num = reset($option_nums);
 
-        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [$excluded_num];
+        $_SESSION['glpiactiveprofile']['excluded_searchoptions'] = ['Ticket' => [$excluded_num]];
 
         $restricted = SearchOption::getOptionsForItemtype(\Ticket::class);
 
@@ -272,7 +272,7 @@ class SearchOptionTest extends DbTestCase
         $option_nums = array_filter(array_keys($all_options), 'is_int');
         $excluded_num = reset($option_nums);
 
-        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [$excluded_num];
+        $_SESSION['glpiactiveprofile']['excluded_searchoptions'] = ['Ticket' => [$excluded_num]];
 
         $unfiltered = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
 
@@ -286,7 +286,7 @@ class SearchOptionTest extends DbTestCase
 
         $base = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
 
-        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [];
+        $_SESSION['glpiactiveprofile']['excluded_searchoptions'] = [];
 
         $filtered = SearchOption::getOptionsForItemtype(\Ticket::class);
 

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -240,4 +240,70 @@ class SearchOptionTest extends DbTestCase
         $this->assertArrayHasKey('rows', $result2['data']);
         $this->assertGreaterThan(0, $result2['data']['totalcount']);
     }
+
+    public function testProfileRestrictionsApplied(): void
+    {
+        $this->login();
+
+        $all_options = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
+        $option_nums = array_filter(array_keys($all_options), 'is_int');
+        $this->assertNotEmpty($option_nums);
+
+        $excluded_num = reset($option_nums);
+
+        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [$excluded_num];
+
+        $restricted = SearchOption::getOptionsForItemtype(\Ticket::class);
+
+        $this->assertTrue($restricted[$excluded_num]['nosearch'] ?? false);
+        $this->assertTrue($restricted[$excluded_num]['nodisplay'] ?? false);
+
+        $other_nums = array_filter($option_nums, fn($n) => $n !== $excluded_num);
+        $other_num  = reset($other_nums);
+        $this->assertFalse($restricted[$other_num]['nosearch'] ?? false);
+        $this->assertFalse($restricted[$other_num]['nodisplay'] ?? false);
+    }
+
+    public function testProfileRestrictionsSkippedWhenDisabled(): void
+    {
+        $this->login();
+
+        $all_options = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
+        $option_nums = array_filter(array_keys($all_options), 'is_int');
+        $excluded_num = reset($option_nums);
+
+        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [$excluded_num];
+
+        $unfiltered = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
+
+        $this->assertFalse($unfiltered[$excluded_num]['nosearch'] ?? false);
+        $this->assertFalse($unfiltered[$excluded_num]['nodisplay'] ?? false);
+    }
+
+    public function testNoRestrictionsWithoutExcludedOptions(): void
+    {
+        $this->login();
+
+        $base = SearchOption::getOptionsForItemtype(\Ticket::class, true, false);
+
+        $_SESSION['glpiactiveprofile']['excluded_ticket_searchoptions'] = [];
+
+        $filtered = SearchOption::getOptionsForItemtype(\Ticket::class);
+
+        foreach ($base as $key => $val) {
+            if (!is_array($val) || count($val) <= 1) {
+                continue;
+            }
+            $this->assertEquals(
+                $val['nosearch'] ?? false,
+                $filtered[$key]['nosearch'] ?? false,
+                "Option $key nosearch should be unchanged with empty exclusions"
+            );
+            $this->assertEquals(
+                $val['nodisplay'] ?? false,
+                $filtered[$key]['nodisplay'] ?? false,
+                "Option $key nodisplay should be unchanged with empty exclusions"
+            );
+        }
+    }
 }

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -443,4 +443,35 @@ class ProfileTest extends DbTestCase
             }
         }
     }
+
+    public function testExcludedTicketSearchOptionsPrepareInput(): void
+    {
+        $this->login();
+
+        $profile = $this->createItem(\Profile::class, [
+            'name'      => 'Test excluded searchoptions ' . __FUNCTION__,
+            'interface' => 'central',
+        ]);
+
+        // deduplication and non-integer filtering
+        $profile->update([
+            'id'                             => $profile->getID(),
+            'excluded_ticket_searchoptions'  => [5, 3, 5, 0, 'abc'],
+        ]);
+        $reloaded = new \Profile();
+        $reloaded->getFromDB($profile->getID());
+        $reloaded->cleanProfile();
+        $actual = $reloaded->fields['excluded_ticket_searchoptions'];
+        sort($actual);
+        $this->assertEquals([3, 5], $actual);
+
+        // empty array stores null (no restrictions)
+        $profile->update([
+            'id'                             => $profile->getID(),
+            'excluded_ticket_searchoptions'  => [],
+        ]);
+        $reloaded->getFromDB($profile->getID());
+        $reloaded->cleanProfile();
+        $this->assertEquals([], $reloaded->fields['excluded_ticket_searchoptions']);
+    }
 }

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -444,7 +444,7 @@ class ProfileTest extends DbTestCase
         }
     }
 
-    public function testExcludedTicketSearchOptionsPrepareInput(): void
+    public function testExcludedSearchOptionsPrepareInput(): void
     {
         $this->login();
 
@@ -455,23 +455,25 @@ class ProfileTest extends DbTestCase
 
         // deduplication and non-integer filtering
         $profile->update([
-            'id'                             => $profile->getID(),
-            'excluded_ticket_searchoptions'  => [5, 3, 5, 0, 'abc'],
+            'id'                     => $profile->getID(),
+            'excluded_searchoptions' => [
+                'Ticket' => [5, 3, 5, 0, 'abc'],
+            ],
         ]);
         $reloaded = new \Profile();
         $reloaded->getFromDB($profile->getID());
         $reloaded->cleanProfile();
-        $actual = $reloaded->fields['excluded_ticket_searchoptions'];
-        sort($actual);
-        $this->assertEquals([3, 5], $actual);
+        $actual = $reloaded->fields['excluded_searchoptions'];
+        sort($actual['Ticket']);
+        $this->assertEquals([3, 5], $actual['Ticket']);
 
-        // empty array stores null (no restrictions)
+        // empty input stores null (no restrictions)
         $profile->update([
-            'id'                             => $profile->getID(),
-            'excluded_ticket_searchoptions'  => [],
+            'id'                     => $profile->getID(),
+            'excluded_searchoptions' => [],
         ]);
         $reloaded->getFromDB($profile->getID());
         $reloaded->cleanProfile();
-        $this->assertEquals([], $reloaded->fields['excluded_ticket_searchoptions']);
+        $this->assertEquals([], $reloaded->fields['excluded_searchoptions']);
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43307

Administrators can now configure a "Search / list" tab on each profile to hide specific ticket search columns from that profile's users. A new `show_map` flag on the profile also controls whether the map view appears in search results.

## Screenshots (if appropriate):

<img width="789" height="622" alt="image" src="https://github.com/user-attachments/assets/210a1a9f-da68-45e1-9063-661c18d85bfa" />

