### PR TITLE
Fix(OauthClient): clean DB on Purge

### DIFF
--- a/src/Glpi/OAuth/AccessTokenRepository.php
+++ b/src/Glpi/OAuth/AccessTokenRepository.php
@@ -93,6 +93,20 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     }
 
     /**
+     * Revoke all access tokens issued for the given client.
+     *
+     * @param string $clientIdentifier
+     *
+     * @return void
+     */
+    public function revokeByClient(string $clientIdentifier): void
+    {
+        global $DB;
+
+        $DB->delete('glpi_oauth_access_tokens', ['client' => $clientIdentifier]);
+    }
+
+    /**
      * @param string $tokenId
      *
      * @return bool

--- a/src/Glpi/OAuth/AuthCodeRepository.php
+++ b/src/Glpi/OAuth/AuthCodeRepository.php
@@ -79,6 +79,20 @@ class AuthCodeRepository implements AuthCodeRepositoryInterface
     }
 
     /**
+     * Revoke all authorization codes issued for the given client.
+     *
+     * @param string $clientIdentifier
+     *
+     * @return void
+     */
+    public function revokeByClient(string $clientIdentifier): void
+    {
+        global $DB;
+
+        $DB->delete('glpi_oauth_auth_codes', ['client' => $clientIdentifier]);
+    }
+
+    /**
      * @param string $codeId
      *
      * @return bool

--- a/src/Glpi/OAuth/RefreshTokenRepository.php
+++ b/src/Glpi/OAuth/RefreshTokenRepository.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\OAuth;
 
+use Glpi\DBAL\QuerySubQuery;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 
@@ -75,6 +76,26 @@ class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 
         $DB->delete('glpi_oauth_refresh_tokens', [
             'identifier' => $tokenId,
+        ]);
+    }
+
+    /**
+     * Revoke all refresh tokens whose linked access token was issued for the given client.
+     *
+     * @param string $clientIdentifier
+     *
+     * @return void
+     */
+    public function revokeByClient(string $clientIdentifier): void
+    {
+        global $DB;
+
+        $DB->delete('glpi_oauth_refresh_tokens', [
+            'access_token' => new QuerySubQuery([
+                'SELECT' => 'identifier',
+                'FROM'   => 'glpi_oauth_access_tokens',
+                'WHERE'  => ['client' => $clientIdentifier],
+            ]),
         ]);
     }
 

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QuerySubQuery;
 use Glpi\OAuth\Server;
 
 use function Safe\json_decode;
@@ -202,6 +203,23 @@ final class OAuthClient extends CommonDBTM
             $this->fields['scopes'] = json_decode($this->fields['scopes'], true);
         }
         $this->fields['redirect_uri'] = json_decode($this->fields['redirect_uri'], true);
+    }
+
+    public function cleanDBonPurge(): void
+    {
+        global $DB;
+
+        $identifier = $this->fields['identifier'] ?? '';
+        $DB->delete('glpi_oauth_refresh_tokens', [
+            'access_token' => new QuerySubQuery([
+                'SELECT' => 'identifier',
+                'FROM'   => 'glpi_oauth_access_tokens',
+                'WHERE'  => ['client' => $identifier],
+            ]),
+        ]);
+
+        $DB->delete('glpi_oauth_access_tokens', ['client' => $identifier]);
+        $DB->delete('glpi_oauth_auth_codes', ['client' => $identifier]);
     }
 
     public function post_getEmpty()

--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -34,7 +34,9 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\DBAL\QuerySubQuery;
+use Glpi\OAuth\AccessTokenRepository;
+use Glpi\OAuth\AuthCodeRepository;
+use Glpi\OAuth\RefreshTokenRepository;
 use Glpi\OAuth\Server;
 
 use function Safe\json_decode;
@@ -207,19 +209,11 @@ final class OAuthClient extends CommonDBTM
 
     public function cleanDBonPurge(): void
     {
-        global $DB;
-
         $identifier = $this->fields['identifier'] ?? '';
-        $DB->delete('glpi_oauth_refresh_tokens', [
-            'access_token' => new QuerySubQuery([
-                'SELECT' => 'identifier',
-                'FROM'   => 'glpi_oauth_access_tokens',
-                'WHERE'  => ['client' => $identifier],
-            ]),
-        ]);
 
-        $DB->delete('glpi_oauth_access_tokens', ['client' => $identifier]);
-        $DB->delete('glpi_oauth_auth_codes', ['client' => $identifier]);
+        (new RefreshTokenRepository())->revokeByClient($identifier);
+        (new AccessTokenRepository())->revokeByClient($identifier);
+        (new AuthCodeRepository())->revokeByClient($identifier);
     }
 
     public function post_getEmpty()

--- a/tests/functional/OAuthClientTest.php
+++ b/tests/functional/OAuthClientTest.php
@@ -83,4 +83,52 @@ class OAuthClientTest extends DbTestCase
             $this->assertSame($allowed_ips, $update_result['allowed_ips']);
         }
     }
+
+    public function testPurgeDeletesAssociatedTokens(): void
+    {
+        global $DB;
+
+        $client = $this->createItem(\OAuthClient::class, ['name' => 'Test client']);
+        $identifier = $client->fields['identifier'];
+
+        $this->assertTrue($DB->insert('glpi_oauth_access_tokens', [
+            'identifier' => 'access_token_purge_test',
+            'client' => $identifier,
+            'date_expiration' => date('Y-m-d H:i:s', time() + 3600),
+        ]));
+        $this->assertTrue($DB->insert('glpi_oauth_refresh_tokens', [
+            'identifier' => 'refresh_token_purge_test',
+            'access_token' => 'access_token_purge_test',
+            'date_expiration' => date('Y-m-d H:i:s', time() + 3600),
+        ]));
+        $this->assertTrue($DB->insert('glpi_oauth_auth_codes', [
+            'identifier' => 'auth_code_purge_test',
+            'client' => $identifier,
+            'date_expiration' => date('Y-m-d H:i:s', time() + 3600),
+        ]));
+        $this->assertTrue($DB->insert('glpi_oauth_access_tokens', [
+            'identifier' => 'access_token_other_client',
+            'client' => 'other_client_identifier',
+            'date_expiration' => date('Y-m-d H:i:s', time() + 3600),
+        ]));
+
+        $client->delete(['id' => $client->getID(), 'purge' => 1]);
+
+        $this->assertCount(0, $DB->request([
+            'FROM'  => 'glpi_oauth_access_tokens',
+            'WHERE' => ['client' => $identifier],
+        ]));
+        $this->assertCount(0, $DB->request([
+            'FROM'  => 'glpi_oauth_refresh_tokens',
+            'WHERE' => ['identifier' => 'refresh_token_purge_test'],
+        ]));
+        $this->assertCount(0, $DB->request([
+            'FROM'  => 'glpi_oauth_auth_codes',
+            'WHERE' => ['client' => $identifier],
+        ]));
+        $this->assertCount(1, $DB->request([
+            'FROM'  => 'glpi_oauth_access_tokens',
+            'WHERE' => ['identifier' => 'access_token_other_client'],
+        ]));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Add `cleanDBonPurge()` to `OAuthClient`. 

  1. Refresh tokens are deleted first, via a subquery on access tokens for this client 
  2. Access tokens are deleted.
  3. Auth codes are deleted.

## Screenshots (if appropriate):


