### PR TITLE
[HLAPI] Forms

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -9788,12 +9788,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSearchResultsBySchema\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSelectCriteria\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -9614,12 +9614,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSearchResultsBySchema\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSelectCriteria\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6128,20 +6128,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Router.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method hydrate\\(\\) on Glpi\\\\Api\\\\HL\\\\Search\\\\RecordSet\\|int\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method maybeRecursive\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSearchResultsBySchema\\(\\) should return array\\{results\\: array, start\\: int, limit\\: int, total\\: int\\} but returns array\\{results\\: list, start\\: 0\\|array, limit\\: array\\|int\\<0, max\\>, total\\: Glpi\\\\Api\\\\HL\\\\Search\\\\RecordSet\\|int\\}\\.$#',
-	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -5630,20 +5630,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Router.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method hydrate\\(\\) on Glpi\\\\Api\\\\HL\\\\Search\\\\RecordSet\\|int\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method maybeRecursive\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Search\\:\\:getSearchResultsBySchema\\(\\) should return array\\{results\\: array, start\\: int, limit\\: int, total\\: int\\} but returns array\\{results\\: list, start\\: 0\\|array, limit\\: array\\|int\\<0, max\\>, total\\: Glpi\\\\Api\\\\HL\\\\Search\\\\RecordSet\\|int\\}\\.$#',
-	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Search.php',
 ];

--- a/src/Glpi/Api/HL/Controller/FormController.php
+++ b/src/Glpi/Api/HL/Controller/FormController.php
@@ -105,12 +105,18 @@ final class FormController extends AbstractController
                                         '_' => 'id', [
                                             'AND' => [
                                                 FormAccessControl::getTable() . '.strategy' => AllowList::class,
+                                                FormAccessControl::getTable() . '.is_active' => 1,
                                             ],
                                         ],
                                     ],
                                 ],
                             ],
-                            'WHERE' => ['OR' => []],
+                            'WHERE' => [
+                                'OR' => [],
+                                '_.is_deleted' => 0,
+                                '_.is_draft' => 0,
+                                '_.is_active' => 1,
+                            ],
                         ];
                         // directly allowed - need to check if the current user's ID is in the "user_ids" array in the config JSON of the access control record
                         $user_ids = ['all', Session::getLoginUserID()];

--- a/src/Glpi/Api/HL/Controller/FormController.php
+++ b/src/Glpi/Api/HL/Controller/FormController.php
@@ -1,0 +1,824 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\Controller;
+
+use Entity;
+use Glpi\Api\HL\APIException;
+use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
+use Glpi\Api\HL\ResourceAccessor;
+use Glpi\Api\HL\Route;
+use Glpi\Api\HL\RouteVersion;
+use Glpi\Api\HL\RSQL\RSQLException;
+use Glpi\Api\HL\Search;
+use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryFunction;
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\ControlType\DirectAccess;
+use Glpi\Form\AccessControl\FormAccessControl;
+use Glpi\Form\Category;
+use Glpi\Form\Condition\ValidationStrategy;
+use Glpi\Form\Condition\VisibilityStrategy;
+use Glpi\Form\Form;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\RenderLayout;
+use Glpi\Form\Section;
+use Glpi\Http\JSONResponse;
+use Glpi\Http\Request;
+use Glpi\Http\Response;
+use GraphQL\Type\Definition\ResolveInfo;
+use Session;
+use stdClass;
+use Throwable;
+
+use function Safe\json_encode;
+
+#[Route(path: '/Form', priority: 1, tags: ['Forms'])]
+final class FormController extends AbstractController
+{
+    protected static function getRawKnownSchemas(): array
+    {
+        // Fix enums issues that ruin snapshot comparison tests
+        $render_layouts = array_map(static fn($l) => $l->value, RenderLayout::cases());
+        sort($render_layouts);
+        $visibility_strategies = array_map(static fn($s) => $s->value, VisibilityStrategy::cases());
+        sort($visibility_strategies);
+        $validation_strategies = array_map(static fn($s) => $s->value, ValidationStrategy::cases());
+        sort($validation_strategies);
+        $question_types = array_filter(
+            array: array_map(static fn($t) => $t::class, QuestionTypesManager::getInstance()->getQuestionTypes()),
+            callback: static fn($t) => !str_starts_with($t, 'GlpiPlugin\\Tester\\'),
+        );
+
+        return [
+            'Form' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-version-introduced' => '2.4.0',
+                'x-itemtype' => Form::class,
+                'x-graphql-resolver' => [self::class, 'graphQLResolveForms'],
+                'x-rights-conditions' => [
+                    'read' => static function () {
+                        if (Session::haveRight(Form::$rightname, READ)) {
+                            return true;
+                        }
+
+                        global $DB;
+
+                        $criteria = [
+                            'LEFT JOIN' => [
+                                FormAccessControl::getTable() => [
+                                    'ON' => [
+                                        FormAccessControl::getTable() => Form::getForeignKeyField(),
+                                        '_' => 'id', [
+                                            'AND' => [
+                                                FormAccessControl::getTable() . '.strategy' => AllowList::class,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'WHERE' => ['OR' => []],
+                        ];
+                        // directly allowed - need to check if the current user's ID is in the "user_ids" array in the config JSON of the access control record
+                        $user_ids = ['all', Session::getLoginUserID()];
+                        $criteria['WHERE']['OR'][] = [
+                            QueryFunction::jsonOverlaps(
+                                doc1: QueryFunction::jsonExtract([FormAccessControl::getTable() . '.config', new QueryExpression($DB::quoteValue('$.user_ids'))]),
+                                doc2: new QueryExpression($DB::quoteValue(json_encode($user_ids)))
+                            ),
+                        ];
+
+                        // allowed by group
+                        $groups = array_values($_SESSION['glpigroups'] ?? []);
+                        if ($groups !== []) {
+                            $criteria['WHERE']['OR'][] = [
+                                QueryFunction::jsonOverlaps(
+                                    doc1: QueryFunction::jsonExtract([FormAccessControl::getTable() . '.config', new QueryExpression($DB::quoteValue('$.group_ids'))]),
+                                    doc2: new QueryExpression($DB::quoteValue(json_encode($groups)))
+                                ),
+                            ];
+                        }
+
+                        // allowed by profile
+                        $profile_id = $_SESSION["glpiactiveprofile"]['id'];
+                        $criteria['WHERE']['OR'][] = [
+                            QueryFunction::jsonOverlaps(
+                                doc1: QueryFunction::jsonExtract([FormAccessControl::getTable() . '.config', new QueryExpression($DB::quoteValue('$.profile_ids'))]),
+                                doc2: new QueryExpression($DB::quoteValue(json_encode([$profile_id])))
+                            ),
+                        ];
+
+                        return $criteria;
+                    },
+                ],
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'uuid' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'pattern' => Doc\Schema::PATTERN_UUIDV4,
+                        'readOnly' => true,
+                    ],
+                    'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
+                    'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'is_draft' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'is_pinned' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'render_layout' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $render_layouts,
+                        'default' => RenderLayout::STEP_BY_STEP->value,
+                    ],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                    'form_description' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'format' => Doc\Schema::FORMAT_STRING_HTML,
+                        'x-field' => 'header',
+                    ],
+                    'service_catalog_description' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'format' => Doc\Schema::FORMAT_STRING_HTML,
+                        'x-field' => 'description',
+                    ],
+                    'illustration' => ['type' => Doc\Schema::TYPE_STRING],
+                    'category' => self::getDropdownTypeSchema(class: Category::class, full_schema: 'FormCategory'),
+                    'usage_count' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'submit_button_visibility_strategy' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $visibility_strategies,
+                        'default' => VisibilityStrategy::ALWAYS_VISIBLE->value,
+                    ],
+                    'submit_button_conditions' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'description' => <<<EOT
+                            JSON encoded array of conditions to apply to the submit button.
+                            The order of the conditions is important as it affects the evaluation with the logic_operator value.
+                            Each condition will contain an `item_type` and an `item_uuid` field to specify the item the condition is based on and `value_operator` to specify the condition operator.
+                            A `logic_operator` field can be set to specify how the condition should be evaluated with the next condition. If not set, it will default to "AND".
+                            If the `value_operator` uses a value, a `value` field will also be present to specify the value to compare with.
+EOT,
+                    ],
+                    'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                    'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
+                    'access_controls' => [
+                        'type' => Doc\Schema::TYPE_ARRAY,
+                        'items' => [
+                            'type' => Doc\Schema::TYPE_OBJECT,
+                            'x-full-schema' => 'FormAccessControl',
+                            'x-join' => [
+                                'table' => FormAccessControl::getTable(),
+                                'fkey' => 'id',
+                                'field' => Form::getForeignKeyField(),
+                                'primary-property' => 'id',
+                            ],
+                            'properties' => [
+                                'id' => [
+                                    'type' => Doc\Schema::TYPE_INTEGER,
+                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                                    'readOnly' => true,
+                                ],
+                                'strategy' => [
+                                    'type' => Doc\Schema::TYPE_STRING,
+                                    'enum' => [
+                                        AllowList::class,
+                                        DirectAccess::class,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'sections' => self::getChildrenTypeSchema(
+                        parent_class: Form::class,
+                        class: Section::class,
+                        full_schema: 'FormSection',
+                        graphql_only: true,
+                    ),
+                ],
+            ],
+            'FormCategory' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-version-introduced' => '2.4.0',
+                'x-itemtype' => Category::class,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
+                    'completename' => ['type' => Doc\Schema::TYPE_STRING, 'readOnly' => true],
+                    'description' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_HTML],
+                    'illustration' => ['type' => Doc\Schema::TYPE_STRING],
+                    'parent' => self::getDropdownTypeSchema(class: Category::class, full_schema: 'FormCategory'),
+                    'level' => ['type' => Doc\Schema::TYPE_INTEGER, 'readOnly' => true],
+                    'comment' => ['type' => Doc\Schema::TYPE_STRING],
+                ],
+            ],
+            'FormAccessControl' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-version-introduced' => '2.4.0',
+                'x-graphql-no-query' => true,
+                'x-itemtype' => FormAccessControl::class,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'form' => self::getDropdownTypeSchema(class: Form::class, full_schema: 'Form'),
+                    'strategy' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => [
+                            AllowList::class,
+                            DirectAccess::class,
+                        ],
+                    ],
+                    'config' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'description' => <<<EOT
+                            JSON encoded configuration for the access control strategy. The content of this field will depend on the strategy used.
+                            DirectAccess strategy contains a `token` string and `allow_unauthenticated` boolean in its config.
+                            AllowList strategy contains `user_ids`, `group_ids` and `profile_ids` array fields in its config where the values are IDs of the items or 'all' (for users only).
+EOT,
+                    ],
+                    'is_active' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                ],
+            ],
+            'FormSection' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-version-introduced' => '2.4.0',
+                'x-graphql-no-query' => true,
+                'x-graphql-resolver' => [self::class, 'graphQLResolveFormSections'],
+                'x-itemtype' => Section::class,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'form' => self::getDropdownTypeSchema(class: Form::class, full_schema: 'Form'),
+                    'uuid' => ['type' => Doc\Schema::TYPE_STRING, 'pattern' => Doc\Schema::PATTERN_UUIDV4, 'readOnly' => true],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'default' => ''],
+                    'description' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_HTML],
+                    'rank' => ['type' => Doc\Schema::TYPE_INTEGER, 'default' => 0],
+                    'visibility_strategy' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $visibility_strategies,
+                        'default' => VisibilityStrategy::ALWAYS_VISIBLE->value,
+                    ],
+                    'conditions' => ['type' => Doc\Schema::TYPE_STRING],
+                    'questions' => self::getChildrenTypeSchema(
+                        parent_class: Section::class,
+                        class: Question::class,
+                        full_schema: 'FormQuestion',
+                        graphql_only: true,
+                    ),
+                ],
+            ],
+            'FormQuestion' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-version-introduced' => '2.4.0',
+                'x-graphql-no-query' => true,
+                'x-itemtype' => Question::class,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                    'section' => self::getDropdownTypeSchema(class: Section::class, full_schema: 'FormSection'),
+                    'uuid' => ['type' => Doc\Schema::TYPE_STRING,  'pattern' => Doc\Schema::PATTERN_UUIDV4, 'readOnly' => true],
+                    'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'default' => ''],
+                    'type' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $question_types,
+                    ],
+                    'is_mandatory' =>  ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false],
+                    'vertical_rank' => ['type' => Doc\Schema::TYPE_INTEGER, 'default' => 0],
+                    'horizontal_rank' => ['type' => Doc\Schema::TYPE_INTEGER, 'default' => 0],
+                    'description' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_HTML],
+                    'default_value' =>  ['type' => Doc\Schema::TYPE_STRING],
+                    'extra_data' => ['type' => Doc\Schema::TYPE_STRING, 'description' => 'JSON encoded value'],
+                    'visibility_strategy' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $visibility_strategies,
+                        'default' => VisibilityStrategy::ALWAYS_VISIBLE->value,
+                    ],
+                    'visibility_conditions' => ['type' => Doc\Schema::TYPE_STRING, 'x-field' => 'conditions'],
+                    'validation_strategy' => [
+                        'type' => Doc\Schema::TYPE_STRING,
+                        'enum' => $validation_strategies,
+                        'default' => ValidationStrategy::NO_VALIDATION->value,
+                    ],
+                    'validation_conditions' => ['type' => Doc\Schema::TYPE_STRING],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param mixed $source
+     * @param array<string, mixed> $args
+     * @param stdClass $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public static function graphQLResolveForms(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
+    {
+        if (!empty($source)) {
+            return $source[$info->fieldName] ?? null;
+        }
+        $results = self::getFormResults($context->api_version, $args);
+
+        $field_selection = $info->getFieldSelection();
+        if ($field_selection['sections'] ?? false) {
+            // getFormResults relies on the REST search and "sections" are only available in GraphQL so we need to manually fetch it here.
+            foreach ($results['results'] as &$result) {
+                $result['sections'] = self::getFormSectionsResults($context->api_version, ['filter' => 'form.id==' . $result['id']])['results'];
+            }
+            unset($result);
+        }
+
+        if (!property_exists($context, 'pagination')) {
+            $context->pagination = [];
+        }
+        $context->pagination[$info->path[0]] = [
+            'start' => $results['start'],
+            'limit' => $results['limit'],
+            'total_count' => $results['total'],
+        ];
+
+        return $results['results'];
+    }
+
+    /**
+     * @param mixed $source
+     * @param array<string, mixed> $args
+     * @param stdClass $context
+     * @param ResolveInfo $info
+     * @return mixed
+     */
+    public static function graphQLResolveFormSections(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
+    {
+        if (!empty($source) && isset($source[$info->fieldName])) {
+            return $source[$info->fieldName];
+        }
+
+        if ($info->fieldName === 'questions') {
+            return self::getFormQuestionsResults($context->api_version, ['filter' => 'section.id==' . $source['id']])['results'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $api_version
+     * @param array<string, mixed> $params
+     * @phpstan-return array{results: list<array<string, mixed>>, start: int, limit: int, total: int}
+     * @throws APIException
+     * @throws RSQLException
+     */
+    private static function getFormResults(string $api_version, array $params): array
+    {
+        $schema = self::getKnownSchemas($api_version)['Form'];
+        $schema = ResourceAccessor::applyFieldReadRestrictions($schema);
+        return Search::getSearchResultsBySchema($schema, $params);
+    }
+
+    /**
+     * @param string $api_version
+     * @param array<string, mixed> $params
+     * @phpstan-return array{results: list<array<string, mixed>>, start: int, limit: int, total: int}
+     * @throws APIException
+     * @throws RSQLException
+     */
+    private static function getFormSectionsResults(string $api_version, array $params): array
+    {
+        $schema = self::getKnownSchemas($api_version)['FormSection'];
+        $schema = ResourceAccessor::applyFieldReadRestrictions($schema);
+        return Search::getSearchResultsBySchema($schema, $params);
+    }
+
+    /**
+     * @param string $api_version
+     * @param array<string, mixed> $params
+     * @phpstan-return array{results: list<array<string, mixed>>, start: int, limit: int, total: int}
+     * @throws APIException
+     * @throws RSQLException
+     */
+    private static function getFormQuestionsResults(string $api_version, array $params): array
+    {
+        $schema = self::getKnownSchemas($api_version)['FormQuestion'];
+        $schema = ResourceAccessor::applyFieldReadRestrictions($schema);
+        return Search::getSearchResultsBySchema($schema, $params);
+    }
+
+    /**
+     * Slimmer copy of ResourceAccessor::searchBySchema without the rights check.
+     * Fully reliant on SQL restrictions.
+     * @param Request $request
+     * @param callable(string, array<string, mixed>): array{results: list<array<string, mixed>>, start: int, limit: int, total: int} $fn_get_results
+     * @return Response
+     */
+    private function unsafeSearch(Request $request, callable $fn_get_results)
+    {
+        try {
+            $results = $fn_get_results($this->getAPIVersion($request), $request->getParameters());
+        } catch (RSQLException $e) {
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_INVALID_PARAMETER, $e->getMessage(), $e->getDetails()), 400);
+        } catch (APIException $e) {
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage(), $e->getDetails()), $e->getCode() ?: 400);
+        } catch (Throwable $e) {
+            $message = (new APIException())->getUserMessage();
+            $detail = null;
+            if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
+                $detail = $e->getMessage();
+            }
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message, $detail), 500);
+        }
+        $has_more = $results['start'] + $results['limit'] < $results['total'];
+        $end = max(0, ($results['start'] + $results['limit'] - 1));
+        if ($end > $results['total']) {
+            $end = $results['total'] - 1;
+        }
+        return new JSONResponse($results['results'], $has_more ? 206 : 200, [
+            'Content-Range' => $results['start'] . '-' . $end . '/' . $results['total'],
+        ]);
+    }
+
+    /**
+     * Slimmer copy of ResourceAccessor::getOneBySchema without the rights check.
+     * Fully reliant on SQL restrictions.
+     * @param Request $request
+     * @param callable(string, array<string, mixed>): array{results: list<array<string, mixed>>, start: int, limit: int, total: int} $fn_get_results
+     * @return Response
+     */
+    private function unsafeGetOneResult(Request $request, callable $fn_get_results): Response
+    {
+        $request->setParameter('limit', 1);
+        $request->setParameter('start', 0);
+        try {
+            $results = $fn_get_results($this->getAPIVersion($request), $request->getParameters());
+        } catch (RSQLException $e) {
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_INVALID_PARAMETER, $e->getMessage(), $e->getDetails()), 400);
+        } catch (APIException $e) {
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $e->getUserMessage(), $e->getDetails()), $e->getCode() ?: 400);
+        } catch (Throwable $e) {
+            $message = (new APIException())->getUserMessage();
+            $detail = null;
+            if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
+                $detail = $e->getMessage();
+            }
+            return new JSONResponse(AbstractController::getErrorResponseBody(AbstractController::ERROR_GENERIC, $message, $detail), 500);
+        }
+        if (count($results['results']) === 0) {
+            return AbstractController::getNotFoundErrorResponse();
+        }
+        return new JSONResponse($results['results'][0]);
+    }
+
+    /**
+     * @param string $api_version The api version to use.
+     * @param int $form_id The form ID to check.
+     * @return bool
+     * @throws APIException
+     * @throws RSQLException
+     */
+    private function canReadForm(string $api_version, int $form_id): bool
+    {
+        $forms = self::getFormResults($api_version, ['filter' => 'id==' . $form_id, 'limit' => 1]);
+        return $forms['results'] !== [];
+    }
+
+    #[Route(path: '/', methods: ['GET'], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\SearchRoute(schema_name: 'Form')]
+    public function searchForms(Request $request): Response
+    {
+        return $this->unsafeSearch($request, self::getFormResults(...));
+    }
+
+    #[Route(path: '/{id}', methods: ['GET'], requirements: [
+        'id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\GetRoute(schema_name: 'Form')]
+    public function getForm(Request $request): Response
+    {
+        $filter = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
+        $filter .= ';id==' . $request->getAttribute('id');
+        $request->setParameter('filter', $filter);
+
+        return $this->unsafeGetOneResult($request, self::getFormResults(...));
+    }
+
+    #[Route(path: '/', methods: ['POST'])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\CreateRoute(schema_name: 'Form')]
+    public function createForm(Request $request): Response
+    {
+        return ResourceAccessor::createBySchema(
+            schema: $this->getKnownSchema('Form', $this->getAPIVersion($request)),
+            request_params: $request->getParameters(),
+            get_route: [self::class, 'getForm']
+        );
+    }
+
+    #[Route(path: '/{id}', methods: ['PATCH'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\UpdateRoute(schema_name: 'Form')]
+    public function updateForm(Request $request): Response
+    {
+        // Updates of forms have normal GLPI permissions so we can use the normal API methods here.
+        return ResourceAccessor::updateBySchema(
+            schema: $this->getKnownSchema('Form', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{id}', methods: ['DELETE'], requirements: ['id' => '\d+'])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\DeleteRoute(schema_name: 'Form')]
+    public function deleteForm(Request $request): Response
+    {
+        return ResourceAccessor::deleteBySchema(
+            schema: $this->getKnownSchema('Form', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section', methods: ['GET'], requirements: [
+        'form_id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\SearchRoute(schema_name: 'FormSection')]
+    public function listFormSections(Request $request): Response
+    {
+        $form_id = $request->getAttribute('form_id');
+        if (!$this->canReadForm($this->getAPIVersion($request), $form_id)) {
+            return self::getNotFoundErrorResponse();
+        }
+        $filter = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
+        $filter .= ';form.id==' . $form_id;
+        $request->setParameter('filter', $filter);
+
+        return $this->unsafeSearch($request, self::getFormSectionsResults(...));
+    }
+
+    #[Route(path: '/{form_id}/Section/{id}', methods: ['GET'], requirements: [
+        'form_id' => '\d+',
+        'id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\GetRoute(schema_name: 'FormSection')]
+    public function getFormSection(Request $request): Response
+    {
+        $form_id = $request->getAttribute('form_id');
+        if (!$this->canReadForm($this->getAPIVersion($request), $form_id)) {
+            return self::getNotFoundErrorResponse();
+        }
+        $filter = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
+        $filter .= ';form.id==' . $form_id . ';id==' . $request->getAttribute('id');
+        $request->setParameter('filter', $filter);
+        return $this->unsafeGetOneResult($request, self::getFormSectionsResults(...));
+    }
+
+    #[Route(path: '/{form_id}/Section', methods: ['POST'], requirements: ['form_id' => '\d+'])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\CreateRoute(schema_name: 'FormSection')]
+    public function createFormSection(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $request->setParameter('form', $request->getAttribute('form_id'));
+        return ResourceAccessor::createBySchema(
+            schema: $this->getKnownSchema('FormSection', $this->getAPIVersion($request)),
+            request_params: $request->getParameters(),
+            get_route: [self::class, 'getFormSection'],
+            extra_get_route_params: [
+                'mapped' => ['form_id' => $request->getAttribute('form_id')],
+            ]
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section/{id}', methods: ['PATCH'], requirements: [
+        'form_id' => '\d+',
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\UpdateRoute(schema_name: 'FormSection')]
+    public function updateFormSection(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        return ResourceAccessor::updateBySchema(
+            schema: $this->getKnownSchema('FormSection', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section/{id}', methods: ['DELETE'], requirements: [
+        'form_id' => '\d+',
+        'id' => '\d+',
+    ])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\DeleteRoute(schema_name: 'FormSection')]
+    public function deleteFormSection(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        return ResourceAccessor::deleteBySchema(
+            schema: $this->getKnownSchema('FormSection', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section/{section_id}/Question', methods: ['GET'], requirements: [
+        'form_id' => '\d+',
+        'section_id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\SearchRoute(schema_name: 'FormQuestion')]
+    public function listFormSectionQuestions(Request $request): Response
+    {
+        $form_id = $request->getAttribute('form_id');
+        if (!$this->canReadForm($this->getAPIVersion($request), $form_id)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $sections = self::getFormSectionsResults($this->getAPIVersion($request), ['filter' => "form.id=={$form_id}"]);
+        $section_ids = array_column($sections['results'], 'id');
+
+        $section_id = (int) $request->getAttribute('section_id');
+        if (!in_array($section_id, $section_ids, true)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $filter = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
+        $filter .= ';section.id==' . $section_id;
+        $request->setParameter('filter', $filter);
+
+        return $this->unsafeSearch($request, self::getFormQuestionsResults(...));
+    }
+
+    #[Route(path: '/{form_id}/Section/{section_id}/Question/{id}', methods: ['GET'], requirements: [
+        'form_id' => '\d+',
+        'section_id' => '\d+',
+        'id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\GetRoute(schema_name: 'FormQuestion')]
+    public function getFormSectionQuestion(Request $request): Response
+    {
+        $form_id = $request->getAttribute('form_id');
+        if (!$this->canReadForm($this->getAPIVersion($request), $form_id)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $sections = self::getFormSectionsResults($this->getAPIVersion($request), ['filter' => "form.id=={$form_id}"]);
+        $section_ids = array_column($sections['results'], 'id');
+
+        $section_id = (int) $request->getAttribute('section_id');
+        if (!in_array($section_id, $section_ids, true)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $filter = $request->hasParameter('filter') ? $request->getParameter('filter') : '';
+        $filter .= ';section.id==' . $section_id . ';id==' . $request->getAttribute('id');
+        $request->setParameter('filter', $filter);
+
+        return $this->unsafeGetOneResult($request, self::getFormQuestionsResults(...));
+    }
+
+    #[Route(path: '/{form_id}/Section/{section_id}/Question', methods: ['POST'], requirements: [
+        'form_id' => '\d+',
+        'section_id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\CreateRoute(schema_name: 'FormQuestion')]
+    public function createFormSectionQuestion(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+        $sections = self::getFormSectionsResults($this->getAPIVersion($request), ['filter' => "form.id=={$request->getAttribute('form_id')}"]);
+        $section_ids = array_column($sections['results'], 'id');
+        if (!in_array((int) $request->getAttribute('section_id'), $section_ids, true)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        $request->setParameter('section', $request->getAttribute('section_id'));
+        return ResourceAccessor::createBySchema(
+            schema: $this->getKnownSchema('FormQuestion', $this->getAPIVersion($request)),
+            request_params: $request->getParameters(),
+            get_route: [self::class, 'getFormSectionQuestion'],
+            extra_get_route_params: [
+                'mapped' => [
+                    'form_id' => $request->getAttribute('form_id'),
+                    'section_id' => $request->getAttribute('section_id'),
+                ],
+            ],
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section/{section_id}/Question/{id}', methods: ['PATCH'], requirements: [
+        'form_id' => '\d+',
+        'section_id' => '\d+',
+        'id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\UpdateRoute(schema_name: 'FormQuestion')]
+    public function updateFormSectionQuestion(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+        $sections = self::getFormSectionsResults($this->getAPIVersion($request), ['filter' => "form.id=={$request->getAttribute('form_id')}"]);
+        $section_ids = array_column($sections['results'], 'id');
+        if (!in_array((int) $request->getAttribute('section_id'), $section_ids, true)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        return ResourceAccessor::updateBySchema(
+            schema: $this->getKnownSchema('FormQuestion', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+
+    #[Route(path: '/{form_id}/Section/{section_id}/Question/{id}', methods: ['DELETE'], requirements: [
+        'form_id' => '\d+',
+        'section_id' => '\d+',
+        'id' => '\d+',
+    ], middlewares: [ResultFormatterMiddleware::class])]
+    #[RouteVersion(introduced: '2.4.0')]
+    #[Doc\DeleteRoute(schema_name: 'FormQuestion')]
+    public function deleteFormSectionQuestion(Request $request): Response
+    {
+        if (!$this->canReadForm($this->getAPIVersion($request), $request->getAttribute('form_id'))) {
+            return self::getNotFoundErrorResponse();
+        }
+        $sections = self::getFormSectionsResults($this->getAPIVersion($request), ['filter' => "form.id=={$request->getAttribute('form_id')}"]);
+        $section_ids = array_column($sections['results'], 'id');
+        if (!in_array((int) $request->getAttribute('section_id'), $section_ids, true)) {
+            return self::getNotFoundErrorResponse();
+        }
+
+        return ResourceAccessor::deleteBySchema(
+            schema: $this->getKnownSchema('FormQuestion', $this->getAPIVersion($request)),
+            request_attrs: $request->getAttributes(),
+            request_params: $request->getParameters()
+        );
+    }
+}

--- a/src/Glpi/Api/HL/Controller/FormController.php
+++ b/src/Glpi/Api/HL/Controller/FormController.php
@@ -60,6 +60,7 @@ use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 use GraphQL\Type\Definition\ResolveInfo;
+use Group;
 use Session;
 use stdClass;
 use Throwable;
@@ -134,6 +135,17 @@ final class FormController extends AbstractController
                                 QueryFunction::jsonOverlaps(
                                     doc1: QueryFunction::jsonExtract([FormAccessControl::getTable() . '.config', new QueryExpression($DB::quoteValue('$.group_ids'))]),
                                     doc2: new QueryExpression($DB::quoteValue(json_encode($groups)))
+                                ),
+                            ];
+                            // allowed because the allow list allows at least one of the ancestors of the user's groups
+                            $criteria['LEFT JOIN'][Group::getTable() . ' AS group_ancestors'] = [
+                                'ON' => new QueryExpression($DB::quoteName('group_ancestors.id') . ' IN (' . implode(',', $groups) . ')'),
+                            ];
+                            $criteria['WHERE']['OR'][] = [
+                                // check overlaps with ancestors_cache JSON-encoded column in the group_ancestors joined table
+                                QueryFunction::jsonOverlaps(
+                                    doc1: QueryFunction::jsonExtract([FormAccessControl::getTable() . '.config', new QueryExpression($DB::quoteValue('$.group_ids'))]),
+                                    doc2: QueryFunction::jsonExtract([$DB::quoteName('group_ancestors') . '.' . $DB::quoteName('ancestors_cache'), new QueryExpression($DB::quoteValue('$.*'))])
                                 ),
                             ];
                         }

--- a/src/Glpi/Api/HL/Controller/HelpdeskController.php
+++ b/src/Glpi/Api/HL/Controller/HelpdeskController.php
@@ -127,7 +127,7 @@ final class HelpdeskController extends AbstractController
                     'description' => ['type' => Doc\Schema::TYPE_STRING],
                     'illustration' => ['type' => Doc\Schema::TYPE_STRING],
                     'weight' => ['type' => Doc\Schema::TYPE_INTEGER],
-                    'form' => self::getDropdownTypeSchema(Form::class),
+                    'form' => self::getDropdownTypeSchema(class: Form::class, full_schema: 'Form'),
                 ],
             ],
             'HelpdeskTilesInfo' => [

--- a/src/Glpi/Api/HL/Controller/ServiceCatalogController.php
+++ b/src/Glpi/Api/HL/Controller/ServiceCatalogController.php
@@ -127,7 +127,7 @@ final class ServiceCatalogController extends AbstractController
                     'description' => ['type' => Doc\Schema::TYPE_STRING],
                     'illustration' => ['type' => Doc\Schema::TYPE_STRING],
                     'weight' => ['type' => Doc\Schema::TYPE_INTEGER],
-                    'form' => self::getDropdownTypeSchema(Form::class),
+                    'form' => self::getDropdownTypeSchema(class: Form::class, full_schema: 'Form'),
                 ],
             ],
             'ServiceCatalogInfo' => [

--- a/src/Glpi/Api/HL/GraphQL.php
+++ b/src/Glpi/Api/HL/GraphQL.php
@@ -77,6 +77,7 @@ final class GraphQL
             $schema = $schema_generator->getSchema();
             Profiler::getInstance()->stop('GraphQL::getSchema');
             $context = new stdClass();
+            $context->api_version = $api_version;
             $result = \GraphQL\GraphQL::executeQuery(
                 schema: $schema,
                 source: $query,

--- a/src/Glpi/Api/HL/GraphQL/SchemaGenerator.php
+++ b/src/Glpi/Api/HL/GraphQL/SchemaGenerator.php
@@ -65,6 +65,9 @@ final readonly class SchemaGenerator
             $component_schemas = Schemas::getInstance($this->api_version)->getAllSchemas();
             Profiler::getInstance()->stop('OpenAPI Component Schemas Retrieval');
             foreach ($component_schemas as $schema_name => $schema_info) {
+                if ($schema_info['x-graphql-no-query'] ?? false) {
+                    continue;
+                }
                 $has_custom_resolver = array_key_exists('x-graphql-resolver', $schema_info);
                 $should_have_query = (
                     !str_starts_with($schema_name, '_')
@@ -107,9 +110,6 @@ final readonly class SchemaGenerator
                     'type' => fn(): Type => Types::load($schema_name, $this->api_version),
                     'args' => $query_args,
                 ];
-                if (isset($schema_info['resolver'])) {
-                    $query_type_config['fields'][$schema_name]['resolve'] = ($schema_info['resolver'])(...);
-                }
             } else {
                 $query_type_config['fields'][$schema_name] = [
                     'type' => Type::listOf(fn(): Type => Types::load($schema_name, $this->api_version)),
@@ -122,6 +122,9 @@ final readonly class SchemaGenerator
                         'order' => ['type' => Type::string()],
                     ],
                 ];
+            }
+            if (isset($schema_info['resolver'])) {
+                $query_type_config['fields'][$schema_name]['resolve'] = ($schema_info['resolver'])(...);
             }
         }
         /** @phpstan-ignore-next-line */

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -240,12 +240,20 @@ final class ResourceAccessor
                     'maximum' => $prop['maximum'] ?? null,
                 ];
             }
-            if (isset($prop['pattern']) && is_string($value) && !preg_match('/' . $prop['pattern'] . '/', $value)) {
-                $errors[$key][] = [
-                    'error' => 'pattern',
-                    'message' => "This field must match the pattern {$prop['pattern']}",
-                    'pattern' => $prop['pattern'],
-                ];
+            if (isset($prop['pattern']) && is_string($value)) {
+                $pattern = $prop['pattern'];
+                // Try to determine if the pattern has delimiters (such as '/') already, and add them if they're missing
+                if (!str_starts_with($pattern, '/')) {
+                    $pattern = '/' . str_replace('/', '\/', $pattern) . '/';
+                }
+
+                if (!preg_match($pattern, $value)) {
+                    $errors[$key][] = [
+                        'error' => 'pattern',
+                        'message' => "This field must match the pattern {$prop['pattern']}",
+                        'pattern' => $prop['pattern'],
+                    ];
+                }
             }
         }
         return $errors;
@@ -371,6 +379,9 @@ final class ResourceAccessor
      */
     public static function searchBySchema(array $schema, array $request_params): Response
     {
+        /**
+         * /!\ If you change this method, check The FormController because it has slimmer copies of this method
+         */
         $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property
@@ -430,6 +441,9 @@ final class ResourceAccessor
      */
     public static function getOneBySchema(array $schema, array $request_attrs, array $request_params, string $field = 'id'): Response
     {
+        /**
+         * /!\ If you change this method, check The FormController because it has slimmer copies of this method
+         */
         $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -248,12 +248,20 @@ final class ResourceAccessor
                     'multipleOf' => $multiple_of,
                 ];
             }
-            if (isset($prop['pattern']) && is_string($value) && !preg_match('/' . $prop['pattern'] . '/', $value)) {
-                $errors[$key][] = [
-                    'error' => 'pattern',
-                    'message' => "This field must match the pattern {$prop['pattern']}",
-                    'pattern' => $prop['pattern'],
-                ];
+            if (isset($prop['pattern']) && is_string($value)) {
+                $pattern = $prop['pattern'];
+                // Try to determine if the pattern has delimiters (such as '/') already, and add them if they're missing
+                if (!str_starts_with($pattern, '/')) {
+                    $pattern = '/' . str_replace('/', '\/', $pattern) . '/';
+                }
+
+                if (!preg_match($pattern, $value)) {
+                    $errors[$key][] = [
+                        'error' => 'pattern',
+                        'message' => "This field must match the pattern {$prop['pattern']}",
+                        'pattern' => $prop['pattern'],
+                    ];
+                }
             }
         }
         return $errors;
@@ -431,6 +439,9 @@ final class ResourceAccessor
      */
     public static function searchBySchema(array $schema, array $request_params): Response
     {
+        /**
+         * /!\ If you change this method, check The FormController because it has slimmer copies of this method
+         */
         $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property
@@ -490,6 +501,9 @@ final class ResourceAccessor
      */
     public static function getOneBySchema(array $schema, array $request_attrs, array $request_params, string $field = 'id'): Response
     {
+        /**
+         * /!\ If you change this method, check The FormController because it has slimmer copies of this method
+         */
         $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -47,6 +47,7 @@ use Glpi\Api\HL\Controller\CRUDControllerTrait;
 use Glpi\Api\HL\Controller\CustomAssetController;
 use Glpi\Api\HL\Controller\DashboardController;
 use Glpi\Api\HL\Controller\DropdownController;
+use Glpi\Api\HL\Controller\FormController;
 use Glpi\Api\HL\Controller\GraphQLController;
 use Glpi\Api\HL\Controller\InventoryController;
 use Glpi\Api\HL\Controller\ITILController;
@@ -271,6 +272,7 @@ EOT;
             self::$instance->registerController(new NotificationController());
             self::$instance->registerController(new ServiceCatalogController());
             self::$instance->registerController(new KanbanController());
+            self::$instance->registerController(new FormController());
 
             // Register controllers from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_CONTROLLERS])) {

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -47,6 +47,7 @@ use Glpi\Api\HL\Controller\CRUDControllerTrait;
 use Glpi\Api\HL\Controller\CustomAssetController;
 use Glpi\Api\HL\Controller\DashboardController;
 use Glpi\Api\HL\Controller\DropdownController;
+use Glpi\Api\HL\Controller\FormController;
 use Glpi\Api\HL\Controller\GraphQLController;
 use Glpi\Api\HL\Controller\HelpdeskController;
 use Glpi\Api\HL\Controller\InventoryController;
@@ -271,6 +272,7 @@ EOT;
             self::$instance->registerController(new NotificationController());
             self::$instance->registerController(new HelpdeskController());
             self::$instance->registerController(new KanbanController());
+            self::$instance->registerController(new FormController());
 
             // Register controllers from plugins
             if (isset($PLUGIN_HOOKS[Hooks::API_CONTROLLERS])) {

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -653,6 +653,7 @@ final class Search
     /**
      * @param bool $count_only
      * @return RecordSet|int
+     * @phpstan-return ($count_only is true ? int : RecordSet)
      * @throws APIException
      * @throws RSQLException
      */
@@ -841,7 +842,7 @@ final class Search
      * @param array $schema
      * @param array $request_params
      * @return array The search results
-     * @phpstan-return array{results: array, start: int, limit: int, total: int}
+     * @phpstan-return array{results: list<array<string, mixed>>, start: int, limit: int, total: int}
      * @throws RSQLException|APIException
      */
     public static function getSearchResultsBySchema(array $schema, array $request_params): array
@@ -916,8 +917,8 @@ final class Search
 
         return [
             'results' => array_values($results),
-            'start' => $criteria['START'] ?? 0,
-            'limit' => $criteria['LIMIT'] ?? count($results),
+            'start' => (int) ($criteria['START'] ?? 0),
+            'limit' => (int) ($criteria['LIMIT'] ?? count($results)),
             'total' => $total,
         ];
     }

--- a/src/Glpi/DBAL/QueryFunction.php
+++ b/src/Glpi/DBAL/QueryFunction.php
@@ -518,4 +518,26 @@ class QueryFunction
             $alias
         );
     }
+
+    public static function jsonOverlaps(string|QueryExpression $doc1, string|QueryExpression $doc2, ?string $alias = null): QueryExpression
+    {
+        global $DB;
+
+        if (is_string($doc1)) {
+            $doc1 = new QueryExpression($DB::quoteName($doc1));
+        }
+
+        if (is_string($doc2)) {
+            $doc2 = new QueryExpression($DB::quoteName($doc2));
+        }
+
+        return self::getExpression(
+            'JSON_OVERLAPS',
+            [
+                $DB->getVersionAndServer()['server'] === 'MariaDB' ? $doc1 : self::cast($doc1, 'JSON'),
+                $DB->getVersionAndServer()['server'] === 'MariaDB' ? $doc2 : self::cast($doc2, 'JSON'),
+            ],
+            $alias
+        );
+    }
 }

--- a/src/Glpi/Form/AccessControl/ControlType/AllowList.php
+++ b/src/Glpi/Form/AccessControl/ControlType/AllowList.php
@@ -119,6 +119,7 @@ final class AllowList implements ControlTypeInterface
         JsonFieldInterface $config,
         FormAccessParameters $parameters
     ): AccessVote {
+        //NOTE: If you change the conditions here, update the HLAPI read restrictions too
         if (!$config instanceof AllowListConfig) {
             throw new InvalidArgumentException("Invalid config class");
         }

--- a/src/Glpi/Form/AccessControl/FormAccessControlManager.php
+++ b/src/Glpi/Form/AccessControl/FormAccessControlManager.php
@@ -254,6 +254,7 @@ final class FormAccessControlManager
      */
     protected function getPossibleAccessControlsStrategies(): array
     {
+        //NOTE: If you add new strategies, please update the HLAPI read resrictions as well
         $types = [
             new AllowList(),
             new DirectAccess(),

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -10792,8 +10792,8 @@
                 "render_layout": {
                     "type": "string",
                     "enum": [
-                        "step_by_step",
-                        "single_page"
+                        "single_page",
+                        "step_by_step"
                     ],
                     "default": "step_by_step"
                 },
@@ -10836,8 +10836,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -11060,8 +11060,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -11071,9 +11071,9 @@
                 "validation_strategy": {
                     "type": "string",
                     "enum": [
+                        "invalid_if",
                         "no_validation",
-                        "valid_if",
-                        "invalid_if"
+                        "valid_if"
                     ],
                     "default": "no_validation"
                 },
@@ -11128,8 +11128,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -11187,14 +11187,14 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
                             "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Form"
                 }
             }
         },

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -10739,6 +10739,420 @@
                 }
             }
         },
+        "Form": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Form",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "entity": {
+                    "type": "object",
+                    "x-itemtype": "Entity",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "readOnly": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Entity"
+                },
+                "is_recursive": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_deleted": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_draft": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_pinned": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "render_layout": {
+                    "type": "string",
+                    "enum": [
+                        "step_by_step",
+                        "single_page"
+                    ],
+                    "default": "step_by_step"
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "form_description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "service_catalog_description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "illustration": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Category",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormCategory"
+                },
+                "usage_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "submit_button_visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "submit_button_conditions": {
+                    "type": "string"
+                },
+                "date_creation": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "date_mod": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "access_controls": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-full-schema": "FormAccessControl",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            },
+                            "strategy": {
+                                "type": "string",
+                                "enum": [
+                                    "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                                    "Glpi\\Form\\AccessControl\\ControlType\\DirectAccess"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-itemtype": "Glpi\\Form\\Section",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            }
+                        },
+                        "x-full-schema": "FormSection"
+                    }
+                }
+            }
+        },
+        "FormAccessControl": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\AccessControl\\FormAccessControl",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "form": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Form",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Form"
+                },
+                "strategy": {
+                    "type": "string",
+                    "enum": [
+                        "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                        "Glpi\\Form\\AccessControl\\ControlType\\DirectAccess"
+                    ]
+                },
+                "config": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "FormCategory": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Category",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "completename": {
+                    "type": "string",
+                    "readOnly": true
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "illustration": {
+                    "type": "string"
+                },
+                "parent": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Category",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormCategory"
+                },
+                "level": {
+                    "type": "integer",
+                    "readOnly": true
+                },
+                "comment": {
+                    "type": "string"
+                }
+            }
+        },
+        "FormQuestion": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Question",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "section": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Section",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormSection"
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "default": ""
+                },
+                "type": {
+                    "type": "string",
+                    "enum": {
+                        "2": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                        "4": "Glpi\\Form\\QuestionType\\QuestionTypeRequester",
+                        "8": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                        "0": "Glpi\\Form\\QuestionType\\QuestionTypeRequestType",
+                        "1": "Glpi\\Form\\QuestionType\\QuestionTypeFile",
+                        "5": "Glpi\\Form\\QuestionType\\QuestionTypeEmail",
+                        "6": "Glpi\\Form\\QuestionType\\QuestionTypeUserDevice",
+                        "7": "Glpi\\Form\\QuestionType\\QuestionTypeDropdown",
+                        "9": "Glpi\\Form\\QuestionType\\QuestionTypeObserver",
+                        "10": "Glpi\\Form\\QuestionType\\QuestionTypeLongText",
+                        "12": "Glpi\\Form\\QuestionType\\QuestionTypeCheckbox",
+                        "13": "Glpi\\Form\\QuestionType\\QuestionTypeDateTime",
+                        "14": "Glpi\\Form\\QuestionType\\QuestionTypeUrgency",
+                        "15": "Glpi\\Form\\QuestionType\\QuestionTypeRadio",
+                        "3": "Glpi\\Form\\QuestionType\\QuestionTypeNumber",
+                        "11": "Glpi\\Form\\QuestionType\\QuestionTypeItemDropdown",
+                        "16": "Glpi\\Form\\QuestionType\\QuestionTypeAssignee"
+                    }
+                },
+                "is_mandatory": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "vertical_rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "horizontal_rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "default_value": {
+                    "type": "string"
+                },
+                "extra_data": {
+                    "type": "string"
+                },
+                "visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "visibility_conditions": {
+                    "type": "string"
+                },
+                "validation_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "no_validation",
+                        "valid_if",
+                        "invalid_if"
+                    ],
+                    "default": "no_validation"
+                },
+                "validation_conditions": {
+                    "type": "string"
+                }
+            }
+        },
+        "FormSection": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Section",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "form": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Form",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Form"
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "default": ""
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "conditions": {
+                    "type": "string"
+                },
+                "questions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-itemtype": "Glpi\\Form\\Question",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            }
+                        },
+                        "x-full-schema": "FormQuestion"
+                    }
+                }
+            }
+        },
         "FormTile": {
             "type": "object",
             "x-itemtype": "Glpi\\Helpdesk\\Tile\\FormTile",

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -8895,6 +8895,420 @@
                 }
             }
         },
+        "Form": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Form",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "entity": {
+                    "type": "object",
+                    "x-itemtype": "Entity",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64",
+                            "readOnly": true
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Entity"
+                },
+                "is_recursive": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_deleted": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_draft": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "is_pinned": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "render_layout": {
+                    "type": "string",
+                    "enum": [
+                        "step_by_step",
+                        "single_page"
+                    ],
+                    "default": "step_by_step"
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "form_description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "service_catalog_description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "illustration": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Category",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormCategory"
+                },
+                "usage_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "submit_button_visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "submit_button_conditions": {
+                    "type": "string"
+                },
+                "date_creation": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "date_mod": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "access_controls": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-full-schema": "FormAccessControl",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            },
+                            "strategy": {
+                                "type": "string",
+                                "enum": [
+                                    "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                                    "Glpi\\Form\\AccessControl\\ControlType\\DirectAccess"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "sections": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-itemtype": "Glpi\\Form\\Section",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            }
+                        },
+                        "x-full-schema": "FormSection"
+                    }
+                }
+            }
+        },
+        "FormAccessControl": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\AccessControl\\FormAccessControl",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "form": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Form",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Form"
+                },
+                "strategy": {
+                    "type": "string",
+                    "enum": [
+                        "Glpi\\Form\\AccessControl\\ControlType\\AllowList",
+                        "Glpi\\Form\\AccessControl\\ControlType\\DirectAccess"
+                    ]
+                },
+                "config": {
+                    "type": "string"
+                },
+                "is_active": {
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "FormCategory": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Category",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255
+                },
+                "completename": {
+                    "type": "string",
+                    "readOnly": true
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "illustration": {
+                    "type": "string"
+                },
+                "parent": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Category",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormCategory"
+                },
+                "level": {
+                    "type": "integer",
+                    "readOnly": true
+                },
+                "comment": {
+                    "type": "string"
+                }
+            }
+        },
+        "FormQuestion": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Question",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "section": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Section",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "FormSection"
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "default": ""
+                },
+                "type": {
+                    "type": "string",
+                    "enum": {
+                        "2": "Glpi\\Form\\QuestionType\\QuestionTypeItem",
+                        "4": "Glpi\\Form\\QuestionType\\QuestionTypeRequester",
+                        "8": "Glpi\\Form\\QuestionType\\QuestionTypeShortText",
+                        "0": "Glpi\\Form\\QuestionType\\QuestionTypeRequestType",
+                        "1": "Glpi\\Form\\QuestionType\\QuestionTypeFile",
+                        "5": "Glpi\\Form\\QuestionType\\QuestionTypeEmail",
+                        "6": "Glpi\\Form\\QuestionType\\QuestionTypeUserDevice",
+                        "7": "Glpi\\Form\\QuestionType\\QuestionTypeDropdown",
+                        "9": "Glpi\\Form\\QuestionType\\QuestionTypeObserver",
+                        "10": "Glpi\\Form\\QuestionType\\QuestionTypeLongText",
+                        "12": "Glpi\\Form\\QuestionType\\QuestionTypeCheckbox",
+                        "13": "Glpi\\Form\\QuestionType\\QuestionTypeDateTime",
+                        "14": "Glpi\\Form\\QuestionType\\QuestionTypeUrgency",
+                        "15": "Glpi\\Form\\QuestionType\\QuestionTypeRadio",
+                        "3": "Glpi\\Form\\QuestionType\\QuestionTypeNumber",
+                        "11": "Glpi\\Form\\QuestionType\\QuestionTypeItemDropdown",
+                        "16": "Glpi\\Form\\QuestionType\\QuestionTypeAssignee"
+                    }
+                },
+                "is_mandatory": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "vertical_rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "horizontal_rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "default_value": {
+                    "type": "string"
+                },
+                "extra_data": {
+                    "type": "string"
+                },
+                "visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "visibility_conditions": {
+                    "type": "string"
+                },
+                "validation_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "no_validation",
+                        "valid_if",
+                        "invalid_if"
+                    ],
+                    "default": "no_validation"
+                },
+                "validation_conditions": {
+                    "type": "string"
+                }
+            }
+        },
+        "FormSection": {
+            "type": "object",
+            "x-itemtype": "Glpi\\Form\\Section",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "readOnly": true
+                },
+                "form": {
+                    "type": "object",
+                    "x-itemtype": "Glpi\\Form\\Form",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "name": {
+                            "type": "string",
+                            "readOnly": true
+                        }
+                    },
+                    "x-full-schema": "Form"
+                },
+                "uuid": {
+                    "type": "string",
+                    "pattern": "/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i",
+                    "readOnly": true
+                },
+                "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "default": ""
+                },
+                "description": {
+                    "type": "string",
+                    "format": "html"
+                },
+                "rank": {
+                    "type": "integer",
+                    "default": 0
+                },
+                "visibility_strategy": {
+                    "type": "string",
+                    "enum": [
+                        "always_visible",
+                        "visible_if",
+                        "hidden_if"
+                    ],
+                    "default": "always_visible"
+                },
+                "conditions": {
+                    "type": "string"
+                },
+                "questions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-itemtype": "Glpi\\Form\\Question",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64",
+                                "readOnly": true
+                            }
+                        },
+                        "x-full-schema": "FormQuestion"
+                    }
+                }
+            }
+        },
         "FormTile": {
             "type": "object",
             "x-itemtype": "Glpi\\Helpdesk\\Tile\\FormTile",

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -8948,8 +8948,8 @@
                 "render_layout": {
                     "type": "string",
                     "enum": [
-                        "step_by_step",
-                        "single_page"
+                        "single_page",
+                        "step_by_step"
                     ],
                     "default": "step_by_step"
                 },
@@ -8992,8 +8992,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -9216,8 +9216,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -9227,9 +9227,9 @@
                 "validation_strategy": {
                     "type": "string",
                     "enum": [
+                        "invalid_if",
                         "no_validation",
-                        "valid_if",
-                        "invalid_if"
+                        "valid_if"
                     ],
                     "default": "no_validation"
                 },
@@ -9284,8 +9284,8 @@
                     "type": "string",
                     "enum": [
                         "always_visible",
-                        "visible_if",
-                        "hidden_if"
+                        "hidden_if",
+                        "visible_if"
                     ],
                     "default": "always_visible"
                 },
@@ -9343,14 +9343,14 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
                             "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Form"
                 }
             }
         },

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -118798,5 +118798,776 @@
                 }
             ]
         }
+    },
+    "/Form/": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Form"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Form"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                },
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormSection"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormSection"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{section_id}/Question": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                },
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormQuestion"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{section_id}/Question/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormQuestion"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
     }
 }

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -122010,6 +122010,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "id",
                     "description": "",
                     "in": "path",
@@ -122041,6 +122047,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "id",
                     "description": "",
@@ -122234,6 +122246,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "form_id",
                     "description": "",
                     "in": "path",
@@ -122275,6 +122293,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "form_id",
                     "description": "",
@@ -122508,6 +122532,12 @@
             },
             "parameters": [
                 {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
+                {
                     "name": "form_id",
                     "description": "",
                     "in": "path",
@@ -122569,6 +122599,12 @@
                 }
             },
             "parameters": [
+                {
+                    "$ref": "#/components/parameters/If-Modified-Since"
+                },
+                {
+                    "$ref": "#/components/parameters/If-Unmodified-Since"
+                },
                 {
                     "name": "form_id",
                     "description": "",

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -121888,5 +121888,776 @@
                 }
             ]
         }
+    },
+    "/Form/": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Form"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Form"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Form"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Form"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormSection"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                },
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormSection"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormSection"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormSection"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{section_id}/Question": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/FormQuestion"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/filter"
+                },
+                {
+                    "$ref": "#/components/parameters/start"
+                },
+                {
+                    "$ref": "#/components/parameters/limit"
+                },
+                {
+                    "$ref": "#/components/parameters/sort"
+                },
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "post": {
+            "responses": {
+                "201": {
+                    "headers": [],
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "readOnly": true
+                                    },
+                                    "href": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormQuestion"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
+    },
+    "/Form/{form_id}/Section/{section_id}/Question/{id}": {
+        "get": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "patch": {
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "text/csv": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        },
+                        "application/xml": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FormQuestion"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/FormQuestion"
+                        }
+                    }
+                }
+            },
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        },
+        "delete": {
+            "responses": [],
+            "parameters": [
+                {
+                    "name": "form_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "section_id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                },
+                {
+                    "name": "id",
+                    "description": "",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "pattern": "\\d+"
+                    }
+                }
+            ],
+            "security": [
+                {
+                    "oauth": [
+                        "api"
+                    ]
+                }
+            ]
+        }
     }
 }

--- a/tests/functional/Glpi/Api/HL/Controller/FormControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/FormControllerTest.php
@@ -1,0 +1,401 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Api\HL\Controller;
+
+use Glpi\Form\AccessControl\ControlType\AllowList;
+use Glpi\Form\AccessControl\FormAccessControl;
+use Glpi\Form\Form;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Section;
+use Glpi\Http\Request;
+use Glpi\Tests\HLAPITestCase;
+use Ramsey\Uuid\Rfc4122\UuidV4;
+
+class FormControllerTest extends HLAPITestCase
+{
+    public function testCRUDForm()
+    {
+        $this->api->autoTestCRUD('/Form');
+    }
+
+    private function createSuperAdminOnlyForm(): int
+    {
+        global $DB;
+
+        $DB->insert(Form::getTable(), [
+            'uuid' => UuidV4::uuid4()->toString(),
+            'name' => 'Super-admin only',
+            'is_active' => 1,
+            'entities_id' => $this->getTestRootEntity(true),
+            'render_layout' => 'step_by_step',
+            'submit_button_visibility_strategy' => 'always_visible',
+            'submit_button_conditions' => '[]',
+        ]);
+        $form_id = $DB->insertId();
+        $section_uuid = UuidV4::uuid4()->toString();
+        $DB->insert(Section::getTable(), [
+            'uuid' => $section_uuid,
+            'forms_forms_id' => $form_id,
+            'name' => 'Section 1',
+            'conditions' => '[]',
+        ]);
+        $section_id = $DB->insertId();
+        $DB->insert(Question::getTable(), [
+            'uuid' => UuidV4::uuid4()->toString(),
+            'forms_sections_id' => $section_id,
+            'forms_sections_uuid' => $section_uuid,
+            'name' => 'Question 1',
+            'type' => QuestionTypeShortText::class,
+            'visibility_strategy' => 'always_visible',
+            'conditions' => '[]',
+            'validation_strategy' => 'no_validation',
+            'validation_conditions' => '[]',
+        ]);
+        $DB->insert(FormAccessControl::getTable(), [
+            'forms_forms_id' => $form_id,
+            'strategy' => AllowList::class,
+            'config' => '{"user_ids":[],"group_ids":[],"profile_ids":[4]}',
+            'is_active' => 1,
+        ]);
+
+        return $form_id;
+    }
+
+    private function createEveryoneForm(): int
+    {
+        global $DB;
+
+        $DB->insert(Form::getTable(), [
+            'uuid' => UuidV4::uuid4()->toString(),
+            'name' => 'Everyone can view',
+            'is_active' => 1,
+            'entities_id' => $this->getTestRootEntity(true),
+            'render_layout' => 'step_by_step',
+            'submit_button_visibility_strategy' => 'always_visible',
+            'submit_button_conditions' => '[]',
+        ]);
+        $form_id = $DB->insertId();
+        $section_uuid = UuidV4::uuid4()->toString();
+        $DB->insert(Section::getTable(), [
+            'uuid' => $section_uuid,
+            'forms_forms_id' => $form_id,
+            'name' => 'Section 1',
+            'conditions' => '[]',
+        ]);
+        $section_id = $DB->insertId();
+        $DB->insert(Question::getTable(), [
+            'uuid' => UuidV4::uuid4()->toString(),
+            'forms_sections_id' => $section_id,
+            'forms_sections_uuid' => $section_uuid,
+            'name' => 'Question 1',
+            'type' => QuestionTypeShortText::class,
+            'visibility_strategy' => 'always_visible',
+            'conditions' => '[]',
+            'validation_strategy' => 'no_validation',
+            'validation_conditions' => '[]',
+        ]);
+        $DB->insert(FormAccessControl::getTable(), [
+            'forms_forms_id' => $form_id,
+            'strategy' => AllowList::class,
+            'config' => '{"user_ids":["all"],"group_ids":[],"profile_ids":[]}',
+            'is_active' => 1,
+        ]);
+
+        return $form_id;
+    }
+
+    public function testCRUDFormNoRights()
+    {
+        $super_admin_form_id = $this->createSuperAdminOnlyForm();
+        $everyone_form_id = $this->createEveryoneForm();
+
+        $this->login('post-only', 'postonly');
+
+        $this->api->call(new Request('GET', '/Form'), function ($call) use ($everyone_form_id, $super_admin_form_id) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) use ($everyone_form_id, $super_admin_form_id) {
+                    $form_ids = array_column($content, 'id');
+                    $this->assertContains($everyone_form_id, $form_ids);
+                    $this->assertNotContains($super_admin_form_id, $form_ids);
+                });
+        });
+
+        $this->api->call(new Request('GET', "/Form/{$super_admin_form_id}"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('GET', "/Form/{$everyone_form_id}"), function ($call) {
+            $call->response->isOK();
+        });
+
+        // Cannot update or delete any form
+        $this->api->call(new Request('PATCH', "/Form/{$super_admin_form_id}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('PATCH', "/Form/{$everyone_form_id}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$super_admin_form_id}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$everyone_form_id}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+
+        // Cannot create new form
+        $create_request = new Request('POST', '/Form');
+        $create_request->setParameter('uuid', UuidV4::uuid4()->toString());
+        $create_request->setParameter('name', 'Forbidden');
+        $create_request->setParameter('is_active', 1);
+        $create_request->setParameter('entities_id', $this->getTestRootEntity(true));
+        $create_request->setParameter('render_layout', 'step_by_step');
+        $create_request->setParameter('submit_button_visibility_strategy', 'always_visible');
+        $create_request->setParameter('submit_button_conditions', '[]');
+        $this->api->call($create_request, function ($call) {
+            $call->response->isAccessDenied();
+        });
+    }
+
+    public function testCRUDFormSection()
+    {
+        $everyone_form_id = $this->createEveryoneForm();
+        $this->api->autoTestCRUD(
+            endpoint: "/Form/{$everyone_form_id}/Section",
+            create_params: ['name' => 'New section'],
+            update_params: ['name' => 'Updated section name']
+        );
+    }
+
+    public function testCRUDFormSectionNoRights()
+    {
+        $super_admin_form_id = $this->createSuperAdminOnlyForm();
+        $everyone_form_id = $this->createEveryoneForm();
+
+        $this->login('post-only', 'postonly');
+
+        $this->api->call(new Request('GET', "/Form/{$super_admin_form_id}/Section"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('GET', "/Form/{$everyone_form_id}/Section"), function ($call) {
+            $call->response->isOK();
+        });
+
+        $super_admin_form_section = array_column(getAllDataFromTable(Section::getTable(), ['forms_forms_id' => $super_admin_form_id]), 'id');
+        $everyone_form_section = array_column(getAllDataFromTable(Section::getTable(), ['forms_forms_id' => $everyone_form_id]), 'id');
+        $super_admin_form_section = reset($super_admin_form_section);
+        $everyone_form_section = reset($everyone_form_section);
+
+        // Cannot create, update or delete any section in any form
+        $this->api->call(new Request('POST', "/Form/{$super_admin_form_id}/Section"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('POST', "/Form/{$everyone_form_id}/Section"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('PATCH', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('PATCH', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+    }
+
+    public function testCRUDFormQuestion()
+    {
+        $everyone_form_id = $this->createEveryoneForm();
+        $everyone_form_section = array_column(getAllDataFromTable(Section::getTable(), ['forms_forms_id' => $everyone_form_id]), 'id');
+        $everyone_form_section = reset($everyone_form_section);
+
+        $this->api->autoTestCRUD(
+            endpoint: "/Form/{$everyone_form_id}/Section/{$everyone_form_section}/Question",
+            create_params: [
+                'name' => 'New question',
+                'type' => QuestionTypeShortText::class,
+                'visibility_strategy' => 'always_visible',
+                'visibility_conditions' => '[]',
+                'validation_strategy' => 'no_validation',
+                'validation_conditions' => '[]',
+            ],
+            update_params: ['name' => 'Updated question name']
+        );
+    }
+
+    public function testCRUDFormQuestionNoRights()
+    {
+        $super_admin_form_id = $this->createSuperAdminOnlyForm();
+        $everyone_form_id = $this->createEveryoneForm();
+
+        $super_admin_form_section = array_column(getAllDataFromTable(Section::getTable(), ['forms_forms_id' => $super_admin_form_id]), 'id');
+        $everyone_form_section = array_column(getAllDataFromTable(Section::getTable(), ['forms_forms_id' => $everyone_form_id]), 'id');
+        $super_admin_form_section = reset($super_admin_form_section);
+        $everyone_form_section = reset($everyone_form_section);
+
+        $this->login('post-only', 'postonly');
+
+        $this->api->call(new Request('GET', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}/Question"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('GET', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}/Question"), function ($call) {
+            $call->response->isOK();
+        });
+
+        $super_admin_form_question = array_column(getAllDataFromTable(Question::getTable(), ['forms_sections_id' => $super_admin_form_section]), 'id');
+        $everyone_form_question = array_column(getAllDataFromTable(Question::getTable(), ['forms_sections_id' => $everyone_form_section]), 'id');
+        $super_admin_form_question = reset($super_admin_form_question);
+        $everyone_form_question = reset($everyone_form_question);
+
+        // Cannot create, update or delete any question in any form
+        $this->api->call(new Request('POST', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}/Question"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('POST', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}/Question"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('PATCH', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}/Question/{$super_admin_form_question}"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('PATCH', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}/Question/{$everyone_form_question}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$super_admin_form_id}/Section/{$super_admin_form_section}/Question/{$super_admin_form_question}"), function ($call) {
+            $call->response->isNotFoundError();
+        });
+        $this->api->call(new Request('DELETE', "/Form/{$everyone_form_id}/Section/{$everyone_form_section}/Question/{$everyone_form_question}"), function ($call) {
+            $call->response->isAccessDenied();
+        });
+    }
+
+    public function testGraphQL()
+    {
+        $graphql = <<<GRAPHQL
+            query {
+                Form {
+                    id name form_description illustration is_recursive is_active is_deleted is_pinned is_draft
+				    category { id name }
+				    entity { id name }
+				    sections { id name questions { id name type } }
+                }
+            }
+GRAPHQL;
+        $request = new Request('POST', '/graphql', [], $graphql);
+        $everyone_form_id = $this->createEveryoneForm();
+        $super_admin_form_id = $this->createSuperAdminOnlyForm();
+
+        $this->login();
+        $this->api->call($request, function ($call) use ($everyone_form_id, $super_admin_form_id) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) use ($everyone_form_id, $super_admin_form_id) {
+                    $this->assertArrayHasKey('data', $content);
+                    $this->assertArrayHasKey('Form', $content['data']);
+
+                    $forms_ids = array_column($content['data']['Form'], 'id');
+                    $this->assertContains($everyone_form_id, $forms_ids);
+                    $this->assertContains($super_admin_form_id, $forms_ids);
+
+                    // Ensure each form has at least one section and each section has at least one question to identify join issues
+                    foreach ($content['data']['Form'] as $form) {
+                        $this->assertNotEmpty($form['sections']);
+                        foreach ($form['sections'] as $section) {
+                            $this->assertNotEmpty($section['questions']);
+                        }
+                    }
+                });
+        });
+    }
+
+    public function testGraphQLNoRight()
+    {
+        $graphql = <<<GRAPHQL
+            query {
+                Form {
+                    id name form_description illustration is_recursive is_active is_deleted is_pinned is_draft
+				    category { id name }
+				    entity { id name }
+				    sections { id name questions { id name type } }
+                }
+            }
+GRAPHQL;
+        $request = new Request('POST', '/graphql', [], $graphql);
+        $everyone_form_id = $this->createEveryoneForm();
+        $super_admin_form_id = $this->createSuperAdminOnlyForm();
+
+        $this->login('post-only', 'postonly');
+        $this->api->call($request, function ($call) use ($everyone_form_id, $super_admin_form_id) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) use ($everyone_form_id, $super_admin_form_id) {
+                    $this->assertArrayHasKey('data', $content);
+                    $this->assertArrayHasKey('Form', $content['data']);
+
+                    $this->assertContains($everyone_form_id, array_column($content['data']['Form'], 'id'));
+                    $this->assertNotContains($super_admin_form_id, array_column($content['data']['Form'], 'id'));
+
+                    // Ensure each form has at least one section and each section has at least one question to identify join issues
+                    foreach ($content['data']['Form'] as $form) {
+                        $this->assertNotEmpty($form['sections']);
+                        foreach ($form['sections'] as $section) {
+                            $this->assertNotEmpty($section['questions']);
+                        }
+                    }
+                });
+        });
+    }
+
+    public function testNoDirectGraphQLQueryOnChildSchemas()
+    {
+        $child_schemas = ['FormSection', 'FormQuestion', 'FormAccessControl'];
+        $this->login();
+        foreach ($child_schemas as $child) {
+            $graphql = "query { $child { id } }";
+            $request = new Request('POST', '/graphql', [], $graphql);
+            $this->api->call($request, function ($call) use ($child) {
+                $call->response
+                    ->isOK()
+                    ->jsonContent(function ($content) use ($child) {
+                        $this->assertArrayHasKey('errors', $content);
+                        $this->assertStringContainsString("Cannot query field \"$child\" on type \"Query\"", $content['errors'][0]['message']);
+                    });
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

HLAPI v2.4. Adds schema/endpoints for the main Form itemtype along with sections, questions, access controls and categories.

Implementation required duplicating the existing standard `ResourceAccessor` methods to bypass the standard GLPI checks since Forms doesn't fully adhere to the GLPI permissions system, at least on the READ side, and thus the read permission checks for these items in the API rely entirely on SQL restrictions which had to be reverse-engineered from the access control logic which loaded entire items individually from the DB to check access. Currently, only the AllowList is checked.

Implementation also required custom GraphQL resolvers.

Side-effect changes:
- Added `JSON_OVERLAPS` SQL function support to the `QueryFunction` DBAL helper.
- Fix pattern matching validation of API input parameters when the pattern already contained delimiters.
- Add the API version being used to the GraphQL context for use in custom resolvers.