### PR TITLE
Fix inventory of custom assets using GenericNetworkAsset in networkports

### DIFF
--- a/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
+++ b/src/Glpi/Asset/Capacity/IsInventoriableCapacity.php
@@ -142,6 +142,10 @@ class IsInventoriableCapacity extends AbstractCapacity
             $this->registerToTypeConfig('printer_types', $classname);
         }
 
+        if ($config->getValue('inventory_mainasset') === GenericNetworkAsset::class) {
+            $this->registerToTypeConfig('networkport_types', $classname);
+        }
+
         CommonGLPI::registerStandardTab($classname, Item_Environment::class, 85);
         CommonGLPI::registerStandardTab($classname, Item_Process::class, 85);
         CommonGLPI::registerStandardTab($classname, RuleMatchedLog::class, 90);
@@ -163,6 +167,7 @@ class IsInventoriableCapacity extends AbstractCapacity
         $this->unregisterFromTypeConfig('process_types', $classname);
         $this->unregisterFromTypeConfig('ruleimportasset_types', $classname);
         $this->unregisterFromTypeConfig('printer_types', $classname);
+        $this->unregisterFromTypeConfig('networkport_types', $classname);
 
         $env_item = new Item_Environment();
         $env_item->deleteByCriteria([

--- a/tests/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
+++ b/tests/functional/Glpi/Asset/Capacity/IsInventoriableCapacityTest.php
@@ -164,6 +164,55 @@ class IsInventoriableCapacityTest extends DbTestCase
         $this->assertContains($classname_2, $CFG_GLPI['process_types']);
     }
 
+    public function testNetworkPortTypesRegistration(): void
+    {
+        global $CFG_GLPI;
+
+        // GenericAsset (default) should not register in networkport_types
+        $definition_generic = $this->initAssetDefinition(
+            capacities: [
+                new Capacity(
+                    name: IsInventoriableCapacity::class,
+                    config: new CapacityConfig(['inventory_mainasset' => GenericAsset::class])
+                ),
+            ]
+        );
+        $classname_generic = $definition_generic->getAssetClassName();
+        $this->assertNotContains($classname_generic, $CFG_GLPI['networkport_types']);
+
+        // GenericPrinterAsset should not register in networkport_types
+        $definition_printer = $this->initAssetDefinition(
+            capacities: [
+                new Capacity(
+                    name: IsInventoriableCapacity::class,
+                    config: new CapacityConfig(['inventory_mainasset' => GenericPrinterAsset::class])
+                ),
+            ]
+        );
+        $classname_printer = $definition_printer->getAssetClassName();
+        $this->assertNotContains($classname_printer, $CFG_GLPI['networkport_types']);
+
+        // GenericNetworkAsset should register in networkport_types
+        $definition_network = $this->initAssetDefinition(
+            capacities: [
+                new Capacity(
+                    name: IsInventoriableCapacity::class,
+                    config: new CapacityConfig(['inventory_mainasset' => GenericNetworkAsset::class])
+                ),
+            ]
+        );
+        $classname_network = $definition_network->getAssetClassName();
+        $this->assertContains($classname_network, $CFG_GLPI['networkport_types']);
+
+        // Disabling the capacity should unregister from networkport_types
+        $this->assertTrue($definition_network->update(['id' => $definition_network->getID(), 'capacities' => []]));
+        $this->assertNotContains($classname_network, $CFG_GLPI['networkport_types']);
+
+        // Other definitions should be unaffected
+        $this->assertNotContains($classname_generic, $CFG_GLPI['networkport_types']);
+        $this->assertNotContains($classname_printer, $CFG_GLPI['networkport_types']);
+    }
+
     public function testIsUsed(): void
     {
         // Retrieve the test root entity


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43931
- Here is a brief description of what this PR does

When a custom asset uses `IsInventoriableCapacity` with `GenericNetworkAsset`, its class is never stored in `$CFG_GLPI[‘networkport_types’]`. This causes `NetworkPort::checkConf()` to return `false` during the SNMP inventory, which skips all processing of network ports.

## Screenshots (if appropriate):


