### PR TITLE
Fix(Dashboard): allow shared-access users to open the "Add filter" form

### DIFF
--- a/ajax/dashboard.php
+++ b/ajax/dashboard.php
@@ -258,7 +258,7 @@ switch ($_REQUEST['action']) {
         break;
 
     case 'display_add_filter':
-        if (!$dashboard->canUpdateCurrent()) {
+        if (!$dashboard->canViewCurrent()) {
             throw new AccessDeniedHttpException();
         }
 

--- a/tests/functional/Glpi/Dashboard/DashboardTest.php
+++ b/tests/functional/Glpi/Dashboard/DashboardTest.php
@@ -353,4 +353,29 @@ class DashboardTest extends DbTestCase
         $_SESSION['glpigroups'] = [];
         $this->assertFalse(Dashboard::checkRights($rights));
     }
+
+    public function testCanViewCurrentForSharedUser(): void
+    {
+        $this->login();
+        $owner_id = (int) \Session::getLoginUserID();
+
+        $shared_user_id = getItemByTypeName(\User::class, 'jsmith123', true);
+
+        // Dashboard with a non-zero users_id is "owned" (private to its owner)
+        $this->createItem(Dashboard::class, [
+            'key'      => 'test_view_current_shared',
+            'name'     => __FUNCTION__,
+            'users_id' => $owner_id,
+        ]);
+        $owned_dashboard = new Dashboard('test_view_current_shared');
+        $owned_dashboard->saveRights(['users_id' => [$shared_user_id]]);
+
+        // Log in as the shared user and restrict to view-only dashboard right
+        $this->login('jsmith123');
+        $_SESSION['glpiactiveprofile']['dashboard'] = READ;
+
+        $dashboard_as_shared = new Dashboard('test_view_current_shared');
+        $this->assertTrue($dashboard_as_shared->canViewCurrent());
+        $this->assertFalse($dashboard_as_shared->canUpdateCurrent());
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44216

Users with shared (view-only) access to a dashboard could toggle filter mode but clicking "Add filter" triggered a 403. The `display_add_filter` AJAX action was guarded by `canUpdateCurrent()` instead of `canViewCurrent()`, unlike all other filter-related actions in the same file.
