### PR TITLE
Optimize fixItemtypeCase() fast path

### DIFF
--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -397,9 +397,14 @@ final class DbUtils
         global $GLPI_CACHE;
 
         // If a class exists for this itemtype, just return the declared class name.
-        $matches = preg_grep('/^' . preg_quote($itemtype, '/') . '$/i', get_declared_classes());
-        if (count($matches) === 1) {
-            return current($matches);
+        // The "false" second parameters make sure we do not trigger autoload since
+        // case might not be correct.
+        if (
+            class_exists($itemtype, false)
+            || interface_exists($itemtype, false)
+            || trait_exists($itemtype, false)
+        ) {
+            return (new ReflectionClass($itemtype))->getName();
         }
 
         static $mapping = []; // Mappings already retrieved in current request

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -399,11 +399,7 @@ final class DbUtils
         // If a class exists for this itemtype, just return the declared class name.
         // The "false" second parameters make sure we do not trigger autoload since
         // case might not be correct.
-        if (
-            class_exists($itemtype, false)
-            || interface_exists($itemtype, false)
-            || trait_exists($itemtype, false)
-        ) {
+        if (class_exists($itemtype, false)) {
             return (new ReflectionClass($itemtype))->getName();
         }
 


### PR DESCRIPTION
This avoid a costly regex operation on a huge array (`get_declared_classes()` might contains a lot of values).

The `xxx_exists` native methods are already case insensitive and won't trigger PSR4 with the second argument set to false.
Then, `ReflectionClass::getName()` return the correct case for the item.

It is not easy to estimate the overall impact on GLPI as this method is used everywhere for small actions, but I did notice that it gains 10ms on the menu generation so any code iterating on many item types might benefits from this.