### PR TITLE
fix(kb): KB comment form: missing icons, avatar alignment, and button hide regression

### DIFF
--- a/css/standalone/kb.scss
+++ b/css/standalone/kb.scss
@@ -117,6 +117,12 @@
     min-height: 70px;
 }
 
+// The .h_item inside the new comment form (outside .forcomments) should not
+// have the pt-3 padding; pt-3 is only meaningful inside the comments timeline.
+.new_comment_form .h_item {
+    padding-top: 0 !important;
+}
+
 input[type="checkbox"].toggle_comments {
     display: none;
 

--- a/templates/pages/tools/kb/comment_form.html.twig
+++ b/templates/pages/tools/kb/comment_form.html.twig
@@ -75,7 +75,7 @@
                     {% endif %}
                     <div class="ms-2">
                         {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Save') : _x('button', 'Add'), 1, {
-                            icon: comment_id ? 'ti ti-device-floppy' : 'ti ti-plus'
+                            icon: comment_id ? 'ti ti-device-floppy' : 'ti ti-message-circle'
                         }) }}
                     </div>
                     <script>

--- a/templates/pages/tools/kb/comment_form.html.twig
+++ b/templates/pages/tools/kb/comment_form.html.twig
@@ -42,14 +42,14 @@
 
 <div class="d-flex flex-wrap align-items-start {{ comment_style ? "mt-3" : "" }}">
     {% if comment_style %}
-        <a href="" class="me-3 mt-n2 ms-n2">
+        <a href="" class="me-3 ms-n2">
             {{ include('components/user/picture.html.twig', {
                 'users_id': session('glpiID'),
                 'with_link': false,
             }, with_context = false) }}
         </a>
     {% endif %}
-    <div class="{{ comment_style ? "h_item d-flex timeline-content flex-column pt-3" : "w-100" }}">
+    <div class="{{ comment_style ? "h_item d-flex timeline-content flex-column" : "w-100" }}">
         <form name="kbcomment_form{{ rand }}" id="kbcomment_form{{ rand }}" class="comment_form" method="post"
             action="{{ 'KnowbaseItem_Comment'|itemtype_form_path }}" data-submit-once data-track-changes="true">
             {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}
@@ -74,7 +74,9 @@
                         </div>
                     {% endif %}
                     <div class="ms-2">
-                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Edit') : _x('button', 'Add'), 1) }}
+                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Edit') : _x('button', 'Add'), 1, {
+                            icon: comment_id ? 'ti ti-device-floppy' : 'ti ti-plus'
+                        }) }}
                     </div>
                     <script>
                         $(`#kbcomment_form{{ rand }}`).on('click', 'button[name="cancel"]', (e) => {

--- a/templates/pages/tools/kb/comment_form.html.twig
+++ b/templates/pages/tools/kb/comment_form.html.twig
@@ -74,7 +74,7 @@
                         </div>
                     {% endif %}
                     <div class="ms-2">
-                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Edit') : _x('button', 'Add'), 1, {
+                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Save') : _x('button', 'Add'), 1, {
                             icon: comment_id ? 'ti ti-device-floppy' : 'ti ti-plus'
                         }) }}
                     </div>

--- a/templates/pages/tools/kb/comment_form.html.twig
+++ b/templates/pages/tools/kb/comment_form.html.twig
@@ -49,7 +49,7 @@
             }, with_context = false) }}
         </a>
     {% endif %}
-    <div class="{{ comment_style ? "h_item d-flex timeline-content flex-column" : "w-100" }}">
+    <div class="{{ comment_style ? "h_item d-flex timeline-content flex-column pt-3" : "w-100" }}">
         <form name="kbcomment_form{{ rand }}" id="kbcomment_form{{ rand }}" class="comment_form" method="post"
             action="{{ 'KnowbaseItem_Comment'|itemtype_form_path }}" data-submit-once data-track-changes="true">
             {{ inputs.hidden('_glpi_csrf_token', csrf_token()) }}

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -47,7 +47,7 @@
                     {% endif %}
                 </span>
             </a>
-            <div class="h_item d-flex timeline-content flex-column pt-3">
+            <div class="h_item d-flex timeline-content flex-column">
                 <div class="d-flex flex-column ps-2">
                     <div class="h_info d-flex">
                         <div class="h_date">{{ comment['date_creation']|formatted_datetime }}</div>

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -47,7 +47,7 @@
                     {% endif %}
                 </span>
             </a>
-            <div class="h_item d-flex timeline-content flex-column">
+            <div class="h_item d-flex timeline-content flex-column pt-3">
                 <div class="d-flex flex-column ps-2">
                     <div class="h_info d-flex">
                         <div class="h_date">{{ comment['date_creation']|formatted_datetime }}</div>

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -107,7 +107,7 @@
             $('button.add_new_comment').on('click', (e) => {
                 e.preventDefault();
                 $('.new_comment_form').removeClass('d-none');
-                $(e.target).addClass('d-none');
+                $(e.currentTarget).addClass('d-none');
             });
         </script>
     </div>

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {% if can_comment %}
-    <div class="new_comment_form d-none">
+    <div class="new_comment_form d-none ms-3">
         {% include 'pages/tools/kb/comment_form.html.twig' with {
             kbitem_id: kbitem_id,
             language: lang,
@@ -100,7 +100,8 @@
     </div>
     <div class="text-center mb-3">
         <button type="button" class="btn btn-primary add_new_comment">
-            {{ __('Add a comment') }}
+            <i class="ti ti-message-circle"></i>
+            <span>{{ __('Add a comment') }}</span>
         </button>
         <script>
             $('button.add_new_comment').on('click', (e) => {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR fixes several visual and behavioral issues in the Knowledge Base comment form (`/front/knowbaseitem.form.php`).

### Changes
#### 🐛 "Add a comment" button missing icon
The **Add a comment** button was rendered without an icon. A `ti-message-circle` icon and a proper `<span>` wrapper were added to match the rest of GLPI's button conventions.
#### 🐛 "Add" / "Edit" submit button missing icon
The submit button inside the comment form was rendered as a plain text button with no icon. Icons are now passed via the `icon` option to `inputs.submit` and uses the same terminology used on Tickets:
- **Add** → `ti ti-plus`
- **Save** → `ti ti-device-floppy`
#### 🐛 Avatar bleeding outside its container (overlapping KB tabs)
The `.new_comment_form` wrapper had no left margin, causing the avatar's `ms-n2` negative margin to push it outside the container and visually overlap the KB navigation tabs. A `ms-3` class was added to the wrapper to offset this.
#### 🐛 Avatar not aligned with the comment form textarea
The avatar link had `mt-n2` (−0.5rem top margin) while the content wrapper had `pt-3` (+1rem top padding), resulting in a net 1.5rem vertical gap between the avatar and the textarea. Both offsets were removed so the avatar and the textarea start at the same baseline.
> Note: `mt-n2` + `pt-3` is intentional on *display* comments to float the avatar into the timeline connector. For the *form*, there is no timeline element above it, so the offsets serve no purpose and conflict with each other.
#### 🐛 Clicking "Add a comment" no longer hid the button after icon was added
The click handler was using `e.target` to apply `d-none`, which points to the **actual clicked element** (e.g. the `<i>` icon or `<span>` text) rather than the button itself. This caused the icon or the label to be hidden instead of the whole button. Fixed by replacing `e.target` with `e.currentTarget`, which always refers to the element the listener is bound to.

## Screenshots (if appropriate):

Before this PR:

<img width="449" height="197" alt="SCR-20260526-mfja" src="https://github.com/user-attachments/assets/107b629e-a319-4c7b-a0cd-375c0437dde5" />

After this PR:

<img width="679" height="228" alt="image" src="https://github.com/user-attachments/assets/c3a14027-a58b-4663-a955-b331dc1877ba" />
