### PR TITLE
fix(ui): vertically align icons with link in breadcrumb

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -186,6 +186,10 @@ body.in_modal {
 
 .breadcrumb-alternate {
     a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25em;
+
         &:hover {
             text-decoration: var(--tblr-link-hover-decoration);
         }

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -186,10 +186,6 @@ body.in_modal {
 
 .breadcrumb-alternate {
     a {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25em;
-
         &:hover {
             text-decoration: var(--tblr-link-hover-decoration);
         }

--- a/templates/layout/parts/breadcrumbs.html.twig
+++ b/templates/layout/parts/breadcrumbs.html.twig
@@ -32,7 +32,7 @@
 
 <ol class="breadcrumb breadcrumb-alternate pe-1 pe-sm-3" aria-label="breadcrumbs">
    <li class="breadcrumb-item text-truncate">
-      <a href="{{ index_path() }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Home') }}">
+      <a href="{{ index_path() }}" class="d-inline-flex align-items-center gap-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Home') }}">
          <i class="ti ti-home-2"></i>
          {{ __('Home') }}
       </a>
@@ -40,7 +40,7 @@
 
    {% if menu[sector] is defined %}
    <li class="breadcrumb-item text-truncate">
-      <a href="{{ path(menu[sector]['default'] ?? '/front/central.php') }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ menu[sector]['title'] }}">
+      <a href="{{ path(menu[sector]['default'] ?? '/front/central.php') }}" class="d-inline-flex align-items-center gap-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ menu[sector]['title'] }}">
          <i class="{{ menu[sector]['icon'] ?? '' }}"></i>
          {{ menu[sector]['title'] }}
       </a>
@@ -53,7 +53,7 @@
       {% set with_option = option is not empty and menu[sector]['content'][item]['options'][option]['title'] is defined and menu[sector]['content'][item]['options'][option]['page'] is defined %}
       <li class="breadcrumb-item text-truncate">
          <a href="{{ path(menu[sector]['content'][item]['page']) }}"
-            class="{{ with_option ? '' : 'here' }}"
+            class="d-inline-flex align-items-center gap-1 {{ with_option ? '' : 'here' }}"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ menu[sector]['content'][item]['title'] }}" >
             <i class="{{ menu[sector]['content'][item]['icon'] ?? '' }}"></i>
@@ -65,7 +65,7 @@
       {% if with_option %}
       <li class="breadcrumb-item text-truncate">
          <a href="{{ path(menu[sector]['content'][item]['options'][option]['page']) }}"
-            class="here"
+            class="d-inline-flex align-items-center gap-1 here"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ menu[sector]['content'][item]['options'][option]['title'] }}" >
             <i class="{{ menu[sector]['content'][item]['options'][option]['icon'] ?? '' }}"></i>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

In the `.breadcrumb-alternate` component, Tabler icons (`<i class="ti ...">`) were not vertically aligned with the adjacent link text (e.g. "Home").

## Screenshots (if appropriate):

Before this PR:

<img width="796" height="42" alt="glpi nethouse inf br_front_knowbaseitem php" src="https://github.com/user-attachments/assets/238a893a-d10e-4b26-a521-2f8ab74eea36" />

After this PR:

<img width="507" height="36" alt="image" src="https://github.com/user-attachments/assets/885affae-a6a1-4b64-819d-d3e4deb85c9c" />
