### PR TITLE
FIX / Broken base path handling for MFA skip and single rule test

### DIFF
--- a/src/Glpi/Controller/Security/MFAController.php
+++ b/src/Glpi/Controller/Security/MFAController.php
@@ -149,7 +149,7 @@ final class MFAController extends AbstractController
         } else {
             // 2FA is not set up yet, the user is in a grace period, and the user chose to skip it
             $_SESSION['mfa_exploit_grace_period'] = true;
-            $next_page = '/front/login.php?' . $query_params;
+            $next_page = $request->getBasePath() . '/front/login.php?' . $query_params;
         }
 
         return new RedirectResponse($next_page);

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -2774,6 +2774,8 @@ TWIG, $twig_params);
      */
     public function showRulePreviewCriteriasForm($rules_id)
     {
+        global $CFG_GLPI;
+
         $criteria = $this->getAllCriteria();
         if (!$this->getRuleWithCriteriasAndActions($rules_id, true, false)) {
             return;
@@ -2791,9 +2793,9 @@ TWIG, $twig_params);
             }
         }
 
-        $target = '/front/rule.test.php';
+        $target = $CFG_GLPI['root_doc'] . '/front/rule.test.php';
         if ($plugin = isPluginItemType(static::class)) {
-            $target = '/plugins/' . $plugin['plugin'] . $target;
+            $target = $CFG_GLPI['root_doc'] . '/plugins/' . $plugin['plugin'] . '/front/rule.test.php';
         }
 
         TemplateRenderer::getInstance()->display('pages/admin/rules/preview_criteria.html.twig', [


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44093
- This PR fixes two additional broken relative paths affecting GLPI instances installed under a subdirectory. Similar issues were already identified and fixed in PR #23994 and PR #24003 , where paths had to be prefixed with `root_doc`. This change applies the same approach to:

- the MFA grace period skip redirect
- the form action used to test a specific rule

As a result, both features now resolve correctly when GLPI is not installed at the web root.

