### PR TITLE
Fix - Progressbar search criteria use numeric comparison instead of string

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1999,7 +1999,7 @@ final class SQLProvider implements SearchProviderInterface
                 case "progressbar":
                     $decimal_contains = $searchopt[$ID]["datatype"] === 'decimal' && $searchtype === 'contains';
 
-                    if (preg_match("/([<>])(=?)[[:space:]]*(-?)[[:space:]]*([0-9]+(.[0-9]+)?)/", $val, $regs)) {
+                    if (preg_match("/([<>])(=?)[[:space:]]*(-?)[[:space:]]*([0-9]+(\.[0-9]+)?)/", $val, $regs)) {
                         if (in_array($searchtype, ["notequals", "notcontains"])) {
                             $nott = !$nott;
                         }
@@ -2014,7 +2014,7 @@ final class SQLProvider implements SearchProviderInterface
                         // progressbar uses LPAD() which returns zero-padded strings ('067' for 67%).
                         // Quoting the value forces a lexicographic comparison ('067' < '20' → TRUE), so we keep it unquoted.
                         $compare_value = $searchopt[$ID]["datatype"] === 'progressbar'
-                            ? ($regs[3] . $regs[4])
+                            ? (float) ($regs[3] . $regs[4])
                             : $DB::quoteValue($regs[3] . $regs[4]);
                         return [
                             new QueryExpression(

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2011,13 +2011,18 @@ final class SQLProvider implements SearchProviderInterface
                             }
                         }
                         $regs[1] .= $regs[2];
+                        // progressbar uses LPAD() which returns zero-padded strings ('067' for 67%).
+                        // Quoting the value forces a lexicographic comparison ('067' < '20' → TRUE), so we keep it unquoted.
+                        $compare_value = $searchopt[$ID]["datatype"] === 'progressbar'
+                            ? ($regs[3] . $regs[4])
+                            : $DB::quoteValue($regs[3] . $regs[4]);
                         return [
                             new QueryExpression(
                                 sprintf(
                                     "%s %s %s",
                                     $tocompute,
                                     $regs[1],
-                                    $DB::quoteValue($regs[3] . $regs[4])
+                                    $compare_value
                                 )
                             ),
                         ];

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -4374,12 +4374,14 @@ class SearchTest extends DbTestCase
                     ];
 
                     // datatype=progressbar (with computation)
+                    // progressbar: unquote the value to avoid lexicographic comparison with LPAD() output.
+                    $signed_value_unquoted = trim($signed_value, "'");
                     yield [
                         'itemtype'          => Computer::class,
                         'search_option'     => 152, // harddrive freepercent
                         'value'             => $searched_value,
-                        'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.`totalsize`, 0), 0), 3, '0') {$operator} {$signed_value})",
-                        'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.`totalsize`, 0), 0), 3, '0') {$not_operator} {$signed_value})",
+                        'expected_and'      => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.`totalsize`, 0), 0), 3, '0') {$operator} {$signed_value_unquoted})",
+                        'expected_and_not'  => "(LPAD(ROUND(100*`glpi_items_disks`.freesize/NULLIF(`glpi_items_disks`.`totalsize`, 0), 0), 3, '0') {$not_operator} {$signed_value_unquoted})",
                     ];
 
                     // datatype=timestamp
@@ -6822,6 +6824,100 @@ class SearchTest extends DbTestCase
         $search_params['metacriteria'][0]['value'] = 99999999;
         $data = $this->doSearch(Form::class, $search_params);
         $this->assertSame(0, $data['data']['totalcount']);
+    }
+
+    /**
+     * Regression test: numeric operators (< > <= >=) on progressbar fields (e.g. "Free percentage")
+     * must produce a numeric SQL comparison, not a lexicographic one.
+     *
+     * Without the fix, LPAD() returns a zero-padded string such as '067'.
+     * Comparing '067' < '20' lexicographically is TRUE (because '0' < '2'), so every
+     * computer would wrongly match a "< 20" filter regardless of its actual free space.
+     */
+    public function testProgressbarNumericOperatorSearch(): void
+    {
+        $this->login();
+
+        $unique     = uniqid('freepct-', true);
+
+        $entity_id  = $this->getTestRootEntity(true);
+
+        $computer_low = $this->createItem(\Computer::class, [
+            'name'        => $unique . '-low',
+            'entities_id' => $entity_id,
+        ]);
+        $computer_high = $this->createItem(\Computer::class, [
+            'name'        => $unique . '-high',
+            'entities_id' => $entity_id,
+        ]);
+
+        // 10% free space  (freesize / totalsize = 10/100)
+        $this->createItem(\Item_Disk::class, [
+            'itemtype'   => \Computer::class,
+            'items_id'   => $computer_low->getID(),
+            'name'       => 'disk-low',
+            'mountpoint' => '/',
+            'totalsize'  => 100,
+            'freesize'   => 10,
+        ]);
+
+        // 67% free space  (freesize / totalsize = 67/100)
+        $this->createItem(\Item_Disk::class, [
+            'itemtype'   => \Computer::class,
+            'items_id'   => $computer_high->getID(),
+            'name'       => 'disk-high',
+            'mountpoint' => '/',
+            'totalsize'  => 100,
+            'freesize'   => 67,
+        ]);
+
+        $search_field = 152; // Volumes - Free percentage
+
+        // "contains < 20": only the 10%-free computer must match (name filter isolates our fixtures)
+        $data = $this->doSearch(\Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => [
+                [
+                    'field'      => 1, // name
+                    'searchtype' => 'contains',
+                    'value'      => $unique,
+                ],
+                [
+                    'link'       => 'AND',
+                    'field'      => $search_field,
+                    'searchtype' => 'contains',
+                    'value'      => '< 20',
+                ],
+            ],
+        ]);
+
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($computer_low->getID(), $ids_found, 'Computer with 10% free space should match "< 20"');
+        $this->assertNotContains($computer_high->getID(), $ids_found, 'Computer with 67% free space must NOT match "< 20"');
+
+        // "contains >= 67": only the 67%-free computer must match
+        $data = $this->doSearch(\Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => [
+                [
+                    'field'      => 1, // name
+                    'searchtype' => 'contains',
+                    'value'      => $unique,
+                ],
+                [
+                    'link'       => 'AND',
+                    'field'      => $search_field,
+                    'searchtype' => 'contains',
+                    'value'      => '>= 67',
+                ],
+            ],
+        ]);
+
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($computer_high->getID(), $ids_found, 'Computer with 67% free space should match ">= 67"');
+        $this->assertNotContains($computer_low->getID(), $ids_found, 'Computer with 10% free space must NOT match ">= 67"');
     }
 }
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -6842,18 +6842,18 @@ class SearchTest extends DbTestCase
 
         $entity_id  = $this->getTestRootEntity(true);
 
-        $computer_low = $this->createItem(\Computer::class, [
+        $computer_low = $this->createItem(Computer::class, [
             'name'        => $unique . '-low',
             'entities_id' => $entity_id,
         ]);
-        $computer_high = $this->createItem(\Computer::class, [
+        $computer_high = $this->createItem(Computer::class, [
             'name'        => $unique . '-high',
             'entities_id' => $entity_id,
         ]);
 
         // 10% free space  (freesize / totalsize = 10/100)
         $this->createItem(\Item_Disk::class, [
-            'itemtype'   => \Computer::class,
+            'itemtype'   => Computer::class,
             'items_id'   => $computer_low->getID(),
             'name'       => 'disk-low',
             'mountpoint' => '/',
@@ -6863,7 +6863,7 @@ class SearchTest extends DbTestCase
 
         // 67% free space  (freesize / totalsize = 67/100)
         $this->createItem(\Item_Disk::class, [
-            'itemtype'   => \Computer::class,
+            'itemtype'   => Computer::class,
             'items_id'   => $computer_high->getID(),
             'name'       => 'disk-high',
             'mountpoint' => '/',
@@ -6874,7 +6874,7 @@ class SearchTest extends DbTestCase
         $search_field = 152; // Volumes - Free percentage
 
         // "contains < 20": only the 10%-free computer must match (name filter isolates our fixtures)
-        $data = $this->doSearch(\Computer::class, [
+        $data = $this->doSearch(Computer::class, [
             'is_deleted' => 0,
             'start'      => 0,
             'criteria'   => [
@@ -6897,7 +6897,7 @@ class SearchTest extends DbTestCase
         $this->assertNotContains($computer_high->getID(), $ids_found, 'Computer with 67% free space must NOT match "< 20"');
 
         // "contains >= 67": only the 67%-free computer must match
-        $data = $this->doSearch(\Computer::class, [
+        $data = $this->doSearch(Computer::class, [
             'is_deleted' => 0,
             'start'      => 0,
             'criteria'   => [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44041
- Here is a brief description of what this PR does


 When searching assets using a "Volumes - Free percentage" criterion with a numeric operator (e.g. `contains < 20`), GLPI was producing wrong results. Computers with 67% free space were incorrectly matched because the SQL comparison was lexicographic (`'067' < '20'` is `TRUE` since `'0' < '2'`).

 This affected any `progressbar` search option whose `computation` uses `LPAD(ROUND(...), 3, '0')`, which zero-pads the percentage to 3 characters (e.g. `'010'`, `'067'`).

 ### Root Cause

 In `SQLProvider::getCriteria()`, the comparison value extracted from the user's input was always wrapped with `DB::quoteValue()`, turning `20` into `'20'`. MySQL then compared two strings lexicographically instead of two numbers.

 ### Fix

 For `progressbar` datatype fields, the comparison value is now passed as a bare numeric literal (without quotes). MySQL implicitly casts the `LPAD()` string result to a number, restoring correct numeric comparison.

 ### Tests

 - Updated the expected SQL in `containsCriterionProvider()` for the `freepercent` option (unquoted value).
 - Added `testProgressbarNumericOperatorSearch()`: creates two computers with known free-space percentages (10% and 67%), then verifies that `< 20` matches only the first and `>= 67` matches only the second.

## Screenshots (if appropriate):

<img width="1088" height="311" alt="image" src="https://github.com/user-attachments/assets/f1e96325-dce1-48a8-b275-4a47b444dbe5" />
