### PR TITLE
Fix: Avoid unnecessary count calls when profile rights are empty Profile.php

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -245,7 +245,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
     {
         global $DB;
 
-        if (count($this->profileRight) > 0) {
+        if ($this->profileRight !== []) {
             // Delegate custom assets specific rights handling to `AssetDefinitionManager`.
             $definitions = AssetDefinitionManager::getInstance()->getDefinitions();
             foreach ($definitions as $definition) {
@@ -294,7 +294,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
         global $DB;
 
         ProfileRight::fillProfileRights($this->fields['id']);
-        if (count($this->profileRight) > 0) {
+        if ($this->profileRight !== []) {
             // Delegate custom assets specific rights handling to `AssetDefinitionManager`.
             $definitions = AssetDefinitionManager::getInstance()->getDefinitions();
             foreach ($definitions as $definition) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Replace count() checks on `profileRight` with direct empty array comparisons.

The property is strictly typed as an array, so direct comparison is sufficient and avoids unnecessary count calls without altering behavior.

## Screenshots (if appropriate):


