### PR TITLE
Use ajax tooltips for user card in search engine results

### DIFF
--- a/src/Glpi/Controller/User/InfoCardController.php
+++ b/src/Glpi/Controller/User/InfoCardController.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\User;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use User;
+
+final class InfoCardController extends AbstractController
+{
+    #[Route("/User/InfoCard/{users_id}", name: "glpi_user_info_card", methods: ["GET"])]
+    public function __invoke(Request $request, int $users_id): Response
+    {
+        if (!Session::haveRight('user', READ)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $user = new User();
+        if (!$user->getFromDB($users_id)) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($user->getInfoCard());
+    }
+}

--- a/src/Glpi/Controller/User/InfoCardController.php
+++ b/src/Glpi/Controller/User/InfoCardController.php
@@ -48,11 +48,11 @@ final class InfoCardController extends AbstractController
     #[Route("/User/InfoCard/{users_id}", name: "glpi_user_info_card", methods: ["GET"])]
     public function __invoke(Request $request, int $users_id): Response
     {
-        if (!Session::haveRight('user', READ)) {
+        $user = new User();
+        if (!$user->can($users_id, READ)) {
             throw new AccessDeniedHttpException();
         }
 
-        $user = new User();
         if (!$user->getFromDB($users_id)) {
             throw new NotFoundHttpException();
         }

--- a/src/Glpi/Controller/User/InfoCardController.php
+++ b/src/Glpi/Controller/User/InfoCardController.php
@@ -37,7 +37,6 @@ namespace Glpi\Controller\User;
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
-use Session;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5802,10 +5802,11 @@ final class SQLProvider implements SearchProviderInterface
                                                 $tooltip = "";
                                                 if (Session::haveRight('user', READ)) {
                                                     $tooltip = Html::showToolTip(
-                                                        $user->getInfoCard(),
+                                                        __s('Loading...'),
                                                         [
                                                             'link'    => $user->getLinkURL(),
                                                             'display' => false,
+                                                            'url'     => '/User/InfoCard/' . $user->getID(),
                                                         ]
                                                     );
                                                 }
@@ -5846,13 +5847,14 @@ final class SQLProvider implements SearchProviderInterface
                         if ($data[$ID][0]['id'] > 0) {
                             $toadd = '';
                             if (is_subclass_of($itemtype, CommonITILObject::class)) {
-                                $user = new User();
-                                if (Session::haveRight('user', READ) && $user->getFromDB($data[$ID][0]['id'])) {
-                                    $toadd    = Html::showToolTip(
-                                        $user->getInfoCard(),
+                                if (Session::haveRight('user', READ)) {
+                                    $users_id = (int) $data[$ID][0]['id'];
+                                    $toadd = Html::showToolTip(
+                                        __s('Loading...'),
                                         [
-                                            'link'    => $user->getLinkURL(),
+                                            'link'    => User::getFormURLWithID($users_id),
                                             'display' => false,
+                                            'url'     => '/User/InfoCard/' . $users_id,
                                         ]
                                     );
                                 }


### PR DESCRIPTION
Search results includes tooltip for every user found:

<img width="1939" height="633" alt="image" src="https://github.com/user-attachments/assets/f004d427-06a8-4f69-ba61-b7d6849feecb" />

This can quickly add up to a lot of HTML and wasted computation time for big lists with multiple user related columns.
It seem better to use an AJAX tooltip that will be rendered on demand instead.