### PR TITLE
Fix positions not reset between rack items when checking model update

### DIFF
--- a/src/CommonDCModelDropdown.php
+++ b/src/CommonDCModelDropdown.php
@@ -331,7 +331,6 @@ abstract class CommonDCModelDropdown extends CommonDropdown
         // If so, check whether the new units required fit into the rack without modifying the positions
         $hasIssues = false;
         $itemtype = $this->getItemtypeForModel();
-        $positionsToCheck = [];
         foreach ($this->getItemsRackForModel() as $item_rack) {
             $rack = Rack::getById($item_rack['racks_id']);
             if (!$rack instanceof Rack) {
@@ -344,6 +343,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
             $depth = $input['depth'] ?? $this->fields['depth'];
 
             // Collect the positions to check
+            $positionsToCheck = [];
             for ($i = 0; $i < $requiredUnits; $i++) {
                 $positionsToCheck[] = $item_rack['position'] + $i;
 

--- a/tests/functional/Item_RackTest.php
+++ b/tests/functional/Item_RackTest.php
@@ -759,6 +759,90 @@ class Item_RackTest extends DbTestCase
     }
 
     /**
+     * Regression test: updating required_units must not produce a false-positive
+     * conflict when the same model is used by multiple items in the same rack.
+     *
+     * Before the fix, $positionsToCheck was initialized outside the foreach loop,
+     * causing positions from item N to accumulate and be checked against item N+1,
+     * triggering a spurious error even though each item individually had enough room.
+     */
+    public function testRackIssuesWithMultipleItemsSameModel(): void
+    {
+        $model = $this->createItem(
+            'ComputerModel',
+            [
+                'name'           => 'SW-1U',
+                'required_units' => 1,
+                'depth'          => 1,
+                'is_half_rack'   => 0,
+            ]
+        );
+
+        $rack = $this->createItem(
+            'Rack',
+            [
+                'name'         => 'Test rack multi',
+                'number_units' => 10,
+                'dcrooms_id'   => 0,
+                'position'     => 0,
+                'entities_id'  => 0,
+            ]
+        );
+
+        $computer1 = $this->createItem(
+            'Computer',
+            [
+                'name'              => 'Computer-A',
+                'computermodels_id' => $model->getID(),
+                'entities_id'       => 0,
+            ]
+        );
+
+        $computer2 = $this->createItem(
+            'Computer',
+            [
+                'name'              => 'Computer-B',
+                'computermodels_id' => $model->getID(),
+                'entities_id'       => 0,
+            ]
+        );
+
+        // computer1 at position 1, computer2 at position 3 — updating to 2U gives
+        // 1-2 for computer1 and 3-4 for computer2, no overlap, must succeed.
+        $this->createItem(
+            'Item_Rack',
+            [
+                'racks_id'    => $rack->getID(),
+                'position'    => 1,
+                'orientation' => 0,
+                'itemtype'    => 'Computer',
+                'items_id'    => $computer1->getID(),
+            ]
+        );
+
+        $this->createItem(
+            'Item_Rack',
+            [
+                'racks_id'    => $rack->getID(),
+                'position'    => 3,
+                'orientation' => 0,
+                'itemtype'    => 'Computer',
+                'items_id'    => $computer2->getID(),
+            ]
+        );
+
+        $this->assertTrue(
+            $model->update([
+                'id'             => $model->getID(),
+                'required_units' => 2,
+            ]),
+            'Model update should succeed when all rack items individually have enough room'
+        );
+
+        $this->hasNoSessionMessages([ERROR]);
+    }
+
+    /**
      * Test for updating horizontal position of items rack
      */
     public function testUpdateItemHorizontalPosition()


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44135
- When updating a DC model's required_units, $positionsToCheck was initialized outside the foreach loop, causing positions from previous rack items to accumulate and trigger false-positive conflicts on unrelated racks. Moving the initialization inside the loop ensures each rack item is checked independently.

## Screenshots (if appropriate):


