### PR TITLE
feat(Dropdowns): add ITIL templates to dropdowns config menu

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -1246,6 +1246,9 @@ HTML;
                 ],
 
                 __('Assistance') => [
+                    'TicketTemplate'  => null,
+                    'ChangeTemplate'  => null,
+                    'ProblemTemplate' => null,
                     'ITILCategory' => null,
                     'TaskCategory' => null,
                     'TaskTemplate' => null,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44185

`TicketTemplate`, `ChangeTemplate`, and `ProblemTemplate` are now listed in **Configuration > Dropdowns > Assistance**, alongside other assistance dropdowns such as `TaskTemplate`, `SolutionTemplate`, and `ITILFollowupTemplate`.
This provides a second access point for ITIL templates without removing the existing entry in the Assistance menu.

## Screenshots (if appropriate):

<img width="824" height="671" alt="image" src="https://github.com/user-attachments/assets/9eff587c-b6f5-46dd-82d6-5b53625fa207" />
