### PR TITLE
feat(ui): improve iframe modal sizing and rule preview display

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -642,10 +642,3 @@ input.form-check-input[type="checkbox"]:disabled {
     opacity: 0.9;
 }
 
-// Remove default margin-bottom that Bootstrap's _reboot.scss applies to headings,
-// which causes extra whitespace inside modal headers.
-.modal-header {
-    h1, h2, h3, h4, h5, h6 {
-        margin-bottom: 0;
-    }
-}

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -641,3 +641,11 @@ input.form-check-input[type="radio"]:disabled,
 input.form-check-input[type="checkbox"]:disabled {
     opacity: 0.9;
 }
+
+// Remove default margin-bottom that Bootstrap's _reboot.scss applies to headings,
+// which causes extra whitespace inside modal headers.
+.modal-header {
+    h1, h2, h3, h4, h5, h6 {
+        margin-bottom: 0;
+    }
+}

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -61,7 +61,7 @@ if (!$rule = getItemForItemtype($sub_type)) {
 }
 $rule->checkGlobal(READ);
 
-$in_modal = isset($_REQUEST['_in_modal']) ? (bool)$_REQUEST['_in_modal'] : false;
+$in_modal = isset($_REQUEST['_in_modal']) ? (bool) $_REQUEST['_in_modal'] : false;
 Html::popHeader(__('Setup'), '', $in_modal);
 
 $rule->showRulePreviewCriteriasForm($rules_id);

--- a/front/rule.test.php
+++ b/front/rule.test.php
@@ -61,7 +61,8 @@ if (!$rule = getItemForItemtype($sub_type)) {
 }
 $rule->checkGlobal(READ);
 
-Html::popHeader(__('Setup'));
+$in_modal = isset($_REQUEST['_in_modal']) ? (bool)$_REQUEST['_in_modal'] : false;
+Html::popHeader(__('Setup'), '', $in_modal);
 
 $rule->showRulePreviewCriteriasForm($rules_id);
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -233,7 +233,8 @@ class Ajax
                 var resizeIframe' . $rand . ' = function() {
                     try {
                         var doc = iframeEl' . $rand . '.contentWindow.document;
-                        var h = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight);
+                        // Set height to content height, BUT cap it at the screen height
+                        var h = Math.min(doc.documentElement.scrollHeight, doc.body.scrollHeight) || ' . ((int) $param['height']) . ';
                     } catch(e) {
                         var h = ' . ((int) $param['height']) . ';
                     }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -211,6 +211,9 @@ class Ajax
                 // move modal to body
                 $(myModalEl' . $rand . ').appendTo($("body"));
 
+                myModalEl' . $rand . '.addEventListener("show.bs.modal", function () {
+                    $("#iframe' . $domid . '").attr("src", "' . jsescape($url) . '").removeClass("hidden");
+                });
         ';
         if ($param['reloadonclose']) {
             $js .= '
@@ -225,49 +228,21 @@ class Ajax
             ';
         }
         $js .= '
-                var h = ' . ((int) $param['height']) . ';
-                var w = ' . ((int) $param['width']) . ';
-                var iframeObj = $("#iframe' . $domid . '");
-                var iframeLoaded = false;
+                var iframeEl' . $rand . ' = document.getElementById("iframe' . $domid . '");
 
-                var adjustHeight = function() {
+                var resizeIframe' . $rand . ' = function() {
                     try {
-                        var doc = iframeObj[0].contentWindow.document;
-                        if (!doc || doc.URL === "about:blank") return;
-
-                        iframeObj.css("height", "0px");
-                        var contentHeight = doc.documentElement.scrollHeight;
-                        var bodyHeight = doc.body.scrollHeight;
-                        var finalHeight = Math.max(contentHeight, bodyHeight);
-                        if (finalHeight > 0) {
-                            iframeObj.css("height", finalHeight + "px");
-                        } else {
-                            iframeObj.css("height", h + "px");
-                        }
-                    } catch (e) {
-                        iframeObj.css("height", h + "px");
-                    }
-                    myModal' . $rand . '.handleUpdate();
+                        var doc = iframeEl' . $rand . '.contentWindow.document;
+                        var h = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight);
+                        $("#iframe' . $domid . '").height(h);
+                        myModal' . $rand . '.handleUpdate();
+                    } catch(e) {}
                 };
 
-                myModalEl' . $rand . '.addEventListener("show.bs.modal", function (e) {
-                    var targetSrc = "' . jsescape($url) . '";
-                    if (!iframeLoaded) {
-                        // Prevent modal from showing until the iframe has fully loaded and calculated its height
-                        e.preventDefault();
-                        iframeObj.attr("src", targetSrc).removeClass("hidden");
-                    }
-                });
+                iframeEl' . $rand . '.onload = function() {
+                    var w = ' . ((int) $param['width']) . ';
 
-                myModalEl' . $rand . '.addEventListener("shown.bs.modal", function () {
-                    adjustHeight();
-                });
-
-                document.getElementById("iframe' . $domid . '").onload = function() {
-                    var initialLoad = !iframeLoaded;
-                    iframeLoaded = true;
-
-                    adjustHeight();
+                    resizeIframe' . $rand . '();
 
                     if (w >= 700) {
                         $("#' . $domid . ' .modal-dialog").addClass("modal-xl");
@@ -276,14 +251,9 @@ class Ajax
                     } else if (w <= 300) {
                         $("#' . $domid . ' .modal-dialog").addClass("modal-sm");
                     }
-
-                    // Show modal now that content is loaded and height is perfectly adjusted
-                    if (initialLoad) {
-                        myModal' . $rand . '.show();
-                    }
                 };
 
-                $(window).on("resize.modal' . $rand . '", adjustHeight);
+                $(window).on("resize.iframemodal' . $rand . '", resizeIframe' . $rand . ');
             });
         ';
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -211,9 +211,6 @@ class Ajax
                 // move modal to body
                 $(myModalEl' . $rand . ').appendTo($("body"));
 
-                myModalEl' . $rand . '.addEventListener("show.bs.modal", function () {
-                    $("#iframe' . $domid . '").attr("src", "' . jsescape($url) . '").removeClass("hidden");
-                });
         ';
         if ($param['reloadonclose']) {
             $js .= '
@@ -228,11 +225,49 @@ class Ajax
             ';
         }
         $js .= '
-                document.getElementById("iframe' . $domid . '").onload = function() {
-                    var h = ' . ((int) $param['height']) . ';
-                    var w = ' . ((int) $param['width']) . ';
+                var h = ' . ((int) $param['height']) . ';
+                var w = ' . ((int) $param['width']) . ';
+                var iframeObj = $("#iframe' . $domid . '");
+                var iframeLoaded = false;
 
-                    $("#iframe' . $domid . '").height(h);
+                var adjustHeight = function() {
+                    try {
+                        var doc = iframeObj[0].contentWindow.document;
+                        if (!doc || doc.URL === "about:blank") return;
+
+                        iframeObj.css("height", "0px");
+                        var contentHeight = doc.documentElement.scrollHeight;
+                        var bodyHeight = doc.body.scrollHeight;
+                        var finalHeight = Math.max(contentHeight, bodyHeight);
+                        if (finalHeight > 0) {
+                            iframeObj.css("height", finalHeight + "px");
+                        } else {
+                            iframeObj.css("height", h + "px");
+                        }
+                    } catch (e) {
+                        iframeObj.css("height", h + "px");
+                    }
+                    myModal' . $rand . '.handleUpdate();
+                };
+
+                myModalEl' . $rand . '.addEventListener("show.bs.modal", function (e) {
+                    var targetSrc = "' . jsescape($url) . '";
+                    if (!iframeLoaded) {
+                        // Prevent modal from showing until the iframe has fully loaded and calculated its height
+                        e.preventDefault();
+                        iframeObj.attr("src", targetSrc).removeClass("hidden");
+                    }
+                });
+
+                myModalEl' . $rand . '.addEventListener("shown.bs.modal", function () {
+                    adjustHeight();
+                });
+
+                document.getElementById("iframe' . $domid . '").onload = function() {
+                    var initialLoad = !iframeLoaded;
+                    iframeLoaded = true;
+
+                    adjustHeight();
 
                     if (w >= 700) {
                         $("#' . $domid . ' .modal-dialog").addClass("modal-xl");
@@ -242,9 +277,13 @@ class Ajax
                         $("#' . $domid . ' .modal-dialog").addClass("modal-sm");
                     }
 
-                    // reajust height to content
-                    myModal' . $rand . '.handleUpdate()
+                    // Show modal now that content is loaded and height is perfectly adjusted
+                    if (initialLoad) {
+                        myModal' . $rand . '.show();
+                    }
                 };
+
+                $(window).on("resize.modal' . $rand . '", adjustHeight);
             });
         ';
 

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -189,7 +189,7 @@ class Ajax
                     <div class="modal-content">
                         <div class="modal-header">
                             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                            <h3>' . htmlescape($param['title']) . '</h3>
+                            <h3 class="modal-title">' . htmlescape($param['title']) . '</h3>
                         </div>
                         <div class="modal-body">
                             <iframe id="iframe' . htmlescape($domid) . '" class="iframe hidden"

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -235,8 +235,11 @@ class Ajax
                         var doc = iframeEl' . $rand . '.contentWindow.document;
                         var h = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight);
                         $("#iframe' . $domid . '").height(h);
-                        myModal' . $rand . '.handleUpdate();
-                    } catch(e) {}
+                    } catch(e) {
+                        var h = ' . ((int) $param['height']) . ';
+                        $("#iframe' . $domid . '").height(h);
+                    }
+                    myModal' . $rand . '.handleUpdate();
                 };
 
                 iframeEl' . $rand . '.onload = function() {

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -234,11 +234,12 @@ class Ajax
                     try {
                         var doc = iframeEl' . $rand . '.contentWindow.document;
                         var h = Math.max(doc.documentElement.scrollHeight, doc.body.scrollHeight);
-                        $("#iframe' . $domid . '").height(h);
                     } catch(e) {
                         var h = ' . ((int) $param['height']) . ';
-                        $("#iframe' . $domid . '").height(h);
                     }
+                    $("#iframe' . $domid . '").height(h);
+
+                    // reajust height to content
                     myModal' . $rand . '.handleUpdate();
                 };
 

--- a/templates/pages/admin/rules/preview_criteria.html.twig
+++ b/templates/pages/admin/rules/preview_criteria.html.twig
@@ -62,6 +62,10 @@
                     label_class: 'col-5',
                     input_class: 'col-7'
                 }) }}
+            {% else %}
+                <div class="col-12 text-center text-muted my-3">
+                    {{ __('No rule criteria to display') }}
+                </div>
             {% endfor %}
             {% do call([item, 'showSpecificCriteriasForPreview'], [_post]) %}
         </div>

--- a/templates/pages/admin/rules/preview_criteria.html.twig
+++ b/templates/pages/admin/rules/preview_criteria.html.twig
@@ -31,6 +31,7 @@
  #}
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
+{% import 'components/alerts_macros.html.twig' as alerts %}
 
 <form method="post" action="{{ target }}">
     <div class="card mb-3">
@@ -63,8 +64,8 @@
                     input_class: 'col-7'
                 }) }}
             {% else %}
-                <div class="col-12 text-center text-muted my-3">
-                    {{ __('No rule criteria to display') }}
+                <div class="d-flex justify-content-center w-100">
+                    {{ alerts.alert_info(__('No rule criteria to display')) }}
                 </div>
             {% endfor %}
             {% do call([item, 'showSpecificCriteriasForPreview'], [_post]) %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This Pull Request introduces a set of UI and UX improvements, specifically focusing on how modal windows behave and how the "Rule Preview/Test" interface is displayed.

URL: `/front/ruleright.form.php?id=1`

#### `css/includes/_base.scss`
**Fixing Modal Header Whitespace**
- **What changed:** Removed the default `margin-bottom` from all heading elements (`h1` - `h6`) when they are placed inside a `.modal-header`.
- **How it works:** Bootstrap's internal CSS reset (`_reboot.scss`) automatically applies a `margin-bottom: 16px` to all headings. Inside a modal header, this extra margin creates unwanted vertical whitespace and makes the header look misaligned. By overriding this with `margin-bottom: 0`, the modal header remains compact and visually balanced.

#### `src/Ajax.php`
**Dynamic Auto-Resizing for Iframe Modals**
- **What changed:** The `createIframeModalWindow` function was updated to calculate the height of the modal dynamically based on the iframe's internal content height, rather than relying on a hardcoded static height. 
- **How it works:**
  - Introduces a `resizeIframe` JavaScript function that checks the `scrollHeight` of the iframe's document. 
  - Uses a `try/catch` block to handle potential cross-origin security errors gracefully. If successful, it sets the iframe to the exact content height and updates the modal position via `handleUpdate()`.
  - Binds this resizing function to both the iframe's `onload` event and the `$(window).on("resize")` event. This ensures the modal height adjusts seamlessly when the content initially loads or when the user resizes their browser window.

#### `front/rule.test.php`
**Hiding the Main Header Inside Modals**
- **What changed:** The script now checks if the page is being loaded inside a modal window by looking for an `_in_modal` request parameter.
- **How it works:** It parses `$_REQUEST['_in_modal']` as a boolean and passes it as the third parameter to `Html::popHeader()`. This strips away the main application navigation and headers to prevent a cluttered "website inside a website" visual effect when opening this page within an iframe modal.

#### `templates/pages/admin/rules/preview_criteria.html.twig`
**Adding an Empty State for Rule Criteria**
- **What changed:** Added an `{% else %}` fallback inside the Twig `for` loop that iterates over rule criteria.
- **How it works:** Instead of rendering blank space when a rule has no criteria, the interface now explicitly displays a user-friendly, localized message: _"No rule criteria to display"_ inside a centered, muted text block (`<div class="col-12 text-center text-muted my-3">`).

## Screenshots (if appropriate):

**Before**:

<img width="1138" height="609" alt="SCR-20260516-ojrk" src="https://github.com/user-attachments/assets/a3962d37-a812-4414-8b1d-518f7c8dc874" />

**After**:

<img width="1138" height="323" alt="image" src="https://github.com/user-attachments/assets/3373d62a-32ef-4610-9e04-9b0c82199368" />