### PR TITLE
fix(kb): Standardize KB comment headers

### DIFF
--- a/templates/pages/tools/kb/comments.html.twig
+++ b/templates/pages/tools/kb/comments.html.twig
@@ -50,7 +50,15 @@
             <div class="h_item d-flex timeline-content flex-column">
                 <div class="d-flex flex-column ps-2">
                     <div class="h_info d-flex">
-                        <div class="h_date">{{ comment['date_creation']|formatted_datetime }}</div>
+                        <div class="h_date timeline-header mt-0 mb-1 d-flex creator">
+                            {{ include('components/itilobject/timeline/timeline_item_header_badges.html.twig', {
+                                'users_id': comment['users_id'],
+                                'date_creation': comment['date_creation'],
+                                'date_mod': comment['date_mod'] ?? comment['date_creation'],
+                                'users_id_editor': comment['users_id'],
+                                'anchor': 'kbcomment' ~ comment['id']
+                            }, with_context = false) }}
+                        </div>
                         <div class="d-inline-flex ms-auto">
                             {% if can_comment %}
                                 <button type="button" class="btn btn-sm btn-ghost-secondary add_answer ms-1" title="{{ __('Add an answer') }}">


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Updated the Knowledge Base comment headers (/front/knowbaseitem.form.php) to utilize the standard timeline badges, bringing visual consistency to the UI. This fix ensures that both ITIL items (e.g. Tickets) and KB comments share a unified, correctly-aligned badge component. 

## Screenshots (if appropriate):

Before this PR:

<img width="732" height="54" alt="image" src="https://github.com/user-attachments/assets/13f41155-6f9d-4af4-ae51-550ab460228e" />

After this PR:

<img width="745" height="58" alt="image" src="https://github.com/user-attachments/assets/cb4f96d4-563d-4501-abc0-06de828dc1ab" />
