### PR TITLE
fix(ux): Add stethoscope icon to rule test buttons

### DIFF
--- a/src/Rule.php
+++ b/src/Rule.php
@@ -917,6 +917,7 @@ class Rule extends CommonDBTM
             $add_buttons = [
                 [
                     'text' => _x('button', 'Test'),
+                    'icon' => 'ti ti-stethoscope',
                     'type' => 'button',
                     'onclick' => "$('#ruletestmodal').modal('show');",
                 ],

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -685,7 +685,7 @@ HTML;
                         'content': reset_warning
                     }) }}
                 {% endif %}
-                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest"><i class="ti ti-stethoscope"></i> {{ test_label }}</button>
+                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest"><i class="ti ti-stethoscope"></i> <span>{{ test_label }}</span></button>
                 {% do call('Ajax::createIframeModalWindow', ['allruletest', test_url, {title: test_label}]) %}
                 {% if can_replay %}
                     <a class="btn btn-primary mx-1" role="button" href="{{ rule_class|itemtype_search_path }}?replay_rule=replay_rule">{{ replay_label }}</a>

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -685,7 +685,7 @@ HTML;
                         'content': reset_warning
                     }) }}
                 {% endif %}
-                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest">{{ test_label }}</button>
+                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest"><i class="ti ti-stethoscope"></i> {{ test_label }}</button>
                 {% do call('Ajax::createIframeModalWindow', ['allruletest', test_url, {title: test_label}]) %}
                 {% if can_replay %}
                     <a class="btn btn-primary mx-1" role="button" href="{{ rule_class|itemtype_search_path }}?replay_rule=replay_rule">{{ replay_label }}</a>

--- a/src/RuleRight.php
+++ b/src/RuleRight.php
@@ -413,6 +413,7 @@ class RuleRight extends Rule
             $add_buttons = [
                 [
                     'text' => _x('button', 'Test'),
+                    'icon' => 'ti ti-stethoscope',
                     'type' => 'button',
                     'onclick' => "$('#ruletestmodal').modal('show');",
                 ],

--- a/templates/pages/admin/rules/engine_preview_criteria.html.twig
+++ b/templates/pages/admin/rules/engine_preview_criteria.html.twig
@@ -59,7 +59,7 @@
                   </div>
                </div>
             </div>
-            {{ inputs.submit('test_all_rules', _x('button', 'Test'), 1) }}
+            {{ inputs.submit('test_all_rules', _x('button', 'Test'), 1, {'icon': 'ti ti-stethoscope'}) }}
             {{ inputs.hidden('sub_type', rule_classname) }}
             {{ inputs.hidden('condition', condition) }}
          </form>

--- a/templates/pages/admin/rules/preview_criteria.html.twig
+++ b/templates/pages/admin/rules/preview_criteria.html.twig
@@ -69,7 +69,8 @@
             <input type="hidden" name="{{ rules_id_field }}" value="{{ rules_id }}"/>
             <input type="hidden" name="sub_type" value="{{ item.getType() }}"/>
             <button type="submit" name="test_rule" class="btn btn-primary">
-                {{ _x('button', 'Test') }}
+                <i class="ti ti-stethoscope"></i>
+                <span>{{ _x('button', 'Test') }}</span>
             </button>
         </div>
     </div>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

Add the 'ti ti-stethoscope' icon to the Test action buttons for rules. Updated Rule.php and RuleRight.php to include an 'icon' attribute in the add_buttons array, and updated RuleCollection.php template to render the same icon inside the bulk "Test" button so single and bulk test actions have a consistent UI (same icon used in LDAP's "Test" tab).

## Screenshots (if appropriate):

Main rules page:
<img width="273" height="41" alt="image" src="https://github.com/user-attachments/assets/fecf89ae-286e-43b2-bec8-12b2b9e920c5" />

Test rules engine modal: 
<img width="334" height="318" alt="image" src="https://github.com/user-attachments/assets/4a940517-af64-48c6-a967-9b385dde95d2" />

Rule page:
<img width="376" height="41" alt="image" src="https://github.com/user-attachments/assets/11684071-94e4-4cd7-ba44-918074d54c7c" />

Rule "Test" modal:
<img width="1138" height="329" alt="image" src="https://github.com/user-attachments/assets/68e224b9-feb5-4ac7-88d3-0cf6105fed6c" />