### PR TITLE
fix(ux): Update Targets tab icon for Knowledge Base, RSS Feeds, and Reminders

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -246,7 +246,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                         $ong[2] = self::createTabEntry(
                             _n('Target', 'Targets', Session::getPluralNumber()),
                             $nb,
-                            $item::getType()
+                            $item::getType(),
+                            'ti ti-target-arrow'
                         );
                         $ong[3] = self::createTabEntry(__('Edit'), 0, $item::class, 'ti ti-pencil');
                     }

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -434,7 +434,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb, $item::getType());
+                        ), $nb, $item::getType(), 'ti ti-target-arrow');
                     }
                     return $showtab;
             }

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -487,7 +487,7 @@ class Reminder extends CommonDBVisible implements
                             'Target',
                             'Targets',
                             Session::getPluralNumber()
-                        ), $nb, $item::getType()),
+                        ), $nb, $item::getType(), 'ti ti-target-arrow'),
                         ];
                     }
             }


### PR DESCRIPTION
Pass the 'ti ti-target-arrow' icon class to createTabEntry for the Targets/Target tab in KnowbaseItem so the tab displays the intended icon. Minor argument formatting adjusted for readability.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This PR updates the icon used for the "Targets" tab across Knowledge Base items, RSS Feeds, and Reminders.

Previously, the "Targets" tab in these views inherited the default item icon (e.g., `ti-lifebuoy` for Knowledge Base), making it visually identical to the main tab. This change explicitly sets the "Targets" tab icon to `ti-target-arrow` across the board to provide better visual distinction, consistency, and an improved user experience.

## Screenshots (if appropriate):

**Before this PR:**

<img width="159" height="71" alt="image" src="https://github.com/user-attachments/assets/54a8dec2-b464-4e22-92fb-b46f673ab1b4" />

**After this PR:**

<img width="142" height="68" alt="image" src="https://github.com/user-attachments/assets/21699626-47fc-4b84-be6a-d6e9029ef3e7" />
