### PR TITLE
Optimize import map generation

### DIFF
--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -40,6 +40,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Path;
 
+use function Safe\hash_file;
 use function Safe\file_get_contents;
 use function Safe\preg_replace;
 

--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -284,7 +284,14 @@ class ImportMapGenerator
                 $clean_path = '/' . $relative_path;
 
                 // Generate version parameter
-                $version_param = $this->generateVersionParam($file_path);
+                if (Environment::get() == Environment::DEVELOPMENT) {
+                    // Faster but less precise. It help with performances in
+                    // dev envs where we don't have production specific contraints
+                    // like multiple servers or re-deploy.
+                    $version_param = $file->getMTime();
+                } else {
+                    $version_param = $this->generateVersionParam($file_path);
+                }
 
                 // Add to import map
                 $import_map['imports'][$clean_path] = $this->root_doc . $clean_path . '?v=' . $version_param;

--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -283,10 +283,27 @@ class ImportMapGenerator
                 // Get the path that would be used for a GLPI located at the server root dir (e.g. `/js/modules/Foo.js`)
                 $clean_path = '/' . $relative_path;
 
+                // Generate version parameter
+                $version_param = $this->generateVersionParam($file_path);
+
                 // Add to import map
-                $import_map['imports'][$clean_path] = $this->root_doc . $clean_path . '?v=' . $file->getMTime();
+                $import_map['imports'][$clean_path] = $this->root_doc . $clean_path . '?v=' . $version_param;
             }
         }
     }
 
+    /**
+     * Generate a version parameter based on the file content
+     *
+     * @param string $file_path Path to the file
+     * @return string Version parameter
+     */
+    private function generateVersionParam(string $file_path): string
+    {
+        if (!file_exists($file_path)) {
+            return 'missing';
+        }
+
+        return hash_file('CRC32c', $file_path);
+    }
 }

--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -40,7 +40,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Path;
 
-use function Safe\hash_file;
+use function Safe\file_get_contents;
 use function Safe\preg_replace;
 
 /**
@@ -140,11 +140,11 @@ class ImportMapGenerator
         }
 
         if (!$core_modules) {
+            $core_modules = ['imports' => $this->getLibModulesImports()];
+
             // Scan GLPI core directories
-            $core_modules = ['imports' => []];
             $this->addModulesToImportMap($core_modules, $this->glpi_root . '/js/modules', $this->glpi_root);
             $this->addModulesToImportMap($core_modules, $this->glpi_root . '/public/js/modules', $this->glpi_root);
-            $this->addModulesToImportMap($core_modules, $this->glpi_root . '/public/lib', $this->glpi_root);
             $this->addModulesToImportMap($core_modules, $this->glpi_root . '/public/build', $this->glpi_root);
 
             // Cache core modules
@@ -204,6 +204,50 @@ class ImportMapGenerator
     }
 
     /**
+     * @return array<string, string>
+     */
+    private function getLibModulesImports(): array
+    {
+        $lib_dir  = $this->glpi_root . '/public/lib';
+
+        // We add a cache layer for dev environements, as the import map will
+        // be generated for each requests.
+        // Lib files doesn't change unless dependencies are modified.
+        $package_hash = $this->glpi_root . '/.package.hash';
+        $cache = $this->cache;
+        $use_cache = Environment::get()->shouldExpectResourcesToChange()
+            && $cache
+            && file_exists($this->glpi_root . '/.package.hash')
+        ;
+        $lib_cache_key = null;
+
+        // Compute cache key
+        if ($use_cache) {
+            $package_hash  = file_get_contents($this->glpi_root . '/.package.hash');
+            $lib_cache_key = 'js_import_map_lib_' . \sha1($this->root_doc . '|' . $package_hash);
+        }
+
+        // Try to read from cache
+        if ($use_cache && $lib_cache_key) {
+            $lib_modules = $cache->get($lib_cache_key);
+            if ($lib_modules) {
+                return $lib_modules;
+            }
+        }
+
+        // Read without cache
+        $lib_modules = ['imports' => []];
+        $this->addModulesToImportMap($lib_modules, $lib_dir, $this->glpi_root);
+
+        // Set cache
+        if ($use_cache && $lib_cache_key) {
+            $cache->set($lib_cache_key, $lib_modules['imports']);
+        }
+
+        return $lib_modules['imports'];
+    }
+
+    /**
      * Add modules from a directory to the import map
      *
      * @param array{imports: array<string, string>} $import_map Reference to the import map array
@@ -239,27 +283,10 @@ class ImportMapGenerator
                 // Get the path that would be used for a GLPI located at the server root dir (e.g. `/js/modules/Foo.js`)
                 $clean_path = '/' . $relative_path;
 
-                // Generate version parameter
-                $version_param = $this->generateVersionParam($file_path);
-
                 // Add to import map
-                $import_map['imports'][$clean_path] = $this->root_doc . $clean_path . '?v=' . $version_param;
+                $import_map['imports'][$clean_path] = $this->root_doc . $clean_path . '?v=' . $file->getMTime();
             }
         }
     }
 
-    /**
-     * Generate a version parameter based on the file content
-     *
-     * @param string $file_path Path to the file
-     * @return string Version parameter
-     */
-    private function generateVersionParam(string $file_path): string
-    {
-        if (!file_exists($file_path)) {
-            return 'missing';
-        }
-
-        return hash_file('CRC32c', $file_path);
-    }
 }

--- a/src/Glpi/Application/ImportMapGenerator.php
+++ b/src/Glpi/Application/ImportMapGenerator.php
@@ -40,8 +40,8 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Filesystem\Path;
 
-use function Safe\hash_file;
 use function Safe\file_get_contents;
+use function Safe\hash_file;
 use function Safe\preg_replace;
 
 /**

--- a/tests/functional/Glpi/Application/ImportMapGeneratorTest.php
+++ b/tests/functional/Glpi/Application/ImportMapGeneratorTest.php
@@ -232,32 +232,34 @@ class ImportMapGeneratorTest extends GLPITestCase
 
         // Create generator and get reflection access to private method
         $generator = $this->createMockGenerator(vfsStream::url('glpi'));
+        $reflection = new \ReflectionClass($generator);
+        $method = $reflection->getMethod('generateVersionParam');
 
         // Test file path
         $file_path = vfsStream::url('glpi/js/modules/TestModule.js');
 
         // First version check
-        $initial_map = $generator->generate();
-        $path = $initial_map['imports']['/js/modules/TestModule.js'];
-        $version = parse_url($path, PHP_URL_QUERY);
-        parse_str($version, $initial_version_params);
-        $initial_version = $initial_version_params['v'];
+        $initial_version = $method->invoke($generator, $file_path);
         $this->assertNotEmpty($initial_version, 'Version parameter should not be empty');
 
         // Modify file and check for version change
-        sleep(1);
         file_put_contents($file_path, '// Modified content');
-        $new_map = $generator->generate();
-        $path = $new_map['imports']['/js/modules/TestModule.js'];
-        $version = parse_url($path, PHP_URL_QUERY);
-        parse_str($version, $new_version_params);
-        $new_version = $new_version_params['v'];
+        $new_version = $method->invoke($generator, $file_path);
 
         // Verify version changed
         $this->assertNotEquals(
             $initial_version,
             $new_version,
             'Version parameter should change when file content changes'
+        );
+
+        // Additional verification - changing back should match original hash
+        file_put_contents($file_path, '// Initial content');
+        $reverted_version = $method->invoke($generator, $file_path);
+        $this->assertEquals(
+            $initial_version,
+            $reverted_version,
+            'Version parameter should be the same when content is identical'
         );
     }
 

--- a/tests/functional/Glpi/Application/ImportMapGeneratorTest.php
+++ b/tests/functional/Glpi/Application/ImportMapGeneratorTest.php
@@ -232,34 +232,32 @@ class ImportMapGeneratorTest extends GLPITestCase
 
         // Create generator and get reflection access to private method
         $generator = $this->createMockGenerator(vfsStream::url('glpi'));
-        $reflection = new \ReflectionClass($generator);
-        $method = $reflection->getMethod('generateVersionParam');
 
         // Test file path
         $file_path = vfsStream::url('glpi/js/modules/TestModule.js');
 
         // First version check
-        $initial_version = $method->invoke($generator, $file_path);
+        $initial_map = $generator->generate();
+        $path = $initial_map['imports']['/js/modules/TestModule.js'];
+        $version = parse_url($path, PHP_URL_QUERY);
+        parse_str($version, $initial_version_params);
+        $initial_version = $initial_version_params['v'];
         $this->assertNotEmpty($initial_version, 'Version parameter should not be empty');
 
         // Modify file and check for version change
+        sleep(1);
         file_put_contents($file_path, '// Modified content');
-        $new_version = $method->invoke($generator, $file_path);
+        $new_map = $generator->generate();
+        $path = $new_map['imports']['/js/modules/TestModule.js'];
+        $version = parse_url($path, PHP_URL_QUERY);
+        parse_str($version, $new_version_params);
+        $new_version = $new_version_params['v'];
 
         // Verify version changed
         $this->assertNotEquals(
             $initial_version,
             $new_version,
             'Version parameter should change when file content changes'
-        );
-
-        // Additional verification - changing back should match original hash
-        file_put_contents($file_path, '// Initial content');
-        $reverted_version = $method->invoke($generator, $file_path);
-        $this->assertEquals(
-            $initial_version,
-            $reverted_version,
-            'Version parameter should be the same when content is identical'
         );
     }
 


### PR DESCRIPTION
The import map take 40ms to generate.
This is not an issue in production because it is cached.

It annoys me in development mode because it happens on every request, which pollute my performances logs when looking for actual issues.

With this in mind, I made two quick small improvements to reduce its impact on development env:
- Use mtime instead of hash -> from 40ms to 8ms per request
- Add a cache layer for libs as they don't change until packages are updated -> from 8ms to 2ms

