### PR TITLE
Support ms-DS-ConsistencyGuid as LDAP sync_field

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -3394,7 +3394,14 @@ TWIG, $twig_params);
 
         // Try a search to find the DN
         $filter_value = $values['user_params']['value'];
-        if ($values['login_field'] === 'objectguid' && self::isValidGuid($filter_value)) {
+        // Binary GUID attributes must be sent to the LDAP server as hex-escaped
+        // bytes, not as a canonical GUID string, or the search returns nothing.
+        // Attribute names are case-insensitive (RFC 4512).
+        $guid_fields = ['objectguid', 'ms-ds-consistencyguid'];
+        if (
+            in_array(strtolower($values['login_field']), $guid_fields, true)
+            && self::isValidGuid($filter_value)
+        ) {
             $filter_value = self::guidToHex($filter_value);
         } else {
             $filter_value = ldap_escape($filter_value, '', LDAP_ESCAPE_FILTER);
@@ -4153,21 +4160,24 @@ TWIG, $twig_params);
                 $value = $infos[$field];
             }
         }
-        if ($field !== 'objectguid') {
+        // Binary GUID attributes are returned as a string in canonical form.
+        // Attribute names are case-insensitive (RFC 4512).
+        $guid_fields = ['objectguid', 'ms-ds-consistencyguid'];
+        if (!in_array(strtolower($field), $guid_fields, true)) {
             return $value;
         }
 
-        // handle special objectguid from AD directories
+        // Convert the binary GUID to its string form. If the bytes are not a
+        // valid GUID, keep the raw value.
         try {
-            // prevent double encoding
+            // Skip if the value is already a GUID string.
             if (!self::isValidGuid($value)) {
                 $value = self::guidToString($value);
                 if (!self::isValidGuid($value)) {
-                    throw new RuntimeException('Not an objectguid!');
+                    throw new RuntimeException('Not a valid GUID!');
                 }
             }
         } catch (Throwable $e) {
-            // well... this is not an objectguid apparently
             $value = $infos[$field];
         }
 

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -629,6 +629,15 @@ class AuthLdapTest extends DbTestCase
         $this->assertSame($expected, AuthLDAP::guidToHex($guid));
     }
 
+    public function testGuidToHexForBinaryGuidSearch()
+    {
+        // searchUserDn() feeds binary GUID attributes through guidToHex() to
+        // build the LDAP filter. This is the hex-escaped form AD expects.
+        $guid     = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+        $expected = '\d3\18\57\7c\54\c4\21\41\90\e3\a7\f7\e8\e1\d9\f1';
+        $this->assertSame($expected, AuthLDAP::guidToHex($guid));
+    }
+
     public function testGetFieldValue()
     {
         $infos = ['field' => 'value'];
@@ -636,6 +645,48 @@ class AuthLdapTest extends DbTestCase
 
         $infos = ['objectguid' => 'value'];
         $this->assertSame('value', AuthLDAP::getFieldValue($infos, 'objectguid'));
+    }
+
+    public function testGetFieldValueConvertsObjectGuidBinary()
+    {
+        // Binary objectGUID from AD must be converted to the canonical string form.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['objectguid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'objectguid'));
+    }
+
+    public function testGetFieldValueConvertsMsDsConsistencyGuid()
+    {
+        // ms-DS-ConsistencyGuid shares the same 16-byte binary layout as objectGUID.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['ms-ds-consistencyguid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'ms-ds-consistencyguid'));
+    }
+
+    public function testGetFieldValueIsCaseInsensitiveForGuidAttributes()
+    {
+        // LDAP attribute names are case-insensitive per RFC 4512.
+        $bin      = hex2bin('d318577c54c4214190e3a7f7e8e1d9f1');
+        $expected = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['ms-DS-ConsistencyGuid' => [$bin]];
+        $this->assertSame($expected, AuthLDAP::getFieldValue($infos, 'ms-DS-ConsistencyGuid'));
+    }
+
+    public function testGetFieldValueDoesNotDoubleConvertGuidString()
+    {
+        // If the value is already a GUID string, return it unchanged.
+        $guid = '7c5718d3-c454-4121-90e3-a7f7e8e1d9f1';
+
+        $infos = ['objectguid' => [$guid]];
+        $this->assertSame($guid, AuthLDAP::getFieldValue($infos, 'objectguid'));
+
+        $infos = ['ms-ds-consistencyguid' => [$guid]];
+        $this->assertSame($guid, AuthLDAP::getFieldValue($infos, 'ms-ds-consistencyguid'));
     }
 
     public function testPassword()


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Closes #24332

`AuthLDAP` only handled the attribute named `objectGUID` when reading and searching binary GUID values. Any other binary GUID attribute used as `sync_field` was stored and shown as raw bytes, and user lookups against it returned no results because the LDAP filter was not hex-escaped.

`ms-DS-ConsistencyGuid` has the same binary layout as `objectGUID` and is the immutable anchor used in Entra ID Connect hybrid setups, where it survives inter-forest migrations that `objectGUID` does not.

### Changes

The conversion now applies to a small case-insensitive list of binary GUID attribute names (`objectguid`, `ms-ds-consistencyguid`) in two places:

- `searchUserDn()` — the value is hex-escaped before building the LDAP filter, so the directory search actually matches. Without this, user import and synchronization by `ms-DS-ConsistencyGuid` return no results.
- `getFieldValue()` — the value read back from the directory is converted to the canonical GUID string for display and storage.

Attribute names are matched case-insensitively per RFC 4512.

### Tests

Added to `tests/LDAP/AuthLdapTest.php`, alongside the existing `testGetFieldValue()` and `testGuidToHex()` (both kept untouched as non-regression checks):

- `testGetFieldValueConvertsObjectGuidBinary` — existing `objectGUID` conversion still works on binary input.
- `testGetFieldValueConvertsMsDsConsistencyGuid` — the new attribute.
- `testGetFieldValueIsCaseInsensitiveForGuidAttributes` — mixed-case name, as it appears in Microsoft documentation.
- `testGetFieldValueDoesNotDoubleConvertGuidString` — values already in GUID string form are returned unchanged.
- `testGuidToHexForBinaryGuidSearch` — the hex-escaped form `searchUserDn()` builds for the LDAP filter.

### Verified against a real directory

Tested on a GLPI 11.0.7 instance against an Active Directory with `ms-DS-ConsistencyGuid` populated on user objects, with the LDAP `sync_field` set to that attribute.

**Before** — the value is stored and shown as raw bytes in the LDAP information tab:

<img width="683" height="232" alt="image" src="https://github.com/user-attachments/assets/832c5e54-acb3-4fa9-a248-95d6360e8f43" />


**After** — the same value is rendered as a canonical GUID string:

<img width="474" height="159" alt="image" src="https://github.com/user-attachments/assets/000ca39f-8b6f-4583-a64b-a6b76a63acab" />

**User synchronization** — users are correctly imported and synchronized using `ms-DS-ConsistencyGuid` as `sync_field`:

<img width="1468" height="410" alt="image" src="https://github.com/user-attachments/assets/185a8bf4-0281-47d2-8820-19e733938ba6" />

<img width="1507" height="652" alt="image" src="https://github.com/user-attachments/assets/a719044f-fdda-4c43-bc1a-3e25bedb3e54" />


### Out of scope

- `objectSid` uses a different binary layout (SID → SDDL) and would need its own decoder. Happy to address in a follow-up if there is interest.

### Local checks

- `php -l` clean on both files.
- `php-cs-fixer fix --dry-run` clean against the project config.
- `phpstan analyze src/AuthLDAP.php` clean.

---

*AI-assisted: used an LLM to verify code references and draft the wording; all logic reviewed and authored by me.*