### PR TITLE
Fix(Inventory): prevent SQL error related to locked field on add

### DIFF
--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -760,6 +760,10 @@ abstract class MainAsset extends InventoryAsset
 
         if ($items_id != 0) {
             $this->item->getFromDB($items_id);
+        }else {
+            // reset item with default values to be able to use handleLinks
+            // without keep previous item values (from stacked switch for example)
+            $this->item->getEmpty();
         }
 
         // set entities_id in known links

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -763,7 +763,7 @@ abstract class MainAsset extends InventoryAsset
         } else {
             // reset item with default values to be able to use handleLinks
             // without keep previous item values (from stacked switch for example)
-            $this->item->getEmpty();
+            $this->item = new $itemtype();
         }
 
         // set entities_id in known links

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -760,7 +760,7 @@ abstract class MainAsset extends InventoryAsset
 
         if ($items_id != 0) {
             $this->item->getFromDB($items_id);
-        }else {
+        } else {
             // reset item with default values to be able to use handleLinks
             // without keep previous item values (from stacked switch for example)
             $this->item->getEmpty();

--- a/src/Glpi/Inventory/MainAsset/MainAsset.php
+++ b/src/Glpi/Inventory/MainAsset/MainAsset.php
@@ -763,7 +763,7 @@ abstract class MainAsset extends InventoryAsset
         } else {
             // reset item with default values to be able to use handleLinks
             // without keep previous item values (from stacked switch for example)
-            $this->item = new $itemtype();
+            $this->item->reset();
         }
 
         // set entities_id in known links


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42307

Alternative to https://github.com/glpi-project/glpi/pull/23883

## Context reminder

On a stacked switch environment (multiple physical switches represented as a single logical switch), I manually create the first stack entry in GLPI and enforce the device type through a global lock (in this case: `Networking`).

When importing the inventory file, GLPI correctly updates the first stack (the one created manually), but the second stack triggers an SQL error:

```shell
An error occured during import: `MySQL query error: Incorrect integer value: 'Networking' for column 
'networkequipmenttypes_id' at row 1 (1366) in SQL query "INSERT INTO `glpi_networkequipments` 
(`autoupdatesystems_id`, `last_inventory_update`, `is_deleted`, `contact`, `name`, `serial`, `uptime`, `sysdescr`, 
`locations_id`, `networkequipmentmodels_id`, `networkequipmenttypes_id`, `manufacturers_id`, `is_dynamic`, 
`entities_id`, `states_id`, `date_creation`, `date_mod`) VALUES ('4', '2026-05-20 06:50:39', '0', 'test@test.fr', 'Cisco - stack2 - 
2', 'SN-01-0000002', '11 days, 23:16:29.06', 'CISCO-OW', '5004', '14', 'Networking', '287', '1', '0', '0', '2026-05-20 06:50:39', 
'2026-05-20 06:50:39')".`.
```

## Root cause

The issue occurs because the inventory process keeps in memory the reference of the first stack while processing external links through `handleLink()` (and locked fields).

As a result, when processing the second stack, the locked field about `networkequipmenttypes_id`  is reused directly instead of resolving the corresponding integer ID expected by the `networkequipmenttypes_id` column.

This leads to the following invalid assignment:

```sql
networkequipmenttypes_id = 'Networking'
```

instead of:

```sql
networkequipmenttypes_id = <integer_id>
```

## Screenshots (if appropriate):


