### PR TITLE
fix(kb): improve responsive layout for associated elements form

### DIFF
--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -41,15 +41,15 @@
         {{ inputs.hidden('items_id', item.getID()) }}
         {{ inputs.hidden('itemtype', get_class(item)) }}
     {% endif %}
-    <div class="d-flex align-items-center mb-2">
+    <div class="row align-items-center mb-2 ms-3">
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
-            <label class="me-2 text-nowrap">{{ __('Add a linked item') }}</label>
-            <div class="me-2">
+            <label class="col-auto col-form-label text-nowrap fw-bold">{{ __('Add a linked item') }}</label>
+            <div class="col-12 col-sm-6 col-md-4">
                 {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
             </div>
         {% else %}
-            <div class="me-2">
+            <div class="col-12 col-sm-6 col-md-4">
                 {{ 'KnowbaseItem'|itemtype_dropdown({
                     'entity': item.getEntityID(),
                     'used': used_knowbase_items,
@@ -57,7 +57,7 @@
                 }) }}
             </div>
         {% endif %}
-        <div>
+        <div class="col-auto">
             {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary', 'icon': 'ti ti-link'}) }}
         </div>
     </div>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -44,7 +44,7 @@
     <div class="row align-items-center mb-2 ms-3">
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
-            <label class="col-auto col-form-label text-nowrap fw-bold">{{ __('Add a linked item') }}</label>
+            <label class="col-auto col-form-label">{{ __('Add a linked item') }}</label>
             <div class="col-12 col-sm-6 col-md-4">
                 {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
             </div>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -45,11 +45,11 @@
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
             <label class="col-auto col-form-label">{{ __('Add a linked item') }}</label>
-            <div class="col-12 col-sm-6 col-md-4">
+            <div class="col-12 col-sm-8 col-md-6 mb-2 mb-md-0">
                 {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
             </div>
         {% else %}
-            <div class="col-12 col-sm-6 col-md-4">
+            <div class="col-12 col-sm-8 col-md-6 mb-2 mb-md-0">
                 {{ 'KnowbaseItem'|itemtype_dropdown({
                     'entity': item.getEntityID(),
                     'used': used_knowbase_items,
@@ -57,7 +57,7 @@
                 }) }}
             </div>
         {% endif %}
-        <div class="col-auto">
+        <div class="col-auto mt-2 mt-md-0">
             {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary', 'icon': 'ti ti-link'}) }}
         </div>
     </div>

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -30,7 +30,6 @@
  # ---------------------------------------------------------------------
  #}
 
-{% import 'components/form/fields_macros.html.twig' as fields %}
 {% import 'components/form/basic_inputs_macros.html.twig' as inputs %}
 
 <form method="post" action="{{ 'KnowbaseItem_Item'|itemtype_form_path }}">

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -45,11 +45,11 @@
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
             <label class="col-auto col-form-label">{{ __('Add a linked item') }}</label>
-            <div class="col-12 col-sm-8 col-md-6 mb-2 mb-md-0">
+            <div class="col-12 col-sm-8 col-md-3 mb-2 mb-md-0">
                 {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
             </div>
         {% else %}
-            <div class="col-12 col-sm-8 col-md-6 mb-2 mb-md-0">
+            <div class="col-12 col-sm-8 col-md-3 mb-2 mb-md-0">
                 {{ 'KnowbaseItem'|itemtype_dropdown({
                     'entity': item.getEntityID(),
                     'used': used_knowbase_items,

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -41,22 +41,24 @@
         {{ inputs.hidden('items_id', item.getID()) }}
         {{ inputs.hidden('itemtype', get_class(item)) }}
     {% endif %}
-    <div class="d-flex align-items-baseline">
+    <div class="d-flex align-items-center mb-2">
         {% if get_class(item) == 'KnowbaseItem' %}
             {# TODO pass used array to restrict visible items in list #}
-            {% set dropdown %}
+            <label class="me-2 text-nowrap">{{ __('Add a linked item') }}</label>
+            <div class="me-2">
                 {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
-            {% endset %}
-            {{ fields.htmlField('', dropdown, __('Add a linked item')) }}
+            </div>
         {% else %}
-            {{ 'KnowbaseItem'|itemtype_dropdown({
-                'entity': item.getEntityID(),
-                'used': used_knowbase_items,
-                'condition': visibility_condition
-            }) }}
+            <div class="me-2">
+                {{ 'KnowbaseItem'|itemtype_dropdown({
+                    'entity': item.getEntityID(),
+                    'used': used_knowbase_items,
+                    'condition': visibility_condition
+                }) }}
+            </div>
         {% endif %}
         <div>
-            {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary ms-1', 'icon': 'ti ti-link'}) }}
+            {{ inputs.submit('add', _x('button', 'Add'), 1, {'class': 'btn btn-primary', 'icon': 'ti ti-link'}) }}
         </div>
     </div>
 </form>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Description

This PR fixes multiple layout issues with the "Associated elements" ("Add a linked item") dropdown form in the Knowledge Base interface (/front/knowbaseitem.form.php). 

Previously, the dropdown was wrapped in a `fields.htmlField` macro and placed inside a `.d-flex` container without proper width scaling. This caused the default `80%` width of the `<select>` element to be awkwardly crushed on desktop. Additionally, on mobile views, the elements would stack with no vertical margin, causing the "Add" button to sit flush against the second dropdown that appears dynamically via AJAX.

### Changes made
* **Replaced Flexbox with Grid**: Replaced the `.d-flex` container with a standard Bootstrap `.row` wrapper and used `.col-*` classes to structure the form linearly.
* **Unwrapped Macro**: Removed the `fields.htmlField` macro wrapping the dropdown to bypass arbitrary `.form-field` grid constraints.
* **Proportional Width**: Placed the dropdown inside a `.col-12 .col-sm-8 .col-md-3` container. This allows the backend's default `style="width: 80%"` on the select element to scale proportionally and comfortably without getting crushed.
* **Responsive Spacing**: Added `.mb-2 .mb-md-0` to the dropdown container and `.mt-2 .mt-md-0` to the button wrapper. This guarantees sufficient vertical margins between the dropdown and the submit button when they stack on mobile screens, while neutralizing the margins on desktop view.

## How to test

1. Navigate to a Knowledge Base article (`Tools` > `Knowledge base` > Select any article).
2. Look at the "Associated elements" section at the bottom.
3. Verify that the "Add a linked item" dropdown has a normal, readable width on desktop.
4. Select an item type (e.g., "Computers") to trigger the AJAX load of the second dropdown, and verify the width is maintained.
5. Shrink your browser window to simulate a mobile view.
6. Verify that the label, dropdowns, and "Add" button stack neatly, and there is a visible gap between the second dropdown and the "Add" button.

## Screenshots (if appropriate):

Before this PR:

<img width="288" height="140" alt="image" src="https://github.com/user-attachments/assets/11c28125-50fa-47d3-98c2-1e8507bdc40d" />

After this PR:

<img width="586" height="93" alt="image" src="https://github.com/user-attachments/assets/34d91e44-2432-4056-87ca-7d940f51202f" />
