### PR TITLE
fix(forms): location name used instead of completename to create a ticket

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -402,7 +402,9 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return $item->getFriendlyName();
         }
 
-        $name = $item->fields['name'];
+        $name = $item instanceof CommonTreeDropdown
+            ? $item->fields['completename']
+            : $item->fields['name'];
 
         // Append additional fields to match what is displayed in renderEndUserTemplate.
         $itemtype = $answer['itemtype'];

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -35,13 +35,13 @@
 namespace tests\units\Glpi\Form\QuestionType;
 
 use Computer;
+use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Location;
-use Glpi\Form\Question;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ticket;
 use User;
@@ -373,33 +373,6 @@ final class QuestionTypeItemTest extends DbTestCase
                         'expected' => 'France > Paris > Office',
                     ];
                 })(),
-            ],
-
-            'Item is a computer' => [
-                fn(self $t) => [
-                    'answer'   => [
-                        'itemtype' => Computer::class,
-                        'items_id' => $t->createItem(Computer::class, [
-                            'name'        => 'My PC',
-                            'entities_id' => $t->getTestRootEntity(true),
-                        ])->getID(),
-                    ],
-                    'expected' => 'My PC',
-                ],
-            ],
-
-            'computer with serial' => [
-                fn(self $t) => [
-                    'answer'   => [
-                        'itemtype' => Computer::class,
-                        'items_id' => $t->createItem(Computer::class, [
-                            'name'        => 'My Laptop',
-                            'serial'      => 'SN-1234',
-                            'entities_id' => $t->getTestRootEntity(true),
-                        ])->getID(),
-                    ],
-                    'expected' => 'My Laptop - SN-1234',
-                ],
             ],
 
             'non-existent item' => [

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -41,6 +41,7 @@ use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Location;
+use Glpi\Form\Question;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ticket;
 use User;
@@ -419,19 +420,7 @@ final class QuestionTypeItemTest extends DbTestCase
         $this->login();
 
         $case = $setup($this);
-
-        $builder = new FormBuilder();
-        $builder->addQuestion(
-            name: 'Q',
-            type: QuestionTypeItem::class,
-            extra_data: json_encode(
-                (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
-            ),
-        );
-        $form = $this->createForm($builder);
-        $question = current($form->getQuestions());
-
-        $result = (new QuestionTypeItem())->formatRawAnswer($case['answer'], $question);
+        $result = (new QuestionTypeItem())->formatRawAnswer($case['answer'], new Question());
 
         $this->assertEquals($case['expected'], $result);
     }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -40,6 +40,7 @@ use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Location;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ticket;
 use User;
@@ -315,5 +316,123 @@ final class QuestionTypeItemTest extends DbTestCase
             $case['question_config']
         );
         $this->assertEquals($case['expected_name'], $name);
+    }
+
+    public static function formatRawAnswerProvider(): array
+    {
+        return [
+            'item is a user' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => User::class,
+                        'items_id' => $t->createItem(User::class, [
+                            'name'      => 'jdoe',
+                            'firstname' => 'John',
+                            'realname'  => 'Doe',
+                        ])->getID(),
+                    ],
+                    'expected' => 'Doe John',
+                ],
+            ],
+
+            'location without parent' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => Location::class,
+                        'items_id' => $t->createItem(Location::class, [
+                            'name'        => 'Headquarters',
+                            'entities_id' => $t->getTestRootEntity(true),
+                        ])->getID(),
+                    ],
+                    'expected' => 'Headquarters',
+                ],
+            ],
+
+            'location with deep hierarchy' => [
+                fn(self $t) => (static function () use ($t) {
+                    $root = $t->createItem(Location::class, [
+                        'name'        => 'France',
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ]);
+                    $mid = $t->createItem(Location::class, [
+                        'name'        => 'Paris',
+                        'locations_id' => $root->getID(),
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ]);
+                    $leaf = $t->createItem(Location::class, [
+                        'name'        => 'Office',
+                        'locations_id' => $mid->getID(),
+                        'entities_id' => $t->getTestRootEntity(true),
+                    ]);
+                    return [
+                        'answer'   => [
+                            'itemtype' => Location::class,
+                            'items_id' => $leaf->getID(),
+                        ],
+                        'expected' => 'France > Paris > Office',
+                    ];
+                })(),
+            ],
+
+            'Item is a computer' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $t->createItem(Computer::class, [
+                            'name'        => 'My PC',
+                            'entities_id' => $t->getTestRootEntity(true),
+                        ])->getID(),
+                    ],
+                    'expected' => 'My PC',
+                ],
+            ],
+
+            'computer with serial' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => Computer::class,
+                        'items_id' => $t->createItem(Computer::class, [
+                            'name'        => 'My Laptop',
+                            'serial'      => 'SN-1234',
+                            'entities_id' => $t->getTestRootEntity(true),
+                        ])->getID(),
+                    ],
+                    'expected' => 'My Laptop - SN-1234',
+                ],
+            ],
+
+            'non-existent item' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => Computer::class,
+                        'items_id' => PHP_INT_MAX,
+                    ],
+                    'expected' => '',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('formatRawAnswerProvider')]
+    public function testFormatRawAnswer(callable $setup): void
+    {
+        $this->login();
+
+        $case = $setup($this);
+
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: 'Q',
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(
+                (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+            ),
+        );
+        $form = $this->createForm($builder);
+        $question = current($form->getQuestions());
+
+        $result = (new QuestionTypeItem())->formatRawAnswer($case['answer'], $question);
+
+        $this->assertEquals($case['expected'], $result);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes ticket !44160
- Here is a brief description of what this PR does :
When a form contains a location question and the answer to this question is used in the ticket created after submitting the form, only the last name of the location hierarchy was displayed. This issue was caused by formatting the answer using the `name` field instead of the `completename` field, even when the item was a `CommonTreeDropdown`.