### PR TITLE
fix(ui): Make the form translation modal compatible with custom rich text

### DIFF
--- a/css/includes/components/form/_item-translations.scss
+++ b/css/includes/components/form/_item-translations.scss
@@ -34,6 +34,8 @@
 // Common styles for ItemTranslation-based components (FormTranslation and HelpdeskTranslation)
 #glpi-form-translations-languages,
 #glpi-helpdesk-translations-languages {
+    table-layout: fixed;
+
     tr {
         &:has(input.form-control:focus) {
             box-shadow: inset 2px 0 0 var(--tblr-primary);
@@ -66,6 +68,10 @@
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
         white-space: nowrap;
+    }
+
+    .rich_text_container_translation {
+        overflow: auto;
     }
 
     div[data-glpi-tinymce-init-on-demand-render] {

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -144,7 +144,7 @@
             {% if handler.getValue() is empty %}
                 {% set default_value = '<span class="text-muted fst-italic">' ~ __('No default value') ~ '</span>' %}
             {% else %}
-                {% set default_value = handler.isRichText() ? default_value|safe_html : default_value|e %}
+                {% set default_value = handler.isRichText() ? '<div class="rich_text_container" style="overflow: auto;">' ~ (default_value|safe_html) ~ '</div>' : default_value|e %}
             {% endif %}
             {% set group_entries = group_entries|merge([{
                 'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',
@@ -264,4 +264,8 @@
             </form>
         {% endif %}
     </div>
+
+    <style>
+        #glpi-form-translations-languages { table-layout: fixed; }
+    </style>
 </div>

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -144,7 +144,7 @@
             {% if handler.getValue() is empty %}
                 {% set default_value = '<span class="text-muted fst-italic">' ~ __('No default value') ~ '</span>' %}
             {% else %}
-                {% set default_value = handler.isRichText() ? '<div class="rich_text_container" style="overflow: auto;">' ~ (default_value|safe_html) ~ '</div>' : default_value|e %}
+                {% set default_value = handler.isRichText() ? '<div class="rich_text_container rich_text_container_translation">' ~ (default_value|safe_html) ~ '</div>' : default_value|e %}
             {% endif %}
             {% set group_entries = group_entries|merge([{
                 'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',
@@ -264,8 +264,4 @@
             </form>
         {% endif %}
     </div>
-
-    <style>
-        #glpi-form-translations-languages { table-layout: fixed; }
-    </style>
 </div>

--- a/templates/pages/admin/helpdesk_home_translation.html.twig
+++ b/templates/pages/admin/helpdesk_home_translation.html.twig
@@ -99,7 +99,7 @@
             {% if handler.getValue() is empty %}
                 {% set default_value = '<span class="text-muted fst-italic">' ~ __('No default value') ~ '</span>' %}
             {% else %}
-                {% set default_value = handler.isRichText() ? default_value|safe_html : default_value|e %}
+                {% set default_value = handler.isRichText() ? '<div class="rich_text_container rich_text_container_translation">' ~ default_value|safe_html ~ '</div>' : default_value|e %}
             {% endif %}
             {% set group_entries = group_entries|merge([{
                 'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43878
- Here is a brief description of what this PR does
If a user enters HTML code in the description of a form field within a rich text editor, the modal that allows the user to enter translations does not display correctly.

## Screenshots (if appropriate):

Before fix:
<img width="1168" height="670" alt="image" src="https://github.com/user-attachments/assets/58c6a183-da8b-4e5d-83c8-a9cd99256da9" />

After fix:
<img width="1174" height="578" alt="image" src="https://github.com/user-attachments/assets/1bfae272-ae9f-48d9-b6bd-83abe1d3483b" />


