### PR TITLE
fix(ui): Status area alert icon alignment and responsiveness

### DIFF
--- a/css/includes/pages/_search.scss
+++ b/css/includes/pages/_search.scss
@@ -294,3 +294,10 @@ table.search-results {
         }
     }
 }
+
+.status-area {
+    .ti-alert-triangle {
+        height: 20px;
+        line-height: 20px;
+    }
+}

--- a/templates/components/search/status_area.html.twig
+++ b/templates/components/search/status_area.html.twig
@@ -32,7 +32,7 @@
 
 <div class="status-area">
     <span class="alert alert-warning p-1 m-0 d-flex align-items-center">
-        <i class="ti ti-alert-triangle me-2 d-flex align-items-center justify-content-center flex-shrink-0"></i>
+        <i class="ti ti-alert-triangle d-flex align-items-center justify-content-center flex-shrink-0"></i>
         <span>{{ status_message|raw }}</span>
     {% if extra_message is defined %}
         <span class="form-help flex-shrink-0" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ extra_message }}">

--- a/templates/components/search/status_area.html.twig
+++ b/templates/components/search/status_area.html.twig
@@ -31,11 +31,11 @@
  #}
 
 <div class="status-area">
-    <span class="alert alert-warning p-1 m-0">
-        <i class="ti ti-alert-triangle me-2"></i>
+    <span class="alert alert-warning p-1 m-0 d-flex align-items-center">
+        <i class="ti ti-alert-triangle me-2 d-flex align-items-center justify-content-center flex-shrink-0"></i>
         <span>{{ status_message|raw }}</span>
     {% if extra_message is defined %}
-        <span class="form-help" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ extra_message }}">
+        <span class="form-help flex-shrink-0" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ extra_message }}">
             ?
         </span>
     {% endif %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR fixes vertical and horizontal alignment issues of the `ti-alert-triangle` icon inside the status area alert banner, while also ensuring that the icons do not shrink on smaller viewports.

Previously, the warning icon lacked a strict height constraint, causing it to misalign vertically with the text. Additionally, the existing `me-2` margin was creating an asymmetrical visual space between the icon and the text. Finally, on smaller screens, both the warning icon and the help indicator would collapse/squish horizontally.

## Changes Made
- **Vertical Centering**: Applied Bootstrap flex utility classes (`d-flex align-items-center justify-content-center`) to the warning icon to ensure it perfectly aligns vertically with the alert text.
- **Consistent Sizing**: Added a fixed `20px` height and line-height for the `.ti-alert-triangle` via SCSS (`css/includes/pages/_search.scss`) to standardize its bounding box and support proper vertical centering.
- **Horizontal Balancing**: Removed the `me-2` margin class from the icon to fix the optical horizontal misalignment, resulting in a cleaner and balanced spacing between the alert border and the message.
- **Prevent Shrinkage**: Added the `flex-shrink-0` utility class to both the `ti-alert-triangle` and the help popover (`?`) indicator, preventing them from collapsing when the message wraps on smaller screens.

## Files Modified
- `templates/components/search/status_area.html.twig`
- `css/includes/pages/_search.scss`

## Screenshots (if appropriate):

**Before:**

<img width="436" height="46" alt="2026-05-25 10_40_22-Greenshot" src="https://github.com/user-attachments/assets/799c159d-ffb2-4620-981d-20650f87a7e7" />
<br>
<img width="315" height="65" alt="2026-05-25 10_43_55-Microsoft OneDrive" src="https://github.com/user-attachments/assets/ef6e1661-c170-49da-a02f-6c412769197e" />

**After:**

<img width="418" height="39" alt="2026-05-25 11_11_15-Greenshot" src="https://github.com/user-attachments/assets/ba261054-5375-4543-983d-e16f9e82e11a" />
<br>
<img width="390" height="62" alt="2026-05-25 11_11_21-Microsoft OneDrive" src="https://github.com/user-attachments/assets/1bb90cc9-ec46-49c8-a920-a820fe989e85" />