### PR TITLE
fix(ui): Use flex layout for user info entries

### DIFF
--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -52,69 +52,52 @@
             {% endif %}
          </h4>
 
-         <div class="text-muted">
+         <div class="text-muted d-grid gap-y-1" style="grid-template-columns: auto 1fr; column-gap: 0.5rem; align-items: center;">
             {% if user.login is defined and user['login'] is not empty %}
-                <div class="d-flex align-items-center gap-1">
-                    <i class="ti ti-id-badge"></i>
-                    <span>{{ user['login'] }}</span>
-                </div>
+                <i class="ti ti-id-badge"></i>
+                <span>{{ user['login'] }}</span>
             {% endif %}
             {% if user['email']|length > 0 %}
-               <div class="d-flex align-items-center gap-1">
-                  <i class="ti ti-mail"></i>
-                  <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
-               </div>
+               <i class="ti ti-mail"></i>
+               <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
             {% endif %}
             {% if not user['phone'] is empty or not user['phone2'] is empty %}
-               <div class="d-flex align-items-center flex-wrap gap-1">
+               <i class="ti ti-phone"></i>
+               <span class="d-flex align-items-center flex-wrap gap-1">
                   {% if not user['phone'] is empty %}
-                     <i class="ti ti-phone"></i>
                      <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
                   {% endif %}
                   {% if not user['phone'] is empty and not user['phone2'] is empty %}
                      <span> - </span>
                   {% endif %}
                   {% if not user['phone2'] is empty %}
-                     <i class="ti ti-phone"></i>
                      <a href="tel:{{ user['phone2'] }}">{{ user['phone2'] }}</a>
                   {% endif %}
-               </div>
+               </span>
             {% endif %}
             {% if user['mobile']|length > 0 %}
-               <div class="d-flex align-items-center gap-1">
-                  <i class="ti ti-device-mobile"></i>
-                  <a href="tel:{{ user['mobile'] }}">{{ user['mobile'] }}</a>
-               </div>
+               <i class="ti ti-device-mobile"></i>
+               <a href="tel:{{ user['mobile'] }}">{{ user['mobile'] }}</a>
             {% endif %}
             {% if user['registration_number']|length > 0 %}
-               <div class="d-flex align-items-center gap-1">
-                  <i class="ti ti-id-badge-2"></i>
-                  <span>{{ user['registration_number'] }}</span>
-               </div>
+               <i class="ti ti-id-badge-2"></i>
+               <span>{{ user['registration_number'] }}</span>
             {% endif %}
             {% if user['locations_id'] > 0 %}
-               <div class="d-flex align-items-center gap-1" title="{{ 'Location'|itemtype_name }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="{{ 'Location'|itemtype_icon }}"></i>
-                  <span>{{ get_item_name('Location', user['locations_id']) }}</span>
-               </div>
+               <i class="{{ 'Location'|itemtype_icon }}"></i>
+               <span title="{{ 'Location'|itemtype_name }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('Location', user['locations_id']) }}</span>
             {% endif %}
             {% if user['usertitles_id'] > 0 %}
-               <div class="d-flex align-items-center gap-1" title="{{ _x('person', 'Title') }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="{{ 'UserTitle'|itemtype_icon }}"></i>
-                  <span>{{ get_item_name('UserTitle', user['usertitles_id']) }}</span>
-               </div>
+               <i class="{{ 'UserTitle'|itemtype_icon }}"></i>
+               <span title="{{ _x('person', 'Title') }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('UserTitle', user['usertitles_id']) }}</span>
             {% endif %}
             {% if user['usercategories_id'] > 0 %}
-               <div class="d-flex align-items-center gap-1" title="{{ _n('Category', 'Categories', 1) }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="{{ 'UserCategory'|itemtype_icon }}"></i>
-                  <span>{{ get_item_name('UserCategory', user['usercategories_id']) }}</span>
-               </div>
+               <i class="{{ 'UserCategory'|itemtype_icon }}"></i>
+               <span title="{{ _n('Category', 'Categories', 1) }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('UserCategory', user['usercategories_id']) }}</span>
             {% endif %}
             {% if user['groups_id'] > 0 %}
-               <div class="d-flex align-items-center gap-1" title="{{ __('Default group') }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                  <i class="{{ 'Group'|itemtype_icon }}"></i>
-                  <span>{{ get_item_name('Group', user['groups_id']) }}</span>
-               </div>
+               <i class="{{ 'Group'|itemtype_icon }}"></i>
+               <span title="{{ __('Default group') }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('Group', user['groups_id']) }}</span>
             {% endif %}
          </div>
       </div>

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -54,19 +54,19 @@
 
          <div class="text-muted">
             {% if user.login is defined and user['login'] is not empty %}
-                <div>
+                <div class="d-flex align-items-center gap-1">
                     <i class="ti ti-id-badge"></i>
-                    {{ user['login'] }}
+                    <span>{{ user['login'] }}</span>
                 </div>
             {% endif %}
             {% if user['email']|length > 0 %}
-               <div>
+               <div class="d-flex align-items-center gap-1">
                   <i class="ti ti-mail"></i>
                   <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
                </div>
             {% endif %}
             {% if not user['phone'] is empty or not user['phone2'] is empty %}
-               <div>
+               <div class="d-flex align-items-center flex-wrap gap-1">
                   {% if not user['phone'] is empty %}
                      <i class="ti ti-phone"></i>
                      <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
@@ -81,39 +81,39 @@
                </div>
             {% endif %}
             {% if user['mobile']|length > 0 %}
-               <div>
+               <div class="d-flex align-items-center gap-1">
                   <i class="ti ti-device-mobile"></i>
                   <a href="tel:{{ user['mobile'] }}">{{ user['mobile'] }}</a>
                </div>
             {% endif %}
             {% if user['registration_number']|length > 0 %}
-               <div>
+               <div class="d-flex align-items-center gap-1">
                   <i class="ti ti-id-badge-2"></i>
-                  {{ user['registration_number'] }}
+                  <span>{{ user['registration_number'] }}</span>
                </div>
             {% endif %}
             {% if user['locations_id'] > 0 %}
-               <div title="{{ 'Location'|itemtype_name }}" data-bs-toggle="tooltip" data-bs-placement="top">
+               <div class="d-flex align-items-center gap-1" title="{{ 'Location'|itemtype_name }}" data-bs-toggle="tooltip" data-bs-placement="top">
                   <i class="{{ 'Location'|itemtype_icon }}"></i>
-                  {{ get_item_name('Location', user['locations_id']) }}
+                  <span>{{ get_item_name('Location', user['locations_id']) }}</span>
                </div>
             {% endif %}
             {% if user['usertitles_id'] > 0 %}
-               <div title="{{ _x('person', 'Title') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+               <div class="d-flex align-items-center gap-1" title="{{ _x('person', 'Title') }}" data-bs-toggle="tooltip" data-bs-placement="top">
                   <i class="{{ 'UserTitle'|itemtype_icon }}"></i>
-                  {{ get_item_name('UserTitle', user['usertitles_id']) }}
+                  <span>{{ get_item_name('UserTitle', user['usertitles_id']) }}</span>
                </div>
             {% endif %}
             {% if user['usercategories_id'] > 0 %}
-               <div title="{{ _n('Category', 'Categories', 1) }}" data-bs-toggle="tooltip" data-bs-placement="top">
+               <div class="d-flex align-items-center gap-1" title="{{ _n('Category', 'Categories', 1) }}" data-bs-toggle="tooltip" data-bs-placement="top">
                   <i class="{{ 'UserCategory'|itemtype_icon }}"></i>
-                  {{ get_item_name('UserCategory', user['usercategories_id']) }}
+                  <span>{{ get_item_name('UserCategory', user['usercategories_id']) }}</span>
                </div>
             {% endif %}
             {% if user['groups_id'] > 0 %}
-               <div title="{{ __('Default group') }}" data-bs-toggle="tooltip" data-bs-placement="top">
+               <div class="d-flex align-items-center gap-1" title="{{ __('Default group') }}" data-bs-toggle="tooltip" data-bs-placement="top">
                   <i class="{{ 'Group'|itemtype_icon }}"></i>
-                  {{ get_item_name('Group', user['groups_id']) }}
+                  <span>{{ get_item_name('Group', user['groups_id']) }}</span>
                </div>
             {% endif %}
          </div>

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -52,7 +52,7 @@
             {% endif %}
          </h4>
 
-         <div class="text-muted d-grid gap-y-1" style="grid-template-columns: auto 1fr; column-gap: 0.5rem; align-items: center;">
+         <div class="text-muted d-grid gap-y-1" style="grid-template-columns: auto 1fr; column-gap: 0.25rem; align-items: center;">
             {% if user.login is defined and user['login'] is not empty %}
                 <i class="ti ti-id-badge"></i>
                 <span>{{ user['login'] }}</span>


### PR DESCRIPTION
Standardize the layout in templates/components/user/info_card.html.twig by replacing plain divs with Bootstrap flex containers (d-flex align-items-center gap-1) and using flex-wrap for the phone block. Wrap textual outputs in <span> elements to ensure consistent spacing and alignment with icons and tooltips.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

### Description

This PR fixes a minor UI issue in the `.user-info-card` component where the icons and their corresponding text were not vertically aligned.

By adding the flexbox utility classes `d-flex`, `align-items-center`, and `gap-1` to the `<div>` wrappers inside the `.text-muted` section, the icons (such as the ID badge, email, phone, and location) are now perfectly centered relative to their accompanying text, and the spacing is handled uniformly. 

### Changes made
* Updated `templates/components/user/info_card.html.twig` to apply `d-flex align-items-center gap-1` (and `flex-wrap` where applicable) to the property rows.
* Wrapped naked text nodes in `<span>` tags within those flex containers to ensure reliable rendering.

### How to test

1. Go to any page that renders the `user-info-card` component (e.g. Tickets).
2. Look at the username badge section that displays the user's login, email, phone numbers, and other properties.
3. Verify that the icons are perfectly vertically aligned with the text next to them.

## Screenshots (if appropriate):

Before this PR:

<img width="108" height="63" alt="SCR-20260527-conr" src="https://github.com/user-attachments/assets/04b5dfd7-93ed-4d57-8d57-5af7cc9fafd2" />

After this PR:

<img width="171" height="123" alt="SCR-20260527-cqds" src="https://github.com/user-attachments/assets/2e8965da-e0ec-4c75-8321-24231b4f0cf5" />
