### PR TITLE
fix(ui): add missing plus icon to 'add an authorization' button

### DIFF
--- a/templates/pages/admin/add_profile_authorization.html.twig
+++ b/templates/pages/admin/add_profile_authorization.html.twig
@@ -75,7 +75,7 @@
             </div>
         </div>
         <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap py-2">
-            {{ inputs.submit('add', _x('button', 'Add')) }}
+            {{ inputs.submit('add', _x('button', 'Add'), '', {'icon': 'ti ti-plus'}) }}
         </div>
     </form>
 </div>

--- a/templates/pages/admin/rules/criteria.html.twig
+++ b/templates/pages/admin/rules/criteria.html.twig
@@ -40,15 +40,15 @@
     {% block more_fields %}
         {{ inputs.hidden(rule.getRuleIdField, item.fields[rules_id_field]) }}
         {% set criteria_dropdown %}
-            <div class="d-flex">
-                <div>
+            <div class="d-flex w-100">
+                <div class="btn-group btn-group-sm" role="group">
                     {% do call([rule, 'dropdownCriteria'], [{
                         value: item.fields['criteria'],
                         rand: rand
                     }]) %}
                     {% if rule.specific_parameters %}
                         {% set param_itemtype = get_class(rule) ~ 'Parameter' %}
-                        <button type="button" class="btn btn-ghost-secondary btn-sm" title="{{ __('Add a criterion') }}"
+                        <button type="button" class="btn btn-outline-secondary" title="{{ __('Add a criterion') }}"
                                 data-bs-toggle="modal" data-bs-target="#addcriterion{{ rand }}">
                             <i class="ti ti-plus"></i>
                         </button>
@@ -61,7 +61,7 @@
                         ]) %}
                     {% endif %}
                 </div>
-                <span id="criteria_span" class="d-flex"></span>
+                <span id="criteria_span" class="d-flex ms-2"></span>
             </div>
         {% endset %}
         {{ fields.htmlField('', criteria_dropdown, get_class(item)|itemtype_name, {

--- a/templates/pages/admin/rules/criteria.html.twig
+++ b/templates/pages/admin/rules/criteria.html.twig
@@ -40,15 +40,15 @@
     {% block more_fields %}
         {{ inputs.hidden(rule.getRuleIdField, item.fields[rules_id_field]) }}
         {% set criteria_dropdown %}
-            <div class="d-flex w-100">
-                <div class="btn-group btn-group-sm" role="group">
+            <div class="d-flex">
+                <div>
                     {% do call([rule, 'dropdownCriteria'], [{
                         value: item.fields['criteria'],
                         rand: rand
                     }]) %}
                     {% if rule.specific_parameters %}
                         {% set param_itemtype = get_class(rule) ~ 'Parameter' %}
-                        <button type="button" class="btn btn-outline-secondary" title="{{ __('Add a criterion') }}"
+                        <button type="button" class="btn btn-ghost-secondary btn-sm" title="{{ __('Add a criterion') }}"
                                 data-bs-toggle="modal" data-bs-target="#addcriterion{{ rand }}">
                             <i class="ti ti-plus"></i>
                         </button>
@@ -61,7 +61,7 @@
                         ]) %}
                     {% endif %}
                 </div>
-                <span id="criteria_span" class="d-flex ms-2"></span>
+                <span id="criteria_span" class="d-flex"></span>
             </div>
         {% endset %}
         {{ fields.htmlField('', criteria_dropdown, get_class(item)|itemtype_name, {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Pass an icon option to the `Add` submit button in `templates/pages/admin/add_profile_authorization.html.twig` (`/front/user.form.php`) by calling inputs.submit with `{'icon': 'ti ti-plus'}`. This updates the button to display a plus icon for improved UI clarity without changing functionality.

## Screenshots (if appropriate):

Before this PR:

<img width="1635" height="191" alt="2026-05-25 13_09_40" src="https://github.com/user-attachments/assets/2cd1aeac-2a55-42f6-afce-95ce420e34c5" />

After this PR:

<img width="1643" height="198" alt="2026-05-25 13_11_47" src="https://github.com/user-attachments/assets/b1b3c4c5-e471-476f-a4f9-d42a225fc118" />