### PR TITLE
[Fix] Avoid duplicate entries in session navigate list

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -366,7 +366,12 @@ class Session
      */
     public static function addToNavigateListItems($itemtype, $ID)
     {
-        $_SESSION['glpilistitems'][$itemtype][] = $ID;
+        if (!isset($_SESSION['glpilistitems'][$itemtype])) {
+            $_SESSION['glpilistitems'][$itemtype] = [];
+        }
+        if (!in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
+            $_SESSION['glpilistitems'][$itemtype][] = $ID;
+        }
     }
 
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -382,15 +382,17 @@ class Session
      */
     public static function initNavigateListItems($itemtype, $title = "", $url = null)
     {
+        if (Request::createFromGlobals()->isXmlHttpRequest() && $url === null) {
+            return;
+        }
+
         if (empty($title)) {
             $title = __('List');
         }
         if ($url === null) {
             $url = '';
 
-            $is_ajax = Request::createFromGlobals()->isXmlHttpRequest();
-
-            if (!isset($_SERVER['REQUEST_URI']) || $is_ajax || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
+            if (!isset($_SERVER['REQUEST_URI']) || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
                 $url = Html::getRefererUrl();
             } else {
                 $url = $_SERVER['REQUEST_URI'];

--- a/src/Session.php
+++ b/src/Session.php
@@ -366,9 +366,6 @@ class Session
      */
     public static function addToNavigateListItems($itemtype, $ID)
     {
-        if (!isset($_SESSION['glpilistitems'][$itemtype])) {
-            $_SESSION['glpilistitems'][$itemtype] = [];
-        }
         if (!in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
             $_SESSION['glpilistitems'][$itemtype][] = $ID;
         }
@@ -385,17 +382,15 @@ class Session
      */
     public static function initNavigateListItems($itemtype, $title = "", $url = null)
     {
-        if (Request::createFromGlobals()->isXmlHttpRequest() && $url === null) {
-            return;
-        }
-
         if (empty($title)) {
             $title = __('List');
         }
         if ($url === null) {
             $url = '';
 
-            if (!isset($_SERVER['REQUEST_URI']) || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
+            $is_ajax = Request::createFromGlobals()->isXmlHttpRequest();
+
+            if (!isset($_SERVER['REQUEST_URI']) || $is_ajax || (strpos($_SERVER['REQUEST_URI'], "tabs") > 0)) {
                 $url = Html::getRefererUrl();
             } else {
                 $url = $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable): #22936
- Here is a brief description of what this PR does:

Initialize `$_SESSION['glpilistitems'][$itemtype]` if missing and only append `$ID` when it is not already present. This prevents undefined index notices and avoids adding duplicate IDs to the navigation list in `Session::addToNavigateListItems`.

**Background**

Historically, GLPI implemented this to optimize performance and avoid heavy database queries. 

Imagine you are looking at the Tickets list, and you apply a complex set of filters (e.g., "Tickets assigned to me," "Modified in the last 7 days," "Sorted by Priority descending"). When you click on the 1st ticket in that list to view its form, GLPI needs to know what the "Next" ticket is so it can render the > arrow at the top of the form.

If it relied solely on the backend, GLPI would have to:

   1. Re-execute the exact same complex search query.
   2. Re-calculate the sorting and permissions.
   3. Locate the current ticket in that result set.
   4. Pick the adjacent record.

By storing the raw array of IDs in `$_SESSION['glpilistitems'][$itemtype]` when the list is initially rendered, GLPI can instantly look up the current ID in the session array and grab the next one. It acts as a lightweight cache of your current search.

**Why isn't it based on backend queries?**

While the session approach saves database load, it comes with severe drawbacks:

1. **Concurrency Bugs**: If a user opens two browser tabs with different searches for the same item type (e.g., two different Ticket lists), the last loaded tab overwrites `$_SESSION['glpilistitems']['Ticket']`. When the user clicks "Next" in the first tab, it will take them to a ticket from the second tab's search.
2. **Session Bloat**: If you load a massive list, the session size balloons.
3. **AJAX Duplication Bug** (Issue #22936): `Session::initNavigateListItems()` has a specific line of code that says: "If this is an AJAX request, don't clear the session array." It does this assuming an AJAX request means infinite scrolling (appending to a list). However, because GLPI loads form tabs via AJAX, every time you switch tabs or sort an AJAX list, it just blindly appends the same IDs to the session indefinitely.

**Root Cause**

Historically, GLPI added a blanket `if (Request::createFromGlobals()->isXmlHttpRequest() && $url === null) { return; }` early return in `Session::initNavigateListItems`. The original intention was to prevent background AJAX scripts (like autocomplete dropdowns) from destroying a user's main navigation list by accidentally clearing it.

However, because GLPI also uses AJAX to load main content (like tabs showing lists of Rules, Appliances, linked Tickets, etc.), this early return caused a massive bug: when loading a tab, the list was never cleared, but the code still called `addToNavigateListItems()` for every item. This caused the session list to infinitely accumulate duplicated IDs.

**Global Fix (`src/Session.php`)**

1. **Prevent Duplicates (`addToNavigateListItems`)**: Added an `in_array()` check so that even if the list fails to clear or is loaded incorrectly, the session array can never grow infinitely with duplicate IDs. This directly solves the crash mentioned in Issue #22936.

**Known Limitation**

The `$_SESSION['glpilistitems']` array functions as a chronological browsing log rather than a true representation of the database query. Because the `addToNavigateListItems()` function is a simple "append" operation, it blindly adds IDs to the end of the session array in the exact order the user renders them on screen. It has no awareness of SQL offsets, `ORDER BY` clauses, or unvisited pages.

If a user views a paginated table (e.g., /front/ruleimportasset.php with 20 results per page) and navigates out of sequence:

- Load Page 1: Items 1–20 are added to the session.
- Jump to Page 3: Items 41–60 are appended to the session.
- Jump back to Page 2: Items 21–40 are appended to the session.

The session array is now ordered as [Page 1] -> [Page 3] -> [Page 2].

If the user opens an item from Page 1 and clicks the "Next Item" arrow in the top navigation, the system will eventually jump them directly from Page 1 into Page 3, then backward into Page 2. Furthermore, because Page 4 was never explicitly visited, its items are completely missing from the session array, meaning the user will hit a dead-end at the end of Page 2 and cannot continue navigating.

**The "Perfect" Architectural Fix**:

The ideal solution is to stop storing raw IDs, shifting from **Stateful Session Storage** to **Stateless / Cursor-Based Pagination**. Instead, GLPI should store a token representing the Search Criteria in the session (or pass it in the URL).

When a user performs a search, the server generates a unique random ID for that specific search event (e.g., `req_559`):

```php
// Server saves the criteria under a unique key
$_SESSION['search_history']['req_559'] = ['RAM' => 64, 'Status' => 'Active'];
$_SESSION['search_history']['req_882'] = ['RAM' => 16, 'Status' => 'Broken'];
```

Then, it puts only that tiny ID in the URL: ``/front/computer.php?id=12&req_id=req_559``

If GLPI transitioned to storing a **Search Token** (a hash representing the user's `WHERE` clauses, `JOINs`, and `ORDER BY` preferences) instead of raw IDs, it would instantly solve several massive systemic issues:

- **Zero Session Bloat**: Instead of storing arrays of thousands of IDs in PHP's session memory, the server only stores a tiny serialized string or token (e.g., `search_token_xyz`).
- **Absolute Accuracy**: Navigating out of sequence (Pages 1 > 3 > 2) no longer breaks anything. The database is the single source of truth. The moment the user opens an item from Page 1, the system accurately displays "Item 12 of 5,000", giving them a true sense of where they are in the entire dataset.
- **Real-Time Resiliency**: If you are viewing Item 15, and a colleague deletes Item 16, clicking "Next" under the current system throws a "Not Found" error (`Glpi\Exception\Http\NotFoundHttpException`). Under this proposed system, the query re-runs, realizes Item 16 is gone, and seamlessly loads Item 17.

However, completely rewriting GLPI's core navigation and search engine is a massive undertaking that would touch hundreds of files and require a large PR to the core team.

## Screenshots (if appropriate):


