### PR TITLE
KB : add category management to history

### DIFF
--- a/src/Glpi/Knowbase/History/HistoryBuilder.php
+++ b/src/Glpi/Knowbase/History/HistoryBuilder.php
@@ -40,6 +40,7 @@ use Glpi\UI\IllustrationManager;
 use Group;
 use KnowbaseItem;
 use KnowbaseItem_Revision;
+use KnowbaseItemCategory;
 use KnowbaseItemTranslation;
 use Log;
 use LogicException;
@@ -65,6 +66,7 @@ final class HistoryBuilder
         $this->addFaqStatusChangesToHistory();
         $this->addServiceCatalogChangesToHistory();
         $this->addAssociatedItemChangesToHistory();
+        $this->addCategoryChangesToHistory();
         $this->addDocumentChangesToHistory();
         $this->addPermissionChangesToHistory();
         $this->addNameChangesToHistory();
@@ -374,6 +376,54 @@ final class HistoryBuilder
             $description = sprintf(
                 $is_add ? __('%s — Linked by') : __('%s — Unlinked by'),
                 $type_name . ': ' . $item_name
+            );
+
+            $this->history->addEvent(new LogEvent(
+                label: $label,
+                description: $description,
+                date: $row['date_mod'],
+                author: $row['user_name'],
+            ));
+        }
+    }
+
+    private function addCategoryChangesToHistory(): void
+    {
+        global $DB;
+
+        $logs = $DB->request([
+            'SELECT' => [
+                'date_mod',
+                'user_name',
+                'linked_action',
+                'old_value',
+                'new_value',
+            ],
+            'FROM' => Log::getTable(),
+            'WHERE' => [
+                'itemtype'      => KnowbaseItem::class,
+                'items_id'      => $this->kb->getID(),
+                'itemtype_link' => KnowbaseItemCategory::class,
+                'linked_action' => [
+                    Log::HISTORY_ADD_RELATION,
+                    Log::HISTORY_DEL_RELATION,
+                ],
+            ],
+            'ORDER' => 'id DESC',
+        ]);
+
+        foreach ($logs as $row) {
+            $is_add = $row['linked_action'] == Log::HISTORY_ADD_RELATION;
+            $category_name = $is_add ? $row['new_value'] : $row['old_value'];
+
+            $label = $is_add
+                ? __("Added to category")
+                : __("Removed from category")
+            ;
+
+            $description = sprintf(
+                $is_add ? __('%s — Added by') : __('%s — Removed by'),
+                $category_name
             );
 
             $this->history->addEvent(new LogEvent(

--- a/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/History/HistoryBuilderTest.php
@@ -49,8 +49,10 @@ use Glpi\Knowbase\History\TranslationRevisionEvent;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItem_Item;
+use KnowbaseItem_KnowbaseItemCategory;
 use KnowbaseItem_Revision;
 use KnowbaseItem_User;
+use KnowbaseItemCategory;
 use KnowbaseItemTranslation;
 use Session;
 use Ticket;
@@ -860,6 +862,86 @@ final class HistoryBuilderTest extends DbTestCase
 
         $this->assertInstanceOf(LogEvent::class, $events[1]);
         $this->assertEquals("File added", $events[1]->getLabel());
+    }
+
+    public function testCategoryAddedAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $category = $this->createItem(KnowbaseItemCategory::class, [
+            'name' => 'How-to',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'is_recursive' => 1,
+            'knowbaseitemcategories_id' => 0,
+        ]);
+
+        $this->createItem(KnowbaseItem_KnowbaseItemCategory::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'knowbaseitemcategories_id' => $category->getID(),
+        ]);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(2, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Added to category", $events[0]->getLabel());
+        $this->assertStringContainsString("How-to", $events[0]->getDescription());
+
+        $this->assertInstanceOf(CreationEvent::class, $events[1]);
+    }
+
+    public function testCategoryRemovedAppearsInHistory(): void
+    {
+        $this->login();
+        $this->setCurrentTime("2026-01-15 10:00:00");
+
+        $kb = $this->createItem(KnowbaseItem::class, [
+            'users_id' => 2,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'name' => 'Test article',
+            'answer' => 'Test content',
+        ]);
+
+        $this->setCurrentTime("2026-01-15 11:00:00");
+        $category = $this->createItem(KnowbaseItemCategory::class, [
+            'name' => 'Obsolete',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+            'is_recursive' => 1,
+            'knowbaseitemcategories_id' => 0,
+        ]);
+
+        $relation = $this->createItem(KnowbaseItem_KnowbaseItemCategory::class, [
+            'knowbaseitems_id' => $kb->getID(),
+            'knowbaseitemcategories_id' => $category->getID(),
+        ]);
+
+        $this->setCurrentTime("2026-01-15 12:00:00");
+        $this->deleteItem(KnowbaseItem_KnowbaseItemCategory::class, $relation->getID(), purge: true);
+
+        $kb->getFromDB($kb->getID());
+        $history = (new HistoryBuilder($kb))->buildHistory();
+        $events = $history->getEvents();
+
+        $this->assertCount(3, $events);
+
+        $this->assertInstanceOf(LogEvent::class, $events[0]);
+        $this->assertEquals("Removed from category", $events[0]->getLabel());
+        $this->assertStringContainsString("Obsolete", $events[0]->getDescription());
+
+        $this->assertInstanceOf(LogEvent::class, $events[1]);
+        $this->assertEquals("Added to category", $events[1]->getLabel());
     }
 
     public function testDocumentChangesWithContentRevisions(): void


### PR DESCRIPTION


- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/295
- Here is a brief description of what this PR does : add category changes of the current article to the hystory aside's panel. Based on previous PR about history. Tested w/ a local merge of https://github.com/glpi-project/glpi/pull/24213

## Screenshots : 
<img width="575" height="463" alt="image" src="https://github.com/user-attachments/assets/bb3d021a-5116-46fa-9adc-825e576e11e1" />



