### PR TITLE
fix: missing parentheses for tab badge counters on mobile tabpanel dropdowns

### DIFF
--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 
 use function Safe\json_encode;
 use function Safe\preg_match;
+use function Safe\preg_replace;
 
 /**
  * Ajax Class

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -347,7 +347,10 @@ class Ajax
                 $tab_content_url = $val['url'] . (isset($val['params']) ? '?' . $val['params'] : '');
                 $selected = $active_id == $target ? 'selected' : '';
                 $title = $val['title'];
-                $title_clean = strip_tags($title);
+                
+                // Format the badge with parentheses before stripping tags for option and aria-label
+                $title_clean = preg_replace('/ <span[^>]*class="[^"]*\bbadge\b[^"]*"[^>]*>(.*?)<\/span>/', ' ($1)', $title);
+                $title_clean = strip_tags($title_clean);
 
                 // Compute direct link that user can reach in a new tab using
                 // middle mouse click.
@@ -375,7 +378,7 @@ class Ajax
                             >{$title}</a>
                         </li>
                     ";
-                    $html_sele .= "<option value='$i' {$selected}>{$title}</option>";
+                    $html_sele .= "<option value='$i' {$selected}>{$title_clean}</option>";
                 } else {
                     // All tabs
                     $html_tabs .= <<<HTML
@@ -384,7 +387,7 @@ class Ajax
                                 href='#' data-show-all-tabs="true">{$title}</a>
                         </li>
 HTML;
-                    $html_sele .= "<option value='$i' {$selected}>{$title}</option>";
+                    $html_sele .= "<option value='$i' {$selected}>{$title_clean}</option>";
                 }
                 $i++;
             }

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -350,7 +350,7 @@ class Ajax
                 $title = $val['title'];
 
                 // Format the badge with parentheses before stripping tags for option and aria-label
-                $title_clean = preg_replace('/ <span[^>]*class="[^"]*\bbadge\b[^"]*"[^>]*>(.*?)<\/span>/', ' ($1)', $title);
+                $title_clean = preg_replace('/<span[^>]*class="[^"]*\bbadge\b[^"]*"[^>]*>(.*?)<\/span>/', '($1)', $title);
                 $title_clean = strip_tags($title_clean);
 
                 // Compute direct link that user can reach in a new tab using

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -347,7 +347,7 @@ class Ajax
                 $tab_content_url = $val['url'] . (isset($val['params']) ? '?' . $val['params'] : '');
                 $selected = $active_id == $target ? 'selected' : '';
                 $title = $val['title'];
-                
+
                 // Format the badge with parentheses before stripping tags for option and aria-label
                 $title_clean = preg_replace('/ <span[^>]*class="[^"]*\bbadge\b[^"]*"[^>]*>(.*?)<\/span>/', ' ($1)', $title);
                 $title_clean = strip_tags($title_clean);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

On mobile views, the `tabpanel` is transformed into a responsive `<select>` dropdown element (`#tabspanel-select`). Previously, the raw title (which contains HTML tags for the badge counter, e.g., `<span class="badge...">1</span>`) was being injected directly into the `<option>` tags.

Since `<option>` tags cannot render HTML, browsers fall back to stripping the tags automatically but preserve the inner text as-is. This resulted in tab names blending awkwardly with their counts, displaying as **"History 1"** instead of **"History (1)"**. 

## Solution

Modified the tab rendering logic in `Ajax::createTabs` (`src/Ajax.php`):

1. Introduced a regex replacement to specifically look for the badge element and wrap its content in parentheses _before_ calling `strip_tags()`. Because `$title_clean` is also used for the `aria-label` attribute on the desktop tabs, screen readers will now correctly announce "History (1)" instead of "History 1".
2. Updated the `<select>` options to use the resulting `$title_clean` variable instead of the raw `$title`. No stray HTML markup is sent to the `<option>` fields anymore, keeping the DOM much cleaner.

## Screenshots (if appropriate):

**Before:**

<img width="680" height="809" alt="Captura de Tela 2026-05-24 às 09 55 43" src="https://github.com/user-attachments/assets/802ea97e-fa10-4164-b70e-0b87d2c7782b" />

**After:**

<img width="680" height="809" alt="Captura de Tela 2026-05-24 às 09 56 48" src="https://github.com/user-attachments/assets/1779af91-eb61-427a-9d7c-c9d3f745f83d" />
