### PR TITLE
FIX / Fix authentication settings not being saved

### DIFF
--- a/templates/pages/setup/authentication/setup.html.twig
+++ b/templates/pages/setup/authentication/setup.html.twig
@@ -92,7 +92,7 @@
                 </div>
             </div>
             <div class="card-footer d-flex">
-                <button type="submit" name="update_auth" class="btn btn-primary ms-auto">
+                <button type="submit" name="update_auth" value="1" class="btn btn-primary ms-auto">
                     <i class="ti ti-device-floppy"></i>
                     <span>{{ _x('button', 'Save') }}</span>
                 </button>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44007
- This PR fixes the authentication settings form submission.

When saving changes from `Configuration > Authentication > Setup`, the form posts to `config.form.php`, which only handles this flow when `update_auth` is present and non-empty. The submit button was sending `update_auth` without a value, so the request was not processed by the authentication settings update branch. As a result, the request fell back to the generic configuration page and the changes were not saved.
This change adds an explicit value to the `update_auth` submit button so the authentication settings save flow is correctly triggered.


