### PR TITLE
Prevent repeated SQL queries when rendering dashboards

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -7724,25 +7724,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Filters/AbstractGroupFilter.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method canViewCurrent\\(\\) on Glpi\\\\Dashboard\\\\Dashboard\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getTitle\\(\\) on Glpi\\\\Dashboard\\\\Dashboard\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Dashboard\\\\Grid\\:\\:dropdownDashboard\\(\\) should return string but returns int\\|string\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Dashboard\\\\Grid\\:\\:getDashboard\\(\\) should return Glpi\\\\Dashboard\\\\Dashboard but returns Glpi\\\\Dashboard\\\\Dashboard\\|null\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Dashboard/Grid.php',

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -507,6 +507,26 @@ class Dashboard extends CommonDBTM
         ];
     }
 
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @param array<string, mixed> $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rights
+     */
+    public function setRights(array $rights): void
+    {
+        $this->rights = $rights;
+    }
 
     /**
      * Retrieve all dashboards and store them into a static var
@@ -533,7 +553,18 @@ class Dashboard extends CommonDBTM
                 $id  = $dashboard['id'];
 
                 $d_rights = array_filter($rights, static fn($right_line) => $right_line['dashboards_dashboards_id'] == $id);
+                $d_items = array_filter($items, static fn($i) => $i['dashboards_dashboards_id'] == $id);
+                $d_items = array_map(static function ($item) {
+                    $item['card_options'] = importArrayFromDB($item['card_options']);
+                    return $item;
+                }, $d_items);
+
+                // Load known data directly into the item properties to avoid
+                // an useless trip to the database
                 $dashboardItem = new self($key);
+                $dashboardItem->fields = $dashboard;
+                $dashboardItem->items  = $d_items;
+                $dashboardItem->rights = $d_rights;
                 if ($check_rights && !$dashboardItem->canViewCurrent()) {
                     continue;
                 }

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -65,7 +65,7 @@ class Grid
     protected int $grid_cols       = 26;
     protected int $grid_rows       = 24;
     protected string $current         = "";
-    protected ?Dashboard $dashboard       = null;
+    protected Dashboard $dashboard;
     protected array $items           = [];
     protected string $context            = '';
 
@@ -111,7 +111,7 @@ class Grid
      *
      * @return bool
      */
-    public static function loadAllDashboards(bool $force = true): bool
+    public static function loadAllDashboards(bool $force = false): bool
     {
         if (
             count(self::$all_dashboards) === 0
@@ -225,13 +225,7 @@ HTML;
     {
         self::loadAllDashboards();
 
-        $dashboard = new Dashboard($key);
-        $dashboard->load();
-        // check global (admin) right
-        if (Dashboard::canView() && !$dashboard->isPrivate()) {
-            return true;
-        }
-
+        // The dashboards in the static property are filtered for the current user
         return isset(self::$all_dashboards[$key]);
     }
 
@@ -243,17 +237,24 @@ HTML;
      */
     public function show(bool $mini = false, ?string $token = null)
     {
-        global $GLPI_CACHE;
-
         $rand = mt_rand();
-
-        if (!self::$embed && !$this->dashboard->canViewCurrent()) {
-            return;
-        }
 
         self::loadAllDashboards();
 
+        $can_view_current = isset(self::$all_dashboards[$this->dashboard->getKey()]);
+        if (!self::$embed && !$can_view_current) {
+            return;
+        }
+
         $this->restoreLastDashboard();
+
+        // Load known database values into $this->dashboard properties to prevent
+        // it from being loaded again when used by other methods
+        if ($can_view_current) {
+            $this->dashboard->fields = self::$all_dashboards[$this->dashboard->getKey()];
+            $this->dashboard->setItems(self::$all_dashboards[$this->dashboard->getKey()]['items'] ?? []);
+            $this->dashboard->setRights(self::$all_dashboards[$this->dashboard->getKey()]['rights'] ?? []);
+        }
 
         if ($mini) {
             $this->cell_margin = 3;


### PR DESCRIPTION
I've noticed that enabling the "mini dashboard" on top of tickets drastically increase the number of executed SQL request on the /front/ticket.php page.

On my mostly empty dev instance with default data, enabling the dashboard add 90 sql requests.
On our production support instance, it adds 450 sql requests.

It seems a lot for a dashboard of around 5 cards, especially since I am only counting the SQL requests for the main http request (so each card content is not even loaded yet, this is done by AJAX later).

I found out that we load all dashboard data with 3 sql requests at the top of the process like this:
<img width="672" height="75" alt="image" src="https://github.com/user-attachments/assets/b6b40647-3f20-4168-92e0-01a0e180f56b" />

But this data is then mostly ignored and we keep reloading it in multiple method each time we need to do something (like checking some rights).

Overall it is not easy to get a clear picture as data seems to be loaded all over the place in inner methods, but I think I reduced the load quite a bit by setting the `force` parameter default value to `false` for `loadAllDashboards` (we only need to force a reload if data changed, which is never the case in the code I've encountered) and by injecting known data into objects when possible to prevent individual `load` calls from loading data that we already fetched.

On my test instance, the "extra" queries dropped from 90 to 8 after these changes, which seems way more reasonable.


