### PR TITLE
bug: Fix port assignment logic for pop ssl type toolbox

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -1838,9 +1838,9 @@ class Toolbox
         if ($forceport && empty($tab['port'])) {
             if ($tab['type'] == 'pop') {
                 if ($tab['ssl']) {
-                    $tab['port'] = 110;
-                } else {
                     $tab['port'] = 995;
+                } else {
+                    $tab['port'] = 110;
                 }
             }
             if ($tab['type'] == 'imap') {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Fix inverted POP3 SSL default port in Toolbox::parseMailServerConnectString()

Current behavior:
- SSL enabled  -> 110
- SSL disabled -> 995

Expected behavior:
- SSL enabled  -> 995
- SSL disabled -> 110

## Screenshots (if appropriate):


