### PR TITLE
KB : signal articles linked to multiple categories in aside tree

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -795,39 +795,10 @@
         cursor: pointer;
     }
 
-    // Multi-category article: a subtle italic "also live in …" subtitle listing
-    // the other categories (a M2M with no canonical one, so every occurrence is
-    // flagged identically) + sibling highlight lighting up the same article
-    // wherever else it is listed.
+    // Multi-category article (a M2M with no canonical category, so every
+    // occurrence is flagged identically): hovering/focusing one occurrence lights
+    // up all of them across the tree, revealing where else the article is listed.
     .article[data-glpi-kb-article-multi] {
-        // min-width:0 lets the title and subtitle truncate inside the flex row.
-        .kb-article-stack {
-            min-width: 0;
-        }
-
-        // Title line: truncating title + a trailing "stack" marker kept visible.
-        .kb-article-titleline {
-            display: flex;
-            align-items: center;
-            min-width: 0;
-        }
-
-        .kb-article-title {
-            min-width: 0;
-        }
-
-        .kb-article-multi-icon {
-            flex: 0 0 auto;
-            margin-left: 0.25rem;
-            color: var(--tblr-secondary);
-            font-size: 0.875rem;
-        }
-
-        .kb-article-also-in {
-            font-size: 0.75rem;
-            color: var(--tblr-secondary);
-        }
-
         &.kb-article--sibling,
         &:hover {
             background-color: color-mix(in srgb, var(--tblr-primary) 12%, transparent);
@@ -837,6 +808,15 @@
                 color: var(--tblr-primary);
             }
         }
+    }
+
+    // When a copy of the hovered article is folded away inside a collapsed
+    // category, its row is hidden — so we light that category's (still visible)
+    // header instead, keeping the "also listed here" signal from being lost.
+    [data-glpi-kb-aside-category].kb-category--sibling > [data-glpi-kb-aside-category-toggle] {
+        background-color: color-mix(in srgb, var(--tblr-primary) 12%, transparent);
+        border-radius: var(--tblr-border-radius);
+        color: var(--tblr-primary);
     }
 
     // KB aside tree hierarchy connector lines

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -795,26 +795,45 @@
         cursor: pointer;
     }
 
-    // Multi-category article: left border accent + sibling highlight on hover
-    [data-glpi-kb-aside-tree] {
-        .article[data-glpi-kb-article-multi] {
+    // Multi-category article: a subtle italic "also live in …" subtitle listing
+    // the other categories (a M2M with no canonical one, so every occurrence is
+    // flagged identically) + sibling highlight lighting up the same article
+    // wherever else it is listed.
+    .article[data-glpi-kb-article-multi] {
+        // min-width:0 lets the title and subtitle truncate inside the flex row.
+        .kb-article-stack {
+            min-width: 0;
+        }
+
+        // Title line: truncating title + a trailing "stack" marker kept visible.
+        .kb-article-titleline {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+        }
+
+        .kb-article-title {
+            min-width: 0;
+        }
+
+        .kb-article-multi-icon {
+            flex: 0 0 auto;
+            margin-left: 0.25rem;
+            color: var(--tblr-secondary);
+            font-size: 0.875rem;
+        }
+
+        .kb-article-also-in {
+            font-size: 0.75rem;
+            color: var(--tblr-secondary);
+        }
+
+        &.kb-article--sibling,
+        &:hover {
+            background-color: color-mix(in srgb, var(--tblr-primary) 12%, transparent);
+            border-radius: var(--tblr-border-radius);
+
             > a {
-                border-left: 2px solid color-mix(in srgb, var(--tblr-primary) 35%, transparent);
-                padding-left: 4px;
-            }
-
-            &.kb-article--sibling > a,
-            &:hover > a {
-                border-left-color: var(--tblr-primary);
-            }
-
-            &.kb-article--sibling > a {
-                background-color: color-mix(in srgb, var(--tblr-primary) 8%, transparent);
-                color: var(--tblr-primary);
-            }
-
-            &:hover > a {
-                background-color: color-mix(in srgb, var(--tblr-primary) 14%, transparent);
                 color: var(--tblr-primary);
             }
         }
@@ -864,31 +883,5 @@
                 }
             }
         }
-    }
-}
-
-// Tooltip for KB aside multi-category articles.
-// Lives at body level (appended by AsideController.js), so it must NOT be scoped
-// to [data-main-page-aside="knowbaseitem"] — otherwise no styles apply.
-.kb-aside-multi-tooltip {
-    position: fixed;
-    background: var(--tblr-dark);
-    color: #fff;
-    padding: 4px 10px;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    white-space: nowrap;
-    pointer-events: none;
-    z-index: 1080;
-    box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
-
-    &::after {
-        content: '';
-        position: absolute;
-        left: 50%;
-        top: 100%;
-        transform: translateX(-50%);
-        border: 5px solid transparent;
-        border-top-color: var(--tblr-dark);
     }
 }

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -795,6 +795,31 @@
         cursor: pointer;
     }
 
+    // Multi-category article: left border accent + sibling highlight on hover
+    [data-glpi-kb-aside-tree] {
+        .article[data-glpi-kb-article-multi] {
+            > a {
+                border-left: 2px solid color-mix(in srgb, var(--tblr-primary) 35%, transparent);
+                padding-left: 4px;
+            }
+
+            &.kb-article--sibling > a,
+            &:hover > a {
+                border-left-color: var(--tblr-primary);
+            }
+
+            &.kb-article--sibling > a {
+                background-color: color-mix(in srgb, var(--tblr-primary) 8%, transparent);
+                color: var(--tblr-primary);
+            }
+
+            &:hover > a {
+                background-color: color-mix(in srgb, var(--tblr-primary) 14%, transparent);
+                color: var(--tblr-primary);
+            }
+        }
+    }
+
     // KB aside tree hierarchy connector lines
     .kb-tree {
         list-style: none;
@@ -839,5 +864,31 @@
                 }
             }
         }
+    }
+}
+
+// Tooltip for KB aside multi-category articles.
+// Lives at body level (appended by AsideController.js), so it must NOT be scoped
+// to [data-main-page-aside="knowbaseitem"] — otherwise no styles apply.
+.kb-aside-multi-tooltip {
+    position: fixed;
+    background: var(--tblr-dark);
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 1080;
+    box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
+
+    &::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: 100%;
+        transform: translateX(-50%);
+        border: 5px solid transparent;
+        border-top-color: var(--tblr-dark);
     }
 }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -62,6 +62,7 @@ export class GlpiKnowbaseAsideController
         this.#aside = aside;
         this.#initCategoryToggle();
         this.#initSearch();
+        this.#initMultiCategoryHover();
     }
 
     #initCategoryToggle()
@@ -309,5 +310,108 @@ export class GlpiKnowbaseAsideController
         }
 
         return has_visible;
+    }
+
+    #initMultiCategoryHover()
+    {
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
+        if (!tree) {
+            return;
+        }
+
+        const label = tree.getAttribute('data-glpi-kb-also-in-label') ?? 'Also in';
+        let active_li = null;
+        let tooltip_el = null;
+        let tooltip_seq = 0;
+
+        const activate = (article_li) => {
+            const article_id = article_li.getAttribute('data-glpi-kb-article-id');
+            const other_cats = article_li.getAttribute('data-glpi-kb-article-other-categories');
+
+            tree.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(article_id)}"]`)
+                .forEach(el => {
+                    if (el !== article_li) {
+                        el.classList.add('kb-article--sibling');
+                    }
+                });
+
+            if (!other_cats) {
+                return;
+            }
+
+            tooltip_el = document.createElement('div');
+            tooltip_el.id = `kb-aside-multi-tooltip-${++tooltip_seq}`;
+            tooltip_el.setAttribute('role', 'tooltip');
+            tooltip_el.className = 'kb-aside-multi-tooltip';
+            tooltip_el.textContent = `${label}: ${other_cats}`;
+            document.body.appendChild(tooltip_el);
+
+            // Link the tooltip to the article's anchor for screen reader announcement.
+            article_li.querySelector('a')?.setAttribute('aria-describedby', tooltip_el.id);
+
+            const rect     = article_li.getBoundingClientRect();
+            const tip_rect = tooltip_el.getBoundingClientRect();
+            tooltip_el.style.left = `${rect.left + rect.width / 2 - tip_rect.width / 2}px`;
+            tooltip_el.style.top  = `${rect.top - tip_rect.height - 8}px`;
+        };
+
+        const deactivate = (article_li) => {
+            const article_id = article_li.getAttribute('data-glpi-kb-article-id');
+            tree.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(article_id)}"]`)
+                .forEach(el => el.classList.remove('kb-article--sibling'));
+            article_li.querySelector('a')?.removeAttribute('aria-describedby');
+            tooltip_el?.remove();
+            tooltip_el = null;
+        };
+
+        const enter = (article_li) => {
+            if (article_li === active_li) {
+                return;
+            }
+            if (active_li) {
+                deactivate(active_li);
+            }
+            active_li = article_li;
+            activate(article_li);
+        };
+
+        const leave = (related_target) => {
+            if (!active_li) {
+                return;
+            }
+            // Pointer / focus moved to a descendant of the active <li> — stay active.
+            if (related_target && active_li.contains(related_target)) {
+                return;
+            }
+            deactivate(active_li);
+            active_li = null;
+        };
+
+        // Delegation via bubbling events. Resilient to DOM mutations (drag-and-drop
+        // reparenting, search filtering) — data attributes are read fresh on every event.
+        tree.addEventListener('mouseover', (e) => {
+            const article_li = e.target.closest('[data-glpi-kb-article-multi]');
+            if (article_li) {
+                enter(article_li);
+            }
+        });
+        tree.addEventListener('mouseout', (e) => leave(e.relatedTarget));
+
+        // Keyboard parity: tabbing to a multi-category article surfaces the same tooltip.
+        tree.addEventListener('focusin', (e) => {
+            const article_li = e.target.closest('[data-glpi-kb-article-multi]');
+            if (article_li) {
+                enter(article_li);
+            }
+        });
+        tree.addEventListener('focusout', (e) => leave(e.relatedTarget));
+
+        // ARIA Tooltip pattern: Escape dismisses without moving focus.
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && active_li) {
+                deactivate(active_li);
+                active_li = null;
+            }
+        });
     }
 }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -317,8 +317,11 @@ export class GlpiKnowbaseAsideController
      *
      * A multi-category article is shown once under each of its categories. Those
      * copies live in disjoint DOM subtrees, so CSS :hover cannot reach them — JS
-     * toggles a shared class on every node carrying the same article id. The
-     * "also in …" text itself is a native Bootstrap tooltip (no JS here).
+     * toggles a shared class on every node carrying the same article id.
+     *
+     * When a copy is folded away inside a collapsed category its own row is
+     * hidden, so we light the collapsed ancestor's header instead — the signal
+     * must never disappear behind a fold.
      */
     #initMultiCategoryHighlight()
     {
@@ -331,12 +334,36 @@ export class GlpiKnowbaseAsideController
             `[data-glpi-kb-article-id="${CSS.escape(article_li.getAttribute('data-glpi-kb-article-id'))}"]`,
         );
 
+        // The outermost collapsed category wrapping `el`, or null when every
+        // ancestor is expanded (so `el` is actually visible). The outermost one
+        // is the only category whose header stays visible while the rest folds.
+        const collapsedAncestor = (el) => {
+            let collapsed = null;
+            for (let node = el.parentElement; node && node !== tree; node = node.parentElement) {
+                if (
+                    node.matches('[data-glpi-kb-aside-category]')
+                    && node.hasAttribute('data-glpi-kb-aside-category-collapsed')
+                ) {
+                    collapsed = node;
+                }
+            }
+            return collapsed;
+        };
+
         // Delegation via bubbling events. Resilient to DOM mutations (drag-and-drop
         // reparenting, search filtering) — the article id is read fresh every time.
         const highlight = (e, on) => {
             const article_li = e.target.closest('[data-glpi-kb-article-multi]');
-            if (article_li) {
-                siblings(article_li).forEach(el => el.classList.toggle('kb-article--sibling', on));
+            if (!article_li) {
+                return;
+            }
+            for (const el of siblings(article_li)) {
+                const folded = collapsedAncestor(el);
+                if (folded) {
+                    folded.classList.toggle('kb-category--sibling', on);
+                } else {
+                    el.classList.toggle('kb-article--sibling', on);
+                }
             }
         };
 

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -62,7 +62,7 @@ export class GlpiKnowbaseAsideController
         this.#aside = aside;
         this.#initCategoryToggle();
         this.#initSearch();
-        this.#initMultiCategoryHover();
+        this.#initMultiCategoryHighlight();
     }
 
     #initCategoryToggle()
@@ -312,106 +312,38 @@ export class GlpiKnowbaseAsideController
         return has_visible;
     }
 
-    #initMultiCategoryHover()
+    /**
+     * Light up every other listing of the hovered/focused article across the tree.
+     *
+     * A multi-category article is shown once under each of its categories. Those
+     * copies live in disjoint DOM subtrees, so CSS :hover cannot reach them — JS
+     * toggles a shared class on every node carrying the same article id. The
+     * "also in …" text itself is a native Bootstrap tooltip (no JS here).
+     */
+    #initMultiCategoryHighlight()
     {
         const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
         if (!tree) {
             return;
         }
 
-        const label = tree.getAttribute('data-glpi-kb-also-in-label') ?? 'Also in';
-        let active_li = null;
-        let tooltip_el = null;
-        let tooltip_seq = 0;
-
-        const activate = (article_li) => {
-            const article_id = article_li.getAttribute('data-glpi-kb-article-id');
-            const other_cats = article_li.getAttribute('data-glpi-kb-article-other-categories');
-
-            tree.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(article_id)}"]`)
-                .forEach(el => {
-                    if (el !== article_li) {
-                        el.classList.add('kb-article--sibling');
-                    }
-                });
-
-            if (!other_cats) {
-                return;
-            }
-
-            tooltip_el = document.createElement('div');
-            tooltip_el.id = `kb-aside-multi-tooltip-${++tooltip_seq}`;
-            tooltip_el.setAttribute('role', 'tooltip');
-            tooltip_el.className = 'kb-aside-multi-tooltip';
-            tooltip_el.textContent = `${label}: ${other_cats}`;
-            document.body.appendChild(tooltip_el);
-
-            // Link the tooltip to the article's anchor for screen reader announcement.
-            article_li.querySelector('a')?.setAttribute('aria-describedby', tooltip_el.id);
-
-            const rect     = article_li.getBoundingClientRect();
-            const tip_rect = tooltip_el.getBoundingClientRect();
-            tooltip_el.style.left = `${rect.left + rect.width / 2 - tip_rect.width / 2}px`;
-            tooltip_el.style.top  = `${rect.top - tip_rect.height - 8}px`;
-        };
-
-        const deactivate = (article_li) => {
-            const article_id = article_li.getAttribute('data-glpi-kb-article-id');
-            tree.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(article_id)}"]`)
-                .forEach(el => el.classList.remove('kb-article--sibling'));
-            article_li.querySelector('a')?.removeAttribute('aria-describedby');
-            tooltip_el?.remove();
-            tooltip_el = null;
-        };
-
-        const enter = (article_li) => {
-            if (article_li === active_li) {
-                return;
-            }
-            if (active_li) {
-                deactivate(active_li);
-            }
-            active_li = article_li;
-            activate(article_li);
-        };
-
-        const leave = (related_target) => {
-            if (!active_li) {
-                return;
-            }
-            // Pointer / focus moved to a descendant of the active <li> — stay active.
-            if (related_target && active_li.contains(related_target)) {
-                return;
-            }
-            deactivate(active_li);
-            active_li = null;
-        };
+        const siblings = (article_li) => tree.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(article_li.getAttribute('data-glpi-kb-article-id'))}"]`,
+        );
 
         // Delegation via bubbling events. Resilient to DOM mutations (drag-and-drop
-        // reparenting, search filtering) — data attributes are read fresh on every event.
-        tree.addEventListener('mouseover', (e) => {
+        // reparenting, search filtering) — the article id is read fresh every time.
+        const highlight = (e, on) => {
             const article_li = e.target.closest('[data-glpi-kb-article-multi]');
             if (article_li) {
-                enter(article_li);
+                siblings(article_li).forEach(el => el.classList.toggle('kb-article--sibling', on));
             }
-        });
-        tree.addEventListener('mouseout', (e) => leave(e.relatedTarget));
+        };
 
-        // Keyboard parity: tabbing to a multi-category article surfaces the same tooltip.
-        tree.addEventListener('focusin', (e) => {
-            const article_li = e.target.closest('[data-glpi-kb-article-multi]');
-            if (article_li) {
-                enter(article_li);
-            }
-        });
-        tree.addEventListener('focusout', (e) => leave(e.relatedTarget));
-
-        // ARIA Tooltip pattern: Escape dismisses without moving focus.
-        document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && active_li) {
-                deactivate(active_li);
-                active_li = null;
-            }
-        });
+        tree.addEventListener('mouseover', (e) => highlight(e, true));
+        tree.addEventListener('mouseout', (e) => highlight(e, false));
+        // Keyboard parity: tabbing to a multi-category article lights up its copies too.
+        tree.addEventListener('focusin', (e) => highlight(e, true));
+        tree.addEventListener('focusout', (e) => highlight(e, false));
     }
 }

--- a/src/Glpi/Knowbase/Aside/Article.php
+++ b/src/Glpi/Knowbase/Aside/Article.php
@@ -42,5 +42,8 @@ final class Article
         public readonly string $illustration,
         public readonly string $link,
         public readonly bool $is_current = false,
+        public readonly int $categories_count = 1,
+        /** @var array<int, string> Map of category id => category name */
+        public readonly array $all_categories = [],
     ) {}
 }

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -35,11 +35,49 @@
 namespace Glpi\Knowbase\Aside;
 
 use KnowbaseItem;
+use KnowbaseItem_KnowbaseItemCategory;
 use KnowbaseItemCategory;
 
 final class Builder
 {
-    public function __construct(private readonly int $current_id = 0) {}
+    /** @var array<int, array<int, string>> Map of article_id => [category_id => category_name] */
+    private readonly array $multi_category_data;
+
+    public function __construct(private readonly int $current_id = 0)
+    {
+        $this->multi_category_data = $this->loadMultiCategoryData();
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function loadMultiCategoryData(): array
+    {
+        global $DB;
+
+        $iterator = $DB->request([
+            'SELECT'     => [
+                'kikc.knowbaseitems_id',
+                'kic.id AS category_id',
+                'kic.name AS category_name',
+            ],
+            'FROM'       => KnowbaseItem_KnowbaseItemCategory::getTable() . ' AS kikc',
+            'INNER JOIN' => [
+                KnowbaseItemCategory::getTable() . ' AS kic' => [
+                    'ON' => ['kic' => 'id', 'kikc' => 'knowbaseitemcategories_id'],
+                ],
+            ],
+            'WHERE'      => getEntitiesRestrictCriteria('kic', '', '', true),
+            'ORDERBY'    => 'kic.name',
+        ]);
+
+        $data = [];
+        foreach ($iterator as $row) {
+            $data[(int) $row['knowbaseitems_id']][(int) $row['category_id']] = $row['category_name'];
+        }
+
+        return array_filter($data, static fn(array $names) => count($names) > 1);
+    }
 
     public function buildTree(): Tree
     {
@@ -59,12 +97,15 @@ final class Builder
             )
         );
         foreach ($articles as $article_data) {
+            $multi = $this->multi_category_data[(int) $article_data['id']] ?? null;
             $node->addArticle(new Article(
                 id: (int) $article_data['id'],
                 title: $article_data['name'] ?? '',
                 illustration: $article_data['illustration'] ?? 'kb-faq',
                 link: KnowbaseItem::getFormURLWithID($article_data['id']),
                 is_current: $this->current_id > 0 && (int) $article_data['id'] === $this->current_id,
+                categories_count: $multi !== null ? count($multi) : 1,
+                all_categories: $multi ?? [],
             ));
         }
 
@@ -73,6 +114,7 @@ final class Builder
         ]);
         foreach ($categories as $cat_data) {
             $category = new Category(
+                id: (int) $cat_data['id'],
                 title: $cat_data['name'] ?? '',
                 illustration: $cat_data['illustration'] ?: 'kb-faq',
             );

--- a/src/Glpi/Knowbase/Aside/Category.php
+++ b/src/Glpi/Knowbase/Aside/Category.php
@@ -43,6 +43,7 @@ final class Category implements Node
     protected array $categories = [];
 
     public function __construct(
+        public readonly int $id,
         public readonly string $title,
         public readonly string $illustration,
     ) {}

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -45,12 +45,16 @@
             <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
         </button>
         <ul>
-            {{ macros.render_node(category) }}
+            {{ macros.render_node(category, category.id) }}
         </ul>
     </li>
 {% endmacro %}
 
-{% macro render_article(article, add_margin = false, favorite_state = null) %}
+{% macro render_article(article, add_margin = false, favorite_state = null, current_category_id = 0) %}
+    {% set is_multi = article.categories_count > 1 %}
+    {% if is_multi %}
+        {% set other_categories = article.all_categories | filter((name, id) => id != current_category_id) %}
+    {% endif %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
         {% if favorite_state is not null %}
@@ -59,6 +63,10 @@
         {% if article.is_current %}
             data-glpi-kb-article-current
             aria-current="page"
+        {% endif %}
+        {% if is_multi %}
+            data-glpi-kb-article-multi
+            data-glpi-kb-article-other-categories="{{ other_categories | join(' · ') }}"
         {% endif %}
         class="article {{ add_margin ? 'mb-2' : '' }}"
     >
@@ -69,10 +77,10 @@
     </li>
 {% endmacro %}
 
-{% macro render_node(node) %}
+{% macro render_node(node, current_category_id = 0) %}
     {% import _self as macros %}
     {% for article in node.articles %}
-        {{ macros.render_article(article) }}
+        {{ macros.render_article(article, false, null, current_category_id) }}
     {% endfor %}
     {% for category in node.categories %}
         {{ macros.render_category(category) }}
@@ -131,11 +139,12 @@
         </ul>
 </div>
 
-<div class="card-body" data-glpi-kb-aside-tree>
+<div class="card-body" data-glpi-kb-aside-tree data-glpi-kb-also-in-label="{{ __('Also in') }}">
     <ul class="kb-tree ps-0">
         {# Render root articles in a special "uncategorized" category #}
         {% if tree.articles|length %}
             {{ macros.render_category({
+                id: 0,
                 title: __("Uncategorized"),
                 illustration: "kb-faq",
                 articles: tree.articles,

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -53,7 +53,7 @@
 {% macro render_article(article, add_margin = false, favorite_state = null, current_category_id = 0) %}
     {% set is_multi = article.categories_count > 1 %}
     {% if is_multi %}
-        {% set other_categories = article.all_categories | filter((name, id) => id != current_category_id) %}
+        {% set other_categories = article.all_categories|filter((name, id) => id != current_category_id) %}
     {% endif %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
@@ -66,7 +66,7 @@
         {% endif %}
         {% if is_multi %}
             data-glpi-kb-article-multi
-            data-glpi-kb-article-other-categories="{{ other_categories | join(' · ') }}"
+            data-glpi-kb-article-other-categories="{{ other_categories|join(' · ') }}"
         {% endif %}
         class="article {{ add_margin ? 'mb-2' : '' }}"
     >

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -45,16 +45,12 @@
             <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
         </button>
         <ul>
-            {{ macros.render_node(category, category.id) }}
+            {{ macros.render_node(category) }}
         </ul>
     </li>
 {% endmacro %}
 
-{% macro render_article(article, add_margin = false, favorite_state = null, current_category_id = 0) %}
-    {% set is_multi = article.categories_count > 1 %}
-    {% if is_multi %}
-        {% set other_categories = article.all_categories|filter((name, id) => id != current_category_id) %}
-    {% endif %}
+{% macro render_article(article, add_margin = false, favorite_state = null) %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
         {% if favorite_state is not null %}
@@ -64,35 +60,22 @@
             data-glpi-kb-article-current
             aria-current="page"
         {% endif %}
-        {% if is_multi %}
+        {% if article.categories_count > 1 %}
             data-glpi-kb-article-multi
         {% endif %}
         class="article {{ add_margin ? 'mb-2' : '' }}"
     >
-        {% if is_multi %}
-            <a class="text-dark text-hover-link d-flex align-items-start" href="{{ article.link }}">
-                {{ render_illustration(article.illustration, 20) }}
-                <span class="kb-article-stack ms-1">
-                    <span class="kb-article-titleline">
-                        <span class="kb-article-title text-truncate">{{ article.title }}</span>
-                        <i class="ti ti-stack-2 kb-article-multi-icon" aria-hidden="true"></i>
-                    </span>
-                    <span class="kb-article-also-in d-block text-truncate fst-italic">{{ __('Also live in') }}: {{ other_categories|join(' · ') }}</span>
-                </span>
-            </a>
-        {% else %}
-            <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
-                {{ render_illustration(article.illustration, 20) }}
-                {{ article.title }}
-            </a>
-        {% endif %}
+        <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
+            {{ render_illustration(article.illustration, 20) }}
+            {{ article.title }}
+        </a>
     </li>
 {% endmacro %}
 
-{% macro render_node(node, current_category_id = 0) %}
+{% macro render_node(node) %}
     {% import _self as macros %}
     {% for article in node.articles %}
-        {{ macros.render_article(article, false, null, current_category_id) }}
+        {{ macros.render_article(article) }}
     {% endfor %}
     {% for category in node.categories %}
         {{ macros.render_category(category) }}

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -66,14 +66,26 @@
         {% endif %}
         {% if is_multi %}
             data-glpi-kb-article-multi
-            data-glpi-kb-article-other-categories="{{ other_categories|join(' · ') }}"
         {% endif %}
         class="article {{ add_margin ? 'mb-2' : '' }}"
     >
-        <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
-            {{ render_illustration(article.illustration, 20) }}
-            {{ article.title }}
-        </a>
+        {% if is_multi %}
+            <a class="text-dark text-hover-link d-flex align-items-start" href="{{ article.link }}">
+                {{ render_illustration(article.illustration, 20) }}
+                <span class="kb-article-stack ms-1">
+                    <span class="kb-article-titleline">
+                        <span class="kb-article-title text-truncate">{{ article.title }}</span>
+                        <i class="ti ti-stack-2 kb-article-multi-icon" aria-hidden="true"></i>
+                    </span>
+                    <span class="kb-article-also-in d-block text-truncate fst-italic">{{ __('Also live in') }}: {{ other_categories|join(' · ') }}</span>
+                </span>
+            </a>
+        {% else %}
+            <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
+                {{ render_illustration(article.illustration, 20) }}
+                {{ article.title }}
+            </a>
+        {% endif %}
     </li>
 {% endmacro %}
 
@@ -139,7 +151,7 @@
         </ul>
 </div>
 
-<div class="card-body" data-glpi-kb-aside-tree data-glpi-kb-also-in-label="{{ __('Also in') }}">
+<div class="card-body" data-glpi-kb-aside-tree>
     <ul class="kb-tree ps-0">
         {# Render root articles in a special "uncategorized" category #}
         {% if tree.articles|length %}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -90,6 +90,10 @@ export class KnowbaseItemPage extends GlpiPage
             `/front/knowbaseitem.form.php?id=${id}&forcetab=KnowbaseItem$1`,
             { waitUntil: 'domcontentloaded' }
         );
+
+        // The aside controller attaches its listeners after `domcontentloaded`,
+        // then drops `pe-none` — wait for that or early interactions are dropped.
+        await expect(this.asideSearchInput).not.toHaveClass(/pe-none/);
     }
 
     public async doToggleFaqStatus(): Promise<void>

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -90,10 +90,6 @@ export class KnowbaseItemPage extends GlpiPage
             `/front/knowbaseitem.form.php?id=${id}&forcetab=KnowbaseItem$1`,
             { waitUntil: 'domcontentloaded' }
         );
-
-        // The aside controller attaches its listeners after `domcontentloaded`,
-        // then drops `pe-none` — wait for that or early interactions are dropped.
-        await expect(this.asideSearchInput).not.toHaveClass(/pe-none/);
     }
 
     public async doToggleFaqStatus(): Promise<void>
@@ -302,6 +298,14 @@ export class KnowbaseItemPage extends GlpiPage
     public get asideSearchInput(): Locator
     {
         return this.page.getByLabel('Search articles');
+    }
+
+    // The aside controller attaches its listeners after `domcontentloaded`, then
+    // drops `pe-none`. Specs that interact with the aside (hover, fold) must await
+    // this or their early pointer events are silently dropped.
+    public async waitForAsideReady(): Promise<void>
+    {
+        await expect(this.asideSearchInput).not.toHaveClass(/pe-none/);
     }
 
     public get asideNoResultsMessage(): Locator

--- a/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
@@ -70,7 +70,7 @@ test('Article linked to several categories appears under each one', async ({
     await expect(kb.getAsideCategoryArticle(category_b, article_name)).toBeVisible();
 });
 
-test('Hovering a multi-category article reveals its other categories in a tooltip', async ({
+test('A multi-category article lists its other categories in a subtitle under each listing', async ({
     page,
     profile,
     api,
@@ -79,10 +79,10 @@ test('Hovering a multi-category article reveals its other categories in a toolti
     const kb = new KnowbaseItemPage(page);
 
     const token        = randomUUID().slice(0, 8);
-    const category_a   = `E2E Hover Cat A ${token}`;
-    const category_b   = `E2E Hover Cat B ${token}`;
-    const category_c   = `E2E Hover Cat C ${token}`;
-    const article_name = `E2E Hover Article ${token}`;
+    const category_a   = `E2E Sub Cat A ${token}`;
+    const category_b   = `E2E Sub Cat B ${token}`;
+    const category_c   = `E2E Sub Cat C ${token}`;
+    const article_name = `E2E Sub Article ${token}`;
 
     const category_a_id = await api.createItem('KnowbaseItemCategory', {
         name: category_a,
@@ -105,32 +105,20 @@ test('Hovering a multi-category article reveals its other categories in a toolti
 
     await kb.goto(article_id);
 
-    const tooltip = page.getByRole('tooltip');
+    // Under category A → subtitle names B and C, not A.
+    const subtitle_under_a = kb.getAsideCategory(category_a).getByText('Also live in');
+    await expect(subtitle_under_a).toContainText(category_b);
+    await expect(subtitle_under_a).toContainText(category_c);
+    await expect(subtitle_under_a).not.toContainText(category_a);
 
-    // Hover the instance under category A → tooltip mentions B and C, not A
-    await kb.getAsideCategoryArticle(category_a, article_name).hover();
-    await expect(tooltip).toBeVisible();
-    // Guard against missing styles: tooltip CSS must apply (position is the load-bearing
-    // property — without it the tooltip falls into the document flow, breaking the UX
-    // even though Playwright considers the element "visible" in the DOM sense).
-    await expect(tooltip).toHaveCSS('position', 'fixed');
-    await expect(tooltip).toContainText(category_b);
-    await expect(tooltip).toContainText(category_c);
-    await expect(tooltip).not.toContainText(category_a);
-
-    // Move away — tooltip disappears
-    await page.mouse.move(0, 0);
-    await expect(tooltip).toBeHidden();
-
-    // Hover the instance under category B → tooltip now mentions A and C, not B
-    await kb.getAsideCategoryArticle(category_b, article_name).hover();
-    await expect(tooltip).toBeVisible();
-    await expect(tooltip).toContainText(category_a);
-    await expect(tooltip).toContainText(category_c);
-    await expect(tooltip).not.toContainText(category_b);
+    // Under category B → subtitle names A and C, not B.
+    const subtitle_under_b = kb.getAsideCategory(category_b).getByText('Also live in');
+    await expect(subtitle_under_b).toContainText(category_a);
+    await expect(subtitle_under_b).toContainText(category_c);
+    await expect(subtitle_under_b).not.toContainText(category_b);
 });
 
-test('Focusing a multi-category article via keyboard surfaces the tooltip and Escape dismisses it', async ({
+test('Hovering one listing of a multi-category article highlights its other listings', async ({
     page,
     profile,
     api,
@@ -139,9 +127,9 @@ test('Focusing a multi-category article via keyboard surfaces the tooltip and Es
     const kb = new KnowbaseItemPage(page);
 
     const token        = randomUUID().slice(0, 8);
-    const category_a   = `E2E Kbd Cat A ${token}`;
-    const category_b   = `E2E Kbd Cat B ${token}`;
-    const article_name = `E2E Kbd Article ${token}`;
+    const category_a   = `E2E Hl Cat A ${token}`;
+    const category_b   = `E2E Hl Cat B ${token}`;
+    const article_name = `E2E Hl Article ${token}`;
 
     const category_a_id = await api.createItem('KnowbaseItemCategory', {
         name: category_a,
@@ -160,25 +148,19 @@ test('Focusing a multi-category article via keyboard surfaces the tooltip and Es
 
     await kb.goto(article_id);
 
-    const tooltip = page.getByRole('tooltip');
-    const article_link = kb.getAsideCategoryArticle(category_a, article_name);
+    // The listing under category B is the cross-tree copy we expect to light up.
+    const row_under_b = kb.getAsideCategory(category_b).getByRole('listitem');
+    await expect(row_under_b).not.toHaveClass(/kb-article--sibling/);
 
-    // Tab focus is the realistic keyboard path; .focus() also works for the assertion.
-    await article_link.focus();
-    await expect(tooltip).toBeVisible();
-    await expect(tooltip).toContainText(category_b);
+    await kb.getAsideCategoryArticle(category_a, article_name).hover();
+    await expect(row_under_b).toHaveClass(/kb-article--sibling/);
 
-    // The focused link must advertise the tooltip to assistive tech.
-    await expect(article_link).toHaveAttribute('aria-describedby', /kb-aside-multi-tooltip-/);
-
-    // Escape dismisses the tooltip without moving focus (ARIA Tooltip pattern).
-    await page.keyboard.press('Escape');
-    await expect(tooltip).toBeHidden();
-    await expect(article_link).not.toHaveAttribute('aria-describedby', /.+/);
-    await expect(article_link).toBeFocused();
+    // Moving away clears the highlight everywhere.
+    await page.mouse.move(0, 0);
+    await expect(row_under_b).not.toHaveClass(/kb-article--sibling/);
 });
 
-test('Single-category article shows no tooltip on hover', async ({
+test('Single-category article shows no "also live in" subtitle', async ({
     page,
     profile,
     api,
@@ -203,6 +185,6 @@ test('Single-category article shows no tooltip on hover', async ({
 
     await kb.goto(article_id);
 
-    await kb.getAsideCategoryArticle(category_a, article_name).hover();
-    await expect(page.getByRole('tooltip')).toBeHidden();
+    await expect(kb.getAsideCategoryArticle(category_a, article_name)).toBeVisible();
+    await expect(kb.getAsideCategory(category_a).getByText('Also live in')).toHaveCount(0);
 });

--- a/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
@@ -145,6 +145,9 @@ test('A copy folded inside a collapsed category lights up that category header',
     // Fold category B so its copy of the article is hidden behind the header.
     await kb.doToggleAsideCategory(category_b);
 
+    // Park the pointer so the collapse reflow can't fire a stray hover.
+    await page.mouse.move(0, 0);
+
     const category_b_node = kb.getAsideCategory(category_b);
     await expect(category_b_node).not.toHaveClass(/kb-category--sibling/);
 

--- a/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
@@ -99,6 +99,7 @@ test('Hovering one listing of a multi-category article highlights its other list
     });
 
     await kb.goto(article_id);
+    await kb.waitForAsideReady();
 
     // The listing under category B is the cross-tree copy we expect to light up.
     const row_under_b = kb.getAsideCategory(category_b).getByRole('listitem');
@@ -141,6 +142,7 @@ test('A copy folded inside a collapsed category lights up that category header',
     });
 
     await kb.goto(article_id);
+    await kb.waitForAsideReady();
 
     // Fold category B so its copy of the article is hidden behind the header.
     await kb.doToggleAsideCategory(category_b);

--- a/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { KnowbaseItemPage } from '../../pages/KnowbaseItemPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test('Article linked to several categories appears under each one', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const category_a   = `E2E Multi Cat A ${token}`;
+    const category_b   = `E2E Multi Cat B ${token}`;
+    const article_name = `E2E Multi Article ${token}`;
+
+    const category_a_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_a,
+        entities_id: getWorkerEntityId(),
+    });
+    const category_b_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_b,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_a_id, category_b_id],
+    });
+
+    await kb.goto(article_id);
+
+    await expect(kb.getAsideCategoryArticle(category_a, article_name)).toBeVisible();
+    await expect(kb.getAsideCategoryArticle(category_b, article_name)).toBeVisible();
+});
+
+test('Hovering a multi-category article reveals its other categories in a tooltip', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const category_a   = `E2E Hover Cat A ${token}`;
+    const category_b   = `E2E Hover Cat B ${token}`;
+    const category_c   = `E2E Hover Cat C ${token}`;
+    const article_name = `E2E Hover Article ${token}`;
+
+    const category_a_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_a,
+        entities_id: getWorkerEntityId(),
+    });
+    const category_b_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_b,
+        entities_id: getWorkerEntityId(),
+    });
+    const category_c_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_c,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_a_id, category_b_id, category_c_id],
+    });
+
+    await kb.goto(article_id);
+
+    const tooltip = page.getByRole('tooltip');
+
+    // Hover the instance under category A → tooltip mentions B and C, not A
+    await kb.getAsideCategoryArticle(category_a, article_name).hover();
+    await expect(tooltip).toBeVisible();
+    // Guard against missing styles: tooltip CSS must apply (position is the load-bearing
+    // property — without it the tooltip falls into the document flow, breaking the UX
+    // even though Playwright considers the element "visible" in the DOM sense).
+    await expect(tooltip).toHaveCSS('position', 'fixed');
+    await expect(tooltip).toContainText(category_b);
+    await expect(tooltip).toContainText(category_c);
+    await expect(tooltip).not.toContainText(category_a);
+
+    // Move away — tooltip disappears
+    await page.mouse.move(0, 0);
+    await expect(tooltip).toBeHidden();
+
+    // Hover the instance under category B → tooltip now mentions A and C, not B
+    await kb.getAsideCategoryArticle(category_b, article_name).hover();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText(category_a);
+    await expect(tooltip).toContainText(category_c);
+    await expect(tooltip).not.toContainText(category_b);
+});
+
+test('Focusing a multi-category article via keyboard surfaces the tooltip and Escape dismisses it', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const category_a   = `E2E Kbd Cat A ${token}`;
+    const category_b   = `E2E Kbd Cat B ${token}`;
+    const article_name = `E2E Kbd Article ${token}`;
+
+    const category_a_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_a,
+        entities_id: getWorkerEntityId(),
+    });
+    const category_b_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_b,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_a_id, category_b_id],
+    });
+
+    await kb.goto(article_id);
+
+    const tooltip = page.getByRole('tooltip');
+    const article_link = kb.getAsideCategoryArticle(category_a, article_name);
+
+    // Tab focus is the realistic keyboard path; .focus() also works for the assertion.
+    await article_link.focus();
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText(category_b);
+
+    // The focused link must advertise the tooltip to assistive tech.
+    await expect(article_link).toHaveAttribute('aria-describedby', /kb-aside-multi-tooltip-/);
+
+    // Escape dismisses the tooltip without moving focus (ARIA Tooltip pattern).
+    await page.keyboard.press('Escape');
+    await expect(tooltip).toBeHidden();
+    await expect(article_link).not.toHaveAttribute('aria-describedby', /.+/);
+    await expect(article_link).toBeFocused();
+});
+
+test('Single-category article shows no tooltip on hover', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const category_a   = `E2E Single Cat ${token}`;
+    const article_name = `E2E Single Article ${token}`;
+
+    const category_a_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_a,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_a_id],
+    });
+
+    await kb.goto(article_id);
+
+    await kb.getAsideCategoryArticle(category_a, article_name).hover();
+    await expect(page.getByRole('tooltip')).toBeHidden();
+});

--- a/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-multi-category.spec.ts
@@ -70,54 +70,6 @@ test('Article linked to several categories appears under each one', async ({
     await expect(kb.getAsideCategoryArticle(category_b, article_name)).toBeVisible();
 });
 
-test('A multi-category article lists its other categories in a subtitle under each listing', async ({
-    page,
-    profile,
-    api,
-}) => {
-    await profile.set(Profiles.SuperAdmin);
-    const kb = new KnowbaseItemPage(page);
-
-    const token        = randomUUID().slice(0, 8);
-    const category_a   = `E2E Sub Cat A ${token}`;
-    const category_b   = `E2E Sub Cat B ${token}`;
-    const category_c   = `E2E Sub Cat C ${token}`;
-    const article_name = `E2E Sub Article ${token}`;
-
-    const category_a_id = await api.createItem('KnowbaseItemCategory', {
-        name: category_a,
-        entities_id: getWorkerEntityId(),
-    });
-    const category_b_id = await api.createItem('KnowbaseItemCategory', {
-        name: category_b,
-        entities_id: getWorkerEntityId(),
-    });
-    const category_c_id = await api.createItem('KnowbaseItemCategory', {
-        name: category_c,
-        entities_id: getWorkerEntityId(),
-    });
-    const article_id = await api.createItem('KnowbaseItem', {
-        name: article_name,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-        _categories: [category_a_id, category_b_id, category_c_id],
-    });
-
-    await kb.goto(article_id);
-
-    // Under category A → subtitle names B and C, not A.
-    const subtitle_under_a = kb.getAsideCategory(category_a).getByText('Also live in');
-    await expect(subtitle_under_a).toContainText(category_b);
-    await expect(subtitle_under_a).toContainText(category_c);
-    await expect(subtitle_under_a).not.toContainText(category_a);
-
-    // Under category B → subtitle names A and C, not B.
-    const subtitle_under_b = kb.getAsideCategory(category_b).getByText('Also live in');
-    await expect(subtitle_under_b).toContainText(category_a);
-    await expect(subtitle_under_b).toContainText(category_c);
-    await expect(subtitle_under_b).not.toContainText(category_b);
-});
-
 test('Hovering one listing of a multi-category article highlights its other listings', async ({
     page,
     profile,
@@ -160,7 +112,53 @@ test('Hovering one listing of a multi-category article highlights its other list
     await expect(row_under_b).not.toHaveClass(/kb-article--sibling/);
 });
 
-test('Single-category article shows no "also live in" subtitle', async ({
+test('A copy folded inside a collapsed category lights up that category header', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token        = randomUUID().slice(0, 8);
+    const category_a   = `E2E Fold Cat A ${token}`;
+    const category_b   = `E2E Fold Cat B ${token}`;
+    const article_name = `E2E Fold Article ${token}`;
+
+    const category_a_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_a,
+        entities_id: getWorkerEntityId(),
+    });
+    const category_b_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_b,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_a_id, category_b_id],
+    });
+
+    await kb.goto(article_id);
+
+    // Fold category B so its copy of the article is hidden behind the header.
+    await kb.doToggleAsideCategory(category_b);
+
+    const category_b_node = kb.getAsideCategory(category_b);
+    await expect(category_b_node).not.toHaveClass(/kb-category--sibling/);
+
+    // Hovering the still-visible copy under A lights up B's collapsed header
+    // instead of its now-hidden row.
+    await kb.getAsideCategoryArticle(category_a, article_name).hover();
+    await expect(category_b_node).toHaveClass(/kb-category--sibling/);
+
+    // Moving away clears the highlight.
+    await page.mouse.move(0, 0);
+    await expect(category_b_node).not.toHaveClass(/kb-category--sibling/);
+});
+
+test('Single-category article is not flagged as multi-category', async ({
     page,
     profile,
     api,
@@ -186,5 +184,7 @@ test('Single-category article shows no "also live in" subtitle', async ({
     await kb.goto(article_id);
 
     await expect(kb.getAsideCategoryArticle(category_a, article_name)).toBeVisible();
-    await expect(kb.getAsideCategory(category_a).getByText('Also live in')).toHaveCount(0);
+    // A single-category article carries no cross-listing marker, so it never highlights.
+    await expect(kb.getAsideCategory(category_a).getByRole('listitem'))
+        .not.toHaveAttribute('data-glpi-kb-article-multi');
 });


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/302
- Here is a brief description of what this PR does : 

Multi-category KB articles appeared identically under each category in the aside tree with no signal they were the same item. Adds a subtle left-border accent, a hover/focus tooltip listing the other categories, and sibling highlight across visible copies. Fully keyboard-accessible (focus + Escape, aria-describedby).


## Screenshot : 

<img width="373" height="782" alt="image" src="https://github.com/user-attachments/assets/d89e391f-32cf-4542-98cc-c91c3ba2794b" />



