### PR TITLE
fix(kb): Fix tabs pluralization, button icons, and tooltips

### DIFF
--- a/src/KnowbaseItem_Comment.php
+++ b/src/KnowbaseItem_Comment.php
@@ -141,7 +141,7 @@ class KnowbaseItem_Comment extends CommonDBTM
                 $where
             );
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb, $item::getType());
+        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::getType());
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -68,7 +68,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             }
 
             if ($item::class === KnowbaseItem::class) {
-                $type_name = _n('Associated element', 'Associated elements', $nb);
+                $type_name = _n('Associated element', 'Associated elements', Session::getPluralNumber());
             } else {
                 $type_name = __('Knowledge base');
             }

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -299,7 +299,7 @@ class KnowbaseItem_Item extends CommonDBRelation
 
     public static function getIcon()
     {
-        return KnowbaseItem::getIcon();
+        return 'ti ti-link';
     }
 
     public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])

--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -236,7 +236,10 @@ class KnowbaseItem_Revision extends CommonDBTM
             'filtered_number' => $number,
             'showmassiveactions' => false,
         ]);
-        echo "<button class='btn btn-sm btn-secondary compare' data-kbitem_id='{$kb_item_id}'>" . _sx('button', 'Compare selected revisions') . "</button>";
+        echo "<button class='btn btn-sm btn-secondary compare' data-kbitem_id='{$kb_item_id}'>
+            <i class='ti ti-git-compare'></i>
+            <span>" . _sx('button', 'Compare selected revisions') . "</span>
+        </button>";
     }
 
     /**

--- a/src/KnowbaseItem_Revision.php
+++ b/src/KnowbaseItem_Revision.php
@@ -83,7 +83,7 @@ class KnowbaseItem_Revision extends CommonDBTM
                 $where
             );
         }
-        return self::createTabEntry(self::getTypeName($nb), $nb, $item::class);
+        return self::createTabEntry(self::getTypeName(Session::getPluralNumber()), $nb, $item::class);
     }
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -162,7 +162,7 @@
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
-                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip" role="img" aria-label="{{ comment }}"></i>
+                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip" role="img"></i>
                </span>
             </label>
          </span>

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -162,7 +162,7 @@
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
-                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip"></i>
+                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip" role="img" aria-label="{{ comment }}"></i>
                </span>
             </label>
          </span>

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -162,7 +162,7 @@
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
-                  <i class="ti ti-info-circle ms-1" title="{{ comment }}"></i>
+                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip"></i>
                </span>
             </label>
          </span>

--- a/tests/functional/KnowbaseItem_RevisionTest.php
+++ b/tests/functional/KnowbaseItem_RevisionTest.php
@@ -178,7 +178,7 @@ class KnowbaseItem_RevisionTest extends DbTestCase
 
         $_SESSION['glpishow_count_on_tabs'] = 1;
         $name = $kb_rev->getTabNameForItem($kb1);
-        $this->assertSame("Revision 1", strip_tags($name));
+        $this->assertSame("Revisions 1", strip_tags($name));
 
         $this->assertTrue(
             $kb1->update(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

This PR addresses two UI and localization inconsistencies related to the tabs within the Knowledge Base.

**1. "Associated elements" Tab Icon Fix**
The "Associated elements" tab within the Knowledge Base was incorrectly displaying the `ti-lifebuoy` icon (which is the default icon for Knowledge Base articles) instead of a standard link icon. This occurred because `KnowbaseItem_Item` was falling back to its parent `KnowbaseItem`'s icon. 
This PR explicitly overrides the `getIcon()` method in the `KnowbaseItem_Item` relation class to return the `ti ti-link` icon. This ensures the tab uses the correct visual indicator without affecting the primary `ti-lifebuoy` icon used by Knowledge Base articles.

Before this PR:

<img width="197" height="44" alt="image" src="https://github.com/user-attachments/assets/fc7e6ef1-de73-4019-a964-9b60a2d1d5f6" />

After this PR:

<img width="188" height="44" alt="image" src="https://github.com/user-attachments/assets/3d3c7116-7e83-4c4c-a24b-f7c878128d86" />

**2. Tab Title Pluralization Fix**
In languages where the pluralization rule for `0` evaluates to the singular form (such as `pt_BR`), Knowledge Base tabs were incorrectly displaying their titles in the singular when they had no items (e.g., displaying "Revisão" [Revision] instead of "Revisões" [Revisions], or "Elemento associado" [Associated element] instead of "Elementos associados" [Associated elements]).

To standardize this behavior across all languages and match the English baseline, this PR updates the `getTabNameForItem` methods for KB-related tabs (`KnowbaseItem_Revision`, `KnowbaseItem_Item`, and `KnowbaseItem_Comment`) to explicitly use `Session::getPluralNumber()` when retrieving their type name. This ensures that the tab titles consistently render in the plural form, matching the standard tab behavior across the rest of GLPI.

<img width="211" height="35" alt="image" src="https://github.com/user-attachments/assets/7ffc54d6-803c-4af6-98a1-37284b540b35" />

**3. "Compare selected revisions" Button Enhancement**
Additionally, a `ti-git-compare` icon has been added to the "Compare selected revisions" button located within the Revisions tab. The button's text has also been wrapped in a `<span>` element. This improves the visual clarity of the action and aligns its styling with modern GLPI UI standards.

**4. Child Entities Visibility Tooltip Enhancement**
The informational `title` attribute for the "Child entities" checkbox (used to change visibility in child entities) within `header_content.html.twig` has been upgraded to a native Bootstrap tooltip. By adding `data-bs-toggle="tooltip"` to the `ti-info-circle` icon, the explanatory text now displays in a clean, modern popover instead of the browser's default, plain-text title box.

<img width="222" height="83" alt="image" src="https://github.com/user-attachments/assets/b66d5ab9-4ed2-43c1-a7a9-2d072935b334" />

## Screenshots (if appropriate):
