### PR TITLE
feat(ui): Center lcon .fa-cog in marketplace UI

### DIFF
--- a/css/standalone/marketplace.scss
+++ b/css/standalone/marketplace.scss
@@ -259,6 +259,11 @@ $break_s_screen: 1400px;
                         padding: 5px;
                         margin-left: auto;
 
+                        &:has(> .fa-cog:only-child) {
+                            display: block;
+                            text-align: center;
+                        }
+
                         button {
                             background-color: rgb(100, 100, 100, 10%);
                             border: 1px solid rgb(100, 100, 100, 40%);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Add a `:has(> .fa-cog:only-child)` rule in marketplace.scss to make containers that only contain a Font Awesome cog icon display as block and center-align their content. This ensures a standalone settings/cog icon is visually centered during plugin update without affecting the existing button styles.

## Screenshots (if appropriate):

**Before this PR:**

<img width="402" height="120" alt="2026-05-25 12_45_51" src="https://github.com/user-attachments/assets/e71504be-7750-4125-a34a-1c7e4db84412" />

**After this PR:**

<img width="403" height="117" alt="2026-05-25 12_46_07" src="https://github.com/user-attachments/assets/565cc774-1caf-44fa-997a-36a02769872a" />