### PR TITLE
Fix: Initialize kbitem_ids array and format checkbox input in CommonGLPI.php

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1376,6 +1376,7 @@ class CommonGLPI implements CommonGLPIInterface
         ]);
 
         $found_kbitem = [];
+        $kbitem_ids = [];
         foreach ($iterator as $line) {
             $found_kbitem[$line['id']] = $line;
             $kbitem_ids[$line['id']] = $line['id'];
@@ -1389,7 +1390,7 @@ class CommonGLPI implements CommonGLPIInterface
             $ret .= "<label for='display_faq_chkbox$rand'>";
             $ret .= "<i class='ti ti-zoom-question cursor-pointer'></i>";
             $ret .= "</label>";
-            $ret .= "<input type='checkbox'  class='display_faq_chkbox' id='display_faq_chkbox$rand'>";
+            $ret .= "<input type='checkbox' class='display_faq_chkbox' id='display_faq_chkbox$rand'>";
             $ret .= "<div class='faqadd_entries' style='position:relative;'>";
             if (count($found_kbitem) == 1) {
                 $ret .= "<div class='faqadd_block_content' id='faqadd_block_content$rand'>";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Initialize `$kbitem_ids` before iterating over database results to avoid undefined variable warnings when no related knowledge base items are found.

## Screenshots (if appropriate):


