### PR TITLE
fix(ui): Fix vertical alignment of text and icons in timeline item badges

### DIFF
--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -32,9 +32,9 @@
 
 {% set timeline_display_date = session('glpitimeline_date_format') %}
 
-<span class="badge user-select-auto text-wrap d-none d-md-block">
+<span class="badge user-select-auto text-wrap d-none d-md-flex align-items-center flex-wrap">
    {% set date_span %}
-      <span
+      <span class="d-inline-flex align-items-center"
          {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
             title="{{ date_creation|formatted_datetime }}"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
@@ -61,8 +61,8 @@
          }, with_context = false) }}
       {% endset %}
       {% set group_span %}
-         <span id="group_{{ random() }}">
-            <i class="ti ti-users ms-1"></i>
+         <span id="group_{{ random() }}" class="d-inline-flex align-items-center">
+            <i class="ti ti-users ms-1 me-1"></i>
             {{ get_item_link('Group', entry['item']['items_id_target'], {
                'enable_anonymization': enable_anonymization
             })|raw }}
@@ -89,9 +89,9 @@
 </span>
 
 {% if users_id_editor > 0 and date_creation != date_mod %}
-   <span class="badge user-select-auto text-wrap ms-1 d-none d-md-block">
+   <span class="badge user-select-auto text-wrap ms-1 d-none d-md-flex align-items-center flex-wrap">
       {% set date_span %}
-         <span
+         <span class="d-inline-flex align-items-center"
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
                title="{{ date_mod|formatted_datetime }}"
                data-bs-toggle="tooltip" data-bs-placement="bottom"

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -32,8 +32,8 @@
 
 {% set rand = random() %}
 
-<span id="user_{{ rand }}">
-    <i class="ti ti-user ms-1"></i>
+<span id="user_{{ rand }}" class="d-inline-flex align-items-center">
+    <i class="ti ti-user ms-1 me-1"></i>
     {{ get_item_link('User', users_id, {'enable_anonymization': enable_anonymization}) }}
 </span>
 

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -33,7 +33,7 @@
 {% set rand = random() %}
 
 <span id="user_{{ rand }}" class="d-inline-flex align-items-center">
-    <i class="ti ti-user ms-1 me-1"></i>
+    <i class="ti ti-user me-1"></i>
     {{ get_item_link('User', users_id, {'enable_anonymization': enable_anonymization}) }}
 </span>
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

This PR fixes a visual issue where the text (e.g., "Created:", "by") and the icons inside the timeline item header badges were not vertically aligned with each other. 

### Why was this change needed?
Previously, the badges were using a block display (`d-md-block`), and the inner text and icons were relying on default inline baselines. Because the icons are slightly taller than standard text, this caused the text outside the links to appear vertically misaligned compared to the icons and links.

### How was it fixed?
- Converted the outer badge containers in `timeline_item_header_badges.html.twig` to use flexbox (`d-md-flex align-items-center flex-wrap`) to properly center all elements in the row.
- Added `d-inline-flex align-items-center` to the inner spans (such as the date, group, and the user span in `link_with_tooltip.html.twig`) to ensure the icons (`ti`) and the link texts inside them share the same vertical center.
- Adjusted margins (`me-1`) where necessary to maintain correct spacing between the flex items.

## Screenshots (if appropriate):

Before this PR:

<img width="210" height="33" alt="SCR-20260527-bwci" src="https://github.com/user-attachments/assets/7eb15b8c-c402-46b9-84ea-56e9b54390db" />

After this PR:

<img width="195" height="26" alt="SCR-20260527-cbfq" src="https://github.com/user-attachments/assets/ca407da0-cbc0-48ae-b7c3-49d87644d94a" />
