### PR TITLE
Fix: recurrent changes cron fails with RecurrentChange items

### DIFF
--- a/src/CommonITILRecurrentCron.php
+++ b/src/CommonITILRecurrentCron.php
@@ -95,7 +95,7 @@ class CommonITILRecurrentCron extends CommonDBTM
                 // get items
                 $related_items = $item->getRelatedElements();
 
-                if ($item->fields['ticket_per_item']) {
+                if ($item->fields['ticket_per_item'] ?? false) {
                     foreach ($related_items as $related_itemtype => $related_items_ids) {
                         foreach ($related_items_ids as $related_item_id) {
                             if ($item->createItem([$related_itemtype => [$related_item_id]])) {

--- a/src/Session.php
+++ b/src/Session.php
@@ -2321,6 +2321,13 @@ class Session
         }
         $_SESSION['glpiactiveentities']        = $entities;
         $_SESSION['glpiactiveentities_string'] = "'" . implode("', '", $entities) . "'";
+
+        $ancestors = getAncestorsOf("glpi_entities", $entities_id);
+        $_SESSION['glpiparententities']        = $ancestors;
+        $_SESSION['glpiparententities_string'] = implode("', '", $ancestors);
+        if (!empty($_SESSION['glpiparententities_string'])) {
+            $_SESSION['glpiparententities_string'] = "'" . $_SESSION['glpiparententities_string'] . "'";
+        }
     }
 
     /**

--- a/tests/functional/SessionTest.php
+++ b/tests/functional/SessionTest.php
@@ -1631,4 +1631,16 @@ class SessionTest extends DbTestCase
         \Html::generateMenuSession(true);
         $this->assertArrayHasKey('content', $_SESSION['glpimenu']['config']);
     }
+
+    public function testLoadEntitySetsParentEntities(): void
+    {
+        // Non-regression: Session::loadEntity() was not setting glpiparententities,
+        // causing getEntitiesRestrictRequest() to call getAncestorsOf("glpi_entities", '')
+        // and generate an invalid "IN ()" SQL clause.
+        \Session::loadEntity(0, true);
+
+        $this->assertArrayHasKey('glpiparententities', $_SESSION);
+        $this->assertArrayHasKey('glpiparententities_string', $_SESSION);
+        $this->assertIsArray($_SESSION['glpiparententities']);
+    }
 }

--- a/tests/src/CommonITILRecurrentTest.php
+++ b/tests/src/CommonITILRecurrentTest.php
@@ -726,6 +726,43 @@ abstract class CommonITILRecurrentTest extends DbTestCase
         $this->assertEquals($expected_date, $recurrent->fields['next_creation_date']);
     }
 
+    public function testCronDoesNotWarnOnMissingTicketPerItemField(): void
+    {
+        global $DB;
+
+        $this->login();
+
+        $child_class = $this->getChildClass();
+        $template_class = $child_class::getTemplateClass();
+
+        $template = $this->createItem($template_class, [
+            'name' => $this->getUniqueString(),
+        ]);
+
+        $recurrent = $this->createItem($child_class, [
+            'name'                          => $this->getUniqueString(),
+            $template->getForeignKeyField() => $template->getID(),
+            'begin_date'                    => '2020-01-01 00:00:00',
+            'end_date'                      => null,
+            'periodicity'                   => HOUR_TIMESTAMP,
+            'create_before'                 => 0,
+            'calendars_id'                  => 0,
+            'is_active'                     => 1,
+            'entities_id'                   => $this->getTestRootEntity(true),
+        ]);
+
+        // Bypass prepareInputForUpdate to force next_creation_date in the past
+        $DB->update($child_class::getTable(), ['next_creation_date' => '2020-01-01 00:00:00'], ['id' => $recurrent->getID()]);
+
+        $task = $this->createMock(\CronTask::class);
+
+        // GLPITestCase::tearDown() asserts no unexpected log entries — a PHP warning
+        // "Undefined array key ticket_per_item" would fail here for RecurrentChange
+        $result = \CommonITILRecurrentCron::cronRecurrentItems($task);
+
+        $this->assertSame(1, $result);
+    }
+
     public function testTemplateIsSetOnCreatedItem(): void
     {
         // Arrange: create a template and a reccurent item


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44245

The recurrent changes cron (`cronRecurrentItems`) failed in two ways when processing `RecurrentChange` items.

**Fix 1**: `CommonITILRecurrentCron`: accessing `$item->fields['ticket_per_item']` without a null-coalesce guard caused a PHP warning because that field only exists on `TicketRecurrent`, not `RecurrentChange`.

```
glpi.WARNING:   *** Warning: Undefined array key "ticket_per_item" at CommonITILRecurrentCron.php line 98
  Backtrace :
  ./src/CommonITILRecurrentCron.php:98               
  ./src/CronTask.php:887                             CommonITILRecurrentCron::cronRecurrentItems()
  ./front/crontask.form.php:55                       CronTask::launch()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

**Fix 2**: `Session::loadEntity()` (called by the cron at startup) did not initialize `$_SESSION['glpiparententities']`, causing `getEntitiesRestrictRequest()` to call `getAncestorsOf("glpi_entities", '')` and generate an invalid `IN ()` SQL clause that crashed MariaDB when sending post-creation notifications.

```
glpi.ERROR:   *** Caught RuntimeException: MySQL query error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')) )  AND (   ( `glpi_changes`.`priority` = '4') AND `glpi_changes`.`id` = 45...' at line 2 (1064) in SQL query "SELECT DISTINCT `glpi_changes`.`id` AS id, 'cron' AS currentuser,
                        `glpi_changes`.`entities_id`, `glpi_changes`.`is_recursive`, `glpi_changes`.`id` AS `ITEM_Change_2`, `glpi_changes`.`name` AS `ITEM_Change_1`, `glpi_changes`.`id` AS `ITEM_Change_1_id`, `glpi_changes`.`id` AS `ITEM_Change_1_id`, `glpi_changes`.`status` AS `ITEM_Change_1_status`, `glpi_entities`.`completename` AS `ITEM_Change_80`, `glpi_changes`.`priority` AS `ITEM_Change_3` FROM `glpi_changes`   LEFT JOIN `glpi_entities` ON (`glpi_changes`.`entities_id` = `glpi_entities`.`id`)   WHERE  `glpi_changes`.`is_deleted` = 0  AND  ( `glpi_changes`.`entities_id` IN ('0', '1', '2', '4', '3', '94', '54', '11', '8', '10', '12', '13', '59', '15', '16', '17', '99', '18', '20', '21', '22', '23', '24', '25', '27', '95', '98', '30', '33', '34', '96', '35', '36', '37', '38', '39', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '53', '57', '58', '60', '61', '64', '67', '68', '69', '71', '72', '73', '74', '75', '76', '82', '83', '85', '87', '88', '89', '90', '91', '92', '81', '93', '9', '14', '19', '26', '28', '31', '32', '52', '55', '56', '97', '65', '70', '79', '80', '84', '100')  OR (`glpi_changes`.`is_recursive`='1' AND `glpi_changes`.`entities_id` IN ()) )  AND (   ( `glpi_changes`.`priority` = '4') AND `glpi_changes`.`id` = 455 ) ORDER BY `id` ".
  Backtrace :
  ./src/DBmysql.php:416                              
  ./src/Glpi/Search/Provider/SQLProvider.php:4988    DBmysql->doQuery()
  ./src/Glpi/Search/SearchEngine.php:678             Glpi\Search\Provider\SQLProvider::constructData()
  ./src/Glpi/Search/FilterableTrait.php:91           Glpi\Search\SearchEngine::getData()
  ./src/NotificationEvent.php:144                    Notification->itemMatchFilter()
  ./src/CommonITILObject.php:9004                    NotificationEvent::raiseEvent()
  ./src/Change.php:468                               CommonITILObject->handleNewItemNotifications()
  ./src/CommonDBTM.php:1398                          Change->post_addItem()
  ./src/CommonITILRecurrent.php:640                  CommonDBTM->add()
  ./src/CommonITILRecurrentCron.php:115              CommonITILRecurrent->createItem()
  ./src/CronTask.php:887                             CommonITILRecurrentCron::cronRecurrentItems()
  ./front/cron.php:136                               CronTask::launch()
```

## Screenshots (if appropriate):


