### PR TITLE
fix(contract): prevent infinite loop in getWarrantyExpire()

### DIFF
--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -2024,6 +2024,9 @@ HTML;
             // For TACIT contracts: renewal is based on addwarranty, not periodicity
             // For EXPRESS contracts: renewal is based on periodicity
             $renewal_period = $auto_renew ? $addwarranty : $periodicity;
+            if ($renewal_period <= 0) {
+                return '';
+            }
 
             // Find which period we are in
             $current_period = floor($months_elapsed / $renewal_period);
@@ -2105,6 +2108,9 @@ HTML;
         if ($auto_renew && $periodicity > 0 && $deletenotice == 0) {
             // Renewal occurs every addwarranty months (initial duration)
             $renewal_period = ($periodicity != $addwarranty) ? $addwarranty : $periodicity;
+            if ($renewal_period <= 0) {
+                return '';
+            }
 
             while ($timestamp < strtotime($_SESSION['glpi_currenttime'])) {
                 $datetime = new DateTime();

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -1998,10 +1998,7 @@ HTML;
     {
 
         // Life warranty
-        if (
-            ($addwarranty == -1)
-            && ($deletenotice == 0)
-        ) {
+        if ($addwarranty == -1) {
             return __s('Never');
         }
 
@@ -2025,7 +2022,7 @@ HTML;
             // For EXPRESS contracts: renewal is based on periodicity
             $renewal_period = $auto_renew ? $addwarranty : $periodicity;
             if ($renewal_period <= 0) {
-                return '';
+                return htmlescape(Html::convDate($from));
             }
 
             // Find which period we are in
@@ -2040,7 +2037,7 @@ HTML;
             }
 
             // The notice is X months before the end of the period (without subtracting 1 day)
-            $notice_months = $period_end_months - $deletenotice;
+            $notice_months = max(0, $period_end_months - $deletenotice);
             $notice_date = new DateTime($from);
             $notice_date->add(new DateInterval("P{$notice_months}M"));
             $timestamp = $notice_date->getTimestamp();
@@ -2066,7 +2063,10 @@ HTML;
             // Standard calculation
             if ($deletenotice > 0) {
                 // For NOTICE: duration - notice (WITHOUT subtracting 1 day)
-                $initial_notice_timestamp = strtotime("$from+$addwarranty month -$deletenotice month");
+                $notice_months = max(0, $addwarranty - $deletenotice);
+                $initial_notice_date = new DateTime($from);
+                $initial_notice_date->add(new DateInterval("P{$notice_months}M"));
+                $initial_notice_timestamp = $initial_notice_date->getTimestamp();
 
                 // For TACIT contracts: calculate the next FUTURE notice
                 if ($auto_renew && $periodicity > 0) {
@@ -2074,8 +2074,8 @@ HTML;
 
                     $start_date = new DateTime($from);
                     $first_notice_date = clone $start_date;
-                    $first_notice_date->modify("+{$addwarranty} month");
-                    $first_notice_date->modify("-{$deletenotice} month");
+                    $first_notice_months = max(0, $addwarranty - $deletenotice);
+                    $first_notice_date->add(new DateInterval("P{$first_notice_months}M"));
 
                     $timestamp = $first_notice_date->getTimestamp();
 
@@ -2109,7 +2109,7 @@ HTML;
             // Renewal occurs every addwarranty months (initial duration)
             $renewal_period = ($periodicity != $addwarranty) ? $addwarranty : $periodicity;
             if ($renewal_period <= 0) {
-                return '';
+                return __s('Never');
             }
 
             while ($timestamp < strtotime($_SESSION['glpi_currenttime'])) {
@@ -2118,7 +2118,7 @@ HTML;
                 $datetime->add(new DateInterval("P{$renewal_period}M"));
                 $timestamp = $datetime->getTimestamp();
             }
-        } elseif ($deletenotice == 0) {
+        } elseif ($deletenotice == 0 && $addwarranty > 0) {
             $datetime = new DateTime();
             $datetime->setTimestamp($timestamp);
             $datetime->sub(new DateInterval("P1D"));

--- a/tests/functional/ContractTest.php
+++ b/tests/functional/ContractTest.php
@@ -232,51 +232,130 @@ class ContractTest extends DbTestCase
         $this->assertCount(1, $relation_items, 'Original Contract_User not found!');
     }
 
-    public function testContractExpirationWithEdgeDates()
+    public static function warrantyExpirProvider(): array
     {
-        $this->login();
-        $this->setEntity('_test_root_entity', true);
-
-        $test_cases = [
+        return [
             [
-                'name' => 'Contract start 01/31 for 12 months should end on 01/30',
-                'begin_date' => '2025-01-31',
-                'duration' => 12,
-                'expected_date' => '2026-01-30',
+                'current_time' => '2027-01-01',
+                'from'         => '2025-01-31',
+                'addwarranty'  => 12,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2026-01-30',
             ],
             [
-                'name' => 'Contract start 03/01 for 12 months should end on 02/28',
-                'begin_date' => '2025-03-01',
-                'duration' => 12,
-                'expected_date' => '2026-02-28',
+                'current_time' => '2027-01-01',
+                'from'         => '2025-03-01',
+                'addwarranty'  => 12,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2026-02-28',
             ],
             [
-                'name' => 'Contract starting on 03/01/2031 for 12 months should end on 02/29',
-                'begin_date' => '2031-03-01',
-                'duration' => 12,
-                'expected_date' => '2032-02-29',
+                'current_time' => '2027-01-01',
+                'from'         => '2031-03-01',
+                'addwarranty'  => 12,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2032-02-29',
             ],
             [
-                'name' => 'Contract start 05/31 for 6 months should end on 11/30',
-                'begin_date' => '2025-05-31',
-                'duration' => 6,
-                'expected_date' => '2025-11-30',
+                'current_time' => '2027-01-01',
+                'from'         => '2025-05-31',
+                'addwarranty'  => 6,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2025-11-30',
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2024-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '',
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2024-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 2,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '',
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '2028-01-01',
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2025-01-01',
+                'addwarranty'  => 6,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 3,
+                'expected'     => '2025-06-30',
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => __('Never'),
+            ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '',
+                'addwarranty'  => 0,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '',
             ],
         ];
+    }
 
-        foreach ($test_cases as $test_case) {
-            $expiration = \Infocom::getWarrantyExpir(
-                $test_case['begin_date'],
-                $test_case['duration'],
-            );
+    #[DataProvider('warrantyExpirProvider')]
+    public function testContractExpirationWithEdgeDates(
+        string $current_time,
+        string $from,
+        int $addwarranty,
+        int $deletenotice,
+        bool $color,
+        bool $auto_renew,
+        int $periodicity,
+        string $expected
+    ): void {
+        $this->login();
+        $_SESSION['glpi_currenttime'] = $current_time;
 
-            $formatted_expected = \Html::convDate($test_case['expected_date']);
+        $result = \Infocom::getWarrantyExpir($from, $addwarranty, $deletenotice, $color, $auto_renew, $periodicity);
 
-            $this->assertEquals(
-                $formatted_expected,
-                $expiration,
-                $test_case['name'] . " - Expected: {$formatted_expected}, Got: {$expiration}"
-            );
-        }
+        $formatted_expected = in_array($expected, [__('Never'), ''], true) ? $expected : \Html::convDate($expected);
+
+        $this->assertEquals($formatted_expected, $result);
     }
 }

--- a/tests/functional/ContractTest.php
+++ b/tests/functional/ContractTest.php
@@ -335,6 +335,16 @@ class ContractTest extends DbTestCase
                 'periodicity'  => 0,
                 'expected'     => '',
             ],
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => '2028-01-01',
+            ],
         ];
     }
 

--- a/tests/functional/ContractTest.php
+++ b/tests/functional/ContractTest.php
@@ -235,6 +235,7 @@ class ContractTest extends DbTestCase
     public static function warrantyExpirProvider(): array
     {
         return [
+            // Standard expiration: correct end-of-month when day overflows (31 Jan + 12 months = 30 Jan).
             [
                 'current_time' => '2027-01-01',
                 'from'         => '2025-01-31',
@@ -245,6 +246,7 @@ class ContractTest extends DbTestCase
                 'periodicity'  => 0,
                 'expected'     => '2026-01-30',
             ],
+            // Standard expiration: end-of-month in February (28 days, non-leap year).
             [
                 'current_time' => '2027-01-01',
                 'from'         => '2025-03-01',
@@ -255,6 +257,7 @@ class ContractTest extends DbTestCase
                 'periodicity'  => 0,
                 'expected'     => '2026-02-28',
             ],
+            // Standard expiration: end-of-month in February of a leap year (29 days).
             [
                 'current_time' => '2027-01-01',
                 'from'         => '2031-03-01',
@@ -265,56 +268,7 @@ class ContractTest extends DbTestCase
                 'periodicity'  => 0,
                 'expected'     => '2032-02-29',
             ],
-            [
-                'current_time' => '2027-01-01',
-                'from'         => '2025-05-31',
-                'addwarranty'  => 6,
-                'deletenotice' => 0,
-                'color'        => false,
-                'auto_renew'   => false,
-                'periodicity'  => 0,
-                'expected'     => '2025-11-30',
-            ],
-            [
-                'current_time' => '2027-01-01',
-                'from'         => '2024-01-01',
-                'addwarranty'  => 0,
-                'deletenotice' => 0,
-                'color'        => false,
-                'auto_renew'   => true,
-                'periodicity'  => 12,
-                'expected'     => '',
-            ],
-            [
-                'current_time' => '2027-01-01',
-                'from'         => '2024-01-01',
-                'addwarranty'  => 0,
-                'deletenotice' => 2,
-                'color'        => false,
-                'auto_renew'   => true,
-                'periodicity'  => 12,
-                'expected'     => '',
-            ],
-            [
-                'current_time' => '2027-01-01',
-                'from'         => '2020-01-01',
-                'addwarranty'  => 24,
-                'deletenotice' => 0,
-                'color'        => false,
-                'auto_renew'   => true,
-                'periodicity'  => 12,
-                'expected'     => '2028-01-01',
-            ],
-            [
-                'current_time' => '2027-01-01',
-                'from'         => '2025-01-01',
-                'addwarranty'  => 6,
-                'deletenotice' => 0,
-                'color'        => false,
-                'auto_renew'   => false,
-                'periodicity'  => 3,
-                'expected'     => '2025-06-30',
-            ],
+            // Lifelong warranty without notice: returns "Never".
             [
                 'current_time' => '2027-01-01',
                 'from'         => '2020-01-01',
@@ -325,16 +279,84 @@ class ContractTest extends DbTestCase
                 'periodicity'  => 0,
                 'expected'     => __('Never'),
             ],
+            // Zero duration without notice: returns the start date.
             [
                 'current_time' => '2027-01-01',
-                'from'         => '',
+                'from'         => '2020-01-01',
                 'addwarranty'  => 0,
                 'deletenotice' => 0,
                 'color'        => false,
                 'auto_renew'   => false,
                 'periodicity'  => 0,
-                'expected'     => '',
+                'expected'     => '2020-01-01',
             ],
+            // Standard expiration without notice or renewal (24 months → last day included).
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2021-12-31',
+            ],
+            // Lifelong warranty with notice: returns "Never" because duration is infinite.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration with 1-month notice: notice is clamped to the start date.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2020-01-01',
+            ],
+            // 1-month notice on a 24-month contract without renewal.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 0,
+                'expected'     => '2021-12-01',
+            ],
+            // Lifelong warranty with tacit renewal and no notice: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration with tacit renewal and no notice: returns the start date.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => '2020-01-01',
+            ],
+            // Tacit renewal without notice: next future expiration (2020 + n×24 months).
             [
                 'current_time' => '2027-01-01',
                 'from'         => '2020-01-01',
@@ -344,6 +366,171 @@ class ContractTest extends DbTestCase
                 'auto_renew'   => true,
                 'periodicity'  => 0,
                 'expected'     => '2028-01-01',
+            ],
+            // Lifelong warranty with tacit renewal and notice: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration, tacit renewal, 1-month notice: notice is clamped to the start date.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => '2020-01-01',
+            ],
+            // Tacit renewal with notice: next future notice (1 month before the next due date).
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 0,
+                'expected'     => '2027-12-01',
+            ],
+            // Lifelong warranty, periodicity different from duration, no notice: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration, 12-month periodicity, no notice or renewal: returns the start date.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => '2020-01-01',
+            ],
+            // 24-month contract with 12-month periodicity, no notice or renewal: standard expiration.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => '2021-12-31',
+            ],
+            // Lifelong warranty, 12-month periodicity, 1-month notice, no renewal: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration, 12-month periodicity, 1-month notice: clamped to the start date.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => '2020-01-01',
+            ],
+            // 24-month contract, 12-month periodicity, 1-month notice, no renewal: notice of the last period.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => false,
+                'periodicity'  => 12,
+                'expected'     => '2021-12-01',
+            ],
+            // Lifelong warranty, tacit renewal, 12-month periodicity, no notice: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration, tacit renewal, 12-month periodicity: zero renewal period → "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => __('Never'),
+            ],
+            // Tacit renewal, 12-month periodicity different from duration (24 months): next future expiration.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 0,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '2028-01-01',
+            ],
+            // Lifelong warranty, tacit renewal, 12-month periodicity, 1-month notice: returns "Never".
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => -1,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => __('Never'),
+            ],
+            // Zero duration, tacit renewal, 1-month notice, 12-month periodicity: notice active from contract start.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 0,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '2020-01-01',
+            ],
+            // Tacit renewal, 12-month periodicity, 1-month notice: next future notice.
+            [
+                'current_time' => '2027-01-01',
+                'from'         => '2020-01-01',
+                'addwarranty'  => 24,
+                'deletenotice' => 1,
+                'color'        => false,
+                'auto_renew'   => true,
+                'periodicity'  => 12,
+                'expected'     => '2027-12-01',
             ],
         ];
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44166
- Here is a brief description of what this PR does
When calculating the expiration date of a contract, if the contract has a TACIT renewal with a frequency of 0 months, an infinite loop occurs in the getWarrantyExpir() method.

## Screenshots (if appropriate):

<img width="433" height="214" alt="image" src="https://github.com/user-attachments/assets/7475f31b-0a0b-4e99-9a63-609d74efe850" />