### PR TITLE
fix(php): Guard criteria['field'] with null coalesce

### DIFF
--- a/src/RuleImportEntity.php
+++ b/src/RuleImportEntity.php
@@ -130,7 +130,7 @@ class RuleImportEntity extends Rule
     {
         global $CFG_GLPI, $PLUGIN_HOOKS;
 
-        if ($criteria['field'] === '_source') {
+        if (($criteria['field'] ?? '') === '_source') {
             $tab = ['GLPI' => __('GLPI'), 'NATIVE_INVENTORY' => AutoUpdateSystem::getLabelFor(AutoUpdateSystem::NATIVE_INVENTORY)];
             foreach (array_keys($PLUGIN_HOOKS[Hooks::IMPORT_ITEM] ?? []) as $plug) {
                 if (!Plugin::isPluginActive($plug)) {
@@ -142,7 +142,7 @@ class RuleImportEntity extends Rule
             return true;
         }
 
-        if ($criteria['field'] === 'itemtype') {
+        if (($criteria['field'] ?? '') === 'itemtype') {
             Dropdown::showItemTypes($name, $CFG_GLPI['asset_types'], ['value' => $value]);
             return true;
         }

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -247,7 +247,7 @@ class RuleRight extends Rule
 
     public function displayAdditionalRuleCondition($condition, $criteria, $name, $value, $test = false)
     {
-        if ($criteria['field'] === 'type') {
+        if (($criteria['field'] ?? '') === 'type') {
             Auth::dropdown([
                 'name'  => $name,
                 'value' => $value,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR fixes a PHP warning (`Undefined array key "field"`) that occurs in the Rule Engine when selecting the default ("-----") empty option for a rule criterion. 

Replace direct accesses to $criteria['field'] with null-coalescing expressions (($criteria['field'] ?? '') === ...) to prevent PHP undefined index notices when 'field' is not set. Applied to RuleImportEntity (checks for '_source' and 'itemtype') and RuleRight (check for 'type'). No functional behavior changes intended.

## How to test
1. Go to **Administration > Rules**.
2. Open a rule such as **Automatic user assignment** or **Rules for assigning an item to an entity**.
3. Go to the **Criteria** tab.
4. Try to add a new criterion.
5. In the Criterion dropdown, select the default empty option (`-----`).
6. Verify your `php-errors.log` (or GLPI logs); the `Undefined array key "field"` warning should no longer appear.

## Screenshots (if appropriate):

<img width="1000" height="155" alt="2026-05-25 13_35_52-Calendar _ Bruno Xavier _ virtueyes com br _ eduardo oliveira@virtueyes com br _" src="https://github.com/user-attachments/assets/0397fb3b-f6e1-4cf9-8d7f-633479dc055b" />

`php-errors.log`:

```
glpi.WARNING:   *** Warning: Undefined array key "field" at RuleRight.php line 250
  Backtrace :
  ./src/RuleRight.php:250                            
  ./src/Rule.php:2593                                RuleRight->displayAdditionalRuleCondition()
  ./ajax/rulecriteriavalue.php:46                    Rule->displayCriteriaSelectPattern()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```