### PR TITLE
Fix(migration): use giveRight to add impersonate bit to existing prof…

### DIFF
--- a/install/migrations/update_10.0.x_to_11.0.0/impersonate_right.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/impersonate_right.php
@@ -35,4 +35,4 @@
 /**
  * @var Migration $migration
  */
-$migration->addRight('user', User::IMPERSONATE, ['config' => UPDATE]);
+$migration->giveRight('user', User::IMPERSONATE, ['config' => UPDATE]);

--- a/install/migrations/update_10.0.x_to_11.0.0/slm.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/slm.php
@@ -35,4 +35,4 @@
 /**
  * @var Migration $migration
  */
-$migration->addRight(SLM::$rightname, SLM::RIGHT_ASSIGN, ['ticket' => UPDATE]);
+$migration->giveRight(SLM::$rightname, SLM::RIGHT_ASSIGN, ['ticket' => UPDATE]);

--- a/install/migrations/update_10.0.x_to_11.0.0/ticket.php
+++ b/install/migrations/update_10.0.x_to_11.0.0/ticket.php
@@ -36,7 +36,7 @@
  * @var DBmysql $DB
  * @var Migration $migration
  */
-$migration->addRight('ticket', Ticket::READNEWTICKET, [
+$migration->giveRight('ticket', Ticket::READNEWTICKET, [
     'ticket' => Ticket::ASSIGN,
 ]);
 


### PR DESCRIPTION
…iles

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- When upgrading from GLPI 10 to 11, the impersonate right was never granted to existing super-admin profiles.
- The migration used `addRight`, which only inserts a new row for profiles that have no existing `user` right entry. Since all GLPI 10 profiles already have a `user` right row, the method returned early and the `IMPERSONATE` bit was never set.
- Replacing it with `giveRight` correctly ORs the new bit into existing rows, matching the pattern used by the `changesatisfactions` migration fix.

## Screenshots (if appropriate):


