### PR TITLE
fix(kb): Pass `used` array to restrict visible items in Knowledge Base item link dropdown

### DIFF
--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -123,8 +123,8 @@ class KnowbaseItem_Item extends CommonDBRelation
             if ($item::class !== KnowbaseItem::class) {
                 $visibility = KnowbaseItem::getVisibilityCriteria();
                 $condition = (isset($visibility['WHERE']) && count($visibility['WHERE'])) ? $visibility['WHERE'] : [];
-                $used_knowbase_items = self::getItems($item, 0, 0, true);
             }
+            $used_knowbase_items = self::getItems($item, 0, 0, true);
             TemplateRenderer::getInstance()->display('pages/tools/kb/knowbaseitem_item.html.twig', [
                 'item' => $item,
                 'visibility_condition' => $condition ?? [],
@@ -191,11 +191,12 @@ class KnowbaseItem_Item extends CommonDBRelation
      *
      * @param CommonDBTM $item Item instance
      * @param string     $name Field name
+     * @param array<class-string<CommonDBTM>, array<int, int>> $used Already used items
      *
      * @return string
      * @used-by 'templates/tools/kb/knowbaseitem_item.html.twig'
      */
-    public static function dropdownAllTypes(CommonDBTM $item, $name)
+    public static function dropdownAllTypes(CommonDBTM $item, $name, $used = [])
     {
         global $CFG_GLPI;
 
@@ -209,6 +210,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             'itemtypes'       => $CFG_GLPI['kb_types'],
             'onlyglobal'      => $onlyglobal,
             'checkright'      => $checkright,
+            'used'            => $used,
         ]);
     }
 
@@ -263,8 +265,11 @@ class KnowbaseItem_Item extends CommonDBRelation
             if ($used === false) {
                 $linked_items[] = $data;
             } else {
-                $key = $item::class === KnowbaseItem::class ? 'items_id' : 'knowbaseitems_id';
-                $linked_items[$data[$key]] = $data[$key];
+                if ($item::class === KnowbaseItem::class) {
+                    $linked_items[$data['itemtype']][$data['items_id']] = $data['items_id'];
+                } else {
+                    $linked_items[$data['knowbaseitems_id']] = $data['knowbaseitems_id'];
+                }
             }
         }
         return $linked_items;

--- a/templates/pages/tools/kb/knowbaseitem_item.html.twig
+++ b/templates/pages/tools/kb/knowbaseitem_item.html.twig
@@ -42,10 +42,9 @@
     {% endif %}
     <div class="row align-items-center mb-2 ms-3">
         {% if get_class(item) == 'KnowbaseItem' %}
-            {# TODO pass used array to restrict visible items in list #}
             <label class="col-auto col-form-label">{{ __('Add a linked item') }}</label>
             <div class="col-12 col-sm-8 col-md-3 mb-2 mb-md-0">
-                {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id']) %}
+                {% do call('KnowbaseItem_Item::dropdownAllTypes', [item, 'items_id', used_knowbase_items]) %}
             </div>
         {% else %}
             <div class="col-12 col-sm-8 col-md-3 mb-2 mb-md-0">


### PR DESCRIPTION
Pass the already-used knowbase items into the dropdown renderer and adjust how linked items are aggregated.

- Add fallback to set $used_knowbase_items in KnowbaseItem_Item controller.
- Extend dropdownAllTypes signature to accept an array $used and pass it into the template context.
- Change linked items collection to group by itemtype for KnowbaseItem links (preserve flat keys for non-KnowbaseItem cases).
- Update the knowbaseitem_item Twig template to pass used_knowbase_items into KnowbaseItem_Item::dropdownAllTypes, enabling the dropdown to restrict visible items.

These changes implement the TODO to restrict visible items in the add-linked-item dropdown and ensure linked items are keyed appropriately by item type.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This PR addresses a `TODO` in `knowbaseitem_item.html.twig` by correctly passing the array of already associated items to the dropdown so that they are restricted (hidden) from the list of available items to add.

**Changes made:**

**`src/KnowbaseItem_Item.php`**: 
- Updated `getItems()` to return a correctly nested 2D array (`['itemtype' => ['items_id' => 'items_id']]`) when retrieving used items for a `KnowbaseItem`. Previously, it was replacing data with the same ID but different item types because it ignored `itemtype`.

```php
// Old Code
$linked_items[$data['items_id']] = $data['items_id'];

// New Code
$linked_items[$data['itemtype']][$data['items_id']] = $data['items_id'];

// Output
[
    'Ticket' => [
        1 => 1
    ],
    'Computer' => [
        1 => 1
    ]
]
```

  - Updated `showForItem()` to ensure it properly populates and passes the `used_knowbase_items` variable down to the template when the item is a `KnowbaseItem`.
  - Added the `$used` array argument to the `dropdownAllTypes()` method signature to pass it into `Dropdown::showSelectItemFromItemtypes()`.
- **`templates/pages/tools/kb/knowbaseitem_item.html.twig`**: 
  - Removed the `TODO` comment.
  - Passed `used_knowbase_items` as the third argument to the `KnowbaseItem_Item::dropdownAllTypes` call.

**How to test:**
1. Navigate to a Knowledge Base item.
2. Go to the **Associated elements** tab.
3. Link an item (e.g., a Computer or Ticket) to the KB article.
4. Open the dropdown to add another item.
5. Ensure the item you just linked no longer appears in the dropdown list.

## Screenshots (if appropriate):

<img width="809" height="276" alt="image" src="https://github.com/user-attachments/assets/c22f73d3-619e-49b2-a4d7-81ca94117a46" />
