### PR TITLE
fix(forms): use completename for TreeDropdown objects visibility condition comparisons

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -531,6 +531,9 @@ class QuestionTypeItem extends AbstractQuestionType implements
 
         $item = getItemForItemtype($question_config->getItemtype());
         if ($item && $item->getfromDB($config->getItemsId())) {
+            if ($item instanceof CommonTreeDropdown) {
+                return $item->fields['completename'];
+            }
             return $item->getName();
         }
 

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -258,4 +258,52 @@ final class QuestionTypeItemTest extends DbTestCase
         // Clean up any session flags set by the case
         unset($_SESSION['glpiis_ids_visible']);
     }
+
+    public function transformConditionValueForComparisonsProvider()
+    {
+        return [
+            [
+                'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: Computer::class),
+                'itemtype_id' => ['items_id' => $this->createItem(Computer::class, [
+                    'name'        => 'ComputerTest',
+                    'entities_id' => $this->getTestRootEntity(true),
+                ])->getID()],
+                'expected_name' => 'ComputerTest',
+            ],
+            [
+                'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: \ITILCategory::class),
+                'itemtype_id' => ['items_id' => $this->createItem(\ITILCategory::class, [
+                    'name' => 'Parent Category',
+                    'entities_id' => $this->getTestRootEntity(true),
+                ])->getID()],
+                'expected_name' => 'Parent Category',
+            ],
+            [
+                'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: \ITILCategory::class),
+                'itemtype_id' => ['items_id' => $this->createItem(\ITILCategory::class, [
+                    'name' => 'Child Category',
+                    'entities_id' => $this->getTestRootEntity(true),
+                    'itilcategories_id' => $this->createItem(\ITILCategory::class, [
+                        'name' => 'Parent Category',
+                        'entities_id' => $this->getTestRootEntity(true),
+                    ])->getID(),
+                ])->getID()],
+                'expected_name' => 'Parent Category > Child Category',
+            ],
+        ];
+    }
+
+    public function testTransformConditionValueForComparisons(): void
+    {
+        $this->login();
+
+        $question_type = new QuestionTypeItem();
+        foreach ($this->transformConditionValueForComparisonsProvider() as $case) {
+            $output = $question_type->transformConditionValueForComparisons(
+                $case['itemtype_id'],
+                $case['question_config']
+            );
+            $this->assertEquals($case['expected_name'], $output);
+        }
+    }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -263,33 +263,39 @@ final class QuestionTypeItemTest extends DbTestCase
      * Data provider for testing the transformation of condition values for comparisons.
      * Each case provides a question configuration, an input itemtype_id value, and the expected output after transformation.
      */
-    public function transformConditionValueForComparisonsProvider()
+    public static function transformConditionValueForComparisonsProvider()
     {
-        return [
-            [
+        yield [
+            fn(self $t) => [
                 'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: Computer::class),
-                'itemtype_id' => ['items_id' => $this->createItem(Computer::class, [
+                'itemtype_id' => ['items_id' => $t->createItem(Computer::class, [
                     'name'        => 'ComputerTest',
-                    'entities_id' => $this->getTestRootEntity(true),
+                    'entities_id' => $t->getTestRootEntity(true),
                 ])->getID()],
                 'expected_name' => 'ComputerTest',
             ],
-            [
+        ];
+
+        yield [
+            fn(self $t) => [
                 'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: \ITILCategory::class),
-                'itemtype_id' => ['items_id' => $this->createItem(\ITILCategory::class, [
+                'itemtype_id' => ['items_id' => $t->createItem(\ITILCategory::class, [
                     'name' => 'Parent Category',
-                    'entities_id' => $this->getTestRootEntity(true),
+                    'entities_id' => $t->getTestRootEntity(true),
                 ])->getID()],
                 'expected_name' => 'Parent Category',
             ],
-            [
+        ];
+
+        yield [
+            fn(self $t) => [
                 'question_config' => new QuestionTypeItemExtraDataConfig(itemtype: \ITILCategory::class),
-                'itemtype_id' => ['items_id' => $this->createItem(\ITILCategory::class, [
+                'itemtype_id' => ['items_id' => $t->createItem(\ITILCategory::class, [
                     'name' => 'Child Category',
-                    'entities_id' => $this->getTestRootEntity(true),
-                    'itilcategories_id' => $this->createItem(\ITILCategory::class, [
+                    'entities_id' => $t->getTestRootEntity(true),
+                    'itilcategories_id' => $t->createItem(\ITILCategory::class, [
                         'name' => 'Parent Category',
-                        'entities_id' => $this->getTestRootEntity(true),
+                        'entities_id' => $t->getTestRootEntity(true),
                     ])->getID(),
                 ])->getID()],
                 'expected_name' => 'Parent Category > Child Category',
@@ -297,17 +303,17 @@ final class QuestionTypeItemTest extends DbTestCase
         ];
     }
 
-    public function testTransformConditionValueForComparisons(): void
+    #[DataProvider('transformConditionValueForComparisonsProvider')]
+    public function testTransformConditionValueForComparisons(callable $setup): void
     {
         $this->login();
 
         $question_type = new QuestionTypeItem();
-        foreach ($this->transformConditionValueForComparisonsProvider() as $case) {
-            $output = $question_type->transformConditionValueForComparisons(
-                $case['itemtype_id'],
-                $case['question_config']
-            );
-            $this->assertEquals($case['expected_name'], $output);
-        }
+        $case = $setup($this);
+        $name = $question_type->transformConditionValueForComparisons(
+            $case['itemtype_id'],
+            $case['question_config']
+        );
+        $this->assertEquals($case['expected_name'], $name);
     }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -259,6 +259,10 @@ final class QuestionTypeItemTest extends DbTestCase
         unset($_SESSION['glpiis_ids_visible']);
     }
 
+    /**
+     * Data provider for testing the transformation of condition values for comparisons.
+     * Each case provides a question configuration, an input itemtype_id value, and the expected output after transformation.
+     */
     public function transformConditionValueForComparisonsProvider()
     {
         return [


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44048
- Here is a brief description of what this PR does
If a question's display condition is based on the answer to another question that uses a TreeDropdown type, such as ITILCategory, the filtering is performed based on the category name rather than the completename.

## Screenshots (if appropriate):
In the example, I set a visibility condition for the “ITILCategory Condition” question such that it is visible only if the category response to the “ITILCategory Question” question contains the string “Content”.  

Conditional visibility:
<img width="756" height="232" alt="image" src="https://github.com/user-attachments/assets/c4422840-1196-4f77-8b73-8824e5d21a1e" />

Before fix:
<img width="987" height="168" alt="image" src="https://github.com/user-attachments/assets/498b2990-1f39-484e-a34b-a93e94998c37" />

After fix:
<img width="991" height="262" alt="image" src="https://github.com/user-attachments/assets/1c2d7b14-f85f-4b03-b6de-87b8e2a18493" />