### PR TITLE
Fix: reactivate LDAP users re-enabled in Active Directory

### DIFF
--- a/phpunit/LDAP/AuthLdapTest.php
+++ b/phpunit/LDAP/AuthLdapTest.php
@@ -3086,4 +3086,36 @@ class AuthLdapTest extends DbTestCase
             'User should still be member of the rule-assigned group after sync'
         );
     }
+
+    /**
+     * A user disabled in AD (is_deleted_ldap=1, is_active=0) must be
+     * re-activated during the login request once they are re-enabled in LDAP.
+     *
+     * @requires extension ldap
+     */
+    public function testLoginRestoresLdapDeletedUser(): void
+    {
+        global $CFG_GLPI;
+
+        // First login imports the user into GLPI.
+        $first_auth = $this->login('brazil8', 'password', false);
+        $user_id = $first_auth->user->fields['id'];
+
+        // Simulate the user being disabled in AD and synced.
+        $user = new \User();
+        $this->assertTrue($user->update(['id' => $user_id, 'is_active' => 0, 'is_deleted_ldap' => 1]));
+
+        $original_restore_cfg = $CFG_GLPI['user_restored_ldap'] ?? null;
+        $CFG_GLPI['user_restored_ldap'] = \AuthLDAP::RESTORED_USER_ENABLE;
+
+        // Login after re-enablement in AD must restore the account.
+        $auth = new \Auth();
+        $auth->login('brazil8', 'password', false, false, 'ldap-' . $this->ldap->getID());
+
+        $CFG_GLPI['user_restored_ldap'] = $original_restore_cfg;
+
+        $user->getFromDB($user_id);
+        $this->assertSame(1, (int) $user->fields['is_active']);
+        $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
+    }
 }

--- a/phpunit/functional/AuthLdapUserRestoreTest.php
+++ b/phpunit/functional/AuthLdapUserRestoreTest.php
@@ -90,30 +90,4 @@ class AuthLdapUserRestoreTest extends DbTestCase
         $this->assertSame(1, (int) $user->fields['is_active']);
         $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
     }
-
-    /**
-     * If a re-enabled AD user logs in before the next sync, Auth clears
-     * is_deleted_ldap to 0 without activating the account. The subsequent
-     * sync must still restore the user based on is_active alone.
-     */
-    public function testRestoreAfterLoginClearedIsDeletedLdap(): void
-    {
-        global $CFG_GLPI;
-
-        $user = $this->createItem(User::class, [
-            'name'            => $this->getUniqueString(),
-            'is_active'       => 0,
-            'is_deleted_ldap' => 1,
-        ]);
-
-        // Simulate Auth.php clearing is_deleted_ldap on login without restoring is_active.
-        $user->update(['id' => $user->getID(), 'is_deleted_ldap' => 0]);
-
-        $CFG_GLPI['user_restored_ldap'] = AuthLDAP::RESTORED_USER_ENABLE;
-        User::manageRestoredUserInLdap($user->getID());
-
-        $user->getFromDB($user->getID());
-        $this->assertSame(1, (int) $user->fields['is_active']);
-        $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
-    }
 }

--- a/phpunit/functional/AuthLdapUserRestoreTest.php
+++ b/phpunit/functional/AuthLdapUserRestoreTest.php
@@ -90,4 +90,30 @@ class AuthLdapUserRestoreTest extends DbTestCase
         $this->assertSame(1, (int) $user->fields['is_active']);
         $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
     }
+
+    /**
+     * If a re-enabled AD user logs in before the next sync, Auth clears
+     * is_deleted_ldap to 0 without activating the account. The subsequent
+     * sync must still restore the user based on is_active alone.
+     */
+    public function testRestoreAfterLoginClearedIsDeletedLdap(): void
+    {
+        global $CFG_GLPI;
+
+        $user = $this->createItem(User::class, [
+            'name'            => $this->getUniqueString(),
+            'is_active'       => 0,
+            'is_deleted_ldap' => 1,
+        ]);
+
+        // Simulate Auth.php clearing is_deleted_ldap on login without restoring is_active.
+        $user->update(['id' => $user->getID(), 'is_deleted_ldap' => 0]);
+
+        $CFG_GLPI['user_restored_ldap'] = AuthLDAP::RESTORED_USER_ENABLE;
+        User::manageRestoredUserInLdap($user->getID());
+
+        $user->getFromDB($user->getID());
+        $this->assertSame(1, (int) $user->fields['is_active']);
+        $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
+    }
 }

--- a/phpunit/functional/AuthLdapUserRestoreTest.php
+++ b/phpunit/functional/AuthLdapUserRestoreTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use AuthLDAP;
+use DbTestCase;
+use User;
+
+/**
+ * Non-regression tests for LDAP user restore.
+ *
+ * When a user is disabled in Active Directory and the sync runs without
+ * ACTION_ALL, is_deleted_ldap is never set. On re-enable, the restore
+ * must still fire based on is_active alone.
+ */
+class AuthLdapUserRestoreTest extends DbTestCase
+{
+    /**
+     * A user inactive with is_deleted_ldap=0 must be re-enabled by
+     * manageRestoredUserInLdap().
+     */
+    public function testRestoreEnablesUserEvenWhenIsDeletedLdapIsFalse(): void
+    {
+        global $CFG_GLPI;
+
+        $user = $this->createItem(User::class, [
+            'name'            => $this->getUniqueString(),
+            'is_active'       => 0,
+            'is_deleted_ldap' => 0,
+        ]);
+
+        $CFG_GLPI['user_restored_ldap'] = AuthLDAP::RESTORED_USER_ENABLE;
+        User::manageRestoredUserInLdap($user->getID());
+
+        $user->getFromDB($user->getID());
+        $this->assertSame(1, (int) $user->fields['is_active']);
+        $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
+    }
+
+    /**
+     * Nominal path: user marked as LDAP-deleted (is_deleted_ldap=1) must
+     * be re-enabled by manageRestoredUserInLdap().
+     */
+    public function testRestoreEnablesUserWhenIsDeletedLdapIsTrue(): void
+    {
+        global $CFG_GLPI;
+
+        $user = $this->createItem(User::class, [
+            'name'            => $this->getUniqueString(),
+            'is_active'       => 0,
+            'is_deleted_ldap' => 1,
+        ]);
+
+        $CFG_GLPI['user_restored_ldap'] = AuthLDAP::RESTORED_USER_ENABLE;
+        User::manageRestoredUserInLdap($user->getID());
+
+        $user->getFromDB($user->getID());
+        $this->assertSame(1, (int) $user->fields['is_active']);
+        $this->assertSame(0, (int) $user->fields['is_deleted_ldap']);
+    }
+}

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1010,6 +1010,11 @@ class Auth extends CommonGLPI
         // is not present on the DB, so we add him.
         // if not, we update him.
         if ($this->auth_succeded) {
+            // Capture restore need before clearing the flag (original DB state still in fields).
+            $needs_ldap_restore = $this->user_present
+                && ($this->user->fields['authtype'] ?? 0) == self::LDAP
+                && ($this->user->fields['is_deleted_ldap'] || !$this->user->fields['is_active']);
+
             //Set user an not deleted from LDAP
             $this->user->fields['is_deleted_ldap'] = 0;
 
@@ -1036,6 +1041,10 @@ class Auth extends CommonGLPI
                     unset($input['api_token'], $input['cookie_token'], $input['password_forget_token'], $input['personal_token']);
 
                     $this->user->update(Sanitizer::sanitize($input));
+
+                    if ($needs_ldap_restore) {
+                        User::manageRestoredUserInLdap($this->user->fields['id']);
+                    }
                 } elseif ($CFG_GLPI["is_users_auto_add"]) {
                     // Auto add user
                     $input = $this->user->fields;

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -2941,7 +2941,7 @@ class AuthLDAP extends CommonDBTM
                             //In case user id has changed : get id by dn (Used to check if restoration is needed)
                             $user_found = $searched_user->getFromDBbyDn(Sanitizer::sanitize($user_dn));
                         }
-                        if ($user_found && $searched_user->fields['is_deleted_ldap'] && $searched_user->fields['user_dn']) {
+                        if ($user_found && ($searched_user->fields['is_deleted_ldap'] || !$searched_user->fields['is_active']) && $searched_user->fields['user_dn']) {
                             User::manageRestoredUserInLdap($searched_user->fields['id']);
                             return ['action' => self::USER_RESTORED_LDAP,
                                 'id' => $searched_user->fields['id'],

--- a/src/User.php
+++ b/src/User.php
@@ -5480,12 +5480,12 @@ HTML;
         $myuser = new self();
         if (
             !$myuser->getFromDB($users_id) // invalid user
-            || $myuser->fields['is_deleted_ldap'] == 0 // user already considered as restored from LDAP
+            || ($myuser->fields['is_deleted_ldap'] == 0 && $myuser->fields['is_active'] == 1) // already active, nothing to restore
         ) {
             return;
         }
 
-        //User is present in DB and in the directory but 'is_ldap_deleted' was true : it's been restored in LDAP
+        //User is present in DB and in the directory but was inactive or flagged as LDAP-deleted: restore it
         $tmp = [
             'id'              => $users_id,
             'is_deleted_ldap' => 0,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44308

When a user was disabled in Active Directory and the sync ran in ACTION_SYNCHRONIZE mode (no delete/restore detection), `is_deleted_ldap` was never set to 1.
When the user was later re-enabled in AD, both the call site in `ldapImportUserByServerId()` and the guard in `manageRestoredUserInLdap()` checked only `is_deleted_ldap`, so the restore was silently skipped and `is_active` stayed 0.
The fix extends both checks to also trigger restore when `is_active=0`, regardless of `is_deleted_ldap`.


