### PR TITLE
Fix(Form): Prevent error on savepoint

### DIFF
--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1773,7 +1773,7 @@ class DBmysql
         ];
     }
 
-    private function isInTransaction(): bool
+    public function isInTransaction(): bool
     {
         return $this->transaction_level > 0;
     }
@@ -1866,18 +1866,25 @@ class DBmysql
         if (!$this->isInNestedTransaction()) {
             // A simple transaction is underway, roll it back.
             $success = $this->dbh->rollback();
+            if ($success) {
+                $this->transaction_level--;
+            } else {
+                throw new RuntimeException("Failed to rollback transaction.");
+            }
         } else {
-            // A nested transaction is already underway, roolback to current savepoint.
+            // A nested transaction is already underway, rollback to current savepoint.
             $savepoint = $this->formatAndQuoteSavePointName(
                 $this->transaction_level
             );
-            $success = $this->doQuery("ROLLBACK TO $savepoint");
-        }
-
-        if ($success) {
-            $this->transaction_level--;
-        } else {
-            throw new RuntimeException("Failed to rollback transaction.");
+            try {
+                $this->doQuery("ROLLBACK TO $savepoint");
+                $this->transaction_level--;
+            } catch (RuntimeException $e) {
+                // The savepoint no longer exists (e.g. an implicit commit caused by a
+                // DDL statement invalidated all savepoints). Fall back to a full rollback.
+                $this->dbh->rollback();
+                $this->transaction_level = 0;
+            }
         }
     }
 

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -410,6 +410,7 @@ class DBmysql
         $start_time = microtime(true);
 
         $this->checkForDeprecatedTableOptions($query);
+        $this->checkForDDLInsideTransaction($query);
 
         $res = $this->dbh->query($query);
         if (!$res) {
@@ -1876,15 +1877,8 @@ class DBmysql
             $savepoint = $this->formatAndQuoteSavePointName(
                 $this->transaction_level
             );
-            try {
-                $this->doQuery("ROLLBACK TO $savepoint");
-                $this->transaction_level--;
-            } catch (RuntimeException $e) {
-                // The savepoint no longer exists (e.g. an implicit commit caused by a
-                // DDL statement invalidated all savepoints). Fall back to a full rollback.
-                $this->dbh->rollback();
-                $this->transaction_level = 0;
-            }
+            $this->doQuery("ROLLBACK TO $savepoint");
+            $this->transaction_level--;
         }
     }
 
@@ -2260,6 +2254,30 @@ class DBmysql
                     'Usage of signed integers in primary or foreign keys is discouraged, please use unsigned integers instead in `%s`.`%s`.',
                     $table_matches['table'],
                     $field_matches['field']
+                ),
+                E_USER_WARNING
+            );
+        }
+    }
+
+    /**
+     * Warn when a DDL statement is executed inside an active transaction.
+     *
+     * DDL statements (ALTER, CREATE, DROP, RENAME, TRUNCATE) cause an implicit
+     * commit in MySQL/MariaDB, which silently invalidates all open savepoints.
+     * Running such a statement inside a transaction is almost certainly a bug.
+     */
+    private function checkForDDLInsideTransaction(string $query): void
+    {
+        if (!$this->isInTransaction()) {
+            return;
+        }
+
+        if (preg_match('/^\s*(ALTER|CREATE|DROP|RENAME|TRUNCATE)\s+/i', $query)) {
+            trigger_error(
+                sprintf(
+                    'DDL statement executed inside a transaction will cause an implicit commit: "%s".',
+                    substr($query, 0, 200)
                 ),
                 E_USER_WARNING
             );

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1851,7 +1851,19 @@ class DBmysql
         if ($success) {
             $this->transaction_level--;
         } else {
-            throw new RuntimeException("Failed to commit transaction.");
+            $exception = new RuntimeException("Failed to commit transaction.");
+            ;
+
+            // Error is logged here since it is likely to caught and silented by the caller.
+            // It may result in being logged twice, but it is probalby preferable than risking having it not logged
+            // at all for a few specific cases.
+            global $PHPLOGGER;
+            $PHPLOGGER->error(
+                'An error occurred during DB transaction commit.',
+                ['exception' => $exception]
+            );
+
+            throw $exception;
         }
     }
 
@@ -1870,7 +1882,18 @@ class DBmysql
             if ($success) {
                 $this->transaction_level--;
             } else {
-                throw new RuntimeException("Failed to rollback transaction.");
+                $exception = new RuntimeException("Failed to rollback transaction.");
+
+                // Error is logged here since it is likely to caught and silented by the caller.
+                // It may result in being logged twice, but it is probalby preferable than risking having it not logged
+                // at all for a few specific cases.
+                global $PHPLOGGER;
+                $PHPLOGGER->error(
+                    'An error occurred during DB transaction rollback.',
+                    ['exception' => $exception]
+                );
+
+                throw $exception;
             }
         } else {
             // A nested transaction is already underway, rollback to current savepoint.

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2274,7 +2274,7 @@ class DBmysql
         }
 
         if (preg_match('/^\s*(ALTER|CREATE|DROP|RENAME|TRUNCATE)\s+/i', $query)) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf(
                     'DDL statement executed inside a transaction will cause an implicit commit: "%s".',
                     substr($query, 0, 200)

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -1774,7 +1774,7 @@ class DBmysql
         ];
     }
 
-    public function isInTransaction(): bool
+    private function isInTransaction(): bool
     {
         return $this->transaction_level > 0;
     }

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2261,7 +2261,7 @@ class DBmysql
     }
 
     /**
-     * Warn when a DDL statement is executed inside an active transaction.
+     * Block DDL statement execution inside an active transaction.
      *
      * DDL statements (ALTER, CREATE, DROP, RENAME, TRUNCATE) cause an implicit
      * commit in MySQL/MariaDB, which silently invalidates all open savepoints.

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2274,12 +2274,11 @@ class DBmysql
         }
 
         if (preg_match('/^\s*(ALTER|CREATE|DROP|RENAME|TRUNCATE)\s+/i', $query)) {
-            trigger_error(
+            throw new \RuntimeException(
                 sprintf(
                     'DDL statement executed inside a transaction will cause an implicit commit: "%s".',
                     substr($query, 0, 200)
-                ),
-                E_USER_WARNING
+                )
             );
         }
     }

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -207,7 +207,11 @@ final class AnswersHandler
             $DB->commit();
             return $answers_set;
         } catch (Throwable $e) {
-            $DB->rollback();
+            try {
+                $DB->rollback();
+            } catch (Throwable) {
+                // Ignore rollback failures so the original exception is propagated
+            }
 
             // Propagate the exception
             throw $e;

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -209,8 +209,14 @@ final class AnswersHandler
         } catch (Throwable $e) {
             try {
                 $DB->rollback();
-            } catch (Throwable) {
-                // Ignore rollback failures so the original exception is propagated
+            } catch (Throwable $rollback_e) {
+                // Catch rollback failures so the original exception is propagated
+
+                global $PHPLOGGER;
+                $PHPLOGGER->error(
+                    'Unable to get code integrity check summary.',
+                    ['exception' => $rollback_e]
+                );
             }
 
             // Propagate the exception

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -211,12 +211,6 @@ final class AnswersHandler
                 $DB->rollback();
             } catch (Throwable $rollback_e) {
                 // Catch rollback failures so the original exception is propagated
-
-                global $PHPLOGGER;
-                $PHPLOGGER->error(
-                    'An error occurred during DB transaction rollback.',
-                    ['exception' => $rollback_e]
-                );
             }
 
             // Propagate the exception

--- a/src/Glpi/Form/AnswersHandler/AnswersHandler.php
+++ b/src/Glpi/Form/AnswersHandler/AnswersHandler.php
@@ -214,7 +214,7 @@ final class AnswersHandler
 
                 global $PHPLOGGER;
                 $PHPLOGGER->error(
-                    'Unable to get code integrity check summary.',
+                    'An error occurred during DB transaction rollback.',
                     ['exception' => $rollback_e]
                 );
             }

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -307,7 +307,13 @@ final class FormSerializer extends AbstractFormSerializer
             $forms = $this->doImportFormFormSpecs($form_spec, $mapper);
             $DB->commit();
         } catch (Throwable $e) {
-            $DB->rollback();
+            try {
+                $DB->rollback();
+            } catch (Throwable $rollback_e) {
+                // Catch rollback failures so the original exception is propagated
+            }
+
+            // Propagate the exception
             throw $e;
         }
         return $forms;

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -394,7 +394,13 @@ final class Form extends CommonDBTM implements
             'force_update'  => true,
         ]);
 
-        $DB->beginTransaction();
+        // Only own the transaction if no outer transaction is already in progress.
+        // When called from within AnswersHandler (or any other outer transaction),
+        // we let the caller manage commit/rollback to avoid nested savepoint issues.
+        $owns_transaction = !$DB->isInTransaction();
+        if ($owns_transaction) {
+            $DB->beginTransaction();
+        }
         try {
             // Update questions and sections
             $this->updateExtraFormData();
@@ -417,7 +423,13 @@ final class Form extends CommonDBTM implements
             );
 
             // Do not keep half updated data
-            $DB->rollback();
+            if ($owns_transaction) {
+                try {
+                    $DB->rollback();
+                } catch (Throwable) {
+                    // Ignore rollback failures so the original exception is propagated
+                }
+            }
 
             // Propagate exception to ensure the server return an error code
             throw $e;

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -420,7 +420,13 @@ final class Form extends CommonDBTM implements
             try {
                 $DB->rollback();
             } catch (Throwable) {
-                // Ignore rollback failures so the original exception is propagated
+                // Catch rollback failures so the original exception is propagated
+
+                global $PHPLOGGER;
+                $PHPLOGGER->error(
+                    'Unable to get code integrity check summary.',
+                    ['exception' => $rollback_e]
+                );
             }
 
             // Propagate exception to ensure the server return an error code

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -424,7 +424,7 @@ final class Form extends CommonDBTM implements
 
                 global $PHPLOGGER;
                 $PHPLOGGER->error(
-                    'Unable to get code integrity check summary.',
+                    'An error occurred during DB transaction rollback.',
                     ['exception' => $rollback_e]
                 );
             }

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -421,12 +421,6 @@ final class Form extends CommonDBTM implements
                 $DB->rollback();
             } catch (Throwable $rollback_e) {
                 // Catch rollback failures so the original exception is propagated
-
-                global $PHPLOGGER;
-                $PHPLOGGER->error(
-                    'An error occurred during DB transaction rollback.',
-                    ['exception' => $rollback_e]
-                );
             }
 
             // Propagate exception to ensure the server return an error code

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -394,13 +394,7 @@ final class Form extends CommonDBTM implements
             'force_update'  => true,
         ]);
 
-        // Only own the transaction if no outer transaction is already in progress.
-        // When called from within AnswersHandler (or any other outer transaction),
-        // we let the caller manage commit/rollback to avoid nested savepoint issues.
-        $owns_transaction = !$DB->isInTransaction();
-        if ($owns_transaction) {
-            $DB->beginTransaction();
-        }
+        $DB->beginTransaction();
         try {
             // Update questions and sections
             $this->updateExtraFormData();
@@ -423,12 +417,10 @@ final class Form extends CommonDBTM implements
             );
 
             // Do not keep half updated data
-            if ($owns_transaction) {
-                try {
-                    $DB->rollback();
-                } catch (Throwable) {
-                    // Ignore rollback failures so the original exception is propagated
-                }
+            try {
+                $DB->rollback();
+            } catch (Throwable) {
+                // Ignore rollback failures so the original exception is propagated
             }
 
             // Propagate exception to ensure the server return an error code

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -419,7 +419,7 @@ final class Form extends CommonDBTM implements
             // Do not keep half updated data
             try {
                 $DB->rollback();
-            } catch (Throwable) {
+            } catch (Throwable $rollback_e) {
                 // Catch rollback failures so the original exception is propagated
 
                 global $PHPLOGGER;

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -471,8 +471,14 @@ class Inventory
             }
         } catch (Throwable $e) {
             if (!defined('TU_USER')) {
-                $DB->rollback();
+                try {
+                    $DB->rollback();
+                } catch (Throwable $rollback_e) {
+                    // Catch rollback failures so the original exception is propagated
+                }
             }
+
+            // Propagate the exception
             throw $e;
         } finally {
             unset($_SESSION['glpiinventoryuserrunning']);

--- a/tests/functional/Glpi/Form/FormTest.php
+++ b/tests/functional/Glpi/Form/FormTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form;
 
 use CronTask;
+use DBmysql;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
@@ -71,6 +72,7 @@ use Item_Ticket;
 use Log;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
+use ReflectionProperty;
 use User;
 
 class FormTest extends DbTestCase
@@ -917,5 +919,61 @@ class FormTest extends DbTestCase
         // Assert: tab count should only indicate two items
         $name = strip_tags($name);
         $this->assertEquals("Forms 2", $name);
+    }
+
+    /**
+     * Regression test for issue #23861.
+     *
+     * Before the fix, Form::post_updateItem() unconditionally opened a nested
+     * transaction (savepoint) even when an outer transaction was already in
+     * progress. When MariaDB implicitly committed that savepoint (e.g. due to a
+     * DDL statement), the subsequent ROLLBACK TO SAVEPOINT failed with:
+     *   "MySQL query error: SAVEPOINT savepoint_0 does not exist"
+     *
+     * The fix makes post_updateItem() skip its own transaction when one is
+     * already active, delegating commit/rollback to the outer caller.
+     */
+    public function testPostUpdateItemDoesNotCreateNestedTransactionWhenInsideOuterTransaction(): void
+    {
+        global $DB;
+
+        $this->login();
+
+        // Create a minimal form to update later.
+        $builder = new FormBuilder("Savepoint regression test");
+        $builder->addQuestion("Question 1", QuestionTypeShortText::class);
+        $form = $this->createForm($builder);
+
+        // Open an outer transaction that wraps the form update,
+        // as AnswersHandler (and other callers) do.
+        $DB->beginTransaction();
+
+        $level_before = $this->getDbTransactionLevel($DB);
+
+        // Updating the form triggers post_updateItem().
+        // The fix ensures it does NOT start a new nested transaction (savepoint)
+        // when one is already in progress.
+        $form->update([
+            'id'   => $form->getID(),
+            'name' => 'Updated name',
+        ]);
+
+        $level_after = $this->getDbTransactionLevel($DB);
+
+        $this->assertSame(
+            $level_before,
+            $level_after,
+            'Form::post_updateItem() must not create a nested transaction when already inside an outer transaction'
+        );
+
+        // Outer transaction must still be open and closeable without errors.
+        $this->assertTrue($DB->isInTransaction());
+        $DB->rollback();
+    }
+
+    private function getDbTransactionLevel(DBmysql $db): int
+    {
+        $prop = new ReflectionProperty(DBmysql::class, 'transaction_level');
+        return $prop->getValue($db);
     }
 }

--- a/tests/functional/Glpi/Form/FormTest.php
+++ b/tests/functional/Glpi/Form/FormTest.php
@@ -924,16 +924,17 @@ class FormTest extends DbTestCase
     /**
      * Regression test for issue #23861.
      *
-     * Before the fix, Form::post_updateItem() unconditionally opened a nested
-     * transaction (savepoint) even when an outer transaction was already in
-     * progress. When MariaDB implicitly committed that savepoint (e.g. due to a
-     * DDL statement), the subsequent ROLLBACK TO SAVEPOINT failed with:
+     * Form::post_updateItem() opens its own savepoint (nested transaction) via
+     * beginTransaction(). When a DDL statement is executed inside that savepoint,
+     * MariaDB issues an implicit commit that invalidates the savepoint, causing
+     * the subsequent "ROLLBACK TO SAVEPOINT" to fail with:
      *   "MySQL query error: SAVEPOINT savepoint_0 does not exist"
      *
-     * The fix makes post_updateItem() skip its own transaction when one is
-     * already active, delegating commit/rollback to the outer caller.
+     * The fix detects DDL statements executed inside a transaction and emits an
+     * E_USER_WARNING so callers never reach a broken savepoint state silently.
+     * The savepoint itself is created and released normally when no DDL is involved.
      */
-    public function testPostUpdateItemDoesNotCreateNestedTransactionWhenInsideOuterTransaction(): void
+    public function testPostUpdateItemSavepointIsCreatedAndReleasedCleanly(): void
     {
         global $DB;
 
@@ -950,9 +951,9 @@ class FormTest extends DbTestCase
 
         $level_before = $this->getDbTransactionLevel($DB);
 
-        // Updating the form triggers post_updateItem().
-        // The fix ensures it does NOT start a new nested transaction (savepoint)
-        // when one is already in progress.
+        // Updating the form triggers post_updateItem(), which opens a savepoint.
+        // After the update the savepoint must be released, returning to the outer
+        // transaction level.
         $form->update([
             'id'   => $form->getID(),
             'name' => 'Updated name',
@@ -963,7 +964,7 @@ class FormTest extends DbTestCase
         $this->assertSame(
             $level_before,
             $level_after,
-            'Form::post_updateItem() must not create a nested transaction when already inside an outer transaction'
+            'Form::post_updateItem() savepoint must be released cleanly, leaving the outer transaction level unchanged'
         );
 
         // Outer transaction must still be open and closeable without errors.

--- a/tests/functional/Glpi/Form/FormTest.php
+++ b/tests/functional/Glpi/Form/FormTest.php
@@ -35,7 +35,6 @@
 namespace tests\units\Glpi\Form;
 
 use CronTask;
-use DBmysql;
 use Glpi\Form\AccessControl\ControlType\AllowList;
 use Glpi\Form\AccessControl\ControlType\AllowListConfig;
 use Glpi\Form\AccessControl\ControlType\DirectAccess;
@@ -72,7 +71,6 @@ use Item_Ticket;
 use Log;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
-use ReflectionProperty;
 use User;
 
 class FormTest extends DbTestCase
@@ -919,62 +917,5 @@ class FormTest extends DbTestCase
         // Assert: tab count should only indicate two items
         $name = strip_tags($name);
         $this->assertEquals("Forms 2", $name);
-    }
-
-    /**
-     * Regression test for issue #23861.
-     *
-     * Form::post_updateItem() opens its own savepoint (nested transaction) via
-     * beginTransaction(). When a DDL statement is executed inside that savepoint,
-     * MariaDB issues an implicit commit that invalidates the savepoint, causing
-     * the subsequent "ROLLBACK TO SAVEPOINT" to fail with:
-     *   "MySQL query error: SAVEPOINT savepoint_0 does not exist"
-     *
-     * The fix detects DDL statements executed inside a transaction and emits an
-     * E_USER_WARNING so callers never reach a broken savepoint state silently.
-     * The savepoint itself is created and released normally when no DDL is involved.
-     */
-    public function testPostUpdateItemSavepointIsCreatedAndReleasedCleanly(): void
-    {
-        global $DB;
-
-        $this->login();
-
-        // Create a minimal form to update later.
-        $builder = new FormBuilder("Savepoint regression test");
-        $builder->addQuestion("Question 1", QuestionTypeShortText::class);
-        $form = $this->createForm($builder);
-
-        // Open an outer transaction that wraps the form update,
-        // as AnswersHandler (and other callers) do.
-        $DB->beginTransaction();
-
-        $level_before = $this->getDbTransactionLevel($DB);
-
-        // Updating the form triggers post_updateItem(), which opens a savepoint.
-        // After the update the savepoint must be released, returning to the outer
-        // transaction level.
-        $form->update([
-            'id'   => $form->getID(),
-            'name' => 'Updated name',
-        ]);
-
-        $level_after = $this->getDbTransactionLevel($DB);
-
-        $this->assertSame(
-            $level_before,
-            $level_after,
-            'Form::post_updateItem() savepoint must be released cleanly, leaving the outer transaction level unchanged'
-        );
-
-        // Outer transaction must still be open and closeable without errors.
-        $this->assertTrue($DB->isInTransaction());
-        $DB->rollback();
-    }
-
-    private function getDbTransactionLevel(DBmysql $db): int
-    {
-        $prop = new ReflectionProperty(DBmysql::class, 'transaction_level');
-        return $prop->getValue($db);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixe !43807 
- It fixe #23861 

Should fix

```
*** An error occured during the form `1. Test` submission: MySQL query error: SAVEPOINT savepoint_0 
does not exist (1305) in SQL query "ROLLBACK TO `savepoint_0`".
```

When submitting a form, `Form::post_updateItem()` started its own database transaction while `AnswersHandler` already had an active transaction. This caused MySQL to invalidate the existing savepoint due to an implicit commit, resulting in a rollback failure.


## Screenshots (if appropriate):


