### PR TITLE
Fix(Search): make time optional in "Specify a date" datetime picker

### DIFF
--- a/ajax/genericdate.php
+++ b/ajax/genericdate.php
@@ -35,6 +35,8 @@
 
 use Glpi\Application\View\TemplateRenderer;
 
+use function Safe\preg_match;
+
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();

--- a/ajax/genericdate.php
+++ b/ajax/genericdate.php
@@ -33,17 +33,38 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\View\TemplateRenderer;
+
 // Send UTF8 Headers
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
 if (isset($_POST['value']) && (strcmp($_POST['value'], '0') == 0)) {
-    $withtime = filter_var($_POST['withtime'], FILTER_VALIDATE_BOOLEAN);
-    if ($withtime) {
-        Html::showDateTimeField($_POST['name'], ['value' => $_POST['specificvalue']]);
-    } else {
-        Html::showDateField($_POST['name'], ['value' => $_POST['specificvalue']]);
+    global $CFG_GLPI;
+
+    $name           = $_POST['name'];
+    $specific_value = $_POST['specificvalue'];
+    $rand           = mt_rand();
+
+    $date_part   = date('Y-m-d');
+    $hour_part   = '00';
+    $minute_part = '00';
+    $has_time    = false;
+
+    if (preg_match('/^(\d{4}-\d{2}-\d{2}) (\d{2}):(\d{2})/', $specific_value, $m)) {
+        [$date_part, $hour_part, $minute_part] = [$m[1], $m[2], $m[3]];
+        $has_time = true;
+    } elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $specific_value)) {
+        $date_part = $specific_value;
     }
+
+    TemplateRenderer::getInstance()->display('components/form/genericdate_picker.html.twig', [
+        'name'          => $name,
+        'rand'          => $rand,
+        'has_time'      => $has_time,
+        'initial_value' => $has_time ? "{$date_part} {$hour_part}:{$minute_part}:00" : $date_part,
+        'timestep'      => max(1, (int) ($CFG_GLPI['time_step'] ?? 5)),
+    ]);
 } else {
     echo "<input type='hidden' name='" . htmlescape($_POST['name']) . "' value='" . htmlescape($_POST['value']) . "'>";
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -2951,7 +2951,7 @@ JS;
         if (empty($value)) {
             $value = 'NOW';
         }
-        $specific_value = date("Y-m-d H:i:s");
+        $specific_value = date("Y-m-d");
 
         if (preg_match("/\d{4}-\d{2}-\d{2}.*/", $value)) {
             $specific_value = $value;
@@ -2977,7 +2977,7 @@ JS;
 
         $params     = ['value'         => '__VALUE__',
             'name'          => $element,
-            'withtime'      => $p['with_time'],
+            'withtime'      => false,
             'specificvalue' => $specific_value,
         ];
 

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -41,6 +41,7 @@
         <input type="text" name="{{ name }}" data-input class="form-control rounded-start ps-2">
         <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
             <i class="ti ti-calendar-time"></i>
+            <span class="sr-only">{{ __('Enter or select a date') }}</span>
         </button>
     </div>
     <label class="d-flex align-items-center gap-2 text-nowrap mb-0">
@@ -51,7 +52,7 @@
 <script>
 $(function() {
     function buildFp(hasTime, defaultDate) {
-        var el = document.getElementById('showdate{{ rand }}');
+        const el = document.getElementById('showdate{{ rand }}');
         if (el._flatpickr) el._flatpickr.destroy();
         return $('#showdate{{ rand }}').flatpickr({
             defaultDate:     defaultDate,
@@ -73,7 +74,7 @@ $(function() {
         });
     }
 
-    var fp = buildFp({{ has_time ? 'true' : 'false' }}, {{ initial_value|json_encode|raw }});
+    let fp = buildFp({{ has_time ? 'true' : 'false' }}, {{ initial_value|json_encode|raw }});
 
     document.getElementById('time_toggle_{{ rand }}').addEventListener('change', function() {
         fp = buildFp(this.checked, fp.selectedDates[0]);

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -52,9 +52,9 @@
 <script>
 $(function() {
     function buildFp(hasTime, defaultDate) {
-        const el = document.getElementById('showdate{{ rand }}');
+        const el = document.getElementById('showdate{{ rand|e('js') }}');
         if (el._flatpickr) el._flatpickr.destroy();
-        return $('#showdate{{ rand }}').flatpickr({
+        return $(el).flatpickr({
             defaultDate:     defaultDate,
             altInput:        true,
             altFormat:       hasTime ? '{{ alt_fmt_dt|e('js') }}' : '{{ alt_fmt_date|e('js') }}',
@@ -76,7 +76,7 @@ $(function() {
 
     let fp = buildFp({{ has_time ? 'true' : 'false' }}, {{ initial_value|json_encode|raw }});
 
-    document.getElementById('time_toggle_{{ rand }}').addEventListener('change', function() {
+    document.getElementById('time_toggle_{{ rand|e('js') }}').addEventListener('change', function() {
         fp = buildFp(this.checked, fp.selectedDates[0]);
     });
 });

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -1,0 +1,82 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set date_fmt = call('Toolbox::getDateFormat', ['js']) %}
+{% set locale = get_current_locale() %}
+{% set alt_fmt_date = date_fmt %}
+{% set alt_fmt_dt = date_fmt ~ ' H:i' %}
+
+<div class="d-flex align-items-center gap-2">
+    <div class="button-group flex-grow-1 flatpickr d-flex align-items-center" id="showdate{{ rand }}"
+         data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Enter or select a date') }}">
+        <input type="text" name="{{ name }}" data-input class="form-control rounded-start ps-2">
+        <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
+            <i class="ti ti-calendar-time"></i>
+        </button>
+    </div>
+    <label class="d-flex align-items-center gap-2 text-nowrap mb-0">
+        <input type="checkbox" class="form-check-input mt-0" id="time_toggle_{{ rand }}"{{ has_time ? ' checked' : '' }}>
+        <span class="form-check-label text-secondary small">{{ __('Specify a time') }}</span>
+    </label>
+</div>
+<script>
+$(function() {
+    function buildFp(hasTime, defaultDate) {
+        var el = document.getElementById('showdate{{ rand }}');
+        if (el._flatpickr) el._flatpickr.destroy();
+        return $('#showdate{{ rand }}').flatpickr({
+            defaultDate:     defaultDate,
+            altInput:        true,
+            altFormat:       hasTime ? '{{ alt_fmt_dt|e('js') }}' : '{{ alt_fmt_date|e('js') }}',
+            dateFormat:      hasTime ? 'Y-m-d H:i:S' : 'Y-m-d',
+            wrap:            true,
+            enableTime:      hasTime,
+            enableSeconds:   false,
+            time_24hr:       true,
+            weekNumbers:     true,
+            locale:          getFlatPickerLocale("{{ locale['language']|e('js') }}", "{{ locale['region']|e('js') }}"),
+            minuteIncrement: {{ timestep }},
+            allowInput:      true,
+            onClose:         function(dates, str, picker) {
+                picker.setDate(picker.altInput.value, true, picker.config.altFormat);
+            },
+            plugins:         [CustomFlatpickrButtons()]
+        });
+    }
+
+    var fp = buildFp({{ has_time ? 'true' : 'false' }}, {{ initial_value|json_encode|raw }});
+
+    document.getElementById('time_toggle_{{ rand }}').addEventListener('change', function() {
+        fp = buildFp(this.checked, fp.selectedDates[0]);
+    });
+});
+</script>

--- a/tests/e2e/pages/SearchEnginePage.ts
+++ b/tests/e2e/pages/SearchEnginePage.ts
@@ -40,20 +40,37 @@ export class SearchEnginePage extends GlpiPage
     public readonly search_sorts_button: Locator;
     public readonly search_filters_panel: Locator;
     public readonly search_sorts_panel: Locator;
+    public readonly datetime_time_toggle: Locator;
+    public readonly datetime_calendar_button: Locator;
 
     public constructor(page: Page)
     {
         super(page);
-        this.search_page           = page.getByTestId('search-page');
-        this.search_filters_button = page.getByTestId('search-filters-button');
-        this.search_sorts_button   = page.getByTestId('search-sorts-button');
-        this.search_filters_panel  = page.getByTestId('search-filters-panel');
-        this.search_sorts_panel    = page.getByTestId('search-sorts-panel');
+        this.search_page              = page.getByTestId('search-page');
+        this.search_filters_button    = page.getByTestId('search-filters-button');
+        this.search_sorts_button      = page.getByTestId('search-sorts-button');
+        this.search_filters_panel     = page.getByTestId('search-filters-panel');
+        this.search_sorts_panel       = page.getByTestId('search-sorts-panel');
+        this.datetime_time_toggle     = page.getByRole('checkbox', { name: 'Specify a time' });
+        this.datetime_calendar_button = page.getByRole('button', { name: 'Enter or select a date' });
     }
 
     public async goto(): Promise<void>
     {
         await this.page.goto('/front/computer.php');
+    }
+
+    /**
+     * Navigate to ticket search with a datetime field criterion preset to "Specify a date".
+     * Field 15 = Opening date (datetime). Using searchtype=lessthan to trigger relative_dates rendering.
+     * Passing an ISO date as value causes the inner dropdown to pre-select "Specify a date".
+     */
+    public async gotoTicketWithDatetimeCriteria(date: string = '2023-06-15'): Promise<void>
+    {
+        await this.page.goto(
+            `/front/ticket.php?criteria[0][link]=AND&criteria[0][field]=15`
+            + `&criteria[0][searchtype]=lessthan&criteria[0][value]=${date}`
+        );
     }
 
     public async doOpenSearchFilters(): Promise<void>
@@ -64,5 +81,10 @@ export class SearchEnginePage extends GlpiPage
     public async doOpenSearchSorts(): Promise<void>
     {
         await this.search_sorts_button.click();
+    }
+
+    public async doOpenDatetimeCalendar(): Promise<void>
+    {
+        await this.datetime_calendar_button.click();
     }
 }

--- a/tests/e2e/specs/Search/datetime_picker.spec.ts
+++ b/tests/e2e/specs/Search/datetime_picker.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { test, expect } from '../../fixtures/glpi_fixture';
+import { SearchEnginePage } from '../../pages/SearchEnginePage';
+import { Profiles } from '../../utils/Profiles';
+
+test.describe('Datetime picker in search criteria', () => {
+    test('Time toggle defaults to unchecked and toggles flatpickr time mode', async ({ page, profile }) => {
+        await profile.set(Profiles.SuperAdmin);
+
+        const search = new SearchEnginePage(page);
+        await search.gotoTicketWithDatetimeCriteria();
+
+        // Open the filters panel so the AJAX-rendered criteria are visible
+        await search.doOpenSearchFilters();
+
+        // Wait for the AJAX-rendered date picker
+        await expect(search.datetime_time_toggle).toBeVisible();
+
+        // Default: time toggle unchecked (date-only, no forced H:i:S)
+        await expect(search.datetime_time_toggle).not.toBeChecked();
+
+        // Open calendar: no time fields in date-only mode
+        await search.doOpenDatetimeCalendar();
+        // eslint-disable-next-line playwright/no-raw-locators
+        await expect(page.locator('.flatpickr-time')).not.toBeAttached();
+        await search.doOpenDatetimeCalendar(); // toggle close
+
+        // Enable time
+        await search.datetime_time_toggle.click();
+        await expect(search.datetime_time_toggle).toBeChecked();
+
+        // Open calendar: time fields now visible
+        await search.doOpenDatetimeCalendar();
+        // eslint-disable-next-line playwright/no-raw-locators
+        await expect(page.locator('.flatpickr-time')).toBeVisible();
+        await search.doOpenDatetimeCalendar(); // toggle close
+
+        // Disable time
+        await search.datetime_time_toggle.click();
+        await expect(search.datetime_time_toggle).not.toBeChecked();
+    });
+});

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -1122,6 +1122,91 @@ SCSS,
         }
     }
 
+    public function testShowGenericDateTimeSearchSpecificDateAlwaysSendsWithtimeFalse(): void
+    {
+        // Non-regression: with_time=true must NOT propagate to the specific date AJAX call.
+        // Before the fix, withtime:true was sent, forcing a full H:i:S datetime picker.
+        $output = \Html::showGenericDateTimeSearch(
+            'test_field',
+            '2023-06-15',
+            ['with_time' => true, 'with_specific_date' => true, 'display' => false]
+        );
+
+        $this->assertStringContainsString('withtime:false', $output);
+        $this->assertStringNotContainsString('withtime:true', $output);
+    }
+
+    public function testShowGenericDateTimeSearchDefaultSpecificValueIsDateOnly(): void
+    {
+        // Non-regression: when the current value is not a specific date (e.g. 'NOW'),
+        // specificvalue must default to Y-m-d (no time), so the time toggle starts unchecked.
+        // Before the fix, the default was date("Y-m-d H:i:s"), which made the toggle default ON.
+        $output = \Html::showGenericDateTimeSearch(
+            'test_field',
+            'NOW',
+            ['with_specific_date' => true, 'display' => false]
+        );
+
+        $this->assertMatchesRegularExpression('/specificvalue:"\d{4}-\d{2}-\d{2}"/', $output);
+        $this->assertDoesNotMatchRegularExpression('/specificvalue:"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"/', $output);
+    }
+
+    public static function computeGenericDateTimeSearchProvider(): iterable
+    {
+        yield 'specific date only passes through' => [
+            'val'          => '2023-06-15',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-15',
+        ];
+        yield 'specific datetime passes through' => [
+            'val'          => '2023-06-15 10:30:00',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-15 10:30:00',
+        ];
+        yield 'NOW without force_day returns datetime' => [
+            'val'          => 'NOW',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-15 14:30:00',
+        ];
+        yield 'NOW with force_day returns date only' => [
+            'val'          => 'NOW',
+            'force_day'    => true,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-15',
+        ];
+        yield 'relative -1DAY' => [
+            'val'          => '-1DAY',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-14 14:30:00',
+        ];
+        yield 'relative -2HOUR' => [
+            'val'          => '-2HOUR',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-15 12:30:00',
+        ];
+        yield 'BEGINMONTH' => [
+            'val'          => 'BEGINMONTH',
+            'force_day'    => false,
+            'specifictime' => mktime(14, 30, 0, 6, 15, 2023),
+            'expected'     => '2023-06-01 00:00:00',
+        ];
+    }
+
+    #[DataProvider('computeGenericDateTimeSearchProvider')]
+    public function testComputeGenericDateTimeSearch(
+        string $val,
+        bool $force_day,
+        int $specifictime,
+        string $expected
+    ): void {
+        $this->assertEquals($expected, \Html::computeGenericDateTimeSearch($val, $force_day, $specifictime));
+    }
+
     public static function inputNameProvider(): iterable
     {
         yield [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- When searching on a datetime field with "Specify a date", the picker previously forced entry of a full date and time (H:i:S), which was unnecessary.
- The picker now defaults to date-only, with an optional "Specify a time" checkbox that expands it to include hours and minutes when needed.
- The `withtime` parameter is no longer forwarded from the search context to the AJAX call; the date-only default is now enforced at the source.

## Screenshots (if appropriate):

<img width="923" height="167" alt="image" src="https://github.com/user-attachments/assets/6a6f8458-76a5-4e64-a8a6-9cd280f6663f" />

<img width="923" height="167" alt="image" src="https://github.com/user-attachments/assets/51438274-b410-4209-a088-393da401e191" />


