### PR TITLE
Fix(Forms): prevent crash on mixed block layout at same rank

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -9122,12 +9122,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/QuestionType/QuestionTypeUserDevice.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access an offset on Glpi\\\\Form\\\\Comment\\|Glpi\\\\Form\\\\Question\\|list\\<Glpi\\\\Form\\\\Comment\\|Glpi\\\\Form\\\\Question\\>\\.$#',
-	'identifier' => 'offsetAccess.nonOffsetAccessible',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Section.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Form\\\\Section\\:\\:getQuestions\\(\\) should return array\\<Glpi\\\\Form\\\\Question\\> but returns array\\<Glpi\\\\Form\\\\Question\\>\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -20612,16 +20606,16 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/autoload/legacy-autoloader.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
-    'identifier' => 'argument.type',
-    'count' => 2,
-    'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
+	'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
+	'identifier' => 'argument.type',
+	'count' => 2,
+	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
-    'identifier' => 'argument.type',
-    'count' => 1,
-    'path' => __DIR__ . '/src/Glpi/Api/HL/StreamedResponseWrapper.php',
+	'message' => '#^Parameter \\#2 $headers of class Glpi\\Http\\Response constructor expects array<array<string>|string>, array<string, list<string|null>> given.#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Glpi/Api/HL/StreamedResponseWrapper.php',
 ];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/src/Glpi/Form/Section.php
+++ b/src/Glpi/Form/Section.php
@@ -265,10 +265,13 @@ final class Section extends CommonDBChild implements ConditionableVisibilityInte
             if ($horizontalRank !== null) {
                 if (!isset($groupedBlocks[$verticalRank])) {
                     $groupedBlocks[$verticalRank] = [];
+                } elseif (!is_array($groupedBlocks[$verticalRank])) {
+                    // A solo block was already placed at this rank (corrupted data after migration)
+                    $groupedBlocks[$verticalRank] = [$groupedBlocks[$verticalRank]];
                 }
                 $groupedBlocks[$verticalRank][] = $block;
             } else {
-                $groupedBlocks[] = $block;
+                $groupedBlocks[$verticalRank] = $block;
             }
         }
 

--- a/tests/functional/Glpi/Form/SectionTest.php
+++ b/tests/functional/Glpi/Form/SectionTest.php
@@ -164,6 +164,54 @@ class SectionTest extends DbTestCase
         $this->assertNotEmpty($name);
     }
 
+    /**
+     * Non-regression test for a crash when blocks have mixed solo/horizontal layout at the same vertical rank.
+     * Triggered by corrupted data after plugin migration (e.g. Fields plugin 1.24.x → GLPI 11).
+     */
+    public function testGetBlocksDoesNotCrashWithMixedLayoutAtSameVerticalRank(): void
+    {
+        $this->login();
+
+        $form = $this->createForm(
+            (new FormBuilder())->addSection('Section 1')
+        );
+        $section_id = $this->getSectionId($form, 'Section 1');
+
+        // Q1 at (vr=0, hr=0): horizontal group — sets explicit key 0, PHP auto-inc becomes 1
+        // Q2 at (vr=1, hr=null): solo block — buggy code assigns PHP auto-inc key 1
+        // Q3 at (vr=1, hr=0): horizontal at vr=1 — buggy code crashes: $groupedBlocks[1] is a Question, not an array
+        $this->createItem(Question::class, [
+            'forms_sections_id' => $section_id,
+            'name'              => 'Q1',
+            'type'              => QuestionTypeShortText::class,
+            'vertical_rank'     => 0,
+            'horizontal_rank'   => 0,
+        ]);
+        $this->createItem(Question::class, [
+            'forms_sections_id' => $section_id,
+            'name'              => 'Q2',
+            'type'              => QuestionTypeShortText::class,
+            'vertical_rank'     => 1,
+            'horizontal_rank'   => null,
+        ], ['horizontal_rank']);
+        $this->createItem(Question::class, [
+            'forms_sections_id' => $section_id,
+            'name'              => 'Q3',
+            'type'              => QuestionTypeShortText::class,
+            'vertical_rank'     => 1,
+            'horizontal_rank'   => 0,
+        ]);
+
+        $section = Section::getById($section_id);
+        $blocks = $section->getBlocks();
+
+        $this->assertCount(2, $blocks);
+        $this->assertIsArray($blocks[0]);
+        $this->assertCount(1, $blocks[0]);
+        $this->assertIsArray($blocks[1]);
+        $this->assertCount(2, $blocks[1]);
+    }
+
     private function checkGetQuestions(
         Section $section,
         array $expected_questions_names


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44201
- Activating a plugin that injected form questions with a mix of solo and horizontally-grouped blocks at the same vertical rank caused the service catalog to become completely inaccessible.
- The root cause was that solo blocks used PHP auto-increment array insertion (`$arr[] = $val`), which could assign a key equal to the `vertical_rank` of a later horizontal group, triggering a fatal type error when trying to append to that slot.
- The fix uses the `vertical_rank` as the explicit key for solo blocks, and adds a guard to convert an existing solo block into an array if a horizontal block is found at the same rank (graceful handling of corrupted data from plugin migrations).

```
Cannot use object of type Glpi\Form\Question as array
In ./src/Glpi/Form/Section.php(269)
#0 ./src/Glpi/Form/Section.php(216): Glpi\Form\Section->getBlocks()
#1 ./src/Glpi/Form/Form.php(494): Glpi\Form\Section->listTranslationsHandlers()
#2 [internal function]: Glpi\Form\Form->Glpi\Form\{closure}()
#3 ./src/Glpi/Form/Form.php(493): array_map()
#4 ./src/Glpi/ItemTranslation/ItemTranslation.php(248): Glpi\Form\Form->listTranslationsHandlers()
#5 ./src/Glpi/Form/Form.php(1178): Glpi\ItemTranslation\ItemTranslation::translate()
#6 ./src/Glpi/Form/ServiceCatalog/SortStrategy/PopularitySort.php(57): Glpi\Form\Form->getServiceCatalogItemTitle()
#7 ./src/Glpi/Form/ServiceCatalog/SortStrategy/AbstractSortStrategy.php(69): Glpi\Form\ServiceCatalog\SortStrategy\PopularitySort->compareItems()
#8 [internal function]: Glpi\Form\ServiceCatalog\SortStrategy\AbstractSortStrategy->Glpi\Form\ServiceCatalog\SortStrategy\{closure}()
#9 ./src/Glpi/Form/ServiceCatalog/SortStrategy/AbstractSortStrategy.php(44): usort()
#10 ./src/Glpi/Form/ServiceCatalog/ServiceCatalogManager.php(247): Glpi\Form\ServiceCatalog\SortStrategy\AbstractSortStrategy->sort()
#11 ./src/Glpi/Form/ServiceCatalog/ServiceCatalogManager.php(109): Glpi\Form\ServiceCatalog\ServiceCatalogManager->sortItems()
#12 ./src/Glpi/Controller/ServiceCatalog/IndexController.php(96): Glpi\Form\ServiceCatalog\ServiceCatalogManager->getItems()
```

## Screenshots (if appropriate):
