### PR TITLE
Fix(NetworkPort): avoid crash when deleting ports with duplicate links

### DIFF
--- a/src/NetworkPort_NetworkPort.php
+++ b/src/NetworkPort_NetworkPort.php
@@ -322,7 +322,9 @@ class NetworkPort_NetworkPort extends CommonDBRelation
 
         $log = new NetworkPortConnectionLog();
 
-        $opposite_port = $this->getOppositeContact($netports_id);
+        $opposite_port = $netports_id === $this->fields['networkports_id_1']
+            ? $this->fields['networkports_id_2']
+            : $this->fields['networkports_id_1'];
         if (!$opposite_port) {
             return;
         }

--- a/tests/functional/NetworkPort_NetworkPortTest.php
+++ b/tests/functional/NetworkPort_NetworkPortTest.php
@@ -86,6 +86,67 @@ class NetworkPort_NetworkPortTest extends DbTestCase
         $this->assertSame($id_1, $wired->getOppositeContact($id_2));
     }
 
+    /**
+     * Non-regression: deleting a NetworkPort_NetworkPort record must not throw
+     * TooManyResultsException when the same port appears in multiple connection rows
+     * (corrupted data caused by SNMP discovery creating duplicate entries).
+     */
+    public function testDeleteSucceedsWithDuplicateConnectionRows(): void
+    {
+        global $DB;
+        $this->login();
+
+        $switch = $this->createItem(\NetworkEquipment::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $port_switch = $this->createItem(\NetworkPort::class, [
+            'items_id'           => $switch->getID(),
+            'itemtype'           => \NetworkEquipment::class,
+            'entities_id'        => $switch->fields['entities_id'],
+            'name'               => 'eth0',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]);
+
+        $unmanaged1 = $this->createItem(\Unmanaged::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $port_b = $this->createItem(\NetworkPort::class, [
+            'items_id'           => $unmanaged1->getID(),
+            'itemtype'           => \Unmanaged::class,
+            'entities_id'        => $unmanaged1->fields['entities_id'],
+            'name'               => 'eth0',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]);
+
+        $unmanaged2 = $this->createItem(\Unmanaged::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $port_c = $this->createItem(\NetworkPort::class, [
+            'items_id'           => $unmanaged2->getID(),
+            'itemtype'           => \Unmanaged::class,
+            'entities_id'        => $unmanaged2->fields['entities_id'],
+            'name'               => 'eth0',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]);
+
+        $conn = $this->createItem(\NetworkPort_NetworkPort::class, [
+            'networkports_id_1' => $port_switch->getID(),
+            'networkports_id_2' => $port_b->getID(),
+        ]);
+
+        // Bypass prepareInputForAdd to simulate corrupted data: switch port appears in two rows
+        $DB->insert(\NetworkPort_NetworkPort::getTable(), [
+            'networkports_id_1' => $port_switch->getID(),
+            'networkports_id_2' => $port_c->getID(),
+        ]);
+
+        $nnp = new \NetworkPort_NetworkPort();
+        $this->assertTrue($nnp->delete(['id' => $conn->getID()]));
+    }
+
     public function testHub()
     {
         $this->login();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !43986

When deleting an unmanaged network device whose port appeared in more than one row of `glpi_networkports_networkports` (corrupted data from SNMP discovery), the deletion failed with a fatal `TooManyResultsException`:

```
Glpi\Exception\TooManyResultsException: `NetworkPort_NetworkPort::getFromDBByCrit()` expects to get one result, 2 found in query
"SELECT `id` FROM `glpi_networkports_networkports`
WHERE (`glpi_networkports_networkports`.`networkports_id_1` = '11529'
    OR `glpi_networkports_networkports`.`networkports_id_2` = '11529')"
```

`storeConnectionLog()` called `getOppositeContact()` which issued a fresh DB query and threw when it found two rows. Since `$this->fields` already holds both port IDs at `pre_deleteItem` time, the opposite port is now read directly from the loaded record without any additional query.

## Screenshots (if appropriate):


