### PR TITLE
fix(ui): Align KB search results table styles with modern list views

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -478,7 +478,6 @@
       align-items: center;
       gap: 4px;
       text-align: left;
-      padding-top: 5px;
    }
 
    .kb_resume {
@@ -501,7 +500,7 @@
    }
 
    a.knowbase {
-      margin-left: 0;
+      margin-left: 8px;
    }
 
    .kb i {

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -474,6 +474,9 @@
    }
 
    .kb {
+      display: flex;
+      align-items: center;
+      gap: 4px;
       text-align: left;
       padding-top: 5px;
    }
@@ -498,7 +501,7 @@
    }
 
    a.knowbase {
-      margin-left: 8px;
+      margin-left: 0;
    }
 
    .kb i {

--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -478,6 +478,11 @@
       align-items: center;
       gap: 4px;
       text-align: left;
+      padding-top: 5px;
+   }
+
+   .search-results .kb {
+      padding-top: 0;
    }
 
    .kb_resume {

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -360,7 +360,7 @@ class HTMLSearchOutput extends AbstractSearchOutput
     public static function showItem($value, &$num, $row, $extraparam = ''): string
     {
         global $CFG_GLPI;
-        $out = "<td $extraparam valign='top'>";
+        $out = "<td $extraparam valign='top' class='align-middle'>";
 
         if (!preg_match('/' . Search::LBHR . '/', $value)) {
             $values = preg_split('/' . Search::LBBR . '/i', $value);

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -360,7 +360,7 @@ class HTMLSearchOutput extends AbstractSearchOutput
     public static function showItem($value, &$num, $row, $extraparam = ''): string
     {
         global $CFG_GLPI;
-        $out = "<td $extraparam valign='top' class='align-middle'>";
+        $out = "<td $extraparam valign='top'>";
 
         if (!preg_match('/' . Search::LBHR . '/', $value)) {
             $values = preg_split('/' . Search::LBBR . '/i', $value);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This pull request resolves vertical alignment and styling inconsistencies in search results tables (most notably the Knowledge Base list view), aligning them with modern table list views across GLPI (such as the Tickets table).

## Screenshots (if appropriate):

Before this PR:

<img width="894" height="62" alt="image" src="https://github.com/user-attachments/assets/cb85b09e-1b35-4b47-a88f-866ed478c83c" />

After this PR:

<img width="895" height="63" alt="image" src="https://github.com/user-attachments/assets/95357c67-2ee5-490d-9e9c-784a9426debd" />
