### PR TITLE
fix(ui): Prevent double tooltips on user info card links

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1456,6 +1456,7 @@ class CommonDBTM extends CommonGLPI
      *    - class       : string  / CSS class to add to the link
      *    - icon        : boolean / display item icon next to label
      *    - forceid     : boolean  override config and display item's ID (false by default)
+     *    - tooltip     : boolean / display item tooltip (true by default)
      *
      * @return string HTML link
      **/
@@ -1468,6 +1469,7 @@ class CommonDBTM extends CommonGLPI
             'additional' => false,
             'icon'       => false,
             'forceid'    => false,
+            'tooltip'    => true,
         ];
         if (array_key_exists('linkoption', $options)) {
             trigger_error('`linkoption` option is now ignored in `CommonDBTM::getLink()`.', E_USER_WARNING);
@@ -1502,9 +1504,9 @@ class CommonDBTM extends CommonGLPI
         $html = '';
         if ($link_url !== '') {
             $html .= sprintf(
-                '<a href="%s" data-bs-toggle="tooltip" data-bs-placement="bottom" title="%s"%s>',
+                '<a href="%s"%s%s>',
                 htmlescape($link_url),
-                htmlescape($link_title),
+                $p['tooltip'] ? sprintf(' data-bs-toggle="tooltip" data-bs-placement="bottom" title="%s"', htmlescape($link_title)) : '',
                 $p['class'] !== '' ? sprintf(' class="%s"', htmlescape($p['class'])) : '',
             );
         }

--- a/src/Glpi/Application/View/Extension/ItemtypeExtension.php
+++ b/src/Glpi/Application/View/Extension/ItemtypeExtension.php
@@ -235,13 +235,15 @@ class ItemtypeExtension extends AbstractExtension
         }
 
         if ($instance instanceof Group) {
-            return $instance->getGroupLink(true);
+            $enable_anonymization = $options['enable_anonymization'] ?? true;
+            return $instance->getGroupLink($enable_anonymization, $options);
         }
         if ($instance instanceof User) {
-            return $instance->getUserLink(true);
+            $enable_anonymization = $options['enable_anonymization'] ?? true;
+            return $instance->getUserLink($enable_anonymization, $options);
         }
 
-        return $instance->getLink();
+        return $instance->getLink($options);
     }
 
     /**

--- a/src/Group.php
+++ b/src/Group.php
@@ -920,18 +920,19 @@ class Group extends CommonTreeDropdown
     /**
      * Get group link.
      *
-     * @param bool $enable_anonymization
+     * @param bool  $enable_anonymization
+     * @param array<string, mixed> $options
      *
      * @return string
      */
-    public function getGroupLink(bool $enable_anonymization = false): string
+    public function getGroupLink(bool $enable_anonymization = false, $options = []): string
     {
         if ($enable_anonymization && Session::getCurrentInterface() === 'helpdesk' && ($anon = static::getAnonymizedName()) !== null) {
             // if anonymized name active, return only the anonymized name
             return $anon;
         }
 
-        return $this->getLink();
+        return $this->getLink($options);
     }
 
     public function post_addItem()

--- a/src/User.php
+++ b/src/User.php
@@ -6712,11 +6712,12 @@ HTML;
     /**
      * Get user link.
      *
-     * @param bool $enable_anonymization
+     * @param bool  $enable_anonymization
+     * @param array<string, mixed> $options
      *
      * @return string
      */
-    public function getUserLink(bool $enable_anonymization = false): string
+    public function getUserLink(bool $enable_anonymization = false, $options = []): string
     {
         if (
             $enable_anonymization
@@ -6728,7 +6729,7 @@ HTML;
             return $anon;
         }
 
-        return $this->getLink();
+        return $this->getLink($options);
     }
 
     /**

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -34,7 +34,7 @@
 
 <span id="user_{{ rand }}" class="d-inline-flex align-items-center">
     <i class="ti ti-user me-1"></i>
-    {{ get_item_link('User', users_id, {'enable_anonymization': enable_anonymization}) }}
+    {{ get_item_link('User', users_id, {'enable_anonymization': enable_anonymization, 'tooltip': false}) }}
 </span>
 
 {% if not enable_anonymization %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This PR fixes an issue where hovering over a user's name (for example, in a timeline item header badge in Tickets) would display two overlapping tooltips: the standard Bootstrap/qtip title tooltip and the richer user `info_card` tooltip. 

## Screenshots (if appropriate):

Before this PR:

<img width="171" height="123" alt="SCR-20260527-cqds" src="https://github.com/user-attachments/assets/2e8965da-e0ec-4c75-8321-24231b4f0cf5" />

After this PR:

<img width="196" height="135" alt="image" src="https://github.com/user-attachments/assets/eaa69d6b-5223-4f36-8977-f8c6beb92fda" />
