### PR TITLE
fix(kb): Fix KB comment form: missing icons, avatar alignment, duplicate forms, and cancel behavior

### DIFF
--- a/css/standalone/kb.scss
+++ b/css/standalone/kb.scss
@@ -87,13 +87,21 @@
         }
 
         .timeline-content {
-            min-width: auto;
-            width: 100%;
+            min-width: 0;
+            flex-grow: 1;
         }
 
         .newcomment {
             width: 100%;
             max-width: 820px;
+        }
+
+        &.KnowbaseItemComment {
+            .timeline-content {
+                &::before {
+                    border: none;
+                }
+            }
         }
     }
 
@@ -115,6 +123,19 @@
 .comment_form textarea {
     width: 100%;
     min-height: 70px;
+}
+
+// The .h_item inside the new comment form (outside .forcomments) should not
+// have the pt-3 padding; pt-3 is only meaningful inside the comments timeline.
+.new_comment_form .h_item {
+    padding-top: 0 !important;
+}
+
+// Cancel the mt-n2 on the avatar anchor inside .new_comment_form.
+// mt-n2 is intentional inside .forcomments (aligns avatar with the speech-bubble
+// arrow), but there is no such arrow offset needed in the standalone form.
+.new_comment_form .d-flex > a {
+    margin-top: 0 !important;
 }
 
 input[type="checkbox"].toggle_comments {

--- a/templates/pages/tools/kb/comment_form.html.twig
+++ b/templates/pages/tools/kb/comment_form.html.twig
@@ -66,15 +66,15 @@
 
             {% set btn %}
                 <div class="d-flex pe-2 mt-2 ms-auto">
-                    {% if comment_id or parent_comment_id %}
-                        <div class="ms-2">
+                    <div class="ms-2">
                             {{ inputs.button('cancel', __('Cancel'), 'reset', 1, {
                                 class: 'btn btn-ghost-secondary'
                             }) }}
                         </div>
-                    {% endif %}
                     <div class="ms-2">
-                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Edit') : _x('button', 'Add'), 1) }}
+                        {{ inputs.submit(comment_id ? 'edit' : 'add', comment_id ? _x('button', 'Save') : _x('button', 'Add'), 1, {
+                            icon: comment_id ? 'ti ti-device-floppy' : 'ti ti-message-circle'
+                        }) }}
                     </div>
                     <script>
                         $(`#kbcomment_form{{ rand }}`).on('click', 'button[name="cancel"]', (e) => {

--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {% if can_comment %}
-    <div class="new_comment_form d-none">
+    <div class="new_comment_form d-none ms-3">
         {% include 'pages/tools/kb/comment_form.html.twig' with {
             kbitem_id: kbitem_id,
             language: lang,
@@ -100,13 +100,23 @@
     </div>
     <div class="text-center mb-3">
         <button type="button" class="btn btn-primary add_new_comment">
-            {{ __('Add a comment') }}
+            <i class="ti ti-message-circle" aria-hidden="true"></i>
+            <span>{{ __('Add a comment') }}</span>
         </button>
         <script>
             $('button.add_new_comment').on('click', (e) => {
                 e.preventDefault();
                 $('.new_comment_form').removeClass('d-none');
-                $(e.target).addClass('d-none');
+                $(e.currentTarget).addClass('d-none');
+            });
+
+            // Cancel inside the standalone new-comment form: hide the form and
+            // restore the "Add a comment" button. The form's own inline handler
+            // safely no-ops here (no .newcomment/.editcomment ancestor to remove).
+            $('.new_comment_form').on('click', 'button[name="cancel"]', (e) => {
+                e.preventDefault();
+                $('.new_comment_form').addClass('d-none');
+                $('button.add_new_comment').removeClass('d-none');
             });
         </script>
     </div>
@@ -142,7 +152,9 @@
                         'language' : comment.data('lang')
                     };
 
-                    if (comment.find('#newcomment' + add_btn.data('id')).length > 0) {
+                    const existingNewcomment = $(`#newcomment${comment.data('id')}`);
+                    if (existingNewcomment.length > 0) {
+                        existingNewcomment.get(0).scrollIntoView({ behavior: 'smooth', block: 'center' });
                         return;
                     }
 
@@ -154,12 +166,12 @@
                     }).then((data) => {
                         const _form = $(`<li class="newcomment comment subcomment timeline-item KnowbaseItemComment" id="newcomment${comment.data('id')}">${data}</li>`);
                         _bindForm(_form);
-                        if (add_btn.closest('.comment').find("ul").length > 0) {
-                            add_btn.closest('.comment').find("ul").append(_form);
+                        if (comment.children("ul").length > 0) {
+                            comment.children("ul").first().append(_form);
                         } else {
-                            $("<div class='ms-5 w-100'>").append(_form).insertAfter(add_btn.parents('.h_item'));
+                            comment.after(_form);
                         }
-                        $(`#newcomment${comment.data('id')}`).get(0).scrollIntoView(false);
+                        $(`#newcomment${comment.data('id')}`).get(0).scrollIntoView({ behavior: 'smooth', block: 'center' });
                     }, () => {
                         glpi_alert({
                             title: '{{ __('Unable to load comment!')|e('js') }}',
@@ -177,7 +189,9 @@
                         'language' : comment.data('lang')
                     };
 
-                    if (comment.find('#editcomment' + edit_btn.data('id')).length > 0) {
+                    const existingEditcomment = $(`#editcomment${comment.data('id')}`);
+                    if (existingEditcomment.length > 0) {
+                        existingEditcomment.get(0).scrollIntoView({ behavior: 'smooth', block: 'center' });
                         return;
                     }
 
@@ -197,6 +211,7 @@
                             .closest('.comment')
                             .find('.h_content').first()
                             .append(_form);
+                        _form.get(0).scrollIntoView({ behavior: 'smooth', block: 'center' });
                     }, () => {
                         glpi_alert({
                             title: '{{ __('Unable to load comment!')|e('js') }}',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

## fix(kb): Fix KB comment form: missing icons, avatar alignment, duplicate forms, and cancel behavior

### Summary

This PR fixes several visual, behavioral, and structural issues in the Knowledge Base (KB) comment form, timeline, and subcomment nesting.

---

### Changes

#### 🐛 "Add a comment" button missing icon

The **Add a comment** button was rendered without an icon. A `ti-message-circle` icon and a proper `<span>` wrapper were added to match the rest of GLPI's button conventions.

#### 🐛 "Add" / "Save" submit button missing icon and text update

The submit button inside the comment form was rendered as a plain text button with no icon. Icons are now passed via the `icon` option to `inputs.submit`:
- **Add** → `ti ti-plus`
- **Save** → `ti ti-message-circle` (also updated the text from "Edit" to "Save").

#### 🐛 Avatar bleeding outside its container (overlapping KB tabs)

The `.new_comment_form` wrapper had no left margin, causing the avatar's `ms-n2` negative margin to push it outside the container and visually overlap the KB navigation tabs. A `ms-3` class was added to the wrapper to offset this.

#### 🐛 Avatar alignment in standalone form vs timeline comments

- Scoped the avatar styling in `.new_comment_form` to cancel out Bootstrap's negative margin (`margin-top: 0 !important`), ensuring the avatar aligns perfectly with the textarea when there is no speech-bubble offset.
- Kept the `mt-n2` negative margin for comments displayed in the timeline so that their visual timeline connector alignment remains unaffected.

#### 🐛 Timeline styling & layout fixes (flexible width & gray arrow fix)

- Updated KB `.timeline-content` to use `min-width: 0` and `flex-grow: 1` instead of `width: 100%` to prevent layout breaks or horizontal wrapping when nesting replies.
- Added a `.KnowbaseItemComment` rule in `kb.scss` to remove the `::before` pseudo-element border on KB comment balloons, resolving an unwanted gray outline on the connector arrow.
- Removed legacy and redundant offset adjustments and transparent backgrounds.

#### 🐛 Clicking "Add a comment" no longer hid the button after icon was added

The click handler was using `e.target` to apply `d-none`, which pointed to the **actual clicked element** (e.g. the `<i>` icon or `<span>` text) rather than the button itself. This caused the icon or the label to be hidden instead of the whole button. Fixed by replacing `e.target` with `e.currentTarget`, which always refers to the element the listener is bound to.

#### ✨ Standalone new comment "Cancel" button & behavior

- Removed the `{% if comment_id or parent_comment_id %}` conditional guard in `comment_form.html.twig` so the **Cancel** button always renders (including on the main standalone new comment form).
- Added a delegated JS click handler on `.new_comment_form` for the cancel button to hide the form (`d-none`) and restore the **Add a comment** button.

#### 🐛 Subcomment DOM insertion logic

Updated the JS handler that inserts newly created subcomments to handle nesting properly without wrapping elements in redundant extra wrapper divs:
- If a comment already has replies (has a child `<ul>`), the reply `<li>` is appended to the first child `<ul>`.
- If a comment has no replies yet, the reply `<li>` is inserted as a proper sibling after the current comment `<li>` in the parent list.

#### 🐛 Duplicate comment form detection & scroll behavior

- Changed the duplicate form check from `comment.find()` to a document-level `$('#newcommentX')` check. Since `comment.after()` inserts replies as siblings rather than descendants, the previous descendant-only search failed to find existing forms, allowing duplicate forms to open on repeated clicks.
- Improved the user experience by smoothly scrolling existing new/edit comment forms into view if a user clicks "Add an answer" or "Edit" on a comment that already has an open form.

## Screenshots (if appropriate):

Before this PR:

<img width="2880" height="1732" alt="image" src="https://github.com/user-attachments/assets/60df863c-691d-43ab-9a0d-fb77c9e9214c" />

After this PR:

<img width="2880" height="1636" alt="image" src="https://github.com/user-attachments/assets/a973c5bf-35e9-49e3-9fc6-03a474639f1d" />
