### PR TITLE
fix(ui): Adjust criteria dropdown layout and button styling

### DIFF
--- a/templates/pages/admin/rules/criteria.html.twig
+++ b/templates/pages/admin/rules/criteria.html.twig
@@ -40,15 +40,15 @@
     {% block more_fields %}
         {{ inputs.hidden(rule.getRuleIdField, item.fields[rules_id_field]) }}
         {% set criteria_dropdown %}
-            <div class="d-flex">
-                <div>
+            <div class="d-flex w-100">
+                <div class="btn-group btn-group-sm" role="group">
                     {% do call([rule, 'dropdownCriteria'], [{
                         value: item.fields['criteria'],
                         rand: rand
                     }]) %}
                     {% if rule.specific_parameters %}
                         {% set param_itemtype = get_class(rule) ~ 'Parameter' %}
-                        <button type="button" class="btn btn-ghost-secondary btn-sm" title="{{ __('Add a criterion') }}"
+                        <button type="button" class="btn btn-outline-secondary" title="{{ __('Add a criterion') }}"
                                 data-bs-toggle="modal" data-bs-target="#addcriterion{{ rand }}">
                             <i class="ti ti-plus"></i>
                         </button>
@@ -61,7 +61,7 @@
                         ]) %}
                     {% endif %}
                 </div>
-                <span id="criteria_span" class="d-flex"></span>
+                <span id="criteria_span" class="d-flex ms-2"></span>
             </div>
         {% endset %}
         {{ fields.htmlField('', criteria_dropdown, get_class(item)|itemtype_name, {


### PR DESCRIPTION


<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Update admin rules criteria template to improve layout and spacing: make the flex container full-width, group action buttons with btn-group-sm, change the add-criterion button to use btn-outline-secondary, and add left margin to the criteria span for better spacing and alignment while preserving the modal trigger.

## Screenshots (if appropriate):

Before this PR:

<img width="608" height="75" alt="2026-05-25 13_19_37-WhatsApp" src="https://github.com/user-attachments/assets/5066d48f-f3e0-4e07-9dd5-043b9e2ee4f3" />

After this PR:

<img width="604" height="58" alt="2026-05-25 13_31_08-WhatsApp" src="https://github.com/user-attachments/assets/9b825ae3-c5a2-4e2f-a524-3d90b6b50256" />