### PR TITLE
fix(ui): Use Group icon for LDAP group tab

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -4026,7 +4026,7 @@ TWIG, $twig_params);
             $ong     = [];
             $ong[1]  = self::createTabEntry(_x('button', 'Test'), 0, $item::class, "ti ti-stethoscope"); // test connexion
             $ong[2]  = self::createTabEntry(User::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
-            $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::class, User::getIcon());
+            $ong[3]  = self::createTabEntry(Group::getTypeName(Session::getPluralNumber()), 0, $item::class, Group::getIcon());
             $ong[5]  = self::createTabEntry(__('Advanced information'));   // params for entity advanced config
             $count = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

Fix incorrect icon on the group tab in src/AuthLDAP.php: the tab entry at index 3 was using User::getIcon(), causing groups to show the user icon. Replace with Group::getIcon() so the group tab displays the correct icon.

## Screenshots (if appropriate):

<img width="200" height="75" alt="image" src="https://github.com/user-attachments/assets/c3876b9e-caf6-4ff4-b7d4-8de1e332a56a" />
