### PR TITLE
fix(search): keep user ITIL counters consistent when actor role changes on existing relations

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1667,6 +1667,7 @@ $RELATION = [
             'users_id',
         ],
         '_glpi_useremails'              => 'users_id',
+        'glpi_users_itilobject_counts'  => 'users_id',
         'glpi_users'                    => 'users_id_supervisor',
         '_glpi_validatorsubstitutes'     => [
             'users_id',

--- a/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
+++ b/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
@@ -49,7 +49,6 @@ if (!$DB->tableExists('glpi_users_itilobject_counts')) {
         `date_mod` timestamp NULL DEFAULT NULL,
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`users_id`, `itemtype`, `actor_type`),
-        KEY `users_id` (`users_id`),
         KEY `itemtype_actor_type_count` (`itemtype`, `actor_type`, `count`),
         KEY `date_mod` (`date_mod`)
       ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC";

--- a/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
+++ b/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ */
+$default_charset = DBConnection::getDefaultCharset();
+$default_collation = DBConnection::getDefaultCollation();
+$default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+if (!$DB->tableExists('glpi_users_itilobject_counts')) {
+    $query = "CREATE TABLE `glpi_users_itilobject_counts` (
+        `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+        `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+        `itemtype` varchar(100) NOT NULL,
+        `actor_type` tinyint NOT NULL DEFAULT '0',
+        `count` int NOT NULL DEFAULT '0',
+        `date_mod` timestamp NULL DEFAULT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `unicity` (`users_id`, `itemtype`, `actor_type`),
+        KEY `users_id` (`users_id`),
+        KEY `itemtype_actor_type_count` (`itemtype`, `actor_type`, `count`),
+        KEY `date_mod` (`date_mod`)
+      ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC";
+    $DB->doQuery($query);
+}
+
+$DB->delete('glpi_users_itilobject_counts', ['id' => ['>', 0]]);
+
+$counts_queries = [
+    [
+        'itemtype'      => Ticket::class,
+        'relation'      => Ticket_User::getTable(),
+        'relation_fk'   => Ticket_User::getItilObjectForeignKey(),
+        'itil_table'    => Ticket::getTable(),
+    ],
+    [
+        'itemtype'      => Problem::class,
+        'relation'      => Problem_User::getTable(),
+        'relation_fk'   => Problem_User::getItilObjectForeignKey(),
+        'itil_table'    => Problem::getTable(),
+    ],
+    [
+        'itemtype'      => Change::class,
+        'relation'      => Change_User::getTable(),
+        'relation_fk'   => Change_User::getItilObjectForeignKey(),
+        'itil_table'    => Change::getTable(),
+    ],
+];
+
+foreach ($counts_queries as $query_data) {
+    $itemtype = $DB->escape($query_data['itemtype']);
+    $relation = DBmysql::quoteName($query_data['relation']);
+    $relation_fk = DBmysql::quoteName($query_data['relation_fk']);
+    $itil_table = DBmysql::quoteName($query_data['itil_table']);
+
+    $query = "INSERT INTO `glpi_users_itilobject_counts`
+        (`users_id`, `itemtype`, `actor_type`, `count`, `date_mod`)
+        SELECT
+            {$relation}.`users_id`,
+            '{$itemtype}',
+            {$relation}.`type`,
+            COUNT(DISTINCT {$relation}.{$relation_fk}) AS `count`,
+            NOW()
+        FROM {$relation}
+        INNER JOIN {$itil_table}
+            ON {$itil_table}.`id` = {$relation}.{$relation_fk}
+        WHERE {$relation}.`users_id` > 0
+            AND {$itil_table}.`is_deleted` = 0
+        GROUP BY {$relation}.`users_id`, {$relation}.`type`";
+    $DB->doQuery($query);
+}

--- a/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
+++ b/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
@@ -34,6 +34,7 @@
 
 /**
  * @var DBmysql $DB
+ * @var Migration $migration
  */
 $default_charset = DBConnection::getDefaultCharset();
 $default_collation = DBConnection::getDefaultCollation();
@@ -46,13 +47,34 @@ if (!$DB->tableExists('glpi_users_itilobject_counts')) {
         `itemtype` varchar(100) NOT NULL,
         `actor_type` tinyint NOT NULL DEFAULT '0',
         `count` int NOT NULL DEFAULT '0',
+        `date_creation` timestamp NULL DEFAULT NULL,
         `date_mod` timestamp NULL DEFAULT NULL,
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`users_id`, `itemtype`, `actor_type`),
         KEY `itemtype_actor_type_count` (`itemtype`, `actor_type`, `count`),
+        KEY `date_creation` (`date_creation`),
         KEY `date_mod` (`date_mod`)
       ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC";
     $DB->doQuery($query);
+}
+
+// Keep migration idempotent for instances where table was created
+// by a previous revision without date_creation.
+$has_schema_updates = false;
+if (!$DB->fieldExists('glpi_users_itilobject_counts', 'date_creation')) {
+    $has_schema_updates = $migration->addField(
+        'glpi_users_itilobject_counts',
+        'date_creation',
+        "timestamp NULL DEFAULT NULL",
+        ['after' => 'count']
+    ) || $has_schema_updates;
+}
+if (!isIndex('glpi_users_itilobject_counts', 'date_creation')) {
+    $migration->addKey('glpi_users_itilobject_counts', 'date_creation');
+    $has_schema_updates = true;
+}
+if ($has_schema_updates) {
+    $migration->migrationOneTable('glpi_users_itilobject_counts');
 }
 
 $DB->delete('glpi_users_itilobject_counts', ['id' => ['>', 0]]);
@@ -88,12 +110,13 @@ foreach ($counts_queries as $query_data) {
     $itil_table = DBmysql::quoteName($query_data['itil_table']);
 
     $query = "INSERT INTO `glpi_users_itilobject_counts`
-        (`users_id`, `itemtype`, `actor_type`, `count`, `date_mod`)
+        (`users_id`, `itemtype`, `actor_type`, `count`, `date_creation`, `date_mod`)
         SELECT
             {$relation}.`users_id`,
             '{$itemtype}',
             {$relation}.`type`,
             COUNT(DISTINCT {$relation}.{$relation_fk}) AS `count`,
+            NOW(),
             NOW()
         FROM {$relation}
         INNER JOIN {$itil_table}

--- a/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
+++ b/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
@@ -82,6 +82,9 @@ $counts_queries = [
 foreach ($counts_queries as $query_data) {
     $itemtype = $DB->escape($query_data['itemtype']);
     $relation = DBmysql::quoteName($query_data['relation']);
+    if ($query_data['relation_fk'] === null) {
+        continue;
+    }
     $relation_fk = DBmysql::quoteName($query_data['relation_fk']);
     $itil_table = DBmysql::quoteName($query_data['itil_table']);
 

--- a/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
+++ b/install/migrations/update_11.0.7_to_11.0.8/user_itilobject_counts.php
@@ -52,8 +52,8 @@ if (!$DB->tableExists('glpi_users_itilobject_counts')) {
         PRIMARY KEY (`id`),
         UNIQUE KEY `unicity` (`users_id`, `itemtype`, `actor_type`),
         KEY `itemtype_actor_type_count` (`itemtype`, `actor_type`, `count`),
-        KEY `date_creation` (`date_creation`),
-        KEY `date_mod` (`date_mod`)
+        KEY `date_mod` (`date_mod`),
+        KEY `date_creation` (`date_creation`)
       ) ENGINE=InnoDB DEFAULT CHARSET = {$default_charset} COLLATE = {$default_collation} ROW_FORMAT=DYNAMIC";
     $DB->doQuery($query);
 }
@@ -62,12 +62,13 @@ if (!$DB->tableExists('glpi_users_itilobject_counts')) {
 // by a previous revision without date_creation.
 $has_schema_updates = false;
 if (!$DB->fieldExists('glpi_users_itilobject_counts', 'date_creation')) {
-    $has_schema_updates = $migration->addField(
+    $migration->addField(
         'glpi_users_itilobject_counts',
         'date_creation',
         "timestamp NULL DEFAULT NULL",
         ['after' => 'count']
-    ) || $has_schema_updates;
+    );
+    $has_schema_updates = true;
 }
 if (!isIndex('glpi_users_itilobject_counts', 'date_creation')) {
     $migration->addKey('glpi_users_itilobject_counts', 'date_creation');

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10222,8 +10222,8 @@ CREATE TABLE `glpi_users_itilobject_counts` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`users_id`,`itemtype`,`actor_type`),
   KEY `itemtype_actor_type_count` (`itemtype`,`actor_type`,`count`),
-  KEY `date_creation` (`date_creation`),
-  KEY `date_mod` (`date_mod`)
+  KEY `date_mod` (`date_mod`),
+  KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10210,4 +10210,19 @@ CREATE TABLE `glpi_itemtranslations_itemtranslations` (
   KEY `item` (`itemtype`, `items_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
+DROP TABLE IF EXISTS `glpi_users_itilobject_counts`;
+CREATE TABLE `glpi_users_itilobject_counts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `users_id` int unsigned NOT NULL DEFAULT '0',
+  `itemtype` varchar(100) NOT NULL,
+  `actor_type` tinyint NOT NULL DEFAULT '0',
+  `count` int NOT NULL DEFAULT '0',
+  `date_mod` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unicity` (`users_id`,`itemtype`,`actor_type`),
+  KEY `users_id` (`users_id`),
+  KEY `itemtype_actor_type_count` (`itemtype`,`actor_type`,`count`),
+  KEY `date_mod` (`date_mod`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10217,10 +10217,12 @@ CREATE TABLE `glpi_users_itilobject_counts` (
   `itemtype` varchar(100) NOT NULL,
   `actor_type` tinyint NOT NULL DEFAULT '0',
   `count` int NOT NULL DEFAULT '0',
+  `date_creation` timestamp NULL DEFAULT NULL,
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`users_id`,`itemtype`,`actor_type`),
   KEY `itemtype_actor_type_count` (`itemtype`,`actor_type`,`count`),
+  KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10220,7 +10220,6 @@ CREATE TABLE `glpi_users_itilobject_counts` (
   `date_mod` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicity` (`users_id`,`itemtype`,`actor_type`),
-  KEY `users_id` (`users_id`),
   KEY `itemtype_actor_type_count` (`itemtype`,`actor_type`,`count`),
   KEY `date_mod` (`date_mod`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -188,6 +188,9 @@ abstract class CommonITILActor extends CommonDBRelation
     {
         global $CFG_GLPI;
 
+        $users_id = (int) ($this->fields['users_id'] ?? 0);
+        $actor_type = (int) ($this->fields['type'] ?? 0);
+
         $donotif = !isset($this->input['_disablenotif']) && $CFG_GLPI["use_notifications"];
 
         $item = $this->getConnexityItem(static::$itemtype_1, static::getItilObjectForeignKey());
@@ -225,6 +228,10 @@ abstract class CommonITILActor extends CommonDBRelation
         $this->_force_log_option = $this->getForceLogOption();
         parent::post_deleteFromDB();
         $this->_force_log_option = $current_log_option;
+
+        if ($users_id > 0) {
+            UserITILObjectCount::refreshForActor(static::class, $users_id, $actor_type);
+        }
     }
 
     public function prepareInputForAdd($input)
@@ -347,5 +354,37 @@ abstract class CommonITILActor extends CommonDBRelation
         $this->_force_log_option = $this->getForceLogOption();
         parent::post_addItem();
         $this->_force_log_option = $current_log_option;
+
+        if (isset($this->fields['users_id']) && (int) $this->fields['users_id'] > 0) {
+            UserITILObjectCount::refreshForActor(
+                static::class,
+                (int) $this->fields['users_id'],
+                (int) ($this->fields['type'] ?? 0)
+            );
+        }
     }
+
+    public function post_updateItem($history = true)
+    {
+        parent::post_updateItem($history);
+
+        $users_to_refresh = [];
+        if (isset($this->oldvalues['users_id']) && (int) $this->oldvalues['users_id'] > 0) {
+            $users_to_refresh[] = [
+                'users_id' => (int) $this->oldvalues['users_id'],
+                'type'     => (int) ($this->oldvalues['type'] ?? $this->fields['type'] ?? 0),
+            ];
+        }
+        if (isset($this->fields['users_id']) && (int) $this->fields['users_id'] > 0) {
+            $users_to_refresh[] = [
+                'users_id' => (int) $this->fields['users_id'],
+                'type'     => (int) ($this->fields['type'] ?? 0),
+            ];
+        }
+
+        foreach ($users_to_refresh as $target) {
+            UserITILObjectCount::refreshForActor(static::class, $target['users_id'], $target['type']);
+        }
+    }
+
 }

--- a/src/CommonITILActor.php
+++ b/src/CommonITILActor.php
@@ -369,6 +369,16 @@ abstract class CommonITILActor extends CommonDBRelation
         parent::post_updateItem($history);
 
         $users_to_refresh = [];
+        if (
+            isset($this->oldvalues['type'])
+            && isset($this->fields['users_id'])
+            && (int) $this->fields['users_id'] > 0
+        ) {
+            $users_to_refresh[] = [
+                'users_id' => (int) $this->fields['users_id'],
+                'type'     => (int) $this->oldvalues['type'],
+            ];
+        }
         if (isset($this->oldvalues['users_id']) && (int) $this->oldvalues['users_id'] > 0) {
             $users_to_refresh[] = [
                 'users_id' => (int) $this->oldvalues['users_id'],

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2459,12 +2459,22 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
     }
 
+    /**
+     * Refresh materialized ITIL user counters when the object is moved to trash.
+     *
+     * @return void
+     */
     public function post_deleteItem()
     {
         parent::post_deleteItem();
         UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
     }
 
+    /**
+     * Refresh materialized ITIL user counters when the object is restored from trash.
+     *
+     * @return void
+     */
     public function post_restoreItem()
     {
         parent::post_restoreItem();

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -2455,6 +2455,20 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $this->manageITILObjectLinkInput($this->input);
 
         parent::post_updateItem();
+
+        UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
+    }
+
+    public function post_deleteItem()
+    {
+        parent::post_deleteItem();
+        UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
+    }
+
+    public function post_restoreItem()
+    {
+        parent::post_restoreItem();
+        UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
     }
 
 
@@ -3265,6 +3279,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         $this->manageITILObjectLinkInput($this->input);
 
         parent::post_addItem();
+
+        UserITILObjectCount::refreshForItilObject(static::class, (int) $this->getID());
     }
 
     /**

--- a/src/User.php
+++ b/src/User.php
@@ -3727,57 +3727,43 @@ HTML;
 
         $tab[] = [
             'id'                 => '60',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of tickets as requester'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => 'glpi_tickets_users',
-                    'joinparams'         => [
-                        'jointype'           => 'child',
-                        'condition'          => ['NEWTABLE.type' => CommonITILActor::REQUESTER],
-                    ],
-                ],
-            ],
+            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
+                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
+                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::REQUESTER . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [
             'id'                 => '61',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of written tickets'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'jointype'           => 'child',
-                'linkfield'          => 'users_id_recipient',
-            ],
+            'computation'        => '(SELECT COUNT(' . DBmysql::quoteName('t.id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets') . ' AS ' . DBmysql::quoteName('t') . ' 
+                                      WHERE ' . DBmysql::quoteName('t.users_id_recipient') . ' = ' . DBmysql::quoteName('TABLE.id') . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [
             'id'                 => '64',
-            'table'              => 'glpi_tickets',
+            'table'              => 'glpi_users',
             'field'              => 'id',
             'name'               => __('Number of assigned tickets'),
-            'forcegroupby'       => true,
-            'usehaving'          => true,
-            'datatype'           => 'count',
+            'datatype'           => 'number',
             'massiveaction'      => false,
-            'joinparams'         => [
-                'beforejoin'         => [
-                    'table'              => 'glpi_tickets_users',
-                    'joinparams'         => [
-                        'jointype'           => 'child',
-                        'condition'          => ['NEWTABLE.type' => CommonITILActor::ASSIGN],
-                    ],
-                ],
-            ],
+            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
+                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
+                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
+                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::ASSIGN . ')',
+            'nosort'             => true,
         ];
 
         $tab[] = [

--- a/src/User.php
+++ b/src/User.php
@@ -3732,11 +3732,11 @@ HTML;
             'name'               => __('Number of tickets as requester'),
             'datatype'           => 'number',
             'massiveaction'      => false,
-            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
-                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
-                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
-                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::REQUESTER . ')',
-            'nosort'             => true,
+            'computation'        => '(SELECT COALESCE(MAX(' . DBmysql::quoteName('uic.count') . '), 0)
+                                      FROM ' . DBmysql::quoteName(UserITILObjectCount::getTable()) . ' AS ' . DBmysql::quoteName('uic') . '
+                                      WHERE ' . DBmysql::quoteName('uic.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . '
+                                        AND ' . DBmysql::quoteName('uic.itemtype') . ' = ' . DBmysql::quoteValue(Ticket::class) . '
+                                        AND ' . DBmysql::quoteName('uic.actor_type') . ' = ' . CommonITILActor::REQUESTER . ')',
         ];
 
         $tab[] = [
@@ -3759,11 +3759,11 @@ HTML;
             'name'               => __('Number of assigned tickets'),
             'datatype'           => 'number',
             'massiveaction'      => false,
-            'computation'        => '(SELECT COUNT(DISTINCT ' . DBmysql::quoteName('tu.tickets_id') . ') 
-                                      FROM ' . DBmysql::quoteName('glpi_tickets_users') . ' AS ' . DBmysql::quoteName('tu') . ' 
-                                      WHERE ' . DBmysql::quoteName('tu.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . ' 
-                                        AND ' . DBmysql::quoteName('tu.type') . ' = ' . CommonITILActor::ASSIGN . ')',
-            'nosort'             => true,
+            'computation'        => '(SELECT COALESCE(MAX(' . DBmysql::quoteName('uic.count') . '), 0)
+                                      FROM ' . DBmysql::quoteName(UserITILObjectCount::getTable()) . ' AS ' . DBmysql::quoteName('uic') . '
+                                      WHERE ' . DBmysql::quoteName('uic.users_id') . ' = ' . DBmysql::quoteName('TABLE.id') . '
+                                        AND ' . DBmysql::quoteName('uic.itemtype') . ' = ' . DBmysql::quoteValue(Ticket::class) . '
+                                        AND ' . DBmysql::quoteName('uic.actor_type') . ' = ' . CommonITILActor::ASSIGN . ')',
         ];
 
         $tab[] = [

--- a/src/UserITILObjectCount.php
+++ b/src/UserITILObjectCount.php
@@ -37,6 +37,9 @@
  */
 final class UserITILObjectCount extends CommonDBTM
 {
+    /**
+     * @return string Table used to store materialized ITIL actor counters per user.
+     */
     public static function getTable($classname = null): string
     {
         return 'glpi_users_itilobject_counts';
@@ -47,6 +50,15 @@ final class UserITILObjectCount extends CommonDBTM
         return _n('User ITIL object count', 'User ITIL object counts', $nb);
     }
 
+    /**
+     * Recompute the materialized counter for one user, ITIL object type and actor role.
+     *
+     * @param class-string<CommonITILActor> $actor_class Relation class linking users to an ITIL object.
+     * @param int $users_id User identifier to refresh.
+     * @param int $actor_type One of the CommonITILActor::* role constants.
+     *
+     * @return void
+     */
     public static function refreshForActor(string $actor_class, int $users_id, int $actor_type): void
     {
         global $DB;
@@ -113,6 +125,14 @@ final class UserITILObjectCount extends CommonDBTM
         );
     }
 
+    /**
+     * Refresh all user counters related to a specific ITIL object.
+     *
+     * @param class-string<CommonITILObject> $itemtype ITIL object type to inspect.
+     * @param int $items_id ITIL object identifier.
+     *
+     * @return void
+     */
     public static function refreshForItilObject(string $itemtype, int $items_id): void
     {
         global $DB;

--- a/src/UserITILObjectCount.php
+++ b/src/UserITILObjectCount.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Materialized counters used to sort users by ITIL actor relationships.
+ */
+final class UserITILObjectCount extends CommonDBTM
+{
+    public static function getTypeName($nb = 0)
+    {
+        return _n('User ITIL object count', 'User ITIL object counts', $nb);
+    }
+
+    public static function refreshForActor(string $actor_class, int $users_id, int $actor_type): void
+    {
+        global $DB;
+
+        if ($users_id <= 0 || !is_subclass_of($actor_class, CommonITILActor::class)) {
+            return;
+        }
+
+        $itemtype = $actor_class::$itemtype_1;
+        if (!is_a($itemtype, CommonITILObject::class, true)) {
+            return;
+        }
+
+        $relation_table = $actor_class::getTable();
+        $relation_fk = $actor_class::getItilObjectForeignKey();
+        $itil_table = $itemtype::getTable();
+
+        $iterator = $DB->request([
+            'SELECT' => new QueryExpression('COUNT(DISTINCT ' . DBmysql::quoteName($relation_table . '.' . $relation_fk) . ') AS cnt'),
+            'FROM'   => $relation_table,
+            'INNER JOIN' => [
+                $itil_table => [
+                    'FKEY' => [
+                        $itil_table      => 'id',
+                        $relation_table  => $relation_fk,
+                    ],
+                ],
+            ],
+            'WHERE' => [
+                $relation_table . '.users_id'  => $users_id,
+                $relation_table . '.type'      => $actor_type,
+                $itil_table . '.is_deleted'    => 0,
+            ],
+        ]);
+
+        $count = (int) ($iterator->current()['cnt'] ?? 0);
+
+        if ($count > 0) {
+            $DB->updateOrInsert(
+                self::getTable(),
+                [
+                    'users_id'    => $users_id,
+                    'itemtype'    => $itemtype,
+                    'actor_type'  => $actor_type,
+                    'count'       => $count,
+                    'date_mod'    => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
+                ],
+                [
+                    'users_id'    => $users_id,
+                    'itemtype'    => $itemtype,
+                    'actor_type'  => $actor_type,
+                ]
+            );
+            return;
+        }
+
+        $DB->delete(
+            self::getTable(),
+            [
+                'users_id'    => $users_id,
+                'itemtype'    => $itemtype,
+                'actor_type'  => $actor_type,
+            ]
+        );
+    }
+}

--- a/src/UserITILObjectCount.php
+++ b/src/UserITILObjectCount.php
@@ -37,6 +37,11 @@
  */
 final class UserITILObjectCount extends CommonDBTM
 {
+    public static function getTable($classname = null): string
+    {
+        return 'glpi_users_itilobject_counts';
+    }
+
     public static function getTypeName($nb = 0)
     {
         return _n('User ITIL object count', 'User ITIL object counts', $nb);
@@ -106,5 +111,42 @@ final class UserITILObjectCount extends CommonDBTM
                 'actor_type'  => $actor_type,
             ]
         );
+    }
+
+    public static function refreshForItilObject(string $itemtype, int $items_id): void
+    {
+        global $DB;
+
+        if ($items_id <= 0) {
+            return;
+        }
+
+        $actor_class = match ($itemtype) {
+            Ticket::class  => Ticket_User::class,
+            Problem::class => Problem_User::class,
+            Change::class  => Change_User::class,
+            default        => null,
+        };
+
+        if ($actor_class === null) {
+            return;
+        }
+
+        $relation_table = $actor_class::getTable();
+        $relation_fk = $actor_class::getItilObjectForeignKey();
+
+        $iterator = $DB->request([
+            'SELECT' => ['users_id', 'type'],
+            'FROM'   => $relation_table,
+            'WHERE'  => [
+                $relation_fk  => $items_id,
+                'users_id'    => ['>', 0],
+            ],
+            'GROUP'  => ['users_id', 'type'],
+        ]);
+
+        foreach ($iterator as $row) {
+            self::refreshForActor($actor_class, (int) $row['users_id'], (int) $row['type']);
+        }
     }
 }

--- a/src/UserITILObjectCount.php
+++ b/src/UserITILObjectCount.php
@@ -37,7 +37,7 @@ use Glpi\DBAL\QueryExpression;
 /**
  * Materialized counters used to sort users by ITIL actor relationships.
  */
-final class UserITILObjectCount extends CommonDBTM
+class UserITILObjectCount extends CommonDBTM
 {
     /**
      * @return string Table used to store materialized ITIL actor counters per user.

--- a/src/UserITILObjectCount.php
+++ b/src/UserITILObjectCount.php
@@ -32,6 +32,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QueryExpression;
+
 /**
  * Materialized counters used to sort users by ITIL actor relationships.
  */
@@ -68,16 +70,22 @@ final class UserITILObjectCount extends CommonDBTM
         }
 
         $itemtype = $actor_class::$itemtype_1;
-        if (!is_a($itemtype, CommonITILObject::class, true)) {
+        if (!is_string($itemtype) || !is_a($itemtype, CommonITILObject::class, true)) {
             return;
         }
 
         $relation_table = $actor_class::getTable();
         $relation_fk = $actor_class::getItilObjectForeignKey();
+        if ($relation_fk === null) {
+            return;
+        }
         $itil_table = $itemtype::getTable();
 
         $iterator = $DB->request([
-            'SELECT' => new QueryExpression('COUNT(DISTINCT ' . DBmysql::quoteName($relation_table . '.' . $relation_fk) . ') AS cnt'),
+            'SELECT' => new QueryExpression(
+                'COUNT(DISTINCT ' . DBmysql::quoteName($relation_table . '.' . $relation_fk) . ')',
+                'cnt'
+            ),
             'FROM'   => $relation_table,
             'INNER JOIN' => [
                 $itil_table => [
@@ -154,6 +162,9 @@ final class UserITILObjectCount extends CommonDBTM
 
         $relation_table = $actor_class::getTable();
         $relation_fk = $actor_class::getItilObjectForeignKey();
+        if ($relation_fk === null) {
+            return;
+        }
 
         $iterator = $DB->request([
             'SELECT' => ['users_id', 'type'],

--- a/src/User_Itilobject_Count.php
+++ b/src/User_Itilobject_Count.php
@@ -36,6 +36,4 @@
  * Compatibility alias used by table->itemtype resolution for
  * "glpi_users_itilobject_counts" in DbUtils::getItemTypeForTable().
  */
-class User_Itilobject_Count extends UserITILObjectCount
-{
-}
+class User_Itilobject_Count extends UserITILObjectCount {}

--- a/src/User_Itilobject_Count.php
+++ b/src/User_Itilobject_Count.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Compatibility alias used by table->itemtype resolution for
+ * "glpi_users_itilobject_counts" in DbUtils::getItemTypeForTable().
+ */
+class User_Itilobject_Count extends UserITILObjectCount
+{
+}

--- a/tests/functional/UserITILObjectCountTest.php
+++ b/tests/functional/UserITILObjectCountTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Change;
+use Change_User;
+use CommonITILActor;
+use Glpi\Tests\DbTestCase;
+use Problem;
+use Problem_User;
+use Ticket;
+use Ticket_User;
+use User;
+use UserITILObjectCount;
+
+class UserITILObjectCountTest extends DbTestCase
+{
+    public function testTicketCountersWithManyUsersAndLifecycleChanges(): void
+    {
+        $this->login();
+
+        $users = $this->createUsers(12);
+
+        $ticket = $this->createItilObject(Ticket::class);
+        $this->setUserActors($ticket, 'requester', $users);
+
+        foreach ($users as $user) {
+            $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 1);
+        }
+
+        $second_ticket = $this->createItilObject(Ticket::class);
+        $this->setUserActors($second_ticket, 'requester', array_slice($users, 0, 3));
+
+        foreach (array_slice($users, 0, 3) as $user) {
+            $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 2);
+        }
+
+        foreach (array_slice($users, 3) as $user) {
+            $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 1);
+        }
+
+        $this->deleteItem(Ticket::class, $second_ticket->getID());
+        foreach (array_slice($users, 0, 3) as $user) {
+            $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 1);
+        }
+
+        $restored_ticket = new Ticket();
+        $this->assertTrue($restored_ticket->restore(['id' => $second_ticket->getID()]));
+        foreach (array_slice($users, 0, 3) as $user) {
+            $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 2);
+        }
+
+        $this->setUserActors($ticket, 'requester', array_slice($users, 1));
+        $this->assertCounter($users[0]->getID(), Ticket::class, CommonITILActor::REQUESTER, 1);
+        $this->assertCounter($users[1]->getID(), Ticket::class, CommonITILActor::REQUESTER, 2);
+    }
+
+    public function testCountersForAllUserActorRolesAndItilTypes(): void
+    {
+        $this->login();
+
+        $roles = [
+            CommonITILActor::REQUESTER,
+            CommonITILActor::OBSERVER,
+            CommonITILActor::ASSIGN,
+        ];
+
+        foreach ([Ticket::class, Problem::class, Change::class] as $itemtype) {
+            foreach ($roles as $actor_type) {
+                $user = $this->createUsers(1)[0];
+                $item = $this->createItilObject($itemtype);
+
+                $this->addUserActorWithRelation($itemtype, $item->getID(), $user->getID(), $actor_type);
+                $this->assertCounter($user->getID(), $itemtype, $actor_type, 1);
+
+                $this->removeUserActorWithRelation($itemtype, $item->getID(), $user->getID(), $actor_type);
+                $this->assertCounter($user->getID(), $itemtype, $actor_type, 0);
+            }
+        }
+    }
+
+    /**
+     * @return User[]
+     */
+    private function createUsers(int $count): array
+    {
+        $users = [];
+        for ($i = 0; $i < $count; $i++) {
+            $users[] = $this->createItem(User::class, [
+                'name' => $this->getUniqueString(),
+            ]);
+        }
+
+        return $users;
+    }
+
+    private function createItilObject(string $itemtype): Ticket|Problem|Change
+    {
+        return $this->createItem(
+            $itemtype,
+            $this->getMinimalCreationInput($itemtype) + [
+                '_skip_auto_assign' => true,
+            ],
+            ['_skip_auto_assign']
+        );
+    }
+
+    /**
+     * @param User[] $users
+     */
+    private function setUserActors(Ticket|Problem|Change $item, string $input_key, array $users): void
+    {
+        $actors = [];
+        foreach ($users as $user) {
+            $actors[] = [
+                'itemtype'          => User::class,
+                'items_id'          => $user->getID(),
+                'use_notification'  => 0,
+                'alternative_email' => '',
+            ];
+        }
+
+        $this->updateItem(
+            $item::class,
+            $item->getID(),
+            [
+                '_actors' => [
+                    $input_key => $actors,
+                ],
+            ],
+            ['_actors']
+        );
+    }
+
+    private function removeUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): void
+    {
+        $relation_class = match ($itemtype) {
+            Ticket::class  => Ticket_User::class,
+            Problem::class => Problem_User::class,
+            Change::class  => Change_User::class,
+            default        => throw new \RuntimeException("Unsupported ITIL object type: $itemtype"),
+        };
+
+        $relation = new $relation_class();
+        $relation_fk = $relation_class::getItilObjectForeignKey();
+        $relations = $relation->find([
+            $relation_fk => $items_id,
+            'users_id'   => $users_id,
+            'type'       => $actor_type,
+        ]);
+
+        $this->assertCount(1, $relations);
+        $relation_data = reset($relations);
+        $this->assertTrue($relation->delete(['id' => $relation_data['id']]));
+    }
+
+    private function addUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): void
+    {
+        $relation_class = match ($itemtype) {
+            Ticket::class  => Ticket_User::class,
+            Problem::class => Problem_User::class,
+            Change::class  => Change_User::class,
+            default        => throw new \RuntimeException("Unsupported ITIL object type: $itemtype"),
+        };
+
+        $relation = new $relation_class();
+        $relation_fk = $relation_class::getItilObjectForeignKey();
+
+        $this->assertGreaterThan(
+            0,
+            (int) $relation->add([
+                $relation_fk         => $items_id,
+                'users_id'           => $users_id,
+                'type'               => $actor_type,
+                'use_notification'   => 0,
+                'alternative_email'  => '',
+            ])
+        );
+    }
+
+    private function assertCounter(int $users_id, string $itemtype, int $actor_type, int $expected): void
+    {
+        global $DB;
+
+        $row = $DB->request([
+            'FROM'  => UserITILObjectCount::getTable(),
+            'WHERE' => [
+                'users_id'    => $users_id,
+                'itemtype'    => $itemtype,
+                'actor_type'  => $actor_type,
+            ],
+        ])->current();
+
+        $this->assertSame($expected, (int) ($row['count'] ?? 0));
+    }
+}

--- a/tests/functional/UserITILObjectCountTest.php
+++ b/tests/functional/UserITILObjectCountTest.php
@@ -47,6 +47,11 @@ use UserITILObjectCount;
 
 class UserITILObjectCountTest extends DbTestCase
 {
+    /**
+     * Validate requester counters when several users are attached to tickets and tickets change lifecycle.
+     *
+     * @return void
+     */
     public function testTicketCountersWithManyUsersAndLifecycleChanges(): void
     {
         $this->login();
@@ -87,6 +92,11 @@ class UserITILObjectCountTest extends DbTestCase
         $this->assertCounter($users[1]->getID(), Ticket::class, CommonITILActor::REQUESTER, 2);
     }
 
+    /**
+     * Validate counter refresh hooks for every supported ITIL object type and user actor role.
+     *
+     * @return void
+     */
     public function testCountersForAllUserActorRolesAndItilTypes(): void
     {
         $this->login();
@@ -112,6 +122,8 @@ class UserITILObjectCountTest extends DbTestCase
     }
 
     /**
+     * @param int $count Number of users to create.
+     *
      * @return User[]
      */
     private function createUsers(int $count): array
@@ -126,6 +138,13 @@ class UserITILObjectCountTest extends DbTestCase
         return $users;
     }
 
+    /**
+     * Create a minimal ITIL object with auto assignment disabled.
+     *
+     * @param class-string<Ticket|Problem|Change> $itemtype ITIL object type to create.
+     *
+     * @return Ticket|Problem|Change
+     */
     private function createItilObject(string $itemtype): Ticket|Problem|Change
     {
         return $this->createItem(
@@ -138,7 +157,13 @@ class UserITILObjectCountTest extends DbTestCase
     }
 
     /**
-     * @param User[] $users
+     * Replace one actor list through the public ITIL object input format.
+     *
+     * @param Ticket|Problem|Change $item ITIL object to update.
+     * @param string $input_key Actor input key, for example requester, observer or assign.
+     * @param User[] $users Users to keep in the actor list.
+     *
+     * @return void
      */
     private function setUserActors(Ticket|Problem|Change $item, string $input_key, array $users): void
     {
@@ -164,6 +189,16 @@ class UserITILObjectCountTest extends DbTestCase
         );
     }
 
+    /**
+     * Remove one user actor using the underlying relation object.
+     *
+     * @param class-string<Ticket|Problem|Change> $itemtype ITIL object type.
+     * @param int $items_id ITIL object identifier.
+     * @param int $users_id User identifier.
+     * @param int $actor_type One of the CommonITILActor::* role constants.
+     *
+     * @return void
+     */
     private function removeUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): void
     {
         $relation_class = match ($itemtype) {
@@ -186,6 +221,16 @@ class UserITILObjectCountTest extends DbTestCase
         $this->assertTrue($relation->delete(['id' => $relation_data['id']]));
     }
 
+    /**
+     * Add one user actor using the underlying relation object.
+     *
+     * @param class-string<Ticket|Problem|Change> $itemtype ITIL object type.
+     * @param int $items_id ITIL object identifier.
+     * @param int $users_id User identifier.
+     * @param int $actor_type One of the CommonITILActor::* role constants.
+     *
+     * @return void
+     */
     private function addUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): void
     {
         $relation_class = match ($itemtype) {
@@ -210,6 +255,16 @@ class UserITILObjectCountTest extends DbTestCase
         );
     }
 
+    /**
+     * Assert the materialized counter value for a user and actor role.
+     *
+     * @param int $users_id User identifier.
+     * @param class-string<Ticket|Problem|Change> $itemtype ITIL object type.
+     * @param int $actor_type One of the CommonITILActor::* role constants.
+     * @param int $expected Expected counter value.
+     *
+     * @return void
+     */
     private function assertCounter(int $users_id, string $itemtype, int $actor_type, int $expected): void
     {
         global $DB;

--- a/tests/functional/UserITILObjectCountTest.php
+++ b/tests/functional/UserITILObjectCountTest.php
@@ -122,6 +122,32 @@ class UserITILObjectCountTest extends DbTestCase
     }
 
     /**
+     * Validate counters when a relation keeps the same user but changes actor role.
+     *
+     * @return void
+     */
+    public function testCounterRefreshWhenActorTypeChangesOnSameRelation(): void
+    {
+        $this->login();
+
+        $user = $this->createUsers(1)[0];
+        $ticket = $this->createItilObject(Ticket::class);
+
+        $relation_id = $this->addUserActorWithRelation(
+            Ticket::class,
+            $ticket->getID(),
+            $user->getID(),
+            CommonITILActor::REQUESTER
+        );
+        $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 1);
+        $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::ASSIGN, 0);
+
+        $this->updateUserActorTypeWithRelation(Ticket::class, $relation_id, CommonITILActor::ASSIGN);
+        $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::REQUESTER, 0);
+        $this->assertCounter($user->getID(), Ticket::class, CommonITILActor::ASSIGN, 1);
+    }
+
+    /**
      * @param int $count Number of users to create.
      *
      * @return User[]
@@ -231,7 +257,7 @@ class UserITILObjectCountTest extends DbTestCase
      *
      * @return void
      */
-    private function addUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): void
+    private function addUserActorWithRelation(string $itemtype, int $items_id, int $users_id, int $actor_type): int
     {
         $relation_class = match ($itemtype) {
             Ticket::class  => Ticket_User::class,
@@ -243,16 +269,41 @@ class UserITILObjectCountTest extends DbTestCase
         $relation = new $relation_class();
         $relation_fk = $relation_class::getItilObjectForeignKey();
 
-        $this->assertGreaterThan(
-            0,
-            (int) $relation->add([
-                $relation_fk         => $items_id,
-                'users_id'           => $users_id,
-                'type'               => $actor_type,
-                'use_notification'   => 0,
-                'alternative_email'  => '',
-            ])
-        );
+        $relation_id = (int) $relation->add([
+            $relation_fk         => $items_id,
+            'users_id'           => $users_id,
+            'type'               => $actor_type,
+            'use_notification'   => 0,
+            'alternative_email'  => '',
+        ]);
+        $this->assertGreaterThan(0, $relation_id);
+
+        return $relation_id;
+    }
+
+    /**
+     * Update actor role on an existing relation.
+     *
+     * @param class-string<Ticket|Problem|Change> $itemtype ITIL object type.
+     * @param int $relation_id Relation identifier.
+     * @param int $actor_type One of the CommonITILActor::* role constants.
+     *
+     * @return void
+     */
+    private function updateUserActorTypeWithRelation(string $itemtype, int $relation_id, int $actor_type): void
+    {
+        $relation_class = match ($itemtype) {
+            Ticket::class  => Ticket_User::class,
+            Problem::class => Problem_User::class,
+            Change::class  => Change_User::class,
+            default        => throw new \RuntimeException("Unsupported ITIL object type: $itemtype"),
+        };
+
+        $relation = new $relation_class();
+        $this->assertTrue($relation->update([
+            'id'   => $relation_id,
+            'type' => $actor_type,
+        ]));
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- This PR fixes a counter consistency bug in the materialized ITIL user counters (evolution of https://github.com/glpi-project/glpi/pull/24227).

When an existing user-actor relation changes only its role (`type`) while keeping the same `users_id` (for example, requester -> assignee on the same `Ticket_User` row), the previous role counter could remain stale.

### Root cause
`CommonITILActor::post_updateItem()` refreshed old counters based on `oldvalues['users_id']`.  
In role-only updates, `oldvalues` may contain `type` but not `users_id`, so old-role refresh could be skipped.

### What was changed
- Updated `CommonITILActor::post_updateItem()` to also refresh `(users_id, old_type)` when `oldvalues['type']` exists and current `users_id` is valid.
- Kept refresh of `(users_id, new_type)` to ensure both sides of the transition are synchronized.
- Added functional test coverage for same-relation role transition in `UserITILObjectCountTest`:
  - create relation as requester,
  - update same relation to assignee,
  - assert requester counter becomes `0`,
  - assert assignee counter becomes `1`.

### Validation performed
- `php -l src/CommonITILActor.php`
- `php -l tests/functional/UserITILObjectCountTest.php`
- `./vendor/bin/phpunit tests/functional/UserITILObjectCountTest.php`  
  - `OK (3 tests, 398 assertions)`
- `bash .github/actions/test_tests-functional_parallel.sh --filter UserITILObjectCountTest`  
  - `OK (3 tests, 398 assertions)`
- Runtime behavior battery (multi-user, multi-role, Ticket/Problem/Change):  
  - `checks=166`, `rollback=ok`

## Screenshots (if appropriate):

N/A (backend logic and tests only).