### PR TITLE
Generalize binary GUID attribute handling in AuthLDAP

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4153,21 +4153,28 @@ TWIG, $twig_params);
                 $value = $infos[$field];
             }
         }
-        if ($field !== 'objectguid') {
+        // Binary GUID attributes from AD: stored as 16 little-endian bytes.
+        // Convert them to the canonical string form so they are readable
+        // and usable as sync_field. LDAP attribute names are case-insensitive
+        // (RFC 4512), so normalize before matching.
+        $guid_attributes = ['objectguid', 'ms-ds-consistencyguid'];
+
+        if (!in_array(strtolower($field), $guid_attributes, true)) {
             return $value;
         }
 
-        // handle special objectguid from AD directories
+        // Convert binary GUID to canonical string. Fall back to the raw
+        // value if the bytes do not actually represent a valid GUID.
         try {
-            // prevent double encoding
+            // Skip conversion if the value already looks like a GUID string.
             if (!self::isValidGuid($value)) {
                 $value = self::guidToString($value);
                 if (!self::isValidGuid($value)) {
-                    throw new RuntimeException('Not an objectguid!');
+                    throw new RuntimeException('Not a valid GUID attribute!');
                 }
             }
         } catch (Throwable $e) {
-            // well... this is not an objectguid apparently
+            // Not a valid GUID after all, fall back to the raw value.
             $value = $infos[$field];
         }
 

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -638,6 +638,48 @@ class AuthLdapTest extends DbTestCase
         $this->assertSame('value', AuthLDAP::getFieldValue($infos, 'objectguid'));
     }
 
+    public function testGetFieldValueConvertsObjectGuidBinary()
+    {
+        // Binary objectGUID from AD must be converted to the canonical string form.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['objectguid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'objectguid'));
+    }
+
+    public function testGetFieldValueConvertsMsDsConsistencyGuid()
+    {
+        // ms-DS-ConsistencyGuid shares the same 16-byte binary layout as objectGUID.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['ms-ds-consistencyguid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'ms-ds-consistencyguid'));
+    }
+
+    public function testGetFieldValueIsCaseInsensitiveForGuidAttributes()
+    {
+        // LDAP attribute names are case-insensitive per RFC 4512.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['ms-DS-ConsistencyGuid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'ms-DS-ConsistencyGuid'));
+    }
+
+    public function testGetFieldValueDoesNotDoubleConvertGuidString()
+    {
+        // If the value is already a GUID string, return it unchanged.
+        $guid = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['objectguid' => [$guid]];
+        $this->assertSame($guid, AuthLDAP::getFieldValue($infos, 'objectguid'));
+
+        $infos = ['ms-ds-consistencyguid' => [$guid]];
+        $this->assertSame($guid, AuthLDAP::getFieldValue($infos, 'ms-ds-consistencyguid'));
+    }
+
     public function testPassword()
     {
         $ldap = new AuthLDAP();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Closes #24332

Generalizes the binary-to-string GUID conversion in `AuthLDAP::getFieldValue()` so it also applies to `ms-DS-ConsistencyGuid`, not only to `objectGUID`. Both attributes share the same 16-byte little-endian layout, so the existing `guidToString()` conversion works for both with no changes.

### Motivation

`ms-DS-ConsistencyGuid` is the immutable anchor that Microsoft documents for hybrid AD / Entra ID Connect deployments, since it survives inter-forest migrations where `objectGUID` does not. Without this change, using it as `sync_field` stores and displays raw binary bytes, producing unreadable values in the LDAP information tab and fragile string comparisons in the database.

### Before / After

**Before** — `ms-DS-ConsistencyGuid` as `sync_field` renders as raw binary in the LDAP information tab:

<img width="533" height="256" alt="image" src="https://github.com/user-attachments/assets/2b641e35-8b96-42d5-8ce2-2a7f47cc47ef" />

**After** — with this PR, the same attribute renders as a canonical GUID string, e.g. `7c5718d3-c454-4121-90e3-a7f7e8e1d9f1`, identical to how `objectGUID` already works.

<img width="474" height="159" alt="image" src="https://github.com/user-attachments/assets/21331b3f-1eb4-4d23-8b49-3353e3fccce7" />

### Changes

- `AuthLDAP::getFieldValue()` now matches the attribute name against a small case-insensitive list (`objectguid`, `ms-ds-consistencyguid`) before applying the GUID conversion.
- LDAP attribute names are case-insensitive per RFC 4512, so `strtolower()` is used before comparison.
- The conversion path itself (`guidToString()`) is unchanged.

### Tests

Four new test methods added to `tests/LDAP/AuthLdapTest.php`, alongside the existing `testGetFieldValue()` (which is kept untouched as a non-regression check):

- `testGetFieldValueConvertsObjectGuidBinary` — confirms the existing `objectGUID` conversion still works on binary input.
- `testGetFieldValueConvertsMsDsConsistencyGuid` — the new case.
- `testGetFieldValueIsCaseInsensitiveForGuidAttributes` — covers `ms-DS-ConsistencyGuid` with mixed case, as it appears in Microsoft documentation.
- `testGetFieldValueDoesNotDoubleConvertGuidString` — ensures values that are already canonical GUID strings are returned unchanged.

### Out of scope

- `objectSid` uses a different binary layout (SID → SDDL) and would need its own decoder. Happy to address in a follow-up if there is interest.
- `login_field` handling is intentionally left unchanged: a binary GUID attribute is not a realistic login field.

### Local checks

- `php -l` clean on both files.
- `php-cs-fixer fix --dry-run` clean against the project config (no changes needed).
- `phpstan analyze src/AuthLDAP.php` clean.
- PHPUnit not executed locally (no test DB available in my environment); relying on the project CI to validate.

---

*AI-assisted: used an LLM to verify code references and draft the wording; all logic reviewed and authored by me.*