### PR TITLE
Update/patch vulnerable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ext-session": "*",
         "ext-simplexml": "*",
         "ext-zlib": "*",
+        "benmorel/weakmap-polyfill": "^0.5.0",
         "donatj/phpuseragentparser": "^1.7",
         "elvanto/litemoji": "^4.1",
         "glpi-project/inventory_format": "^1.2",
@@ -80,7 +81,7 @@
         "atoum/stubs": "^2.6",
         "friendsofphp/php-cs-fixer": "^3.94",
         "friendsoftwig/twigcs": "^6.1",
-        "glpi-project/tools": "^0.7",
+        "glpi-project/tools": "^0.8",
         "maglnet/composer-require-checker": "^3.5",
         "mikey179/vfsstream": "^1.6",
         "php-parallel-lint/php-parallel-lint": "^1.4",
@@ -121,7 +122,21 @@
                 "true/punycode": "Replacement done in GLPI 11.0"
             },
             "ignore": {
-                "CVE-2025-45769": "Patch has been applied manually."
+                "CVE-2025-45769": "Patch has been applied manually.",
+                "CVE-2026-24425": "Patch has been applied manually.",
+                "CVE-2026-46627": "Patch has been applied manually.",
+                "CVE-2026-46628": "Patch has been applied manually.",
+                "CVE-2026-46633": "Patch has been applied manually.",
+                "CVE-2026-46634": "Patch has been applied manually.",
+                "CVE-2026-46635": "Patch has been applied manually.",
+                "CVE-2026-46636": "Patch has been applied manually.",
+                "CVE-2026-46638": "Patch has been applied manually.",
+                "CVE-2026-47730": "Patch has been applied manually.",
+                "CVE-2026-47732": "Patch has been applied manually.",
+                "CVE-2026-48805": "Patch has been applied manually.",
+                "CVE-2026-48806": "Patch has been applied manually.",
+                "CVE-2026-48807": "Patch has been applied manually.",
+                "CVE-2026-48808": "Patch has been applied manually."
             }
         }
     },
@@ -178,6 +193,8 @@
             "patch -f -p1 -d vendor/psr/http-factory/ < tools/patches/psr-http-factory-php8.4-compat.patch || true",
             "patch -f -p1 -d vendor/scssphp/scssphp/ < tools/patches/scssphp-scssphp-php8.4-compat.patch || true",
             "patch -f -p1 -d vendor/symfony/string/ < tools/patches/symfony-string-php8.5-compat.patch || true",
+            "(patch -f -p1 -d vendor/twig/twig/ < tools/patches/twig-twig-v3.11.3...v3.27.0.patch --dry-run && patch -f -p1 -d vendor/twig/twig/ < tools/patches/twig-twig-v3.11.3...v3.27.0.patch) || true",
+            "patch -f -p1 -d vendor/twig/twig/ < tools/patches/twig-twig-php7.4-compat.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.4-compat.patch || true",
             "patch -f -p1 -d vendor/wapmorgan/unified-archive/ < tools/patches/wapmorgan-unified-archive-php-8.5-compat.patch || true"
         ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1440d7cc098746f83254ebb3c42fc68c",
+    "content-hash": "f5d0c56ef56d4ecb3029628635b88ced",
     "packages": [
+        {
+            "name": "benmorel/weakmap-polyfill",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BenMorel/weakmap-polyfill.git",
+                "reference": "032b88d36f0398111a3f97699f355d10636d8f98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BenMorel/weakmap-polyfill/zipball/032b88d36f0398111a3f97699f355d10636d8f98",
+                "reference": "032b88d36f0398111a3f97699f355d10636d8f98",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.4",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A WeakMap polyfill for PHP 7.4",
+            "keywords": [
+                "weakmap",
+                "weakref",
+                "weakreference"
+            ],
+            "support": {
+                "issues": "https://github.com/BenMorel/weakmap-polyfill/issues",
+                "source": "https://github.com/BenMorel/weakmap-polyfill/tree/0.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-02T16:29:05+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.9.3",
@@ -5907,16 +5956,16 @@
         },
         {
             "name": "glpi-project/tools",
-            "version": "0.7.8",
+            "version": "0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/glpi-project/tools.git",
-                "reference": "bd78ad2ab0d30510729530c077f84d52b8f02866"
+                "reference": "8ea2a7d4702a858f4b0360ba7d4f1841a5e77026"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/glpi-project/tools/zipball/bd78ad2ab0d30510729530c077f84d52b8f02866",
-                "reference": "bd78ad2ab0d30510729530c077f84d52b8f02866",
+                "url": "https://api.github.com/repos/glpi-project/tools/zipball/8ea2a7d4702a858f4b0360ba7d4f1841a5e77026",
+                "reference": "8ea2a7d4702a858f4b0360ba7d4f1841a5e77026",
                 "shasum": ""
             },
             "require": {
@@ -5959,7 +6008,7 @@
                 "issues": "https://github.com/glpi-project/tools/issues",
                 "source": "https://github.com/glpi-project/tools"
             },
-            "time": "2025-08-20T09:58:56+00:00"
+            "time": "2025-10-14T10:26:06+00:00"
         },
         {
             "name": "maglnet/composer-require-checker",

--- a/composer.lock
+++ b/composer.lock
@@ -3349,16 +3349,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.4.46",
+            "version": "v5.4.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b"
+                "reference": "bf581474737420d5c932ae80b868e253f465ee5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
-                "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/bf581474737420d5c932ae80b868e253f465ee5b",
+                "reference": "bf581474737420d5c932ae80b868e253f465ee5b",
                 "shasum": ""
             },
             "require": {
@@ -3426,7 +3426,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.4.46"
+                "source": "https://github.com/symfony/cache/tree/v5.4.53"
             },
             "funding": [
                 {
@@ -3438,11 +3438,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T11:43:55+00:00"
+            "time": "2026-05-24T08:41:21+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -3757,16 +3761,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.48",
+            "version": "v5.4.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "b57df76f4757a9a8dfbb57ba48d7780cc20776c6"
+                "reference": "b4cf17ff405a77341ad86e81e06ff09298f5aa8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b57df76f4757a9a8dfbb57ba48d7780cc20776c6",
-                "reference": "b57df76f4757a9a8dfbb57ba48d7780cc20776c6",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b4cf17ff405a77341ad86e81e06ff09298f5aa8f",
+                "reference": "b4cf17ff405a77341ad86e81e06ff09298f5aa8f",
                 "shasum": ""
             },
             "require": {
@@ -3812,7 +3816,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.48"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.52"
             },
             "funding": [
                 {
@@ -3824,11 +3828,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T14:36:38+00:00"
+            "time": "2026-04-17T07:30:55+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8797,16 +8805,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v5.4.49",
+            "version": "v5.4.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "d77d8e212cde7b5c4a64142bf431522f19487c28"
+                "reference": "b9bb0c36216de55c64c4cc904fab1c3e8765a996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/d77d8e212cde7b5c4a64142bf431522f19487c28",
-                "reference": "d77d8e212cde7b5c4a64142bf431522f19487c28",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/b9bb0c36216de55c64c4cc904fab1c3e8765a996",
+                "reference": "b9bb0c36216de55c64c4cc904fab1c3e8765a996",
                 "shasum": ""
             },
             "require": {
@@ -8868,7 +8876,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v5.4.49"
+                "source": "https://github.com/symfony/http-client/tree/v5.4.53"
             },
             "funding": [
                 {
@@ -8880,11 +8888,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-28T08:37:04+00:00"
+            "time": "2026-05-22T10:25:12+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -8966,16 +8978,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v5.4.45",
+            "version": "v5.4.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "8c1b9b3e5b52981551fc6044539af1d974e39064"
+                "reference": "8f89d3a319b92486b0bcc43c0479d19fdb0e2f64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/8c1b9b3e5b52981551fc6044539af1d974e39064",
-                "reference": "8c1b9b3e5b52981551fc6044539af1d974e39064",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/8f89d3a319b92486b0bcc43c0479d19fdb0e2f64",
+                "reference": "8f89d3a319b92486b0bcc43c0479d19fdb0e2f64",
                 "shasum": ""
             },
             "require": {
@@ -9031,7 +9043,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.4.45"
+                "source": "https://github.com/symfony/mime/tree/v5.4.52"
             },
             "funding": [
                 {
@@ -9043,11 +9055,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-23T20:18:32+00:00"
+            "time": "2026-05-05T14:35:32+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3169,9 +3169,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10060,9 +10060,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10598,9 +10598,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -2412,6 +2412,10 @@ HTML;
                 'name'  => 'thenetworg/oauth2-azure',
                 'check' => 'TheNetworg\\OAuth2\\Client\\Provider\\Azure',
             ],
+            [
+                'name'  => 'benmorel/weakmap-polyfill',
+                'check' => 'WeakMap',
+            ],
         ];
         if (Toolbox::canUseCAS()) {
             $deps[] = [

--- a/tools/patches/twig-twig-php7.4-compat.patch
+++ b/tools/patches/twig-twig-php7.4-compat.patch
@@ -1,0 +1,2085 @@
+diff -u a/src/Cache/ChainCache.php b/src/Cache/ChainCache.php
+--- a/src/Cache/ChainCache.php
++++ b/src/Cache/ChainCache.php
+@@ -21,12 +21,15 @@
+  */
+ final class ChainCache implements CacheInterface, RemovableCacheInterface
+ {
++    private iterable $caches;
++
+     /**
+      * @param iterable<CacheInterface> $caches The ordered list of caches used to store and fetch cached items
+      */
+     public function __construct(
+-        private iterable $caches,
++        iterable $caches
+     ) {
++        $this->caches = $caches;
+     }
+ 
+     public function generateKey(string $name, string $className): string
+diff -u a/src/Compiler.php b/src/Compiler.php
+--- a/src/Compiler.php
++++ b/src/Compiler.php
+@@ -29,9 +29,12 @@
+     private $didUseEcho = false;
+     private $didUseEchoStack = [];
+ 
++    private Environment $env;
++
+     public function __construct(
+-        private Environment $env,
++        Environment $env
+     ) {
++        $this->env = $env;
+     }
+ 
+     public function getEnvironment(): Environment
+@@ -74,7 +77,7 @@
+             $node->compile($this);
+ 
+             if ($this->didUseEcho) {
+-                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, $node::class);
++                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, get_class($node));
+             }
+ 
+             return $this;
+@@ -99,7 +102,7 @@
+             $node->compile($this);
+ 
+             if ($this->didUseEcho) {
+-                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, $node::class);
++                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, get_class($node));
+             }
+ 
+             return $this;
+diff -u a/src/DeprecatedCallableInfo.php b/src/DeprecatedCallableInfo.php
+--- a/src/DeprecatedCallableInfo.php
++++ b/src/DeprecatedCallableInfo.php
+@@ -19,13 +19,24 @@
+     private string $type;
+     private string $name;
+ 
++    private string $package;
++    private string $version;
++    private ?string $altName;
++    private ?string $altPackage;
++    private ?string $altVersion;
++
+     public function __construct(
+-        private string $package,
+-        private string $version,
+-        private ?string $altName = null,
+-        private ?string $altPackage = null,
+-        private ?string $altVersion = null,
++        string $package,
++        string $version,
++        ?string $altName = null,
++        ?string $altPackage = null,
++        ?string $altVersion = null
+     ) {
++        $this->package = $package;
++        $this->version = $version;
++        $this->altName = $altName;
++        $this->altPackage = $altPackage;
++        $this->altVersion = $altVersion;
+     }
+ 
+     public function setType(string $type): void
+diff -u a/src/ExpressionParser/AbstractExpressionParser.php b/src/ExpressionParser/AbstractExpressionParser.php
+--- a/src/ExpressionParser/AbstractExpressionParser.php
++++ b/src/ExpressionParser/AbstractExpressionParser.php
+@@ -15,7 +15,14 @@
+ {
+     public function __toString(): string
+     {
+-        return \sprintf('%s(%s)', ExpressionParserType::getType($this)->value, $this->getName());
++        if ($this instanceof PrefixExpressionParserInterface) {
++            $type = 'prefix';
++        }
++        if ($this instanceof InfixExpressionParserInterface) {
++            $type = 'infix';
++        }
++
++        return \sprintf('%s(%s)', $type, $this->getName());
+     }
+ 
+     public function getPrecedenceChange(): ?PrecedenceChange
+diff -u a/src/ExpressionParser/ExpressionParsers.php b/src/ExpressionParser/ExpressionParsers.php
+--- a/src/ExpressionParser/ExpressionParsers.php
++++ b/src/ExpressionParser/ExpressionParsers.php
+@@ -46,7 +46,7 @@
+      *
+      * @return $this
+      */
+-    public function add(array $parsers): static
++    public function add(array $parsers)/*: static*/
+     {
+         foreach ($parsers as $parser) {
+             if ($parser->getPrecedence() > 512 || $parser->getPrecedence() < 0) {
+@@ -54,7 +54,7 @@
+                 // throw new \InvalidArgumentException(\sprintf('Precedence for "%s" must be between 0 and 512, got %d.', $parser->getName(), $parser->getPrecedence()));
+             }
+             $interface = $parser instanceof PrefixExpressionParserInterface ? PrefixExpressionParserInterface::class : InfixExpressionParserInterface::class;
+-            $this->parsersByClass[$parser::class] = $parser;
++            $this->parsersByClass[get_class($parser)] = $parser;
+             foreach (self::getOperatorTokensFor($parser) as $token) {
+                 $this->parsersByName[$interface][$token] = $parser;
+             }
+@@ -128,7 +128,7 @@
+                         if (!isset($this->precedenceChanges[$e])) {
+                             $this->precedenceChanges[$e] = [];
+                         }
+-                        $this->precedenceChanges[$e][] = $ep;
++                        @$this->precedenceChanges[$e][] = $ep;
+                     }
+                 }
+             }
+@@ -148,7 +148,7 @@
+             return $parser->getOperatorTokens();
+         }
+ 
+-        trigger_deprecation('twig/twig', '3.24', 'Not implementing the "getOperatorTokens()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', $parser::class, ExpressionParserInterface::class);
++        trigger_deprecation('twig/twig', '3.24', 'Not implementing the "getOperatorTokens()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', get_class($parser), ExpressionParserInterface::class);
+ 
+         return [$parser->getName(), ...$parser->getAliases()];
+     }
+diff -u a/src/ExpressionParser/Infix/ArgumentsTrait.php b/src/ExpressionParser/Infix/ArgumentsTrait.php
+--- a/src/ExpressionParser/Infix/ArgumentsTrait.php
++++ b/src/ExpressionParser/Infix/ArgumentsTrait.php
+@@ -64,7 +64,7 @@
+                 $value = $value->getNode('right');
+             } elseif (($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) || ($token = $stream->nextIf(Token::PUNCTUATION_TYPE, ':'))) {
+                 if (!$value instanceof ContextVariable) {
+-                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', $value::class), $token->getLine(), $stream->getSourceContext());
++                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', get_class($value)), $token->getLine(), $stream->getSourceContext());
+                 }
+                 $name = $value->getAttribute('name');
+                 $value = $parser->parseExpression();
+diff -u a/src/ExpressionParser/Infix/ArrowExpressionParser.php b/src/ExpressionParser/Infix/ArrowExpressionParser.php
+--- a/src/ExpressionParser/Infix/ArrowExpressionParser.php
++++ b/src/ExpressionParser/Infix/ArrowExpressionParser.php
+@@ -13,7 +13,6 @@
+ 
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ArrowFunctionExpression;
+@@ -46,8 +45,8 @@
+         return 250;
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/AssignmentExpressionParser.php b/src/ExpressionParser/Infix/AssignmentExpressionParser.php
+--- a/src/ExpressionParser/Infix/AssignmentExpressionParser.php
++++ b/src/ExpressionParser/Infix/AssignmentExpressionParser.php
+@@ -12,7 +12,6 @@
+ namespace Twig\ExpressionParser\Infix;
+ 
+ use Twig\Error\SyntaxError;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ArrayExpression;
+ use Twig\Node\Expression\Binary\AbstractBinary;
+@@ -29,9 +28,9 @@
+ class AssignmentExpressionParser extends BinaryOperatorExpressionParser
+ {
+     public function __construct(
+-        string $name,
++        string $name
+     ) {
+-        parent::__construct(SetBinary::class, $name, 0, InfixAssociativity::Right);
++        parent::__construct(SetBinary::class, $name, 0, 2);
+     }
+ 
+     /**
+@@ -40,12 +39,11 @@
+     public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression
+     {
+         if (!$left instanceof ContextVariable && !$left instanceof ArrayExpression) {
+-            throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned.', $left::class), $token->getLine(), $parser->getStream()->getSourceContext());
++            throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned.', get_class($left)), $token->getLine(), $parser->getStream()->getSourceContext());
+         }
+-        $right = $parser->parseExpression(InfixAssociativity::Left === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
+-        $right = match ($this->getName()) {
+-            '=' => $right,
+-            default => throw new \LogicException(\sprintf('Unknown operator: %s.', $this->getName())),
++        $right = $parser->parseExpression(1 === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
++        if ($this->getName() !== '=') {
++            throw new \LogicException(\sprintf('Unknown operator: %s.', $this->getName()));
+         };
+ 
+         if ($left instanceof ArrayExpression) {
+diff -u a/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php b/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php
+--- a/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php
++++ b/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php
+@@ -13,7 +13,6 @@
+ 
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\ExpressionParser\PrecedenceChange;
+ use Twig\Node\Expression\AbstractExpression;
+@@ -26,16 +25,31 @@
+  */
+ class BinaryOperatorExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
+ {
++    private string $nodeClass;
++    private string $name;
++    private int $precedence;
++    private int $associativity;
++    private ?PrecedenceChange $precedenceChange;
++    private ?string $description;
++    private array $aliases;
++
+     public function __construct(
+         /** @var class-string<AbstractBinary> */
+-        private string $nodeClass,
+-        private string $name,
+-        private int $precedence,
+-        private InfixAssociativity $associativity = InfixAssociativity::Left,
+-        private ?PrecedenceChange $precedenceChange = null,
+-        private ?string $description = null,
+-        private array $aliases = [],
++        string $nodeClass,
++        string $name,
++        int $precedence,
++        int $associativity = 1,
++        ?PrecedenceChange $precedenceChange = null,
++        ?string $description = null,
++        array $aliases = []
+     ) {
++        $this->nodeClass = $nodeClass;
++        $this->name = $name;
++        $this->precedence = $precedence;
++        $this->associativity = $associativity;
++        $this->precedenceChange = $precedenceChange;
++        $this->description = $description;
++        $this->aliases = $aliases;
+     }
+ 
+     /**
+@@ -43,12 +57,13 @@
+      */
+     public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression
+     {
+-        $right = $parser->parseExpression(InfixAssociativity::Left === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
++        $right = $parser->parseExpression(1 === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
+ 
+-        return new ($this->nodeClass)($left, $right, $token->getLine());
++        $nodeClass = $this->nodeClass;
++        return new $nodeClass($left, $right, $token->getLine());
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+         return $this->associativity;
+     }
+diff -u a/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php b/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php
+--- a/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php
++++ b/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php
+@@ -13,7 +13,6 @@
+ 
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ConstantExpression;
+@@ -55,8 +54,8 @@
+         return 0;
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/DotExpressionParser.php b/src/ExpressionParser/Infix/DotExpressionParser.php
+--- a/src/ExpressionParser/Infix/DotExpressionParser.php
++++ b/src/ExpressionParser/Infix/DotExpressionParser.php
+@@ -14,7 +14,6 @@
+ use Twig\Error\SyntaxError;
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Lexer;
+ use Twig\Node\Expression\AbstractExpression;
+@@ -101,8 +100,8 @@
+         return 512;
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/FilterExpressionParser.php b/src/ExpressionParser/Infix/FilterExpressionParser.php
+--- a/src/ExpressionParser/Infix/FilterExpressionParser.php
++++ b/src/ExpressionParser/Infix/FilterExpressionParser.php
+@@ -14,7 +14,6 @@
+ use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\ExpressionParser\PrecedenceChange;
+ use Twig\Node\EmptyNode;
+@@ -46,12 +45,14 @@
+ 
+         $filter = $parser->getFilter($token->getValue(), $line);
+ 
++        $class = $filter->getNodeClass();
++
+         $ready = true;
+-        if (!isset($this->readyNodes[$class = $filter->getNodeClass()])) {
++        if (\PHP_VERSION_ID >= 80000 && !isset($this->readyNodes[$class])) {
+             $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
+         }
+ 
+-        if (!$ready = $this->readyNodes[$class]) {
++        if (\PHP_VERSION_ID >= 80000 && !$ready = $this->readyNodes[$class]) {
+             trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigFilter" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
+         }
+ 
+@@ -78,8 +79,8 @@
+         return new PrecedenceChange('twig/twig', '3.21', 300);
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/FunctionExpressionParser.php b/src/ExpressionParser/Infix/FunctionExpressionParser.php
+--- a/src/ExpressionParser/Infix/FunctionExpressionParser.php
++++ b/src/ExpressionParser/Infix/FunctionExpressionParser.php
+@@ -15,7 +15,6 @@
+ use Twig\Error\SyntaxError;
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Node\EmptyNode;
+ use Twig\Node\Expression\AbstractExpression;
+@@ -63,11 +62,14 @@
+             return $node;
+         }
+ 
+-        if (!isset($this->readyNodes[$class = $function->getNodeClass()])) {
++        $class = $function->getNodeClass();
++
++        $ready = true;
++        if (\PHP_VERSION_ID >= 80000 && !isset($this->readyNodes[$class])) {
+             $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
+         }
+ 
+-        if (!$ready = $this->readyNodes[$class]) {
++        if (\PHP_VERSION_ID >= 80000 && !$ready = $this->readyNodes[$class]) {
+             trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigFunction" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
+         }
+ 
+@@ -89,8 +91,8 @@
+         return 512;
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/IsExpressionParser.php b/src/ExpressionParser/Infix/IsExpressionParser.php
+--- a/src/ExpressionParser/Infix/IsExpressionParser.php
++++ b/src/ExpressionParser/Infix/IsExpressionParser.php
+@@ -14,7 +14,6 @@
+ use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ArrayExpression;
+@@ -50,12 +49,14 @@
+             $expr = new MacroReferenceExpression($alias['node']->getNode('var'), $alias['name'], new ArrayExpression([], $expr->getTemplateLine()), $expr->getTemplateLine());
+         }
+ 
++        $class = $test->getNodeClass();
++
+         $ready = $test instanceof TwigTest;
+-        if (!isset($this->readyNodes[$class = $test->getNodeClass()])) {
++        if (\PHP_VERSION_ID >= 80000 && !isset($this->readyNodes[$class])) {
+             $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
+         }
+ 
+-        if (!$ready = $this->readyNodes[$class]) {
++        if (\PHP_VERSION_ID >= 80000 && !$ready = $this->readyNodes[$class]) {
+             trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigTest" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
+         }
+ 
+@@ -77,8 +78,8 @@
+         return 'Twig tests';
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/Infix/SquareBracketExpressionParser.php b/src/ExpressionParser/Infix/SquareBracketExpressionParser.php
+--- a/src/ExpressionParser/Infix/SquareBracketExpressionParser.php
++++ b/src/ExpressionParser/Infix/SquareBracketExpressionParser.php
+@@ -13,7 +13,6 @@
+ 
+ use Twig\ExpressionParser\AbstractExpressionParser;
+ use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ArrayExpression;
+@@ -57,7 +56,9 @@
+ 
+             $filter = $parser->getFilter('slice', $token->getLine());
+             $arguments = new Nodes([$attribute, $length]);
+-            $filter = new ($filter->getNodeClass())($expr, $filter, $arguments, $token->getLine());
++
++            $nodeClass = $filter->getNodeClass();
++            $filter = new $nodeClass($expr, $filter, $arguments, $token->getLine());
+ 
+             $stream->expect(Token::PUNCTUATION_TYPE, ']');
+ 
+@@ -84,8 +85,8 @@
+         return 512;
+     }
+ 
+-    public function getAssociativity(): InfixAssociativity
++    public function getAssociativity(): int
+     {
+-        return InfixAssociativity::Left;
++        return 1;
+     }
+ }
+diff -u a/src/ExpressionParser/InfixExpressionParserInterface.php b/src/ExpressionParser/InfixExpressionParserInterface.php
+--- a/src/ExpressionParser/InfixExpressionParserInterface.php
++++ b/src/ExpressionParser/InfixExpressionParserInterface.php
+@@ -23,5 +23,5 @@
+      */
+     public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression;
+ 
+-    public function getAssociativity(): InfixAssociativity;
++    public function getAssociativity(): int;
+ }
+diff -u a/src/ExpressionParser/PrecedenceChange.php b/src/ExpressionParser/PrecedenceChange.php
+--- a/src/ExpressionParser/PrecedenceChange.php
++++ b/src/ExpressionParser/PrecedenceChange.php
+@@ -18,11 +18,18 @@
+  */
+ class PrecedenceChange
+ {
++    private string $package;
++    private string $version;
++    private int $newPrecedence;
++
+     public function __construct(
+-        private string $package,
+-        private string $version,
+-        private int $newPrecedence,
++        string $package,
++        string $version,
++        int $newPrecedence
+     ) {
++        $this->package = $package;
++        $this->version = $version;
++        $this->newPrecedence = $newPrecedence;
+     }
+ 
+     public function getPackage(): string
+diff -u a/src/ExpressionParser/Prefix/GroupingExpressionParser.php b/src/ExpressionParser/Prefix/GroupingExpressionParser.php
+--- a/src/ExpressionParser/Prefix/GroupingExpressionParser.php
++++ b/src/ExpressionParser/Prefix/GroupingExpressionParser.php
+@@ -59,7 +59,7 @@
+             throw new SyntaxError('A list of variables must be followed by an arrow.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+         }
+ 
+-        return new ListExpression(array_map(self::toAssignContextVariable(...), $names), $token->getLine());
++        return new ListExpression(array_map([self::class, 'toAssignContextVariable'], $names), $token->getLine());
+     }
+ 
+     private static function toAssignContextVariable(AbstractExpression $expr): AssignContextVariable
+diff -u a/src/ExpressionParser/Prefix/LiteralExpressionParser.php b/src/ExpressionParser/Prefix/LiteralExpressionParser.php
+--- a/src/ExpressionParser/Prefix/LiteralExpressionParser.php
++++ b/src/ExpressionParser/Prefix/LiteralExpressionParser.php
+@@ -67,11 +67,8 @@
+ 
+             case $token->test(Token::PUNCTUATION_TYPE):
+                 // In 4.0, we should always return the node or throw an error for default
+-                if ($node = match ($token->getValue()) {
+-                    '{' => $this->parseMappingExpression($parser),
+-                    default => null,
+-                }) {
+-                    return $node;
++                if ($token->getValue() === '{') {
++                    return $this->parseMappingExpression($parser);
+                 }
+ 
+                 // no break
+diff -u a/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php b/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php
+--- a/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php
++++ b/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php
+@@ -25,16 +25,31 @@
+  */
+ final class UnaryOperatorExpressionParser extends AbstractExpressionParser implements PrefixExpressionParserInterface, ExpressionParserDescriptionInterface
+ {
++    private string $nodeClass;
++    private string $name;
++    private int $precedence;
++    private ?PrecedenceChange $precedenceChange;
++    private ?string $description;
++    private array $aliases;
++    private ?int $operandPrecedence;
++
+     public function __construct(
+         /** @var class-string<AbstractUnary> */
+-        private string $nodeClass,
+-        private string $name,
+-        private int $precedence,
+-        private ?PrecedenceChange $precedenceChange = null,
+-        private ?string $description = null,
+-        private array $aliases = [],
+-        private ?int $operandPrecedence = null,
++        string $nodeClass,
++        string $name,
++        int $precedence,
++        ?PrecedenceChange $precedenceChange = null,
++        ?string $description = null,
++        array $aliases = [],
++        ?int $operandPrecedence = null
+     ) {
++        $this->nodeClass = $nodeClass;
++        $this->name = $name;
++        $this->precedence = $precedence;
++        $this->precedenceChange = $precedenceChange;
++        $this->description = $description;
++        $this->aliases = $aliases;
++        $this->operandPrecedence = $operandPrecedence;
+     }
+ 
+     /**
+@@ -42,7 +57,8 @@
+      */
+     public function parse(Parser $parser, Token $token): AbstractExpression
+     {
+-        return new ($this->nodeClass)($parser->parseExpression($this->operandPrecedence ?? $this->precedence), $token->getLine());
++        $nodeClass = $this->nodeClass;
++        return new $nodeClass($parser->parseExpression($this->operandPrecedence ?? $this->precedence), $token->getLine());
+     }
+ 
+     public function getName(): string
+diff -u a/src/ExpressionParser.php b/src/ExpressionParser.php
+--- a/src/ExpressionParser.php
++++ b/src/ExpressionParser.php
+@@ -49,10 +49,16 @@
+      */
+     public const OPERATOR_RIGHT = 2;
+ 
++
++    private Parser $parser;
++    private Environment $env;
++
+     public function __construct(
+-        private Parser $parser,
+-        private Environment $env,
++        Parser $parser,
++        Environment $env
+     ) {
++        $this->parser = $parser;
++        $this->env = $env;
+         trigger_deprecation('twig/twig', '3.21', 'Class "%s" is deprecated, use "Parser::parseExpression()" instead.', __CLASS__);
+     }
+ 
+@@ -258,7 +264,7 @@
+             $name = null;
+             if ($namedArguments && (($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) || (!$definition && $token = $stream->nextIf(Token::PUNCTUATION_TYPE, ':')))) {
+                 if (!$value instanceof ContextVariable) {
+-                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', $value::class), $token->getLine(), $stream->getSourceContext());
++                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', get_class($value)), $token->getLine(), $stream->getSourceContext());
+                 }
+                 $name = $value->getAttribute('name');
+ 
+diff -u a/src/Extension/AttributeExtension.php b/src/Extension/AttributeExtension.php
+--- a/src/Extension/AttributeExtension.php
++++ b/src/Extension/AttributeExtension.php
+@@ -29,14 +29,16 @@
+     private array $filters;
+     private array $functions;
+     private array $tests;
++    private string $class;
+ 
+     /**
+      * Use a runtime class using PHP attributes to define filters, functions, and tests.
+      *
+      * @param class-string $class
+      */
+-    public function __construct(private string $class)
++    public function __construct(string $class)
+     {
++        $this->class = $class;
+     }
+ 
+     /**
+diff -u a/src/Extension/CoreExtension.php b/src/Extension/CoreExtension.php
+--- a/src/Extension/CoreExtension.php
++++ b/src/Extension/CoreExtension.php
+@@ -26,7 +26,6 @@
+ use Twig\ExpressionParser\Infix\IsExpressionParser;
+ use Twig\ExpressionParser\Infix\IsNotExpressionParser;
+ use Twig\ExpressionParser\Infix\SquareBracketExpressionParser;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\PrecedenceChange;
+ use Twig\ExpressionParser\Prefix\GroupingExpressionParser;
+ use Twig\ExpressionParser\Prefix\LiteralExpressionParser;
+@@ -336,13 +335,13 @@
+         return [
+             // unary operators
+             new UnaryOperatorExpressionParser(NotUnary::class, 'not', 50, new PrecedenceChange('twig/twig', '3.15', 70)),
+-            new UnaryOperatorExpressionParser(SpreadUnary::class, '...', 512, description: 'Spread operator', operandPrecedence: 0),
++            new UnaryOperatorExpressionParser(SpreadUnary::class, '...', 512, null, 'Spread operator', [], 0),
+             new UnaryOperatorExpressionParser(NegUnary::class, '-', 500),
+             new UnaryOperatorExpressionParser(PosUnary::class, '+', 500),
+ 
+             // binary operators
+-            new BinaryOperatorExpressionParser(ElvisBinary::class, '?:', 5, InfixAssociativity::Right, description: 'Elvis operator (a ?: b)', aliases: ['? :']),
+-            new BinaryOperatorExpressionParser(NullCoalesceBinary::class, '??', 300, InfixAssociativity::Right, new PrecedenceChange('twig/twig', '3.15', 5), description: 'Null coalescing operator (a ?? b)'),
++            new BinaryOperatorExpressionParser(ElvisBinary::class, '?:', 5, 2, null, 'Elvis operator (a ?: b)', ['? :']),
++            new BinaryOperatorExpressionParser(NullCoalesceBinary::class, '??', 300, 2, new PrecedenceChange('twig/twig', '3.15', 5), 'Null coalescing operator (a ?? b)'),
+             new BinaryOperatorExpressionParser(OrBinary::class, 'or', 10),
+             new BinaryOperatorExpressionParser(XorBinary::class, 'xor', 12),
+             new BinaryOperatorExpressionParser(AndBinary::class, 'and', 15),
+@@ -368,12 +367,12 @@
+             new BinaryOperatorExpressionParser(RangeBinary::class, '..', 25),
+             new BinaryOperatorExpressionParser(AddBinary::class, '+', 30),
+             new BinaryOperatorExpressionParser(SubBinary::class, '-', 30),
+-            new BinaryOperatorExpressionParser(ConcatBinary::class, '~', 40, precedenceChange: new PrecedenceChange('twig/twig', '3.15', 27)),
++            new BinaryOperatorExpressionParser(ConcatBinary::class, '~', 40, 1, new PrecedenceChange('twig/twig', '3.15', 27)),
+             new BinaryOperatorExpressionParser(MulBinary::class, '*', 60),
+             new BinaryOperatorExpressionParser(DivBinary::class, '/', 60),
+-            new BinaryOperatorExpressionParser(FloorDivBinary::class, '//', 60, description: 'Floor division'),
++            new BinaryOperatorExpressionParser(FloorDivBinary::class, '//', 60, 1, null, 'Floor division'),
+             new BinaryOperatorExpressionParser(ModBinary::class, '%', 60),
+-            new BinaryOperatorExpressionParser(PowerBinary::class, '**', 200, InfixAssociativity::Right, description: 'Exponentiation operator'),
++            new BinaryOperatorExpressionParser(PowerBinary::class, '**', 200, 2, null, 'Exponentiation operator'),
+ 
+             // ternary operator
+             new ConditionalTernaryExpressionParser(),
+@@ -412,7 +411,7 @@
+      *
+      * @internal
+      */
+-    public static function cycle($values, $position): mixed
++    public static function cycle($values, $position)/*: mixed*/
+     {
+         if (!\is_array($values)) {
+             if (!$values instanceof \ArrayAccess) {
+@@ -960,7 +959,7 @@
+      *
+      * @internal
+      */
+-    public static function invoke(\Closure $arrow, ...$arguments): mixed
++    public static function invoke(\Closure $arrow, ...$arguments)/*: mixed*/
+     {
+         return $arrow(...$arguments);
+     }
+@@ -1200,18 +1199,25 @@
+      *
+      * @internal
+      */
+-    public static function trim($string, $characterMask = null, $side = 'both'): string|\Stringable
++    public static function trim($string, $characterMask = null, $side = 'both')/*: string|\Stringable*/
+     {
+         if (null === $characterMask) {
+             $characterMask = self::DEFAULT_TRIM_CHARS;
+         }
+ 
+-        $trimmed = match ($side) {
+-            'both' => trim($string ?? '', $characterMask),
+-            'left' => ltrim($string ?? '', $characterMask),
+-            'right' => rtrim($string ?? '', $characterMask),
+-            default => throw new RuntimeError('Trimming side must be "left", "right" or "both".'),
+-        };
++        switch ($side) {
++            case 'both':
++                $trimmed = trim($string ?? '', $characterMask);
++                break;
++            case 'left':
++                $trimmed = ltrim($string ?? '', $characterMask);
++                break;
++            case 'right':
++                $trimmed = rtrim($string ?? '', $characterMask);
++                break;
++            default:
++                throw new RuntimeError('Trimming side must be "left", "right" or "both".');
++        }
+ 
+         // trimming a safe string with the default character mask always returns a safe string (independently of the context)
+         return $string instanceof Markup && self::DEFAULT_TRIM_CHARS === $characterMask ? new Markup($trimmed, $string->getCharset()) : $trimmed;
+@@ -1580,7 +1586,7 @@
+      *
+      * @internal
+      */
+-    public static function enum(string $enum): \UnitEnum
++    public static function enum(string $enum)/*: \UnitEnum*/
+     {
+         if (!enum_exists($enum)) {
+             throw new RuntimeError(\sprintf('"%s" is not an enum.', $enum));
+@@ -1610,10 +1616,10 @@
+     {
+         if (null !== $object) {
+             if ('class' === $constant) {
+-                return $checkDefined ? true : $object::class;
++                return $checkDefined ? true : get_class($object);
+             }
+ 
+-            $constant = $object::class.'::'.$constant;
++            $constant = get_class($object).'::'.$constant;
+         }
+ 
+         if (!\defined($constant)) {
+@@ -1690,7 +1696,7 @@
+         if (Template::METHOD_CALL !== $type) {
+             $arrayItem = \is_bool($item) || \is_float($item) ? (int) $item : $item;
+ 
+-            if ($sandboxed && $object instanceof \ArrayAccess && !\in_array($object::class, self::ARRAY_LIKE_CLASSES, true)) {
++            if ($sandboxed && $object instanceof \ArrayAccess && !\in_array(get_class($object), self::ARRAY_LIKE_CLASSES, true)) {
+                 try {
+                     $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $arrayItem, $lineno, $source);
+                 } catch (SecurityNotAllowedPropertyError $propertyNotAllowedError) {
+@@ -1702,11 +1708,10 @@
+                 }
+             }
+ 
+-            if (match (true) {
+-                \is_array($object) => \array_key_exists($arrayItem = (string) $arrayItem, $object),
+-                $object instanceof \ArrayAccess => $object->offsetExists($arrayItem),
+-                default => false,
+-            }) {
++            if (
++                (\is_array($object) && \array_key_exists($arrayItem = (string) $arrayItem, $object))
++                || ($object instanceof \ArrayAccess && $object->offsetExists($arrayItem))
++            ) {
+                 if ($isDefinedTest) {
+                     return true;
+                 }
+@@ -1792,7 +1797,7 @@
+             static $propertyCheckers = [];
+ 
+             if (isset($object->$item)
+-                || ($propertyCheckers[$object::class][$item] ??= self::getPropertyChecker($object::class, $item))($object, $item)
++                || ($propertyCheckers[get_class($object)][$item] ??= self::getPropertyChecker(get_class($object), $item))($object, $item)
+             ) {
+                 if ($isDefinedTest) {
+                     return true;
+@@ -1809,12 +1814,12 @@
+                 return ((array) $object)[$item];
+             }
+ 
+-            if (\defined($object::class.'::'.$item)) {
++            if (\defined(get_class($object).'::'.$item)) {
+                 if ($isDefinedTest) {
+                     return true;
+                 }
+ 
+-                return \constant($object::class.'::'.$item);
++                return \constant(get_class($object).'::'.$item);
+             }
+         }
+ 
+@@ -1822,7 +1827,7 @@
+ 
+         static $cache = [];
+ 
+-        $class = $object::class;
++        $class = get_class($object);
+ 
+         // object method
+         // precedence: getXxx() > isXxx() > hasXxx()
+diff -u a/src/Extension/OptimizerExtension.php b/src/Extension/OptimizerExtension.php
+--- a/src/Extension/OptimizerExtension.php
++++ b/src/Extension/OptimizerExtension.php
+@@ -15,9 +15,12 @@
+ 
+ final class OptimizerExtension extends AbstractExtension
+ {
++    private int $optimizers;
++
+     public function __construct(
+-        private int $optimizers = -1,
++        int $optimizers = -1
+     ) {
++        $this->optimizers = $optimizers;
+     }
+ 
+     public function getNodeVisitors(): array
+diff -u a/src/Extension/YieldNotReadyExtension.php b/src/Extension/YieldNotReadyExtension.php
+--- a/src/Extension/YieldNotReadyExtension.php
++++ b/src/Extension/YieldNotReadyExtension.php
+@@ -18,9 +18,12 @@
+  */
+ final class YieldNotReadyExtension extends AbstractExtension
+ {
++    private bool $useYield;
++
+     public function __construct(
+-        private bool $useYield,
++        bool $useYield
+     ) {
++        $this->useYield = $useYield;
+     }
+ 
+     public function getNodeVisitors(): array
+diff -u a/src/ExtensionSet.php b/src/ExtensionSet.php
+--- a/src/ExtensionSet.php
++++ b/src/ExtensionSet.php
+@@ -14,7 +14,6 @@
+ use Twig\Error\RuntimeError;
+ use Twig\ExpressionParser\ExpressionParsers;
+ use Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser;
+-use Twig\ExpressionParser\InfixAssociativity;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\ExpressionParser\PrecedenceChange;
+ use Twig\ExpressionParser\Prefix\UnaryOperatorExpressionParser;
+@@ -152,7 +151,7 @@
+         if ($extension instanceof AttributeExtension) {
+             $class = $extension->getClass();
+         } else {
+-            $class = $extension::class;
++            $class = \get_class($extension);
+         }
+ 
+         if ($this->initialized) {
+@@ -509,11 +508,11 @@
+ 
+         $operators = $extension->getOperators();
+         if (!\is_array($operators)) {
+-            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array with operators, got "%s".', $extension::class, get_debug_type($operators).(\is_resource($operators) ? '' : '#'.$operators)));
++            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array with operators, got "%s".', get_class($extension), get_debug_type($operators).(\is_resource($operators) ? '' : '#'.$operators)));
+         }
+ 
+         if (2 !== \count($operators)) {
+-            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array of 2 elements, got %d.', $extension::class, \count($operators)));
++            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array of 2 elements, got %d.', get_class($extension), \count($operators)));
+         }
+ 
+         $expressionParsers = [];
+@@ -521,12 +520,6 @@
+             $expressionParsers[] = new UnaryOperatorExpressionParser($op['class'], $operator, $op['precedence'], $op['precedence_change'] ?? null, '', $op['aliases'] ?? []);
+         }
+         foreach ($operators[1] as $operator => $op) {
+-            $op['associativity'] = match ($op['associativity']) {
+-                1 => InfixAssociativity::Left,
+-                2 => InfixAssociativity::Right,
+-                default => throw new \InvalidArgumentException(\sprintf('Invalid associativity "%s" for operator "%s".', $op['associativity'], $operator)),
+-            };
+-
+             if (isset($op['callable'])) {
+                 $expressionParsers[] = $this->convertInfixExpressionParser($op['class'], $operator, $op['precedence'], $op['associativity'], $op['precedence_change'] ?? null, $op['aliases'] ?? [], $op['callable']);
+             } else {
+@@ -535,26 +528,29 @@
+         }
+ 
+         if (\count($expressionParsers)) {
+-            trigger_deprecation('twig/twig', '3.21', \sprintf('Extension "%s" uses the old signature for "getOperators()", please implement "getExpressionParsers()" instead.', $extension::class));
++            trigger_deprecation('twig/twig', '3.21', \sprintf('Extension "%s" uses the old signature for "getOperators()", please implement "getExpressionParsers()" instead.', get_class($extension)));
+ 
+             $this->expressionParsers->add($expressionParsers);
+         }
+     }
+ 
+-    private function convertInfixExpressionParser(string $nodeClass, string $operator, int $precedence, InfixAssociativity $associativity, ?PrecedenceChange $precedenceChange, array $aliases, callable $callable): InfixExpressionParserInterface
++    private function convertInfixExpressionParser(string $nodeClass, string $operator, int $precedence, int $associativity, ?PrecedenceChange $precedenceChange, array $aliases, callable $callable): InfixExpressionParserInterface
+     {
+         trigger_deprecation('twig/twig', '3.21', \sprintf('Using a non-ExpressionParserInterface object to define the "%s" binary operator is deprecated.', $operator));
+ 
+         return new class($nodeClass, $operator, $precedence, $associativity, $precedenceChange, $aliases, $callable) extends BinaryOperatorExpressionParser {
++            private $callable = null;
++
+             public function __construct(
+                 string $nodeClass,
+                 string $operator,
+                 int $precedence,
+-                InfixAssociativity $associativity = InfixAssociativity::Left,
++                int $associativity = 1,
+                 ?PrecedenceChange $precedenceChange = null,
+                 array $aliases = [],
+-                private $callable = null,
++                $callable = null
+             ) {
++                $this->callable = $callable;
+                 parent::__construct($nodeClass, $operator, $precedence, $associativity, $precedenceChange, $aliases);
+             }
+ 
+diff -u a/src/Loader/ArrayLoader.php b/src/Loader/ArrayLoader.php
+--- a/src/Loader/ArrayLoader.php
++++ b/src/Loader/ArrayLoader.php
+@@ -28,12 +28,15 @@
+  */
+ final class ArrayLoader implements LoaderInterface
+ {
++    private array $templates;
++
+     /**
+      * @param array $templates An array of templates (keys are the names, and values are the source code)
+      */
+     public function __construct(
+-        private array $templates = [],
++        array $templates = []
+     ) {
++        $this->templates = $templates;
+     }
+ 
+     public function setTemplate(string $name, string $template): void
+diff -u a/src/Loader/ChainLoader.php b/src/Loader/ChainLoader.php
+--- a/src/Loader/ChainLoader.php
++++ b/src/Loader/ChainLoader.php
+@@ -25,13 +25,15 @@
+      * @var array<string, bool>
+      */
+     private $hasSourceCache = [];
++    private iterable $loaders;
+ 
+     /**
+      * @param iterable<LoaderInterface> $loaders
+      */
+     public function __construct(
+-        private iterable $loaders = [],
++        iterable $loaders = []
+     ) {
++        $this->loaders = $loaders;
+     }
+ 
+     public function addLoader(LoaderInterface $loader): void
+@@ -104,7 +106,7 @@
+             try {
+                 return $loader->getCacheKey($name);
+             } catch (LoaderError $e) {
+-                $exceptions[] = $loader::class.': '.$e->getMessage();
++                $exceptions[] = get_class($loader).': '.$e->getMessage();
+             }
+         }
+ 
+@@ -123,7 +125,7 @@
+             try {
+                 return $loader->isFresh($name, $time);
+             } catch (LoaderError $e) {
+-                $exceptions[] = $loader::class.': '.$e->getMessage();
++                $exceptions[] = get_class($loader).': '.$e->getMessage();
+             }
+         }
+ 
+diff -u a/src/Node/Expression/Binary/AbstractBinary.php b/src/Node/Expression/Binary/AbstractBinary.php
+--- a/src/Node/Expression/Binary/AbstractBinary.php
++++ b/src/Node/Expression/Binary/AbstractBinary.php
+@@ -25,10 +25,10 @@
+     public function __construct(Node $left, Node $right, int $lineno)
+     {
+         if (!$left instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $left::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($left));
+         }
+         if (!$right instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $right::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($right));
+         }
+ 
+         parent::__construct(['left' => $left, 'right' => $right], [], $lineno);
+diff -u a/src/Node/Expression/Binary/MatchesBinary.php b/src/Node/Expression/Binary/MatchesBinary.php
+--- a/src/Node/Expression/Binary/MatchesBinary.php
++++ b/src/Node/Expression/Binary/MatchesBinary.php
+@@ -24,15 +24,15 @@
+     public function __construct(Node $left, Node $right, int $lineno)
+     {
+         if (!$left instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" first argument is deprecated, pass an "AbstractExpression" instance instead.', $left::class, __METHOD__);
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" first argument is deprecated, pass an "AbstractExpression" instance instead.', get_class($left), __METHOD__);
+         }
+         if (!$right instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" second argument is deprecated, pass an "AbstractExpression" instance instead.', $right::class, __METHOD__);
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" second argument is deprecated, pass an "AbstractExpression" instance instead.', get_class($right), __METHOD__);
+         }
+ 
+         if ($right instanceof ConstantExpression) {
+             $regexp = $right->getAttribute('value');
+-            set_error_handler(static fn ($t, $m) => throw new SyntaxError(\sprintf('Regexp "%s" passed to "matches" is not valid: %s.', $regexp, substr($m, 14)), $lineno));
++            set_error_handler(static function ($t, $m) use ($regexp, $lineno) { throw new SyntaxError(\sprintf('Regexp "%s" passed to "matches" is not valid: %s.', $regexp, substr($m, 14)), $lineno); });
+             try {
+                 preg_match($regexp, '');
+             } finally {
+diff -u a/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php b/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
+--- a/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
++++ b/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
+@@ -38,7 +38,7 @@
+         }
+         foreach ($left->getKeyValuePairs() as $pair) {
+             if (!$pair['value'] instanceof ContextVariable) {
+-                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in object/mapping destructuring.', $pair['value']::class), $lineno);
++                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in object/mapping destructuring.', get_class($pair['value'])), $lineno);
+             }
+ 
+             $this->mappings[] = [
+diff -u a/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php b/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
+--- a/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
++++ b/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
+@@ -38,7 +38,7 @@
+             } elseif ($pair['value'] instanceof ContextVariable) {
+                 $this->variables[] = $pair['value']->getAttribute('name');
+             } else {
+-                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in sequence destructuring.', $pair['value']::class), $lineno);
++                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in sequence destructuring.', get_class($pair['value'])), $lineno);
+             }
+         }
+ 
+diff -u a/src/Node/Expression/BlockReferenceExpression.php b/src/Node/Expression/BlockReferenceExpression.php
+--- a/src/Node/Expression/BlockReferenceExpression.php
++++ b/src/Node/Expression/BlockReferenceExpression.php
+@@ -32,7 +32,7 @@
+     public function __construct(Node $name, ?Node $template, int $lineno)
+     {
+         if (!$name instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $name::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($name));
+         }
+ 
+         $nodes = ['name' => $name];
+diff -u a/src/Node/Expression/CallExpression.php b/src/Node/Expression/CallExpression.php
+--- a/src/Node/Expression/CallExpression.php
++++ b/src/Node/Expression/CallExpression.php
+@@ -342,7 +342,7 @@
+             return $twigCallable->needsIsSandboxed();
+         }
+ 
+-        trigger_deprecation('twig/twig', '3.25', 'Not implementing the "needsIsSandboxed()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', $twigCallable::class, TwigCallableInterface::class);
++        trigger_deprecation('twig/twig', '3.25', 'Not implementing the "needsIsSandboxed()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', get_class($twigCallable), TwigCallableInterface::class);
+ 
+         return false;
+     }
+@@ -356,38 +356,47 @@
+     {
+         $current = $this->getAttribute('twig_callable');
+ 
+-        $this->setAttribute('twig_callable', match ($this->getAttribute('type')) {
+-            'test' => (new TwigTest(
++        $value = '';
++        switch($this->getAttribute('type')) {
++            case 'test':
++                $value = (new TwigTest(
++                    $this->getAttribute('name'),
++                    $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
++                    [
++                        'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                        'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                    ],
++                ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments());
++                break;
++            case 'function':
++                $value = (new TwigFunction(
++                    $this->hasAttribute('name') ? $this->getAttribute('name') : $current->getName(),
++                    $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
++                    [
++                        'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
++                        'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
++                        'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
++                        'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                        'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                    ],
++                ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments());
++                break;
++            case 'filter':
++                $value = (new TwigFilter(
+                 $this->getAttribute('name'),
+                 $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
+-                [
+-                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
+-                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
+-                ],
+-            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
+-            'function' => (new TwigFunction(
+-                $this->hasAttribute('name') ? $this->getAttribute('name') : $current->getName(),
+-                $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
+-                [
+-                    'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
+-                    'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
+-                    'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
+-                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
+-                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
+-                ],
+-            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
+-            'filter' => (new TwigFilter(
+-                $this->getAttribute('name'),
+-                $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
+-                [
+-                    'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
+-                    'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
+-                    'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
+-                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
+-                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
+-                ],
+-            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
+-        });
++                    [
++                        'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
++                        'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
++                        'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
++                        'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                        'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                    ],
++                ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments());
++                break;
++        }
++
++        $this->setAttribute('twig_callable', $value);
+ 
+         return $this->getAttribute('twig_callable');
+     }
+diff -u a/src/Node/Expression/Filter/DefaultFilter.php b/src/Node/Expression/Filter/DefaultFilter.php
+--- a/src/Node/Expression/Filter/DefaultFilter.php
++++ b/src/Node/Expression/Filter/DefaultFilter.php
+@@ -39,10 +39,10 @@
+      * @param AbstractExpression $node
+      */
+     #[FirstClassTwigCallableReady]
+-    public function __construct(Node $node, TwigFilter|ConstantExpression $filter, Node $arguments, int $lineno)
++    public function __construct(Node $node, /*TwigFilter|ConstantExpression*/ $filter, Node $arguments, int $lineno)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         if ($filter instanceof TwigFilter) {
+diff -u a/src/Node/Expression/Filter/RawFilter.php b/src/Node/Expression/Filter/RawFilter.php
+--- a/src/Node/Expression/Filter/RawFilter.php
++++ b/src/Node/Expression/Filter/RawFilter.php
+@@ -29,10 +29,10 @@
+      * @param AbstractExpression $node
+      */
+     #[FirstClassTwigCallableReady]
+-    public function __construct(Node $node, TwigFilter|ConstantExpression|null $filter = null, ?Node $arguments = null, int $lineno = 0)
++    public function __construct(Node $node, /*TwigFilter|ConstantExpression|null*/ $filter = null, ?Node $arguments = null, int $lineno = 0)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         parent::__construct($node, $filter ?: new TwigFilter('raw', null, ['is_safe' => ['all']]), $arguments ?: new EmptyNode(), $lineno ?: $node->getTemplateLine());
+diff -u a/src/Node/Expression/FilterExpression.php b/src/Node/Expression/FilterExpression.php
+--- a/src/Node/Expression/FilterExpression.php
++++ b/src/Node/Expression/FilterExpression.php
+@@ -25,10 +25,10 @@
+      * @param AbstractExpression $node
+      */
+     #[FirstClassTwigCallableReady]
+-    public function __construct(Node $node, TwigFilter|ConstantExpression $filter, Node $arguments, int $lineno)
++    public function __construct(Node $node, /*TwigFilter|ConstantExpression*/ $filter, Node $arguments, int $lineno)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         if ($filter instanceof TwigFilter) {
+diff -u a/src/Node/Expression/FunctionExpression.php b/src/Node/Expression/FunctionExpression.php
+--- a/src/Node/Expression/FunctionExpression.php
++++ b/src/Node/Expression/FunctionExpression.php
+@@ -24,7 +24,7 @@
+     use SupportDefinedTestTrait;
+ 
+     #[FirstClassTwigCallableReady]
+-    public function __construct(TwigFunction|string $function, Node $arguments, int $lineno)
++    public function __construct(/*TwigFunction|string*/ $function, Node $arguments, int $lineno)
+     {
+         if ($function instanceof TwigFunction) {
+             $name = $function->getName();
+diff -u a/src/Node/Expression/GetAttrExpression.php b/src/Node/Expression/GetAttrExpression.php
+--- a/src/Node/Expression/GetAttrExpression.php
++++ b/src/Node/Expression/GetAttrExpression.php
+@@ -34,7 +34,7 @@
+         }
+ 
+         if ($arguments && !$arguments instanceof ArrayExpression && !$arguments instanceof ContextVariable) {
+-            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, $arguments::class));
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, get_class($arguments)));
+         }
+ 
+         parent::__construct($nodes, ['type' => $type, 'ignore_strict_check' => false, 'optimizable' => !$nullSafe, 'null_safe' => $nullSafe, 'is_short_circuited' => false, 'var_name' => null], $lineno);
+diff -u a/src/Node/Expression/NullCoalesceExpression.php b/src/Node/Expression/NullCoalesceExpression.php
+--- a/src/Node/Expression/NullCoalesceExpression.php
++++ b/src/Node/Expression/NullCoalesceExpression.php
+@@ -33,10 +33,10 @@
+         trigger_deprecation('twig/twig', '3.17', \sprintf('"%s" is deprecated; use "%s" instead.', __CLASS__, NullCoalesceBinary::class));
+ 
+         if (!$left instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $left::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($left));
+         }
+         if (!$right instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $right::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($right));
+         }
+ 
+         $test = new DefinedTest(clone $left, new TwigTest('defined'), new EmptyNode(), $left->getTemplateLine());
+diff -u a/src/Node/Expression/TempNameExpression.php b/src/Node/Expression/TempNameExpression.php
+--- a/src/Node/Expression/TempNameExpression.php
++++ b/src/Node/Expression/TempNameExpression.php
+@@ -18,7 +18,7 @@
+ {
+     public const RESERVED_NAMES = ['varargs', 'context', 'macros', 'blocks', 'this'];
+ 
+-    public function __construct(string|int|null $name, int $lineno)
++    public function __construct(/*string|int|null*/ $name, int $lineno)
+     {
+         // All names supported by ExpressionParser::parsePrimaryExpression() should be excluded
+         if ($name && \in_array(strtolower($name), ['true', 'false', 'none', 'null'], true)) {
+diff -u a/src/Node/Expression/Test/DefinedTest.php b/src/Node/Expression/Test/DefinedTest.php
+--- a/src/Node/Expression/Test/DefinedTest.php
++++ b/src/Node/Expression/Test/DefinedTest.php
+@@ -36,10 +36,10 @@
+      * @param AbstractExpression $node
+      */
+     #[FirstClassTwigCallableReady]
+-    public function __construct(Node $node, TwigTest|string $name, ?Node $arguments, int $lineno)
++    public function __construct(Node $node, /*TwigTest|string*/ $name, ?Node $arguments, int $lineno)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         if (!$node instanceof SupportDefinedTestInterface) {
+diff -u a/src/Node/Expression/TestExpression.php b/src/Node/Expression/TestExpression.php
+--- a/src/Node/Expression/TestExpression.php
++++ b/src/Node/Expression/TestExpression.php
+@@ -24,10 +24,10 @@
+     /**
+      * @param AbstractExpression $node
+      */
+-    public function __construct(Node $node, string|TwigTest $test, ?Node $arguments, int $lineno)
++    public function __construct(Node $node, /*string|TwigTest*/ $test, ?Node $arguments, int $lineno)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         $nodes = ['node' => $node];
+diff -u a/src/Node/Expression/Unary/AbstractUnary.php b/src/Node/Expression/Unary/AbstractUnary.php
+--- a/src/Node/Expression/Unary/AbstractUnary.php
++++ b/src/Node/Expression/Unary/AbstractUnary.php
+@@ -24,7 +24,7 @@
+     public function __construct(Node $node, int $lineno)
+     {
+         if (!$node instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance argument to "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance argument to "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, get_class($node));
+         }
+ 
+         parent::__construct(['node' => $node], ['with_parentheses' => false], $lineno);
+diff -u a/src/Node/ImportNode.php b/src/Node/ImportNode.php
+--- a/src/Node/ImportNode.php
++++ b/src/Node/ImportNode.php
+@@ -25,14 +25,14 @@
+ #[YieldReady]
+ class ImportNode extends Node implements CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $expr, AbstractExpression|AssignTemplateVariable $var, int $lineno)
++    public function __construct(AbstractExpression $expr, /*AbstractExpression|AssignTemplateVariable*/ $var, int $lineno)
+     {
+         if (\func_num_args() > 3) {
+             trigger_deprecation('twig/twig', '3.15', \sprintf('Passing more than 3 arguments to "%s()" is deprecated.', __METHOD__));
+         }
+ 
+         if (!$var instanceof AssignTemplateVariable) {
+-            trigger_deprecation('twig/twig', '3.15', \sprintf('Passing a "%s" instance as the second argument of "%s" is deprecated, pass a "%s" instead.', $var::class, __CLASS__, AssignTemplateVariable::class));
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Passing a "%s" instance as the second argument of "%s" is deprecated, pass a "%s" instead.', get_class($var), __CLASS__, AssignTemplateVariable::class));
+ 
+             $var = new AssignTemplateVariable($var->getAttribute('name'), $lineno);
+         }
+diff -u a/src/Node/MacroNode.php b/src/Node/MacroNode.php
+--- a/src/Node/MacroNode.php
++++ b/src/Node/MacroNode.php
+@@ -34,11 +34,11 @@
+     public function __construct(string $name, Node $body, Node $arguments, int $lineno)
+     {
+         if (!$body instanceof BodyNode) {
+-            trigger_deprecation('twig/twig', '3.12', \sprintf('Not passing a "%s" instance as the "body" argument of the "%s" constructor is deprecated ("%s" given).', BodyNode::class, static::class, $body::class));
++            trigger_deprecation('twig/twig', '3.12', \sprintf('Not passing a "%s" instance as the "body" argument of the "%s" constructor is deprecated ("%s" given).', BodyNode::class, static::class, get_class($body)));
+         }
+ 
+         if (!$arguments instanceof ArrayExpression) {
+-            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, $arguments::class));
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, get_class($arguments)));
+ 
+             $args = new ArrayExpression([], $arguments->getTemplateLine());
+             foreach ($arguments as $n => $default) {
+diff -u a/src/Node/SetNode.php b/src/Node/SetNode.php
+--- a/src/Node/SetNode.php
++++ b/src/Node/SetNode.php
+@@ -34,7 +34,7 @@
+         if ($capture) {
+             $safe = true;
+             // Node::class === get_class($values) should be removed in Twig 4.0
+-            if (($values instanceof Nodes || Node::class === $values::class) && !\count($values)) {
++            if (($values instanceof Nodes || Node::class === get_class($values)) && !\count($values)) {
+                 $values = new ConstantExpression('', $values->getTemplateLine());
+                 $capture = false;
+             } elseif ($values instanceof TextNode) {
+diff -u a/src/NodeVisitor/EscaperNodeVisitor.php b/src/NodeVisitor/EscaperNodeVisitor.php
+--- a/src/NodeVisitor/EscaperNodeVisitor.php
++++ b/src/NodeVisitor/EscaperNodeVisitor.php
+@@ -160,7 +160,7 @@
+     /**
+      * @return string|false
+      */
+-    private function needEscaping(): string|bool
++    private function needEscaping()/*: string|bool*/
+     {
+         if (\count($this->statusStack)) {
+             return $this->statusStack[\count($this->statusStack) - 1];
+diff -u a/src/NodeVisitor/OptimizerNodeVisitor.php b/src/NodeVisitor/OptimizerNodeVisitor.php
+--- a/src/NodeVisitor/OptimizerNodeVisitor.php
++++ b/src/NodeVisitor/OptimizerNodeVisitor.php
+@@ -48,12 +48,16 @@
+     private $loops = [];
+     private $loopsTargets = [];
+ 
++    private int $optimizers;
++
+     /**
+      * @param int $optimizers The optimizer mode
+      */
+     public function __construct(
+-        private int $optimizers = -1,
++        int $optimizers = -1
+     ) {
++        $this->optimizers = $optimizers;
++
+         if ($optimizers > (self::OPTIMIZE_FOR | self::OPTIMIZE_RAW_FILTER | self::OPTIMIZE_TEXT_NODES)) {
+             throw new \InvalidArgumentException(\sprintf('Optimizer mode "%s" is not valid.', $optimizers));
+         }
+diff -u a/src/NodeVisitor/SafeAnalysisNodeVisitor.php b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+--- a/src/NodeVisitor/SafeAnalysisNodeVisitor.php
++++ b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+@@ -122,7 +122,7 @@
+             if ($filter) {
+                 $safe = $filter->getSafe($node->getNode('arguments'));
+                 if (null === $safe) {
+-                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', $filter::class);
++                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', get_class($filter));
+                     $safe = [];
+                 }
+ 
+@@ -143,7 +143,7 @@
+             if ($function) {
+                 $safe = $function->getSafe($node->getNode('arguments'));
+                 if (null === $safe) {
+-                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', $function::class);
++                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', get_class($function));
+                     $safe = [];
+                 }
+                 $this->setSafe($node, $safe);
+diff -u a/src/NodeVisitor/YieldNotReadyNodeVisitor.php b/src/NodeVisitor/YieldNotReadyNodeVisitor.php
+--- a/src/NodeVisitor/YieldNotReadyNodeVisitor.php
++++ b/src/NodeVisitor/YieldNotReadyNodeVisitor.php
+@@ -22,15 +22,17 @@
+ final class YieldNotReadyNodeVisitor implements NodeVisitorInterface
+ {
+     private $yieldReadyNodes = [];
++    private bool $useYield;
+ 
+     public function __construct(
+-        private bool $useYield,
++        bool $useYield
+     ) {
++        $this->useYield = $useYield;
+     }
+ 
+     public function enterNode(Node $node, Environment $env): Node
+     {
+-        $class = $node::class;
++        $class = get_class($node);
+ 
+         if ($node instanceof AbstractExpression || isset($this->yieldReadyNodes[$class])) {
+             return $node;
+diff -u a/src/OperatorPrecedenceChange.php b/src/OperatorPrecedenceChange.php
+--- a/src/OperatorPrecedenceChange.php
++++ b/src/OperatorPrecedenceChange.php
+@@ -23,9 +23,9 @@
+ class OperatorPrecedenceChange extends PrecedenceChange
+ {
+     public function __construct(
+-        private string $package,
+-        private string $version,
+-        private int $newPrecedence,
++        string $package,
++        string $version,
++        int $newPrecedence
+     ) {
+         trigger_deprecation('twig/twig', '3.21', 'The "%s" class is deprecated since Twig 3.21. Use "%s" instead.', self::class, PrecedenceChange::class);
+ 
+diff -u a/src/Parser.php b/src/Parser.php
+--- a/src/Parser.php
++++ b/src/Parser.php
+@@ -15,7 +15,6 @@
+ use Twig\Error\SyntaxError;
+ use Twig\ExpressionParser\ExpressionParserInterface;
+ use Twig\ExpressionParser\ExpressionParsers;
+-use Twig\ExpressionParser\ExpressionParserType;
+ use Twig\ExpressionParser\InfixExpressionParserInterface;
+ use Twig\ExpressionParser\Prefix\LiteralExpressionParser;
+ use Twig\ExpressionParser\PrefixExpressionParserInterface;
+@@ -59,9 +58,12 @@
+     private $ignoreUnknownTwigCallables = false;
+     private ExpressionParsers $parsers;
+ 
++    private Environment $env;
++
+     public function __construct(
+-        private Environment $env,
++        Environment $env
+     ) {
++        $this->env = $env;
+         $this->parsers = $env->getExpressionParsers();
+     }
+ 
+@@ -229,7 +231,7 @@
+                     $subparser->setParser($this);
+                     $node = $subparser->parse($token);
+                     if (!$node) {
+-                        trigger_deprecation('twig/twig', '3.12', 'Returning "null" from "%s" is deprecated and forbidden by "TokenParserInterface".', $subparser::class);
++                        trigger_deprecation('twig/twig', '3.12', 'Returning "null" from "%s" is deprecated and forbidden by "TokenParserInterface".', get_class($subparser));
+                     } else {
+                         $node->setNodeTag($subparser->getTag());
+                         $rv[] = $node;
+@@ -330,10 +332,10 @@
+         $this->embeddedTemplates[] = $template;
+     }
+ 
+-    public function addImportedSymbol(string $type, string $alias, ?string $name = null, AbstractExpression|AssignTemplateVariable|null $internalRef = null): void
++    public function addImportedSymbol(string $type, string $alias, ?string $name = null, /*AbstractExpression|AssignTemplateVariable|null*/ $internalRef = null): void
+     {
+         if ($internalRef && !$internalRef instanceof AssignTemplateVariable) {
+-            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance as an internal reference is deprecated ("%s" given).', __METHOD__, AssignTemplateVariable::class, $internalRef::class);
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance as an internal reference is deprecated ("%s" given).', __METHOD__, AssignTemplateVariable::class, get_class($internalRef));
+ 
+             $internalRef = new AssignTemplateVariable(new TemplateVariable($internalRef->getAttribute('name'), $internalRef->getTemplateLine()), $internalRef->getAttribute('global'));
+         }
+@@ -423,7 +425,7 @@
+         }
+ 
+         if (null !== $parent && !$parent instanceof AbstractExpression) {
+-            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" is deprecated, pass an "AbstractExpression" instance instead.', $parent::class, __METHOD__);
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" is deprecated, pass an "AbstractExpression" instance instead.', get_class($parent), __METHOD__);
+         }
+ 
+         if (null !== $this->parent) {
+@@ -588,7 +590,7 @@
+         // here, $nested means "being at the root level of a child template"
+         // we need to discard the wrapping "Node" for the "body" node
+         // Node::class !== \get_class($node) should be removed in Twig 4.0
+-        $nested = $nested || (Node::class !== $node::class && !$node instanceof Nodes);
++        $nested = $nested || (Node::class !== get_class($node) && !$node instanceof Nodes);
+         foreach ($node as $k => $n) {
+             if (null !== $n && null === $this->filterBodyNodes($n, $nested)) {
+                 $node->removeNode($k);
+@@ -621,7 +623,15 @@
+                 }
+                 if (isset($this->expressionRefs[$node]) && $ep === $this->expressionRefs[$node]) {
+                     $change = $expressionParser->getPrecedenceChange();
+-                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $expressionParser->getName(), ExpressionParserType::getType($expressionParser)->value, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
++
++                    if ($expressionParser instanceof PrefixExpressionParserInterface) {
++                        $type = 'prefix';
++                    }
++                    if ($expressionParser instanceof InfixExpressionParserInterface) {
++                        $type = 'infix';
++                    }
++
++                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $expressionParser->getName(), $type, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
+                 }
+             }
+         }
+@@ -631,7 +641,15 @@
+                 /** @var AbstractExpression $node */
+                 if (isset($this->expressionRefs[$node]) && $ep === $this->expressionRefs[$node] && !$node->hasExplicitParentheses()) {
+                     $change = $ep->getPrecedenceChange();
+-                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $ep->getName(), ExpressionParserType::getType($ep)->value, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
++
++                    if ($ep instanceof PrefixExpressionParserInterface) {
++                        $type = 'prefix';
++                    }
++                    if ($ep instanceof InfixExpressionParserInterface) {
++                        $type = 'infix';
++                    }
++
++                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $ep->getName(), $type, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
+                 }
+             }
+         }
+diff -u a/src/Profiler/Profile.php b/src/Profiler/Profile.php
+--- a/src/Profiler/Profile.php
++++ b/src/Profiler/Profile.php
+@@ -24,11 +24,17 @@
+     private $ends = [];
+     private $profiles = [];
+ 
++    private string $template;
++    private string $type;
++    private string $name;
++
+     public function __construct(
+-        private string $template = 'main',
+-        private string $type = self::ROOT,
+-        private string $name = 'main',
++        string $template = 'main',
++        string $type = self::ROOT,
++        string $name = 'main'
+     ) {
++        $this->template = $template;
++        $this->type = $type;
+         $this->name = str_starts_with($name, '__internal_') ? 'INTERNAL' : $name;
+         $this->enter();
+     }
+diff -u a/src/Runtime/EscaperRuntime.php b/src/Runtime/EscaperRuntime.php
+--- a/src/Runtime/EscaperRuntime.php
++++ b/src/Runtime/EscaperRuntime.php
+@@ -26,9 +26,12 @@
+     /** @internal */
+     public $safeLookup = [];
+ 
++    private $charset;
++
+     public function __construct(
+-        private $charset = 'UTF-8',
++        $charset = 'UTF-8'
+     ) {
++        $this->charset = $charset;
+     }
+ 
+     /**
+@@ -106,7 +109,7 @@
+         if (!\is_string($string)) {
+             if ($string instanceof \Stringable) {
+                 if ($autoescape) {
+-                    $c = $string::class;
++                    $c = get_class($string);
+                     if (!isset($this->safeClasses[$c])) {
+                         $this->safeClasses[$c] = [];
+                         foreach (class_parents($string) + class_implements($string) as $class) {
+@@ -199,16 +202,32 @@
+                     * Escape sequences supported only by JavaScript, not JSON, are omitted.
+                     * \" is also supported but omitted, because the resulting string is not HTML safe.
+                     */
+-                    $short = match ($char) {
+-                        '\\' => '\\\\',
+-                        '/' => '\\/',
+-                        "\x08" => '\b',
+-                        "\x0C" => '\f',
+-                        "\x0A" => '\n',
+-                        "\x0D" => '\r',
+-                        "\x09" => '\t',
+-                        default => false,
+-                    };
++                    switch ($char) {
++                        case '\\':
++                            $short = '\\\\';
++                            break;
++                        case '/':
++                            $short = '\\/';
++                            break;
++                        case "\x08":
++                            $short = '\b';
++                            break;
++                        case "\x0C":
++                            $short = '\f';
++                            break;
++                        case "\x0A":
++                            $short = '\n';
++                            break;
++                        case "\x0D":
++                            $short = '\r';
++                            break;
++                        case "\x09":
++                            $short = '\t';
++                            break;
++                        default:
++                            $short = false;
++                            break;
++                    }
+ 
+                     if ($short) {
+                         return $short;
+@@ -265,10 +284,13 @@
+                     throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+                 }
+ 
+-                $regex = match ($strategy) {
+-                    'html_attr' => '#[^a-zA-Z0-9,\.\-_]#Su',
+-                    'html_attr_relaxed' => '#[^a-zA-Z0-9,\.\-_:@\[\]]#Su',
+-                };
++                switch ($strategy) {
++                    case 'html_attr':
++                        $regex = '#[^a-zA-Z0-9,\.\-_]#Su';
++                    case 'html_attr_relaxed':
++                        $regex = '#[^a-zA-Z0-9,\.\-_:@\[\]]#Su';
++                        break;
++                }
+ 
+                 $string = preg_replace_callback($regex, static function ($matches) {
+                     /**
+@@ -299,13 +321,18 @@
+                         * entities that XML supports. Using HTML entities would result in this error:
+                         *     XML Parsing Error: undefined entity
+                         */
+-                        return match ($ord) {
+-                            34 => '&quot;', /* quotation mark */
+-                            38 => '&amp;',  /* ampersand */
+-                            60 => '&lt;',   /* less-than sign */
+-                            62 => '&gt;',   /* greater-than sign */
+-                            default => \sprintf('&#x%02X;', $ord),
+-                        };
++                        switch ($ord) {
++                            case 34:
++                                return '&quot;'; /* quotation mark */
++                            case 38:
++                                return '&amp;'; /* ampersand */
++                            case 60:
++                                return '&lt;'; /* less-than sign */
++                            case 62:
++                                return '&gt;'; /* greater-than sign */
++                            default:
++                                return \sprintf('&#x%02X;', $ord);
++                        }
+                     }
+ 
+                     /*
+diff -u a/src/RuntimeLoader/ContainerRuntimeLoader.php b/src/RuntimeLoader/ContainerRuntimeLoader.php
+--- a/src/RuntimeLoader/ContainerRuntimeLoader.php
++++ b/src/RuntimeLoader/ContainerRuntimeLoader.php
+@@ -23,9 +23,12 @@
+  */
+ class ContainerRuntimeLoader implements RuntimeLoaderInterface
+ {
++    private ContainerInterface $container;
++
+     public function __construct(
+-        private ContainerInterface $container,
++        ContainerInterface $container
+     ) {
++        $this->container = $container;
+     }
+ 
+     public function load(string $class)
+diff -u a/src/RuntimeLoader/FactoryRuntimeLoader.php b/src/RuntimeLoader/FactoryRuntimeLoader.php
+--- a/src/RuntimeLoader/FactoryRuntimeLoader.php
++++ b/src/RuntimeLoader/FactoryRuntimeLoader.php
+@@ -18,12 +18,15 @@
+  */
+ class FactoryRuntimeLoader implements RuntimeLoaderInterface
+ {
++    private array $map;
++
+     /**
+      * @param array $map An array where keys are class names and values factory callables
+      */
+     public function __construct(
+-        private array $map = [],
++        array $map = []
+     ) {
++        $this->map = $map;
+     }
+ 
+     public function load(string $class)
+diff -u a/src/Sandbox/SecurityPolicy.php b/src/Sandbox/SecurityPolicy.php
+--- a/src/Sandbox/SecurityPolicy.php
++++ b/src/Sandbox/SecurityPolicy.php
+@@ -130,7 +130,7 @@
+         }
+ 
+         if (!$allowed) {
+-            $class = $obj::class;
++            $class = get_class($obj);
+             throw new SecurityNotAllowedMethodError(\sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, $class), $class, $method);
+         }
+     }
+@@ -146,7 +146,7 @@
+         }
+ 
+         if (!$allowed) {
+-            $class = $obj::class;
++            $class = get_class($obj);
+             throw new SecurityNotAllowedPropertyError(\sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, $class), $class, $property);
+         }
+     }
+diff -u a/src/Source.php b/src/Source.php
+--- a/src/Source.php
++++ b/src/Source.php
+@@ -18,16 +18,23 @@
+  */
+ final class Source
+ {
++    private string $code;
++    private string $name;
++    private string $path;
++
+     /**
+      * @param string $code The template source code
+      * @param string $name The template logical name
+      * @param string $path The filesystem path of the template if any
+      */
+     public function __construct(
+-        private string $code,
+-        private string $name,
+-        private string $path = '',
++        string $code,
++        string $name,
++        string $path = ''
+     ) {
++        $this->code = $code;
++        $this->name = $name;
++        $this->path = $path;
+     }
+ 
+     public function getCode(): string
+diff -u a/src/Template.php b/src/Template.php
+--- a/src/Template.php
++++ b/src/Template.php
+@@ -42,9 +42,12 @@
+ 
+     private $useYield;
+ 
++    protected Environment $env;
++
+     public function __construct(
+-        protected Environment $env,
++        Environment $env
+     ) {
++        $this->env = $env;
+         $this->useYield = $env->useYield();
+         $this->extensions = $env->getExtensions();
+     }
+@@ -74,7 +77,7 @@
+      *
+      * @return self|TemplateWrapper|false The parent template or false if there is no parent
+      */
+-    public function getParent(array $context): self|TemplateWrapper|false
++    public function getParent(array $context)/*: self|TemplateWrapper|false*/
+     {
+         if (null !== $this->parent) {
+             return $this->parent;
+@@ -103,7 +106,7 @@
+         return $this->parents[$parent];
+     }
+ 
+-    protected function doGetParent(array $context): bool|string|self|TemplateWrapper
++    protected function doGetParent(array $context)/*: bool|string|self|TemplateWrapper*/
+     {
+         return false;
+     }
+@@ -278,7 +281,7 @@
+     /**
+      * @param string|TemplateWrapper|array<string|TemplateWrapper> $template
+      */
+-    protected function load(string|TemplateWrapper|array $template, int $line, ?int $index = null): self
++    protected function load(/*string|TemplateWrapper|array*/ $template, int $line, ?int $index = null): self
+     {
+         try {
+             if (\is_array($template)) {
+@@ -323,7 +326,7 @@
+      *
+      * @deprecated since Twig 3.21 and will be removed in 4.0. Use Template::load() instead.
+      */
+-    protected function loadTemplate($template, $templateName = null, ?int $line = null, ?int $index = null): self|TemplateWrapper
++    protected function loadTemplate($template, $templateName = null, ?int $line = null, ?int $index = null)/*: self|TemplateWrapper*/
+     {
+         trigger_deprecation('twig/twig', '3.21', 'The "%s" method is deprecated.', __METHOD__);
+ 
+diff -u a/src/TemplateWrapper.php b/src/TemplateWrapper.php
+--- a/src/TemplateWrapper.php
++++ b/src/TemplateWrapper.php
+@@ -18,6 +18,9 @@
+  */
+ final class TemplateWrapper
+ {
++    private Environment $env;
++    private Template $template;
++
+     /**
+      * This method is for internal use only and should never be called
+      * directly (use Twig\Environment::load() instead).
+@@ -25,9 +28,11 @@
+      * @internal
+      */
+     public function __construct(
+-        private Environment $env,
+-        private Template $template,
++        Environment $env,
++        Template $template
+     ) {
++        $this->env = $env;
++        $this->template = $template;
+     }
+ 
+     /**
+diff -u a/src/Test/IntegrationTestCase.php b/src/Test/IntegrationTestCase.php
+--- a/src/Test/IntegrationTestCase.php
++++ b/src/Test/IntegrationTestCase.php
+@@ -287,14 +287,14 @@
+             } catch (\Exception $e) {
+                 if (false !== $exception) {
+                     $message = $e->getMessage();
+-                    $this->assertSame(trim($exception), trim(\sprintf('%s: %s', $e::class, $message)));
++                    $this->assertSame(trim($exception), trim(\sprintf('%s: %s', get_class($e), $message)));
+                     $last = substr($message, \strlen($message) - 1);
+                     $this->assertTrue('.' === $last || '?' === $last, 'Exception message must end with a dot or a question mark.');
+ 
+                     return;
+                 }
+ 
+-                throw new Error(\sprintf('%s: %s', $e::class, $e->getMessage()), -1, null, $e);
++                throw new Error(\sprintf('%s: %s', get_class($e), $e->getMessage()), -1, null, $e);
+             } finally {
+                 restore_error_handler();
+             }
+@@ -305,14 +305,14 @@
+                 $output = trim($template->render(eval($match[1].';')), "\n ");
+             } catch (\Exception $e) {
+                 if (false !== $exception) {
+-                    $this->assertStringMatchesFormat(trim($exception), trim(\sprintf('%s: %s', $e::class, $e->getMessage())));
++                    $this->assertStringMatchesFormat(trim($exception), trim(\sprintf('%s: %s', get_class($e), $e->getMessage())));
+ 
+                     return;
+                 }
+ 
+-                $e = new Error(\sprintf('%s: %s', $e::class, $e->getMessage()), -1, null, $e);
++                $e = new Error(\sprintf('%s: %s', get_class($e), $e->getMessage()), -1, null, $e);
+ 
+-                $output = trim(\sprintf('%s: %s', $e::class, $e->getMessage()));
++                $output = trim(\sprintf('%s: %s', get_class($e), $e->getMessage()));
+             }
+ 
+             if (false !== $exception) {
+diff -u a/src/TokenParser/GuardTokenParser.php b/src/TokenParser/GuardTokenParser.php
+--- a/src/TokenParser/GuardTokenParser.php
++++ b/src/TokenParser/GuardTokenParser.php
+@@ -41,7 +41,7 @@
+ 
+         try {
+             $exists = null !== $this->parser->getEnvironment()->$method($name);
+-        } catch (SyntaxError) {
++        } catch (SyntaxError $e) {
+             $exists = false;
+         }
+ 
+diff -u a/src/Token.php b/src/Token.php
+--- a/src/Token.php
++++ b/src/Token.php
+@@ -39,11 +39,19 @@
+      */
+     public const SPREAD_TYPE = 13;
+ 
++    private int $type;
++    private $value;
++    private int $lineno;
++
+     public function __construct(
+-        private int $type,
+-        private $value,
+-        private int $lineno,
++        int $type,
++        $value,
++        int $lineno
+     ) {
++        $this->type = $type;
++        $this->value = $value;
++        $this->lineno = $lineno;
++
+         if (self::ARROW_TYPE === $type) {
+             trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "arrow" is now an operator.', self::ARROW_TYPE);
+         }
+diff -u a/src/TokenStream.php b/src/TokenStream.php
+--- a/src/TokenStream.php
++++ b/src/TokenStream.php
+@@ -22,11 +22,16 @@
+ final class TokenStream
+ {
+     private $current = 0;
++    private array $tokens;
++    private ?Source $source;
+ 
+     public function __construct(
+-        private array $tokens,
+-        private ?Source $source = null,
++        array $tokens,
++        ?Source $source = null
+     ) {
++        $this->tokens = $tokens;
++        $this->source = $source;
++
+         if (null === $this->source) {
+             trigger_deprecation('twig/twig', '3.16', \sprintf('Not passing a "%s" object to "%s" constructor is deprecated.', Source::class, __CLASS__));
+ 
+diff -u a/src/Util/CallableArgumentsExtractor.php b/src/Util/CallableArgumentsExtractor.php
+--- a/src/Util/CallableArgumentsExtractor.php
++++ b/src/Util/CallableArgumentsExtractor.php
+@@ -28,10 +28,16 @@
+ {
+     private ReflectionCallable $rc;
+ 
++    private Node $node;
++    private TwigCallableInterface $twigCallable;
++
+     public function __construct(
+-        private Node $node,
+-        private TwigCallableInterface $twigCallable,
++        Node $node,
++        TwigCallableInterface $twigCallable
+     ) {
++        $this->node = $node;
++        $this->twigCallable = $twigCallable;
++
+         $this->rc = new ReflectionCallable($twigCallable);
+     }
+ 
+diff -u a/src/Util/DeprecationCollector.php b/src/Util/DeprecationCollector.php
+--- a/src/Util/DeprecationCollector.php
++++ b/src/Util/DeprecationCollector.php
+@@ -20,9 +20,12 @@
+  */
+ final class DeprecationCollector
+ {
++    private Environment $twig;
++
+     public function __construct(
+-        private Environment $twig,
++        Environment $twig
+     ) {
++        $this->twig = $twig;
+     }
+ 
+     /**
+diff -u a/src/Util/ReflectionCallable.php b/src/Util/ReflectionCallable.php
+--- a/src/Util/ReflectionCallable.php
++++ b/src/Util/ReflectionCallable.php
+@@ -25,7 +25,7 @@
+     private $name;
+ 
+     public function __construct(
+-        TwigCallableInterface $twigCallable,
++        TwigCallableInterface $twigCallable
+     ) {
+         $callable = $twigCallable->getCallable();
+         if (\is_string($callable) && false !== $pos = strpos($callable, '::')) {
+diff -u a/src/ExpressionParser/ExpressionParserType.php b/src/ExpressionParser/ExpressionParserType.php
+deleted file mode 100644
+--- a/src/ExpressionParser/ExpressionParserType.php
++++ /dev/null
+@@ -1,33 +0,0 @@
+-<?php
+-
+-/*
+- * This file is part of Twig.
+- *
+- * (c) Fabien Potencier
+- *
+- * For the full copyright and license information, please view the LICENSE
+- * file that was distributed with this source code.
+- */
+-
+-namespace Twig\ExpressionParser;
+-
+-/**
+- * @internal
+- */
+-enum ExpressionParserType: string
+-{
+-    case Prefix = 'prefix';
+-    case Infix = 'infix';
+-
+-    public static function getType(object $object): ExpressionParserType
+-    {
+-        if ($object instanceof PrefixExpressionParserInterface) {
+-            return self::Prefix;
+-        }
+-        if ($object instanceof InfixExpressionParserInterface) {
+-            return self::Infix;
+-        }
+-
+-        throw new \InvalidArgumentException(\sprintf('Unsupported expression parser type: %s', $object::class));
+-    }
+-}
+diff -u a/src/ExpressionParser/InfixAssociativity.php b/src/ExpressionParser/InfixAssociativity.php
+deleted file mode 100644
+--- a/src/ExpressionParser/InfixAssociativity.php
++++ /dev/null
+@@ -1,18 +0,0 @@
+-<?php
+-
+-/*
+- * This file is part of Twig.
+- *
+- * (c) Fabien Potencier
+- *
+- * For the full copyright and license information, please view the LICENSE
+- * file that was distributed with this source code.
+- */
+-
+-namespace Twig\ExpressionParser;
+-
+-enum InfixAssociativity
+-{
+-    case Left;
+-    case Right;
+-}
+diff -u a/src/Node/MacroNode.php b/src/Node/MacroNode.php
+--- a/src/Node/MacroNode.php
++++ b/src/Node/MacroNode.php
+@@ -78,7 +78,7 @@
+ 
+         $compiler
+             ->raw('...$varargs')
+-            ->raw("): string|Markup\n")
++            ->raw(")/*: string|Markup*/\n")
+             ->write("{\n")
+             ->indent()
+             ->write("\$macros = \$this->macros;\n")
+diff -u a/src/Node/ModuleNode.php b/src/Node/ModuleNode.php
+--- a/src/Node/ModuleNode.php
++++ b/src/Node/ModuleNode.php
+@@ -139,7 +139,7 @@
+         $parent = $this->getNode('parent');
+ 
+         $compiler
+-            ->write("protected function doGetParent(array \$context): bool|string|Template|TemplateWrapper\n", "{\n")
++            ->write("protected function doGetParent(array \$context)/*: bool|string|Template|TemplateWrapper*/\n", "{\n")
+             ->indent()
+             ->addDebugInfo($parent)
+             ->write('return ')

--- a/tools/patches/twig-twig-v3.11.3...v3.27.0.patch
+++ b/tools/patches/twig-twig-v3.11.3...v3.27.0.patch
@@ -1,0 +1,17805 @@
+
+
+diff --git a/CHANGELOG b/CHANGELOG
+index 525e2385c69..4e4a7a2c3c1 100644
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -1,10 +1,256 @@
+-# 3.11.3 (2024-11-07)
++# 3.27.0 (2026-05-27)
++
++ * Add a strict mode to `Twig\Sandbox\SecurityPolicy` to opt-in to the 4.0 behavior for the `extends`/`use` tags and the `parent`/`block`/`attribute` functions, which are otherwise still implicitly allowed in a sandbox
++ * Deprecate the fact that the `parent`, `block`, and `attribute` functions are always allowed in a sandboxed template
++ * Fix sandbox filter/tag/function allow-list bypass when the sandbox state changed between renders of a cached `Template` instance
++ * Fix PHP 8.1+ implicit float-to-int deprecation triggered by sandboxed `ArrayAccess` attribute access with a float key
++ * Restrict allowed classes in `Twig\Profiler\Profile::unserialize()` to prevent arbitrary class instantiation
++ * Escape root profile name in `HtmlDumper`
++ * Fix sandbox bypass in deprecated internal wrappers `twig_array_some()`, `twig_array_every()`, and `twig_check_arrow_in_sandbox()` (`src/Resources/core.php`)
++ * Deprecate the `Twig\Sandbox\SourcePolicyInterface` interface with no replacement
++ * Fix sandbox bypass in the "column" filter when sandboxing is enabled via `SourcePolicyInterface`
++ * Fix sandbox `__toString` bypass via `Traversable` arguments to the `join` and `replace` filters (also covers containers that implement both `Stringable` and `Traversable`)
++ * Fix sandbox `__toString` bypass via the `in` and `not in` operators
++ * Prevent a stack overflow in `SandboxExtension::ensureToStringAllowed()` when a self-referencing iterable is passed to a sandboxed template
++ * Add support for any expression as a dynamic mapping key (attribute access, filters, ...)
++ * Fix sandbox `__toString` policy bypass via dynamic mapping keys
++
++# 3.26.0 (2026-05-20)
++
++ * Document that the sandbox doesn't protect against resource exhaustion
++ * Document `template_from_string` caveats when used in a sandboxed environment
++ * Add docs on `Markup` about the goal of this class in the context of a sandbox
++ * Pre-escape HTML input on the `spaceless` filter
++ * Pre-escape HTML input on `inline_css` and `inky_to_html` filters
++ * Fix XSS by adjusting `is_safe` annotation on HTML-emitting filters
++ * [Profiler] Escape template and profile names in `HtmlDumper`
++ * Fix unbounded memoisation of `IntlDateFormatter` / `NumberFormatter`
++ * Fix sandbox bypass in the "column" filter
++ * Fix sandbox bypass in the `{% sandbox %}` tag when including a preloaded template
++ * Fix sandbox bypass: PHP code injection via `{% use %}` template name
++ * Fix sandbox bypass: PHP code injection via `_self` / import macro reference
++ * Fix sandbox bypass in object destructuring assignment
++ * Fix sandbox bypass: propagate `Source` to `checkArrow` for source-policy sandboxing
++ * Encode single quotes as `\x27` in `Compiler::string()` as a defense-in-depth measure
++ * Fix sandbox `__toString` bypasses
++ * Add `Twig\Node\CoercesChildrenToStringInterface` to let nodes declare which of their child nodes will be string-coerced at runtime so the sandbox wraps them with a `__toString` check
++
++# 3.25.0 (2026-05-17)
++
++ * Add a `needs_is_sandboxed` option for filters, functions, and tests
++ * Use deterministic suffixes for generated embed classes
++ * Lazy-load `EscaperRuntime` in `EscaperExtension`
++
++# 3.24.0 (2026-03-17)
++
++ * Deprecate not implementing the `getOperatorTokens()` method in `ExpressionParserInterface` implementations
++ * Deprecate passing a non-`AbstractExpression` node to `Twig\Node\Expression\Binary\MatchesBinary` constructor
++ * Deprecate passing a non-`AbstractExpression` node to `Parser::setParent()`
++ * Add support for renaming variables in object destructuring (`{name: userName} = user`)
++ * Add `html_attr_relaxed` escaping strategy that preserves :, @, [, and ] for front-end framework attribute names
++ * Add support for short-circuiting in null-safe operator chains
++ * Add the `html_attr` function and `html_attr_merge` as well as `html_attr_type` filters
++
++# 3.23.0 (2026-01-23)
++
++ * Add `=` assignment operator (allows to set variables in expression or to replace the short-form of the set tag)
++ * Add sequence, mapping, and object destructuring
++ * Add `?.` null-safe operator
++ * Add `===` and `!==` operators (equivalent to the `same as` and `not same as` tests)
++ * Fix opcache preload warning for unlinked anonymous class
++ * Fix spread operator behavior
++
++# 3.22.2 (2025-12-14)
++
++ * Fix "cycle" with non-countable ArrayAccess + Traversable objects
++ * Use "getShareDir" as an indicator of Symfony version in Symfony bundle
++ * Fix escaper compatibility with PHP 8.5
++
++# 3.22.1 (2025-11-16)
++
++ * Add support for Symfony 8
++
++# 3.22.0 (2025-10-29)
++
++ * Add support for two words test in guard tag
++ * Add `Environment::registerUndefinedTestCallback()`
++ * Fix compatibility with Symfony 8
++ * Fix accessing arrays with stringable objects as key
++ * Avoid errors when failing to guess the template info for an error
++ * Fix expression parser compatibility layer
++ * Fix compiling 'index' with repr (not string) in EmbedNode
++ * Update configuration keys + allow extra keys for CommonMark extensions
++ * Allow usage of other Markdown converters than CommonMark in LeagueMarkdown
++
++# 3.21.1 (2025-05-03)
++
++ * Fix ExtensionSet usage of BinaryOperatorExpressionParser
++
++# 3.21.0 (2025-05-02)
++
++ * Fix wrong array index
++ * Deprecate `Template::loadTemplate()`
++ * Fix testing and expression when it evaluates to an instance of `Markup`
++ * Add `ReturnPrimitiveTypeInterface` (and sub-interfaces for number, boolean, string, and array)
++ * Add `SupportDefinedTestInterface` for expression nodes supporting the `defined` test
++ * Deprecate using the `|` operator in an expression with `+` or `-` without using parentheses to clarify precedence
++ * Deprecate operator precedence outside of the [0, 512] range
++ * Introduce expression parser classes to describe operators and operands provided by extensions
++   instead of arrays (it comes with many deprecations that are documented in
++   the ``deprecated`` documentation chapter)
++ * Deprecate the `Twig\ExpressionParser`, and `Twig\OperatorPrecedenceChange` classes
++ * Add attributes `AsTwigFilter`, `AsTwigFunction`, and `AsTwigTest` to ease extension development
++
++# 3.20.0 (2025-02-13)
++
++ * Fix support for ignoring syntax errors in an undefined handler in guard
++ * Add configuration for Commonmark
++ * Fix wrong array index
++ * Bump minimum PHP version to 8.1
++ * Add support for registering callbacks for undefined functions, filters or token parsers in the IntegrationTestCase
++ * Use correct line number for `ForElseNode`
++ * Fix timezone conversion on strings
++
++# 3.19.0 (2025-01-28)
++
++ * Fix a security issue where escaping was missing when using `??`
++ * Deprecate `Token::getType()`, use `Token::test()` instead
++ * Add `Token::toEnglish()`
++ * Add `ForElseNode`
++ * Deprecate `Twig\ExpressionParser::parseOnlyArguments()` and
++  `Twig\ExpressionParser::parseArguments()` (use
++  `Twig\ExpressionParser::parseNamedArguments()` instead)
++ * Fix `constant()` behavior when used with `??`
++ * Add the `invoke` filter
++ * Make `{}` optional for the `types` tag
++ * Add `LastModifiedExtensionInterface` and implementation in `AbstractExtension` to track modification of runtime classes
++ * Ignore static properties when using the dot operator
++
++# 3.18.0 (2024-12-29)
++
++ * Support for invoking closures
++ * Fix unary operator precedence change
++ * Ignore `SyntaxError` exceptions from undefined handlers when using the `guard` tag
++ * Add a way to stream template rendering (`TemplateWrapper::stream()` and `TemplateWrapper::streamBlock()`)
++
++# 3.17.1 (2024-12-12)
++
++ * Fix the null coalescing operator when the test returns null
++ * Fix the Elvis operator when used as '? :' instead of '?:'
++
++# 3.17.0 (2024-12-10)
++
++ * Fix ArrayAccess with objects as keys
++ * Support underscores in number literals
++ * Deprecate `ConditionalExpression` and `NullCoalesceExpression` (use `ConditionalTernary` and `NullCoalesceBinary` instead)
++
++# 3.16.0 (2024-11-29)
++
++ * Deprecate `InlinePrint`
++ * Fix having macro variables starting with an underscore
++ * Deprecate not passing a `Source` instance to `TokenStream`
++ * Deprecate returning `null` from `TwigFilter::getSafe()` and `TwigFunction::getSafe()`, return `[]` instead
++
++# 3.15.0 (2024-11-17)
++
++ * [BC BREAK] Add support for accessing class constants with the dot operator;
++   this can be a BC break if you don't use UPPERCASE constant names
++ * Add Spanish inflector support for the `plural` and `singular` filters in the String extension
++ * Deprecate `TempNameExpression` in favor of `LocalVariable`
++ * Deprecate `NameExpression` in favor of `ContextVariable`
++ * Deprecate `AssignNameExpression` in favor of `AssignContextVariable`
++ * Remove `MacroAutoImportNodeVisitor`
++ * Deprecate `MethodCallExpression` in favor of `MacroReferenceExpression`
++ * Fix support for the "is defined" test on `_self.xxx` (auto-imported) macros
++ * Fix support for the "is defined" test on inherited macros
++ * Add named arguments support for the dot operator arguments (`foo.bar(some: arg)`)
++ * Add named arguments support for macros
++ * Add a new `guard` tag that allows to test if some Twig callables are available at compilation time
++ * Allow arrow functions everywhere
++ * Deprecate passing a string or an array to Twig callable arguments accepting arrow functions (pass a `\Closure`)
++ * Add support for triggering deprecations for future operator precedence changes
++ * Deprecate using the `not` unary operator in an expression with ``*``, ``/``, ``//``, or ``%`` without using explicit parentheses to clarify precedence
++ * Deprecate using the `??` binary operator without explicit parentheses
++ * Deprecate using the `~` binary operator in an expression with `+` or `-` without using parentheses to clarify precedence
++ * Deprecate not passing `AbstractExpression` args to most constructor arguments for classes extending `AbstractExpression`
++ * Fix `power` expressions with a negative number in parenthesis (`(-1) ** 2`)
++ * Deprecate instantiating `Node` directly. Use `EmptyNode` or `Nodes` instead.
++ * Add support for inline comments
++ * Add `Profile::getStartTime()` and `Profile::getEndTime()`
++ * Fix "ignore missing" when used on an "embed" tag
++ * Fix the possibility to override an aliased block (via use)
++ * Add template cache hot reload
++ * Allow Twig callable argument names to be free-form (snake-case or camelCase) independently of the PHP callable signature
++   They were automatically converted to snake-cased before
++ * Deprecate the `attribute` function; use the `.` notation and wrap the name with parenthesis instead
++ * Add support for argument unpackaging
++ * Add JSON support for the file extension escaping strategy
++ * Support Markup instances (and any other \Stringable) as dynamic mapping keys
++ * Deprecate the `sandbox` tag
++ * Improve the way one can deprecate a Twig callable (use `deprecation_info` instead of the other callable options)
++ * Add the `enum` function
++ * Add support for logical `xor` operator
++
++# 3.14.2 (2024-11-07)
+ 
+  * Fix an infinite recursion in the sandbox code
+ 
++# 3.14.1 (2024-11-06)
++
++ * [BC BREAK] Fix a security issue in the sandbox mode allowing an attacker to call attributes on Array-like objects
++   They are now checked via the property policy
++ * Fix a security issue in the sandbox mode allowing an attacker to be able to call `toString()`
++   under some circumstances on an object even if the `__toString()` method is not allowed by the security policy
++
++# 3.14.0 (2024-09-09)
++
++ * Fix a security issue when an included sandboxed template has been loaded before without the sandbox context
++ * Add the possibility to reset globals via `Environment::resetGlobals()`
++ * Deprecate `Environment::mergeGlobals()`
++
++# 3.13.0 (2024-09-07)
++
++ * Add the `types` tag (experimental)
++ * Deprecate the `Twig\Test\NodeTestCase::getTests()` data provider, override `provideTests()` instead.
++ * Mark `Twig\Test\NodeTestCase::getEnvironment()` as final, override `createEnvironment()` instead.
++ * Deprecate `Twig\Test\NodeTestCase::getVariableGetter()`, call `createVariableGetter()` instead.
++ * Deprecate `Twig\Test\NodeTestCase::getAttributeGetter()`, call `createAttributeGetter()` instead.
++ * Deprecate not overriding `Twig\Test\IntegrationTestCase::getFixturesDirectory()`, this method will be abstract in 4.0
++ * Marked `Twig\Test\IntegrationTestCase::getTests()` and `getLegacyTests()` as final
++
++# 3.12.0 (2024-08-29)
++
++ * Deprecate the fact that the `extends` and `use` tags are always allowed in a sandboxed template.
++   This behavior will change in 4.0 where these tags will need to be explicitly allowed like any other tag.
++ * Deprecate the "tag" constructor argument of the "Twig\Node\Node" class as the tag is now automatically set by the Parser when needed
++ * Fix precedence of two-word tests when the first word is a valid test
++ * Deprecate the `spaceless` filter
++ * Deprecate some internal methods from `Parser`: `getBlockStack()`, `hasBlock()`, `getBlock()`, `hasMacro()`, `hasTraits()`, `getParent()`
++ * Deprecate passing `null` to `Twig\Parser::setParent()`
++ * Update `Node::__toString()` to include the node tag if set
++ * Add support for integers in methods of `Twig\Node\Node` that take a Node name
++ * Deprecate not passing a `BodyNode` instance as the body of a `ModuleNode` or `MacroNode` constructor
++ * Deprecate returning "null" from "TokenParserInterface::parse()".
++ * Deprecate `OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES`
++ * Fix performance regression when `use_yield` is `false` (which is the default)
++ * Improve compatibility when `use_yield` is `false` (as extensions still using `echo` will work as is)
++ * Accept colons (`:`) in addition to equals (`=`) to separate argument names and values in named arguments
++ * Add the `html_cva` function (in the HTML extra package)
++ * Add support for named arguments to the `block` and `attribute` functions
++ * Throw a SyntaxError exception at compile time when a Twig callable has not the minimum number of required arguments
++ * Add a `CallableArgumentsExtractor` class
++ * Deprecate passing a name to `FunctionExpression`, `FilterExpression`, and `TestExpression`;
++   pass a `TwigFunction`, `TwigFilter`, or `TestFilter` instead
++ * Deprecate all Twig callable attributes on `FunctionExpression`, `FilterExpression`, and `TestExpression`
++ * Deprecate the `filter` node of `FilterExpression`
++ * Add the notion of Twig callables (functions, filters, and tests)
++ * Bump minimum PHP version to 8.0
++ * Fix integration tests when a test has more than one data/expect section and deprecations
++ * Add the `enum_cases` function
++
+ # 3.11.2 (2024-11-06)
+ 
+- * [BC BREAK] Fix a security issue in the sandbox mode allowing an attacker to call attributes on Array-like objects
++ * [BC BREAK] Fix a security issue in the sandbox mode allowing an attacker to call attributes on Array-like objects
+    They are now checked via the property policy
+  * Fix a security issue in the sandbox mode allowing an attacker to be able to call `toString()`
+    under some circumstances on an object even if the `__toString()` method is not allowed by the security policy
+@@ -15,6 +261,7 @@
+ 
+ # 3.11.0 (2024-08-08)
+ 
++ * Deprecate `OptimizerNodeVisitor::OPTIMIZE_RAW_FILTER`
+  * Add `Twig\Cache\ChainCache` and `Twig\Cache\ReadOnlyFilesystemCache`
+  * Add the possibility to deprecate attributes and nodes on `Node`
+  * Add the possibility to add a package and a version to the `deprecated` tag
+diff --git a/composer.json b/composer.json
+index 26cb4972ec5..788ebe708af 100644
+--- a/composer.json
++++ b/composer.json
+@@ -24,16 +24,16 @@
+         }
+     ],
+     "require": {
+-        "php": ">=7.2.5",
+-        "symfony/polyfill-php80": "^1.22",
++        "php": ">=8.1.0",
+         "symfony/deprecation-contracts": "^2.5|^3",
+         "symfony/polyfill-mbstring": "^1.3",
+-        "symfony/polyfill-ctype": "^1.8",
+-        "symfony/polyfill-php81": "^1.29"
++        "symfony/polyfill-ctype": "^1.8"
+     },
+     "require-dev": {
+         "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0",
+-        "psr/container": "^1.0|^2.0"
++        "psr/container": "^1.0|^2.0",
++        "phpstan/phpstan": "^2.0@stable",
++        "php-cs-fixer/shim": "^3.0@stable"
+     },
+     "autoload": {
+         "files": [
+diff --git a/src/AbstractTwigCallable.php b/src/AbstractTwigCallable.php
+new file mode 100644
+index 00000000000..008d4d395c8
+--- /dev/null
++++ b/src/AbstractTwigCallable.php
+@@ -0,0 +1,193 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++abstract class AbstractTwigCallable implements TwigCallableInterface
++{
++    protected $options;
++
++    private $name;
++    private $dynamicName;
++    private $callable;
++    private $arguments;
++
++    public function __construct(string $name, $callable = null, array $options = [])
++    {
++        $this->name = $this->dynamicName = $name;
++        $this->callable = $callable;
++        $this->arguments = [];
++        $this->options = array_merge([
++            'needs_environment' => false,
++            'needs_context' => false,
++            'needs_charset' => false,
++            'needs_is_sandboxed' => false,
++            'is_variadic' => false,
++            'deprecation_info' => null,
++            'deprecated' => false,
++            'deprecating_package' => '',
++            'alternative' => null,
++        ], $options);
++
++        if ($this->options['deprecation_info'] && !$this->options['deprecation_info'] instanceof DeprecatedCallableInfo) {
++            throw new \LogicException(\sprintf('The "deprecation_info" option must be an instance of "%s".', DeprecatedCallableInfo::class));
++        }
++
++        if ($this->options['deprecated']) {
++            if ($this->options['deprecation_info']) {
++                throw new \LogicException('When setting the "deprecation_info" option, you need to remove the obsolete deprecated options.');
++            }
++
++            trigger_deprecation('twig/twig', '3.15', 'Using the "deprecated", "deprecating_package", and "alternative" options is deprecated, pass a "deprecation_info" one instead.');
++
++            $this->options['deprecation_info'] = new DeprecatedCallableInfo(
++                $this->options['deprecating_package'],
++                $this->options['deprecated'],
++                null,
++                $this->options['alternative'],
++            );
++        }
++
++        if ($this->options['deprecation_info']) {
++            $this->options['deprecation_info']->setName($name);
++            $this->options['deprecation_info']->setType($this->getType());
++        }
++    }
++
++    public function __toString(): string
++    {
++        return \sprintf('%s(%s)', static::class, $this->name);
++    }
++
++    public function getName(): string
++    {
++        return $this->name;
++    }
++
++    public function getDynamicName(): string
++    {
++        return $this->dynamicName;
++    }
++
++    /**
++     * @return callable|array{class-string, string}|null
++     */
++    public function getCallable()
++    {
++        return $this->callable;
++    }
++
++    public function getNodeClass(): string
++    {
++        return $this->options['node_class'];
++    }
++
++    public function needsCharset(): bool
++    {
++        return $this->options['needs_charset'];
++    }
++
++    public function needsEnvironment(): bool
++    {
++        return $this->options['needs_environment'];
++    }
++
++    public function needsContext(): bool
++    {
++        return $this->options['needs_context'];
++    }
++
++    public function needsIsSandboxed(): bool
++    {
++        return $this->options['needs_is_sandboxed'];
++    }
++
++    /**
++     * @return static
++     */
++    public function withDynamicArguments(string $name, string $dynamicName, array $arguments): self
++    {
++        $new = clone $this;
++        $new->name = $name;
++        $new->dynamicName = $dynamicName;
++        $new->arguments = $arguments;
++
++        return $new;
++    }
++
++    /**
++     * @deprecated since Twig 3.12, use withDynamicArguments() instead
++     */
++    public function setArguments(array $arguments): void
++    {
++        trigger_deprecation('twig/twig', '3.12', 'The "%s::setArguments()" method is deprecated, use "%s::withDynamicArguments()" instead.', static::class, static::class);
++
++        $this->arguments = $arguments;
++    }
++
++    public function getArguments(): array
++    {
++        return $this->arguments;
++    }
++
++    public function isVariadic(): bool
++    {
++        return $this->options['is_variadic'];
++    }
++
++    public function isDeprecated(): bool
++    {
++        return (bool) $this->options['deprecation_info'];
++    }
++
++    public function triggerDeprecation(?string $file = null, ?int $line = null): void
++    {
++        $this->options['deprecation_info']->triggerDeprecation($file, $line);
++    }
++
++    /**
++     * @deprecated since Twig 3.15
++     */
++    public function getDeprecatingPackage(): string
++    {
++        trigger_deprecation('twig/twig', '3.15', 'The "%s" method is deprecated, use "%s::triggerDeprecation()" instead.', __METHOD__, static::class);
++
++        return $this->options['deprecating_package'];
++    }
++
++    /**
++     * @deprecated since Twig 3.15
++     */
++    public function getDeprecatedVersion(): string
++    {
++        trigger_deprecation('twig/twig', '3.15', 'The "%s" method is deprecated, use "%s::triggerDeprecation()" instead.', __METHOD__, static::class);
++
++        return \is_bool($this->options['deprecated']) ? '' : $this->options['deprecated'];
++    }
++
++    /**
++     * @deprecated since Twig 3.15
++     */
++    public function getAlternative(): ?string
++    {
++        trigger_deprecation('twig/twig', '3.15', 'The "%s" method is deprecated, use "%s::triggerDeprecation()" instead.', __METHOD__, static::class);
++
++        return $this->options['alternative'];
++    }
++
++    public function getMinimalNumberOfRequiredArguments(): int
++    {
++        return ($this->options['needs_charset'] ? 1 : 0) + ($this->options['needs_environment'] ? 1 : 0) + ($this->options['needs_context'] ? 1 : 0) + ($this->options['needs_is_sandboxed'] ? 1 : 0) + \count($this->arguments);
++    }
++}
+diff --git a/src/Attribute/AsTwigFilter.php b/src/Attribute/AsTwigFilter.php
+new file mode 100644
+index 00000000000..59c4726dec7
+--- /dev/null
++++ b/src/Attribute/AsTwigFilter.php
+@@ -0,0 +1,58 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Attribute;
++
++use Twig\DeprecatedCallableInfo;
++use Twig\TwigFilter;
++
++/**
++ * Registers a method as template filter.
++ *
++ * If the first argument of the method has Twig\Environment type-hint, the filter will receive the current environment.
++ * Additional arguments of the method come from the filter call.
++ *
++ *     #[AsTwigFilter(name: 'foo')]
++ *     function fooFilter(Environment $env, $string, $arg1 = null, ...) { ... }
++ *
++ *    {{ 'string'|foo(arg1) }}
++ *
++ * @see TwigFilter
++ */
++#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
++final class AsTwigFilter
++{
++    /**
++     * @param non-empty-string            $name             The name of the filter in Twig
++     * @param bool|null                   $needsCharset     Whether the filter needs the charset passed as the first argument
++     * @param bool|null                   $needsEnvironment Whether the filter needs the environment passed as the first argument, or after the charset
++     * @param bool|null                   $needsContext     Whether the filter needs the context array passed as the first argument, or after the charset and the environment
++     * @param bool|null                   $needsIsSandboxed Whether the filter needs the current sandbox state (a boolean) passed as the first argument, or after the charset, the environment, and the context
++     * @param string[]|null               $isSafe           List of formats in which you want the raw output to be printed unescaped
++     * @param string|array|null           $isSafeCallback   Function called at compilation time to determine if the filter is safe
++     * @param string|null                 $preEscape        Some filters may need to work on input that is already escaped or safe
++     * @param string[]|null               $preservesSafety  Preserves the safety of the value that the filter is applied to
++     * @param DeprecatedCallableInfo|null $deprecationInfo  Information about the deprecation
++     */
++    public function __construct(
++        public string $name,
++        public ?bool $needsCharset = null,
++        public ?bool $needsEnvironment = null,
++        public ?bool $needsContext = null,
++        public ?bool $needsIsSandboxed = null,
++        public ?array $isSafe = null,
++        public string|array|null $isSafeCallback = null,
++        public ?string $preEscape = null,
++        public ?array $preservesSafety = null,
++        public ?DeprecatedCallableInfo $deprecationInfo = null,
++    ) {
++    }
++}
+diff --git a/src/Attribute/AsTwigFunction.php b/src/Attribute/AsTwigFunction.php
+new file mode 100644
+index 00000000000..1199180858a
+--- /dev/null
++++ b/src/Attribute/AsTwigFunction.php
+@@ -0,0 +1,54 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Attribute;
++
++use Twig\DeprecatedCallableInfo;
++use Twig\TwigFunction;
++
++/**
++ * Registers a method as template function.
++ *
++ * If the first argument of the method has Twig\Environment type-hint, the function will receive the current environment.
++ * Additional arguments of the method come from the function call.
++ *
++ *     #[AsTwigFunction(name: 'foo')]
++ *     function fooFunction(Environment $env, string $string, $arg1 = null, ...) { ... }
++ *
++ *     {{ foo('string', arg1) }}
++ *
++ * @see TwigFunction
++ */
++#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
++final class AsTwigFunction
++{
++    /**
++     * @param non-empty-string            $name             The name of the function in Twig
++     * @param bool|null                   $needsCharset     Whether the function needs the charset passed as the first argument
++     * @param bool|null                   $needsEnvironment Whether the function needs the environment passed as the first argument, or after the charset
++     * @param bool|null                   $needsContext     Whether the function needs the context array passed as the first argument, or after the charset and the environment
++     * @param bool|null                   $needsIsSandboxed Whether the function needs the current sandbox state (a boolean) passed as the first argument, or after the charset, the environment, and the context
++     * @param string[]|null               $isSafe           List of formats in which you want the raw output to be printed unescaped
++     * @param string|array|null           $isSafeCallback   Function called at compilation time to determine if the function is safe
++     * @param DeprecatedCallableInfo|null $deprecationInfo  Information about the deprecation
++     */
++    public function __construct(
++        public string $name,
++        public ?bool $needsCharset = null,
++        public ?bool $needsEnvironment = null,
++        public ?bool $needsContext = null,
++        public ?bool $needsIsSandboxed = null,
++        public ?array $isSafe = null,
++        public string|array|null $isSafeCallback = null,
++        public ?DeprecatedCallableInfo $deprecationInfo = null,
++    ) {
++    }
++}
+diff --git a/src/Attribute/AsTwigTest.php b/src/Attribute/AsTwigTest.php
+new file mode 100644
+index 00000000000..a5f32529bf9
+--- /dev/null
++++ b/src/Attribute/AsTwigTest.php
+@@ -0,0 +1,50 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Attribute;
++
++use Twig\DeprecatedCallableInfo;
++use Twig\TwigTest;
++
++/**
++ * Registers a method as template test.
++ *
++ * The first argument is the value to test and the other arguments are the
++ * arguments passed to the test in the template.
++ *
++ *     #[AsTwigTest(name: 'foo')]
++ *     public function fooTest($value, $arg1 = null) { ... }
++ *
++ *     {% if value is foo(arg1) %}
++ *
++ * @see TwigTest
++ */
++#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
++final class AsTwigTest
++{
++    /**
++     * @param non-empty-string            $name             The name of the test in Twig
++     * @param bool|null                   $needsCharset     Whether the test needs the charset passed as the first argument
++     * @param bool|null                   $needsEnvironment Whether the test needs the environment passed as the first argument, or after the charset
++     * @param bool|null                   $needsContext     Whether the test needs the context array passed as the first argument, or after the charset and the environment
++     * @param bool|null                   $needsIsSandboxed Whether the test needs the current sandbox state (a boolean) passed as the first argument, or after the charset, the environment, and the context
++     * @param DeprecatedCallableInfo|null $deprecationInfo  Information about the deprecation
++     */
++    public function __construct(
++        public string $name,
++        public ?bool $needsCharset = null,
++        public ?bool $needsEnvironment = null,
++        public ?bool $needsContext = null,
++        public ?bool $needsIsSandboxed = null,
++        public ?DeprecatedCallableInfo $deprecationInfo = null,
++    ) {
++    }
++}
+diff --git a/src/Attribute/FirstClassTwigCallableReady.php b/src/Attribute/FirstClassTwigCallableReady.php
+new file mode 100644
+index 00000000000..ffd8cffc812
+--- /dev/null
++++ b/src/Attribute/FirstClassTwigCallableReady.php
+@@ -0,0 +1,20 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Attribute;
++
++/**
++ * Marks nodes that are ready to accept a TwigCallable instead of its name.
++ */
++#[\Attribute(\Attribute::TARGET_METHOD)]
++final class FirstClassTwigCallableReady
++{
++}
+diff --git a/src/Cache/ChainCache.php b/src/Cache/ChainCache.php
+index 18c66f35f95..1c2098f1f98 100644
+--- a/src/Cache/ChainCache.php
++++ b/src/Cache/ChainCache.php
+@@ -19,16 +19,14 @@
+  *
+  * @author Quentin Devos <quentin@devos.pm>
+  */
+-final class ChainCache implements CacheInterface
++final class ChainCache implements CacheInterface, RemovableCacheInterface
+ {
+-    private $caches;
+-
+     /**
+      * @param iterable<CacheInterface> $caches The ordered list of caches used to store and fetch cached items
+      */
+-    public function __construct(iterable $caches)
+-    {
+-        $this->caches = $caches;
++    public function __construct(
++        private iterable $caches,
++    ) {
+     }
+ 
+     public function generateKey(string $name, string $className): string
+@@ -71,6 +69,15 @@ public function getTimestamp(string $key): int
+         return 0;
+     }
+ 
++    public function remove(string $name, string $cls): void
++    {
++        foreach ($this->caches as $cache) {
++            if ($cache instanceof RemovableCacheInterface) {
++                $cache->remove($name, $cls);
++            }
++        }
++    }
++
+     /**
+      * @return string[]
+      */
+diff --git a/src/Cache/FilesystemCache.php b/src/Cache/FilesystemCache.php
+index 2e79fac0508..5840585e3e9 100644
+--- a/src/Cache/FilesystemCache.php
++++ b/src/Cache/FilesystemCache.php
+@@ -16,7 +16,7 @@
+  *
+  * @author Andrew Tch <andrew@noop.lv>
+  */
+-class FilesystemCache implements CacheInterface
++class FilesystemCache implements CacheInterface, RemovableCacheInterface
+ {
+     public const FORCE_BYTECODE_INVALIDATION = 1;
+ 
+@@ -76,6 +76,14 @@ public function write(string $key, string $content): void
+         throw new \RuntimeException(\sprintf('Failed to write cache file "%s".', $key));
+     }
+ 
++    public function remove(string $name, string $cls): void
++    {
++        $key = $this->generateKey($name, $cls);
++        if (!@unlink($key) && file_exists($key)) {
++            throw new \RuntimeException(\sprintf('Failed to delete cache file "%s".', $key));
++        }
++    }
++
+     public function getTimestamp(string $key): int
+     {
+         if (!is_file($key)) {
+diff --git a/src/Cache/NullCache.php b/src/Cache/NullCache.php
+index 8d20d59d8b3..1ae21692800 100644
+--- a/src/Cache/NullCache.php
++++ b/src/Cache/NullCache.php
+@@ -16,7 +16,7 @@
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+-final class NullCache implements CacheInterface
++final class NullCache implements CacheInterface, RemovableCacheInterface
+ {
+     public function generateKey(string $name, string $className): string
+     {
+@@ -35,4 +35,8 @@ public function getTimestamp(string $key): int
+     {
+         return 0;
+     }
++
++    public function remove(string $name, string $cls): void
++    {
++    }
+ }
+diff --git a/src/Cache/RemovableCacheInterface.php b/src/Cache/RemovableCacheInterface.php
+new file mode 100644
+index 00000000000..05da569136b
+--- /dev/null
++++ b/src/Cache/RemovableCacheInterface.php
+@@ -0,0 +1,20 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Cache;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++interface RemovableCacheInterface
++{
++    public function remove(string $name, string $cls): void;
++}
+diff --git a/src/Compiler.php b/src/Compiler.php
+index 1e7ed04c61d..976030f7951 100644
+--- a/src/Compiler.php
++++ b/src/Compiler.php
+@@ -22,7 +22,6 @@ class Compiler
+     private $lastLine;
+     private $source;
+     private $indentation;
+-    private $env;
+     private $debugInfo = [];
+     private $sourceOffset;
+     private $sourceLine;
+@@ -30,9 +29,9 @@ class Compiler
+     private $didUseEcho = false;
+     private $didUseEchoStack = [];
+ 
+-    public function __construct(Environment $env)
+-    {
+-        $this->env = $env;
++    public function __construct(
++        private Environment $env,
++    ) {
+     }
+ 
+     public function getEnvironment(): Environment
+@@ -75,7 +74,7 @@ public function compile(Node $node, int $indentation = 0)
+             $node->compile($this);
+ 
+             if ($this->didUseEcho) {
+-                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[YieldReady].', $this->didUseEcho, \get_class($node));
++                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, $node::class);
+             }
+ 
+             return $this;
+@@ -100,7 +99,7 @@ public function subcompile(Node $node, bool $raw = true)
+             $node->compile($this);
+ 
+             if ($this->didUseEcho) {
+-                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[YieldReady].', $this->didUseEcho, \get_class($node));
++                trigger_deprecation('twig/twig', '3.9', 'Using "%s" is deprecated, use "yield" instead in "%s", then flag the class with #[\Twig\Attribute\YieldReady].', $this->didUseEcho, $node::class);
+             }
+ 
+             return $this;
+@@ -144,7 +143,13 @@ public function write(...$strings)
+      */
+     public function string(string $value)
+     {
+-        $this->source .= \sprintf('"%s"', addcslashes($value, "\0\t\"\$\\"));
++        // Single quotes are encoded as \x27 (not \') as a defense-in-depth measure:
++        // it guarantees that the compiled output never contains a literal "'" derived
++        // from user input, which prevents breaking out of a surrounding single-quoted
++        // PHP context if a caller mistakenly concatenates the result into one.
++        // \' is not a recognized escape sequence in PHP double-quoted strings (the
++        // backslash would be kept literally), so \x27 is used instead.
++        $this->source .= \sprintf('"%s"', str_replace("'", '\\x27', addcslashes($value, "\0\t\"\$\\")));
+ 
+         return $this;
+     }
+@@ -171,7 +176,7 @@ public function repr($value)
+         } elseif (\is_bool($value)) {
+             $this->raw($value ? 'true' : 'false');
+         } elseif (\is_array($value)) {
+-            $this->raw('array(');
++            $this->raw('[');
+             $first = true;
+             foreach ($value as $key => $v) {
+                 if (!$first) {
+@@ -182,7 +187,7 @@ public function repr($value)
+                 $this->raw(' => ');
+                 $this->repr($v);
+             }
+-            $this->raw(')');
++            $this->raw(']');
+         } else {
+             $this->string($value);
+         }
+@@ -244,7 +249,7 @@ public function outdent(int $step = 1)
+ 
+     public function getVarName(): string
+     {
+-        return \sprintf('__internal_compile_%d', $this->varNameSalt++);
++        return \sprintf('_v%d', $this->varNameSalt++);
+     }
+ 
+     private function checkForEcho(string $string): void
+diff --git a/src/DeprecatedCallableInfo.php b/src/DeprecatedCallableInfo.php
+new file mode 100644
+index 00000000000..2db9f3d28af
+--- /dev/null
++++ b/src/DeprecatedCallableInfo.php
+@@ -0,0 +1,67 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++final class DeprecatedCallableInfo
++{
++    private string $type;
++    private string $name;
++
++    public function __construct(
++        private string $package,
++        private string $version,
++        private ?string $altName = null,
++        private ?string $altPackage = null,
++        private ?string $altVersion = null,
++    ) {
++    }
++
++    public function setType(string $type): void
++    {
++        $this->type = $type;
++    }
++
++    public function setName(string $name): void
++    {
++        $this->name = $name;
++    }
++
++    public function triggerDeprecation(?string $file = null, ?int $line = null): void
++    {
++        $message = \sprintf('Twig %s "%s" is deprecated', ucfirst($this->type), $this->name);
++
++        if ($this->altName) {
++            $message .= \sprintf('; use "%s"', $this->altName);
++            if ($this->altPackage) {
++                $message .= \sprintf(' from the "%s" package', $this->altPackage);
++            }
++            if ($this->altVersion) {
++                $message .= \sprintf(' (available since version %s)', $this->altVersion);
++            }
++            $message .= ' instead';
++        }
++
++        if ($file) {
++            $message .= \sprintf(' in %s', $file);
++            if ($line) {
++                $message .= \sprintf(' at line %d', $line);
++            }
++        }
++
++        $message .= '.';
++
++        trigger_deprecation($this->package, $this->version, $message);
++    }
++}
+diff --git a/src/Environment.php b/src/Environment.php
+index 571b4614114..3678bcfbdb1 100644
+--- a/src/Environment.php
++++ b/src/Environment.php
+@@ -14,10 +14,12 @@
+ use Twig\Cache\CacheInterface;
+ use Twig\Cache\FilesystemCache;
+ use Twig\Cache\NullCache;
++use Twig\Cache\RemovableCacheInterface;
+ use Twig\Error\Error;
+ use Twig\Error\LoaderError;
+ use Twig\Error\RuntimeError;
+ use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\ExpressionParsers;
+ use Twig\Extension\CoreExtension;
+ use Twig\Extension\EscaperExtension;
+ use Twig\Extension\ExtensionInterface;
+@@ -26,8 +28,6 @@
+ use Twig\Loader\ArrayLoader;
+ use Twig\Loader\ChainLoader;
+ use Twig\Loader\LoaderInterface;
+-use Twig\Node\Expression\Binary\AbstractBinary;
+-use Twig\Node\Expression\Unary\AbstractUnary;
+ use Twig\Node\ModuleNode;
+ use Twig\Node\Node;
+ use Twig\NodeVisitor\NodeVisitorInterface;
+@@ -43,11 +43,11 @@
+  */
+ class Environment
+ {
+-    public const VERSION = '3.11.3';
+-    public const VERSION_ID = 301103;
+-    public const MAJOR_VERSION = 4;
+-    public const MINOR_VERSION = 11;
+-    public const RELEASE_VERSION = 3;
++    public const VERSION = '3.27.0';
++    public const VERSION_ID = 32700;
++    public const MAJOR_VERSION = 3;
++    public const MINOR_VERSION = 27;
++    public const RELEASE_VERSION = 0;
+     public const EXTRA_VERSION = '';
+ 
+     private $charset;
+@@ -71,6 +71,7 @@ class Environment
+     /** @var bool */
+     private $useYield;
+     private $defaultRuntimeLoader;
++    private array $hotCache = [];
+ 
+     /**
+      * Constructor.
+@@ -103,11 +104,11 @@ class Environment
+      *                   (default to -1 which means that all optimizations are enabled;
+      *                   set it to 0 to disable).
+      *
+-     *  * use_yield: Enable templates to exclusively use "yield" instead of "echo"
+-     *               (default to "false", but switch it to "true" when possible
+-     *               as this will be the only supported mode in Twig 4.0)
++     *  * use_yield: true: forces templates to exclusively use "yield" instead of "echo" (all extensions must be yield ready)
++     *               false (default): allows templates to use a mix of "yield" and "echo" calls to allow for a progressive migration
++     *               Switch to "true" when possible as this will be the only supported mode in Twig 4.0
+      */
+-    public function __construct(LoaderInterface $loader, $options = [])
++    public function __construct(LoaderInterface $loader, array $options = [])
+     {
+         $this->setLoader($loader);
+ 
+@@ -153,6 +154,8 @@ public function useYield(): bool
+ 
+     /**
+      * Enables debugging mode.
++     *
++     * @return void
+      */
+     public function enableDebug()
+     {
+@@ -162,6 +165,8 @@ public function enableDebug()
+ 
+     /**
+      * Disables debugging mode.
++     *
++     * @return void
+      */
+     public function disableDebug()
+     {
+@@ -181,6 +186,8 @@ public function isDebug()
+ 
+     /**
+      * Enables the auto_reload option.
++     *
++     * @return void
+      */
+     public function enableAutoReload()
+     {
+@@ -189,6 +196,8 @@ public function enableAutoReload()
+ 
+     /**
+      * Disables the auto_reload option.
++     *
++     * @return void
+      */
+     public function disableAutoReload()
+     {
+@@ -207,6 +216,8 @@ public function isAutoReload()
+ 
+     /**
+      * Enables the strict_variables option.
++     *
++     * @return void
+      */
+     public function enableStrictVariables()
+     {
+@@ -216,6 +227,8 @@ public function enableStrictVariables()
+ 
+     /**
+      * Disables the strict_variables option.
++     *
++     * @return void
+      */
+     public function disableStrictVariables()
+     {
+@@ -233,6 +246,18 @@ public function isStrictVariables()
+         return $this->strictVariables;
+     }
+ 
++    public function removeCache(string $name): void
++    {
++        $cls = $this->getTemplateClass($name);
++        $this->hotCache[$name] = $cls.'_'.bin2hex(random_bytes(16));
++
++        if ($this->cache instanceof RemovableCacheInterface) {
++            $this->cache->remove($name, $cls);
++        } else {
++            throw new \LogicException(\sprintf('The "%s" cache class does not support removing template cache as it does not implement the "RemovableCacheInterface" interface.', \get_class($this->cache)));
++        }
++    }
++
+     /**
+      * Gets the current cache implementation.
+      *
+@@ -253,6 +278,8 @@ public function getCache($original = true)
+      * @param CacheInterface|string|false $cache A Twig\Cache\CacheInterface implementation,
+      *                                           an absolute path to the compiled templates,
+      *                                           or false to disable cache
++     *
++     * @return void
+      */
+     public function setCache($cache)
+     {
+@@ -287,7 +314,7 @@ public function setCache($cache)
+      */
+     public function getTemplateClass(string $name, ?int $index = null): string
+     {
+-        $key = $this->getLoader()->getCacheKey($name).$this->optionsHash;
++        $key = ($this->hotCache[$name] ?? $this->getLoader()->getCacheKey($name)).$this->optionsHash;
+ 
+         return '__TwigTemplate_'.hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $key).(null === $index ? '' : '___'.$index);
+     }
+@@ -379,8 +406,10 @@ public function loadTemplate(string $cls, string $name, ?int $index = null): Tem
+             if (!class_exists($cls, false)) {
+                 $source = $this->getLoader()->getSourceContext($name);
+                 $content = $this->compileSource($source);
+-                $this->cache->write($key, $content);
+-                $this->cache->load($key);
++                if (!isset($this->hotCache[$name])) {
++                    $this->cache->write($key, $content);
++                    $this->cache->load($key);
++                }
+ 
+                 if (!class_exists($mainCls, false)) {
+                     /* Last line of defense if either $this->bcWriteCacheFile was used,
+@@ -487,6 +516,9 @@ public function resolveTemplate($names): TemplateWrapper
+         throw new LoaderError(\sprintf('Unable to find one of the following templates: "%s".', implode('", "', $names)));
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setLexer(Lexer $lexer)
+     {
+         $this->lexer = $lexer;
+@@ -504,6 +536,9 @@ public function tokenize(Source $source): TokenStream
+         return $this->lexer->tokenize($source);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setParser(Parser $parser)
+     {
+         $this->parser = $parser;
+@@ -523,6 +558,9 @@ public function parse(TokenStream $stream): ModuleNode
+         return $this->parser->parse($stream);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setCompiler(Compiler $compiler)
+     {
+         $this->compiler = $compiler;
+@@ -557,6 +595,9 @@ public function compileSource(Source $source): string
+         }
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setLoader(LoaderInterface $loader)
+     {
+         $this->loader = $loader;
+@@ -567,6 +608,9 @@ public function getLoader(): LoaderInterface
+         return $this->loader;
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setCharset(string $charset)
+     {
+         if ('UTF8' === $charset = strtoupper($charset ?: '')) {
+@@ -587,6 +631,9 @@ public function hasExtension(string $class): bool
+         return $this->extensionSet->hasExtension($class);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addRuntimeLoader(RuntimeLoaderInterface $loader)
+     {
+         $this->runtimeLoaders[] = $loader;
+@@ -634,6 +681,9 @@ public function getRuntime(string $class)
+         throw new RuntimeError(\sprintf('Unable to load the "%s" runtime.', $class));
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addExtension(ExtensionInterface $extension)
+     {
+         $this->extensionSet->addExtension($extension);
+@@ -642,6 +692,8 @@ public function addExtension(ExtensionInterface $extension)
+ 
+     /**
+      * @param ExtensionInterface[] $extensions An array of extensions
++     *
++     * @return void
+      */
+     public function setExtensions(array $extensions)
+     {
+@@ -657,6 +709,9 @@ public function getExtensions(): array
+         return $this->extensionSet->getExtensions();
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addTokenParser(TokenParserInterface $parser)
+     {
+         $this->extensionSet->addTokenParser($parser);
+@@ -680,11 +735,17 @@ public function getTokenParser(string $name): ?TokenParserInterface
+         return $this->extensionSet->getTokenParser($name);
+     }
+ 
++    /**
++     * @param callable(string): (TokenParserInterface|false) $callable
++     */
+     public function registerUndefinedTokenParserCallback(callable $callable): void
+     {
+         $this->extensionSet->registerUndefinedTokenParserCallback($callable);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addNodeVisitor(NodeVisitorInterface $visitor)
+     {
+         $this->extensionSet->addNodeVisitor($visitor);
+@@ -700,6 +761,9 @@ public function getNodeVisitors(): array
+         return $this->extensionSet->getNodeVisitors();
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addFilter(TwigFilter $filter)
+     {
+         $this->extensionSet->addFilter($filter);
+@@ -713,6 +777,9 @@ public function getFilter(string $name): ?TwigFilter
+         return $this->extensionSet->getFilter($name);
+     }
+ 
++    /**
++     * @param callable(string): (TwigFilter|false) $callable
++     */
+     public function registerUndefinedFilterCallback(callable $callable): void
+     {
+         $this->extensionSet->registerUndefinedFilterCallback($callable);
+@@ -734,6 +801,9 @@ public function getFilters(): array
+         return $this->extensionSet->getFilters();
+     }
+ 
++    /**
++     * @return void
++     */
+     public function addTest(TwigTest $test)
+     {
+         $this->extensionSet->addTest($test);
+@@ -757,6 +827,17 @@ public function getTest(string $name): ?TwigTest
+         return $this->extensionSet->getTest($name);
+     }
+ 
++    /**
++     * @param callable(string): (TwigTest|false) $callable
++     */
++    public function registerUndefinedTestCallback(callable $callable): void
++    {
++        $this->extensionSet->registerUndefinedTestCallback($callable);
++    }
++
++    /**
++     * @return void
++     */
+     public function addFunction(TwigFunction $function)
+     {
+         $this->extensionSet->addFunction($function);
+@@ -770,6 +851,9 @@ public function getFunction(string $name): ?TwigFunction
+         return $this->extensionSet->getFunction($name);
+     }
+ 
++    /**
++     * @param callable(string): (TwigFunction|false) $callable
++     */
+     public function registerUndefinedFunctionCallback(callable $callable): void
+     {
+         $this->extensionSet->registerUndefinedFunctionCallback($callable);
+@@ -798,6 +882,8 @@ public function getFunctions(): array
+      * but after, you can only update existing globals.
+      *
+      * @param mixed $value The global value
++     *
++     * @return void
+      */
+     public function addGlobal(string $name, $value)
+     {
+@@ -813,8 +899,6 @@ public function addGlobal(string $name, $value)
+     }
+ 
+     /**
+-     * @internal
+-     *
+      * @return array<string, mixed>
+      */
+     public function getGlobals(): array
+@@ -830,37 +914,28 @@ public function getGlobals(): array
+         return array_merge($this->extensionSet->getGlobals(), $this->globals);
+     }
+ 
+-    public function mergeGlobals(array $context): array
++    public function resetGlobals(): void
+     {
+-        // we don't use array_merge as the context being generally
+-        // bigger than globals, this code is faster.
+-        foreach ($this->getGlobals() as $key => $value) {
+-            if (!\array_key_exists($key, $context)) {
+-                $context[$key] = $value;
+-            }
+-        }
+-
+-        return $context;
++        $this->resolvedGlobals = null;
++        $this->extensionSet->resetGlobals();
+     }
+ 
+     /**
+-     * @internal
+-     *
+-     * @return array<string, array{precedence: int, class: class-string<AbstractUnary>}>
++     * @deprecated since Twig 3.14
+      */
+-    public function getUnaryOperators(): array
++    public function mergeGlobals(array $context): array
+     {
+-        return $this->extensionSet->getUnaryOperators();
++        trigger_deprecation('twig/twig', '3.14', 'The "%s" method is deprecated.', __METHOD__);
++
++        return $context + $this->getGlobals();
+     }
+ 
+     /**
+      * @internal
+-     *
+-     * @return array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}>
+      */
+-    public function getBinaryOperators(): array
++    public function getExpressionParsers(): ExpressionParsers
+     {
+-        return $this->extensionSet->getBinaryOperators();
++        return $this->extensionSet->getExpressionParsers();
+     }
+ 
+     private function updateOptionsHash(): void
+diff --git a/src/Error/Error.php b/src/Error/Error.php
+index 4efd9cafba9..97ed2df9913 100644
+--- a/src/Error/Error.php
++++ b/src/Error/Error.php
+@@ -29,20 +29,17 @@
+  * Whenever possible, you must set these information (original template name
+  * and line number) yourself by passing them to the constructor. If some or all
+  * these information are not available from where you throw the exception, then
+- * this class will guess them automatically (when the line number is set to -1
+- * and/or the name is set to null). As this is a costly operation, this
+- * can be disabled by passing false for both the name and the line number
+- * when creating a new instance of this class.
++ * this class will guess them automatically.
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ class Error extends \Exception
+ {
+     private $lineno;
+-    private $name;
+     private $rawMessage;
+-    private $sourcePath;
+-    private $sourceCode;
++    private ?Source $source;
++    private string $phpFile;
++    private int $phpLine;
+ 
+     /**
+      * Constructor.
+@@ -57,16 +54,10 @@ public function __construct(string $message, int $lineno = -1, ?Source $source =
+     {
+         parent::__construct('', 0, $previous);
+ 
+-        if (null === $source) {
+-            $name = null;
+-        } else {
+-            $name = $source->getName();
+-            $this->sourceCode = $source->getCode();
+-            $this->sourcePath = $source->getPath();
+-        }
+-
++        $this->phpFile = $this->getFile();
++        $this->phpLine = $this->getLine();
+         $this->lineno = $lineno;
+-        $this->name = $name;
++        $this->source = $source;
+         $this->rawMessage = $message;
+         $this->updateRepr();
+     }
+@@ -84,30 +75,26 @@ public function getTemplateLine(): int
+     public function setTemplateLine(int $lineno): void
+     {
+         $this->lineno = $lineno;
+-
+         $this->updateRepr();
+     }
+ 
+     public function getSourceContext(): ?Source
+     {
+-        return $this->name ? new Source($this->sourceCode, $this->name, $this->sourcePath) : null;
++        return $this->source;
+     }
+ 
+     public function setSourceContext(?Source $source = null): void
+     {
+-        if (null === $source) {
+-            $this->sourceCode = $this->name = $this->sourcePath = null;
+-        } else {
+-            $this->sourceCode = $source->getCode();
+-            $this->name = $source->getName();
+-            $this->sourcePath = $source->getPath();
+-        }
+-
++        $this->source = $source;
+         $this->updateRepr();
+     }
+ 
+     public function guess(): void
+     {
++        if ($this->lineno > -1) {
++            return;
++        }
++
+         $this->guessTemplateInfo();
+         $this->updateRepr();
+     }
+@@ -120,80 +107,49 @@ public function appendMessage($rawMessage): void
+ 
+     private function updateRepr(): void
+     {
+-        $this->message = $this->rawMessage;
+-
+-        if ($this->sourcePath && $this->lineno > 0) {
+-            $this->file = $this->sourcePath;
+-            $this->line = $this->lineno;
+-
+-            return;
++        if ($this->source && $this->source->getPath()) {
++            // we only update the file and the line together
++            $this->file = $this->source->getPath();
++            if ($this->lineno > 0) {
++                $this->line = $this->lineno;
++            } else {
++                $this->line = -1;
++            }
+         }
+ 
+-        $dot = false;
+-        if (str_ends_with($this->message, '.')) {
++        $this->message = $this->rawMessage;
++        $last = substr($this->message, -1);
++        if ($punctuation = '.' === $last || '?' === $last ? $last : '') {
+             $this->message = substr($this->message, 0, -1);
+-            $dot = true;
+         }
+-
+-        $questionMark = false;
+-        if (str_ends_with($this->message, '?')) {
+-            $this->message = substr($this->message, 0, -1);
+-            $questionMark = true;
++        if ($this->source && $this->source->getName()) {
++            $this->message .= \sprintf(' in "%s"', $this->source->getName());
+         }
+-
+-        if ($this->name) {
+-            if (\is_string($this->name) || (\is_object($this->name) && method_exists($this->name, '__toString'))) {
+-                $name = \sprintf('"%s"', $this->name);
+-            } else {
+-                $name = json_encode($this->name);
+-            }
+-            $this->message .= \sprintf(' in %s', $name);
+-        }
+-
+-        if ($this->lineno && $this->lineno >= 0) {
++        if ($this->lineno > 0) {
+             $this->message .= \sprintf(' at line %d', $this->lineno);
+         }
+-
+-        if ($dot) {
+-            $this->message .= '.';
+-        }
+-
+-        if ($questionMark) {
+-            $this->message .= '?';
++        if ($punctuation) {
++            $this->message .= $punctuation;
+         }
+     }
+ 
+     private function guessTemplateInfo(): void
+     {
+-        $template = null;
+-        $templateClass = null;
++        // $this->source is never null here (see guess() usage in Template)
+ 
++        $this->lineno = 0;
++        $template = null;
+         $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS | \DEBUG_BACKTRACE_PROVIDE_OBJECT);
+         foreach ($backtrace as $trace) {
+-            if (isset($trace['object']) && $trace['object'] instanceof Template) {
+-                $currentClass = \get_class($trace['object']);
+-                $isEmbedContainer = null === $templateClass ? false : str_starts_with($templateClass, $currentClass);
+-                if (null === $this->name || ($this->name == $trace['object']->getTemplateName() && !$isEmbedContainer)) {
+-                    $template = $trace['object'];
+-                    $templateClass = \get_class($trace['object']);
+-                }
+-            }
+-        }
+-
+-        // update template name
+-        if (null !== $template && null === $this->name) {
+-            $this->name = $template->getTemplateName();
+-        }
++            if (isset($trace['object']) && $trace['object'] instanceof Template && $this->source->getName() === $trace['object']->getTemplateName()) {
++                $template = $trace['object'];
+ 
+-        // update template path if any
+-        if (null !== $template && null === $this->sourcePath) {
+-            $src = $template->getSourceContext();
+-            $this->sourceCode = $src->getCode();
+-            $this->sourcePath = $src->getPath();
++                break;
++            }
+         }
+ 
+-        if (null === $template || $this->lineno > -1) {
+-            return;
++        if (null === $template) {
++            return; // Impossible to guess the info as the template was not found in the backtrace
+         }
+ 
+         $r = new \ReflectionObject($template);
+@@ -206,8 +162,7 @@ private function guessTemplateInfo(): void
+ 
+         while ($e = array_pop($exceptions)) {
+             $traces = $e->getTrace();
+-            array_unshift($traces, ['file' => $e->getFile(), 'line' => $e->getLine()]);
+-
++            array_unshift($traces, ['file' => $e instanceof self ? $e->phpFile : $e->getFile(), 'line' => $e instanceof self ? $e->phpLine : $e->getLine()]);
+             while ($trace = array_shift($traces)) {
+                 if (!isset($trace['file']) || !isset($trace['line']) || $file != $trace['file']) {
+                     continue;
+diff --git a/src/ExpressionParser.php b/src/ExpressionParser.php
+index 84484404864..3ba94d076fa 100644
+--- a/src/ExpressionParser.php
++++ b/src/ExpressionParser.php
+@@ -13,25 +13,18 @@
+ namespace Twig;
+ 
+ use Twig\Error\SyntaxError;
+-use Twig\Node\Expression\AbstractExpression;
++use Twig\ExpressionParser\Infix\DotExpressionParser;
++use Twig\ExpressionParser\Infix\FilterExpressionParser;
++use Twig\ExpressionParser\Infix\SquareBracketExpressionParser;
+ use Twig\Node\Expression\ArrayExpression;
+-use Twig\Node\Expression\ArrowFunctionExpression;
+-use Twig\Node\Expression\AssignNameExpression;
+-use Twig\Node\Expression\Binary\AbstractBinary;
+-use Twig\Node\Expression\Binary\ConcatBinary;
+-use Twig\Node\Expression\BlockReferenceExpression;
+-use Twig\Node\Expression\ConditionalExpression;
+ use Twig\Node\Expression\ConstantExpression;
+-use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\MethodCallExpression;
+-use Twig\Node\Expression\NameExpression;
+-use Twig\Node\Expression\ParentExpression;
+-use Twig\Node\Expression\TestExpression;
+-use Twig\Node\Expression\Unary\AbstractUnary;
+ use Twig\Node\Expression\Unary\NegUnary;
+-use Twig\Node\Expression\Unary\NotUnary;
+ use Twig\Node\Expression\Unary\PosUnary;
++use Twig\Node\Expression\Unary\SpreadUnary;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ 
+ /**
+  * Parses expressions.
+@@ -42,401 +35,108 @@
+  * @see https://en.wikipedia.org/wiki/Operator-precedence_parser
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @deprecated since Twig 3.21
+  */
+ class ExpressionParser
+ {
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public const OPERATOR_LEFT = 1;
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public const OPERATOR_RIGHT = 2;
+ 
+-    private $parser;
+-    private $env;
+-    /** @var array<string, array{precedence: int, class: class-string<AbstractUnary>}> */
+-    private $unaryOperators;
+-    /** @var array<string, array{precedence: int, class: class-string<AbstractBinary>, associativity: self::OPERATOR_*}> */
+-    private $binaryOperators;
+-
+-    public function __construct(Parser $parser, Environment $env)
+-    {
+-        $this->parser = $parser;
+-        $this->env = $env;
+-        $this->unaryOperators = $env->getUnaryOperators();
+-        $this->binaryOperators = $env->getBinaryOperators();
++    public function __construct(
++        private Parser $parser,
++        private Environment $env,
++    ) {
++        trigger_deprecation('twig/twig', '3.21', 'Class "%s" is deprecated, use "Parser::parseExpression()" instead.', __CLASS__);
+     }
+ 
+-    public function parseExpression($precedence = 0, $allowArrow = false)
++    public function parseExpression($precedence = 0)
+     {
+-        if ($allowArrow && $arrow = $this->parseArrow()) {
+-            return $arrow;
+-        }
+-
+-        $expr = $this->getPrimary();
+-        $token = $this->parser->getCurrentToken();
+-        while ($this->isBinary($token) && $this->binaryOperators[$token->getValue()]['precedence'] >= $precedence) {
+-            $op = $this->binaryOperators[$token->getValue()];
+-            $this->parser->getStream()->next();
+-
+-            if ('is not' === $token->getValue()) {
+-                $expr = $this->parseNotTestExpression($expr);
+-            } elseif ('is' === $token->getValue()) {
+-                $expr = $this->parseTestExpression($expr);
+-            } elseif (isset($op['callable'])) {
+-                $expr = $op['callable']($this->parser, $expr);
+-            } else {
+-                $expr1 = $this->parseExpression(self::OPERATOR_LEFT === $op['associativity'] ? $op['precedence'] + 1 : $op['precedence'], true);
+-                $class = $op['class'];
+-                $expr = new $class($expr, $expr1, $token->getLine());
+-            }
+-
+-            $token = $this->parser->getCurrentToken();
++        if (\func_num_args() > 1) {
++            trigger_deprecation('twig/twig', '3.15', 'Passing a second argument ($allowArrow) to "%s()" is deprecated.', __METHOD__);
+         }
+ 
+-        if (0 === $precedence) {
+-            return $this->parseConditionalExpression($expr);
+-        }
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated, use "Parser::parseExpression()" instead.', __METHOD__);
+ 
+-        return $expr;
++        return $this->parser->parseExpression((int) $precedence);
+     }
+ 
+     /**
+-     * @return ArrowFunctionExpression|null
++     * @deprecated since Twig 3.21
+      */
+-    private function parseArrow()
+-    {
+-        $stream = $this->parser->getStream();
+-
+-        // short array syntax (one argument, no parentheses)?
+-        if ($stream->look(1)->test(/* Token::ARROW_TYPE */ 12)) {
+-            $line = $stream->getCurrent()->getLine();
+-            $token = $stream->expect(/* Token::NAME_TYPE */ 5);
+-            $names = [new AssignNameExpression($token->getValue(), $token->getLine())];
+-            $stream->expect(/* Token::ARROW_TYPE */ 12);
+-
+-            return new ArrowFunctionExpression($this->parseExpression(0), new Node($names), $line);
+-        }
+-
+-        // first, determine if we are parsing an arrow function by finding => (long form)
+-        $i = 0;
+-        if (!$stream->look($i)->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-            return null;
+-        }
+-        ++$i;
+-        while (true) {
+-            // variable name
+-            ++$i;
+-            if (!$stream->look($i)->test(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
+-                break;
+-            }
+-            ++$i;
+-        }
+-        if (!$stream->look($i)->test(/* Token::PUNCTUATION_TYPE */ 9, ')')) {
+-            return null;
+-        }
+-        ++$i;
+-        if (!$stream->look($i)->test(/* Token::ARROW_TYPE */ 12)) {
+-            return null;
+-        }
+-
+-        // yes, let's parse it properly
+-        $token = $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '(');
+-        $line = $token->getLine();
+-
+-        $names = [];
+-        while (true) {
+-            $token = $stream->expect(/* Token::NAME_TYPE */ 5);
+-            $names[] = new AssignNameExpression($token->getValue(), $token->getLine());
+-
+-            if (!$stream->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
+-                break;
+-            }
+-        }
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ')');
+-        $stream->expect(/* Token::ARROW_TYPE */ 12);
+-
+-        return new ArrowFunctionExpression($this->parseExpression(0), new Node($names), $line);
+-    }
+-
+-    private function getPrimary(): AbstractExpression
+-    {
+-        $token = $this->parser->getCurrentToken();
+-
+-        if ($this->isUnary($token)) {
+-            $operator = $this->unaryOperators[$token->getValue()];
+-            $this->parser->getStream()->next();
+-            $expr = $this->parseExpression($operator['precedence']);
+-            $class = $operator['class'];
+-
+-            return $this->parsePostfixExpression(new $class($expr, $token->getLine()));
+-        } elseif ($token->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-            $this->parser->getStream()->next();
+-            $expr = $this->parseExpression();
+-            $this->parser->getStream()->expect(/* Token::PUNCTUATION_TYPE */ 9, ')', 'An opened parenthesis is not properly closed');
+-
+-            return $this->parsePostfixExpression($expr);
+-        }
+-
+-        return $this->parsePrimaryExpression();
+-    }
+-
+-    private function parseConditionalExpression($expr): AbstractExpression
+-    {
+-        while ($this->parser->getStream()->nextIf(/* Token::PUNCTUATION_TYPE */ 9, '?')) {
+-            if (!$this->parser->getStream()->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ':')) {
+-                $expr2 = $this->parseExpression();
+-                if ($this->parser->getStream()->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ':')) {
+-                    // Ternary operator (expr ? expr2 : expr3)
+-                    $expr3 = $this->parseExpression();
+-                } else {
+-                    // Ternary without else (expr ? expr2)
+-                    $expr3 = new ConstantExpression('', $this->parser->getCurrentToken()->getLine());
+-                }
+-            } else {
+-                // Ternary without then (expr ?: expr3)
+-                $expr2 = $expr;
+-                $expr3 = $this->parseExpression();
+-            }
+-
+-            $expr = new ConditionalExpression($expr, $expr2, $expr3, $this->parser->getCurrentToken()->getLine());
+-        }
+-
+-        return $expr;
+-    }
+-
+-    private function isUnary(Token $token): bool
+-    {
+-        return $token->test(/* Token::OPERATOR_TYPE */ 8) && isset($this->unaryOperators[$token->getValue()]);
+-    }
+-
+-    private function isBinary(Token $token): bool
+-    {
+-        return $token->test(/* Token::OPERATOR_TYPE */ 8) && isset($this->binaryOperators[$token->getValue()]);
+-    }
+-
+     public function parsePrimaryExpression()
+     {
+-        $token = $this->parser->getCurrentToken();
+-        switch ($token->getType()) {
+-            case /* Token::NAME_TYPE */ 5:
+-                $this->parser->getStream()->next();
+-                switch ($token->getValue()) {
+-                    case 'true':
+-                    case 'TRUE':
+-                        $node = new ConstantExpression(true, $token->getLine());
+-                        break;
+-
+-                    case 'false':
+-                    case 'FALSE':
+-                        $node = new ConstantExpression(false, $token->getLine());
+-                        break;
+-
+-                    case 'none':
+-                    case 'NONE':
+-                    case 'null':
+-                    case 'NULL':
+-                        $node = new ConstantExpression(null, $token->getLine());
+-                        break;
+-
+-                    default:
+-                        if ('(' === $this->parser->getCurrentToken()->getValue()) {
+-                            $node = $this->getFunctionNode($token->getValue(), $token->getLine());
+-                        } else {
+-                            $node = new NameExpression($token->getValue(), $token->getLine());
+-                        }
+-                }
+-                break;
+-
+-            case /* Token::NUMBER_TYPE */ 6:
+-                $this->parser->getStream()->next();
+-                $node = new ConstantExpression($token->getValue(), $token->getLine());
+-                break;
+-
+-            case /* Token::STRING_TYPE */ 7:
+-            case /* Token::INTERPOLATION_START_TYPE */ 10:
+-                $node = $this->parseStringExpression();
+-                break;
+-
+-            case /* Token::OPERATOR_TYPE */ 8:
+-                if (preg_match(Lexer::REGEX_NAME, $token->getValue(), $matches) && $matches[0] == $token->getValue()) {
+-                    // in this context, string operators are variable names
+-                    $this->parser->getStream()->next();
+-                    $node = new NameExpression($token->getValue(), $token->getLine());
+-                    break;
+-                }
+-
+-                if (isset($this->unaryOperators[$token->getValue()])) {
+-                    $class = $this->unaryOperators[$token->getValue()]['class'];
+-                    if (!\in_array($class, [NegUnary::class, PosUnary::class])) {
+-                        throw new SyntaxError(\sprintf('Unexpected unary operator "%s".', $token->getValue()), $token->getLine(), $this->parser->getStream()->getSourceContext());
+-                    }
+-
+-                    $this->parser->getStream()->next();
+-                    $expr = $this->parsePrimaryExpression();
+-
+-                    $node = new $class($expr, $token->getLine());
+-                    break;
+-                }
+-
+-                // no break
+-            default:
+-                if ($token->test(/* Token::PUNCTUATION_TYPE */ 9, '[')) {
+-                    $node = $this->parseSequenceExpression();
+-                } elseif ($token->test(/* Token::PUNCTUATION_TYPE */ 9, '{')) {
+-                    $node = $this->parseMappingExpression();
+-                } elseif ($token->test(/* Token::OPERATOR_TYPE */ 8, '=') && ('==' === $this->parser->getStream()->look(-1)->getValue() || '!=' === $this->parser->getStream()->look(-1)->getValue())) {
+-                    throw new SyntaxError(\sprintf('Unexpected operator of value "%s". Did you try to use "===" or "!==" for strict comparison? Use "is same as(value)" instead.', $token->getValue()), $token->getLine(), $this->parser->getStream()->getSourceContext());
+-                } else {
+-                    throw new SyntaxError(\sprintf('Unexpected token "%s" of value "%s".', Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $this->parser->getStream()->getSourceContext());
+-                }
+-        }
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-        return $this->parsePostfixExpression($node);
++        return $this->parseExpression();
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseStringExpression()
+     {
+-        $stream = $this->parser->getStream();
+-
+-        $nodes = [];
+-        // a string cannot be followed by another string in a single expression
+-        $nextCanBeString = true;
+-        while (true) {
+-            if ($nextCanBeString && $token = $stream->nextIf(/* Token::STRING_TYPE */ 7)) {
+-                $nodes[] = new ConstantExpression($token->getValue(), $token->getLine());
+-                $nextCanBeString = false;
+-            } elseif ($stream->nextIf(/* Token::INTERPOLATION_START_TYPE */ 10)) {
+-                $nodes[] = $this->parseExpression();
+-                $stream->expect(/* Token::INTERPOLATION_END_TYPE */ 11);
+-                $nextCanBeString = true;
+-            } else {
+-                break;
+-            }
+-        }
+-
+-        $expr = array_shift($nodes);
+-        foreach ($nodes as $node) {
+-            $expr = new ConcatBinary($expr, $node, $node->getTemplateLine());
+-        }
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-        return $expr;
++        return $this->parseExpression();
+     }
+ 
+     /**
+-     * @deprecated since 3.11, use parseSequenceExpression() instead
++     * @deprecated since Twig 3.11, use parseExpression() instead
+      */
+     public function parseArrayExpression()
+     {
+-        trigger_deprecation('twig/twig', '3.11', 'Calling "%s()" is deprecated, use "parseSequenceExpression()" instead.', __METHOD__);
++        trigger_deprecation('twig/twig', '3.11', 'Calling "%s()" is deprecated, use "parseExpression()" instead.', __METHOD__);
+ 
+-        return $this->parseSequenceExpression();
++        return $this->parseExpression();
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseSequenceExpression()
+     {
+-        $stream = $this->parser->getStream();
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '[', 'A sequence element was expected');
+-
+-        $node = new ArrayExpression([], $stream->getCurrent()->getLine());
+-        $first = true;
+-        while (!$stream->test(/* Token::PUNCTUATION_TYPE */ 9, ']')) {
+-            if (!$first) {
+-                $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ',', 'A sequence element must be followed by a comma');
+-
+-                // trailing ,?
+-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ']')) {
+-                    break;
+-                }
+-            }
+-            $first = false;
+-
+-            if ($stream->test(/* Token::SPREAD_TYPE */ 13)) {
+-                $stream->next();
+-                $expr = $this->parseExpression();
+-                $expr->setAttribute('spread', true);
+-                $node->addElement($expr);
+-            } else {
+-                $node->addElement($this->parseExpression());
+-            }
+-        }
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ']', 'An opened sequence is not properly closed');
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-        return $node;
++        return $this->parseExpression();
+     }
+ 
+     /**
+-     * @deprecated since 3.11, use parseMappingExpression() instead
++     * @deprecated since Twig 3.11, use parseExpression() instead
+      */
+     public function parseHashExpression()
+     {
+-        trigger_deprecation('twig/twig', '3.11', 'Calling "%s()" is deprecated, use "parseMappingExpression()" instead.', __METHOD__);
++        trigger_deprecation('twig/twig', '3.11', 'Calling "%s()" is deprecated, use "parseExpression()" instead.', __METHOD__);
+ 
+-        return $this->parseMappingExpression();
++        return $this->parseExpression();
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseMappingExpression()
+     {
+-        $stream = $this->parser->getStream();
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '{', 'A mapping element was expected');
+-
+-        $node = new ArrayExpression([], $stream->getCurrent()->getLine());
+-        $first = true;
+-        while (!$stream->test(/* Token::PUNCTUATION_TYPE */ 9, '}')) {
+-            if (!$first) {
+-                $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ',', 'A mapping value must be followed by a comma');
+-
+-                // trailing ,?
+-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, '}')) {
+-                    break;
+-                }
+-            }
+-            $first = false;
+-
+-            if ($stream->test(/* Token::SPREAD_TYPE */ 13)) {
+-                $stream->next();
+-                $value = $this->parseExpression();
+-                $value->setAttribute('spread', true);
+-                $node->addElement($value);
+-                continue;
+-            }
+-
+-            // a mapping key can be:
+-            //
+-            //  * a number -- 12
+-            //  * a string -- 'a'
+-            //  * a name, which is equivalent to a string -- a
+-            //  * an expression, which must be enclosed in parentheses -- (1 + 2)
+-            if ($token = $stream->nextIf(/* Token::NAME_TYPE */ 5)) {
+-                $key = new ConstantExpression($token->getValue(), $token->getLine());
+-
+-                // {a} is a shortcut for {a:a}
+-                if ($stream->test(Token::PUNCTUATION_TYPE, [',', '}'])) {
+-                    $value = new NameExpression($key->getAttribute('value'), $key->getTemplateLine());
+-                    $node->addElement($value, $key);
+-                    continue;
+-                }
+-            } elseif (($token = $stream->nextIf(/* Token::STRING_TYPE */ 7)) || $token = $stream->nextIf(/* Token::NUMBER_TYPE */ 6)) {
+-                $key = new ConstantExpression($token->getValue(), $token->getLine());
+-            } elseif ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-                $key = $this->parseExpression();
+-            } else {
+-                $current = $stream->getCurrent();
+-
+-                throw new SyntaxError(\sprintf('A mapping key must be a quoted string, a number, a name, or an expression enclosed in parentheses (unexpected token "%s" of value "%s".', Token::typeToEnglish($current->getType()), $current->getValue()), $current->getLine(), $stream->getSourceContext());
+-            }
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-            $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ':', 'A mapping key must be followed by a colon (:)');
+-            $value = $this->parseExpression();
+-
+-            $node->addElement($value, $key);
+-        }
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '}', 'An opened mapping is not properly closed');
+-
+-        return $node;
++        return $this->parseExpression();
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parsePostfixExpression($node)
+     {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
++
+         while (true) {
+             $token = $this->parser->getCurrentToken();
+-            if (/* Token::PUNCTUATION_TYPE */ 9 == $token->getType()) {
++            if ($token->test(Token::PUNCTUATION_TYPE)) {
+                 if ('.' == $token->getValue() || '[' == $token->getValue()) {
+                     $node = $this->parseSubscriptExpression($node);
+                 } elseif ('|' == $token->getValue()) {
+@@ -452,155 +152,49 @@ public function parsePostfixExpression($node)
+         return $node;
+     }
+ 
+-    public function getFunctionNode($name, $line)
+-    {
+-        switch ($name) {
+-            case 'parent':
+-                $this->parseArguments();
+-                if (!\count($this->parser->getBlockStack())) {
+-                    throw new SyntaxError('Calling "parent" outside a block is forbidden.', $line, $this->parser->getStream()->getSourceContext());
+-                }
+-
+-                if (!$this->parser->getParent() && !$this->parser->hasTraits()) {
+-                    throw new SyntaxError('Calling "parent" on a template that does not extend nor "use" another template is forbidden.', $line, $this->parser->getStream()->getSourceContext());
+-                }
+-
+-                return new ParentExpression($this->parser->peekBlockStack(), $line);
+-            case 'block':
+-                $args = $this->parseArguments();
+-                if (\count($args) < 1) {
+-                    throw new SyntaxError('The "block" function takes one argument (the block name).', $line, $this->parser->getStream()->getSourceContext());
+-                }
+-
+-                return new BlockReferenceExpression($args->getNode('0'), \count($args) > 1 ? $args->getNode('1') : null, $line);
+-            case 'attribute':
+-                $args = $this->parseArguments();
+-                if (\count($args) < 2) {
+-                    throw new SyntaxError('The "attribute" function takes at least two arguments (the variable and the attributes).', $line, $this->parser->getStream()->getSourceContext());
+-                }
+-
+-                return new GetAttrExpression($args->getNode('0'), $args->getNode('1'), \count($args) > 2 ? $args->getNode('2') : null, Template::ANY_CALL, $line);
+-            default:
+-                if (null !== $alias = $this->parser->getImportedSymbol('function', $name)) {
+-                    $arguments = new ArrayExpression([], $line);
+-                    foreach ($this->parseArguments() as $n) {
+-                        $arguments->addElement($n);
+-                    }
+-
+-                    $node = new MethodCallExpression($alias['node'], $alias['name'], $arguments, $line);
+-                    $node->setAttribute('safe', true);
+-
+-                    return $node;
+-                }
+-
+-                $args = $this->parseArguments(true);
+-                $class = $this->getFunctionNodeClass($name, $line);
+-
+-                return new $class($name, $args, $line);
+-        }
+-    }
+-
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseSubscriptExpression($node)
+     {
+-        $stream = $this->parser->getStream();
+-        $token = $stream->next();
+-        $lineno = $token->getLine();
+-        $arguments = new ArrayExpression([], $lineno);
+-        $type = Template::ANY_CALL;
+-        if ('.' == $token->getValue()) {
+-            $token = $stream->next();
+-            if (
+-                /* Token::NAME_TYPE */ 5 == $token->getType()
+-                ||
+-                /* Token::NUMBER_TYPE */ 6 == $token->getType()
+-                ||
+-                (/* Token::OPERATOR_TYPE */ 8 == $token->getType() && preg_match(Lexer::REGEX_NAME, $token->getValue()))
+-            ) {
+-                $arg = new ConstantExpression($token->getValue(), $lineno);
+-
+-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-                    $type = Template::METHOD_CALL;
+-                    foreach ($this->parseArguments() as $n) {
+-                        $arguments->addElement($n);
+-                    }
+-                }
+-            } else {
+-                throw new SyntaxError(\sprintf('Expected name or number, got value "%s" of type %s.', $token->getValue(), Token::typeToEnglish($token->getType())), $lineno, $stream->getSourceContext());
+-            }
+-
+-            if ($node instanceof NameExpression && null !== $this->parser->getImportedSymbol('template', $node->getAttribute('name'))) {
+-                $name = $arg->getAttribute('value');
+-
+-                $node = new MethodCallExpression($node, 'macro_'.$name, $arguments, $lineno);
+-                $node->setAttribute('safe', true);
+-
+-                return $node;
+-            }
+-        } else {
+-            $type = Template::ARRAY_CALL;
+-
+-            // slice?
+-            $slice = false;
+-            if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ':')) {
+-                $slice = true;
+-                $arg = new ConstantExpression(0, $token->getLine());
+-            } else {
+-                $arg = $this->parseExpression();
+-            }
+-
+-            if ($stream->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ':')) {
+-                $slice = true;
+-            }
+-
+-            if ($slice) {
+-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ']')) {
+-                    $length = new ConstantExpression(null, $token->getLine());
+-                } else {
+-                    $length = $this->parseExpression();
+-                }
+-
+-                $class = $this->getFilterNodeClass('slice', $token->getLine());
+-                $arguments = new Node([$arg, $length]);
+-                $filter = new $class($node, new ConstantExpression('slice', $token->getLine()), $arguments, $token->getLine());
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-                $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ']');
++        $parsers = new \ReflectionProperty($this->parser, 'parsers');
+ 
+-                return $filter;
+-            }
+-
+-            $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ']');
++        if ('.' === $this->parser->getStream()->next()->getValue()) {
++            return $parsers->getValue($this->parser)->getByClass(DotExpressionParser::class)->parse($this->parser, $node, $this->parser->getCurrentToken());
+         }
+ 
+-        return new GetAttrExpression($node, $arg, $arguments, $type, $lineno);
++        return $parsers->getValue($this->parser)->getByClass(SquareBracketExpressionParser::class)->parse($this->parser, $node, $this->parser->getCurrentToken());
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseFilterExpression($node)
+     {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
++
+         $this->parser->getStream()->next();
+ 
+         return $this->parseFilterExpressionRaw($node);
+     }
+ 
+-    public function parseFilterExpressionRaw($node, $tag = null)
++    /**
++     * @deprecated since Twig 3.21
++     */
++    public function parseFilterExpressionRaw($node)
+     {
+-        while (true) {
+-            $token = $this->parser->getStream()->expect(/* Token::NAME_TYPE */ 5);
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
+ 
+-            $name = new ConstantExpression($token->getValue(), $token->getLine());
+-            if (!$this->parser->getStream()->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-                $arguments = new Node();
+-            } else {
+-                $arguments = $this->parseArguments(true, false, true);
+-            }
+-
+-            $class = $this->getFilterNodeClass($name->getAttribute('value'), $token->getLine());
+-
+-            $node = new $class($node, $name, $arguments, $token->getLine(), $tag);
++        $parsers = new \ReflectionProperty($this->parser, 'parsers');
+ 
+-            if (!$this->parser->getStream()->test(/* Token::PUNCTUATION_TYPE */ 9, '|')) {
++        $op = $parsers->getValue($this->parser)->getByClass(FilterExpressionParser::class);
++        while (true) {
++            $node = $op->parse($this->parser, $node, $this->parser->getCurrentToken());
++            if (!$this->parser->getStream()->test(Token::OPERATOR_TYPE, '|')) {
+                 break;
+             }
+-
+             $this->parser->getStream()->next();
+         }
+ 
+@@ -610,51 +204,72 @@ public function parseFilterExpressionRaw($node, $tag = null)
+     /**
+      * Parses arguments.
+      *
+-     * @param bool $namedArguments Whether to allow named arguments or not
+-     * @param bool $definition     Whether we are parsing arguments for a function definition
+-     *
+      * @return Node
+      *
+      * @throws SyntaxError
++     *
++     * @deprecated since Twig 3.19 Use Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments() instead
+      */
+-    public function parseArguments($namedArguments = false, $definition = false, $allowArrow = false)
++    public function parseArguments()
+     {
++        trigger_deprecation('twig/twig', '3.19', \sprintf('The "%s()" method is deprecated, use "Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments()" instead.', __METHOD__));
++
++        $parsePrimaryExpression = new \ReflectionMethod($this->parser, 'parsePrimaryExpression');
++
++        $namedArguments = false;
++        $definition = false;
++        if (\func_num_args() > 1) {
++            $definition = func_get_arg(1);
++        }
++        if (\func_num_args() > 0) {
++            trigger_deprecation('twig/twig', '3.15', 'Passing arguments to "%s()" is deprecated.', __METHOD__);
++            $namedArguments = func_get_arg(0);
++        }
++
+         $args = [];
+         $stream = $this->parser->getStream();
+ 
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, '(', 'A list of arguments must begin with an opening parenthesis');
+-        while (!$stream->test(/* Token::PUNCTUATION_TYPE */ 9, ')')) {
+-            if (!empty($args)) {
+-                $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ',', 'Arguments must be separated by a comma');
++        $stream->expect(Token::OPERATOR_TYPE, '(', 'A list of arguments must begin with an opening parenthesis');
++        $hasSpread = false;
++        while (!$stream->test(Token::PUNCTUATION_TYPE, ')')) {
++            if ($args) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'Arguments must be separated by a comma');
+ 
+                 // if the comma above was a trailing comma, early exit the argument parse loop
+-                if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, ')')) {
++                if ($stream->test(Token::PUNCTUATION_TYPE, ')')) {
+                     break;
+                 }
+             }
+ 
+             if ($definition) {
+-                $token = $stream->expect(/* Token::NAME_TYPE */ 5, null, 'An argument must be a name');
+-                $value = new NameExpression($token->getValue(), $this->parser->getCurrentToken()->getLine());
++                $token = $stream->expect(Token::NAME_TYPE, null, 'An argument must be a name');
++                $value = new ContextVariable($token->getValue(), $this->parser->getCurrentToken()->getLine());
+             } else {
+-                $value = $this->parseExpression(0, $allowArrow);
++                if ($stream->nextIf(Token::SPREAD_TYPE)) {
++                    $hasSpread = true;
++                    $value = new SpreadUnary($this->parseExpression(), $stream->getCurrent()->getLine());
++                } elseif ($hasSpread) {
++                    throw new SyntaxError('Normal arguments must be placed before argument unpacking.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
++                } else {
++                    $value = $this->parseExpression();
++                }
+             }
+ 
+             $name = null;
+-            if ($namedArguments && $token = $stream->nextIf(/* Token::OPERATOR_TYPE */ 8, '=')) {
+-                if (!$value instanceof NameExpression) {
+-                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', \get_class($value)), $token->getLine(), $stream->getSourceContext());
++            if ($namedArguments && (($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) || (!$definition && $token = $stream->nextIf(Token::PUNCTUATION_TYPE, ':')))) {
++                if (!$value instanceof ContextVariable) {
++                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', $value::class), $token->getLine(), $stream->getSourceContext());
+                 }
+                 $name = $value->getAttribute('name');
+ 
+                 if ($definition) {
+-                    $value = $this->parsePrimaryExpression();
++                    $value = $parsePrimaryExpression->invoke($this->parser);
+ 
+                     if (!$this->checkConstantExpression($value)) {
+                         throw new SyntaxError('A default value for an argument must be a constant (a boolean, a string, a number, a sequence, or a mapping).', $token->getLine(), $stream->getSourceContext());
+                     }
+                 } else {
+-                    $value = $this->parseExpression(0, $allowArrow);
++                    $value = $this->parseExpression();
+                 }
+             }
+ 
+@@ -662,6 +277,7 @@ public function parseArguments($namedArguments = false, $definition = false, $al
+                 if (null === $name) {
+                     $name = $value->getAttribute('name');
+                     $value = new ConstantExpression(null, $this->parser->getCurrentToken()->getLine());
++                    $value->setAttribute('is_implicit', true);
+                 }
+                 $args[$name] = $value;
+             } else {
+@@ -672,167 +288,58 @@ public function parseArguments($namedArguments = false, $definition = false, $al
+                 }
+             }
+         }
+-        $stream->expect(/* Token::PUNCTUATION_TYPE */ 9, ')', 'A list of arguments must be closed by a parenthesis');
++        $stream->expect(Token::PUNCTUATION_TYPE, ')', 'A list of arguments must be closed by a parenthesis');
+ 
+-        return new Node($args);
++        return new Nodes($args);
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21, use "AbstractTokenParser::parseAssignmentExpression()" instead
++     */
+     public function parseAssignmentExpression()
+     {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated, use "AbstractTokenParser::parseAssignmentExpression()" instead.', __METHOD__);
++
+         $stream = $this->parser->getStream();
+         $targets = [];
+         while (true) {
+             $token = $this->parser->getCurrentToken();
+-            if ($stream->test(/* Token::OPERATOR_TYPE */ 8) && preg_match(Lexer::REGEX_NAME, $token->getValue())) {
++            if ($stream->test(Token::OPERATOR_TYPE) && preg_match(Lexer::REGEX_NAME, $token->getValue())) {
+                 // in this context, string operators are variable names
+                 $this->parser->getStream()->next();
+             } else {
+-                $stream->expect(/* Token::NAME_TYPE */ 5, null, 'Only variables can be assigned to');
++                $stream->expect(Token::NAME_TYPE, null, 'Only variables can be assigned to');
+             }
+-            $value = $token->getValue();
+-            if (\in_array(strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), ['true', 'false', 'none', 'null'])) {
+-                throw new SyntaxError(\sprintf('You cannot assign a value to "%s".', $value), $token->getLine(), $stream->getSourceContext());
+-            }
+-            $targets[] = new AssignNameExpression($value, $token->getLine());
++            $targets[] = new AssignContextVariable($token->getValue(), $token->getLine());
+ 
+-            if (!$stream->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
++            if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
+                 break;
+             }
+         }
+ 
+-        return new Node($targets);
++        return new Nodes($targets);
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function parseMultitargetExpression()
+     {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s()" method is deprecated.', __METHOD__);
++
+         $targets = [];
+         while (true) {
+             $targets[] = $this->parseExpression();
+-            if (!$this->parser->getStream()->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
++            if (!$this->parser->getStream()->nextIf(Token::PUNCTUATION_TYPE, ',')) {
+                 break;
+             }
+         }
+ 
+-        return new Node($targets);
+-    }
+-
+-    private function parseNotTestExpression(Node $node): NotUnary
+-    {
+-        return new NotUnary($this->parseTestExpression($node), $this->parser->getCurrentToken()->getLine());
+-    }
+-
+-    private function parseTestExpression(Node $node): TestExpression
+-    {
+-        $stream = $this->parser->getStream();
+-        [$name, $test] = $this->getTest($node->getTemplateLine());
+-
+-        $class = $this->getTestNodeClass($test);
+-        $arguments = null;
+-        if ($stream->test(/* Token::PUNCTUATION_TYPE */ 9, '(')) {
+-            $arguments = $this->parseArguments(true);
+-        } elseif ($test->hasOneMandatoryArgument()) {
+-            $arguments = new Node([0 => $this->parsePrimaryExpression()]);
+-        }
+-
+-        if ('defined' === $name && $node instanceof NameExpression && null !== $alias = $this->parser->getImportedSymbol('function', $node->getAttribute('name'))) {
+-            $node = new MethodCallExpression($alias['node'], $alias['name'], new ArrayExpression([], $node->getTemplateLine()), $node->getTemplateLine());
+-            $node->setAttribute('safe', true);
+-        }
+-
+-        return new $class($node, $name, $arguments, $this->parser->getCurrentToken()->getLine());
+-    }
+-
+-    private function getTest(int $line): array
+-    {
+-        $stream = $this->parser->getStream();
+-        $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
+-
+-        if ($test = $this->env->getTest($name)) {
+-            return [$name, $test];
+-        }
+-
+-        if ($stream->test(/* Token::NAME_TYPE */ 5)) {
+-            // try 2-words tests
+-            $name = $name.' '.$this->parser->getCurrentToken()->getValue();
+-
+-            if ($test = $this->env->getTest($name)) {
+-                $stream->next();
+-
+-                return [$name, $test];
+-            }
+-        }
+-
+-        $e = new SyntaxError(\sprintf('Unknown "%s" test.', $name), $line, $stream->getSourceContext());
+-        $e->addSuggestions($name, array_keys($this->env->getTests()));
+-
+-        throw $e;
+-    }
+-
+-    private function getTestNodeClass(TwigTest $test): string
+-    {
+-        if ($test->isDeprecated()) {
+-            $stream = $this->parser->getStream();
+-            $message = \sprintf('Twig Test "%s" is deprecated', $test->getName());
+-
+-            if ($test->getAlternative()) {
+-                $message .= \sprintf('. Use "%s" instead', $test->getAlternative());
+-            }
+-            $src = $stream->getSourceContext();
+-            $message .= \sprintf(' in %s at line %d.', $src->getPath() ?: $src->getName(), $stream->getCurrent()->getLine());
+-
+-            trigger_deprecation($test->getDeprecatingPackage(), $test->getDeprecatedVersion(), $message);
+-        }
+-
+-        return $test->getNodeClass();
+-    }
+-
+-    private function getFunctionNodeClass(string $name, int $line): string
+-    {
+-        if (!$function = $this->env->getFunction($name)) {
+-            $e = new SyntaxError(\sprintf('Unknown "%s" function.', $name), $line, $this->parser->getStream()->getSourceContext());
+-            $e->addSuggestions($name, array_keys($this->env->getFunctions()));
+-
+-            throw $e;
+-        }
+-
+-        if ($function->isDeprecated()) {
+-            $message = \sprintf('Twig Function "%s" is deprecated', $function->getName());
+-            if ($function->getAlternative()) {
+-                $message .= \sprintf('. Use "%s" instead', $function->getAlternative());
+-            }
+-            $src = $this->parser->getStream()->getSourceContext();
+-            $message .= \sprintf(' in %s at line %d.', $src->getPath() ?: $src->getName(), $line);
+-
+-            trigger_deprecation($function->getDeprecatingPackage(), $function->getDeprecatedVersion(), $message);
+-        }
+-
+-        return $function->getNodeClass();
+-    }
+-
+-    private function getFilterNodeClass(string $name, int $line): string
+-    {
+-        if (!$filter = $this->env->getFilter($name)) {
+-            $e = new SyntaxError(\sprintf('Unknown "%s" filter.', $name), $line, $this->parser->getStream()->getSourceContext());
+-            $e->addSuggestions($name, array_keys($this->env->getFilters()));
+-
+-            throw $e;
+-        }
+-
+-        if ($filter->isDeprecated()) {
+-            $message = \sprintf('Twig Filter "%s" is deprecated', $filter->getName());
+-            if ($filter->getAlternative()) {
+-                $message .= \sprintf('. Use "%s" instead', $filter->getAlternative());
+-            }
+-            $src = $this->parser->getStream()->getSourceContext();
+-            $message .= \sprintf(' in %s at line %d.', $src->getPath() ?: $src->getName(), $line);
+-
+-            trigger_deprecation($filter->getDeprecatingPackage(), $filter->getDeprecatedVersion(), $message);
+-        }
+-
+-        return $filter->getNodeClass();
++        return new Nodes($targets);
+     }
+ 
+     // checks that the node only contains "constant" elements
++    // to be removed in 4.0
+     private function checkConstantExpression(Node $node): bool
+     {
+         if (!($node instanceof ConstantExpression || $node instanceof ArrayExpression
+@@ -849,4 +356,14 @@ private function checkConstantExpression(Node $node): bool
+ 
+         return true;
+     }
++
++    /**
++     * @deprecated since Twig 3.19 Use Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments() instead
++     */
++    public function parseOnlyArguments()
++    {
++        trigger_deprecation('twig/twig', '3.19', \sprintf('The "%s()" method is deprecated, use "Twig\ExpressionParser\Infix\ArgumentsTrait::parseNamedArguments()" instead.', __METHOD__));
++
++        return $this->parseArguments();
++    }
+ }
+diff --git a/src/ExpressionParser/AbstractExpressionParser.php b/src/ExpressionParser/AbstractExpressionParser.php
+new file mode 100644
+index 00000000000..b8b963a1fce
+--- /dev/null
++++ b/src/ExpressionParser/AbstractExpressionParser.php
+@@ -0,0 +1,35 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++abstract class AbstractExpressionParser implements ExpressionParserInterface
++{
++    public function __toString(): string
++    {
++        return \sprintf('%s(%s)', ExpressionParserType::getType($this)->value, $this->getName());
++    }
++
++    public function getPrecedenceChange(): ?PrecedenceChange
++    {
++        return null;
++    }
++
++    public function getAliases(): array
++    {
++        return [];
++    }
++
++    public function getOperatorTokens(): array
++    {
++        return [$this->getName(), ...$this->getAliases()];
++    }
++}
+diff --git a/src/ExpressionParser/ExpressionParserDescriptionInterface.php b/src/ExpressionParser/ExpressionParserDescriptionInterface.php
+new file mode 100644
+index 00000000000..686f8a59f1e
+--- /dev/null
++++ b/src/ExpressionParser/ExpressionParserDescriptionInterface.php
+@@ -0,0 +1,17 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++interface ExpressionParserDescriptionInterface
++{
++    public function getDescription(): string;
++}
+diff --git a/src/ExpressionParser/ExpressionParserInterface.php b/src/ExpressionParser/ExpressionParserInterface.php
+new file mode 100644
+index 00000000000..2013a114e23
+--- /dev/null
++++ b/src/ExpressionParser/ExpressionParserInterface.php
+@@ -0,0 +1,36 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++/**
++ * @method list<string> getOperatorTokens() Returns the operator token strings that this expression parser handles.
++ *                                          These are the strings that should be recognized as operator tokens by the Lexer,
++ *                                          and used to look up the parser in the registry.
++ *                                          For most parsers, this returns the name and aliases. Parsers that don't handle
++ *                                          operator tokens (like LiteralExpressionParser) should return an empty array.
++ *                                          This method will be added to the interface in Twig 4.0.
++ */
++interface ExpressionParserInterface
++{
++    public function __toString(): string;
++
++    public function getName(): string;
++
++    public function getPrecedence(): int;
++
++    public function getPrecedenceChange(): ?PrecedenceChange;
++
++    /**
++     * @return array<string>
++     */
++    public function getAliases(): array;
++}
+diff --git a/src/ExpressionParser/ExpressionParserType.php b/src/ExpressionParser/ExpressionParserType.php
+new file mode 100644
+index 00000000000..8c21a8d7633
+--- /dev/null
++++ b/src/ExpressionParser/ExpressionParserType.php
+@@ -0,0 +1,33 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++/**
++ * @internal
++ */
++enum ExpressionParserType: string
++{
++    case Prefix = 'prefix';
++    case Infix = 'infix';
++
++    public static function getType(object $object): ExpressionParserType
++    {
++        if ($object instanceof PrefixExpressionParserInterface) {
++            return self::Prefix;
++        }
++        if ($object instanceof InfixExpressionParserInterface) {
++            return self::Infix;
++        }
++
++        throw new \InvalidArgumentException(\sprintf('Unsupported expression parser type: %s', $object::class));
++    }
++}
+diff --git a/src/ExpressionParser/ExpressionParsers.php b/src/ExpressionParser/ExpressionParsers.php
+new file mode 100644
+index 00000000000..7efaffc1435
+--- /dev/null
++++ b/src/ExpressionParser/ExpressionParsers.php
+@@ -0,0 +1,155 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++/**
++ * @template-implements \IteratorAggregate<ExpressionParserInterface>
++ *
++ * @internal
++ */
++final class ExpressionParsers implements \IteratorAggregate
++{
++    /**
++     * @var array<class-string<ExpressionParserInterface>, array<string, ExpressionParserInterface>>
++     */
++    private array $parsersByName = [];
++
++    /**
++     * @var array<class-string<ExpressionParserInterface>, ExpressionParserInterface>
++     */
++    private array $parsersByClass = [];
++
++    /**
++     * @var \WeakMap<ExpressionParserInterface, array<ExpressionParserInterface>>|null
++     */
++    private ?\WeakMap $precedenceChanges = null;
++
++    /**
++     * @param array<ExpressionParserInterface> $parsers
++     */
++    public function __construct(array $parsers = [])
++    {
++        $this->add($parsers);
++    }
++
++    /**
++     * @param array<ExpressionParserInterface> $parsers
++     *
++     * @return $this
++     */
++    public function add(array $parsers): static
++    {
++        foreach ($parsers as $parser) {
++            if ($parser->getPrecedence() > 512 || $parser->getPrecedence() < 0) {
++                trigger_deprecation('twig/twig', '3.21', 'Precedence for "%s" must be between 0 and 512, got %d.', $parser->getName(), $parser->getPrecedence());
++                // throw new \InvalidArgumentException(\sprintf('Precedence for "%s" must be between 0 and 512, got %d.', $parser->getName(), $parser->getPrecedence()));
++            }
++            $interface = $parser instanceof PrefixExpressionParserInterface ? PrefixExpressionParserInterface::class : InfixExpressionParserInterface::class;
++            $this->parsersByClass[$parser::class] = $parser;
++            foreach (self::getOperatorTokensFor($parser) as $token) {
++                $this->parsersByName[$interface][$token] = $parser;
++            }
++        }
++
++        return $this;
++    }
++
++    /**
++     * @template T of ExpressionParserInterface
++     *
++     * @param class-string<T> $class
++     *
++     * @return T|null
++     */
++    public function getByClass(string $class): ?ExpressionParserInterface
++    {
++        return $this->parsersByClass[$class] ?? null;
++    }
++
++    /**
++     * @template T of ExpressionParserInterface
++     *
++     * @param class-string<T> $interface
++     *
++     * @return T|null
++     */
++    public function getByName(string $interface, string $name): ?ExpressionParserInterface
++    {
++        return $this->parsersByName[$interface][$name] ?? null;
++    }
++
++    public function getIterator(): \Traversable
++    {
++        $seen = [];
++        foreach ($this->parsersByName as $parsers) {
++            foreach ($parsers as $parser) {
++                $id = spl_object_id($parser);
++                if (!isset($seen[$id])) {
++                    $seen[$id] = true;
++                    yield $parser;
++                }
++            }
++        }
++        foreach ($this->parsersByClass as $parser) {
++            $id = spl_object_id($parser);
++            if (!isset($seen[$id])) {
++                $seen[$id] = true;
++                yield $parser;
++            }
++        }
++    }
++
++    /**
++     * @internal
++     *
++     * @return \WeakMap<ExpressionParserInterface, array<ExpressionParserInterface>>
++     */
++    public function getPrecedenceChanges(): \WeakMap
++    {
++        if (null === $this->precedenceChanges) {
++            $this->precedenceChanges = new \WeakMap();
++            foreach ($this as $ep) {
++                if (!$ep->getPrecedenceChange()) {
++                    continue;
++                }
++                $min = min($ep->getPrecedenceChange()->getNewPrecedence(), $ep->getPrecedence());
++                $max = max($ep->getPrecedenceChange()->getNewPrecedence(), $ep->getPrecedence());
++                foreach ($this as $e) {
++                    if ($e->getPrecedence() > $min && $e->getPrecedence() < $max) {
++                        if (!isset($this->precedenceChanges[$e])) {
++                            $this->precedenceChanges[$e] = [];
++                        }
++                        $this->precedenceChanges[$e][] = $ep;
++                    }
++                }
++            }
++        }
++
++        return $this->precedenceChanges;
++    }
++
++    /**
++     * @internal
++     *
++     * @return array<string>
++     */
++    public static function getOperatorTokensFor(ExpressionParserInterface $parser): array
++    {
++        if (method_exists($parser, 'getOperatorTokens')) {
++            return $parser->getOperatorTokens();
++        }
++
++        trigger_deprecation('twig/twig', '3.24', 'Not implementing the "getOperatorTokens()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', $parser::class, ExpressionParserInterface::class);
++
++        return [$parser->getName(), ...$parser->getAliases()];
++    }
++}
+diff --git a/src/ExpressionParser/Infix/ArgumentsTrait.php b/src/ExpressionParser/Infix/ArgumentsTrait.php
+new file mode 100644
+index 00000000000..96bde555d3a
+--- /dev/null
++++ b/src/ExpressionParser/Infix/ArgumentsTrait.php
+@@ -0,0 +1,83 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\Binary\SetBinary;
++use Twig\Node\Expression\Unary\SpreadUnary;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Node\Expression\Variable\LocalVariable;
++use Twig\Node\Nodes;
++use Twig\Parser;
++use Twig\Token;
++
++trait ArgumentsTrait
++{
++    private function parseCallableArguments(Parser $parser, int $line, bool $parseOpenParenthesis = true): ArrayExpression
++    {
++        $arguments = new ArrayExpression([], $line);
++        foreach ($this->parseNamedArguments($parser, $parseOpenParenthesis) as $k => $n) {
++            $arguments->addElement($n, new LocalVariable($k, $line));
++        }
++
++        return $arguments;
++    }
++
++    private function parseNamedArguments(Parser $parser, bool $parseOpenParenthesis = true): Nodes
++    {
++        $args = [];
++        $stream = $parser->getStream();
++        if ($parseOpenParenthesis) {
++            $stream->expect(Token::OPERATOR_TYPE, '(', 'A list of arguments must begin with an opening parenthesis');
++        }
++        $hasSpread = false;
++        while (!$stream->test(Token::PUNCTUATION_TYPE, ')')) {
++            if ($args) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'Arguments must be separated by a comma');
++
++                // if the comma above was a trailing comma, early exit the argument parse loop
++                if ($stream->test(Token::PUNCTUATION_TYPE, ')')) {
++                    break;
++                }
++            }
++
++            $value = $parser->parseExpression();
++            if ($value instanceof SpreadUnary) {
++                $hasSpread = true;
++            } elseif ($hasSpread) {
++                throw new SyntaxError('Normal arguments must be placed before argument unpacking.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
++            }
++
++            $name = null;
++            if ($value instanceof SetBinary) {
++                $name = $value->getNode('left')->getAttribute('name');
++                $value = $value->getNode('right');
++            } elseif (($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) || ($token = $stream->nextIf(Token::PUNCTUATION_TYPE, ':'))) {
++                if (!$value instanceof ContextVariable) {
++                    throw new SyntaxError(\sprintf('A parameter name must be a string, "%s" given.', $value::class), $token->getLine(), $stream->getSourceContext());
++                }
++                $name = $value->getAttribute('name');
++                $value = $parser->parseExpression();
++            }
++
++            if (null === $name) {
++                $args[] = $value;
++            } else {
++                $args[$name] = $value;
++            }
++        }
++        $stream->expect(Token::PUNCTUATION_TYPE, ')', 'A list of arguments must be closed by a parenthesis');
++
++        return new Nodes($args);
++    }
++}
+diff --git a/src/ExpressionParser/Infix/ArrowExpressionParser.php b/src/ExpressionParser/Infix/ArrowExpressionParser.php
+new file mode 100644
+index 00000000000..c8630da41e7
+--- /dev/null
++++ b/src/ExpressionParser/Infix/ArrowExpressionParser.php
+@@ -0,0 +1,53 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrowFunctionExpression;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class ArrowExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        // As the expression of the arrow function is independent from the current precedence, we want a precedence of 0
++        return new ArrowFunctionExpression($parser->parseExpression(), $expr, $token->getLine());
++    }
++
++    public function getName(): string
++    {
++        return '=>';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Arrow function (x => expr)';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 250;
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/AssignmentExpressionParser.php b/src/ExpressionParser/Infix/AssignmentExpressionParser.php
+new file mode 100644
+index 00000000000..1f042845c0e
+--- /dev/null
++++ b/src/ExpressionParser/Infix/AssignmentExpressionParser.php
+@@ -0,0 +1,66 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\Binary\AbstractBinary;
++use Twig\Node\Expression\Binary\ObjectDestructuringSetBinary;
++use Twig\Node\Expression\Binary\SequenceDestructuringSetBinary;
++use Twig\Node\Expression\Binary\SetBinary;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++class AssignmentExpressionParser extends BinaryOperatorExpressionParser
++{
++    public function __construct(
++        string $name,
++    ) {
++        parent::__construct(SetBinary::class, $name, 0, InfixAssociativity::Right);
++    }
++
++    /**
++     * @return AbstractBinary
++     */
++    public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression
++    {
++        if (!$left instanceof ContextVariable && !$left instanceof ArrayExpression) {
++            throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned.', $left::class), $token->getLine(), $parser->getStream()->getSourceContext());
++        }
++        $right = $parser->parseExpression(InfixAssociativity::Left === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
++        $right = match ($this->getName()) {
++            '=' => $right,
++            default => throw new \LogicException(\sprintf('Unknown operator: %s.', $this->getName())),
++        };
++
++        if ($left instanceof ArrayExpression) {
++            if ($left->isSequence()) {
++                return new SequenceDestructuringSetBinary($left, $right, $token->getLine());
++            }
++
++            return new ObjectDestructuringSetBinary($left, $right, $token->getLine());
++        }
++
++        return new SetBinary($left, $right, $token->getLine());
++    }
++
++    public function getDescription(): string
++    {
++        return 'Assignment operator';
++    }
++}
+diff --git a/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php b/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php
+new file mode 100644
+index 00000000000..4c66da73bc1
+--- /dev/null
++++ b/src/ExpressionParser/Infix/BinaryOperatorExpressionParser.php
+@@ -0,0 +1,80 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\Binary\AbstractBinary;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++class BinaryOperatorExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function __construct(
++        /** @var class-string<AbstractBinary> */
++        private string $nodeClass,
++        private string $name,
++        private int $precedence,
++        private InfixAssociativity $associativity = InfixAssociativity::Left,
++        private ?PrecedenceChange $precedenceChange = null,
++        private ?string $description = null,
++        private array $aliases = [],
++    ) {
++    }
++
++    /**
++     * @return AbstractBinary
++     */
++    public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression
++    {
++        $right = $parser->parseExpression(InfixAssociativity::Left === $this->getAssociativity() ? $this->getPrecedence() + 1 : $this->getPrecedence());
++
++        return new ($this->nodeClass)($left, $right, $token->getLine());
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return $this->associativity;
++    }
++
++    public function getName(): string
++    {
++        return $this->name;
++    }
++
++    public function getDescription(): string
++    {
++        return $this->description ?? '';
++    }
++
++    public function getPrecedence(): int
++    {
++        return $this->precedence;
++    }
++
++    public function getPrecedenceChange(): ?PrecedenceChange
++    {
++        return $this->precedenceChange;
++    }
++
++    public function getAliases(): array
++    {
++        return $this->aliases;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php b/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php
+new file mode 100644
+index 00000000000..9707c0a04bd
+--- /dev/null
++++ b/src/ExpressionParser/Infix/ConditionalTernaryExpressionParser.php
+@@ -0,0 +1,62 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\Ternary\ConditionalTernary;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class ConditionalTernaryExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression
++    {
++        $then = $parser->parseExpression($this->getPrecedence());
++        if ($parser->getStream()->nextIf(Token::PUNCTUATION_TYPE, ':')) {
++            // Ternary operator (expr ? expr2 : expr3)
++            $else = $parser->parseExpression($this->getPrecedence());
++        } else {
++            // Ternary without else (expr ? expr2)
++            $else = new ConstantExpression('', $token->getLine());
++        }
++
++        return new ConditionalTernary($left, $then, $else, $token->getLine());
++    }
++
++    public function getName(): string
++    {
++        return '?';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Conditional operator (a ? b : c)';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 0;
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/DotExpressionParser.php b/src/ExpressionParser/Infix/DotExpressionParser.php
+new file mode 100644
+index 00000000000..e1afa5f59eb
+--- /dev/null
++++ b/src/ExpressionParser/Infix/DotExpressionParser.php
+@@ -0,0 +1,108 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Lexer;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\GetAttrExpression;
++use Twig\Node\Expression\MacroReferenceExpression;
++use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\Variable\TemplateVariable;
++use Twig\Parser;
++use Twig\Template;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class DotExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    use ArgumentsTrait;
++
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        $nullSafe = '?.' === $token->getValue();
++        $stream = $parser->getStream();
++        $token = $stream->getCurrent();
++        $lineno = $token->getLine();
++        $arguments = new ArrayExpression([], $lineno);
++        $type = Template::ANY_CALL;
++
++        if ($stream->nextIf(Token::OPERATOR_TYPE, '(')) {
++            $attribute = $parser->parseExpression();
++            $stream->expect(Token::PUNCTUATION_TYPE, ')');
++        } else {
++            $token = $stream->next();
++            if (
++                $token->test(Token::NAME_TYPE)
++                || $token->test(Token::NUMBER_TYPE)
++                || ($token->test(Token::OPERATOR_TYPE) && preg_match(Lexer::REGEX_NAME, $token->getValue()))
++            ) {
++                $attribute = new ConstantExpression($token->getValue(), $token->getLine());
++            } else {
++                throw new SyntaxError(\sprintf('Expected name or number, got value "%s" of type "%s".', $token->getValue(), $token->toEnglish()), $token->getLine(), $stream->getSourceContext());
++            }
++        }
++
++        if ($stream->test(Token::OPERATOR_TYPE, '(')) {
++            $type = Template::METHOD_CALL;
++            $arguments = $this->parseCallableArguments($parser, $token->getLine());
++        }
++
++        if (
++            $expr instanceof NameExpression
++            && $attribute instanceof ConstantExpression
++            && \is_string($name = $attribute->getAttribute('value'))
++            && preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#D', $name)
++            && (
++                null !== $parser->getImportedSymbol('template', $expr->getAttribute('name'))
++                || '_self' === $expr->getAttribute('name')
++            )
++        ) {
++            return new MacroReferenceExpression(new TemplateVariable($expr->getAttribute('name'), $expr->getTemplateLine()), 'macro_'.$name, $arguments, $expr->getTemplateLine());
++        }
++
++        return new GetAttrExpression($expr, $attribute, $arguments, $type, $lineno, $nullSafe);
++    }
++
++    public function getName(): string
++    {
++        return '.';
++    }
++
++    public function getAliases(): array
++    {
++        return ['?.'];
++    }
++
++    public function getDescription(): string
++    {
++        return 'Get an attribute on a variable';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 512;
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/FilterExpressionParser.php b/src/ExpressionParser/Infix/FilterExpressionParser.php
+new file mode 100644
+index 00000000000..0bbe6b40969
+--- /dev/null
++++ b/src/ExpressionParser/Infix/FilterExpressionParser.php
+@@ -0,0 +1,85 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Attribute\FirstClassTwigCallableReady;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class FilterExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    use ArgumentsTrait;
++
++    private $readyNodes = [];
++
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        $stream = $parser->getStream();
++        $token = $stream->expect(Token::NAME_TYPE);
++        $line = $token->getLine();
++
++        if (!$stream->test(Token::OPERATOR_TYPE, '(')) {
++            $arguments = new EmptyNode();
++        } else {
++            $arguments = $this->parseNamedArguments($parser);
++        }
++
++        $filter = $parser->getFilter($token->getValue(), $line);
++
++        $ready = true;
++        if (!isset($this->readyNodes[$class = $filter->getNodeClass()])) {
++            $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
++        }
++
++        if (!$ready = $this->readyNodes[$class]) {
++            trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigFilter" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
++        }
++
++        return new $class($expr, $ready ? $filter : new ConstantExpression($filter->getName(), $line), $arguments, $line);
++    }
++
++    public function getName(): string
++    {
++        return '|';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Twig filter call';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 512;
++    }
++
++    public function getPrecedenceChange(): ?PrecedenceChange
++    {
++        return new PrecedenceChange('twig/twig', '3.21', 300);
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/FunctionExpressionParser.php b/src/ExpressionParser/Infix/FunctionExpressionParser.php
+new file mode 100644
+index 00000000000..b0ad8af1c4a
+--- /dev/null
++++ b/src/ExpressionParser/Infix/FunctionExpressionParser.php
+@@ -0,0 +1,96 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Attribute\FirstClassTwigCallableReady;
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\MacroReferenceExpression;
++use Twig\Node\Expression\NameExpression;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class FunctionExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    use ArgumentsTrait;
++
++    private $readyNodes = [];
++
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        $line = $token->getLine();
++        if (!$expr instanceof NameExpression) {
++            throw new SyntaxError('Function name must be an identifier.', $line, $parser->getStream()->getSourceContext());
++        }
++
++        $name = $expr->getAttribute('name');
++
++        if (null !== $alias = $parser->getImportedSymbol('function', $name)) {
++            return new MacroReferenceExpression($alias['node']->getNode('var'), $alias['name'], $this->parseCallableArguments($parser, $line, false), $line);
++        }
++
++        $args = $this->parseNamedArguments($parser, false);
++
++        $function = $parser->getFunction($name, $line);
++
++        if ($function->getParserCallable()) {
++            $fakeNode = new EmptyNode($line);
++            $fakeNode->setSourceContext($parser->getStream()->getSourceContext());
++
++            $node = ($function->getParserCallable())($parser, $fakeNode, $args, $line);
++            // remember the original function name so the sandbox can enforce
++            // the `allowedFunctions` allow-list even though the parser callable
++            // returned a specialized node (e.g. `parent`, `block`, `attribute`).
++            $node->setAttribute('sandboxed_function_name', $name);
++
++            return $node;
++        }
++
++        if (!isset($this->readyNodes[$class = $function->getNodeClass()])) {
++            $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
++        }
++
++        if (!$ready = $this->readyNodes[$class]) {
++            trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigFunction" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
++        }
++
++        return new $class($ready ? $function : $function->getName(), $args, $line);
++    }
++
++    public function getName(): string
++    {
++        return '(';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Twig function call';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 512;
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/IsExpressionParser.php b/src/ExpressionParser/Infix/IsExpressionParser.php
+new file mode 100644
+index 00000000000..88d54f70a7b
+--- /dev/null
++++ b/src/ExpressionParser/Infix/IsExpressionParser.php
+@@ -0,0 +1,84 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Attribute\FirstClassTwigCallableReady;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\MacroReferenceExpression;
++use Twig\Node\Expression\NameExpression;
++use Twig\Node\Nodes;
++use Twig\Parser;
++use Twig\Token;
++use Twig\TwigTest;
++
++/**
++ * @internal
++ */
++class IsExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    use ArgumentsTrait;
++
++    private $readyNodes = [];
++
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        $stream = $parser->getStream();
++        $test = $parser->getTest($token->getLine());
++
++        $arguments = null;
++        if ($stream->test(Token::OPERATOR_TYPE, '(')) {
++            $arguments = $this->parseNamedArguments($parser);
++        } elseif ($test->hasOneMandatoryArgument()) {
++            $arguments = new Nodes([0 => $parser->parseExpression($this->getPrecedence())]);
++        }
++
++        if ('defined' === $test->getName() && $expr instanceof NameExpression && null !== $alias = $parser->getImportedSymbol('function', $expr->getAttribute('name'))) {
++            $expr = new MacroReferenceExpression($alias['node']->getNode('var'), $alias['name'], new ArrayExpression([], $expr->getTemplateLine()), $expr->getTemplateLine());
++        }
++
++        $ready = $test instanceof TwigTest;
++        if (!isset($this->readyNodes[$class = $test->getNodeClass()])) {
++            $this->readyNodes[$class] = (bool) (new \ReflectionClass($class))->getConstructor()->getAttributes(FirstClassTwigCallableReady::class);
++        }
++
++        if (!$ready = $this->readyNodes[$class]) {
++            trigger_deprecation('twig/twig', '3.12', 'Twig node "%s" is not marked as ready for passing a "TwigTest" in the constructor instead of its name; please update your code and then add #[FirstClassTwigCallableReady] attribute to the constructor.', $class);
++        }
++
++        return new $class($expr, $ready ? $test : $test->getName(), $arguments, $stream->getCurrent()->getLine());
++    }
++
++    public function getPrecedence(): int
++    {
++        return 100;
++    }
++
++    public function getName(): string
++    {
++        return 'is';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Twig tests';
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/Infix/IsNotExpressionParser.php b/src/ExpressionParser/Infix/IsNotExpressionParser.php
+new file mode 100644
+index 00000000000..1e1085aa835
+--- /dev/null
++++ b/src/ExpressionParser/Infix/IsNotExpressionParser.php
+@@ -0,0 +1,33 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\Unary\NotUnary;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class IsNotExpressionParser extends IsExpressionParser
++{
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        return new NotUnary(parent::parse($parser, $expr, $token), $token->getLine());
++    }
++
++    public function getName(): string
++    {
++        return 'is not';
++    }
++}
+diff --git a/src/ExpressionParser/Infix/SquareBracketExpressionParser.php b/src/ExpressionParser/Infix/SquareBracketExpressionParser.php
+new file mode 100644
+index 00000000000..c47c91dee36
+--- /dev/null
++++ b/src/ExpressionParser/Infix/SquareBracketExpressionParser.php
+@@ -0,0 +1,91 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Infix;
++
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\GetAttrExpression;
++use Twig\Node\Nodes;
++use Twig\Parser;
++use Twig\Template;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class SquareBracketExpressionParser extends AbstractExpressionParser implements InfixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++    {
++        $stream = $parser->getStream();
++        $lineno = $token->getLine();
++        $arguments = new ArrayExpression([], $lineno);
++
++        // slice?
++        $slice = false;
++        if ($stream->test(Token::PUNCTUATION_TYPE, ':')) {
++            $slice = true;
++            $attribute = new ConstantExpression(0, $token->getLine());
++        } else {
++            $attribute = $parser->parseExpression();
++        }
++
++        if ($stream->nextIf(Token::PUNCTUATION_TYPE, ':')) {
++            $slice = true;
++        }
++
++        if ($slice) {
++            if ($stream->test(Token::PUNCTUATION_TYPE, ']')) {
++                $length = new ConstantExpression(null, $token->getLine());
++            } else {
++                $length = $parser->parseExpression();
++            }
++
++            $filter = $parser->getFilter('slice', $token->getLine());
++            $arguments = new Nodes([$attribute, $length]);
++            $filter = new ($filter->getNodeClass())($expr, $filter, $arguments, $token->getLine());
++
++            $stream->expect(Token::PUNCTUATION_TYPE, ']');
++
++            return $filter;
++        }
++
++        $stream->expect(Token::PUNCTUATION_TYPE, ']');
++
++        return new GetAttrExpression($expr, $attribute, $arguments, Template::ARRAY_CALL, $lineno);
++    }
++
++    public function getName(): string
++    {
++        return '[';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Array access';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 512;
++    }
++
++    public function getAssociativity(): InfixAssociativity
++    {
++        return InfixAssociativity::Left;
++    }
++}
+diff --git a/src/ExpressionParser/InfixAssociativity.php b/src/ExpressionParser/InfixAssociativity.php
+new file mode 100644
+index 00000000000..3aeccce4565
+--- /dev/null
++++ b/src/ExpressionParser/InfixAssociativity.php
+@@ -0,0 +1,18 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++enum InfixAssociativity
++{
++    case Left;
++    case Right;
++}
+diff --git a/src/ExpressionParser/InfixExpressionParserInterface.php b/src/ExpressionParser/InfixExpressionParserInterface.php
+new file mode 100644
+index 00000000000..4641ef815ad
+--- /dev/null
++++ b/src/ExpressionParser/InfixExpressionParserInterface.php
+@@ -0,0 +1,27 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Parser;
++use Twig\Token;
++
++interface InfixExpressionParserInterface extends ExpressionParserInterface
++{
++    /**
++     * @throws SyntaxError
++     */
++    public function parse(Parser $parser, AbstractExpression $left, Token $token): AbstractExpression;
++
++    public function getAssociativity(): InfixAssociativity;
++}
+diff --git a/src/ExpressionParser/PrecedenceChange.php b/src/ExpressionParser/PrecedenceChange.php
+new file mode 100644
+index 00000000000..768d9fb0269
+--- /dev/null
++++ b/src/ExpressionParser/PrecedenceChange.php
+@@ -0,0 +1,42 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++/**
++ * Represents a precedence change.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++class PrecedenceChange
++{
++    public function __construct(
++        private string $package,
++        private string $version,
++        private int $newPrecedence,
++    ) {
++    }
++
++    public function getPackage(): string
++    {
++        return $this->package;
++    }
++
++    public function getVersion(): string
++    {
++        return $this->version;
++    }
++
++    public function getNewPrecedence(): int
++    {
++        return $this->newPrecedence;
++    }
++}
+diff --git a/src/ExpressionParser/Prefix/GroupingExpressionParser.php b/src/ExpressionParser/Prefix/GroupingExpressionParser.php
+new file mode 100644
+index 00000000000..95a11762f4c
+--- /dev/null
++++ b/src/ExpressionParser/Prefix/GroupingExpressionParser.php
+@@ -0,0 +1,88 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Prefix;
++
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\PrefixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ListExpression;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class GroupingExpressionParser extends AbstractExpressionParser implements PrefixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function parse(Parser $parser, Token $token): AbstractExpression
++    {
++        $stream = $parser->getStream();
++        $expr = $parser->parseExpression($this->getPrecedence());
++
++        if ($stream->nextIf(Token::PUNCTUATION_TYPE, ')')) {
++            if (!$stream->test(Token::OPERATOR_TYPE, '=>')) {
++                return $expr->setExplicitParentheses();
++            }
++
++            return new ListExpression([self::toAssignContextVariable($expr)], $token->getLine());
++        }
++
++        // determine if we are parsing an arrow function arguments
++        if (!$stream->test(Token::PUNCTUATION_TYPE, ',')) {
++            $stream->expect(Token::PUNCTUATION_TYPE, ')', 'An opened parenthesis is not properly closed');
++        }
++
++        $names = [$expr];
++        while (true) {
++            if ($stream->nextIf(Token::PUNCTUATION_TYPE, ')')) {
++                break;
++            }
++            $stream->expect(Token::PUNCTUATION_TYPE, ',');
++            $token = $stream->expect(Token::NAME_TYPE);
++            $names[] = new ContextVariable($token->getValue(), $token->getLine());
++        }
++
++        if (!$stream->test(Token::OPERATOR_TYPE, '=>')) {
++            throw new SyntaxError('A list of variables must be followed by an arrow.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
++        }
++
++        return new ListExpression(array_map(self::toAssignContextVariable(...), $names), $token->getLine());
++    }
++
++    private static function toAssignContextVariable(AbstractExpression $expr): AssignContextVariable
++    {
++        if (!$expr instanceof ContextVariable) {
++            throw new SyntaxError('A list must only contain variables.', $expr->getTemplateLine(), $expr->getSourceContext());
++        }
++
++        return $expr instanceof AssignContextVariable ? $expr : new AssignContextVariable($expr->getAttribute('name'), $expr->getTemplateLine());
++    }
++
++    public function getName(): string
++    {
++        return '(';
++    }
++
++    public function getDescription(): string
++    {
++        return 'Explicit group expression (a)';
++    }
++
++    public function getPrecedence(): int
++    {
++        return 0;
++    }
++}
+diff --git a/src/ExpressionParser/Prefix/LiteralExpressionParser.php b/src/ExpressionParser/Prefix/LiteralExpressionParser.php
+new file mode 100644
+index 00000000000..b467d1aa584
+--- /dev/null
++++ b/src/ExpressionParser/Prefix/LiteralExpressionParser.php
+@@ -0,0 +1,233 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Prefix;
++
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\PrefixExpressionParserInterface;
++use Twig\Lexer;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\Binary\ConcatBinary;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\EmptyExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class LiteralExpressionParser extends AbstractExpressionParser implements PrefixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function parse(Parser $parser, Token $token): AbstractExpression
++    {
++        $stream = $parser->getStream();
++        switch (true) {
++            case $token->test(Token::NAME_TYPE):
++                $stream->next();
++                switch ($token->getValue()) {
++                    case 'true':
++                    case 'TRUE':
++                        return new ConstantExpression(true, $token->getLine());
++
++                    case 'false':
++                    case 'FALSE':
++                        return new ConstantExpression(false, $token->getLine());
++
++                    case 'none':
++                    case 'NONE':
++                    case 'null':
++                    case 'NULL':
++                        return new ConstantExpression(null, $token->getLine());
++
++                    default:
++                        return new ContextVariable($token->getValue(), $token->getLine());
++                }
++
++                // no break
++            case $token->test(Token::NUMBER_TYPE):
++                $stream->next();
++
++                return new ConstantExpression($token->getValue(), $token->getLine());
++
++            case $token->test(Token::STRING_TYPE):
++            case $token->test(Token::INTERPOLATION_START_TYPE):
++                return $this->parseStringExpression($parser);
++
++            case $token->test(Token::PUNCTUATION_TYPE):
++                // In 4.0, we should always return the node or throw an error for default
++                if ($node = match ($token->getValue()) {
++                    '{' => $this->parseMappingExpression($parser),
++                    default => null,
++                }) {
++                    return $node;
++                }
++
++                // no break
++            case $token->test(Token::OPERATOR_TYPE):
++                if ('[' === $token->getValue()) {
++                    return $this->parseSequenceExpression($parser);
++                }
++
++                if (preg_match(Lexer::REGEX_NAME, $token->getValue(), $matches) && $matches[0] == $token->getValue()) {
++                    // in this context, string operators are variable names
++                    $stream->next();
++
++                    return new ContextVariable($token->getValue(), $token->getLine());
++                }
++
++                // no break
++            default:
++                throw new SyntaxError(\sprintf('Unexpected token "%s" of value "%s".', $token->toEnglish(), $token->getValue()), $token->getLine(), $stream->getSourceContext());
++        }
++    }
++
++    public function getName(): string
++    {
++        return 'literal';
++    }
++
++    public function getOperatorTokens(): array
++    {
++        return [];
++    }
++
++    public function getDescription(): string
++    {
++        return 'A literal value (boolean, string, number, sequence, mapping, ...)';
++    }
++
++    public function getPrecedence(): int
++    {
++        // not used
++        return 0;
++    }
++
++    private function parseStringExpression(Parser $parser)
++    {
++        $stream = $parser->getStream();
++
++        $nodes = [];
++        // a string cannot be followed by another string in a single expression
++        $nextCanBeString = true;
++        while (true) {
++            if ($nextCanBeString && $token = $stream->nextIf(Token::STRING_TYPE)) {
++                $nodes[] = new ConstantExpression($token->getValue(), $token->getLine());
++                $nextCanBeString = false;
++            } elseif ($stream->nextIf(Token::INTERPOLATION_START_TYPE)) {
++                $nodes[] = $parser->parseExpression();
++                $stream->expect(Token::INTERPOLATION_END_TYPE);
++                $nextCanBeString = true;
++            } else {
++                break;
++            }
++        }
++
++        $expr = array_shift($nodes);
++        foreach ($nodes as $node) {
++            $expr = new ConcatBinary($expr, $node, $node->getTemplateLine());
++        }
++
++        return $expr;
++    }
++
++    private function parseSequenceExpression(Parser $parser)
++    {
++        $stream = $parser->getStream();
++        $stream->expect(Token::OPERATOR_TYPE, '[', 'A sequence element was expected');
++
++        $node = new ArrayExpression([], $stream->getCurrent()->getLine());
++        $first = true;
++        while (!$stream->test(Token::PUNCTUATION_TYPE, ']')) {
++            if (!$first) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'A sequence element must be followed by a comma');
++
++                // trailing ,?
++                if ($stream->test(Token::PUNCTUATION_TYPE, ']')) {
++                    break;
++                }
++            }
++            $first = false;
++
++            // Check for empty slots (comma with no expression)
++            if ($stream->test(Token::PUNCTUATION_TYPE, ',')) {
++                $node->addElement(new EmptyExpression($stream->getCurrent()->getLine()));
++            } else {
++                $node->addElement($parser->parseExpression());
++            }
++        }
++        $stream->expect(Token::PUNCTUATION_TYPE, ']', 'An opened sequence is not properly closed');
++
++        return $node;
++    }
++
++    private function parseMappingExpression(Parser $parser)
++    {
++        $stream = $parser->getStream();
++        $stream->expect(Token::PUNCTUATION_TYPE, '{', 'A mapping element was expected');
++
++        $node = new ArrayExpression([], $stream->getCurrent()->getLine());
++        $first = true;
++        while (!$stream->test(Token::PUNCTUATION_TYPE, '}')) {
++            if (!$first) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'A mapping value must be followed by a comma');
++
++                // trailing ,?
++                if ($stream->test(Token::PUNCTUATION_TYPE, '}')) {
++                    break;
++                }
++            }
++            $first = false;
++
++            if ($stream->test(Token::OPERATOR_TYPE, '...')) {
++                $node->addElement($parser->parseExpression());
++
++                continue;
++            }
++
++            // a mapping key can be:
++            //
++            //  * a number -- 12
++            //  * a string -- 'a'
++            //  * a name, which is equivalent to a string -- a
++            //  * an expression, which must be enclosed in parentheses -- (1 + 2)
++            if ($token = $stream->nextIf(Token::NAME_TYPE)) {
++                $key = new ConstantExpression($token->getValue(), $token->getLine());
++
++                // {a} is a shortcut for {a:a}
++                if ($stream->test(Token::PUNCTUATION_TYPE, [',', '}'])) {
++                    $value = new ContextVariable($key->getAttribute('value'), $key->getTemplateLine());
++                    $node->addElement($value, $key);
++                    continue;
++                }
++            } elseif (($token = $stream->nextIf(Token::STRING_TYPE)) || $token = $stream->nextIf(Token::NUMBER_TYPE)) {
++                $key = new ConstantExpression($token->getValue(), $token->getLine());
++            } elseif ($stream->test(Token::OPERATOR_TYPE, '(')) {
++                $key = $parser->parseExpression();
++            } else {
++                $current = $stream->getCurrent();
++
++                throw new SyntaxError(\sprintf('A mapping key must be a quoted string, a number, a name, or an expression enclosed in parentheses (unexpected token "%s" of value "%s".', $current->toEnglish(), $current->getValue()), $current->getLine(), $stream->getSourceContext());
++            }
++
++            $stream->expect(Token::PUNCTUATION_TYPE, ':', 'A mapping key must be followed by a colon (:)');
++            $value = $parser->parseExpression();
++
++            $node->addElement($value, $key);
++        }
++        $stream->expect(Token::PUNCTUATION_TYPE, '}', 'An opened mapping is not properly closed');
++
++        return $node;
++    }
++}
+diff --git a/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php b/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php
+new file mode 100644
+index 00000000000..801390097b2
+--- /dev/null
++++ b/src/ExpressionParser/Prefix/UnaryOperatorExpressionParser.php
+@@ -0,0 +1,72 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser\Prefix;
++
++use Twig\ExpressionParser\AbstractExpressionParser;
++use Twig\ExpressionParser\ExpressionParserDescriptionInterface;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\ExpressionParser\PrefixExpressionParserInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\Unary\AbstractUnary;
++use Twig\Parser;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class UnaryOperatorExpressionParser extends AbstractExpressionParser implements PrefixExpressionParserInterface, ExpressionParserDescriptionInterface
++{
++    public function __construct(
++        /** @var class-string<AbstractUnary> */
++        private string $nodeClass,
++        private string $name,
++        private int $precedence,
++        private ?PrecedenceChange $precedenceChange = null,
++        private ?string $description = null,
++        private array $aliases = [],
++        private ?int $operandPrecedence = null,
++    ) {
++    }
++
++    /**
++     * @return AbstractUnary
++     */
++    public function parse(Parser $parser, Token $token): AbstractExpression
++    {
++        return new ($this->nodeClass)($parser->parseExpression($this->operandPrecedence ?? $this->precedence), $token->getLine());
++    }
++
++    public function getName(): string
++    {
++        return $this->name;
++    }
++
++    public function getDescription(): string
++    {
++        return $this->description ?? '';
++    }
++
++    public function getPrecedence(): int
++    {
++        return $this->precedence;
++    }
++
++    public function getPrecedenceChange(): ?PrecedenceChange
++    {
++        return $this->precedenceChange;
++    }
++
++    public function getAliases(): array
++    {
++        return $this->aliases;
++    }
++}
+diff --git a/src/ExpressionParser/PrefixExpressionParserInterface.php b/src/ExpressionParser/PrefixExpressionParserInterface.php
+new file mode 100644
+index 00000000000..8e39dad37e1
+--- /dev/null
++++ b/src/ExpressionParser/PrefixExpressionParserInterface.php
+@@ -0,0 +1,25 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\ExpressionParser;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Parser;
++use Twig\Token;
++
++interface PrefixExpressionParserInterface extends ExpressionParserInterface
++{
++    /**
++     * @throws SyntaxError
++     */
++    public function parse(Parser $parser, Token $token): AbstractExpression;
++}
+diff --git a/src/Extension/AbstractExtension.php b/src/Extension/AbstractExtension.php
+index a1b083b6884..351fb0698df 100644
+--- a/src/Extension/AbstractExtension.php
++++ b/src/Extension/AbstractExtension.php
+@@ -11,7 +11,7 @@
+ 
+ namespace Twig\Extension;
+ 
+-abstract class AbstractExtension implements ExtensionInterface
++abstract class AbstractExtension implements LastModifiedExtensionInterface
+ {
+     public function getTokenParsers()
+     {
+@@ -42,4 +42,26 @@ public function getOperators()
+     {
+         return [[], []];
+     }
++
++    public function getExpressionParsers(): array
++    {
++        return [];
++    }
++
++    public function getLastModified(): int
++    {
++        $filename = (new \ReflectionClass($this))->getFileName();
++        if (!is_file($filename)) {
++            return 0;
++        }
++
++        $lastModified = filemtime($filename);
++
++        // Track modifications of the runtime class if it exists and follows the naming convention
++        if (str_ends_with($filename, 'Extension.php') && is_file($filename = substr($filename, 0, -13).'Runtime.php')) {
++            $lastModified = max($lastModified, filemtime($filename));
++        }
++
++        return $lastModified;
++    }
+ }
+diff --git a/src/Extension/AttributeExtension.php b/src/Extension/AttributeExtension.php
+new file mode 100644
+index 00000000000..3b51f8dfcc0
+--- /dev/null
++++ b/src/Extension/AttributeExtension.php
+@@ -0,0 +1,176 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Extension;
++
++use Twig\Attribute\AsTwigFilter;
++use Twig\Attribute\AsTwigFunction;
++use Twig\Attribute\AsTwigTest;
++use Twig\Environment;
++use Twig\TwigFilter;
++use Twig\TwigFunction;
++use Twig\TwigTest;
++
++/**
++ * Define Twig filters, functions, and tests with PHP attributes.
++ *
++ * @author Jérôme Tamarelle <jerome@tamarelle.net>
++ */
++final class AttributeExtension extends AbstractExtension
++{
++    private array $filters;
++    private array $functions;
++    private array $tests;
++
++    /**
++     * Use a runtime class using PHP attributes to define filters, functions, and tests.
++     *
++     * @param class-string $class
++     */
++    public function __construct(private string $class)
++    {
++    }
++
++    /**
++     * @return class-string
++     */
++    public function getClass(): string
++    {
++        return $this->class;
++    }
++
++    public function getFilters(): array
++    {
++        if (!isset($this->filters)) {
++            $this->initFromAttributes();
++        }
++
++        return $this->filters;
++    }
++
++    public function getFunctions(): array
++    {
++        if (!isset($this->functions)) {
++            $this->initFromAttributes();
++        }
++
++        return $this->functions;
++    }
++
++    public function getTests(): array
++    {
++        if (!isset($this->tests)) {
++            $this->initFromAttributes();
++        }
++
++        return $this->tests;
++    }
++
++    public function getLastModified(): int
++    {
++        return max(
++            filemtime(__FILE__),
++            is_file($filename = (new \ReflectionClass($this->getClass()))->getFileName()) ? filemtime($filename) : 0,
++        );
++    }
++
++    private function initFromAttributes(): void
++    {
++        $filters = $functions = $tests = [];
++        $reflectionClass = new \ReflectionClass($this->getClass());
++        foreach ($reflectionClass->getMethods() as $method) {
++            foreach ($method->getAttributes(AsTwigFilter::class) as $reflectionAttribute) {
++                /** @var AsTwigFilter $attribute */
++                $attribute = $reflectionAttribute->newInstance();
++
++                $callable = new TwigFilter($attribute->name, [$reflectionClass->name, $method->getName()], [
++                    'needs_context' => $attribute->needsContext ?? false,
++                    'needs_environment' => $attribute->needsEnvironment ?? $this->needsEnvironment($method),
++                    'needs_charset' => $attribute->needsCharset ?? false,
++                    'needs_is_sandboxed' => $attribute->needsIsSandboxed ?? false,
++                    'is_variadic' => $method->isVariadic(),
++                    'is_safe' => $attribute->isSafe,
++                    'is_safe_callback' => $attribute->isSafeCallback,
++                    'pre_escape' => $attribute->preEscape,
++                    'preserves_safety' => $attribute->preservesSafety,
++                    'deprecation_info' => $attribute->deprecationInfo,
++                ]);
++
++                if ($callable->getMinimalNumberOfRequiredArguments() > $method->getNumberOfParameters()) {
++                    throw new \LogicException(\sprintf('"%s::%s()" needs at least %d arguments to be used AsTwigFilter, but only %d defined.', $reflectionClass->getName(), $method->getName(), $callable->getMinimalNumberOfRequiredArguments(), $method->getNumberOfParameters()));
++                }
++
++                $filters[$attribute->name] = $callable;
++            }
++
++            foreach ($method->getAttributes(AsTwigFunction::class) as $reflectionAttribute) {
++                /** @var AsTwigFunction $attribute */
++                $attribute = $reflectionAttribute->newInstance();
++
++                $callable = new TwigFunction($attribute->name, [$reflectionClass->name, $method->getName()], [
++                    'needs_context' => $attribute->needsContext ?? false,
++                    'needs_environment' => $attribute->needsEnvironment ?? $this->needsEnvironment($method),
++                    'needs_charset' => $attribute->needsCharset ?? false,
++                    'needs_is_sandboxed' => $attribute->needsIsSandboxed ?? false,
++                    'is_variadic' => $method->isVariadic(),
++                    'is_safe' => $attribute->isSafe,
++                    'is_safe_callback' => $attribute->isSafeCallback,
++                    'deprecation_info' => $attribute->deprecationInfo,
++                ]);
++
++                if ($callable->getMinimalNumberOfRequiredArguments() > $method->getNumberOfParameters()) {
++                    throw new \LogicException(\sprintf('"%s::%s()" needs at least %d arguments to be used AsTwigFunction, but only %d defined.', $reflectionClass->getName(), $method->getName(), $callable->getMinimalNumberOfRequiredArguments(), $method->getNumberOfParameters()));
++                }
++
++                $functions[$attribute->name] = $callable;
++            }
++
++            foreach ($method->getAttributes(AsTwigTest::class) as $reflectionAttribute) {
++                /** @var AsTwigTest $attribute */
++                $attribute = $reflectionAttribute->newInstance();
++
++                $callable = new TwigTest($attribute->name, [$reflectionClass->name, $method->getName()], [
++                    'needs_context' => $attribute->needsContext ?? false,
++                    'needs_environment' => $attribute->needsEnvironment ?? $this->needsEnvironment($method),
++                    'needs_charset' => $attribute->needsCharset ?? false,
++                    'needs_is_sandboxed' => $attribute->needsIsSandboxed ?? false,
++                    'is_variadic' => $method->isVariadic(),
++                    'deprecation_info' => $attribute->deprecationInfo,
++                ]);
++
++                if ($callable->getMinimalNumberOfRequiredArguments() > $method->getNumberOfParameters()) {
++                    throw new \LogicException(\sprintf('"%s::%s()" needs at least %d arguments to be used AsTwigTest, but only %d defined.', $reflectionClass->getName(), $method->getName(), $callable->getMinimalNumberOfRequiredArguments(), $method->getNumberOfParameters()));
++                }
++
++                $tests[$attribute->name] = $callable;
++            }
++        }
++
++        // Assign all at the end to avoid inconsistent state in case of exception
++        $this->filters = array_values($filters);
++        $this->functions = array_values($functions);
++        $this->tests = array_values($tests);
++    }
++
++    /**
++     * Detect if the first argument of the method is the environment.
++     */
++    private function needsEnvironment(\ReflectionFunctionAbstract $function): bool
++    {
++        if (!$parameters = $function->getParameters()) {
++            return false;
++        }
++
++        return $parameters[0]->getType() instanceof \ReflectionNamedType
++            && Environment::class === $parameters[0]->getType()->getName()
++            && !$parameters[0]->isVariadic();
++    }
++}
+diff --git a/src/Extension/CoreExtension.php b/src/Extension/CoreExtension.php
+index b077e796304..092cd4777bd 100644
+--- a/src/Extension/CoreExtension.php
++++ b/src/Extension/CoreExtension.php
+@@ -11,11 +11,28 @@
+ 
+ namespace Twig\Extension;
+ 
++use Twig\DeprecatedCallableInfo;
+ use Twig\Environment;
+ use Twig\Error\LoaderError;
+ use Twig\Error\RuntimeError;
+-use Twig\ExpressionParser;
++use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\Infix\ArrowExpressionParser;
++use Twig\ExpressionParser\Infix\AssignmentExpressionParser;
++use Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser;
++use Twig\ExpressionParser\Infix\ConditionalTernaryExpressionParser;
++use Twig\ExpressionParser\Infix\DotExpressionParser;
++use Twig\ExpressionParser\Infix\FilterExpressionParser;
++use Twig\ExpressionParser\Infix\FunctionExpressionParser;
++use Twig\ExpressionParser\Infix\IsExpressionParser;
++use Twig\ExpressionParser\Infix\IsNotExpressionParser;
++use Twig\ExpressionParser\Infix\SquareBracketExpressionParser;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\ExpressionParser\Prefix\GroupingExpressionParser;
++use Twig\ExpressionParser\Prefix\LiteralExpressionParser;
++use Twig\ExpressionParser\Prefix\UnaryOperatorExpressionParser;
+ use Twig\Markup;
++use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\Binary\AddBinary;
+ use Twig\Node\Expression\Binary\AndBinary;
+ use Twig\Node\Expression\Binary\BitwiseAndBinary;
+@@ -23,6 +40,7 @@
+ use Twig\Node\Expression\Binary\BitwiseXorBinary;
+ use Twig\Node\Expression\Binary\ConcatBinary;
+ use Twig\Node\Expression\Binary\DivBinary;
++use Twig\Node\Expression\Binary\ElvisBinary;
+ use Twig\Node\Expression\Binary\EndsWithBinary;
+ use Twig\Node\Expression\Binary\EqualBinary;
+ use Twig\Node\Expression\Binary\FloorDivBinary;
+@@ -38,14 +56,22 @@
+ use Twig\Node\Expression\Binary\MulBinary;
+ use Twig\Node\Expression\Binary\NotEqualBinary;
+ use Twig\Node\Expression\Binary\NotInBinary;
++use Twig\Node\Expression\Binary\NotSameAsBinary;
++use Twig\Node\Expression\Binary\NullCoalesceBinary;
+ use Twig\Node\Expression\Binary\OrBinary;
+ use Twig\Node\Expression\Binary\PowerBinary;
+ use Twig\Node\Expression\Binary\RangeBinary;
++use Twig\Node\Expression\Binary\SameAsBinary;
+ use Twig\Node\Expression\Binary\SpaceshipBinary;
+ use Twig\Node\Expression\Binary\StartsWithBinary;
+ use Twig\Node\Expression\Binary\SubBinary;
++use Twig\Node\Expression\Binary\XorBinary;
++use Twig\Node\Expression\BlockReferenceExpression;
+ use Twig\Node\Expression\Filter\DefaultFilter;
+-use Twig\Node\Expression\NullCoalesceExpression;
++use Twig\Node\Expression\FunctionNode\EnumCasesFunction;
++use Twig\Node\Expression\FunctionNode\EnumFunction;
++use Twig\Node\Expression\GetAttrExpression;
++use Twig\Node\Expression\ParentExpression;
+ use Twig\Node\Expression\Test\ConstantTest;
+ use Twig\Node\Expression\Test\DefinedTest;
+ use Twig\Node\Expression\Test\DivisiblebyTest;
+@@ -53,10 +79,13 @@
+ use Twig\Node\Expression\Test\NullTest;
+ use Twig\Node\Expression\Test\OddTest;
+ use Twig\Node\Expression\Test\SameasTest;
++use Twig\Node\Expression\Test\TrueTest;
+ use Twig\Node\Expression\Unary\NegUnary;
+ use Twig\Node\Expression\Unary\NotUnary;
+ use Twig\Node\Expression\Unary\PosUnary;
+-use Twig\NodeVisitor\MacroAutoImportNodeVisitor;
++use Twig\Node\Expression\Unary\SpreadUnary;
++use Twig\Node\Node;
++use Twig\Parser;
+ use Twig\Sandbox\SecurityNotAllowedMethodError;
+ use Twig\Sandbox\SecurityNotAllowedPropertyError;
+ use Twig\Source;
+@@ -71,16 +100,19 @@
+ use Twig\TokenParser\FlushTokenParser;
+ use Twig\TokenParser\ForTokenParser;
+ use Twig\TokenParser\FromTokenParser;
++use Twig\TokenParser\GuardTokenParser;
+ use Twig\TokenParser\IfTokenParser;
+ use Twig\TokenParser\ImportTokenParser;
+ use Twig\TokenParser\IncludeTokenParser;
+ use Twig\TokenParser\MacroTokenParser;
+ use Twig\TokenParser\SetTokenParser;
++use Twig\TokenParser\TypesTokenParser;
+ use Twig\TokenParser\UseTokenParser;
+ use Twig\TokenParser\WithTokenParser;
+ use Twig\TwigFilter;
+ use Twig\TwigFunction;
+ use Twig\TwigTest;
++use Twig\Util\CallableArgumentsExtractor;
+ 
+ final class CoreExtension extends AbstractExtension
+ {
+@@ -98,9 +130,11 @@ final class CoreExtension extends AbstractExtension
+         'WeakMap',
+     ];
+ 
++    private const DEFAULT_TRIM_CHARS = " \t\n\r\0\x0B";
++
+     private $dateFormats = ['F j, Y H:i', '%d days'];
+     private $numberFormat = [0, '.', ','];
+-    private $timezone = null;
++    private $timezone;
+ 
+     /**
+      * Sets the default format to be used by the date filter.
+@@ -189,11 +223,13 @@ public function getTokenParsers(): array
+             new ImportTokenParser(),
+             new FromTokenParser(),
+             new SetTokenParser(),
++            new TypesTokenParser(),
+             new FlushTokenParser(),
+             new DoTokenParser(),
+             new EmbedTokenParser(),
+             new WithTokenParser(),
+             new DeprecatedTokenParser(),
++            new GuardTokenParser(),
+         ];
+     }
+ 
+@@ -222,19 +258,19 @@ public function getFilters(): array
+             new TwigFilter('striptags', [self::class, 'striptags']),
+             new TwigFilter('trim', [self::class, 'trim']),
+             new TwigFilter('nl2br', [self::class, 'nl2br'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+-            new TwigFilter('spaceless', [self::class, 'spaceless'], ['is_safe' => ['html']]),
++            new TwigFilter('spaceless', [self::class, 'spaceless'], ['pre_escape' => 'html', 'is_safe' => ['html'], 'deprecation_info' => new DeprecatedCallableInfo('twig/twig', '3.12')]),
+ 
+             // array helpers
+             new TwigFilter('join', [self::class, 'join']),
+             new TwigFilter('split', [self::class, 'split'], ['needs_charset' => true]),
+-            new TwigFilter('sort', [self::class, 'sort'], ['needs_environment' => true]),
++            new TwigFilter('sort', [self::class, 'sort'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
+             new TwigFilter('merge', [self::class, 'merge']),
+             new TwigFilter('batch', [self::class, 'batch']),
+-            new TwigFilter('column', [self::class, 'column']),
+-            new TwigFilter('filter', [self::class, 'filter'], ['needs_environment' => true]),
+-            new TwigFilter('map', [self::class, 'map'], ['needs_environment' => true]),
+-            new TwigFilter('reduce', [self::class, 'reduce'], ['needs_environment' => true]),
+-            new TwigFilter('find', [self::class, 'find'], ['needs_environment' => true]),
++            new TwigFilter('column', [self::class, 'column'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
++            new TwigFilter('filter', [self::class, 'filter'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
++            new TwigFilter('map', [self::class, 'map'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
++            new TwigFilter('reduce', [self::class, 'reduce'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
++            new TwigFilter('find', [self::class, 'find'], ['needs_environment' => true, 'needs_is_sandboxed' => true]),
+ 
+             // string/array filters
+             new TwigFilter('reverse', [self::class, 'reverse'], ['needs_charset' => true]),
+@@ -247,12 +283,16 @@ public function getFilters(): array
+             // iteration and runtime
+             new TwigFilter('default', [self::class, 'default'], ['node_class' => DefaultFilter::class]),
+             new TwigFilter('keys', [self::class, 'keys']),
++            new TwigFilter('invoke', [self::class, 'invoke']),
+         ];
+     }
+ 
+     public function getFunctions(): array
+     {
+         return [
++            new TwigFunction('parent', null, ['parser_callable' => [self::class, 'parseParentFunction']]),
++            new TwigFunction('block', null, ['parser_callable' => [self::class, 'parseBlockFunction']]),
++            new TwigFunction('attribute', null, ['parser_callable' => [self::class, 'parseAttributeFunction']]),
+             new TwigFunction('max', 'max'),
+             new TwigFunction('min', 'min'),
+             new TwigFunction('range', 'range'),
+@@ -262,6 +302,8 @@ public function getFunctions(): array
+             new TwigFunction('date', [$this, 'convertDate']),
+             new TwigFunction('include', [self::class, 'include'], ['needs_environment' => true, 'needs_context' => true, 'is_safe' => ['all']]),
+             new TwigFunction('source', [self::class, 'source'], ['needs_environment' => true, 'is_safe' => ['all']]),
++            new TwigFunction('enum_cases', [self::class, 'enumCases'], ['node_class' => EnumCasesFunction::class]),
++            new TwigFunction('enum', [self::class, 'enum'], ['node_class' => EnumFunction::class]),
+         ];
+     }
+ 
+@@ -280,79 +322,118 @@ public function getTests(): array
+             new TwigTest('iterable', 'is_iterable'),
+             new TwigTest('sequence', [self::class, 'testSequence']),
+             new TwigTest('mapping', [self::class, 'testMapping']),
++            new TwigTest('true', null, ['node_class' => TrueTest::class]),
+         ];
+     }
+ 
+     public function getNodeVisitors(): array
+     {
+-        return [new MacroAutoImportNodeVisitor()];
++        return [];
+     }
+ 
+-    public function getOperators(): array
++    public function getExpressionParsers(): array
+     {
+         return [
+-            [
+-                'not' => ['precedence' => 50, 'class' => NotUnary::class],
+-                '-' => ['precedence' => 500, 'class' => NegUnary::class],
+-                '+' => ['precedence' => 500, 'class' => PosUnary::class],
+-            ],
+-            [
+-                'or' => ['precedence' => 10, 'class' => OrBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'and' => ['precedence' => 15, 'class' => AndBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'b-or' => ['precedence' => 16, 'class' => BitwiseOrBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'b-xor' => ['precedence' => 17, 'class' => BitwiseXorBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'b-and' => ['precedence' => 18, 'class' => BitwiseAndBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '==' => ['precedence' => 20, 'class' => EqualBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '!=' => ['precedence' => 20, 'class' => NotEqualBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '<=>' => ['precedence' => 20, 'class' => SpaceshipBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '<' => ['precedence' => 20, 'class' => LessBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '>' => ['precedence' => 20, 'class' => GreaterBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '>=' => ['precedence' => 20, 'class' => GreaterEqualBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '<=' => ['precedence' => 20, 'class' => LessEqualBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'not in' => ['precedence' => 20, 'class' => NotInBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'in' => ['precedence' => 20, 'class' => InBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'matches' => ['precedence' => 20, 'class' => MatchesBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'starts with' => ['precedence' => 20, 'class' => StartsWithBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'ends with' => ['precedence' => 20, 'class' => EndsWithBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'has some' => ['precedence' => 20, 'class' => HasSomeBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'has every' => ['precedence' => 20, 'class' => HasEveryBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '..' => ['precedence' => 25, 'class' => RangeBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '+' => ['precedence' => 30, 'class' => AddBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '-' => ['precedence' => 30, 'class' => SubBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '~' => ['precedence' => 40, 'class' => ConcatBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '*' => ['precedence' => 60, 'class' => MulBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '/' => ['precedence' => 60, 'class' => DivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '//' => ['precedence' => 60, 'class' => FloorDivBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '%' => ['precedence' => 60, 'class' => ModBinary::class, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'is' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                'is not' => ['precedence' => 100, 'associativity' => ExpressionParser::OPERATOR_LEFT],
+-                '**' => ['precedence' => 200, 'class' => PowerBinary::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
+-                '??' => ['precedence' => 300, 'class' => NullCoalesceExpression::class, 'associativity' => ExpressionParser::OPERATOR_RIGHT],
+-            ],
++            // unary operators
++            new UnaryOperatorExpressionParser(NotUnary::class, 'not', 50, new PrecedenceChange('twig/twig', '3.15', 70)),
++            new UnaryOperatorExpressionParser(SpreadUnary::class, '...', 512, description: 'Spread operator', operandPrecedence: 0),
++            new UnaryOperatorExpressionParser(NegUnary::class, '-', 500),
++            new UnaryOperatorExpressionParser(PosUnary::class, '+', 500),
++
++            // binary operators
++            new BinaryOperatorExpressionParser(ElvisBinary::class, '?:', 5, InfixAssociativity::Right, description: 'Elvis operator (a ?: b)', aliases: ['? :']),
++            new BinaryOperatorExpressionParser(NullCoalesceBinary::class, '??', 300, InfixAssociativity::Right, new PrecedenceChange('twig/twig', '3.15', 5), description: 'Null coalescing operator (a ?? b)'),
++            new BinaryOperatorExpressionParser(OrBinary::class, 'or', 10),
++            new BinaryOperatorExpressionParser(XorBinary::class, 'xor', 12),
++            new BinaryOperatorExpressionParser(AndBinary::class, 'and', 15),
++            new BinaryOperatorExpressionParser(BitwiseOrBinary::class, 'b-or', 16),
++            new BinaryOperatorExpressionParser(BitwiseXorBinary::class, 'b-xor', 17),
++            new BinaryOperatorExpressionParser(BitwiseAndBinary::class, 'b-and', 18),
++            new BinaryOperatorExpressionParser(EqualBinary::class, '==', 20),
++            new BinaryOperatorExpressionParser(NotEqualBinary::class, '!=', 20),
++            new BinaryOperatorExpressionParser(SpaceshipBinary::class, '<=>', 20),
++            new BinaryOperatorExpressionParser(LessBinary::class, '<', 20),
++            new BinaryOperatorExpressionParser(GreaterBinary::class, '>', 20),
++            new BinaryOperatorExpressionParser(GreaterEqualBinary::class, '>=', 20),
++            new BinaryOperatorExpressionParser(LessEqualBinary::class, '<=', 20),
++            new BinaryOperatorExpressionParser(NotInBinary::class, 'not in', 20),
++            new BinaryOperatorExpressionParser(InBinary::class, 'in', 20),
++            new BinaryOperatorExpressionParser(MatchesBinary::class, 'matches', 20),
++            new BinaryOperatorExpressionParser(StartsWithBinary::class, 'starts with', 20),
++            new BinaryOperatorExpressionParser(EndsWithBinary::class, 'ends with', 20),
++            new BinaryOperatorExpressionParser(HasSomeBinary::class, 'has some', 20),
++            new BinaryOperatorExpressionParser(HasEveryBinary::class, 'has every', 20),
++            new BinaryOperatorExpressionParser(SameAsBinary::class, '===', 20),
++            new BinaryOperatorExpressionParser(NotSameAsBinary::class, '!==', 20),
++            new BinaryOperatorExpressionParser(RangeBinary::class, '..', 25),
++            new BinaryOperatorExpressionParser(AddBinary::class, '+', 30),
++            new BinaryOperatorExpressionParser(SubBinary::class, '-', 30),
++            new BinaryOperatorExpressionParser(ConcatBinary::class, '~', 40, precedenceChange: new PrecedenceChange('twig/twig', '3.15', 27)),
++            new BinaryOperatorExpressionParser(MulBinary::class, '*', 60),
++            new BinaryOperatorExpressionParser(DivBinary::class, '/', 60),
++            new BinaryOperatorExpressionParser(FloorDivBinary::class, '//', 60, description: 'Floor division'),
++            new BinaryOperatorExpressionParser(ModBinary::class, '%', 60),
++            new BinaryOperatorExpressionParser(PowerBinary::class, '**', 200, InfixAssociativity::Right, description: 'Exponentiation operator'),
++
++            // ternary operator
++            new ConditionalTernaryExpressionParser(),
++
++            // assignment operator
++            new AssignmentExpressionParser('='),
++
++            // Twig callables
++            new IsExpressionParser(),
++            new IsNotExpressionParser(),
++            new FilterExpressionParser(),
++            new FunctionExpressionParser(),
++
++            // get attribute operators
++            new DotExpressionParser(),
++            new SquareBracketExpressionParser(),
++
++            // group expression
++            new GroupingExpressionParser(),
++
++            // arrow function
++            new ArrowExpressionParser(),
++
++            // all literals
++            new LiteralExpressionParser(),
+         ];
+     }
+ 
+     /**
+-     * Cycles over a value.
++     * Cycles over a sequence.
+      *
+-     * @param \ArrayAccess|array $values
+-     * @param int                $position The cycle position
++     * @param array|\ArrayAccess $values   A non-empty sequence of values
++     * @param int<0, max>        $position The position of the value to return in the cycle
+      *
+-     * @return string The next value in the cycle
++     * @return mixed The value at the given position in the sequence, wrapping around as needed
+      *
+      * @internal
+      */
+-    public static function cycle($values, $position): string
++    public static function cycle($values, $position): mixed
+     {
+-        if (!\is_array($values) && !$values instanceof \ArrayAccess) {
+-            return $values;
++        if (!\is_array($values)) {
++            if (!$values instanceof \ArrayAccess) {
++                throw new RuntimeError('The "cycle" function expects an array or "ArrayAccess" as first argument.');
++            }
++
++            if (!is_countable($values)) {
++                // To be uncommented in 4.0
++                // throw new RuntimeError('The "cycle" function expects a countable sequence as first argument.');
++
++                trigger_deprecation('twig/twig', '3.12', 'Passing a non-countable sequence of values to "%s()" is deprecated.', __METHOD__);
++
++                $values = self::toArray($values, false);
++            }
+         }
+ 
+-        if (!\count($values)) {
+-            throw new RuntimeError('The "cycle" function does not work on empty sequences/mappings.');
++        if (!$count = \count($values)) {
++            throw new RuntimeError('The "cycle" function expects a non-empty sequence.');
+         }
+ 
+-        return $values[$position % \count($values)];
++        return $values[$position % $count];
+     }
+ 
+     /**
+@@ -419,7 +500,7 @@ public static function random(string $charset, $values = null, $max = null)
+         $values = self::toArray($values);
+ 
+         if (0 === \count($values)) {
+-            throw new RuntimeError('The random function cannot pick from an empty sequence/mapping.');
++            throw new RuntimeError('The "random" function cannot pick from an empty sequence or mapping.');
+         }
+ 
+         return $values[array_rand($values, 1)];
+@@ -430,9 +511,9 @@ public static function random(string $charset, $values = null, $max = null)
+      *
+      *   {{ post.published_at|date("m/d/Y") }}
+      *
+-     * @param \DateTimeInterface|\DateInterval|string $date     A date
+-     * @param string|null                             $format   The target format, null to use the default
+-     * @param \DateTimeZone|string|false|null         $timezone The target timezone, null to use the default, false to leave unchanged
++     * @param \DateTimeInterface|\DateInterval|string|int|null $date     A date, a timestamp or null to use the current time
++     * @param string|null                                      $format   The target format, null to use the default
++     * @param \DateTimeZone|string|false|null                  $timezone The target timezone, null to use the default, false to leave unchanged
+      */
+     public function formatDate($date, $format = null, $timezone = null): string
+     {
+@@ -453,8 +534,8 @@ public function formatDate($date, $format = null, $timezone = null): string
+      *
+      *   {{ post.published_at|date_modify("-1day")|date("m/d/Y") }}
+      *
+-     * @param \DateTimeInterface|string $date     A date
+-     * @param string                    $modifier A modifier string
++     * @param \DateTimeInterface|string|int|null $date     A date, a timestamp or null to use the current time
++     * @param string                             $modifier A modifier string
+      *
+      * @return \DateTime|\DateTimeImmutable
+      *
+@@ -469,7 +550,6 @@ public function modifyDate($date, $modifier)
+      * Returns a formatted string.
+      *
+      * @param string|null $format
+-     * @param ...$values
+      *
+      * @internal
+      */
+@@ -493,8 +573,8 @@ public static function dateConverter(Environment $env, $date, $format = null, $t
+      *      {# do something #}
+      *    {% endif %}
+      *
+-     * @param \DateTimeInterface|string|null  $date     A date or null to use the current time
+-     * @param \DateTimeZone|string|false|null $timezone The target timezone, null to use the default, false to leave unchanged
++     * @param \DateTimeInterface|string|int|null $date     A date, a timestamp or null to use the current time
++     * @param \DateTimeZone|string|false|null    $timezone The target timezone, null to use the default, false to leave unchanged
+      *
+      * @return \DateTime|\DateTimeImmutable
+      */
+@@ -532,10 +612,10 @@ public function convertDate($date = null, $timezone = null)
+         }
+ 
+         $asString = (string) $date;
+-        if (ctype_digit($asString) || (!empty($asString) && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
++        if (ctype_digit($asString) || ('' !== $asString && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
+             $date = new \DateTime('@'.$date);
+         } else {
+-            $date = new \DateTime($date, $this->getTimezone());
++            $date = new \DateTime($date);
+         }
+ 
+         if (false !== $timezone) {
+@@ -556,7 +636,7 @@ public function convertDate($date = null, $timezone = null)
+     public static function replace($str, $from): string
+     {
+         if (!is_iterable($from)) {
+-            throw new RuntimeError(\sprintf('The "replace" filter expects a sequence/mapping or "Traversable" as replace values, got "%s".', \is_object($from) ? \get_class($from) : \gettype($from)));
++            throw new RuntimeError(\sprintf('The "replace" filter expects a sequence or a mapping, got "%s".', get_debug_type($from)));
+         }
+ 
+         return strtr($str ?? '', self::toArray($from));
+@@ -565,11 +645,11 @@ public static function replace($str, $from): string
+     /**
+      * Rounds a number.
+      *
+-     * @param int|float|string|null $value     The value to round
+-     * @param int|float             $precision The rounding precision
+-     * @param string                $method    The method to use for rounding
++     * @param int|float|string|null   $value     The value to round
++     * @param int|float               $precision The rounding precision
++     * @param 'common'|'ceil'|'floor' $method    The method to use for rounding
+      *
+-     * @return int|float The rounded number
++     * @return float The rounded number
+      *
+      * @internal
+      */
+@@ -582,7 +662,7 @@ public static function round($value, $precision = 0, $method = 'common')
+         }
+ 
+         if ('ceil' !== $method && 'floor' !== $method) {
+-            throw new RuntimeError('The round filter only supports the "common", "ceil", and "floor" methods.');
++            throw new RuntimeError('The "round" filter only supports the "common", "ceil", and "floor" methods.');
+         }
+ 
+         return $method($value * 10 ** $precision) / 10 ** $precision;
+@@ -653,7 +733,7 @@ public static function merge(...$arrays): array
+ 
+         foreach ($arrays as $argNumber => $array) {
+             if (!is_iterable($array)) {
+-                throw new RuntimeError(\sprintf('The merge filter only works with sequences/mappings or "Traversable", got "%s" for argument %d.', \gettype($array), $argNumber + 1));
++                throw new RuntimeError(\sprintf('The "merge" filter expects a sequence or a mapping, got "%s" for argument %d.', get_debug_type($array), $argNumber + 1));
+             }
+ 
+             $result = array_merge($result, self::toArray($array));
+@@ -745,9 +825,9 @@ public static function last(string $charset, $item)
+      *  {{ [1, 2, 3]|join }}
+      *  {# returns 123 #}
+      *
+-     * @param array       $value An array
+-     * @param string      $glue  The separator
+-     * @param string|null $and   The separator for the last pair
++     * @param iterable|array|string|float|int|bool|null $value An array
++     * @param string                                    $glue  The separator
++     * @param string|null                               $and   The separator for the last pair
+      *
+      * @internal
+      */
+@@ -820,9 +900,6 @@ public static function split(string $charset, $value, $delimiter, $limit = null)
+         return $r;
+     }
+ 
+-    // The '_default' filter is used internally to avoid using the ternary operator
+-    // which costs a lot for big contexts (before PHP 5.4). So, on average,
+-    // a function call is cheaper.
+     /**
+      * @internal
+      */
+@@ -878,6 +955,16 @@ public static function keys($array): array
+         return array_keys($array);
+     }
+ 
++    /**
++     * Invokes a callable.
++     *
++     * @internal
++     */
++    public static function invoke(\Closure $arrow, ...$arguments): mixed
++    {
++        return $arrow(...$arguments);
++    }
++
+     /**
+      * Reverses a variable.
+      *
+@@ -921,8 +1008,6 @@ public static function reverse(string $charset, $item, $preserveKeys = false)
+      *
+      * @param array|\Traversable|string|null $item
+      *
+-     * @return mixed
+-     *
+      * @internal
+      */
+     public static function shuffle(string $charset, $item)
+@@ -955,19 +1040,20 @@ public static function shuffle(string $charset, $item)
+      * Sorts an array.
+      *
+      * @param array|\Traversable $array
++     * @param ?\Closure          $arrow
+      *
+      * @internal
+      */
+-    public static function sort(Environment $env, $array, $arrow = null): array
++    public static function sort(Environment $env, bool $isSandboxed, $array, $arrow = null): array
+     {
+         if ($array instanceof \Traversable) {
+             $array = iterator_to_array($array);
+         } elseif (!\is_array($array)) {
+-            throw new RuntimeError(\sprintf('The sort filter only works with sequences/mappings or "Traversable", got "%s".', \gettype($array)));
++            throw new RuntimeError(\sprintf('The "sort" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
+         }
+ 
+         if (null !== $arrow) {
+-            self::checkArrowInSandbox($env, $arrow, 'sort', 'filter');
++            self::checkArrow($isSandboxed, $arrow, 'sort', 'filter');
+ 
+             uasort($array, $arrow);
+         } else {
+@@ -1042,9 +1128,9 @@ public static function compare($a, $b)
+             }
+             if ((int) $bTrim == $bTrim) {
+                 return $a <=> (int) $bTrim;
+-            } else {
+-                return (float) $a <=> (float) $bTrim;
+             }
++
++            return (float) $a <=> (float) $bTrim;
+         }
+         if (\is_string($a) && \is_int($b)) {
+             $aTrim = trim($a, " \t\n\r\v\f");
+@@ -1053,9 +1139,9 @@ public static function compare($a, $b)
+             }
+             if ((int) $aTrim == $aTrim) {
+                 return (int) $aTrim <=> $b;
+-            } else {
+-                return (float) $aTrim <=> (float) $b;
+             }
++
++            return (float) $aTrim <=> (float) $b;
+         }
+ 
+         // float <=> string
+@@ -1093,7 +1179,7 @@ public static function compare($a, $b)
+      */
+     public static function matches(string $regexp, ?string $str): int
+     {
+-        set_error_handler(function ($t, $m) use ($regexp) {
++        set_error_handler(static function ($t, $m) use ($regexp) {
+             throw new RuntimeError(\sprintf('Regexp "%s" passed to "matches" is not valid', $regexp).substr($m, 12));
+         });
+         try {
+@@ -1106,30 +1192,29 @@ public static function matches(string $regexp, ?string $str): int
+     /**
+      * Returns a trimmed string.
+      *
+-     * @param string|null $string
+-     * @param string|null $characterMask
+-     * @param string      $side
++     * @param string|\Stringable|null $string
++     * @param string|null             $characterMask
++     * @param string                  $side          left, right, or both
+      *
+-     * @throws RuntimeError When an invalid trimming side is used (not a string or not 'left', 'right', or 'both')
++     * @throws RuntimeError When an invalid trimming side is used
+      *
+      * @internal
+      */
+-    public static function trim($string, $characterMask = null, $side = 'both'): string
++    public static function trim($string, $characterMask = null, $side = 'both'): string|\Stringable
+     {
+         if (null === $characterMask) {
+-            $characterMask = " \t\n\r\0\x0B";
++            $characterMask = self::DEFAULT_TRIM_CHARS;
+         }
+ 
+-        switch ($side) {
+-            case 'both':
+-                return trim($string ?? '', $characterMask);
+-            case 'left':
+-                return ltrim($string ?? '', $characterMask);
+-            case 'right':
+-                return rtrim($string ?? '', $characterMask);
+-            default:
+-                throw new RuntimeError('Trimming side must be "left", "right" or "both".');
+-        }
++        $trimmed = match ($side) {
++            'both' => trim($string ?? '', $characterMask),
++            'left' => ltrim($string ?? '', $characterMask),
++            'right' => rtrim($string ?? '', $characterMask),
++            default => throw new RuntimeError('Trimming side must be "left", "right" or "both".'),
++        };
++
++        // trimming a safe string with the default character mask always returns a safe string (independently of the context)
++        return $string instanceof Markup && self::DEFAULT_TRIM_CHARS === $characterMask ? new Markup($trimmed, $string->getCharset()) : $trimmed;
+     }
+ 
+     /**
+@@ -1197,7 +1282,7 @@ public static function length(string $charset, $thing): int
+             return iterator_count($thing);
+         }
+ 
+-        if (method_exists($thing, '__toString')) {
++        if ($thing instanceof \Stringable) {
+             return mb_strlen((string) $thing, $charset);
+         }
+ 
+@@ -1267,6 +1352,8 @@ public static function capitalize(string $charset, $string): string
+ 
+     /**
+      * @internal
++     *
++     * to be removed in 4.0
+      */
+     public static function callMacro(Template $template, string $method, array $args, int $lineno, array $context, Source $source)
+     {
+@@ -1285,6 +1372,12 @@ public static function callMacro(Template $template, string $method, array $args
+     }
+ 
+     /**
++     * @template TSequence
++     *
++     * @param TSequence $seq
++     *
++     * @return ($seq is iterable ? TSequence : array{})
++     *
+      * @internal
+      */
+     public static function ensureTraversable($seq)
+@@ -1334,7 +1427,7 @@ public static function testEmpty($value): bool
+             return !iterator_count($value);
+         }
+ 
+-        if (\is_object($value) && method_exists($value, '__toString')) {
++        if ($value instanceof \Stringable) {
+             return '' === (string) $value;
+         }
+ 
+@@ -1349,8 +1442,6 @@ public static function testEmpty($value): bool
+      *        {# ... #}
+      *    {% endif %}
+      *
+-     * @param mixed $value
+-     *
+      * @internal
+      */
+     public static function testSequence($value): bool
+@@ -1374,8 +1465,6 @@ public static function testSequence($value): bool
+      *        {# ... #}
+      *    {% endif %}
+      *
+-     * @param mixed $value
+-     *
+      * @internal
+      */
+     public static function testMapping($value): bool
+@@ -1426,13 +1515,11 @@ public static function include(Environment $env, $context, $template, $variables
+                 if (!$ignoreMissing) {
+                     throw $e;
+                 }
+-            }
+ 
+-            if ($isSandboxed && $loaded) {
+-                $loaded->unwrap()->checkSecurity();
++                return '';
+             }
+ 
+-            return $loaded ? $loaded->render($variables) : '';
++            return $loaded->render($variables);
+         } finally {
+             if ($isSandboxed && !$alreadySandboxed) {
+                 $sandbox->disableSandbox();
+@@ -1463,56 +1550,85 @@ public static function source(Environment $env, $name, $ignoreMissing = false):
+     }
+ 
+     /**
+-     * Provides the ability to get constants from instances as well as class/global constants.
++     * Returns the list of cases of the enum.
+      *
+-     * @param string      $constant The name of the constant
+-     * @param object|null $object   The object to get the constant from
++     * @template T of \UnitEnum
+      *
+-     * @return mixed Class constants can return many types like scalars, arrays, and
+-     *               objects depending on the PHP version (\BackedEnum, \UnitEnum, etc.)
++     * @param class-string<T> $enum
++     *
++     * @return list<T>
+      *
+      * @internal
+      */
+-    public static function constant($constant, $object = null)
++    public static function enumCases(string $enum): array
+     {
+-        if (null !== $object) {
+-            if ('class' === $constant) {
+-                return \get_class($object);
+-            }
+-
+-            $constant = \get_class($object).'::'.$constant;
++        if (!enum_exists($enum)) {
++            throw new RuntimeError(\sprintf('Enum "%s" does not exist.', $enum));
+         }
+ 
+-        if (!\defined($constant)) {
+-            if ('::class' === strtolower(substr($constant, -7))) {
+-                throw new RuntimeError(\sprintf('You cannot use the Twig function "constant()" to access "%s". You could provide an object and call constant("class", $object) or use the class name directly as a string.', $constant));
+-            }
++        return $enum::cases();
++    }
+ 
+-            throw new RuntimeError(\sprintf('Constant "%s" is undefined.', $constant));
++    /**
++     * Provides the ability to access enums by their class names.
++     *
++     * @template T of \UnitEnum
++     *
++     * @param class-string<T> $enum
++     *
++     * @return T
++     *
++     * @internal
++     */
++    public static function enum(string $enum): \UnitEnum
++    {
++        if (!enum_exists($enum)) {
++            throw new RuntimeError(\sprintf('"%s" is not an enum.', $enum));
+         }
+ 
+-        return \constant($constant);
++        if (!$cases = $enum::cases()) {
++            throw new RuntimeError(\sprintf('"%s" is an empty enum.', $enum));
++        }
++
++        return $cases[0];
+     }
+ 
+     /**
+-     * Checks if a constant exists.
++     * Provides the ability to get constants from instances as well as class/global constants.
++     *
++     * @param string      $constant     The name of the constant
++     * @param object|null $object       The object to get the constant from
++     * @param bool        $checkDefined Whether to check if the constant is defined or not
+      *
+-     * @param string      $constant The name of the constant
+-     * @param object|null $object   The object to get the constant from
++     * @return mixed Class constants can return many types like scalars, arrays, and
++     *               objects depending on the PHP version (\BackedEnum, \UnitEnum, etc.)
++     *               When $checkDefined is true, returns true when the constant is defined, false otherwise
+      *
+      * @internal
+      */
+-    public static function constantIsDefined($constant, $object = null): bool
++    public static function constant($constant, $object = null, bool $checkDefined = false)
+     {
+         if (null !== $object) {
+             if ('class' === $constant) {
+-                return true;
++                return $checkDefined ? true : $object::class;
+             }
+ 
+-            $constant = \get_class($object).'::'.$constant;
++            $constant = $object::class.'::'.$constant;
+         }
+ 
+-        return \defined($constant);
++        if (!\defined($constant)) {
++            if ($checkDefined) {
++                return false;
++            }
++
++            if ('::class' === strtolower(substr($constant, -7))) {
++                throw new RuntimeError(\sprintf('You cannot use the Twig function "constant" to access "%s". You could provide an object and call constant("class", $object) or use the class name directly as a string.', $constant));
++            }
++
++            throw new RuntimeError(\sprintf('Constant "%s" is undefined.', $constant));
++        }
++
++        return $checkDefined ? true : \constant($constant);
+     }
+ 
+     /**
+@@ -1527,7 +1643,7 @@ public static function constantIsDefined($constant, $object = null): bool
+     public static function batch($items, $size, $fill = null, $preserveKeys = true): array
+     {
+         if (!is_iterable($items)) {
+-            throw new RuntimeError(\sprintf('The "batch" filter expects a sequence/mapping or "Traversable", got "%s".', \is_object($items) ? \get_class($items) : \gettype($items)));
++            throw new RuntimeError(\sprintf('The "batch" filter expects a sequence or a mapping, got "%s".', get_debug_type($items)));
+         }
+ 
+         $size = (int) ceil($size);
+@@ -1563,25 +1679,34 @@ public static function batch($items, $size, $fill = null, $preserveKeys = true):
+      *
+      * @internal
+      */
+-    public static function getAttribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1)
++    public static function getAttribute(Environment $env, Source $source, $object, $item, array $arguments = [], $type = Template::ANY_CALL, $isDefinedTest = false, $ignoreStrictCheck = false, $sandboxed = false, int $lineno = -1)
+     {
+         $propertyNotAllowedError = null;
++        if ($sandboxed && $item instanceof \Stringable) {
++            $env->getExtension(SandboxExtension::class)->ensureToStringAllowed($item, $lineno, $source);
++        }
+ 
+         // array
+-        if (/* Template::METHOD_CALL */ 'method' !== $type) {
++        if (Template::METHOD_CALL !== $type) {
+             $arrayItem = \is_bool($item) || \is_float($item) ? (int) $item : $item;
+ 
+-            if ($sandboxed && $object instanceof \ArrayAccess && !\in_array(get_class($object), self::ARRAY_LIKE_CLASSES, true)) {
++            if ($sandboxed && $object instanceof \ArrayAccess && !\in_array($object::class, self::ARRAY_LIKE_CLASSES, true)) {
+                 try {
+                     $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $arrayItem, $lineno, $source);
+                 } catch (SecurityNotAllowedPropertyError $propertyNotAllowedError) {
++                    // The methodCheck path expects $item to be a string; stringify it here
++                    // to avoid PHP 8.1+ implicit float-to-int deprecations on downstream
++                    // array key lookups (e.g. isset($cache[$class][$item])).
++                    $item = (string) $item;
+                     goto methodCheck;
+                 }
+             }
+ 
+-            if (((\is_array($object) || $object instanceof \ArrayObject) && (isset($object[$arrayItem]) || \array_key_exists($arrayItem, (array) $object)))
+-                || ($object instanceof \ArrayAccess && isset($object[$arrayItem]))
+-            ) {
++            if (match (true) {
++                \is_array($object) => \array_key_exists($arrayItem = (string) $arrayItem, $object),
++                $object instanceof \ArrayAccess => $object->offsetExists($arrayItem),
++                default => false,
++            }) {
+                 if ($isDefinedTest) {
+                     return true;
+                 }
+@@ -1589,7 +1714,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+                 return $object[$arrayItem];
+             }
+ 
+-            if (/* Template::ARRAY_CALL */ 'array' === $type || !\is_object($object)) {
++            if (Template::ARRAY_CALL === $type || !\is_object($object)) {
+                 if ($isDefinedTest) {
+                     return false;
+                 }
+@@ -1599,31 +1724,37 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+                 }
+ 
+                 if ($object instanceof \ArrayAccess) {
+-                    $message = \sprintf('Key "%s" in object with ArrayAccess of class "%s" does not exist.', $arrayItem, \get_class($object));
++                    if (\is_object($arrayItem) || \is_array($arrayItem)) {
++                        $message = \sprintf('Key of type "%s" does not exist in ArrayAccess-able object of class "%s".', get_debug_type($arrayItem), get_debug_type($object));
++                    } else {
++                        $message = \sprintf('Key "%s" does not exist in ArrayAccess-able object of class "%s".', $arrayItem, get_debug_type($object));
++                    }
+                 } elseif (\is_object($object)) {
+-                    $message = \sprintf('Impossible to access a key "%s" on an object of class "%s" that does not implement ArrayAccess interface.', $item, \get_class($object));
++                    $message = \sprintf('Impossible to access a key "%s" on an object of class "%s" that does not implement ArrayAccess interface.', $item, get_debug_type($object));
+                 } elseif (\is_array($object)) {
+-                    if (empty($object)) {
++                    if (!$object) {
+                         $message = \sprintf('Key "%s" does not exist as the sequence/mapping is empty.', $arrayItem);
+                     } else {
+                         $message = \sprintf('Key "%s" for sequence/mapping with keys "%s" does not exist.', $arrayItem, implode(', ', array_keys($object)));
+                     }
+-                } elseif (/* Template::ARRAY_CALL */ 'array' === $type) {
++                } elseif (Template::ARRAY_CALL === $type) {
+                     if (null === $object) {
+                         $message = \sprintf('Impossible to access a key ("%s") on a null variable.', $item);
+                     } else {
+-                        $message = \sprintf('Impossible to access a key ("%s") on a %s variable ("%s").', $item, \gettype($object), $object);
++                        $message = \sprintf('Impossible to access a key ("%s") on a %s variable ("%s").', $item, get_debug_type($object), $object);
+                     }
+                 } elseif (null === $object) {
+                     $message = \sprintf('Impossible to access an attribute ("%s") on a null variable.', $item);
+                 } else {
+-                    $message = \sprintf('Impossible to access an attribute ("%s") on a %s variable ("%s").', $item, \gettype($object), $object);
++                    $message = \sprintf('Impossible to access an attribute ("%s") on a %s variable ("%s").', $item, get_debug_type($object), $object);
+                 }
+ 
+                 throw new RuntimeError($message, $lineno, $source);
+             }
+         }
+ 
++        $item = (string) $item;
++
+         if (!\is_object($object)) {
+             if ($isDefinedTest) {
+                 return false;
+@@ -1638,7 +1769,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+             } elseif (\is_array($object)) {
+                 $message = \sprintf('Impossible to invoke a method ("%s") on a sequence/mapping.', $item);
+             } else {
+-                $message = \sprintf('Impossible to invoke a method ("%s") on a %s variable ("%s").', $item, \gettype($object), $object);
++                $message = \sprintf('Impossible to invoke a method ("%s") on a %s variable ("%s").', $item, get_debug_type($object), $object);
+             }
+ 
+             throw new RuntimeError($message, $lineno, $source);
+@@ -1649,7 +1780,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+         }
+ 
+         // object property
+-        if (/* Template::METHOD_CALL */ 'method' !== $type) {
++        if (Template::METHOD_CALL !== $type) {
+             if ($sandboxed) {
+                 try {
+                     $env->getExtension(SandboxExtension::class)->checkPropertyAllowed($object, $item, $lineno, $source);
+@@ -1658,27 +1789,50 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+                 }
+             }
+ 
+-            if (isset($object->$item) || \array_key_exists((string) $item, (array) $object)) {
++            static $propertyCheckers = [];
++
++            if (isset($object->$item)
++                || ($propertyCheckers[$object::class][$item] ??= self::getPropertyChecker($object::class, $item))($object, $item)
++            ) {
+                 if ($isDefinedTest) {
+                     return true;
+                 }
+ 
+                 return $object->$item;
+             }
++
++            if ($object instanceof \DateTimeInterface && \in_array($item, ['date', 'timezone', 'timezone_type'], true)) {
++                if ($isDefinedTest) {
++                    return true;
++                }
++
++                return ((array) $object)[$item];
++            }
++
++            if (\defined($object::class.'::'.$item)) {
++                if ($isDefinedTest) {
++                    return true;
++                }
++
++                return \constant($object::class.'::'.$item);
++            }
+         }
+ 
+         methodCheck:
+ 
+         static $cache = [];
+ 
+-        $class = \get_class($object);
++        $class = $object::class;
+ 
+         // object method
+         // precedence: getXxx() > isXxx() > hasXxx()
+         if (!isset($cache[$class])) {
+             $methods = get_class_methods($object);
++            if ($object instanceof \Closure) {
++                $methods[] = '__invoke';
++            }
+             sort($methods);
+-            $lcMethods = array_map(function ($value) { return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'); }, $methods);
++            $lcMethods = array_map('strtolower', $methods);
+             $classCache = [];
+             foreach ($methods as $i => $method) {
+                 $classCache[$method] = $method;
+@@ -1693,7 +1847,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+                 } elseif ('h' === $lcName[0] && str_starts_with($lcName, 'has')) {
+                     $name = substr($method, 3);
+                     $lcName = substr($lcName, 3);
+-                    if (\in_array('is'.$lcName, $lcMethods)) {
++                    if (\in_array('is'.$lcName, $lcMethods, true)) {
+                         continue;
+                     }
+                 } else {
+@@ -1717,7 +1871,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+         $call = false;
+         if (isset($cache[$class][$item])) {
+             $method = $cache[$class][$item];
+-        } elseif (isset($cache[$class][$lcItem = strtr($item, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')])) {
++        } elseif (isset($cache[$class][$lcItem = strtolower($item)])) {
+             $method = $cache[$class][$lcItem];
+         } elseif (isset($cache[$class]['__call'])) {
+             $method = $item;
+@@ -1735,7 +1889,7 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+                 return;
+             }
+ 
+-            throw new RuntimeError(\sprintf('Neither the property "%1$s" nor one of the methods "%1$s()", "get%1$s()"/"is%1$s()"/"has%1$s()" or "__call()" exist and have public access in class "%2$s".', $item, $class), $lineno, $source);
++            throw new RuntimeError(\sprintf('Neither the property "%1$s" nor one of the methods "%1$s()", "get%1$s()", "is%1$s()", "has%1$s()" or "__call()" exist and have public access in class "%2$s".', $item, $class), $lineno, $source);
+         }
+ 
+         if ($sandboxed) {
+@@ -1791,27 +1945,46 @@ public static function getAttribute(Environment $env, Source $source, $object, $
+      *
+      * @internal
+      */
+-    public static function column($array, $name, $index = null): array
++    public static function column(Environment $env, bool $isSandboxed, $array, $name, $index = null): array
+     {
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "column" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
++        }
++
+         if ($array instanceof \Traversable) {
+             $array = iterator_to_array($array);
+-        } elseif (!\is_array($array)) {
+-            throw new RuntimeError(\sprintf('The column filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', \gettype($array)));
++        }
++
++        if ($isSandboxed) {
++            // The sandbox might be enabled via a SourcePolicyInterface, in which case the SandboxExtension
++            // would not consider the sandbox active without the current Source: $isSandboxed is already
++            // computed against the call-site source, so check the policy directly to honor that decision.
++            $policy = $env->getExtension(SandboxExtension::class)->getSecurityPolicy();
++            foreach ($array as $item) {
++                if (\is_object($item)) {
++                    $policy->checkPropertyAllowed($item, (string) $name);
++                    if (null !== $index) {
++                        $policy->checkPropertyAllowed($item, (string) $index);
++                    }
++                }
++            }
+         }
+ 
+         return array_column($array, $name, $index);
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function filter(Environment $env, $array, $arrow)
++    public static function filter(Environment $env, bool $isSandboxed, $array, $arrow)
+     {
+         if (!is_iterable($array)) {
+-            throw new RuntimeError(\sprintf('The "filter" filter expects a sequence/mapping or "Traversable", got "%s".', \is_object($array) ? \get_class($array) : \gettype($array)));
++            throw new RuntimeError(\sprintf('The "filter" filter expects a sequence/mapping or "Traversable", got "%s".', get_debug_type($array)));
+         }
+ 
+-        self::checkArrowInSandbox($env, $arrow, 'filter', 'filter');
++        self::checkArrow($isSandboxed, $arrow, 'filter', 'filter');
+ 
+         if (\is_array($array)) {
+             return array_filter($array, $arrow, \ARRAY_FILTER_USE_BOTH);
+@@ -1822,11 +1995,17 @@ public static function filter(Environment $env, $array, $arrow)
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function find(Environment $env, $array, $arrow)
++    public static function find(Environment $env, bool $isSandboxed, $array, $arrow)
+     {
+-        self::checkArrowInSandbox($env, $arrow, 'find', 'filter');
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "find" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
++        }
++
++        self::checkArrow($isSandboxed, $arrow, 'find', 'filter');
+ 
+         foreach ($array as $k => $v) {
+             if ($arrow($v, $k)) {
+@@ -1838,11 +2017,17 @@ public static function find(Environment $env, $array, $arrow)
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function map(Environment $env, $array, $arrow)
++    public static function map(Environment $env, bool $isSandboxed, $array, $arrow)
+     {
+-        self::checkArrowInSandbox($env, $arrow, 'map', 'filter');
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "map" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
++        }
++
++        self::checkArrow($isSandboxed, $arrow, 'map', 'filter');
+ 
+         $r = [];
+         foreach ($array as $k => $v) {
+@@ -1853,16 +2038,18 @@ public static function map(Environment $env, $array, $arrow)
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function reduce(Environment $env, $array, $arrow, $initial = null)
++    public static function reduce(Environment $env, bool $isSandboxed, $array, $arrow, $initial = null)
+     {
+-        self::checkArrowInSandbox($env, $arrow, 'reduce', 'filter');
+-
+-        if (!\is_array($array) && !$array instanceof \Traversable) {
+-            throw new RuntimeError(\sprintf('The "reduce" filter only works with sequences/mappings or "Traversable", got "%s" as first argument.', \gettype($array)));
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "reduce" filter expects a sequence or a mapping, got "%s".', get_debug_type($array)));
+         }
+ 
++        self::checkArrow($isSandboxed, $arrow, 'reduce', 'filter');
++
+         $accumulator = $initial;
+         foreach ($array as $key => $value) {
+             $accumulator = $arrow($accumulator, $value, $key);
+@@ -1872,11 +2059,17 @@ public static function reduce(Environment $env, $array, $arrow, $initial = null)
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function arraySome(Environment $env, $array, $arrow)
++    public static function arraySome(Environment $env, $array, $arrow, bool $isSandboxed = false)
+     {
+-        self::checkArrowInSandbox($env, $arrow, 'has some', 'operator');
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "has some" test expects a sequence or a mapping, got "%s".', get_debug_type($array)));
++        }
++
++        self::checkArrow($isSandboxed, $arrow, 'has some', 'operator');
+ 
+         foreach ($array as $k => $v) {
+             if ($arrow($v, $k)) {
+@@ -1888,11 +2081,17 @@ public static function arraySome(Environment $env, $array, $arrow)
+     }
+ 
+     /**
++     * @param \Closure $arrow
++     *
+      * @internal
+      */
+-    public static function arrayEvery(Environment $env, $array, $arrow)
++    public static function arrayEvery(Environment $env, $array, $arrow, bool $isSandboxed = false)
+     {
+-        self::checkArrowInSandbox($env, $arrow, 'has every', 'operator');
++        if (!is_iterable($array)) {
++            throw new RuntimeError(\sprintf('The "has every" test expects a sequence or a mapping, got "%s".', get_debug_type($array)));
++        }
++
++        self::checkArrow($isSandboxed, $arrow, 'has every', 'operator');
+ 
+         foreach ($array as $k => $v) {
+             if (!$arrow($v, $k)) {
+@@ -1906,11 +2105,17 @@ public static function arrayEvery(Environment $env, $array, $arrow)
+     /**
+      * @internal
+      */
+-    public static function checkArrowInSandbox(Environment $env, $arrow, $thing, $type)
++    public static function checkArrow(bool $isSandboxed, $arrow, $thing, $type)
+     {
+-        if (!$arrow instanceof \Closure && $env->hasExtension(SandboxExtension::class) && $env->getExtension(SandboxExtension::class)->isSandboxed()) {
++        if ($arrow instanceof \Closure) {
++            return;
++        }
++
++        if ($isSandboxed) {
+             throw new RuntimeError(\sprintf('The callable passed to the "%s" %s must be a Closure in sandbox mode.', $thing, $type));
+         }
++
++        trigger_deprecation('twig/twig', '3.15', 'Passing a callable that is not a PHP \Closure as an argument to the "%s" %s is deprecated.', $thing, $type);
+     }
+ 
+     /**
+@@ -1918,29 +2123,91 @@ public static function checkArrowInSandbox(Environment $env, $arrow, $thing, $ty
+      */
+     public static function captureOutput(iterable $body): string
+     {
+-        $output = '';
+         $level = ob_get_level();
+         ob_start();
+ 
+         try {
+             foreach ($body as $data) {
+-                if (ob_get_length()) {
+-                    $output .= ob_get_clean();
+-                    ob_start();
+-                }
+-
+-                $output .= $data;
++                echo $data;
+             }
+-
+-            if (ob_get_length()) {
+-                $output .= ob_get_clean();
+-            }
+-        } finally {
++        } catch (\Throwable $e) {
+             while (ob_get_level() > $level) {
+                 ob_end_clean();
+             }
++
++            throw $e;
++        }
++
++        return ob_get_clean();
++    }
++
++    /**
++     * @internal
++     */
++    public static function parseParentFunction(Parser $parser, Node $fakeNode, $args, int $line): AbstractExpression
++    {
++        if (!$blockName = $parser->peekBlockStack()) {
++            throw new SyntaxError('Calling the "parent" function outside of a block is forbidden.', $line, $parser->getStream()->getSourceContext());
++        }
++
++        if (!$parser->hasInheritance()) {
++            throw new SyntaxError('Calling the "parent" function on a template that does not call "extends" or "use" is forbidden.', $line, $parser->getStream()->getSourceContext());
++        }
++
++        return new ParentExpression($blockName, $line);
++    }
++
++    /**
++     * @internal
++     */
++    public static function parseBlockFunction(Parser $parser, Node $fakeNode, $args, int $line): AbstractExpression
++    {
++        $fakeFunction = new TwigFunction('block', static fn ($name, $template = null) => null);
++        $args = (new CallableArgumentsExtractor($fakeNode, $fakeFunction))->extractArguments($args);
++
++        return new BlockReferenceExpression($args[0], $args[1] ?? null, $line);
++    }
++
++    /**
++     * @internal
++     */
++    public static function parseAttributeFunction(Parser $parser, Node $fakeNode, $args, int $line): AbstractExpression
++    {
++        $fakeFunction = new TwigFunction('attribute', static fn ($variable, $attribute, $arguments = null) => null);
++        $args = (new CallableArgumentsExtractor($fakeNode, $fakeFunction))->extractArguments($args);
++
++        /*
++        Deprecation to uncomment sometimes during the lifetime of the 4.x branch
++        $src = $parser->getStream()->getSourceContext();
++        $dep = new DeprecatedCallableInfo('twig/twig', '3.15', 'The "attribute" function is deprecated, use the "." notation instead.');
++        $dep->setName('attribute');
++        $dep->setType('function');
++        $dep->triggerDeprecation($src->getPath() ?: $src->getName(), $line);
++        */
++
++        return new GetAttrExpression($args[0], $args[1], $args[2] ?? null, Template::ANY_CALL, $line);
++    }
++
++    private static function getPropertyChecker(string $class, string $property): \Closure
++    {
++        static $classReflectors = [];
++
++        $class = $classReflectors[$class] ??= new \ReflectionClass($class);
++
++        if (!$class->hasProperty($property)) {
++            static $propertyExists;
++
++            return $propertyExists ??= \Closure::fromCallable('property_exists');
++        }
++
++        $property = $class->getProperty($property);
++
++        if (!$property->isPublic() || $property->isStatic()) {
++            static $false;
++
++            return $false ??= static fn () => false;
+         }
+ 
+-        return $output;
++        return static fn ($object) => $property->isInitialized($object);
+     }
+ }
+diff --git a/src/Extension/DebugExtension.php b/src/Extension/DebugExtension.php
+index cefb44c5b8d..dac21c31797 100644
+--- a/src/Extension/DebugExtension.php
++++ b/src/Extension/DebugExtension.php
+@@ -22,10 +22,8 @@ public function getFunctions(): array
+     {
+         // dump is safe if var_dump is overridden by xdebug
+         $isDumpOutputHtmlSafe = \extension_loaded('xdebug')
+-            // false means that it was not set (and the default is on) or it explicitly enabled
+-            && (false === \ini_get('xdebug.overload_var_dump') || \ini_get('xdebug.overload_var_dump'))
+-            // false means that it was not set (and the default is on) or it explicitly enabled
+-            // xdebug.overload_var_dump produces HTML only when html_errors is also enabled
++            // Xdebug overloads var_dump in develop mode when html_errors is enabled
++            && str_contains(\ini_get('xdebug.mode'), 'develop')
+             && (false === \ini_get('html_errors') || \ini_get('html_errors'))
+             || 'cli' === \PHP_SAPI
+         ;
+diff --git a/src/Extension/EscaperExtension.php b/src/Extension/EscaperExtension.php
+index d8e9b6e4814..6d9d1ce24d3 100644
+--- a/src/Extension/EscaperExtension.php
++++ b/src/Extension/EscaperExtension.php
+@@ -57,20 +57,31 @@ public function getFilters(): array
+         ];
+     }
+ 
++    public function getLastModified(): int
++    {
++        return max(
++            parent::getLastModified(),
++            filemtime((new \ReflectionClass(EscaperRuntime::class))->getFileName()),
++        );
++    }
++
+     /**
+      * @deprecated since Twig 3.10
+      */
+-    public function setEnvironment(Environment $environment, bool $triggerDeprecation = true): void
++    public function setEnvironment(Environment $environment): void
+     {
++        $triggerDeprecation = \func_num_args() > 1 ? func_get_arg(1) : true;
+         if ($triggerDeprecation) {
+             trigger_deprecation('twig/twig', '3.10', 'The "%s()" method is deprecated and not needed if you are using methods from "Twig\Runtime\EscaperRuntime".', __METHOD__);
+         }
+ 
+         $this->environment = $environment;
+-        $this->escaper = $environment->getRuntime(EscaperRuntime::class);
++        $this->escaper = null;
+     }
+ 
+     /**
++     * @return void
++     *
+      * @deprecated since Twig 3.10
+      */
+     public function setEscaperRuntime(EscaperRuntime $escaper)
+@@ -121,22 +132,22 @@ public function getDefaultStrategy(string $name)
+      * @param string                                        $strategy The strategy name that should be used as a strategy in the escape call
+      * @param callable(Environment, string, string): string $callable A valid PHP callable
+      *
++     * @return void
++     *
+      * @deprecated since Twig 3.10
+      */
+     public function setEscaper($strategy, callable $callable)
+     {
+         trigger_deprecation('twig/twig', '3.10', 'The "%s()" method is deprecated, use the "Twig\Runtime\EscaperRuntime::setEscaper()" method instead (be warned that Environment is not passed anymore to the callable).', __METHOD__);
+ 
+-        if (!isset($this->environment)) {
+-            throw new \LogicException(\sprintf('You must call "setEnvironment()" before calling "%s()".', __METHOD__));
+-        }
++        $escaper = $this->getEscaper(__METHOD__);
+ 
+         $this->escapers[$strategy] = $callable;
+         $callable = function ($string, $charset) use ($callable) {
+             return $callable($this->environment, $string, $charset);
+         };
+ 
+-        $this->escaper->setEscaper($strategy, $callable);
++        $escaper->setEscaper($strategy, $callable);
+     }
+ 
+     /**
+@@ -154,35 +165,46 @@ public function getEscapers()
+     }
+ 
+     /**
++     * @return void
++     *
+      * @deprecated since Twig 3.10
+      */
+     public function setSafeClasses(array $safeClasses = [])
+     {
+         trigger_deprecation('twig/twig', '3.10', 'The "%s()" method is deprecated, use the "Twig\Runtime\EscaperRuntime::setSafeClasses()" method instead.', __METHOD__);
+ 
+-        if (!isset($this->escaper)) {
+-            throw new \LogicException(\sprintf('You must call "setEnvironment()" before calling "%s()".', __METHOD__));
+-        }
+-
+-        $this->escaper->setSafeClasses($safeClasses);
++        $this->getEscaper(__METHOD__)->setSafeClasses($safeClasses);
+     }
+ 
+     /**
++     * @return void
++     *
+      * @deprecated since Twig 3.10
+      */
+     public function addSafeClass(string $class, array $strategies)
+     {
+         trigger_deprecation('twig/twig', '3.10', 'The "%s()" method is deprecated, use the "Twig\Runtime\EscaperRuntime::addSafeClass()" method instead.', __METHOD__);
+ 
+-        if (!isset($this->escaper)) {
+-            throw new \LogicException(\sprintf('You must call "setEnvironment()" before calling "%s()".', __METHOD__));
++        $this->getEscaper(__METHOD__)->addSafeClass($class, $strategies);
++    }
++
++    private function getEscaper(string $fromMethod): EscaperRuntime
++    {
++        if (isset($this->escaper)) {
++            return $this->escaper;
++        }
++
++        if (isset($this->environment)) {
++            return $this->escaper = $this->environment->getRuntime(EscaperRuntime::class);
+         }
+ 
+-        $this->escaper->addSafeClass($class, $strategies);
++        throw new \LogicException(\sprintf('You must call "setEnvironment()" before calling "%s()".', $fromMethod));
+     }
+ 
+     /**
+      * @internal
++     *
++     * @return array<string>
+      */
+     public static function escapeFilterIsSafe(Node $filterArgs)
+     {
+diff --git a/src/Extension/ExtensionInterface.php b/src/Extension/ExtensionInterface.php
+index 10a42b6b161..60ca35b4e6a 100644
+--- a/src/Extension/ExtensionInterface.php
++++ b/src/Extension/ExtensionInterface.php
+@@ -12,7 +12,10 @@
+ namespace Twig\Extension;
+ 
+ use Twig\ExpressionParser;
+-use Twig\Node\Expression\AbstractExpression;
++use Twig\ExpressionParser\ExpressionParserInterface;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\Node\Expression\Binary\AbstractBinary;
++use Twig\Node\Expression\Unary\AbstractUnary;
+ use Twig\NodeVisitor\NodeVisitorInterface;
+ use Twig\TokenParser\TokenParserInterface;
+ use Twig\TwigFilter;
+@@ -23,6 +26,8 @@
+  * Interface implemented by extension classes.
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @method array<ExpressionParserInterface> getExpressionParsers()
+  */
+ interface ExtensionInterface
+ {
+@@ -64,11 +69,11 @@ public function getFunctions();
+     /**
+      * Returns a list of operators to add to the existing list.
+      *
+-     * @return array<array> First array of unary operators, second array of binary operators
++     * @return array<array>
+      *
+      * @psalm-return array{
+-     *     array<string, array{precedence: int, class: class-string<AbstractExpression>}>,
+-     *     array<string, array{precedence: int, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}>
++     *     array<string, array{precedence: int, precedence_change?: PrecedenceChange, class: class-string<AbstractUnary>}>,
++     *     array<string, array{precedence: int, precedence_change?: PrecedenceChange, class?: class-string<AbstractBinary>, associativity: ExpressionParser::OPERATOR_*}>
+      * }
+      */
+     public function getOperators();
+diff --git a/src/Extension/GlobalsInterface.php b/src/Extension/GlobalsInterface.php
+index 6f1dfe8a73e..d52cd107e5e 100644
+--- a/src/Extension/GlobalsInterface.php
++++ b/src/Extension/GlobalsInterface.php
+@@ -12,10 +12,7 @@
+ namespace Twig\Extension;
+ 
+ /**
+- * Enables usage of the deprecated Twig\Extension\AbstractExtension::getGlobals() method.
+- *
+- * Explicitly implement this interface if you really need to implement the
+- * deprecated getGlobals() method in your extensions.
++ * Allows Twig extensions to add globals to the context.
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+diff --git a/src/Extension/LastModifiedExtensionInterface.php b/src/Extension/LastModifiedExtensionInterface.php
+new file mode 100644
+index 00000000000..4bab0c07cd3
+--- /dev/null
++++ b/src/Extension/LastModifiedExtensionInterface.php
+@@ -0,0 +1,23 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Extension;
++
++interface LastModifiedExtensionInterface extends ExtensionInterface
++{
++    /**
++     * Returns the last modification time of the extension for cache invalidation.
++     *
++     * This timestamp should be the last time the source code of the extension class
++     * and all its dependencies were modified (including the Runtime class).
++     */
++    public function getLastModified(): int;
++}
+diff --git a/src/Extension/OptimizerExtension.php b/src/Extension/OptimizerExtension.php
+index 965bfdb041d..d3fe46a675f 100644
+--- a/src/Extension/OptimizerExtension.php
++++ b/src/Extension/OptimizerExtension.php
+@@ -15,11 +15,9 @@
+ 
+ final class OptimizerExtension extends AbstractExtension
+ {
+-    private $optimizers;
+-
+-    public function __construct(int $optimizers = -1)
+-    {
+-        $this->optimizers = $optimizers;
++    public function __construct(
++        private int $optimizers = -1,
++    ) {
+     }
+ 
+     public function getNodeVisitors(): array
+diff --git a/src/Extension/SandboxExtension.php b/src/Extension/SandboxExtension.php
+index 255f2f28dea..5ee4c4bedd0 100644
+--- a/src/Extension/SandboxExtension.php
++++ b/src/Extension/SandboxExtension.php
+@@ -28,6 +28,10 @@ final class SandboxExtension extends AbstractExtension
+ 
+     public function __construct(SecurityPolicyInterface $policy, $sandboxed = false, ?SourcePolicyInterface $sourcePolicy = null)
+     {
++        if (null !== $sourcePolicy) {
++            trigger_deprecation('twig/twig', '3.27.0', 'The "%s" interface is deprecated with no replacement, do not pass an instance to "%s".', SourcePolicyInterface::class, self::class);
++        }
++
+         $this->policy = $policy;
+         $this->sandboxedGlobally = $sandboxed;
+         $this->sourcePolicy = $sourcePolicy;
+@@ -72,7 +76,7 @@ private function isSourceSandboxed(?Source $source): bool
+         return $this->sourcePolicy->enableSandbox($source);
+     }
+ 
+-    public function setSecurityPolicy(SecurityPolicyInterface $policy)
++    public function setSecurityPolicy(SecurityPolicyInterface $policy): void
+     {
+         $this->policy = $policy;
+     }
+@@ -117,15 +121,47 @@ public function checkPropertyAllowed($obj, $property, int $lineno = -1, ?Source
+         }
+     }
+ 
++    /**
++     * @throws SecurityNotAllowedMethodError
++     */
+     public function ensureToStringAllowed($obj, int $lineno = -1, ?Source $source = null)
++    {
++        return $this->doEnsureToStringAllowed($obj, $lineno, $source, new \SplObjectStorage());
++    }
++
++    /**
++     * Materialises a spread operand and runs the policy on every element.
++     *
++     * @internal
++     *
++     * @throws SecurityNotAllowedMethodError
++     */
++    public function ensureSpreadAllowed(iterable $obj, int $lineno = -1, ?Source $source = null): array
++    {
++        $seen = new \SplObjectStorage();
++        if ($obj instanceof \Traversable) {
++            $seen[$obj] = true;
++            $obj = iterator_to_array($obj);
++        }
++
++        $this->ensureToStringAllowedForArray($obj, $lineno, $source, $seen);
++
++        return $obj;
++    }
++
++    private function doEnsureToStringAllowed($obj, int $lineno, ?Source $source, \SplObjectStorage $seen)
+     {
+         if (\is_array($obj)) {
+-            $this->ensureToStringAllowedForArray($obj, $lineno, $source);
++            $this->ensureToStringAllowedForArray($obj, $lineno, $source, $seen);
++
++            return $obj;
++        }
+ 
++        if (!$this->isSandboxed($source)) {
+             return $obj;
+         }
+ 
+-        if ($this->isSandboxed($source) && \is_object($obj) && method_exists($obj, '__toString')) {
++        if ($obj instanceof \Stringable) {
+             try {
+                 $this->policy->checkMethodAllowed($obj, '__toString');
+             } catch (SecurityNotAllowedMethodError $e) {
+@@ -136,10 +172,38 @@ public function ensureToStringAllowed($obj, int $lineno = -1, ?Source $source =
+             }
+         }
+ 
++        // A Traversable would later be materialised (e.g. by filters such as `join`
++        // or `replace`) and its elements coerced to string by PHP itself, bypassing
++        // the policy. Materialise it now and recursively check the contents. This
++        // also applies to objects that implement both `Stringable` and `Traversable`:
++        // the `__toString` check above only validates the container's own coercion,
++        // not the elements yielded by `getIterator()`.
++        if ($obj instanceof \Traversable) {
++            // Guard against self-referencing iterables (e.g. an IteratorAggregate
++            // whose getIterator() yields $this): without this check, materialising
++            // and recursing into the elements would overflow the stack. Mirrors
++            // the array-cycle guard in ensureToStringAllowedForArray().
++            if (isset($seen[$obj])) {
++                return $obj;
++            }
++
++            $seen[$obj] = true;
++            $array = iterator_to_array($obj);
++            $this->ensureToStringAllowedForArray($array, $lineno, $source, $seen);
++
++            // Return the materialised array only when the object is not also
++            // Stringable, so that callers that rely on `__toString` (e.g. `{{ obj }}`)
++            // keep working. Plain consumers of iterables (join, replace, ...) call
++            // `iterator_to_array()` again, so the extra materialisation is benign.
++            if (!$obj instanceof \Stringable) {
++                return $array;
++            }
++        }
++
+         return $obj;
+     }
+ 
+-    private function ensureToStringAllowedForArray(array $obj, int $lineno, ?Source $source, array &$stack = []): void
++    private function ensureToStringAllowedForArray(array $obj, int $lineno, ?Source $source, \SplObjectStorage $seen, array &$stack = []): void
+     {
+         foreach ($obj as $k => $v) {
+             if (!$v) {
+@@ -147,24 +211,7 @@ private function ensureToStringAllowedForArray(array $obj, int $lineno, ?Source
+             }
+ 
+             if (!\is_array($v)) {
+-                $this->ensureToStringAllowed($v, $lineno, $source);
+-                continue;
+-            }
+-
+-            if (\PHP_VERSION_ID < 70400) {
+-                static $cookie;
+-
+-                if ($v === $cookie ?? $cookie = new \stdClass()) {
+-                    continue;
+-                }
+-
+-                $obj[$k] = $cookie;
+-                try {
+-                    $this->ensureToStringAllowedForArray($v, $lineno, $source, $stack);
+-                } finally {
+-                    $obj[$k] = $v;
+-                }
+-
++                $this->doEnsureToStringAllowed($v, $lineno, $source, $seen);
+                 continue;
+             }
+ 
+@@ -176,7 +223,7 @@ private function ensureToStringAllowedForArray(array $obj, int $lineno, ?Source
+                 $stack[$r->getId()] = true;
+             }
+ 
+-            $this->ensureToStringAllowedForArray($v, $lineno, $source, $stack);
++            $this->ensureToStringAllowedForArray($v, $lineno, $source, $seen, $stack);
+         }
+     }
+ }
+diff --git a/src/Extension/StringLoaderExtension.php b/src/Extension/StringLoaderExtension.php
+index 12f5c30aa91..da5b2dae3ff 100644
+--- a/src/Extension/StringLoaderExtension.php
++++ b/src/Extension/StringLoaderExtension.php
+@@ -29,12 +29,14 @@ public function getFunctions(): array
+      *
+      *     {{ include(template_from_string("Hello {{ name }}")) }}
+      *
+-     * @param string      $template A template as a string or object implementing __toString()
+-     * @param string|null $name     An optional name of the template to be used in error messages
++     * Never expose `template_from_string` to untrusted template
++     * authors (like in a sandboxed environment). See the docs for more details.
++     *
++     * @param string|null $name An optional name of the template to be used in error messages
+      *
+      * @internal
+      */
+-    public static function templateFromString(Environment $env, $template, ?string $name = null): TemplateWrapper
++    public static function templateFromString(Environment $env, string|\Stringable $template, ?string $name = null): TemplateWrapper
+     {
+         return $env->createTemplate((string) $template, $name);
+     }
+diff --git a/src/Extension/YieldNotReadyExtension.php b/src/Extension/YieldNotReadyExtension.php
+index 2503c8d8140..49dfb808569 100644
+--- a/src/Extension/YieldNotReadyExtension.php
++++ b/src/Extension/YieldNotReadyExtension.php
+@@ -18,11 +18,9 @@
+  */
+ final class YieldNotReadyExtension extends AbstractExtension
+ {
+-    private $useYield;
+-
+-    public function __construct(bool $useYield)
+-    {
+-        $this->useYield = $useYield;
++    public function __construct(
++        private bool $useYield,
++    ) {
+     }
+ 
+     public function getNodeVisitors(): array
+diff --git a/src/ExtensionSet.php b/src/ExtensionSet.php
+index 8b59a13e186..7bb62fa781f 100644
+--- a/src/ExtensionSet.php
++++ b/src/ExtensionSet.php
+@@ -12,15 +12,25 @@
+ namespace Twig;
+ 
+ use Twig\Error\RuntimeError;
++use Twig\ExpressionParser\ExpressionParsers;
++use Twig\ExpressionParser\Infix\BinaryOperatorExpressionParser;
++use Twig\ExpressionParser\InfixAssociativity;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\ExpressionParser\PrecedenceChange;
++use Twig\ExpressionParser\Prefix\UnaryOperatorExpressionParser;
++use Twig\Extension\AttributeExtension;
+ use Twig\Extension\ExtensionInterface;
+ use Twig\Extension\GlobalsInterface;
++use Twig\Extension\LastModifiedExtensionInterface;
+ use Twig\Extension\StagingExtension;
+ use Twig\Node\Expression\AbstractExpression;
+-use Twig\Node\Expression\Binary\AbstractBinary;
+-use Twig\Node\Expression\Unary\AbstractUnary;
+ use Twig\NodeVisitor\NodeVisitorInterface;
+ use Twig\TokenParser\TokenParserInterface;
+ 
++// Help opcache.preload discover always-needed symbols
++// @see https://github.com/php/php-src/issues/10131
++class_exists(BinaryOperatorExpressionParser::class);
++
+ /**
+  * @author Fabien Potencier <fabien@symfony.com>
+  *
+@@ -36,18 +46,26 @@ final class ExtensionSet
+     private $visitors;
+     /** @var array<string, TwigFilter> */
+     private $filters;
++    /** @var array<string, TwigFilter> */
++    private $dynamicFilters;
+     /** @var array<string, TwigTest> */
+     private $tests;
++    /** @var array<string, TwigTest> */
++    private $dynamicTests;
+     /** @var array<string, TwigFunction> */
+     private $functions;
+-    /** @var array<string, array{precedence: int, class: class-string<AbstractExpression>}> */
+-    private $unaryOperators;
+-    /** @var array<string, array{precedence: int, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}> */
+-    private $binaryOperators;
+-    /** @var array<string, mixed> */
++    /** @var array<string, TwigFunction> */
++    private $dynamicFunctions;
++    private ExpressionParsers $expressionParsers;
++    /** @var array<string, mixed>|null */
+     private $globals;
++    /** @var array<callable(string): (TwigFunction|false)> */
+     private $functionCallbacks = [];
++    /** @var array<callable(string): (TwigFilter|false)> */
+     private $filterCallbacks = [];
++    /** @var array<callable(string): (TwigTest|false)> */
++    private $testCallbacks = [];
++    /** @var array<callable(string): (TokenParserInterface|false)> */
+     private $parserCallbacks = [];
+     private $lastModified = 0;
+ 
+@@ -56,6 +74,9 @@ public function __construct()
+         $this->staging = new StagingExtension();
+     }
+ 
++    /**
++     * @return void
++     */
+     public function initRuntime()
+     {
+         $this->runtimeInitialized = true;
+@@ -111,19 +132,28 @@ public function getLastModified(): int
+             return $this->lastModified;
+         }
+ 
++        $lastModified = 0;
+         foreach ($this->extensions as $extension) {
+-            $r = new \ReflectionObject($extension);
+-            if (is_file($r->getFileName()) && ($extensionTime = filemtime($r->getFileName())) > $this->lastModified) {
+-                $this->lastModified = $extensionTime;
++            if ($extension instanceof LastModifiedExtensionInterface) {
++                $lastModified = max($extension->getLastModified(), $lastModified);
++            } else {
++                $r = new \ReflectionObject($extension);
++                if (is_file($r->getFileName())) {
++                    $lastModified = max(filemtime($r->getFileName()), $lastModified);
++                }
+             }
+         }
+ 
+-        return $this->lastModified;
++        return $this->lastModified = $lastModified;
+     }
+ 
+     public function addExtension(ExtensionInterface $extension): void
+     {
+-        $class = \get_class($extension);
++        if ($extension instanceof AttributeExtension) {
++            $class = $extension->getClass();
++        } else {
++            $class = $extension::class;
++        }
+ 
+         if ($this->initialized) {
+             throw new \LogicException(\sprintf('Unable to register extension "%s" as extensions have already been initialized.', $class));
+@@ -167,14 +197,11 @@ public function getFunction(string $name): ?TwigFunction
+             return $this->functions[$name];
+         }
+ 
+-        foreach ($this->functions as $pattern => $function) {
+-            $pattern = str_replace('\\*', '(.*?)', preg_quote($pattern, '#'), $count);
+-
+-            if ($count && preg_match('#^'.$pattern.'$#', $name, $matches)) {
++        foreach ($this->dynamicFunctions as $pattern => $function) {
++            if (preg_match($pattern, $name, $matches)) {
+                 array_shift($matches);
+-                $function->setArguments($matches);
+ 
+-                return $function;
++                return $function->withDynamicArguments($name, $function->getName(), $matches);
+             }
+         }
+ 
+@@ -187,6 +214,9 @@ public function getFunction(string $name): ?TwigFunction
+         return null;
+     }
+ 
++    /**
++     * @param callable(string): (TwigFunction|false) $callable
++     */
+     public function registerUndefinedFunctionCallback(callable $callable): void
+     {
+         $this->functionCallbacks[] = $callable;
+@@ -223,14 +253,11 @@ public function getFilter(string $name): ?TwigFilter
+             return $this->filters[$name];
+         }
+ 
+-        foreach ($this->filters as $pattern => $filter) {
+-            $pattern = str_replace('\\*', '(.*?)', preg_quote($pattern, '#'), $count);
+-
+-            if ($count && preg_match('#^'.$pattern.'$#', $name, $matches)) {
++        foreach ($this->dynamicFilters as $pattern => $filter) {
++            if (preg_match($pattern, $name, $matches)) {
+                 array_shift($matches);
+-                $filter->setArguments($matches);
+ 
+-                return $filter;
++                return $filter->withDynamicArguments($name, $filter->getName(), $matches);
+             }
+         }
+ 
+@@ -243,6 +270,9 @@ public function getFilter(string $name): ?TwigFilter
+         return null;
+     }
+ 
++    /**
++     * @param callable(string): (TwigFilter|false) $callable
++     */
+     public function registerUndefinedFilterCallback(callable $callable): void
+     {
+         $this->filterCallbacks[] = $callable;
+@@ -309,6 +339,9 @@ public function getTokenParser(string $name): ?TokenParserInterface
+         return null;
+     }
+ 
++    /**
++     * @param callable(string): (TokenParserInterface|false) $callable
++     */
+     public function registerUndefinedTokenParserCallback(callable $callable): void
+     {
+         $this->parserCallbacks[] = $callable;
+@@ -329,12 +362,7 @@ public function getGlobals(): array
+                 continue;
+             }
+ 
+-            $extGlobals = $extension->getGlobals();
+-            if (!\is_array($extGlobals)) {
+-                throw new \UnexpectedValueException(\sprintf('"%s::getGlobals()" must return an array of globals.', \get_class($extension)));
+-            }
+-
+-            $globals = array_merge($globals, $extGlobals);
++            $globals = array_merge($globals, $extension->getGlobals());
+         }
+ 
+         if ($this->initialized) {
+@@ -344,6 +372,11 @@ public function getGlobals(): array
+         return $globals;
+     }
+ 
++    public function resetGlobals(): void
++    {
++        $this->globals = null;
++    }
++
+     public function addTest(TwigTest $test): void
+     {
+         if ($this->initialized) {
+@@ -375,16 +408,17 @@ public function getTest(string $name): ?TwigTest
+             return $this->tests[$name];
+         }
+ 
+-        foreach ($this->tests as $pattern => $test) {
+-            $pattern = str_replace('\\*', '(.*?)', preg_quote($pattern, '#'), $count);
++        foreach ($this->dynamicTests as $pattern => $test) {
++            if (preg_match($pattern, $name, $matches)) {
++                array_shift($matches);
+ 
+-            if ($count) {
+-                if (preg_match('#^'.$pattern.'$#', $name, $matches)) {
+-                    array_shift($matches);
+-                    $test->setArguments($matches);
++                return $test->withDynamicArguments($name, $test->getName(), $matches);
++            }
++        }
+ 
+-                    return $test;
+-                }
++        foreach ($this->testCallbacks as $callback) {
++            if (false !== $test = $callback($name)) {
++                return $test;
+             }
+         }
+ 
+@@ -392,27 +426,20 @@ public function getTest(string $name): ?TwigTest
+     }
+ 
+     /**
+-     * @return array<string, array{precedence: int, class: class-string<AbstractExpression>}>
++     * @param callable(string): (TwigTest|false) $callable
+      */
+-    public function getUnaryOperators(): array
++    public function registerUndefinedTestCallback(callable $callable): void
+     {
+-        if (!$this->initialized) {
+-            $this->initExtensions();
+-        }
+-
+-        return $this->unaryOperators;
++        $this->testCallbacks[] = $callable;
+     }
+ 
+-    /**
+-     * @return array<string, array{precedence: int, class?: class-string<AbstractExpression>, associativity: ExpressionParser::OPERATOR_*}>
+-     */
+-    public function getBinaryOperators(): array
++    public function getExpressionParsers(): ExpressionParsers
+     {
+         if (!$this->initialized) {
+             $this->initExtensions();
+         }
+ 
+-        return $this->binaryOperators;
++        return $this->expressionParsers;
+     }
+ 
+     private function initExtensions(): void
+@@ -421,9 +448,11 @@ private function initExtensions(): void
+         $this->filters = [];
+         $this->functions = [];
+         $this->tests = [];
++        $this->dynamicFilters = [];
++        $this->dynamicFunctions = [];
++        $this->dynamicTests = [];
+         $this->visitors = [];
+-        $this->unaryOperators = [];
+-        $this->binaryOperators = [];
++        $this->expressionParsers = new ExpressionParsers();
+ 
+         foreach ($this->extensions as $extension) {
+             $this->initExtension($extension);
+@@ -437,17 +466,26 @@ private function initExtension(ExtensionInterface $extension): void
+     {
+         // filters
+         foreach ($extension->getFilters() as $filter) {
+-            $this->filters[$filter->getName()] = $filter;
++            $this->filters[$name = $filter->getName()] = $filter;
++            if (str_contains($name, '*')) {
++                $this->dynamicFilters['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $filter;
++            }
+         }
+ 
+         // functions
+         foreach ($extension->getFunctions() as $function) {
+-            $this->functions[$function->getName()] = $function;
++            $this->functions[$name = $function->getName()] = $function;
++            if (str_contains($name, '*')) {
++                $this->dynamicFunctions['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $function;
++            }
+         }
+ 
+         // tests
+         foreach ($extension->getTests() as $test) {
+-            $this->tests[$test->getName()] = $test;
++            $this->tests[$name = $test->getName()] = $test;
++            if (str_contains($name, '*')) {
++                $this->dynamicTests['#^'.str_replace('\\*', '(.*?)', preg_quote($name, '#')).'$#'] = $test;
++            }
+         }
+ 
+         // token parsers
+@@ -464,18 +502,66 @@ private function initExtension(ExtensionInterface $extension): void
+             $this->visitors[] = $visitor;
+         }
+ 
+-        // operators
+-        if ($operators = $extension->getOperators()) {
+-            if (!\is_array($operators)) {
+-                throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array with operators, got "%s".', \get_class($extension), \is_object($operators) ? \get_class($operators) : \gettype($operators).(\is_resource($operators) ? '' : '#'.$operators)));
+-            }
++        // expression parsers
++        if (method_exists($extension, 'getExpressionParsers')) {
++            $this->expressionParsers->add($extension->getExpressionParsers());
++        }
++
++        $operators = $extension->getOperators();
++        if (!\is_array($operators)) {
++            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array with operators, got "%s".', $extension::class, get_debug_type($operators).(\is_resource($operators) ? '' : '#'.$operators)));
++        }
+ 
+-            if (2 !== \count($operators)) {
+-                throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array of 2 elements, got %d.', \get_class($extension), \count($operators)));
++        if (2 !== \count($operators)) {
++            throw new \InvalidArgumentException(\sprintf('"%s::getOperators()" must return an array of 2 elements, got %d.', $extension::class, \count($operators)));
++        }
++
++        $expressionParsers = [];
++        foreach ($operators[0] as $operator => $op) {
++            $expressionParsers[] = new UnaryOperatorExpressionParser($op['class'], $operator, $op['precedence'], $op['precedence_change'] ?? null, '', $op['aliases'] ?? []);
++        }
++        foreach ($operators[1] as $operator => $op) {
++            $op['associativity'] = match ($op['associativity']) {
++                1 => InfixAssociativity::Left,
++                2 => InfixAssociativity::Right,
++                default => throw new \InvalidArgumentException(\sprintf('Invalid associativity "%s" for operator "%s".', $op['associativity'], $operator)),
++            };
++
++            if (isset($op['callable'])) {
++                $expressionParsers[] = $this->convertInfixExpressionParser($op['class'], $operator, $op['precedence'], $op['associativity'], $op['precedence_change'] ?? null, $op['aliases'] ?? [], $op['callable']);
++            } else {
++                $expressionParsers[] = new BinaryOperatorExpressionParser($op['class'], $operator, $op['precedence'], $op['associativity'], $op['precedence_change'] ?? null, '', $op['aliases'] ?? []);
+             }
++        }
++
++        if (\count($expressionParsers)) {
++            trigger_deprecation('twig/twig', '3.21', \sprintf('Extension "%s" uses the old signature for "getOperators()", please implement "getExpressionParsers()" instead.', $extension::class));
+ 
+-            $this->unaryOperators = array_merge($this->unaryOperators, $operators[0]);
+-            $this->binaryOperators = array_merge($this->binaryOperators, $operators[1]);
++            $this->expressionParsers->add($expressionParsers);
+         }
+     }
++
++    private function convertInfixExpressionParser(string $nodeClass, string $operator, int $precedence, InfixAssociativity $associativity, ?PrecedenceChange $precedenceChange, array $aliases, callable $callable): InfixExpressionParserInterface
++    {
++        trigger_deprecation('twig/twig', '3.21', \sprintf('Using a non-ExpressionParserInterface object to define the "%s" binary operator is deprecated.', $operator));
++
++        return new class($nodeClass, $operator, $precedence, $associativity, $precedenceChange, $aliases, $callable) extends BinaryOperatorExpressionParser {
++            public function __construct(
++                string $nodeClass,
++                string $operator,
++                int $precedence,
++                InfixAssociativity $associativity = InfixAssociativity::Left,
++                ?PrecedenceChange $precedenceChange = null,
++                array $aliases = [],
++                private $callable = null,
++            ) {
++                parent::__construct($nodeClass, $operator, $precedence, $associativity, $precedenceChange, $aliases);
++            }
++
++            public function parse(Parser $parser, AbstractExpression $expr, Token $token): AbstractExpression
++            {
++                return ($this->callable)($parser, $expr);
++            }
++        };
++    }
+ }
+diff --git a/src/FileExtensionEscapingStrategy.php b/src/FileExtensionEscapingStrategy.php
+index 812071bf971..2785ab7f497 100644
+--- a/src/FileExtensionEscapingStrategy.php
++++ b/src/FileExtensionEscapingStrategy.php
+@@ -33,7 +33,7 @@ class FileExtensionEscapingStrategy
+      */
+     public static function guess(string $name)
+     {
+-        if (\in_array(substr($name, -1), ['/', '\\'])) {
++        if (\in_array(substr($name, -1), ['/', '\\'], true)) {
+             return 'html'; // return html for directories
+         }
+ 
+@@ -45,6 +45,7 @@ public static function guess(string $name)
+ 
+         switch ($extension) {
+             case 'js':
++            case 'json':
+                 return 'js';
+ 
+             case 'css':
+diff --git a/src/Lexer.php b/src/Lexer.php
+index 8973fbbc8da..e65f5bedc7d 100644
+--- a/src/Lexer.php
++++ b/src/Lexer.php
+@@ -13,6 +13,7 @@
+ namespace Twig;
+ 
+ use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\ExpressionParsers;
+ 
+ /**
+  * @author Fabien Potencier <fabien@symfony.com>
+@@ -36,6 +37,8 @@ class Lexer
+     private $position;
+     private $positions;
+     private $currentVarBlockLine;
++    private array $openingBrackets = ['{', '(', '['];
++    private array $closingBrackets = ['}', ')', ']'];
+ 
+     public const STATE_DATA = 0;
+     public const STATE_BLOCK = 1;
+@@ -44,12 +47,29 @@ class Lexer
+     public const STATE_INTERPOLATION = 4;
+ 
+     public const REGEX_NAME = '/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/A';
+-    public const REGEX_NUMBER = '/[0-9]+(?:\.[0-9]+)?([Ee][\+\-][0-9]+)?/A';
+     public const REGEX_STRING = '/"([^#"\\\\]*(?:\\\\.[^#"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\'/As';
++
++    public const REGEX_NUMBER = '/(?(DEFINE)
++        (?<LNUM>[0-9]+(_[0-9]+)*)               # Integers (with underscores)   123_456
++        (?<FRAC>\.(?&LNUM))                     # Fractional part               .456
++        (?<EXPONENT>[eE][+-]?(?&LNUM))          # Exponent part                 E+10
++        (?<DNUM>(?&LNUM)(?:(?&FRAC))?)          # Decimal number                123_456.456
++    )(?:(?&DNUM)(?:(?&EXPONENT))?)              #                               123_456.456E+10
++    /Ax';
++
+     public const REGEX_DQ_STRING_DELIM = '/"/A';
+     public const REGEX_DQ_STRING_PART = '/[^#"\\\\]*(?:(?:\\\\.|#(?!\{))[^#"\\\\]*)*/As';
++    public const REGEX_INLINE_COMMENT = '/#[^\n]*/A';
+     public const PUNCTUATION = '()[]{}?:.,|';
+ 
++    private const SPECIAL_CHARS = [
++        'f' => "\f",
++        'n' => "\n",
++        'r' => "\r",
++        't' => "\t",
++        'v' => "\v",
++    ];
++
+     public function __construct(Environment $env, array $options = [])
+     {
+         $this->env = $env;
+@@ -65,7 +85,7 @@ public function __construct(Environment $env, array $options = [])
+         ], $options);
+     }
+ 
+-    private function initialize()
++    private function initialize(): void
+     {
+         if ($this->isInitialized) {
+             return;
+@@ -207,9 +227,9 @@ public function tokenize(Source $source): TokenStream
+             }
+         }
+ 
+-        $this->pushToken(/* Token::EOF_TYPE */ -1);
++        $this->pushToken(Token::EOF_TYPE);
+ 
+-        if (!empty($this->brackets)) {
++        if ($this->brackets) {
+             [$expect, $lineno] = array_pop($this->brackets);
+             throw new SyntaxError(\sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
+         }
+@@ -221,7 +241,7 @@ private function lexData(): void
+     {
+         // if no matches are left we return the rest of the template as simple text token
+         if ($this->position == \count($this->positions[0]) - 1) {
+-            $this->pushToken(/* Token::TEXT_TYPE */ 0, substr($this->code, $this->cursor));
++            $this->pushToken(Token::TEXT_TYPE, substr($this->code, $this->cursor));
+             $this->cursor = $this->end;
+ 
+             return;
+@@ -250,7 +270,7 @@ private function lexData(): void
+                 $text = rtrim($text, " \t\0\x0B");
+             }
+         }
+-        $this->pushToken(/* Token::TEXT_TYPE */ 0, $text);
++        $this->pushToken(Token::TEXT_TYPE, $text);
+         $this->moveCursor($textContent.$position[0]);
+ 
+         switch ($this->positions[1][$this->position][0]) {
+@@ -268,14 +288,14 @@ private function lexData(): void
+                     $this->moveCursor($match[0]);
+                     $this->lineno = (int) $match[1];
+                 } else {
+-                    $this->pushToken(/* Token::BLOCK_START_TYPE */ 1);
++                    $this->pushToken(Token::BLOCK_START_TYPE);
+                     $this->pushState(self::STATE_BLOCK);
+                     $this->currentVarBlockLine = $this->lineno;
+                 }
+                 break;
+ 
+             case $this->options['tag_variable'][0]:
+-                $this->pushToken(/* Token::VAR_START_TYPE */ 2);
++                $this->pushToken(Token::VAR_START_TYPE);
+                 $this->pushState(self::STATE_VAR);
+                 $this->currentVarBlockLine = $this->lineno;
+                 break;
+@@ -284,8 +304,8 @@ private function lexData(): void
+ 
+     private function lexBlock(): void
+     {
+-        if (empty($this->brackets) && preg_match($this->regexes['lex_block'], $this->code, $match, 0, $this->cursor)) {
+-            $this->pushToken(/* Token::BLOCK_END_TYPE */ 3);
++        if (!$this->brackets && preg_match($this->regexes['lex_block'], $this->code, $match, 0, $this->cursor)) {
++            $this->pushToken(Token::BLOCK_END_TYPE);
+             $this->moveCursor($match[0]);
+             $this->popState();
+         } else {
+@@ -295,8 +315,8 @@ private function lexBlock(): void
+ 
+     private function lexVar(): void
+     {
+-        if (empty($this->brackets) && preg_match($this->regexes['lex_var'], $this->code, $match, 0, $this->cursor)) {
+-            $this->pushToken(/* Token::VAR_END_TYPE */ 4);
++        if (!$this->brackets && preg_match($this->regexes['lex_var'], $this->code, $match, 0, $this->cursor)) {
++            $this->pushToken(Token::VAR_END_TYPE);
+             $this->moveCursor($match[0]);
+             $this->popState();
+         } else {
+@@ -315,59 +335,34 @@ private function lexExpression(): void
+             }
+         }
+ 
+-        // spread operator
+-        if ('.' === $this->code[$this->cursor] && ($this->cursor + 2 < $this->end) && '.' === $this->code[$this->cursor + 1] && '.' === $this->code[$this->cursor + 2]) {
+-            $this->pushToken(Token::SPREAD_TYPE, '...');
+-            $this->moveCursor('...');
+-        }
+-        // arrow function
+-        elseif ('=' === $this->code[$this->cursor] && ($this->cursor + 1 < $this->end) && '>' === $this->code[$this->cursor + 1]) {
+-            $this->pushToken(Token::ARROW_TYPE, '=>');
+-            $this->moveCursor('=>');
+-        }
+         // operators
+-        elseif (preg_match($this->regexes['operator'], $this->code, $match, 0, $this->cursor)) {
+-            $this->pushToken(/* Token::OPERATOR_TYPE */ 8, preg_replace('/\s+/', ' ', $match[0]));
++        if (preg_match($this->regexes['operator'], $this->code, $match, 0, $this->cursor)) {
++            $operator = preg_replace('/\s+/', ' ', $match[0]);
++            if (\in_array($operator, $this->openingBrackets, true)) {
++                $this->checkBrackets($operator);
++            }
++            $this->pushToken(Token::OPERATOR_TYPE, $operator);
+             $this->moveCursor($match[0]);
+         }
+         // names
+         elseif (preg_match(self::REGEX_NAME, $this->code, $match, 0, $this->cursor)) {
+-            $this->pushToken(/* Token::NAME_TYPE */ 5, $match[0]);
++            $this->pushToken(Token::NAME_TYPE, $match[0]);
+             $this->moveCursor($match[0]);
+         }
+         // numbers
+         elseif (preg_match(self::REGEX_NUMBER, $this->code, $match, 0, $this->cursor)) {
+-            $number = (float) $match[0];  // floats
+-            if (ctype_digit($match[0]) && $number <= \PHP_INT_MAX) {
+-                $number = (int) $match[0]; // integers lower than the maximum
+-            }
+-            $this->pushToken(/* Token::NUMBER_TYPE */ 6, $number);
++            $this->pushToken(Token::NUMBER_TYPE, 0 + str_replace('_', '', $match[0]));
+             $this->moveCursor($match[0]);
+         }
+         // punctuation
+         elseif (str_contains(self::PUNCTUATION, $this->code[$this->cursor])) {
+-            // opening bracket
+-            if (str_contains('([{', $this->code[$this->cursor])) {
+-                $this->brackets[] = [$this->code[$this->cursor], $this->lineno];
+-            }
+-            // closing bracket
+-            elseif (str_contains(')]}', $this->code[$this->cursor])) {
+-                if (empty($this->brackets)) {
+-                    throw new SyntaxError(\sprintf('Unexpected "%s".', $this->code[$this->cursor]), $this->lineno, $this->source);
+-                }
+-
+-                [$expect, $lineno] = array_pop($this->brackets);
+-                if ($this->code[$this->cursor] != strtr($expect, '([{', ')]}')) {
+-                    throw new SyntaxError(\sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
+-                }
+-            }
+-
+-            $this->pushToken(/* Token::PUNCTUATION_TYPE */ 9, $this->code[$this->cursor]);
++            $this->checkBrackets($this->code[$this->cursor]);
++            $this->pushToken(Token::PUNCTUATION_TYPE, $this->code[$this->cursor]);
+             ++$this->cursor;
+         }
+         // strings
+         elseif (preg_match(self::REGEX_STRING, $this->code, $match, 0, $this->cursor)) {
+-            $this->pushToken(/* Token::STRING_TYPE */ 7, stripcslashes(substr($match[0], 1, -1)));
++            $this->pushToken(Token::STRING_TYPE, $this->stripcslashes(substr($match[0], 1, -1), substr($match[0], 0, 1)));
+             $this->moveCursor($match[0]);
+         }
+         // opening double quoted string
+@@ -376,12 +371,73 @@ private function lexExpression(): void
+             $this->pushState(self::STATE_STRING);
+             $this->moveCursor($match[0]);
+         }
++        // inline comment
++        elseif (preg_match(self::REGEX_INLINE_COMMENT, $this->code, $match, 0, $this->cursor)) {
++            $this->moveCursor($match[0]);
++        }
+         // unlexable
+         else {
+             throw new SyntaxError(\sprintf('Unexpected character "%s".', $this->code[$this->cursor]), $this->lineno, $this->source);
+         }
+     }
+ 
++    private function stripcslashes(string $str, string $quoteType): string
++    {
++        $result = '';
++        $length = \strlen($str);
++
++        $i = 0;
++        while ($i < $length) {
++            if (false === $pos = strpos($str, '\\', $i)) {
++                $result .= substr($str, $i);
++                break;
++            }
++
++            $result .= substr($str, $i, $pos - $i);
++            $i = $pos + 1;
++
++            if ($i >= $length) {
++                $result .= '\\';
++                break;
++            }
++
++            $nextChar = $str[$i];
++
++            if (isset(self::SPECIAL_CHARS[$nextChar])) {
++                $result .= self::SPECIAL_CHARS[$nextChar];
++            } elseif ('\\' === $nextChar) {
++                $result .= $nextChar;
++            } elseif ("'" === $nextChar || '"' === $nextChar) {
++                if ($nextChar !== $quoteType) {
++                    trigger_deprecation('twig/twig', '3.12', 'Character "%s" should not be escaped; the "\" character is ignored in Twig 3 but will not be in Twig 4. Please remove the extra "\" character at position %d in "%s" at line %d.', $nextChar, $i + 1, $this->source->getName(), $this->lineno);
++                }
++                $result .= $nextChar;
++            } elseif ('#' === $nextChar && $i + 1 < $length && '{' === $str[$i + 1]) {
++                $result .= '#{';
++                ++$i;
++            } elseif ('x' === $nextChar && $i + 1 < $length && ctype_xdigit($str[$i + 1])) {
++                $hex = $str[++$i];
++                if ($i + 1 < $length && ctype_xdigit($str[$i + 1])) {
++                    $hex .= $str[++$i];
++                }
++                $result .= \chr(hexdec($hex));
++            } elseif (ctype_digit($nextChar) && $nextChar < '8') {
++                $octal = $nextChar;
++                while ($i + 1 < $length && ctype_digit($str[$i + 1]) && $str[$i + 1] < '8' && \strlen($octal) < 3) {
++                    $octal .= $str[++$i];
++                }
++                $result .= \chr(octdec($octal));
++            } else {
++                trigger_deprecation('twig/twig', '3.12', 'Character "%s" should not be escaped; the "\" character is ignored in Twig 3 but will not be in Twig 4. Please remove the extra "\" character at position %d in "%s" at line %d.', $nextChar, $i + 1, $this->source->getName(), $this->lineno);
++                $result .= $nextChar;
++            }
++
++            ++$i;
++        }
++
++        return $result;
++    }
++
+     private function lexRawData(): void
+     {
+         if (!preg_match($this->regexes['lex_raw_data'], $this->code, $match, \PREG_OFFSET_CAPTURE, $this->cursor)) {
+@@ -403,7 +459,7 @@ private function lexRawData(): void
+             }
+         }
+ 
+-        $this->pushToken(/* Token::TEXT_TYPE */ 0, $text);
++        $this->pushToken(Token::TEXT_TYPE, $text);
+     }
+ 
+     private function lexComment(): void
+@@ -419,11 +475,11 @@ private function lexString(): void
+     {
+         if (preg_match($this->regexes['interpolation_start'], $this->code, $match, 0, $this->cursor)) {
+             $this->brackets[] = [$this->options['interpolation'][0], $this->lineno];
+-            $this->pushToken(/* Token::INTERPOLATION_START_TYPE */ 10);
++            $this->pushToken(Token::INTERPOLATION_START_TYPE);
+             $this->moveCursor($match[0]);
+             $this->pushState(self::STATE_INTERPOLATION);
+         } elseif (preg_match(self::REGEX_DQ_STRING_PART, $this->code, $match, 0, $this->cursor) && '' !== $match[0]) {
+-            $this->pushToken(/* Token::STRING_TYPE */ 7, stripcslashes($match[0]));
++            $this->pushToken(Token::STRING_TYPE, $this->stripcslashes($match[0], '"'));
+             $this->moveCursor($match[0]);
+         } elseif (preg_match(self::REGEX_DQ_STRING_DELIM, $this->code, $match, 0, $this->cursor)) {
+             [$expect, $lineno] = array_pop($this->brackets);
+@@ -444,7 +500,7 @@ private function lexInterpolation(): void
+         $bracket = end($this->brackets);
+         if ($this->options['interpolation'][0] === $bracket[0] && preg_match($this->regexes['interpolation_end'], $this->code, $match, 0, $this->cursor)) {
+             array_pop($this->brackets);
+-            $this->pushToken(/* Token::INTERPOLATION_END_TYPE */ 11);
++            $this->pushToken(Token::INTERPOLATION_END_TYPE);
+             $this->moveCursor($match[0]);
+             $this->popState();
+         } else {
+@@ -455,7 +511,7 @@ private function lexInterpolation(): void
+     private function pushToken($type, $value = ''): void
+     {
+         // do not push empty text tokens
+-        if (/* Token::TEXT_TYPE */ 0 === $type && '' === $value) {
++        if (Token::TEXT_TYPE === $type && '' === $value) {
+             return;
+         }
+ 
+@@ -470,27 +526,26 @@ private function moveCursor($text): void
+ 
+     private function getOperatorRegex(): string
+     {
+-        $operators = array_merge(
+-            ['='],
+-            array_keys($this->env->getUnaryOperators()),
+-            array_keys($this->env->getBinaryOperators())
+-        );
++        $expressionParsers = [];
++        foreach ($this->env->getExpressionParsers() as $expressionParser) {
++            $expressionParsers = array_merge($expressionParsers, ExpressionParsers::getOperatorTokensFor($expressionParser));
++        }
+ 
+-        $operators = array_combine($operators, array_map('strlen', $operators));
+-        arsort($operators);
++        $expressionParsers = array_combine($expressionParsers, array_map('strlen', $expressionParsers));
++        arsort($expressionParsers);
+ 
+         $regex = [];
+-        foreach ($operators as $operator => $length) {
++        foreach ($expressionParsers as $expressionParser => $length) {
+             // an operator that ends with a character must be followed by
+             // a whitespace, a parenthesis, an opening map [ or sequence {
+-            $r = preg_quote($operator, '/');
+-            if (ctype_alpha($operator[$length - 1])) {
++            $r = preg_quote($expressionParser, '/');
++            if (ctype_alpha($expressionParser[$length - 1])) {
+                 $r .= '(?=[\s()\[{])';
+             }
+ 
+             // an operator that begins with a character must not have a dot or pipe before
+-            if (ctype_alpha($operator[0])) {
+-                $r = '(?<![\.\|])'.$r;
++            if (ctype_alpha($expressionParser[0])) {
++                $r = '(?<![\.\|]\s|.[\.\|])'.$r;
+             }
+ 
+             // an operator with a space can be any amount of whitespaces
+@@ -516,4 +571,22 @@ private function popState(): void
+ 
+         $this->state = array_pop($this->states);
+     }
++
++    private function checkBrackets(string $code): void
++    {
++        // opening bracket
++        if (\in_array($code, $this->openingBrackets, true)) {
++            $this->brackets[] = [$code, $this->lineno];
++        } elseif (\in_array($code, $this->closingBrackets, true)) {
++            // closing bracket
++            if (!$this->brackets) {
++                throw new SyntaxError(\sprintf('Unexpected "%s".', $code), $this->lineno, $this->source);
++            }
++
++            [$expect, $lineno] = array_pop($this->brackets);
++            if ($code !== str_replace($this->openingBrackets, $this->closingBrackets, $expect)) {
++                throw new SyntaxError(\sprintf('Unclosed "%s".', $expect), $lineno, $this->source);
++            }
++        }
++    }
+ }
+diff --git a/src/Loader/ArrayLoader.php b/src/Loader/ArrayLoader.php
+index ce613c9cc1e..2bb54b7a8df 100644
+--- a/src/Loader/ArrayLoader.php
++++ b/src/Loader/ArrayLoader.php
+@@ -28,14 +28,12 @@
+  */
+ final class ArrayLoader implements LoaderInterface
+ {
+-    private $templates = [];
+-
+     /**
+      * @param array $templates An array of templates (keys are the names, and values are the source code)
+      */
+-    public function __construct(array $templates = [])
+-    {
+-        $this->templates = $templates;
++    public function __construct(
++        private array $templates = [],
++    ) {
+     }
+ 
+     public function setTemplate(string $name, string $template): void
+diff --git a/src/Loader/ChainLoader.php b/src/Loader/ChainLoader.php
+index 163c029f848..0859dcd2f76 100644
+--- a/src/Loader/ChainLoader.php
++++ b/src/Loader/ChainLoader.php
+@@ -21,22 +21,28 @@
+  */
+ final class ChainLoader implements LoaderInterface
+ {
++    /**
++     * @var array<string, bool>
++     */
+     private $hasSourceCache = [];
+-    private $loaders = [];
+ 
+     /**
+-     * @param LoaderInterface[] $loaders
++     * @param iterable<LoaderInterface> $loaders
+      */
+-    public function __construct(array $loaders = [])
+-    {
+-        foreach ($loaders as $loader) {
+-            $this->addLoader($loader);
+-        }
++    public function __construct(
++        private iterable $loaders = [],
++    ) {
+     }
+ 
+     public function addLoader(LoaderInterface $loader): void
+     {
+-        $this->loaders[] = $loader;
++        $current = $this->loaders;
++
++        $this->loaders = (static function () use ($current, $loader): \Generator {
++            yield from $current;
++            yield $loader;
++        })();
++
+         $this->hasSourceCache = [];
+     }
+ 
+@@ -45,13 +51,18 @@ public function addLoader(LoaderInterface $loader): void
+      */
+     public function getLoaders(): array
+     {
++        if (!\is_array($this->loaders)) {
++            $this->loaders = iterator_to_array($this->loaders, false);
++        }
++
+         return $this->loaders;
+     }
+ 
+     public function getSourceContext(string $name): Source
+     {
+         $exceptions = [];
+-        foreach ($this->loaders as $loader) {
++
++        foreach ($this->getLoaders() as $loader) {
+             if (!$loader->exists($name)) {
+                 continue;
+             }
+@@ -72,7 +83,7 @@ public function exists(string $name): bool
+             return $this->hasSourceCache[$name];
+         }
+ 
+-        foreach ($this->loaders as $loader) {
++        foreach ($this->getLoaders() as $loader) {
+             if ($loader->exists($name)) {
+                 return $this->hasSourceCache[$name] = true;
+             }
+@@ -84,7 +95,8 @@ public function exists(string $name): bool
+     public function getCacheKey(string $name): string
+     {
+         $exceptions = [];
+-        foreach ($this->loaders as $loader) {
++
++        foreach ($this->getLoaders() as $loader) {
+             if (!$loader->exists($name)) {
+                 continue;
+             }
+@@ -92,7 +104,7 @@ public function getCacheKey(string $name): string
+             try {
+                 return $loader->getCacheKey($name);
+             } catch (LoaderError $e) {
+-                $exceptions[] = \get_class($loader).': '.$e->getMessage();
++                $exceptions[] = $loader::class.': '.$e->getMessage();
+             }
+         }
+ 
+@@ -102,7 +114,8 @@ public function getCacheKey(string $name): string
+     public function isFresh(string $name, int $time): bool
+     {
+         $exceptions = [];
+-        foreach ($this->loaders as $loader) {
++
++        foreach ($this->getLoaders() as $loader) {
+             if (!$loader->exists($name)) {
+                 continue;
+             }
+@@ -110,7 +123,7 @@ public function isFresh(string $name, int $time): bool
+             try {
+                 return $loader->isFresh($name, $time);
+             } catch (LoaderError $e) {
+-                $exceptions[] = \get_class($loader).': '.$e->getMessage();
++                $exceptions[] = $loader::class.': '.$e->getMessage();
+             }
+         }
+ 
+diff --git a/src/Loader/FilesystemLoader.php b/src/Loader/FilesystemLoader.php
+index c60964f5fc8..49f2b891556 100644
+--- a/src/Loader/FilesystemLoader.php
++++ b/src/Loader/FilesystemLoader.php
+@@ -24,6 +24,9 @@ class FilesystemLoader implements LoaderInterface
+     /** Identifier of the main namespace. */
+     public const MAIN_NAMESPACE = '__main__';
+ 
++    /**
++     * @var array<string, list<string>>
++     */
+     protected $paths = [];
+     protected $cache = [];
+     protected $errorCache = [];
+@@ -31,8 +34,8 @@ class FilesystemLoader implements LoaderInterface
+     private $rootPath;
+ 
+     /**
+-     * @param string|array $paths    A path or an array of paths where to look for templates
+-     * @param string|null  $rootPath The root path common to all relative paths (null for getcwd())
++     * @param string|string[] $paths    A path or an array of paths where to look for templates
++     * @param string|null     $rootPath The root path common to all relative paths (null for getcwd())
+      */
+     public function __construct($paths = [], ?string $rootPath = null)
+     {
+@@ -48,6 +51,8 @@ public function __construct($paths = [], ?string $rootPath = null)
+ 
+     /**
+      * Returns the paths to the templates.
++     *
++     * @return list<string>
+      */
+     public function getPaths(string $namespace = self::MAIN_NAMESPACE): array
+     {
+@@ -58,6 +63,8 @@ public function getPaths(string $namespace = self::MAIN_NAMESPACE): array
+      * Returns the path namespaces.
+      *
+      * The main namespace is always defined.
++     *
++     * @return list<string>
+      */
+     public function getNamespaces(): array
+     {
+@@ -65,7 +72,7 @@ public function getNamespaces(): array
+     }
+ 
+     /**
+-     * @param string|array $paths A path or an array of paths where to look for templates
++     * @param string|string[] $paths A path or an array of paths where to look for templates
+      */
+     public function setPaths($paths, string $namespace = self::MAIN_NAMESPACE): void
+     {
+diff --git a/src/Markup.php b/src/Markup.php
+index 1788acc4f73..7fa8991c453 100644
+--- a/src/Markup.php
++++ b/src/Markup.php
+@@ -14,12 +14,21 @@
+ /**
+  * Marks a content as safe.
+  *
++ * Instances of this class (and any subclass) are trusted by the Twig
++ * sandbox: method calls and property accesses on a Markup instance bypass
++ * the SecurityPolicy method/property allowlists. This is by design: Markup
++ * represents content that has already been deemed safe to output.
++ *
++ * As a consequence, when extending this class, you are responsible for
++ * ensuring that every method and property exposed by your subclass is
++ * safe to call from a sandboxed template.
++ *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+-class Markup implements \Countable, \JsonSerializable
++class Markup implements \Countable, \JsonSerializable, \Stringable
+ {
+     private $content;
+-    private $charset;
++    private ?string $charset;
+ 
+     public function __construct($content, $charset)
+     {
+@@ -27,11 +36,16 @@ public function __construct($content, $charset)
+         $this->charset = $charset;
+     }
+ 
+-    public function __toString()
++    public function __toString(): string
+     {
+         return $this->content;
+     }
+ 
++    public function getCharset(): string
++    {
++        return $this->charset;
++    }
++
+     /**
+      * @return int
+      */
+diff --git a/src/Node/AutoEscapeNode.php b/src/Node/AutoEscapeNode.php
+index f9bc17e078f..ee806396ece 100644
+--- a/src/Node/AutoEscapeNode.php
++++ b/src/Node/AutoEscapeNode.php
+@@ -28,9 +28,9 @@
+ #[YieldReady]
+ class AutoEscapeNode extends Node
+ {
+-    public function __construct($value, Node $body, int $lineno, string $tag = 'autoescape')
++    public function __construct($value, Node $body, int $lineno)
+     {
+-        parent::__construct(['body' => $body], ['value' => $value], $lineno, $tag);
++        parent::__construct(['body' => $body], ['value' => $value], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/BlockNode.php b/src/Node/BlockNode.php
+index 15973a343fb..b4f939cf630 100644
+--- a/src/Node/BlockNode.php
++++ b/src/Node/BlockNode.php
+@@ -23,23 +23,26 @@
+ #[YieldReady]
+ class BlockNode extends Node
+ {
+-    public function __construct(string $name, Node $body, int $lineno, ?string $tag = null)
++    public function __construct(string $name, Node $body, int $lineno)
+     {
+-        parent::__construct(['body' => $body], ['name' => $name], $lineno, $tag);
++        parent::__construct(['body' => $body], ['name' => $name], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+         $compiler
+             ->addDebugInfo($this)
+-            ->write(\sprintf("public function block_%s(\$context, array \$blocks = [])\n", $this->getAttribute('name')), "{\n")
++            ->write("/**\n")
++            ->write(" * @return iterable<null|scalar|\Stringable>\n")
++            ->write(" */\n")
++            ->write(\sprintf("public function block_%s(array \$context, array \$blocks = []): iterable\n", $this->getAttribute('name')), "{\n")
+             ->indent()
+             ->write("\$macros = \$this->macros;\n")
+         ;
+ 
+         $compiler
+             ->subcompile($this->getNode('body'))
+-            ->write("return; yield '';\n") // needed when body doesn't yield anything
++            ->write("yield from [];\n")
+             ->outdent()
+             ->write("}\n\n")
+         ;
+diff --git a/src/Node/BlockReferenceNode.php b/src/Node/BlockReferenceNode.php
+index 23c73eabee9..7c313a04cec 100644
+--- a/src/Node/BlockReferenceNode.php
++++ b/src/Node/BlockReferenceNode.php
+@@ -23,9 +23,9 @@
+ #[YieldReady]
+ class BlockReferenceNode extends Node implements NodeOutputInterface
+ {
+-    public function __construct(string $name, int $lineno, ?string $tag = null)
++    public function __construct(string $name, int $lineno)
+     {
+-        parent::__construct([], ['name' => $name], $lineno, $tag);
++        parent::__construct([], ['name' => $name], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/CaptureNode.php b/src/Node/CaptureNode.php
+index b1cb357f569..3b7f0b6d838 100644
+--- a/src/Node/CaptureNode.php
++++ b/src/Node/CaptureNode.php
+@@ -22,9 +22,9 @@
+ #[YieldReady]
+ class CaptureNode extends Node
+ {
+-    public function __construct(Node $body, int $lineno, ?string $tag = null)
++    public function __construct(Node $body, int $lineno)
+     {
+-        parent::__construct(['body' => $body], ['raw' => false], $lineno, $tag);
++        parent::__construct(['body' => $body], ['raw' => false], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -39,7 +39,7 @@ public function compile(Compiler $compiler): void
+             ->raw("(function () use (&\$context, \$macros, \$blocks) {\n")
+             ->indent()
+             ->subcompile($this->getNode('body'))
+-            ->write("return; yield '';\n")
++            ->write("yield from [];\n")
+             ->outdent()
+             ->write('})()')
+         ;
+diff --git a/src/Node/CheckSecurityCallNode.php b/src/Node/CheckSecurityCallNode.php
+index 9c162d129c6..0667bd0fdb8 100644
+--- a/src/Node/CheckSecurityCallNode.php
++++ b/src/Node/CheckSecurityCallNode.php
+@@ -20,11 +20,13 @@
+ #[YieldReady]
+ class CheckSecurityCallNode extends Node
+ {
++    /**
++     * @return void
++     */
+     public function compile(Compiler $compiler)
+     {
+         $compiler
+             ->write("\$this->sandbox = \$this->extensions[SandboxExtension::class];\n")
+-            ->write("\$this->checkSecurity();\n")
+         ;
+     }
+ }
+diff --git a/src/Node/CheckSecurityNode.php b/src/Node/CheckSecurityNode.php
+index 6e591aad40a..d2aa5a86496 100644
+--- a/src/Node/CheckSecurityNode.php
++++ b/src/Node/CheckSecurityNode.php
+@@ -41,6 +41,17 @@ public function __construct(array $usedFilters, array $usedTags, array $usedFunc
+     public function compile(Compiler $compiler): void
+     {
+         $compiler
++            ->write("\n")
++            ->write("public function ensureSecurityChecked(): void\n")
++            ->write("{\n")
++            ->indent()
++            ->write("if (\$this->sandbox->isSandboxed(\$this->source)) {\n")
++            ->indent()
++            ->write("\$this->checkSecurity();\n")
++            ->outdent()
++            ->write("}\n")
++            ->outdent()
++            ->write("}\n")
+             ->write("\n")
+             ->write("public function checkSecurity()\n")
+             ->write("{\n")
+@@ -52,9 +63,9 @@ public function compile(Compiler $compiler): void
+             ->indent()
+             ->write("\$this->sandbox->checkSecurity(\n")
+             ->indent()
+-            ->write(!$this->usedTags ? "[],\n" : "['".implode("', '", array_keys($this->usedTags))."'],\n")
+-            ->write(!$this->usedFilters ? "[],\n" : "['".implode("', '", array_keys($this->usedFilters))."'],\n")
+-            ->write(!$this->usedFunctions ? "[],\n" : "['".implode("', '", array_keys($this->usedFunctions))."'],\n")
++            ->write('')->repr(array_keys($this->usedTags))->raw(",\n")
++            ->write('')->repr(array_keys($this->usedFilters))->raw(",\n")
++            ->write('')->repr(array_keys($this->usedFunctions))->raw(",\n")
+             ->write("\$this->source\n")
+             ->outdent()
+             ->write(");\n")
+diff --git a/src/Node/CheckToStringNode.php b/src/Node/CheckToStringNode.php
+index 81fb92404f0..11aec9cc0d2 100644
+--- a/src/Node/CheckToStringNode.php
++++ b/src/Node/CheckToStringNode.php
+@@ -28,16 +28,17 @@
+ #[YieldReady]
+ class CheckToStringNode extends AbstractExpression
+ {
+-    public function __construct(AbstractExpression $expr)
++    public function __construct(AbstractExpression $expr, bool $spread = false)
+     {
+-        parent::__construct(['expr' => $expr], [], $expr->getTemplateLine(), $expr->getNodeTag());
++        parent::__construct(['expr' => $expr], ['spread' => $spread], $expr->getTemplateLine());
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+         $expr = $this->getNode('expr');
++        $method = $this->getAttribute('spread') ? 'ensureSpreadAllowed' : 'ensureToStringAllowed';
+         $compiler
+-            ->raw('$this->sandbox->ensureToStringAllowed(')
++            ->raw('$this->sandbox->'.$method.'(')
+             ->subcompile($expr)
+             ->raw(', ')
+             ->repr($expr->getTemplateLine())
+diff --git a/src/Node/CoercesChildrenToStringInterface.php b/src/Node/CoercesChildrenToStringInterface.php
+new file mode 100644
+index 00000000000..e213d1b610a
+--- /dev/null
++++ b/src/Node/CoercesChildrenToStringInterface.php
+@@ -0,0 +1,40 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node;
++
++use Twig\Node\Expression\OperatorEscapeInterface;
++
++/**
++ * Implemented by nodes that implicitly coerce one or more of their child
++ * nodes to string at runtime (PHP string casts, regex matching, comparisons,
++ * range bounds, template-name resolution by the loader, etc.).
++ *
++ * The sandbox node visitor wraps the listed children with a CheckToStringNode
++ * so that an implicit `__toString()` call goes through the sandbox policy
++ * check, independently of where this node's result is used.
++ *
++ * This is distinct from {@see OperatorEscapeInterface}, which describes
++ * operands whose value becomes this expression's value (passthrough operators
++ * like ternaries) and is consumed by the escaper.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++interface CoercesChildrenToStringInterface
++{
++    /**
++     * Returns the names of the child nodes that will be coerced to
++     * string when this node is evaluated.
++     *
++     * @return string[]
++     */
++    public function getStringCoercedChildNames(): array;
++}
+diff --git a/src/Node/DeprecatedNode.php b/src/Node/DeprecatedNode.php
+index afeb8332e29..fea8d355b63 100644
+--- a/src/Node/DeprecatedNode.php
++++ b/src/Node/DeprecatedNode.php
+@@ -22,11 +22,11 @@
+  * @author Yonel Ceruto <yonelceruto@gmail.com>
+  */
+ #[YieldReady]
+-class DeprecatedNode extends Node
++class DeprecatedNode extends Node implements CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $expr, int $lineno, ?string $tag = null)
++    public function __construct(AbstractExpression $expr, int $lineno)
+     {
+-        parent::__construct(['expr' => $expr], [], $lineno, $tag);
++        parent::__construct(['expr' => $expr], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -65,9 +65,23 @@ public function compile(Compiler $compiler): void
+         }
+ 
+         $compiler
+-            ->raw(".")
++            ->raw('.')
+             ->string(\sprintf(' in "%s" at line %d.', $this->getTemplateName(), $this->getTemplateLine()))
+             ->raw(");\n")
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // the message is concatenated with `.`, and `package` / `version` are typed `string` on trigger_deprecation()
++        $names = ['expr'];
++        if ($this->hasNode('package')) {
++            $names[] = 'package';
++        }
++        if ($this->hasNode('version')) {
++            $names[] = 'version';
++        }
++
++        return $names;
++    }
+ }
+diff --git a/src/Node/DoNode.php b/src/Node/DoNode.php
+index 445016ab285..1593fd05024 100644
+--- a/src/Node/DoNode.php
++++ b/src/Node/DoNode.php
+@@ -23,9 +23,9 @@
+ #[YieldReady]
+ class DoNode extends Node
+ {
+-    public function __construct(AbstractExpression $expr, int $lineno, ?string $tag = null)
++    public function __construct(AbstractExpression $expr, int $lineno)
+     {
+-        parent::__construct(['expr' => $expr], [], $lineno, $tag);
++        parent::__construct(['expr' => $expr], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/EmbedNode.php b/src/Node/EmbedNode.php
+index 54550946215..2de39ebb942 100644
+--- a/src/Node/EmbedNode.php
++++ b/src/Node/EmbedNode.php
+@@ -25,26 +25,30 @@
+ class EmbedNode extends IncludeNode
+ {
+     // we don't inject the module to avoid node visitors to traverse it twice (as it will be already visited in the main module)
+-    public function __construct(string $name, int $index, ?AbstractExpression $variables, bool $only, bool $ignoreMissing, int $lineno, ?string $tag = null)
++    public function __construct(string $name, int $index, ?AbstractExpression $variables, bool $only, bool $ignoreMissing, int $lineno)
+     {
+-        parent::__construct(new ConstantExpression('not_used', $lineno), $variables, $only, $ignoreMissing, $lineno, $tag);
++        parent::__construct(new ConstantExpression('not_used', $lineno), $variables, $only, $ignoreMissing, $lineno);
+ 
+         $this->setAttribute('name', $name);
+         $this->setAttribute('index', $index);
+     }
+ 
+-    protected function addGetTemplate(Compiler $compiler): void
++    protected function addGetTemplate(Compiler $compiler, string $template = ''): void
+     {
+         $compiler
+-            ->write('$this->loadTemplate(')
++            ->raw('$this->load(')
+             ->string($this->getAttribute('name'))
+             ->raw(', ')
+-            ->repr($this->getTemplateName())
+-            ->raw(', ')
+             ->repr($this->getTemplateLine())
+             ->raw(', ')
+-            ->string($this->getAttribute('index'))
++            ->repr($this->getAttribute('index'))
+             ->raw(')')
+         ;
++        if ($this->getAttribute('ignore_missing')) {
++            $compiler
++                ->raw(";\n")
++                ->write(\sprintf("\$%s->getParent(\$context);\n", $template))
++            ;
++        }
+     }
+ }
+diff --git a/src/Node/EmptyNode.php b/src/Node/EmptyNode.php
+new file mode 100644
+index 00000000000..fd4717ff4ba
+--- /dev/null
++++ b/src/Node/EmptyNode.php
+@@ -0,0 +1,33 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node;
++
++use Twig\Attribute\YieldReady;
++
++/**
++ * Represents an empty node.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++#[YieldReady]
++final class EmptyNode extends Node
++{
++    public function __construct(int $lineno = 0)
++    {
++        parent::__construct([], [], $lineno);
++    }
++
++    public function setNode(string $name, Node $node): void
++    {
++        throw new \LogicException('EmptyNode cannot have children.');
++    }
++}
+diff --git a/src/Node/Expression/AbstractExpression.php b/src/Node/Expression/AbstractExpression.php
+index 1692f5671ef..22d8617cd72 100644
+--- a/src/Node/Expression/AbstractExpression.php
++++ b/src/Node/Expression/AbstractExpression.php
+@@ -25,4 +25,19 @@ public function isGenerator(): bool
+     {
+         return $this->hasAttribute('is_generator') && $this->getAttribute('is_generator');
+     }
++
++    /**
++     * @return static
++     */
++    public function setExplicitParentheses(): self
++    {
++        $this->setAttribute('with_parentheses', true);
++
++        return $this;
++    }
++
++    public function hasExplicitParentheses(): bool
++    {
++        return $this->hasAttribute('with_parentheses') && $this->getAttribute('with_parentheses');
++    }
+ }
+diff --git a/src/Node/Expression/ArrayExpression.php b/src/Node/Expression/ArrayExpression.php
+index 5f8b0f63f37..189e02f7e45 100644
+--- a/src/Node/Expression/ArrayExpression.php
++++ b/src/Node/Expression/ArrayExpression.php
+@@ -12,9 +12,15 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\Unary\SpreadUnary;
++use Twig\Node\Expression\Unary\StringCastUnary;
+ 
+-class ArrayExpression extends AbstractExpression
++class ArrayExpression extends AbstractExpression implements SupportDefinedTestInterface, ReturnArrayInterface, CoercesChildrenToStringInterface
+ {
++    use SupportDefinedTestTrait;
++
+     private $index;
+ 
+     public function __construct(array $elements, int $lineno)
+@@ -55,6 +61,31 @@ public function hasElement(AbstractExpression $key): bool
+         return false;
+     }
+ 
++    /**
++     * Checks if the array is a sequence (keys are sequential integers starting from 0).
++     *
++     * @internal
++     */
++    public function isSequence(): bool
++    {
++        foreach ($this->getKeyValuePairs() as $i => $pair) {
++            $key = $pair['key'];
++            if ($key instanceof TempNameExpression) {
++                $keyValue = $key->getAttribute('name');
++            } elseif ($key instanceof ConstantExpression) {
++                $keyValue = $key->getAttribute('value');
++            } else {
++                return false;
++            }
++
++            if ($keyValue !== $i) {
++                return false;
++            }
++        }
++
++        return true;
++    }
++
+     public function addElement(AbstractExpression $value, ?AbstractExpression $key = null): void
+     {
+         if (null === $key) {
+@@ -64,72 +95,71 @@ public function addElement(AbstractExpression $value, ?AbstractExpression $key =
+         array_push($this->nodes, $key, $value);
+     }
+ 
++    public function getStringCoercedChildNames(): array
++    {
++        // dynamic mapping keys (computed at runtime) are coerced to string;
++        // static keys (constants or sequence indexes) are emitted as PHP
++        // literals by compile() and never trigger a __toString() call
++        $names = [];
++        foreach (array_chunk($this->nodes, 2) as $i => $pair) {
++            $key = $pair[0];
++            if ($key instanceof ConstantExpression || $key instanceof TempNameExpression) {
++                continue;
++            }
++
++            $names[] = (string) ($i * 2);
++        }
++
++        return $names;
++    }
++
+     public function compile(Compiler $compiler): void
+     {
+-        $keyValuePairs = $this->getKeyValuePairs();
+-        $needsArrayMergeSpread = \PHP_VERSION_ID < 80100 && $this->hasSpreadItem($keyValuePairs);
++        if ($this->definedTest) {
++            $compiler->repr(true);
+ 
+-        if ($needsArrayMergeSpread) {
+-            $compiler->raw('CoreExtension::merge(');
++            return;
+         }
+-        $compiler->raw('[');
+-        $first = true;
+-        $reopenAfterMergeSpread = false;
+-        $nextIndex = 0;
+-        foreach ($keyValuePairs as $pair) {
+-            if ($reopenAfterMergeSpread) {
+-                $compiler->raw(', [');
+-                $reopenAfterMergeSpread = false;
+-            }
+ 
+-            if ($needsArrayMergeSpread && $pair['value']->hasAttribute('spread')) {
+-                $compiler->raw('], ')->subcompile($pair['value']);
+-                $first = true;
+-                $reopenAfterMergeSpread = true;
+-                continue;
++        // Check for empty expressions which are only allowed in destructuring
++        foreach ($this->getKeyValuePairs() as $pair) {
++            if ($pair['value'] instanceof EmptyExpression) {
++                throw new SyntaxError('Empty array elements are only allowed in destructuring assignments.', $pair['value']->getTemplateLine(), $this->getSourceContext());
+             }
+-            if (!$first) {
++        }
++
++        $compiler->raw('[');
++        $isSequence = true;
++        foreach ($this->getKeyValuePairs() as $i => $pair) {
++            if (0 !== $i) {
+                 $compiler->raw(', ');
+             }
+-            $first = false;
+ 
+-            if ($pair['value']->hasAttribute('spread') && !$needsArrayMergeSpread) {
+-                $compiler->raw('...')->subcompile($pair['value']);
+-                ++$nextIndex;
++            $key = null;
++            if ($pair['key'] instanceof TempNameExpression) {
++                $key = $pair['key']->getAttribute('name');
++                $pair['key'] = new ConstantExpression($key, $pair['key']->getTemplateLine());
++            } elseif ($pair['key'] instanceof ConstantExpression) {
++                $key = $pair['key']->getAttribute('value');
+             } else {
+-                $key = $pair['key'] instanceof ConstantExpression ? $pair['key']->getAttribute('value') : null;
+-
+-                if ($nextIndex !== $key) {
+-                    if (\is_int($key)) {
+-                        $nextIndex = $key + 1;
+-                    }
+-                    $compiler
+-                        ->subcompile($pair['key'])
+-                        ->raw(' => ')
+-                    ;
+-                } else {
+-                    ++$nextIndex;
+-                }
+-
+-                $compiler->subcompile($pair['value']);
++                // dynamic key: cast to string so PHP accepts it as an array offset
++                // (the sandbox visitor has already wrapped it with a __toString policy check)
++                $pair['key'] = new StringCastUnary($pair['key'], $pair['key']->getTemplateLine());
+             }
+-        }
+-        if (!$reopenAfterMergeSpread) {
+-            $compiler->raw(']');
+-        }
+-        if ($needsArrayMergeSpread) {
+-            $compiler->raw(')');
+-        }
+-    }
+ 
+-    private function hasSpreadItem(array $pairs): bool
+-    {
+-        foreach ($pairs as $pair) {
+-            if ($pair['value']->hasAttribute('spread')) {
+-                return true;
++            if ($key !== $i) {
++                $isSequence = false;
+             }
+-        }
+ 
+-        return false;
++            if (!$isSequence && !$pair['value'] instanceof SpreadUnary) {
++                $compiler
++                    ->subcompile($pair['key'])
++                    ->raw(' => ')
++                ;
++            }
++
++            $compiler->subcompile($pair['value']);
++        }
++        $compiler->raw(']');
+     }
+ }
+diff --git a/src/Node/Expression/ArrowFunctionExpression.php b/src/Node/Expression/ArrowFunctionExpression.php
+index eaad03c9c05..9156f7c616d 100644
+--- a/src/Node/Expression/ArrowFunctionExpression.php
++++ b/src/Node/Expression/ArrowFunctionExpression.php
+@@ -12,6 +12,9 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
+ 
+ /**
+@@ -21,9 +24,17 @@
+  */
+ class ArrowFunctionExpression extends AbstractExpression
+ {
+-    public function __construct(AbstractExpression $expr, Node $names, $lineno, $tag = null)
++    public function __construct(AbstractExpression $expr, Node $names, $lineno)
+     {
+-        parent::__construct(['expr' => $expr, 'names' => $names], [], $lineno, $tag);
++        if ($names instanceof ContextVariable) {
++            $names = new ListExpression([new AssignContextVariable($names->getAttribute('name'), $names->getTemplateLine())], $lineno);
++        }
++
++        if (!$names instanceof ListExpression) {
++            throw new SyntaxError('The arrow function argument must be a list of variables or a single variable.', $names->getTemplateLine(), $names->getSourceContext());
++        }
++
++        parent::__construct(['expr' => $expr, 'names' => $names], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -31,19 +42,7 @@ public function compile(Compiler $compiler): void
+         $compiler
+             ->addDebugInfo($this)
+             ->raw('function (')
+-        ;
+-        foreach ($this->getNode('names') as $i => $name) {
+-            if ($i) {
+-                $compiler->raw(', ');
+-            }
+-
+-            $compiler
+-                ->raw('$__')
+-                ->raw($name->getAttribute('name'))
+-                ->raw('__')
+-            ;
+-        }
+-        $compiler
++            ->subcompile($this->getNode('names'))
+             ->raw(') use ($context, $macros) { ')
+         ;
+         foreach ($this->getNode('names') as $name) {
+diff --git a/src/Node/Expression/AssignNameExpression.php b/src/Node/Expression/AssignNameExpression.php
+index 7dd1bc4a372..9a7f0f92bca 100644
+--- a/src/Node/Expression/AssignNameExpression.php
++++ b/src/Node/Expression/AssignNameExpression.php
+@@ -13,9 +13,26 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
+ 
+-class AssignNameExpression extends NameExpression
++class AssignNameExpression extends ContextVariable
+ {
++    public function __construct(string $name, int $lineno)
++    {
++        if (self::class === static::class) {
++            trigger_deprecation('twig/twig', '3.15', 'The "%s" class is deprecated, use "%s" instead.', self::class, AssignContextVariable::class);
++        }
++
++        // All names supported by ExpressionParser::parsePrimaryExpression() should be excluded
++        if (\in_array(strtolower($name), ['true', 'false', 'none', 'null'], true)) {
++            throw new SyntaxError(\sprintf('You cannot assign a value to "%s".', $name), $lineno);
++        }
++
++        parent::__construct($name, $lineno);
++    }
++
+     public function compile(Compiler $compiler): void
+     {
+         $compiler
+diff --git a/src/Node/Expression/Binary/AbstractBinary.php b/src/Node/Expression/Binary/AbstractBinary.php
+index c424e5cc5f0..b4bf6662eda 100644
+--- a/src/Node/Expression/Binary/AbstractBinary.php
++++ b/src/Node/Expression/Binary/AbstractBinary.php
+@@ -16,10 +16,21 @@
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Node;
+ 
+-abstract class AbstractBinary extends AbstractExpression
++abstract class AbstractBinary extends AbstractExpression implements BinaryInterface
+ {
++    /**
++     * @param AbstractExpression $left
++     * @param AbstractExpression $right
++     */
+     public function __construct(Node $left, Node $right, int $lineno)
+     {
++        if (!$left instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $left::class);
++        }
++        if (!$right instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $right::class);
++        }
++
+         parent::__construct(['left' => $left, 'right' => $right], [], $lineno);
+     }
+ 
+diff --git a/src/Node/Expression/Binary/AddBinary.php b/src/Node/Expression/Binary/AddBinary.php
+index ee4307e33e2..42377aea056 100644
+--- a/src/Node/Expression/Binary/AddBinary.php
++++ b/src/Node/Expression/Binary/AddBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class AddBinary extends AbstractBinary
++class AddBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/AndBinary.php b/src/Node/Expression/Binary/AndBinary.php
+index 5f2380da545..454ea70e5b2 100644
+--- a/src/Node/Expression/Binary/AndBinary.php
++++ b/src/Node/Expression/Binary/AndBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class AndBinary extends AbstractBinary
++class AndBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/BinaryInterface.php b/src/Node/Expression/Binary/BinaryInterface.php
+new file mode 100644
+index 00000000000..eeeb2eb99ec
+--- /dev/null
++++ b/src/Node/Expression/Binary/BinaryInterface.php
+@@ -0,0 +1,22 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Node\Expression\AbstractExpression;
++
++/**
++ * @internal
++ */
++interface BinaryInterface
++{
++    public function __construct(AbstractExpression $left, AbstractExpression $right, int $lineno);
++}
+diff --git a/src/Node/Expression/Binary/BitwiseAndBinary.php b/src/Node/Expression/Binary/BitwiseAndBinary.php
+index db7d6d612dd..1c26f98933b 100644
+--- a/src/Node/Expression/Binary/BitwiseAndBinary.php
++++ b/src/Node/Expression/Binary/BitwiseAndBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class BitwiseAndBinary extends AbstractBinary
++class BitwiseAndBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/BitwiseOrBinary.php b/src/Node/Expression/Binary/BitwiseOrBinary.php
+index ce803dd9027..ec17e2280b5 100644
+--- a/src/Node/Expression/Binary/BitwiseOrBinary.php
++++ b/src/Node/Expression/Binary/BitwiseOrBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class BitwiseOrBinary extends AbstractBinary
++class BitwiseOrBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/BitwiseXorBinary.php b/src/Node/Expression/Binary/BitwiseXorBinary.php
+index 5c29785014d..e6432a7aeb6 100644
+--- a/src/Node/Expression/Binary/BitwiseXorBinary.php
++++ b/src/Node/Expression/Binary/BitwiseXorBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class BitwiseXorBinary extends AbstractBinary
++class BitwiseXorBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/ConcatBinary.php b/src/Node/Expression/Binary/ConcatBinary.php
+index f825ab874d6..e4ec135dda8 100644
+--- a/src/Node/Expression/Binary/ConcatBinary.php
++++ b/src/Node/Expression/Binary/ConcatBinary.php
+@@ -13,11 +13,18 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnStringInterface;
+ 
+-class ConcatBinary extends AbstractBinary
++class ConcatBinary extends AbstractBinary implements ReturnStringInterface, CoercesChildrenToStringInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('.');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/DivBinary.php b/src/Node/Expression/Binary/DivBinary.php
+index e3817d1cd7f..11c061e18ef 100644
+--- a/src/Node/Expression/Binary/DivBinary.php
++++ b/src/Node/Expression/Binary/DivBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class DivBinary extends AbstractBinary
++class DivBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/ElvisBinary.php b/src/Node/Expression/Binary/ElvisBinary.php
+new file mode 100644
+index 00000000000..25522240b64
+--- /dev/null
++++ b/src/Node/Expression/Binary/ElvisBinary.php
+@@ -0,0 +1,55 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\OperatorEscapeInterface;
++use Twig\Node\Node;
++
++final class ElvisBinary extends AbstractBinary implements OperatorEscapeInterface
++{
++    /**
++     * @param AbstractExpression $left
++     * @param AbstractExpression $right
++     */
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        parent::__construct($left, $right, $lineno);
++
++        $this->setNode('test', clone $left);
++        $left->setAttribute('always_defined', true);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler
++            ->raw('((')
++            ->subcompile($this->getNode('test'))
++            ->raw(') ? (')
++            ->subcompile($this->getNode('left'))
++            ->raw(') : (')
++            ->subcompile($this->getNode('right'))
++            ->raw('))')
++        ;
++    }
++
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('?:');
++    }
++
++    public function getOperandNamesToEscape(): array
++    {
++        return ['left', 'right'];
++    }
++}
+diff --git a/src/Node/Expression/Binary/EndsWithBinary.php b/src/Node/Expression/Binary/EndsWithBinary.php
+index a73a5608dd9..e689d668a67 100644
+--- a/src/Node/Expression/Binary/EndsWithBinary.php
++++ b/src/Node/Expression/Binary/EndsWithBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class EndsWithBinary extends AbstractBinary
++class EndsWithBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+diff --git a/src/Node/Expression/Binary/EqualBinary.php b/src/Node/Expression/Binary/EqualBinary.php
+index 5f423196fee..d438e2b5d8a 100644
+--- a/src/Node/Expression/Binary/EqualBinary.php
++++ b/src/Node/Expression/Binary/EqualBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class EqualBinary extends AbstractBinary
++class EqualBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('==');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/FloorDivBinary.php b/src/Node/Expression/Binary/FloorDivBinary.php
+index d7e7980efde..a60ab3b2129 100644
+--- a/src/Node/Expression/Binary/FloorDivBinary.php
++++ b/src/Node/Expression/Binary/FloorDivBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class FloorDivBinary extends AbstractBinary
++class FloorDivBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+diff --git a/src/Node/Expression/Binary/GreaterBinary.php b/src/Node/Expression/Binary/GreaterBinary.php
+index f42de3f8645..318c3019df9 100644
+--- a/src/Node/Expression/Binary/GreaterBinary.php
++++ b/src/Node/Expression/Binary/GreaterBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class GreaterBinary extends AbstractBinary
++class GreaterBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('>');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/GreaterEqualBinary.php b/src/Node/Expression/Binary/GreaterEqualBinary.php
+index 0c4f43fd94a..2dacd9f0fb1 100644
+--- a/src/Node/Expression/Binary/GreaterEqualBinary.php
++++ b/src/Node/Expression/Binary/GreaterEqualBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class GreaterEqualBinary extends AbstractBinary
++class GreaterEqualBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('>=');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/HasEveryBinary.php b/src/Node/Expression/Binary/HasEveryBinary.php
+index c57bb20e916..9b107111a85 100644
+--- a/src/Node/Expression/Binary/HasEveryBinary.php
++++ b/src/Node/Expression/Binary/HasEveryBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class HasEveryBinary extends AbstractBinary
++class HasEveryBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -22,7 +23,7 @@ public function compile(Compiler $compiler): void
+             ->subcompile($this->getNode('left'))
+             ->raw(', ')
+             ->subcompile($this->getNode('right'))
+-            ->raw(')')
++            ->raw(', $this->env->hasExtension(\Twig\Extension\SandboxExtension::class) && $this->env->getExtension(\Twig\Extension\SandboxExtension::class)->isSandboxed($this->source))')
+         ;
+     }
+ 
+diff --git a/src/Node/Expression/Binary/HasSomeBinary.php b/src/Node/Expression/Binary/HasSomeBinary.php
+index 12293f84cb4..86665a348a6 100644
+--- a/src/Node/Expression/Binary/HasSomeBinary.php
++++ b/src/Node/Expression/Binary/HasSomeBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class HasSomeBinary extends AbstractBinary
++class HasSomeBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -22,7 +23,7 @@ public function compile(Compiler $compiler): void
+             ->subcompile($this->getNode('left'))
+             ->raw(', ')
+             ->subcompile($this->getNode('right'))
+-            ->raw(')')
++            ->raw(', $this->env->hasExtension(\Twig\Extension\SandboxExtension::class) && $this->env->getExtension(\Twig\Extension\SandboxExtension::class)->isSandboxed($this->source))')
+         ;
+     }
+ 
+diff --git a/src/Node/Expression/Binary/InBinary.php b/src/Node/Expression/Binary/InBinary.php
+index 68a98fe15b3..2f11a54fd5f 100644
+--- a/src/Node/Expression/Binary/InBinary.php
++++ b/src/Node/Expression/Binary/InBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class InBinary extends AbstractBinary
++class InBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -30,4 +32,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('in');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/LessBinary.php b/src/Node/Expression/Binary/LessBinary.php
+index fb3264a2d47..3bb629122d1 100644
+--- a/src/Node/Expression/Binary/LessBinary.php
++++ b/src/Node/Expression/Binary/LessBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class LessBinary extends AbstractBinary
++class LessBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('<');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/LessEqualBinary.php b/src/Node/Expression/Binary/LessEqualBinary.php
+index 8f3653892d6..30217454f34 100644
+--- a/src/Node/Expression/Binary/LessEqualBinary.php
++++ b/src/Node/Expression/Binary/LessEqualBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class LessEqualBinary extends AbstractBinary
++class LessEqualBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('<=');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/MatchesBinary.php b/src/Node/Expression/Binary/MatchesBinary.php
+index 4669044e01a..5dd3dbeb027 100644
+--- a/src/Node/Expression/Binary/MatchesBinary.php
++++ b/src/Node/Expression/Binary/MatchesBinary.php
+@@ -12,9 +12,37 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\ReturnBoolInterface;
++use Twig\Node\Node;
+ 
+-class MatchesBinary extends AbstractBinary
++class MatchesBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        if (!$left instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" first argument is deprecated, pass an "AbstractExpression" instance instead.', $left::class, __METHOD__);
++        }
++        if (!$right instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" second argument is deprecated, pass an "AbstractExpression" instance instead.', $right::class, __METHOD__);
++        }
++
++        if ($right instanceof ConstantExpression) {
++            $regexp = $right->getAttribute('value');
++            set_error_handler(static fn ($t, $m) => throw new SyntaxError(\sprintf('Regexp "%s" passed to "matches" is not valid: %s.', $regexp, substr($m, 14)), $lineno));
++            try {
++                preg_match($regexp, '');
++            } finally {
++                restore_error_handler();
++            }
++        }
++
++        parent::__construct($left, $right, $lineno);
++    }
++
+     public function compile(Compiler $compiler): void
+     {
+         $compiler
+@@ -30,4 +58,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/ModBinary.php b/src/Node/Expression/Binary/ModBinary.php
+index 271b45cac88..aef48f3d0a2 100644
+--- a/src/Node/Expression/Binary/ModBinary.php
++++ b/src/Node/Expression/Binary/ModBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class ModBinary extends AbstractBinary
++class ModBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/MulBinary.php b/src/Node/Expression/Binary/MulBinary.php
+index 6d4c1e0b6b8..beb881ae38d 100644
+--- a/src/Node/Expression/Binary/MulBinary.php
++++ b/src/Node/Expression/Binary/MulBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class MulBinary extends AbstractBinary
++class MulBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/NotEqualBinary.php b/src/Node/Expression/Binary/NotEqualBinary.php
+index d137ef62738..c63e32517b9 100644
+--- a/src/Node/Expression/Binary/NotEqualBinary.php
++++ b/src/Node/Expression/Binary/NotEqualBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class NotEqualBinary extends AbstractBinary
++class NotEqualBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -36,4 +38,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('!=');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/NotInBinary.php b/src/Node/Expression/Binary/NotInBinary.php
+index 80c8755d8aa..f46c88ff8b6 100644
+--- a/src/Node/Expression/Binary/NotInBinary.php
++++ b/src/Node/Expression/Binary/NotInBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class NotInBinary extends AbstractBinary
++class NotInBinary extends AbstractBinary implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -30,4 +32,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('not in');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/NotSameAsBinary.php b/src/Node/Expression/Binary/NotSameAsBinary.php
+new file mode 100644
+index 00000000000..ed28c19bb63
+--- /dev/null
++++ b/src/Node/Expression/Binary/NotSameAsBinary.php
+@@ -0,0 +1,23 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
++
++class NotSameAsBinary extends AbstractBinary implements ReturnBoolInterface
++{
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('!==');
++    }
++}
+diff --git a/src/Node/Expression/Binary/NullCoalesceBinary.php b/src/Node/Expression/Binary/NullCoalesceBinary.php
+new file mode 100644
+index 00000000000..a047b6030dd
+--- /dev/null
++++ b/src/Node/Expression/Binary/NullCoalesceBinary.php
+@@ -0,0 +1,71 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\BlockReferenceExpression;
++use Twig\Node\Expression\OperatorEscapeInterface;
++use Twig\Node\Expression\Test\DefinedTest;
++use Twig\Node\Expression\Test\NullTest;
++use Twig\Node\Expression\Unary\NotUnary;
++use Twig\Node\Node;
++use Twig\TwigTest;
++
++final class NullCoalesceBinary extends AbstractBinary implements OperatorEscapeInterface
++{
++    /**
++     * @param AbstractExpression $left
++     * @param AbstractExpression $right
++     */
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        parent::__construct($left, $right, $lineno);
++
++        $test = new DefinedTest(clone $left, new TwigTest('defined'), new EmptyNode(), $left->getTemplateLine());
++        // for "block()", we don't need the null test as the return value is always a string
++        if (!$left instanceof BlockReferenceExpression) {
++            $test = new AndBinary(
++                $test,
++                new NotUnary(new NullTest($left, new TwigTest('null'), new EmptyNode(), $left->getTemplateLine()), $left->getTemplateLine()),
++                $left->getTemplateLine(),
++            );
++        }
++
++        $left->setAttribute('always_defined', true);
++        $this->setNode('test', $test);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler
++            ->raw('((')
++            ->subcompile($this->getNode('test'))
++            ->raw(') ? (')
++            ->subcompile($this->getNode('left'))
++            ->raw(') : (')
++            ->subcompile($this->getNode('right'))
++            ->raw('))')
++        ;
++    }
++
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('??');
++    }
++
++    public function getOperandNamesToEscape(): array
++    {
++        return ['left', 'right'];
++    }
++}
+diff --git a/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php b/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
+new file mode 100644
+index 00000000000..8c5df6a8028
+--- /dev/null
++++ b/src/Node/Expression/Binary/ObjectDestructuringSetBinary.php
+@@ -0,0 +1,77 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Extension\SandboxExtension;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Node\Node;
++
++/**
++ * @internal
++ */
++class ObjectDestructuringSetBinary extends AbstractBinary
++{
++    /** @var list<array{property: string, variable: string}> */
++    private array $mappings = [];
++
++    /**
++     * @param ArrayExpression    $left  The array expression containing object/mapping destructuring properties
++     * @param AbstractExpression $right The expression providing values for assignment
++     */
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        if (!$left instanceof ArrayExpression) {
++            throw new \LogicException('Left side must be ArrayExpression for object/mapping destructuring.');
++        }
++        foreach ($left->getKeyValuePairs() as $pair) {
++            if (!$pair['value'] instanceof ContextVariable) {
++                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in object/mapping destructuring.', $pair['value']::class), $lineno);
++            }
++
++            $this->mappings[] = [
++                'property' => $pair['key']->getAttribute('value'),
++                'variable' => $pair['value']->getAttribute('name'),
++            ];
++        }
++
++        parent::__construct($left, $right, $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler->addDebugInfo($this);
++        $compiler->raw('[');
++        foreach ($this->mappings as $i => $mapping) {
++            if ($i) {
++                $compiler->raw(', ');
++            }
++            $compiler->raw('$context[')->repr($mapping['variable'])->raw(']');
++        }
++        $compiler->raw('] = [');
++        foreach ($this->mappings as $i => $mapping) {
++            if ($i) {
++                $compiler->raw(', ');
++            }
++            $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ')->subcompile($this->getNode('right'))->raw(', ')->repr($mapping['property'])->raw(', [], \\Twig\\Template::ANY_CALL, false, false, ')->repr($compiler->getEnvironment()->hasExtension(SandboxExtension::class))->raw(', ')->repr($this->getNode('right')->getTemplateLine())->raw(')');
++        }
++        $compiler->raw(']');
++    }
++
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('=');
++    }
++}
+diff --git a/src/Node/Expression/Binary/OrBinary.php b/src/Node/Expression/Binary/OrBinary.php
+index 21f87c91b4f..82dcb7e953b 100644
+--- a/src/Node/Expression/Binary/OrBinary.php
++++ b/src/Node/Expression/Binary/OrBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class OrBinary extends AbstractBinary
++class OrBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/PowerBinary.php b/src/Node/Expression/Binary/PowerBinary.php
+index c9f4c6697df..5325e8eb0b2 100644
+--- a/src/Node/Expression/Binary/PowerBinary.php
++++ b/src/Node/Expression/Binary/PowerBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class PowerBinary extends AbstractBinary
++class PowerBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/RangeBinary.php b/src/Node/Expression/Binary/RangeBinary.php
+index 55982c819d7..2d0d2eb5ba2 100644
+--- a/src/Node/Expression/Binary/RangeBinary.php
++++ b/src/Node/Expression/Binary/RangeBinary.php
+@@ -12,8 +12,10 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnArrayInterface;
+ 
+-class RangeBinary extends AbstractBinary
++class RangeBinary extends AbstractBinary implements ReturnArrayInterface, CoercesChildrenToStringInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+@@ -30,4 +32,9 @@ public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('..');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/SameAsBinary.php b/src/Node/Expression/Binary/SameAsBinary.php
+new file mode 100644
+index 00000000000..b08a19072a3
+--- /dev/null
++++ b/src/Node/Expression/Binary/SameAsBinary.php
+@@ -0,0 +1,23 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
++
++class SameAsBinary extends AbstractBinary implements ReturnBoolInterface
++{
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('===');
++    }
++}
+diff --git a/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php b/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
+new file mode 100644
+index 00000000000..a6a873c516a
+--- /dev/null
++++ b/src/Node/Expression/Binary/SequenceDestructuringSetBinary.php
+@@ -0,0 +1,67 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\EmptyExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Node\Node;
++
++/**
++ * @internal
++ */
++class SequenceDestructuringSetBinary extends AbstractBinary
++{
++    private array $variables = [];
++
++    /**
++     * @param ArrayExpression    $left  The array expression containing variables to assign to
++     * @param AbstractExpression $right The expression providing values for assignment
++     */
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        foreach ($left->getKeyValuePairs() as $pair) {
++            if ($pair['value'] instanceof EmptyExpression) {
++                $this->variables[] = null;
++            } elseif ($pair['value'] instanceof ContextVariable) {
++                $this->variables[] = $pair['value']->getAttribute('name');
++            } else {
++                throw new SyntaxError(\sprintf('Cannot assign to "%s", only variables can be assigned in sequence destructuring.', $pair['value']::class), $lineno);
++            }
++        }
++
++        parent::__construct($left, $right, $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler->addDebugInfo($this);
++        $compiler->raw('[');
++        foreach ($this->variables as $i => $name) {
++            if ($i) {
++                $compiler->raw(', ');
++            }
++            if (null !== $name) {
++                $compiler->raw('$context[')->repr($name)->raw(']');
++            }
++        }
++        $compiler->raw('] = array_pad(')->subcompile($this->getNode('right'))->raw(', ')->repr(\count($this->variables))->raw(', null)');
++    }
++
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('=');
++    }
++}
+diff --git a/src/Node/Expression/Binary/SetBinary.php b/src/Node/Expression/Binary/SetBinary.php
+new file mode 100644
+index 00000000000..7b3443298bf
+--- /dev/null
++++ b/src/Node/Expression/Binary/SetBinary.php
+@@ -0,0 +1,44 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
++use Twig\Node\Node;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++class SetBinary extends AbstractBinary
++{
++    /**
++     * @param ContextVariable    $left
++     * @param AbstractExpression $right
++     */
++    public function __construct(Node $left, Node $right, int $lineno)
++    {
++        $name = $left->getAttribute('name');
++        if (!\is_string($name)) {
++            throw new \LogicException('The "name" attribute must be a string.');
++        }
++        $left = new AssignContextVariable($name, $left->getTemplateLine());
++
++        parent::__construct($left, $right, $lineno);
++    }
++
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('=');
++    }
++}
+diff --git a/src/Node/Expression/Binary/SpaceshipBinary.php b/src/Node/Expression/Binary/SpaceshipBinary.php
+index ae5a4a49373..2fb5ddf9e9e 100644
+--- a/src/Node/Expression/Binary/SpaceshipBinary.php
++++ b/src/Node/Expression/Binary/SpaceshipBinary.php
+@@ -12,11 +12,18 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class SpaceshipBinary extends AbstractBinary
++class SpaceshipBinary extends AbstractBinary implements ReturnNumberInterface, CoercesChildrenToStringInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+         return $compiler->raw('<=>');
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['left', 'right'];
++    }
+ }
+diff --git a/src/Node/Expression/Binary/StartsWithBinary.php b/src/Node/Expression/Binary/StartsWithBinary.php
+index 4519f30d9fb..ef2fc950242 100644
+--- a/src/Node/Expression/Binary/StartsWithBinary.php
++++ b/src/Node/Expression/Binary/StartsWithBinary.php
+@@ -12,8 +12,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
+ 
+-class StartsWithBinary extends AbstractBinary
++class StartsWithBinary extends AbstractBinary implements ReturnBoolInterface
+ {
+     public function compile(Compiler $compiler): void
+     {
+diff --git a/src/Node/Expression/Binary/SubBinary.php b/src/Node/Expression/Binary/SubBinary.php
+index eeb87faca96..10663f5c1ef 100644
+--- a/src/Node/Expression/Binary/SubBinary.php
++++ b/src/Node/Expression/Binary/SubBinary.php
+@@ -13,8 +13,9 @@
+ namespace Twig\Node\Expression\Binary;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnNumberInterface;
+ 
+-class SubBinary extends AbstractBinary
++class SubBinary extends AbstractBinary implements ReturnNumberInterface
+ {
+     public function operator(Compiler $compiler): Compiler
+     {
+diff --git a/src/Node/Expression/Binary/XorBinary.php b/src/Node/Expression/Binary/XorBinary.php
+new file mode 100644
+index 00000000000..6f412d22fe2
+--- /dev/null
++++ b/src/Node/Expression/Binary/XorBinary.php
+@@ -0,0 +1,24 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ * (c) Armin Ronacher
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Binary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\ReturnBoolInterface;
++
++class XorBinary extends AbstractBinary implements ReturnBoolInterface
++{
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('xor');
++    }
++}
+diff --git a/src/Node/Expression/BlockReferenceExpression.php b/src/Node/Expression/BlockReferenceExpression.php
+index 62938223371..657a637194c 100644
+--- a/src/Node/Expression/BlockReferenceExpression.php
++++ b/src/Node/Expression/BlockReferenceExpression.php
+@@ -13,6 +13,7 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
+ use Twig\Node\Node;
+ 
+ /**
+@@ -20,21 +21,31 @@
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+-class BlockReferenceExpression extends AbstractExpression
++class BlockReferenceExpression extends AbstractExpression implements SupportDefinedTestInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(Node $name, ?Node $template, int $lineno, ?string $tag = null)
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
++    /**
++     * @param AbstractExpression $name
++     */
++    public function __construct(Node $name, ?Node $template, int $lineno)
+     {
++        if (!$name instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $name::class);
++        }
++
+         $nodes = ['name' => $name];
+         if (null !== $template) {
+             $nodes['template'] = $template;
+         }
+ 
+-        parent::__construct($nodes, ['is_defined_test' => false, 'output' => false], $lineno, $tag);
++        parent::__construct($nodes, ['output' => false], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        if ($this->getAttribute('is_defined_test')) {
++        if ($this->definedTest) {
+             $this->compileTemplateCall($compiler, 'hasBlock');
+         } else {
+             if ($this->getAttribute('output')) {
+@@ -50,17 +61,21 @@ public function compile(Compiler $compiler): void
+         }
+     }
+ 
++    public function getStringCoercedChildNames(): array
++    {
++        // the template expression is resolved through the loader, which coerces it to a string
++        return $this->hasNode('template') ? ['template'] : [];
++    }
++
+     private function compileTemplateCall(Compiler $compiler, string $method): Compiler
+     {
+         if (!$this->hasNode('template')) {
+             $compiler->write('$this');
+         } else {
+             $compiler
+-                ->write('$this->loadTemplate(')
++                ->write('$this->load(')
+                 ->subcompile($this->getNode('template'))
+                 ->raw(', ')
+-                ->repr($this->getTemplateName())
+-                ->raw(', ')
+                 ->repr($this->getTemplateLine())
+                 ->raw(')')
+             ;
+diff --git a/src/Node/Expression/CallExpression.php b/src/Node/Expression/CallExpression.php
+index cd81df47a38..70c56c3c6db 100644
+--- a/src/Node/Expression/CallExpression.php
++++ b/src/Node/Expression/CallExpression.php
+@@ -15,20 +15,29 @@
+ use Twig\Error\SyntaxError;
+ use Twig\Extension\ExtensionInterface;
+ use Twig\Node\Node;
++use Twig\TwigCallableInterface;
++use Twig\TwigFilter;
++use Twig\TwigFunction;
++use Twig\TwigTest;
++use Twig\Util\CallableArgumentsExtractor;
+ use Twig\Util\ReflectionCallable;
+ 
+ abstract class CallExpression extends AbstractExpression
+ {
+-    private $reflector = null;
++    private $reflector;
+ 
++    /**
++     * @return void
++     */
+     protected function compileCallable(Compiler $compiler)
+     {
+-        $callable = $this->getAttribute('callable');
++        $twigCallable = $this->getTwigCallable();
++        $callable = $twigCallable->getCallable();
+ 
+         if (\is_string($callable) && !str_contains($callable, '::')) {
+             $compiler->raw($callable);
+         } else {
+-            $rc = $this->reflectCallable($callable);
++            $rc = $this->reflectCallable($twigCallable);
+             $r = $rc->getReflector();
+             $callable = $rc->getCallable();
+ 
+@@ -51,7 +60,7 @@ protected function compileCallable(Compiler $compiler)
+ 
+                 $compiler->raw(\sprintf('->%s', $callable[1]));
+             } else {
+-                $compiler->raw(\sprintf('$this->env->get%s(\'%s\')->getCallable()', ucfirst($this->getAttribute('type')), $this->getAttribute('name')));
++                $compiler->raw(\sprintf('$this->env->get%s(\'%s\')->getCallable()', ucfirst($this->getAttribute('type')), $twigCallable->getDynamicName()));
+             }
+         }
+ 
+@@ -68,12 +77,14 @@ protected function compileArguments(Compiler $compiler, $isArray = false): void
+ 
+         $first = true;
+ 
+-        if ($this->hasAttribute('needs_charset') && $this->getAttribute('needs_charset')) {
++        $twigCallable = $this->getAttribute('twig_callable');
++
++        if ($twigCallable->needsCharset()) {
+             $compiler->raw('$this->env->getCharset()');
+             $first = false;
+         }
+ 
+-        if ($this->hasAttribute('needs_environment') && $this->getAttribute('needs_environment')) {
++        if ($twigCallable->needsEnvironment()) {
+             if (!$first) {
+                 $compiler->raw(', ');
+             }
+@@ -81,7 +92,7 @@ protected function compileArguments(Compiler $compiler, $isArray = false): void
+             $first = false;
+         }
+ 
+-        if ($this->hasAttribute('needs_context') && $this->getAttribute('needs_context')) {
++        if ($twigCallable->needsContext()) {
+             if (!$first) {
+                 $compiler->raw(', ');
+             }
+@@ -89,14 +100,20 @@ protected function compileArguments(Compiler $compiler, $isArray = false): void
+             $first = false;
+         }
+ 
+-        if ($this->hasAttribute('arguments')) {
+-            foreach ($this->getAttribute('arguments') as $argument) {
+-                if (!$first) {
+-                    $compiler->raw(', ');
+-                }
+-                $compiler->string($argument);
+-                $first = false;
++        if (self::needsIsSandboxed($twigCallable)) {
++            if (!$first) {
++                $compiler->raw(', ');
++            }
++            $compiler->raw('$this->env->hasExtension(\Twig\Extension\SandboxExtension::class) && $this->env->getExtension(\Twig\Extension\SandboxExtension::class)->isSandboxed($this->source)');
++            $first = false;
++        }
++
++        foreach ($twigCallable->getArguments() as $argument) {
++            if (!$first) {
++                $compiler->raw(', ');
+             }
++            $compiler->string($argument);
++            $first = false;
+         }
+ 
+         if ($this->hasNode('node')) {
+@@ -108,8 +125,7 @@ protected function compileArguments(Compiler $compiler, $isArray = false): void
+         }
+ 
+         if ($this->hasNode('arguments')) {
+-            $callable = $this->getAttribute('callable');
+-            $arguments = $this->getArguments($callable, $this->getNode('arguments'));
++            $arguments = (new CallableArgumentsExtractor($this, $this->getTwigCallable()))->extractArguments($this->getNode('arguments'));
+             foreach ($arguments as $node) {
+                 if (!$first) {
+                     $compiler->raw(', ');
+@@ -122,8 +138,13 @@ protected function compileArguments(Compiler $compiler, $isArray = false): void
+         $compiler->raw($isArray ? ']' : ')');
+     }
+ 
++    /**
++     * @deprecated since Twig 3.12, use Twig\Util\CallableArgumentsExtractor::getArguments() instead
++     */
+     protected function getArguments($callable, $arguments)
+     {
++        trigger_deprecation('twig/twig', '3.12', 'The "%s()" method is deprecated, use Twig\Util\CallableArgumentsExtractor::getArguments() instead.', __METHOD__);
++
+         $callType = $this->getAttribute('type');
+         $callName = $this->getAttribute('name');
+ 
+@@ -140,7 +161,7 @@ protected function getArguments($callable, $arguments)
+             $parameters[$name] = $node;
+         }
+ 
+-        $isVariadic = $this->hasAttribute('is_variadic') && $this->getAttribute('is_variadic');
++        $isVariadic = $this->getAttribute('twig_callable')->isVariadic();
+         if (!$named && !$isVariadic) {
+             return $parameters;
+         }
+@@ -198,11 +219,10 @@ protected function getArguments($callable, $arguments)
+             } elseif ($callableParameter->isDefaultValueAvailable()) {
+                 $optionalArguments[] = new ConstantExpression($callableParameter->getDefaultValue(), -1);
+             } elseif ($callableParameter->isOptional()) {
+-                if (empty($parameters)) {
++                if (!$parameters) {
+                     break;
+-                } else {
+-                    $missingArguments[] = $name;
+                 }
++                $missingArguments[] = $name;
+             } else {
+                 throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $name, $callType, $callName), $this->getTemplateLine(), $this->getSourceContext());
+             }
+@@ -225,7 +245,7 @@ protected function getArguments($callable, $arguments)
+             }
+         }
+ 
+-        if (!empty($parameters)) {
++        if ($parameters) {
+             $unknownParameter = null;
+             foreach ($parameters as $parameter) {
+                 if ($parameter instanceof Node) {
+@@ -247,14 +267,21 @@ protected function getArguments($callable, $arguments)
+         return $arguments;
+     }
+ 
++    /**
++     * @deprecated since Twig 3.12
++     */
+     protected function normalizeName(string $name): string
+     {
++        trigger_deprecation('twig/twig', '3.12', 'The "%s()" method is deprecated.', __METHOD__);
++
+         return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], $name));
+     }
+ 
++    // To be removed in 4.0
+     private function getCallableParameters($callable, bool $isVariadic): array
+     {
+-        $rc = $this->reflectCallable($callable);
++        $twigCallable = $this->getAttribute('twig_callable');
++        $rc = $this->reflectCallable($twigCallable);
+         $r = $rc->getReflector();
+         $callableName = $rc->getName();
+ 
+@@ -262,20 +289,22 @@ private function getCallableParameters($callable, bool $isVariadic): array
+         if ($this->hasNode('node')) {
+             array_shift($parameters);
+         }
+-        if ($this->hasAttribute('needs_charset') && $this->getAttribute('needs_charset')) {
++        if ($twigCallable->needsCharset()) {
+             array_shift($parameters);
+         }
+-        if ($this->hasAttribute('needs_environment') && $this->getAttribute('needs_environment')) {
++        if ($twigCallable->needsEnvironment()) {
+             array_shift($parameters);
+         }
+-        if ($this->hasAttribute('needs_context') && $this->getAttribute('needs_context')) {
++        if ($twigCallable->needsContext()) {
+             array_shift($parameters);
+         }
+-        if ($this->hasAttribute('arguments') && null !== $this->getAttribute('arguments')) {
+-            foreach ($this->getAttribute('arguments') as $argument) {
+-                array_shift($parameters);
+-            }
++        if (self::needsIsSandboxed($twigCallable)) {
++            array_shift($parameters);
++        }
++        foreach ($twigCallable->getArguments() as $argument) {
++            array_shift($parameters);
+         }
++
+         $isPhpVariadic = false;
+         if ($isVariadic) {
+             $argument = end($parameters);
+@@ -286,19 +315,80 @@ private function getCallableParameters($callable, bool $isVariadic): array
+                 array_pop($parameters);
+                 $isPhpVariadic = true;
+             } else {
+-                throw new \LogicException(\sprintf('The last parameter of "%s" for %s "%s" must be an array with default value, eg. "array $arg = []".', $callableName, $this->getAttribute('type'), $this->getAttribute('name')));
++                throw new \LogicException(\sprintf('The last parameter of "%s" for %s "%s" must be an array with default value, eg. "array $arg = []".', $callableName, $this->getAttribute('type'), $twigCallable->getName()));
+             }
+         }
+ 
+         return [$parameters, $isPhpVariadic];
+     }
+ 
+-    private function reflectCallable($callable): ReflectionCallable
++    private function reflectCallable(TwigCallableInterface $callable): ReflectionCallable
+     {
+         if (!$this->reflector) {
+-            $this->reflector = new ReflectionCallable($callable, $this->getAttribute('type'), $this->getAttribute('name'));
++            $this->reflector = new ReflectionCallable($callable);
+         }
+ 
+         return $this->reflector;
+     }
++
++    /**
++     * @internal
++     *
++     * To be removed in 4.0 and replaced by $twigCallable->needsIsSandboxed().
++     */
++    public static function needsIsSandboxed(TwigCallableInterface $twigCallable): bool
++    {
++        if (method_exists($twigCallable, 'needsIsSandboxed')) {
++            return $twigCallable->needsIsSandboxed();
++        }
++
++        trigger_deprecation('twig/twig', '3.25', 'Not implementing the "needsIsSandboxed()" method in "%s" is deprecated. This method will be part of the "%s" interface in 4.0.', $twigCallable::class, TwigCallableInterface::class);
++
++        return false;
++    }
++
++    /**
++     * Overrides the Twig callable based on attributes (as potentially, attributes changed between the creation and the compilation of the node).
++     *
++     * To be removed in 4.0 and replace by $this->getAttribute('twig_callable').
++     */
++    private function getTwigCallable(): TwigCallableInterface
++    {
++        $current = $this->getAttribute('twig_callable');
++
++        $this->setAttribute('twig_callable', match ($this->getAttribute('type')) {
++            'test' => (new TwigTest(
++                $this->getAttribute('name'),
++                $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
++                [
++                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                ],
++            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
++            'function' => (new TwigFunction(
++                $this->hasAttribute('name') ? $this->getAttribute('name') : $current->getName(),
++                $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
++                [
++                    'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
++                    'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
++                    'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
++                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                ],
++            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
++            'filter' => (new TwigFilter(
++                $this->getAttribute('name'),
++                $this->hasAttribute('callable') ? $this->getAttribute('callable') : $current->getCallable(),
++                [
++                    'needs_environment' => $this->hasAttribute('needs_environment') ? $this->getAttribute('needs_environment') : $current->needsEnvironment(),
++                    'needs_context' => $this->hasAttribute('needs_context') ? $this->getAttribute('needs_context') : $current->needsContext(),
++                    'needs_charset' => $this->hasAttribute('needs_charset') ? $this->getAttribute('needs_charset') : $current->needsCharset(),
++                    'needs_is_sandboxed' => $this->hasAttribute('needs_is_sandboxed') ? $this->getAttribute('needs_is_sandboxed') : self::needsIsSandboxed($current),
++                    'is_variadic' => $this->hasAttribute('is_variadic') ? $this->getAttribute('is_variadic') : $current->isVariadic(),
++                ],
++            ))->withDynamicArguments($this->getAttribute('name'), $this->hasAttribute('dynamic_name') ? $this->getAttribute('dynamic_name') : $current->getDynamicName(), $this->hasAttribute('arguments') ? $this->getAttribute('arguments') : $current->getArguments()),
++        });
++
++        return $this->getAttribute('twig_callable');
++    }
+ }
+diff --git a/src/Node/Expression/ConditionalExpression.php b/src/Node/Expression/ConditionalExpression.php
+index d7db993579c..7fe309cf300 100644
+--- a/src/Node/Expression/ConditionalExpression.php
++++ b/src/Node/Expression/ConditionalExpression.php
+@@ -13,11 +13,14 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\Ternary\ConditionalTernary;
+ 
+-class ConditionalExpression extends AbstractExpression
++class ConditionalExpression extends AbstractExpression implements OperatorEscapeInterface
+ {
+     public function __construct(AbstractExpression $expr1, AbstractExpression $expr2, AbstractExpression $expr3, int $lineno)
+     {
++        trigger_deprecation('twig/twig', '3.17', \sprintf('"%s" is deprecated; use "%s" instead.', __CLASS__, ConditionalTernary::class));
++
+         parent::__construct(['expr1' => $expr1, 'expr2' => $expr2, 'expr3' => $expr3], [], $lineno);
+     }
+ 
+@@ -42,4 +45,9 @@ public function compile(Compiler $compiler): void
+                 ->raw('))');
+         }
+     }
++
++    public function getOperandNamesToEscape(): array
++    {
++        return ['expr2', 'expr3'];
++    }
+ }
+diff --git a/src/Node/Expression/ConstantExpression.php b/src/Node/Expression/ConstantExpression.php
+index 2a8909d5469..12dc0621fea 100644
+--- a/src/Node/Expression/ConstantExpression.php
++++ b/src/Node/Expression/ConstantExpression.php
+@@ -17,8 +17,10 @@
+ /**
+  * @final
+  */
+-class ConstantExpression extends AbstractExpression
++class ConstantExpression extends AbstractExpression implements SupportDefinedTestInterface, ReturnPrimitiveTypeInterface
+ {
++    use SupportDefinedTestTrait;
++
+     public function __construct($value, int $lineno)
+     {
+         parent::__construct([], ['value' => $value], $lineno);
+@@ -26,6 +28,6 @@ public function __construct($value, int $lineno)
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $compiler->repr($this->getAttribute('value'));
++        $compiler->repr($this->definedTest ? true : $this->getAttribute('value'));
+     }
+ }
+diff --git a/src/Node/Expression/EmptyExpression.php b/src/Node/Expression/EmptyExpression.php
+new file mode 100644
+index 00000000000..768d1d64fae
+--- /dev/null
++++ b/src/Node/Expression/EmptyExpression.php
+@@ -0,0 +1,33 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++use Twig\Compiler;
++
++/**
++ * Represents an empty slot in an array.
++ *
++ * This is currently only used in destructuring contexts.
++ *
++ * @internal
++ */
++final class EmptyExpression extends AbstractExpression
++{
++    public function __construct(int $lineno)
++    {
++        parent::__construct([], [], $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++    }
++}
+diff --git a/src/Node/Expression/Filter/DefaultFilter.php b/src/Node/Expression/Filter/DefaultFilter.php
+index 7eb0ea7704a..04ef06cc4ee 100644
+--- a/src/Node/Expression/Filter/DefaultFilter.php
++++ b/src/Node/Expression/Filter/DefaultFilter.php
+@@ -11,14 +11,20 @@
+ 
+ namespace Twig\Node\Expression\Filter;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
+-use Twig\Node\Expression\ConditionalExpression;
++use Twig\Extension\CoreExtension;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Expression\FilterExpression;
+ use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\Ternary\ConditionalTernary;
+ use Twig\Node\Expression\Test\DefinedTest;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
++use Twig\TwigFilter;
++use Twig\TwigTest;
+ 
+ /**
+  * Returns the value or the default value when it is undefined or empty.
+@@ -29,20 +35,34 @@
+  */
+ class DefaultFilter extends FilterExpression
+ {
+-    public function __construct(Node $node, ConstantExpression $filterName, Node $arguments, int $lineno, ?string $tag = null)
++    /**
++     * @param AbstractExpression $node
++     */
++    #[FirstClassTwigCallableReady]
++    public function __construct(Node $node, TwigFilter|ConstantExpression $filter, Node $arguments, int $lineno)
+     {
+-        $default = new FilterExpression($node, new ConstantExpression('default', $node->getTemplateLine()), $arguments, $node->getTemplateLine());
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++        }
++
++        if ($filter instanceof TwigFilter) {
++            $name = $filter->getName();
++            $default = new FilterExpression($node, $filter, $arguments, $node->getTemplateLine());
++        } else {
++            $name = $filter->getAttribute('value');
++            $default = new FilterExpression($node, new TwigFilter('default', [CoreExtension::class, 'default']), $arguments, $node->getTemplateLine());
++        }
+ 
+-        if ('default' === $filterName->getAttribute('value') && ($node instanceof NameExpression || $node instanceof GetAttrExpression)) {
+-            $test = new DefinedTest(clone $node, 'defined', new Node(), $node->getTemplateLine());
++        if ('default' === $name && ($node instanceof ContextVariable || $node instanceof GetAttrExpression)) {
++            $test = new DefinedTest(clone $node, new TwigTest('defined'), new EmptyNode(), $node->getTemplateLine());
+             $false = \count($arguments) ? $arguments->getNode('0') : new ConstantExpression('', $node->getTemplateLine());
+ 
+-            $node = new ConditionalExpression($test, $default, $false, $node->getTemplateLine());
++            $node = new ConditionalTernary($test, $default, $false, $node->getTemplateLine());
+         } else {
+             $node = $default;
+         }
+ 
+-        parent::__construct($node, $filterName, $arguments, $lineno, $tag);
++        parent::__construct($node, $filter, $arguments, $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/Expression/Filter/RawFilter.php b/src/Node/Expression/Filter/RawFilter.php
+index 584942306f2..707e8ec245c 100644
+--- a/src/Node/Expression/Filter/RawFilter.php
++++ b/src/Node/Expression/Filter/RawFilter.php
+@@ -11,26 +11,31 @@
+ 
+ namespace Twig\Node\Expression\Filter;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Expression\FilterExpression;
+ use Twig\Node\Node;
++use Twig\TwigFilter;
+ 
+ /**
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ class RawFilter extends FilterExpression
+ {
+-    public function __construct(Node $node, ?ConstantExpression $filterName = null, ?Node $arguments = null, int $lineno = 0, ?string $tag = null)
++    /**
++     * @param AbstractExpression $node
++     */
++    #[FirstClassTwigCallableReady]
++    public function __construct(Node $node, TwigFilter|ConstantExpression|null $filter = null, ?Node $arguments = null, int $lineno = 0)
+     {
+-        if (null === $filterName) {
+-            $filterName = new ConstantExpression('raw', $node->getTemplateLine());
+-        }
+-        if (null === $arguments) {
+-            $arguments = new Node();
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
+         }
+ 
+-        parent::__construct($node, $filterName, $arguments, $lineno ?: $node->getTemplateLine(), $tag ?: $node->getNodeTag());
++        parent::__construct($node, $filter ?: new TwigFilter('raw', null, ['is_safe' => ['all']]), $arguments ?: new EmptyNode(), $lineno ?: $node->getTemplateLine());
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/Expression/FilterExpression.php b/src/Node/Expression/FilterExpression.php
+index 251870ae552..eb947201d17 100644
+--- a/src/Node/Expression/FilterExpression.php
++++ b/src/Node/Expression/FilterExpression.php
+@@ -12,22 +12,57 @@
+ 
+ namespace Twig\Node\Expression;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\NameDeprecation;
+ use Twig\Node\Node;
++use Twig\TwigFilter;
+ 
+-class FilterExpression extends CallExpression
++class FilterExpression extends CallExpression implements CoercesChildrenToStringInterface
+ {
+-    public function __construct(Node $node, ConstantExpression $filterName, Node $arguments, int $lineno, ?string $tag = null)
++    /**
++     * @param AbstractExpression $node
++     */
++    #[FirstClassTwigCallableReady]
++    public function __construct(Node $node, TwigFilter|ConstantExpression $filter, Node $arguments, int $lineno)
+     {
+-        parent::__construct(['node' => $node, 'filter' => $filterName, 'arguments' => $arguments], ['name' => $filterName->getAttribute('value'), 'type' => 'filter'], $lineno, $tag);
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++        }
++
++        if ($filter instanceof TwigFilter) {
++            $name = $filter->getName();
++            $filterName = new ConstantExpression($name, $lineno);
++        } else {
++            $name = $filter->getAttribute('value');
++            $filterName = $filter;
++            trigger_deprecation('twig/twig', '3.12', 'Not passing an instance of "TwigFilter" when creating a "%s" filter of type "%s" is deprecated.', $name, static::class);
++        }
++
++        parent::__construct(['node' => $node, 'filter' => $filterName, 'arguments' => $arguments], ['name' => $name, 'type' => 'filter'], $lineno);
++
++        if ($filter instanceof TwigFilter) {
++            $this->setAttribute('twig_callable', $filter);
++        }
++
++        $this->deprecateNode('filter', new NameDeprecation('twig/twig', '3.12'));
++
++        $this->deprecateAttribute('needs_charset', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('needs_environment', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('needs_context', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('arguments', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('callable', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('is_variadic', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('dynamic_name', new NameDeprecation('twig/twig', '3.12'));
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $name = $this->getNode('filter')->getAttribute('value');
++        $name = $this->getNode('filter', false)->getAttribute('value');
+         if ($name !== $this->getAttribute('name')) {
+             trigger_deprecation('twig/twig', '3.11', 'Changing the value of a "filter" node in a NodeVisitor class is not supported anymore.');
+-            $this->setAttribute('name', $name);
++            $this->removeAttribute('twig_callable');
+         }
+         if ('raw' === $name) {
+             trigger_deprecation('twig/twig', '3.11', 'Creating the "raw" filter via "FilterExpression" is deprecated; use "RawFilter" instead.');
+@@ -36,15 +71,17 @@ public function compile(Compiler $compiler): void
+ 
+             return;
+         }
+-        $filter = $compiler->getEnvironment()->getFilter($name);
+ 
+-        $this->setAttribute('needs_charset', $filter->needsCharset());
+-        $this->setAttribute('needs_environment', $filter->needsEnvironment());
+-        $this->setAttribute('needs_context', $filter->needsContext());
+-        $this->setAttribute('arguments', $filter->getArguments());
+-        $this->setAttribute('callable', $filter->getCallable());
+-        $this->setAttribute('is_variadic', $filter->isVariadic());
++        if (!$this->hasAttribute('twig_callable')) {
++            $this->setAttribute('twig_callable', $compiler->getEnvironment()->getFilter($name));
++        }
+ 
+         $this->compileCallable($compiler);
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // a filter may coerce its input and arguments to string (e.g. `upper`, `replace`)
++        return ['node', 'arguments'];
++    }
+ }
+diff --git a/src/Node/Expression/FunctionExpression.php b/src/Node/Expression/FunctionExpression.php
+index ef99c401a94..5983962dc56 100644
+--- a/src/Node/Expression/FunctionExpression.php
++++ b/src/Node/Expression/FunctionExpression.php
+@@ -11,33 +11,78 @@
+ 
+ namespace Twig\Node\Expression;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
+-use Twig\Extension\CoreExtension;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\NameDeprecation;
+ use Twig\Node\Node;
++use Twig\TwigFunction;
+ 
+-class FunctionExpression extends CallExpression
++class FunctionExpression extends CallExpression implements SupportDefinedTestInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(string $name, Node $arguments, int $lineno)
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
++    #[FirstClassTwigCallableReady]
++    public function __construct(TwigFunction|string $function, Node $arguments, int $lineno)
+     {
+-        parent::__construct(['arguments' => $arguments], ['name' => $name, 'type' => 'function', 'is_defined_test' => false], $lineno);
++        if ($function instanceof TwigFunction) {
++            $name = $function->getName();
++        } else {
++            $name = $function;
++            trigger_deprecation('twig/twig', '3.12', 'Not passing an instance of "TwigFunction" when creating a "%s" function of type "%s" is deprecated.', $name, static::class);
++        }
++
++        parent::__construct(['arguments' => $arguments], ['name' => $name, 'type' => 'function'], $lineno);
++
++        if ($function instanceof TwigFunction) {
++            $this->setAttribute('twig_callable', $function);
++        }
++
++        $this->deprecateAttribute('needs_charset', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('needs_environment', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('needs_context', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('arguments', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('callable', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('is_variadic', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('dynamic_name', new NameDeprecation('twig/twig', '3.12'));
+     }
+ 
++    public function enableDefinedTest(): void
++    {
++        if ('constant' === $this->getAttribute('name')) {
++            $this->definedTest = true;
++        }
++    }
++
++    /**
++     * @return void
++     */
+     public function compile(Compiler $compiler)
+     {
+         $name = $this->getAttribute('name');
+-        $function = $compiler->getEnvironment()->getFunction($name);
+-
+-        $this->setAttribute('needs_charset', $function->needsCharset());
+-        $this->setAttribute('needs_environment', $function->needsEnvironment());
+-        $this->setAttribute('needs_context', $function->needsContext());
+-        $this->setAttribute('arguments', $function->getArguments());
+-        $callable = $function->getCallable();
+-        if ('constant' === $name && $this->getAttribute('is_defined_test')) {
+-            $callable = [CoreExtension::class, 'constantIsDefined'];
++        if ($this->hasAttribute('twig_callable')) {
++            $name = $this->getAttribute('twig_callable')->getName();
++            if ($name !== $this->getAttribute('name')) {
++                trigger_deprecation('twig/twig', '3.12', 'Changing the value of a "function" node in a NodeVisitor class is not supported anymore.');
++                $this->removeAttribute('twig_callable');
++            }
++        }
++
++        if (!$this->hasAttribute('twig_callable')) {
++            $this->setAttribute('twig_callable', $compiler->getEnvironment()->getFunction($name));
++        }
++
++        if ('constant' === $name && $this->isDefinedTestEnabled()) {
++            $this->getNode('arguments')->setNode('checkDefined', new ConstantExpression(true, $this->getTemplateLine()));
+         }
+-        $this->setAttribute('callable', $callable);
+-        $this->setAttribute('is_variadic', $function->isVariadic());
+ 
+         $this->compileCallable($compiler);
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // a function may coerce its arguments to string (the host PHP code is opaque to Twig)
++        return ['arguments'];
++    }
+ }
+diff --git a/src/Node/Expression/FunctionNode/EnumCasesFunction.php b/src/Node/Expression/FunctionNode/EnumCasesFunction.php
+new file mode 100644
+index 00000000000..170d0a13b93
+--- /dev/null
++++ b/src/Node/Expression/FunctionNode/EnumCasesFunction.php
+@@ -0,0 +1,50 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\FunctionNode;
++
++use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\FunctionExpression;
++
++class EnumCasesFunction extends FunctionExpression
++{
++    public function compile(Compiler $compiler): void
++    {
++        $arguments = $this->getNode('arguments');
++        if ($arguments->hasNode('enum')) {
++            $firstArgument = $arguments->getNode('enum');
++        } elseif ($arguments->hasNode('0')) {
++            $firstArgument = $arguments->getNode('0');
++        } else {
++            $firstArgument = null;
++        }
++
++        if (!$firstArgument instanceof ConstantExpression || 1 !== \count($arguments)) {
++            parent::compile($compiler);
++
++            return;
++        }
++
++        $value = $firstArgument->getAttribute('value');
++
++        if (!\is_string($value)) {
++            throw new SyntaxError('The first argument of the "enum_cases" function must be a string.', $this->getTemplateLine(), $this->getSourceContext());
++        }
++
++        if (!enum_exists($value)) {
++            throw new SyntaxError(\sprintf('The first argument of the "enum_cases" function must be the name of an enum, "%s" given.', $value), $this->getTemplateLine(), $this->getSourceContext());
++        }
++
++        $compiler->raw(\sprintf('%s::cases()', $value));
++    }
++}
+diff --git a/src/Node/Expression/FunctionNode/EnumFunction.php b/src/Node/Expression/FunctionNode/EnumFunction.php
+new file mode 100644
+index 00000000000..af15b64f767
+--- /dev/null
++++ b/src/Node/Expression/FunctionNode/EnumFunction.php
+@@ -0,0 +1,54 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\FunctionNode;
++
++use Twig\Compiler;
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\FunctionExpression;
++
++class EnumFunction extends FunctionExpression
++{
++    public function compile(Compiler $compiler): void
++    {
++        $arguments = $this->getNode('arguments');
++        if ($arguments->hasNode('enum')) {
++            $firstArgument = $arguments->getNode('enum');
++        } elseif ($arguments->hasNode('0')) {
++            $firstArgument = $arguments->getNode('0');
++        } else {
++            $firstArgument = null;
++        }
++
++        if (!$firstArgument instanceof ConstantExpression || 1 !== \count($arguments)) {
++            parent::compile($compiler);
++
++            return;
++        }
++
++        $value = $firstArgument->getAttribute('value');
++
++        if (!\is_string($value)) {
++            throw new SyntaxError('The first argument of the "enum" function must be a string.', $this->getTemplateLine(), $this->getSourceContext());
++        }
++
++        if (!enum_exists($value)) {
++            throw new SyntaxError(\sprintf('The first argument of the "enum" function must be the name of an enum, "%s" given.', $value), $this->getTemplateLine(), $this->getSourceContext());
++        }
++
++        if (!$cases = $value::cases()) {
++            throw new SyntaxError(\sprintf('The first argument of the "enum" function must be a non-empty enum, "%s" given.', $value), $this->getTemplateLine(), $this->getSourceContext());
++        }
++
++        $compiler->raw(\sprintf('%s::%s', $value, $cases[0]->name));
++    }
++}
+diff --git a/src/Node/Expression/GetAttrExpression.php b/src/Node/Expression/GetAttrExpression.php
+index f54f2f09d54..b9cb74fbdaa 100644
+--- a/src/Node/Expression/GetAttrExpression.php
++++ b/src/Node/Expression/GetAttrExpression.php
+@@ -14,30 +14,49 @@
+ 
+ use Twig\Compiler;
+ use Twig\Extension\SandboxExtension;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Template;
+ 
+-class GetAttrExpression extends AbstractExpression
++class GetAttrExpression extends AbstractExpression implements SupportDefinedTestInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $node, AbstractExpression $attribute, ?AbstractExpression $arguments, string $type, int $lineno)
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
++    /**
++     * @param ArrayExpression|NameExpression|null $arguments
++     */
++    public function __construct(AbstractExpression $node, AbstractExpression $attribute, ?AbstractExpression $arguments, string $type, int $lineno, bool $nullSafe = false)
+     {
+         $nodes = ['node' => $node, 'attribute' => $attribute];
+         if (null !== $arguments) {
+             $nodes['arguments'] = $arguments;
+         }
+ 
+-        parent::__construct($nodes, ['type' => $type, 'is_defined_test' => false, 'ignore_strict_check' => false, 'optimizable' => true], $lineno);
++        if ($arguments && !$arguments instanceof ArrayExpression && !$arguments instanceof ContextVariable) {
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, $arguments::class));
++        }
++
++        parent::__construct($nodes, ['type' => $type, 'ignore_strict_check' => false, 'optimizable' => !$nullSafe, 'null_safe' => $nullSafe, 'is_short_circuited' => false, 'var_name' => null], $lineno);
++    }
++
++    public function enableDefinedTest(): void
++    {
++        $this->definedTest = true;
++        $this->changeIgnoreStrictCheck($this);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+         $env = $compiler->getEnvironment();
+         $arrayAccessSandbox = false;
++        $nullSafe = $this->getAttribute('null_safe');
+ 
+         // optimize array calls
+         if (
+             $this->getAttribute('optimizable')
+             && (!$env->isStrictVariables() || $this->getAttribute('ignore_strict_check'))
+-            && !$this->getAttribute('is_defined_test')
++            && !$this->definedTest
+             && Template::ARRAY_CALL === $this->getAttribute('type')
+         ) {
+             $var = '$'.$compiler->getVarName();
+@@ -67,7 +86,7 @@ public function compile(Compiler $compiler): void
+                 ->raw(') || ')
+                 ->raw($var)
+                 ->raw(' instanceof ArrayAccess && in_array(')
+-                ->raw('get_class('.$var.')')
++                ->raw($var.'::class')
+                 ->raw(', CoreExtension::ARRAY_LIKE_CLASSES, true) ? (')
+                 ->raw($var)
+                 ->raw('[')
+@@ -76,14 +95,41 @@ public function compile(Compiler $compiler): void
+             ;
+         }
+ 
+-        $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
+-
+         if ($this->getAttribute('ignore_strict_check')) {
+             $this->getNode('node')->setAttribute('ignore_strict_check', true);
+         }
+ 
++        if (null === $nullSafeNode = $nullSafe ? $this : null) {
++            $node = $this->getNode('node');
++            while ($node instanceof self) {
++                if ($node->getAttribute('null_safe')) {
++                    $nullSafeNode = $node;
++                    break;
++                }
++                $node = $node->getNode('node');
++            }
++        }
++
++        $isShortCircuited = false;
++        if (null !== $nullSafeNode && !$nullSafeNode->isShortCircuited()) {
++            $compiler
++                ->raw('((null === ('.$nullSafeNode->getVarName($compiler).' = ')
++                ->subcompile($nullSafeNode->getNode('node'))
++                ->raw(')) ? null : ');
++
++            $nullSafeNode->markAsShortCircuited();
++            $isShortCircuited = true;
++        }
++
++        $compiler->raw('CoreExtension::getAttribute($this->env, $this->source, ');
++
++        if ($nullSafe) {
++            $compiler->raw($this->getVarName($compiler));
++        } else {
++            $compiler->subcompile($this->getNode('node'));
++        }
++
+         $compiler
+-            ->subcompile($this->getNode('node'))
+             ->raw(', ')
+             ->subcompile($this->getNode('attribute'))
+         ;
+@@ -96,7 +142,7 @@ public function compile(Compiler $compiler): void
+ 
+         $compiler->raw(', ')
+             ->repr($this->getAttribute('type'))
+-            ->raw(', ')->repr($this->getAttribute('is_defined_test'))
++            ->raw(', ')->repr($this->definedTest)
+             ->raw(', ')->repr($this->getAttribute('ignore_strict_check'))
+             ->raw(', ')->repr($env->hasExtension(SandboxExtension::class))
+             ->raw(', ')->repr($this->getNode('node')->getTemplateLine())
+@@ -106,5 +152,44 @@ public function compile(Compiler $compiler): void
+         if ($arrayAccessSandbox) {
+             $compiler->raw(')');
+         }
++
++        if ($isShortCircuited) {
++            $compiler->raw(')');
++        }
++    }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // for a method-like access, the host PHP method may coerce any of its arguments to string
++        return $this->hasNode('arguments') ? ['arguments'] : [];
++    }
++
++    private function changeIgnoreStrictCheck(self $node): void
++    {
++        $node->setAttribute('optimizable', false);
++        $node->setAttribute('ignore_strict_check', true);
++
++        if ($node->getNode('node') instanceof self) {
++            $this->changeIgnoreStrictCheck($node->getNode('node'));
++        }
++    }
++
++    private function markAsShortCircuited(): void
++    {
++        $this->setAttribute('is_short_circuited', true);
++    }
++
++    private function isShortCircuited(): bool
++    {
++        return $this->getAttribute('is_short_circuited');
++    }
++
++    private function getVarName(Compiler $compiler): string
++    {
++        if (null === $this->getAttribute('var_name')) {
++            $this->setAttribute('var_name', $compiler->getVarName());
++        }
++
++        return '$'.$this->getAttribute('var_name');
+     }
+ }
+diff --git a/src/Node/Expression/InlinePrint.php b/src/Node/Expression/InlinePrint.php
+index 0a3c2e4f9ec..5509f7942b1 100644
+--- a/src/Node/Expression/InlinePrint.php
++++ b/src/Node/Expression/InlinePrint.php
+@@ -19,8 +19,13 @@
+  */
+ final class InlinePrint extends AbstractExpression
+ {
++    /**
++     * @param AbstractExpression $node
++     */
+     public function __construct(Node $node, int $lineno)
+     {
++        trigger_deprecation('twig/twig', '3.16', \sprintf('The "%s" class is deprecated with no replacement.', static::class));
++
+         parent::__construct(['node' => $node], [], $lineno);
+     }
+ 
+diff --git a/src/Node/Expression/ListExpression.php b/src/Node/Expression/ListExpression.php
+new file mode 100644
+index 00000000000..9b23857fccc
+--- /dev/null
++++ b/src/Node/Expression/ListExpression.php
+@@ -0,0 +1,41 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++use Twig\Compiler;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++
++class ListExpression extends AbstractExpression
++{
++    /**
++     * @param array<AssignContextVariable> $items
++     */
++    public function __construct(array $items, int $lineno)
++    {
++        parent::__construct($items, [], $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        foreach ($this as $i => $name) {
++            if ($i) {
++                $compiler->raw(', ');
++            }
++
++            $compiler
++                ->raw('$__')
++                ->raw($name->getAttribute('name'))
++                ->raw('__')
++            ;
++        }
++    }
++}
+diff --git a/src/Node/Expression/MacroReferenceExpression.php b/src/Node/Expression/MacroReferenceExpression.php
+new file mode 100644
+index 00000000000..59cb2092a4b
+--- /dev/null
++++ b/src/Node/Expression/MacroReferenceExpression.php
+@@ -0,0 +1,77 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++use Twig\Compiler;
++use Twig\Node\Expression\Variable\TemplateVariable;
++
++/**
++ * Represents a macro call node.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++class MacroReferenceExpression extends AbstractExpression implements SupportDefinedTestInterface
++{
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
++    public function __construct(TemplateVariable $template, string $name, AbstractExpression $arguments, int $lineno)
++    {
++        // The name is emitted as raw PHP in compile() via "->{$name}(...)",
++        // so it must be a valid PHP method identifier. Reject anything else
++        // as a defense-in-depth against accidental PHP code injection from
++        // a caller that forgot to validate user-controlled input.
++        if (!preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#D', $name)) {
++            throw new \LogicException(\sprintf('Macro name "%s" is not a valid PHP identifier.', $name));
++        }
++
++        parent::__construct(['template' => $template, 'arguments' => $arguments], ['name' => $name], $lineno);
++    }
++
++    public function __clone()
++    {
++        // The template node must not be deep-cloned because its name is
++        // lazily generated during compilation and must stay in sync with
++        // the AssignTemplateVariable that populates the $macros array.
++        $template = $this->nodes['template'];
++        parent::__clone();
++        $this->nodes['template'] = $template;
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        if ($this->definedTest) {
++            $compiler
++                ->subcompile($this->getNode('template'))
++                ->raw('->hasMacro(')
++                ->repr($this->getAttribute('name'))
++                ->raw(', $context')
++                ->raw(')')
++            ;
++
++            return;
++        }
++
++        $compiler
++            ->subcompile($this->getNode('template'))
++            ->raw('->getTemplateForMacro(')
++            ->repr($this->getAttribute('name'))
++            ->raw(', $context, ')
++            ->repr($this->getTemplateLine())
++            ->raw(', $this->getSourceContext())')
++            ->raw(\sprintf('->%s', $this->getAttribute('name')))
++            ->raw('(...')
++            ->subcompile($this->getNode('arguments'))
++            ->raw(')')
++        ;
++    }
++}
+diff --git a/src/Node/Expression/MethodCallExpression.php b/src/Node/Expression/MethodCallExpression.php
+index 01806f91d10..4b180534df9 100644
+--- a/src/Node/Expression/MethodCallExpression.php
++++ b/src/Node/Expression/MethodCallExpression.php
+@@ -12,21 +12,27 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\Variable\ContextVariable;
+ 
+-class MethodCallExpression extends AbstractExpression
++class MethodCallExpression extends AbstractExpression implements SupportDefinedTestInterface
+ {
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
+     public function __construct(AbstractExpression $node, string $method, ArrayExpression $arguments, int $lineno)
+     {
+-        parent::__construct(['node' => $node, 'arguments' => $arguments], ['method' => $method, 'safe' => false, 'is_defined_test' => false], $lineno);
++        trigger_deprecation('twig/twig', '3.15', 'The "%s" class is deprecated, use "%s" instead.', __CLASS__, MacroReferenceExpression::class);
++
++        parent::__construct(['node' => $node, 'arguments' => $arguments], ['method' => $method, 'safe' => false], $lineno);
+ 
+-        if ($node instanceof NameExpression) {
++        if ($node instanceof ContextVariable) {
+             $node->setAttribute('always_defined', true);
+         }
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        if ($this->getAttribute('is_defined_test')) {
++        if ($this->definedTest) {
+             $compiler
+                 ->raw('method_exists($macros[')
+                 ->repr($this->getNode('node')->getAttribute('name'))
+@@ -43,21 +49,9 @@ public function compile(Compiler $compiler): void
+             ->repr($this->getNode('node')->getAttribute('name'))
+             ->raw('], ')
+             ->repr($this->getAttribute('method'))
+-            ->raw(', [')
+-        ;
+-        $first = true;
+-        /** @var ArrayExpression */
+-        $args = $this->getNode('arguments');
+-        foreach ($args->getKeyValuePairs() as $pair) {
+-            if (!$first) {
+-                $compiler->raw(', ');
+-            }
+-            $first = false;
+-
+-            $compiler->subcompile($pair['value']);
+-        }
+-        $compiler
+-            ->raw('], ')
++            ->raw(', ')
++            ->subcompile($this->getNode('arguments'))
++            ->raw(', ')
+             ->repr($this->getTemplateLine())
+             ->raw(', $context, $this->getSourceContext())');
+     }
+diff --git a/src/Node/Expression/NameExpression.php b/src/Node/Expression/NameExpression.php
+index 286aa5ae20d..0e036742086 100644
+--- a/src/Node/Expression/NameExpression.php
++++ b/src/Node/Expression/NameExpression.php
+@@ -13,9 +13,13 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Node\Expression\Variable\ContextVariable;
+ 
+-class NameExpression extends AbstractExpression
++class NameExpression extends AbstractExpression implements SupportDefinedTestInterface
+ {
++    use SupportDefinedTestDeprecationTrait;
++    use SupportDefinedTestTrait;
++
+     private $specialVars = [
+         '_self' => '$this->getTemplateName()',
+         '_context' => '$context',
+@@ -24,7 +28,11 @@ class NameExpression extends AbstractExpression
+ 
+     public function __construct(string $name, int $lineno)
+     {
+-        parent::__construct([], ['name' => $name, 'is_defined_test' => false, 'ignore_strict_check' => false, 'always_defined' => false], $lineno);
++        if (self::class === static::class) {
++            trigger_deprecation('twig/twig', '3.15', 'The "%s" class is deprecated, use "%s" instead.', self::class, ContextVariable::class);
++        }
++
++        parent::__construct([], ['name' => $name, 'ignore_strict_check' => false, 'always_defined' => false], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -33,8 +41,8 @@ public function compile(Compiler $compiler): void
+ 
+         $compiler->addDebugInfo($this);
+ 
+-        if ($this->getAttribute('is_defined_test')) {
+-            if (isset($this->specialVars[$name])) {
++        if ($this->definedTest) {
++            if (isset($this->specialVars[$name]) || $this->getAttribute('always_defined')) {
+                 $compiler->repr(true);
+             } elseif (\PHP_VERSION_ID >= 70400) {
+                 $compiler
+@@ -102,6 +110,6 @@ public function isSimple()
+     {
+         trigger_deprecation('twig/twig', '3.11', 'The "%s()" method is deprecated and will be removed in Twig 4.0.', __METHOD__);
+ 
+-        return !$this->isSpecial() && !$this->getAttribute('is_defined_test');
++        return !isset($this->specialVars[$this->getAttribute('name')]) && !$this->definedTest;
+     }
+ }
+diff --git a/src/Node/Expression/NullCoalesceExpression.php b/src/Node/Expression/NullCoalesceExpression.php
+index a72bc4fc654..f397f71f039 100644
+--- a/src/Node/Expression/NullCoalesceExpression.php
++++ b/src/Node/Expression/NullCoalesceExpression.php
+@@ -12,22 +12,39 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Node\EmptyNode;
+ use Twig\Node\Expression\Binary\AndBinary;
++use Twig\Node\Expression\Binary\NullCoalesceBinary;
+ use Twig\Node\Expression\Test\DefinedTest;
+ use Twig\Node\Expression\Test\NullTest;
+ use Twig\Node\Expression\Unary\NotUnary;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
++use Twig\TwigTest;
+ 
+ class NullCoalesceExpression extends ConditionalExpression
+ {
++    /**
++     * @param AbstractExpression $left
++     * @param AbstractExpression $right
++     */
+     public function __construct(Node $left, Node $right, int $lineno)
+     {
+-        $test = new DefinedTest(clone $left, 'defined', new Node(), $left->getTemplateLine());
++        trigger_deprecation('twig/twig', '3.17', \sprintf('"%s" is deprecated; use "%s" instead.', __CLASS__, NullCoalesceBinary::class));
++
++        if (!$left instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "left" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $left::class);
++        }
++        if (!$right instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "right" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $right::class);
++        }
++
++        $test = new DefinedTest(clone $left, new TwigTest('defined'), new EmptyNode(), $left->getTemplateLine());
+         // for "block()", we don't need the null test as the return value is always a string
+         if (!$left instanceof BlockReferenceExpression) {
+             $test = new AndBinary(
+                 $test,
+-                new NotUnary(new NullTest($left, 'null', new Node(), $left->getTemplateLine()), $left->getTemplateLine()),
++                new NotUnary(new NullTest($left, new TwigTest('null'), new EmptyNode(), $left->getTemplateLine()), $left->getTemplateLine()),
+                 $left->getTemplateLine()
+             );
+         }
+@@ -44,7 +61,7 @@ public function compile(Compiler $compiler): void
+          * cases might be implemented as an optimizer node visitor, but has not been done
+          * as benefits are probably not worth the added complexity.
+          */
+-        if ($this->getNode('expr2') instanceof NameExpression) {
++        if ($this->getNode('expr2') instanceof ContextVariable) {
+             $this->getNode('expr2')->setAttribute('always_defined', true);
+             $compiler
+                 ->raw('((')
+diff --git a/src/Node/Expression/OperatorEscapeInterface.php b/src/Node/Expression/OperatorEscapeInterface.php
+new file mode 100644
+index 00000000000..06db6c61657
+--- /dev/null
++++ b/src/Node/Expression/OperatorEscapeInterface.php
+@@ -0,0 +1,25 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++/**
++ * Interface implemented by n-ary operators for n > 1.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++interface OperatorEscapeInterface
++{
++    /**
++     * @return string[]
++     */
++    public function getOperandNamesToEscape(): array;
++}
+diff --git a/src/Node/Expression/ParentExpression.php b/src/Node/Expression/ParentExpression.php
+index 59d833ac99d..22fe38f6a2d 100644
+--- a/src/Node/Expression/ParentExpression.php
++++ b/src/Node/Expression/ParentExpression.php
+@@ -21,9 +21,9 @@
+  */
+ class ParentExpression extends AbstractExpression
+ {
+-    public function __construct(string $name, int $lineno, ?string $tag = null)
++    public function __construct(string $name, int $lineno)
+     {
+-        parent::__construct([], ['output' => false, 'name' => $name], $lineno, $tag);
++        parent::__construct([], ['output' => false, 'name' => $name], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/Expression/ReturnArrayInterface.php b/src/Node/Expression/ReturnArrayInterface.php
+new file mode 100644
+index 00000000000..a74864b5dbf
+--- /dev/null
++++ b/src/Node/Expression/ReturnArrayInterface.php
+@@ -0,0 +1,16 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++interface ReturnArrayInterface extends ReturnPrimitiveTypeInterface
++{
++}
+diff --git a/src/Node/Expression/ReturnBoolInterface.php b/src/Node/Expression/ReturnBoolInterface.php
+new file mode 100644
+index 00000000000..7046946c75e
+--- /dev/null
++++ b/src/Node/Expression/ReturnBoolInterface.php
+@@ -0,0 +1,16 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++interface ReturnBoolInterface extends ReturnPrimitiveTypeInterface
++{
++}
+diff --git a/src/Node/Expression/ReturnNumberInterface.php b/src/Node/Expression/ReturnNumberInterface.php
+new file mode 100644
+index 00000000000..8ae3b3d346c
+--- /dev/null
++++ b/src/Node/Expression/ReturnNumberInterface.php
+@@ -0,0 +1,16 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++interface ReturnNumberInterface extends ReturnPrimitiveTypeInterface
++{
++}
+diff --git a/src/Node/Expression/ReturnPrimitiveTypeInterface.php b/src/Node/Expression/ReturnPrimitiveTypeInterface.php
+new file mode 100644
+index 00000000000..6b87b8b12d9
+--- /dev/null
++++ b/src/Node/Expression/ReturnPrimitiveTypeInterface.php
+@@ -0,0 +1,16 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++interface ReturnPrimitiveTypeInterface
++{
++}
+diff --git a/src/Node/Expression/ReturnStringInterface.php b/src/Node/Expression/ReturnStringInterface.php
+new file mode 100644
+index 00000000000..53d29aabe26
+--- /dev/null
++++ b/src/Node/Expression/ReturnStringInterface.php
+@@ -0,0 +1,16 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++interface ReturnStringInterface extends ReturnPrimitiveTypeInterface
++{
++}
+diff --git a/src/Node/Expression/SupportDefinedTestDeprecationTrait.php b/src/Node/Expression/SupportDefinedTestDeprecationTrait.php
+new file mode 100644
+index 00000000000..664464bb2e7
+--- /dev/null
++++ b/src/Node/Expression/SupportDefinedTestDeprecationTrait.php
+@@ -0,0 +1,44 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++/**
++ * @internal
++ *
++ * To be removed in 4.0
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++trait SupportDefinedTestDeprecationTrait
++{
++    public function getAttribute($name, $default = null)
++    {
++        if ('is_defined_test' === $name) {
++            trigger_deprecation('twig/twig', '3.21', 'The "is_defined_test" attribute is deprecated, call "isDefinedTestEnabled()" instead.');
++
++            return $this->isDefinedTestEnabled();
++        }
++
++        return parent::getAttribute($name, $default);
++    }
++
++    public function setAttribute(string $name, $value): void
++    {
++        if ('is_defined_test' === $name) {
++            trigger_deprecation('twig/twig', '3.21', 'The "is_defined_test" attribute is deprecated, call "enableDefinedTest()" instead.');
++
++            $this->definedTest = (bool) $value;
++        } else {
++            parent::setAttribute($name, $value);
++        }
++    }
++}
+diff --git a/src/Node/Expression/SupportDefinedTestInterface.php b/src/Node/Expression/SupportDefinedTestInterface.php
+new file mode 100644
+index 00000000000..450c691c59e
+--- /dev/null
++++ b/src/Node/Expression/SupportDefinedTestInterface.php
+@@ -0,0 +1,24 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++/**
++ * Interface implemented by expressions that support the defined test.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++interface SupportDefinedTestInterface
++{
++    public function enableDefinedTest(): void;
++
++    public function isDefinedTestEnabled(): bool;
++}
+diff --git a/src/Node/Expression/SupportDefinedTestTrait.php b/src/Node/Expression/SupportDefinedTestTrait.php
+new file mode 100644
+index 00000000000..4cf1a58d537
+--- /dev/null
++++ b/src/Node/Expression/SupportDefinedTestTrait.php
+@@ -0,0 +1,27 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression;
++
++trait SupportDefinedTestTrait
++{
++    private bool $definedTest = false;
++
++    public function enableDefinedTest(): void
++    {
++        $this->definedTest = true;
++    }
++
++    public function isDefinedTestEnabled(): bool
++    {
++        return $this->definedTest;
++    }
++}
+diff --git a/src/Node/Expression/TempNameExpression.php b/src/Node/Expression/TempNameExpression.php
+index 004c704a588..f996aab05de 100644
+--- a/src/Node/Expression/TempNameExpression.php
++++ b/src/Node/Expression/TempNameExpression.php
+@@ -12,20 +12,38 @@
+ namespace Twig\Node\Expression;
+ 
+ use Twig\Compiler;
++use Twig\Error\SyntaxError;
+ 
+ class TempNameExpression extends AbstractExpression
+ {
+-    public function __construct(string $name, int $lineno)
++    public const RESERVED_NAMES = ['varargs', 'context', 'macros', 'blocks', 'this'];
++
++    public function __construct(string|int|null $name, int $lineno)
+     {
++        // All names supported by ExpressionParser::parsePrimaryExpression() should be excluded
++        if ($name && \in_array(strtolower($name), ['true', 'false', 'none', 'null'], true)) {
++            throw new SyntaxError(\sprintf('You cannot assign a value to "%s".', $name), $lineno);
++        }
++
++        if (self::class === static::class) {
++            trigger_deprecation('twig/twig', '3.15', 'The "%s" class is deprecated.', self::class);
++        }
++
++        if (null !== $name && (\is_int($name) || ctype_digit($name))) {
++            $name = (int) $name;
++        } elseif (\in_array($name, self::RESERVED_NAMES, true)) {
++            $name = "\u{035C}".$name;
++        }
++
+         parent::__construct([], ['name' => $name], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $compiler
+-            ->raw('$_')
+-            ->raw($this->getAttribute('name'))
+-            ->raw('_')
+-        ;
++        if (null === $this->getAttribute('name')) {
++            $this->setAttribute('name', $compiler->getVarName());
++        }
++
++        $compiler->raw('$'.$this->getAttribute('name'));
+     }
+ }
+diff --git a/src/Node/Expression/Ternary/ConditionalTernary.php b/src/Node/Expression/Ternary/ConditionalTernary.php
+new file mode 100644
+index 00000000000..f7cd78c5c6f
+--- /dev/null
++++ b/src/Node/Expression/Ternary/ConditionalTernary.php
+@@ -0,0 +1,49 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Ternary;
++
++use Twig\Compiler;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\OperatorEscapeInterface;
++use Twig\Node\Expression\ReturnPrimitiveTypeInterface;
++use Twig\Node\Expression\Test\TrueTest;
++use Twig\TwigTest;
++
++final class ConditionalTernary extends AbstractExpression implements OperatorEscapeInterface
++{
++    public function __construct(AbstractExpression $test, AbstractExpression $left, AbstractExpression $right, int $lineno)
++    {
++        if (!$test instanceof ReturnPrimitiveTypeInterface) {
++            $test = new TrueTest($test, new TwigTest('true'), null, $test->getTemplateLine());
++        }
++
++        parent::__construct(['test' => $test, 'left' => $left, 'right' => $right], [], $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler
++            ->raw('((')
++            ->subcompile($this->getNode('test'))
++            ->raw(') ? (')
++            ->subcompile($this->getNode('left'))
++            ->raw(') : (')
++            ->subcompile($this->getNode('right'))
++            ->raw('))')
++        ;
++    }
++
++    public function getOperandNamesToEscape(): array
++    {
++        return ['left', 'right'];
++    }
++}
+diff --git a/src/Node/Expression/Test/DefinedTest.php b/src/Node/Expression/Test/DefinedTest.php
+index 3953bbbe2cc..73e43720f37 100644
+--- a/src/Node/Expression/Test/DefinedTest.php
++++ b/src/Node/Expression/Test/DefinedTest.php
+@@ -11,17 +11,14 @@
+ 
+ namespace Twig\Node\Expression\Test;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
+ use Twig\Error\SyntaxError;
+-use Twig\Node\Expression\ArrayExpression;
+-use Twig\Node\Expression\BlockReferenceExpression;
+-use Twig\Node\Expression\ConstantExpression;
+-use Twig\Node\Expression\FunctionExpression;
+-use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\MethodCallExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\SupportDefinedTestInterface;
+ use Twig\Node\Expression\TestExpression;
+ use Twig\Node\Node;
++use Twig\TwigTest;
+ 
+ /**
+  * Checks if a variable is defined in the current context.
+@@ -35,40 +32,37 @@
+  */
+ class DefinedTest extends TestExpression
+ {
+-    public function __construct(Node $node, string $name, ?Node $arguments, int $lineno)
++    /**
++     * @param AbstractExpression $node
++     */
++    #[FirstClassTwigCallableReady]
++    public function __construct(Node $node, TwigTest|string $name, ?Node $arguments, int $lineno)
+     {
+-        if ($node instanceof NameExpression) {
+-            $node->setAttribute('is_defined_test', true);
+-        } elseif ($node instanceof GetAttrExpression) {
+-            $node->setAttribute('is_defined_test', true);
+-            $this->changeIgnoreStrictCheck($node);
+-        } elseif ($node instanceof BlockReferenceExpression) {
+-            $node->setAttribute('is_defined_test', true);
+-        } elseif ($node instanceof FunctionExpression && 'constant' === $node->getAttribute('name')) {
+-            $node->setAttribute('is_defined_test', true);
+-        } elseif ($node instanceof ConstantExpression || $node instanceof ArrayExpression) {
+-            $node = new ConstantExpression(true, $node->getTemplateLine());
+-        } elseif ($node instanceof MethodCallExpression) {
+-            $node->setAttribute('is_defined_test', true);
+-        } else {
+-            throw new SyntaxError('The "defined" test only works with simple variables.', $lineno);
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
+         }
+ 
+-        parent::__construct($node, $name, $arguments, $lineno);
+-    }
++        if (!$node instanceof SupportDefinedTestInterface) {
++            throw new SyntaxError('The "defined" test only works with simple variables.', $lineno);
++        }
+ 
+-    private function changeIgnoreStrictCheck(GetAttrExpression $node)
+-    {
+-        $node->setAttribute('optimizable', false);
+-        $node->setAttribute('ignore_strict_check', true);
++        $node->enableDefinedTest();
+ 
+-        if ($node->getNode('node') instanceof GetAttrExpression) {
+-            $this->changeIgnoreStrictCheck($node->getNode('node'));
++        if (\is_string($name) && 'defined' !== $name) {
++            trigger_deprecation('twig/twig', '3.12', 'Creating a "DefinedTest" instance with a test name that is not "defined" is deprecated.');
+         }
++
++        parent::__construct($node, $name, $arguments, $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+         $compiler->subcompile($this->getNode('node'));
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // the `defined` test does not coerce its node to string (it only inspects existence)
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/DivisiblebyTest.php b/src/Node/Expression/Test/DivisiblebyTest.php
+index 90d58a49a16..ab9dd416b9d 100644
+--- a/src/Node/Expression/Test/DivisiblebyTest.php
++++ b/src/Node/Expression/Test/DivisiblebyTest.php
+@@ -33,4 +33,10 @@ public function compile(Compiler $compiler): void
+             ->raw(')')
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // PHP `%` rejects Stringable with a TypeError, no coercion
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/EvenTest.php b/src/Node/Expression/Test/EvenTest.php
+index a0e3ed62c1a..81a06aa6923 100644
+--- a/src/Node/Expression/Test/EvenTest.php
++++ b/src/Node/Expression/Test/EvenTest.php
+@@ -32,4 +32,10 @@ public function compile(Compiler $compiler): void
+             ->raw(')')
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // PHP `%` rejects Stringable with a TypeError, no coercion
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/NullTest.php b/src/Node/Expression/Test/NullTest.php
+index 45b54ae3709..904aef927f2 100644
+--- a/src/Node/Expression/Test/NullTest.php
++++ b/src/Node/Expression/Test/NullTest.php
+@@ -15,7 +15,7 @@
+ use Twig\Node\Expression\TestExpression;
+ 
+ /**
+- * Checks that a variable is null.
++ * Checks that an expression is null.
+  *
+  *  {{ var is none }}
+  *
+@@ -31,4 +31,10 @@ public function compile(Compiler $compiler): void
+             ->raw(')')
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // `=== null` is strict, no coercion
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/OddTest.php b/src/Node/Expression/Test/OddTest.php
+index d56c711169b..967c3531103 100644
+--- a/src/Node/Expression/Test/OddTest.php
++++ b/src/Node/Expression/Test/OddTest.php
+@@ -32,4 +32,10 @@ public function compile(Compiler $compiler): void
+             ->raw(')')
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // PHP `%` rejects Stringable with a TypeError, no coercion
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/SameasTest.php b/src/Node/Expression/Test/SameasTest.php
+index f1e24db6f7e..cc4d723d07b 100644
+--- a/src/Node/Expression/Test/SameasTest.php
++++ b/src/Node/Expression/Test/SameasTest.php
+@@ -31,4 +31,10 @@ public function compile(Compiler $compiler): void
+             ->raw(')')
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // `===` is strict, no coercion
++        return [];
++    }
+ }
+diff --git a/src/Node/Expression/Test/TrueTest.php b/src/Node/Expression/Test/TrueTest.php
+new file mode 100644
+index 00000000000..f830b8f2e57
+--- /dev/null
++++ b/src/Node/Expression/Test/TrueTest.php
+@@ -0,0 +1,40 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Test;
++
++use Twig\Compiler;
++use Twig\Node\Expression\TestExpression;
++
++/**
++ * Checks that an expression is true.
++ *
++ *  {{ var is true }}
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++class TrueTest extends TestExpression
++{
++    public function compile(Compiler $compiler): void
++    {
++        $compiler
++            ->raw('(($tmp = ')
++            ->subcompile($this->getNode('node'))
++            ->raw(') && $tmp instanceof Markup ? (string) $tmp : $tmp)')
++        ;
++    }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // the `(string)` cast only fires for Markup instances, whose __toString is always allowed
++        return [];
++    }
++}
+diff --git a/src/Node/Expression/TestExpression.php b/src/Node/Expression/TestExpression.php
+index 29c5a522cd8..4d81239414e 100644
+--- a/src/Node/Expression/TestExpression.php
++++ b/src/Node/Expression/TestExpression.php
+@@ -11,29 +11,81 @@
+ 
+ namespace Twig\Node\Expression;
+ 
++use Twig\Attribute\FirstClassTwigCallableReady;
+ use Twig\Compiler;
++use Twig\Node\CoercesChildrenToStringInterface;
++use Twig\Node\NameDeprecation;
+ use Twig\Node\Node;
++use Twig\TwigTest;
+ 
+-class TestExpression extends CallExpression
++class TestExpression extends CallExpression implements ReturnBoolInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(Node $node, string $name, ?Node $arguments, int $lineno)
++    #[FirstClassTwigCallableReady]
++    /**
++     * @param AbstractExpression $node
++     */
++    public function __construct(Node $node, string|TwigTest $test, ?Node $arguments, int $lineno)
+     {
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance to the "node" argument of "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++        }
++
+         $nodes = ['node' => $node];
+         if (null !== $arguments) {
+             $nodes['arguments'] = $arguments;
+         }
+ 
++        if ($test instanceof TwigTest) {
++            $name = $test->getName();
++        } else {
++            $name = $test;
++            trigger_deprecation('twig/twig', '3.12', 'Not passing an instance of "TwigTest" when creating a "%s" test of type "%s" is deprecated.', $name, static::class);
++        }
++
+         parent::__construct($nodes, ['name' => $name, 'type' => 'test'], $lineno);
++
++        if ($test instanceof TwigTest) {
++            $this->setAttribute('twig_callable', $test);
++        }
++
++        $this->deprecateAttribute('arguments', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('callable', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('is_variadic', new NameDeprecation('twig/twig', '3.12'));
++        $this->deprecateAttribute('dynamic_name', new NameDeprecation('twig/twig', '3.12'));
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $test = $compiler->getEnvironment()->getTest($this->getAttribute('name'));
++        $name = $this->getAttribute('name');
++        if ($this->hasAttribute('twig_callable')) {
++            $name = $this->getAttribute('twig_callable')->getName();
++            if ($name !== $this->getAttribute('name')) {
++                trigger_deprecation('twig/twig', '3.12', 'Changing the value of a "test" node in a NodeVisitor class is not supported anymore.');
++                $this->removeAttribute('twig_callable');
++            }
++        }
+ 
+-        $this->setAttribute('arguments', $test->getArguments());
+-        $this->setAttribute('callable', $test->getCallable());
+-        $this->setAttribute('is_variadic', $test->isVariadic());
++        if (!$this->hasAttribute('twig_callable')) {
++            $this->setAttribute('twig_callable', $compiler->getEnvironment()->getTest($this->getAttribute('name')));
++        }
+ 
+         $this->compileCallable($compiler);
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        $names = [];
++
++        // the `empty` test triggers an implicit string coercion through `CoreExtension::testEmpty()`
++        if ('empty' === $this->getAttribute('name')) {
++            $names[] = 'node';
++        }
++
++        // a test may coerce its arguments to string (the host PHP code is opaque to Twig)
++        if ($this->hasNode('arguments')) {
++            $names[] = 'arguments';
++        }
++
++        return $names;
++    }
+ }
+diff --git a/src/Node/Expression/Unary/AbstractUnary.php b/src/Node/Expression/Unary/AbstractUnary.php
+index e31e3f84b07..09f3d0984a5 100644
+--- a/src/Node/Expression/Unary/AbstractUnary.php
++++ b/src/Node/Expression/Unary/AbstractUnary.php
+@@ -16,18 +16,32 @@
+ use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Node;
+ 
+-abstract class AbstractUnary extends AbstractExpression
++abstract class AbstractUnary extends AbstractExpression implements UnaryInterface
+ {
++    /**
++     * @param AbstractExpression $node
++     */
+     public function __construct(Node $node, int $lineno)
+     {
+-        parent::__construct(['node' => $node], [], $lineno);
++        if (!$node instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance argument to "%s" is deprecated ("%s" given).', AbstractExpression::class, static::class, $node::class);
++        }
++
++        parent::__construct(['node' => $node], ['with_parentheses' => false], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $compiler->raw(' ');
++        if ($this->hasExplicitParentheses()) {
++            $compiler->raw('(');
++        } else {
++            $compiler->raw(' ');
++        }
+         $this->operator($compiler);
+         $compiler->subcompile($this->getNode('node'));
++        if ($this->hasExplicitParentheses()) {
++            $compiler->raw(')');
++        }
+     }
+ 
+     abstract public function operator(Compiler $compiler): Compiler;
+diff --git a/src/Node/Expression/Unary/SpreadUnary.php b/src/Node/Expression/Unary/SpreadUnary.php
+new file mode 100644
+index 00000000000..f99072c257f
+--- /dev/null
++++ b/src/Node/Expression/Unary/SpreadUnary.php
+@@ -0,0 +1,22 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Unary;
++
++use Twig\Compiler;
++
++final class SpreadUnary extends AbstractUnary
++{
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('...');
++    }
++}
+diff --git a/src/Node/Expression/Unary/StringCastUnary.php b/src/Node/Expression/Unary/StringCastUnary.php
+new file mode 100644
+index 00000000000..87ea17ca8ad
+--- /dev/null
++++ b/src/Node/Expression/Unary/StringCastUnary.php
+@@ -0,0 +1,22 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Unary;
++
++use Twig\Compiler;
++
++final class StringCastUnary extends AbstractUnary
++{
++    public function operator(Compiler $compiler): Compiler
++    {
++        return $compiler->raw('(string)');
++    }
++}
+diff --git a/src/Node/Expression/Unary/UnaryInterface.php b/src/Node/Expression/Unary/UnaryInterface.php
+new file mode 100644
+index 00000000000..b094ef4f4ce
+--- /dev/null
++++ b/src/Node/Expression/Unary/UnaryInterface.php
+@@ -0,0 +1,22 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Unary;
++
++use Twig\Node\Expression\AbstractExpression;
++
++/**
++ * @internal
++ */
++interface UnaryInterface
++{
++    public function __construct(AbstractExpression $node, int $lineno);
++}
+diff --git a/src/Node/Expression/Variable/AssignContextVariable.php b/src/Node/Expression/Variable/AssignContextVariable.php
+new file mode 100644
+index 00000000000..30d8106751b
+--- /dev/null
++++ b/src/Node/Expression/Variable/AssignContextVariable.php
+@@ -0,0 +1,18 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Variable;
++
++use Twig\Node\Expression\AssignNameExpression;
++
++final class AssignContextVariable extends AssignNameExpression
++{
++}
+diff --git a/src/Node/Expression/Variable/AssignTemplateVariable.php b/src/Node/Expression/Variable/AssignTemplateVariable.php
+new file mode 100644
+index 00000000000..98bcdc10e46
+--- /dev/null
++++ b/src/Node/Expression/Variable/AssignTemplateVariable.php
+@@ -0,0 +1,44 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Variable;
++
++use Twig\Compiler;
++use Twig\Node\Expression\AbstractExpression;
++
++final class AssignTemplateVariable extends AbstractExpression
++{
++    public function __construct(TemplateVariable $var, bool $global = true)
++    {
++        parent::__construct(['var' => $var], ['global' => $global], $var->getTemplateLine());
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        /** @var TemplateVariable $var */
++        $var = $this->nodes['var'];
++
++        $compiler
++            ->addDebugInfo($this)
++            ->write('$macros[')
++            ->string($var->getName($compiler))
++            ->raw('] = ')
++        ;
++
++        if ($this->getAttribute('global')) {
++            $compiler
++                ->raw('$this->macros[')
++                ->string($var->getName($compiler))
++                ->raw('] = ')
++            ;
++        }
++    }
++}
+diff --git a/src/Node/Expression/Variable/ContextVariable.php b/src/Node/Expression/Variable/ContextVariable.php
+new file mode 100644
+index 00000000000..01bbcb71183
+--- /dev/null
++++ b/src/Node/Expression/Variable/ContextVariable.php
+@@ -0,0 +1,18 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Variable;
++
++use Twig\Node\Expression\NameExpression;
++
++class ContextVariable extends NameExpression
++{
++}
+diff --git a/src/Node/Expression/Variable/LocalVariable.php b/src/Node/Expression/Variable/LocalVariable.php
+new file mode 100644
+index 00000000000..a5ee17566b0
+--- /dev/null
++++ b/src/Node/Expression/Variable/LocalVariable.php
+@@ -0,0 +1,18 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Variable;
++
++use Twig\Node\Expression\TempNameExpression;
++
++final class LocalVariable extends TempNameExpression
++{
++}
+diff --git a/src/Node/Expression/Variable/TemplateVariable.php b/src/Node/Expression/Variable/TemplateVariable.php
+new file mode 100644
+index 00000000000..4dd06627359
+--- /dev/null
++++ b/src/Node/Expression/Variable/TemplateVariable.php
+@@ -0,0 +1,42 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node\Expression\Variable;
++
++use Twig\Compiler;
++use Twig\Node\Expression\TempNameExpression;
++
++class TemplateVariable extends TempNameExpression
++{
++    public function getName(Compiler $compiler): string
++    {
++        if (null === $this->getAttribute('name')) {
++            $this->setAttribute('name', $compiler->getVarName());
++        }
++
++        return $this->getAttribute('name');
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $name = $this->getName($compiler);
++
++        if ('_self' === $name) {
++            $compiler->raw('$this');
++        } else {
++            $compiler
++                ->raw('$macros[')
++                ->string($name)
++                ->raw(']')
++            ;
++        }
++    }
++}
+diff --git a/src/Node/FlushNode.php b/src/Node/FlushNode.php
+index 8a3dde6fcc2..ff3bd1cf194 100644
+--- a/src/Node/FlushNode.php
++++ b/src/Node/FlushNode.php
+@@ -22,16 +22,19 @@
+ #[YieldReady]
+ class FlushNode extends Node
+ {
+-    public function __construct(int $lineno, string $tag)
++    public function __construct(int $lineno)
+     {
+-        parent::__construct([], [], $lineno, $tag);
++        parent::__construct([], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $compiler
+-            ->addDebugInfo($this)
+-            ->write("flush();\n")
+-        ;
++        $compiler->addDebugInfo($this);
++
++        if ($compiler->getEnvironment()->useYield()) {
++            $compiler->write("yield '';\n");
++        }
++
++        $compiler->write("flush();\n");
+     }
+ }
+diff --git a/src/Node/ForElseNode.php b/src/Node/ForElseNode.php
+new file mode 100644
+index 00000000000..56d6646bf3b
+--- /dev/null
++++ b/src/Node/ForElseNode.php
+@@ -0,0 +1,41 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node;
++
++use Twig\Attribute\YieldReady;
++use Twig\Compiler;
++
++/**
++ * Represents an else node in a for loop.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++#[YieldReady]
++class ForElseNode extends Node
++{
++    public function __construct(Node $body, int $lineno)
++    {
++        parent::__construct(['body' => $body], [], $lineno);
++    }
++
++    public function compile(Compiler $compiler): void
++    {
++        $compiler
++            ->addDebugInfo($this)
++            ->write("if (!\$context['_iterated']) {\n")
++            ->indent()
++            ->subcompile($this->getNode('body'))
++            ->outdent()
++            ->write("}\n")
++        ;
++    }
++}
+diff --git a/src/Node/ForLoopNode.php b/src/Node/ForLoopNode.php
+index 503687c2b2e..1f0a4f32134 100644
+--- a/src/Node/ForLoopNode.php
++++ b/src/Node/ForLoopNode.php
+@@ -22,9 +22,9 @@
+ #[YieldReady]
+ class ForLoopNode extends Node
+ {
+-    public function __construct(int $lineno, ?string $tag = null)
++    public function __construct(int $lineno)
+     {
+-        parent::__construct([], ['with_loop' => false, 'ifexpr' => false, 'else' => false], $lineno, $tag);
++        parent::__construct([], ['with_loop' => false, 'ifexpr' => false, 'else' => false], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -38,7 +38,7 @@ public function compile(Compiler $compiler): void
+                 ->write("++\$context['loop']['index0'];\n")
+                 ->write("++\$context['loop']['index'];\n")
+                 ->write("\$context['loop']['first'] = false;\n")
+-                ->write("if (isset(\$context['loop']['length'])) {\n")
++                ->write("if (isset(\$context['loop']['revindex0'], \$context['loop']['revindex'])) {\n")
+                 ->indent()
+                 ->write("--\$context['loop']['revindex0'];\n")
+                 ->write("--\$context['loop']['revindex'];\n")
+diff --git a/src/Node/ForNode.php b/src/Node/ForNode.php
+index 5222cf9bf9f..2c86622d473 100644
+--- a/src/Node/ForNode.php
++++ b/src/Node/ForNode.php
+@@ -15,7 +15,7 @@
+ use Twig\Attribute\YieldReady;
+ use Twig\Compiler;
+ use Twig\Node\Expression\AbstractExpression;
+-use Twig\Node\Expression\AssignNameExpression;
++use Twig\Node\Expression\Variable\AssignContextVariable;
+ 
+ /**
+  * Represents a for node.
+@@ -27,16 +27,26 @@ class ForNode extends Node
+ {
+     private $loop;
+ 
+-    public function __construct(AssignNameExpression $keyTarget, AssignNameExpression $valueTarget, AbstractExpression $seq, ?Node $ifexpr, Node $body, ?Node $else, int $lineno, ?string $tag = null)
++    public function __construct(AssignContextVariable $keyTarget, AssignContextVariable $valueTarget, AbstractExpression $seq, ?Node $ifexpr, Node $body, ?Node $else, int $lineno)
+     {
+-        $body = new Node([$body, $this->loop = new ForLoopNode($lineno, $tag)]);
++        $body = new Nodes([$body, $this->loop = new ForLoopNode($lineno)]);
++
++        if (null !== $ifexpr) {
++            trigger_deprecation('twig/twig', '3.19', \sprintf('Passing not-null to the "ifexpr" argument of the "%s" constructor is deprecated.', static::class));
++        }
++
++        if (null !== $else && !$else instanceof ForElseNode) {
++            trigger_deprecation('twig/twig', '3.19', \sprintf('Not passing an instance of "%s" to the "else" argument of the "%s" constructor is deprecated.', ForElseNode::class, static::class));
++
++            $else = new ForElseNode($else, $else->getTemplateLine());
++        }
+ 
+         $nodes = ['key_target' => $keyTarget, 'value_target' => $valueTarget, 'seq' => $seq, 'body' => $body];
+         if (null !== $else) {
+             $nodes['else'] = $else;
+         }
+ 
+-        parent::__construct($nodes, ['with_loop' => true], $lineno, $tag);
++        parent::__construct($nodes, ['with_loop' => true], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -89,19 +99,20 @@ public function compile(Compiler $compiler): void
+         ;
+ 
+         if ($this->hasNode('else')) {
+-            $compiler
+-                ->write("if (!\$context['_iterated']) {\n")
+-                ->indent()
+-                ->subcompile($this->getNode('else'))
+-                ->outdent()
+-                ->write("}\n")
+-            ;
++            $compiler->subcompile($this->getNode('else'));
+         }
+ 
+         $compiler->write("\$_parent = \$context['_parent'];\n");
+ 
+         // remove some "private" loop variables (needed for nested loops)
+-        $compiler->write('unset($context[\'_seq\'], $context[\'_iterated\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\'], $context[\'loop\']);'."\n");
++        $compiler->write('unset($context[\'_seq\'], $context[\''.$this->getNode('key_target')->getAttribute('name').'\'], $context[\''.$this->getNode('value_target')->getAttribute('name').'\'], $context[\'_parent\']');
++        if ($this->hasNode('else')) {
++            $compiler->raw(', $context[\'_iterated\']');
++        }
++        if ($this->getAttribute('with_loop')) {
++            $compiler->raw(', $context[\'loop\']');
++        }
++        $compiler->raw(");\n");
+ 
+         // keep the values set in the inner context for variables defined in the outer context
+         $compiler->write("\$context = array_intersect_key(\$context, \$_parent) + \$_parent;\n");
+diff --git a/src/Node/IfNode.php b/src/Node/IfNode.php
+index 1b883305ad4..2c0e2a8e91b 100644
+--- a/src/Node/IfNode.php
++++ b/src/Node/IfNode.php
+@@ -14,6 +14,9 @@
+ 
+ use Twig\Attribute\YieldReady;
+ use Twig\Compiler;
++use Twig\Node\Expression\ReturnPrimitiveTypeInterface;
++use Twig\Node\Expression\Test\TrueTest;
++use Twig\TwigTest;
+ 
+ /**
+  * Represents an if node.
+@@ -23,14 +26,20 @@
+ #[YieldReady]
+ class IfNode extends Node
+ {
+-    public function __construct(Node $tests, ?Node $else, int $lineno, ?string $tag = null)
++    public function __construct(Node $tests, ?Node $else, int $lineno)
+     {
++        for ($i = 0, $count = \count($tests); $i < $count; $i += 2) {
++            $test = $tests->getNode((string) $i);
++            if (!$test instanceof ReturnPrimitiveTypeInterface) {
++                $tests->setNode($i, new TrueTest($test, new TwigTest('true'), null, $test->getTemplateLine()));
++            }
++        }
+         $nodes = ['tests' => $tests];
+         if (null !== $else) {
+             $nodes['else'] = $else;
+         }
+ 
+-        parent::__construct($nodes, [], $lineno, $tag);
++        parent::__construct($nodes, [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/ImportNode.php b/src/Node/ImportNode.php
+index db47bfe61c9..ab7fe0ff504 100644
+--- a/src/Node/ImportNode.php
++++ b/src/Node/ImportNode.php
+@@ -14,7 +14,8 @@
+ use Twig\Attribute\YieldReady;
+ use Twig\Compiler;
+ use Twig\Node\Expression\AbstractExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\Variable\AssignTemplateVariable;
++use Twig\Node\Expression\Variable\ContextVariable;
+ 
+ /**
+  * Represents an import node.
+@@ -22,39 +23,34 @@
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ #[YieldReady]
+-class ImportNode extends Node
++class ImportNode extends Node implements CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $expr, AbstractExpression $var, int $lineno, ?string $tag = null, bool $global = true)
++    public function __construct(AbstractExpression $expr, AbstractExpression|AssignTemplateVariable $var, int $lineno)
+     {
+-        parent::__construct(['expr' => $expr, 'var' => $var], ['global' => $global], $lineno, $tag);
++        if (\func_num_args() > 3) {
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Passing more than 3 arguments to "%s()" is deprecated.', __METHOD__));
++        }
++
++        if (!$var instanceof AssignTemplateVariable) {
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Passing a "%s" instance as the second argument of "%s" is deprecated, pass a "%s" instead.', $var::class, __CLASS__, AssignTemplateVariable::class));
++
++            $var = new AssignTemplateVariable($var->getAttribute('name'), $lineno);
++        }
++
++        parent::__construct(['expr' => $expr, 'var' => $var], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+     {
+-        $compiler
+-            ->addDebugInfo($this)
+-            ->write('$macros[')
+-            ->repr($this->getNode('var')->getAttribute('name'))
+-            ->raw('] = ')
+-        ;
++        $compiler->subcompile($this->getNode('var'));
+ 
+-        if ($this->getAttribute('global')) {
+-            $compiler
+-                ->raw('$this->macros[')
+-                ->repr($this->getNode('var')->getAttribute('name'))
+-                ->raw('] = ')
+-            ;
+-        }
+-
+-        if ($this->getNode('expr') instanceof NameExpression && '_self' === $this->getNode('expr')->getAttribute('name')) {
++        if ($this->getNode('expr') instanceof ContextVariable && '_self' === $this->getNode('expr')->getAttribute('name')) {
+             $compiler->raw('$this');
+         } else {
+             $compiler
+-                ->raw('$this->loadTemplate(')
++                ->raw('$this->load(')
+                 ->subcompile($this->getNode('expr'))
+                 ->raw(', ')
+-                ->repr($this->getTemplateName())
+-                ->raw(', ')
+                 ->repr($this->getTemplateLine())
+                 ->raw(')->unwrap()')
+             ;
+@@ -62,4 +58,10 @@ public function compile(Compiler $compiler): void
+ 
+         $compiler->raw(";\n");
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // the loader resolves the template-name expression by coercing it to a string
++        return ['expr'];
++    }
+ }
+diff --git a/src/Node/IncludeNode.php b/src/Node/IncludeNode.php
+index 7073fa4ac38..3adf415e1be 100644
+--- a/src/Node/IncludeNode.php
++++ b/src/Node/IncludeNode.php
+@@ -22,16 +22,16 @@
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ #[YieldReady]
+-class IncludeNode extends Node implements NodeOutputInterface
++class IncludeNode extends Node implements NodeOutputInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $expr, ?AbstractExpression $variables, bool $only, bool $ignoreMissing, int $lineno, ?string $tag = null)
++    public function __construct(AbstractExpression $expr, ?AbstractExpression $variables, bool $only, bool $ignoreMissing, int $lineno)
+     {
+         $nodes = ['expr' => $expr];
+         if (null !== $variables) {
+             $nodes['variables'] = $variables;
+         }
+ 
+-        parent::__construct($nodes, ['only' => $only, 'ignore_missing' => $ignoreMissing], $lineno, $tag);
++        parent::__construct($nodes, ['only' => $only, 'ignore_missing' => $ignoreMissing], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -42,13 +42,12 @@ public function compile(Compiler $compiler): void
+             $template = $compiler->getVarName();
+ 
+             $compiler
+-                ->write(\sprintf("$%s = null;\n", $template))
+                 ->write("try {\n")
+                 ->indent()
+                 ->write(\sprintf('$%s = ', $template))
+             ;
+ 
+-            $this->addGetTemplate($compiler);
++            $this->addGetTemplate($compiler, $template);
+ 
+             $compiler
+                 ->raw(";\n")
+@@ -56,13 +55,15 @@ public function compile(Compiler $compiler): void
+                 ->write("} catch (LoaderError \$e) {\n")
+                 ->indent()
+                 ->write("// ignore missing template\n")
++                ->write(\sprintf("\$$template = null;\n", $template))
+                 ->outdent()
+                 ->write("}\n")
+                 ->write(\sprintf("if ($%s) {\n", $template))
+                 ->indent()
+-                ->write(\sprintf('yield from $%s->unwrap()->yield(', $template))
+             ;
+ 
++            $compiler->write(\sprintf('yield from $%s->unwrap()->yield(', $template));
++
+             $this->addTemplateArguments($compiler);
+             $compiler
+                 ->raw(");\n")
+@@ -78,19 +79,23 @@ public function compile(Compiler $compiler): void
+         }
+     }
+ 
+-    protected function addGetTemplate(Compiler $compiler)
++    /**
++     * @return void
++     */
++    protected function addGetTemplate(Compiler $compiler/* , string $template = '' */)
+     {
+         $compiler
+-            ->write('$this->loadTemplate(')
++            ->raw('$this->load(')
+             ->subcompile($this->getNode('expr'))
+             ->raw(', ')
+-            ->repr($this->getTemplateName())
+-            ->raw(', ')
+             ->repr($this->getTemplateLine())
+             ->raw(')')
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function addTemplateArguments(Compiler $compiler)
+     {
+         if (!$this->hasNode('variables')) {
+@@ -107,4 +112,10 @@ protected function addTemplateArguments(Compiler $compiler)
+             $compiler->raw(')');
+         }
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        // the loader resolves the template-name expression by coercing it to a string
++        return ['expr'];
++    }
+ }
+diff --git a/src/Node/MacroNode.php b/src/Node/MacroNode.php
+index a6048de9bd8..db3ca458c88 100644
+--- a/src/Node/MacroNode.php
++++ b/src/Node/MacroNode.php
+@@ -14,6 +14,8 @@
+ use Twig\Attribute\YieldReady;
+ use Twig\Compiler;
+ use Twig\Error\SyntaxError;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\Variable\LocalVariable;
+ 
+ /**
+  * Represents a macro node.
+@@ -25,15 +27,33 @@ class MacroNode extends Node
+ {
+     public const VARARGS_NAME = 'varargs';
+ 
+-    public function __construct(string $name, Node $body, Node $arguments, int $lineno, ?string $tag = null)
++    /**
++     * @param BodyNode        $body
++     * @param ArrayExpression $arguments
++     */
++    public function __construct(string $name, Node $body, Node $arguments, int $lineno)
+     {
+-        foreach ($arguments as $argumentName => $argument) {
+-            if (self::VARARGS_NAME === $argumentName) {
+-                throw new SyntaxError(\sprintf('The argument "%s" in macro "%s" cannot be defined because the variable "%s" is reserved for arbitrary arguments.', self::VARARGS_NAME, $name, self::VARARGS_NAME), $argument->getTemplateLine(), $argument->getSourceContext());
++        if (!$body instanceof BodyNode) {
++            trigger_deprecation('twig/twig', '3.12', \sprintf('Not passing a "%s" instance as the "body" argument of the "%s" constructor is deprecated ("%s" given).', BodyNode::class, static::class, $body::class));
++        }
++
++        if (!$arguments instanceof ArrayExpression) {
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Not passing a "%s" instance as the "arguments" argument of the "%s" constructor is deprecated ("%s" given).', ArrayExpression::class, static::class, $arguments::class));
++
++            $args = new ArrayExpression([], $arguments->getTemplateLine());
++            foreach ($arguments as $n => $default) {
++                $args->addElement($default, new LocalVariable($n, $default->getTemplateLine()));
++            }
++            $arguments = $args;
++        }
++
++        foreach ($arguments->getKeyValuePairs() as $pair) {
++            if ("\u{035C}".self::VARARGS_NAME === $pair['key']->getAttribute('name')) {
++                throw new SyntaxError(\sprintf('The argument "%s" in macro "%s" cannot be defined because the variable "%s" is reserved for arbitrary arguments.', self::VARARGS_NAME, $name, self::VARARGS_NAME), $pair['value']->getTemplateLine(), $pair['value']->getSourceContext());
+             }
+         }
+ 
+-        parent::__construct(['body' => $body, 'arguments' => $arguments], ['name' => $name], $lineno, $tag);
++        parent::__construct(['body' => $body, 'arguments' => $arguments], ['name' => $name], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -43,51 +63,53 @@ public function compile(Compiler $compiler): void
+             ->write(\sprintf('public function macro_%s(', $this->getAttribute('name')))
+         ;
+ 
+-        $count = \count($this->getNode('arguments'));
+-        $pos = 0;
+-        foreach ($this->getNode('arguments') as $name => $default) {
++        /** @var ArrayExpression $arguments */
++        $arguments = $this->getNode('arguments');
++        foreach ($arguments->getKeyValuePairs() as $pair) {
++            $name = $pair['key'];
++            $default = $pair['value'];
+             $compiler
+-                ->raw('$__'.$name.'__ = ')
++                ->subcompile($name)
++                ->raw(' = ')
+                 ->subcompile($default)
++                ->raw(', ')
+             ;
+-
+-            if (++$pos < $count) {
+-                $compiler->raw(', ');
+-            }
+-        }
+-
+-        if ($count) {
+-            $compiler->raw(', ');
+         }
+ 
+         $compiler
+-            ->raw('...$__varargs__')
+-            ->raw(")\n")
++            ->raw('...$varargs')
++            ->raw("): string|Markup\n")
+             ->write("{\n")
+             ->indent()
+             ->write("\$macros = \$this->macros;\n")
+-            ->write("\$context = \$this->env->mergeGlobals([\n")
++            ->write("\$context = [\n")
+             ->indent()
+         ;
+ 
+-        foreach ($this->getNode('arguments') as $name => $default) {
++        foreach ($arguments->getKeyValuePairs() as $pair) {
++            $name = $pair['key'];
++            $var = $name->getAttribute('name');
++            if (str_starts_with($var, "\u{035C}")) {
++                $var = substr($var, \strlen("\u{035C}"));
++            }
+             $compiler
+                 ->write('')
+-                ->string($name)
+-                ->raw(' => $__'.$name.'__')
++                ->string($var)
++                ->raw(' => ')
++                ->subcompile($name)
+                 ->raw(",\n")
+             ;
+         }
+ 
+-        $node = new CaptureNode($this->getNode('body'), $this->getNode('body')->lineno, $this->getNode('body')->tag);
++        $node = new CaptureNode($this->getNode('body'), $this->getNode('body')->lineno);
+ 
+         $compiler
+             ->write('')
+             ->string(self::VARARGS_NAME)
+             ->raw(' => ')
+-            ->raw("\$__varargs__,\n")
++            ->raw("\$varargs,\n")
+             ->outdent()
+-            ->write("]);\n\n")
++            ->write("] + \$this->env->getGlobals();\n\n")
+             ->write("\$blocks = [];\n\n")
+             ->write('return ')
+             ->subcompile($node)
+diff --git a/src/Node/ModuleNode.php b/src/Node/ModuleNode.php
+index fb85cd89546..b2529e9fca5 100644
+--- a/src/Node/ModuleNode.php
++++ b/src/Node/ModuleNode.php
+@@ -21,27 +21,43 @@
+ /**
+  * Represents a module node.
+  *
+- * Consider this class as being final. If you need to customize the behavior of
+- * the generated class, consider adding nodes to the following nodes: display_start,
+- * display_end, constructor_start, constructor_end, and class_end.
++ * If you need to customize the behavior of the generated class, add nodes to
++ * the following nodes: display_start, display_end, constructor_start,
++ * constructor_end, and class_end.
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ #[YieldReady]
+-final class ModuleNode extends Node
++final class ModuleNode extends Node implements CoercesChildrenToStringInterface
+ {
++    /**
++     * @param BodyNode $body
++     */
+     public function __construct(Node $body, ?AbstractExpression $parent, Node $blocks, Node $macros, Node $traits, $embeddedTemplates, Source $source)
+     {
++        if (!$body instanceof BodyNode) {
++            trigger_deprecation('twig/twig', '3.12', \sprintf('Not passing a "%s" instance as the "body" argument of the "%s" constructor is deprecated.', BodyNode::class, static::class));
++        }
++        if (!$embeddedTemplates instanceof Node) {
++            trigger_deprecation('twig/twig', '3.21', \sprintf('Not passing a "%s" instance as the "embedded_templates" argument of the "%s" constructor is deprecated.', Node::class, static::class));
++
++            if (null !== $embeddedTemplates) {
++                $embeddedTemplates = new Nodes($embeddedTemplates);
++            } else {
++                $embeddedTemplates = new EmptyNode();
++            }
++        }
++
+         $nodes = [
+             'body' => $body,
+             'blocks' => $blocks,
+             'macros' => $macros,
+             'traits' => $traits,
+-            'display_start' => new Node(),
+-            'display_end' => new Node(),
+-            'constructor_start' => new Node(),
+-            'constructor_end' => new Node(),
+-            'class_end' => new Node(),
++            'display_start' => new Nodes(),
++            'display_end' => new Nodes(),
++            'constructor_start' => new Nodes(),
++            'constructor_end' => new Nodes(),
++            'class_end' => new Nodes(),
+         ];
+         if (null !== $parent) {
+             $nodes['parent'] = $parent;
+@@ -57,6 +73,9 @@ public function __construct(Node $body, ?AbstractExpression $parent, Node $block
+         $this->setSourceContext($source);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function setIndex($index)
+     {
+         $this->setAttribute('index', $index);
+@@ -71,6 +90,15 @@ public function compile(Compiler $compiler): void
+         }
+     }
+ 
++    public function getStringCoercedChildNames(): array
++    {
++        // the parent expression is resolved through the loader, which coerces it to a string
++        return $this->hasNode('parent') ? ['parent'] : [];
++    }
++
++    /**
++     * @return void
++     */
+     protected function compileTemplate(Compiler $compiler)
+     {
+         if (!$this->getAttribute('index')) {
+@@ -100,6 +128,9 @@ protected function compileTemplate(Compiler $compiler)
+         $this->compileClassFooter($compiler);
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileGetParent(Compiler $compiler)
+     {
+         if (!$this->hasNode('parent')) {
+@@ -108,7 +139,7 @@ protected function compileGetParent(Compiler $compiler)
+         $parent = $this->getNode('parent');
+ 
+         $compiler
+-            ->write("protected function doGetParent(array \$context)\n", "{\n")
++            ->write("protected function doGetParent(array \$context): bool|string|Template|TemplateWrapper\n", "{\n")
+             ->indent()
+             ->addDebugInfo($parent)
+             ->write('return ')
+@@ -118,11 +149,9 @@ protected function compileGetParent(Compiler $compiler)
+             $compiler->subcompile($parent);
+         } else {
+             $compiler
+-                ->raw('$this->loadTemplate(')
++                ->raw('$this->load(')
+                 ->subcompile($parent)
+                 ->raw(', ')
+-                ->repr($this->getSourceContext()->getName())
+-                ->raw(', ')
+                 ->repr($parent->getTemplateLine())
+                 ->raw(')')
+             ;
+@@ -135,6 +164,9 @@ protected function compileGetParent(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileClassHeader(Compiler $compiler)
+     {
+         $compiler
+@@ -153,7 +185,9 @@ protected function compileClassHeader(Compiler $compiler)
+                 ->write("use Twig\Sandbox\SecurityNotAllowedFilterError;\n")
+                 ->write("use Twig\Sandbox\SecurityNotAllowedFunctionError;\n")
+                 ->write("use Twig\Source;\n")
+-                ->write("use Twig\Template;\n\n")
++                ->write("use Twig\Template;\n")
++                ->write("use Twig\TemplateWrapper;\n")
++                ->write("\n")
+             ;
+         }
+         $compiler
+@@ -163,11 +197,17 @@ protected function compileClassHeader(Compiler $compiler)
+             ->raw(" extends Template\n")
+             ->write("{\n")
+             ->indent()
+-            ->write("private \$source;\n")
+-            ->write("private \$macros = [];\n\n")
++            ->write("private Source \$source;\n")
++            ->write("/**\n")
++            ->write(" * @var array<string, Template>\n")
++            ->write(" */\n")
++            ->write("private array \$macros = [];\n\n")
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileConstructor(Compiler $compiler)
+     {
+         $compiler
+@@ -191,11 +231,9 @@ protected function compileConstructor(Compiler $compiler)
+ 
+                 $compiler
+                     ->addDebugInfo($node)
+-                    ->write(\sprintf('$_trait_%s = $this->loadTemplate(', $i))
++                    ->write(\sprintf('$_trait_%s = $this->load(', $i))
+                     ->subcompile($node)
+                     ->raw(', ')
+-                    ->repr($node->getTemplateName())
+-                    ->raw(', ')
+                     ->repr($node->getTemplateLine())
+                     ->raw(");\n")
+                     ->write(\sprintf("if (!\$_trait_%s->unwrap()->isTraitable()) {\n", $i))
+@@ -216,11 +254,11 @@ protected function compileConstructor(Compiler $compiler)
+                         ->string($key)
+                         ->raw("])) {\n")
+                         ->indent()
+-                        ->write("throw new RuntimeError('Block ")
++                        ->write("throw new RuntimeError(sprintf('Block \"%s\" is not defined in trait \"%s\".', ")
+                         ->string($key)
+-                        ->raw(' is not defined in trait ')
++                        ->raw(', ')
+                         ->subcompile($trait->getNode('template'))
+-                        ->raw(".', ")
++                        ->raw('), ')
+                         ->repr($node->getTemplateLine())
+                         ->raw(", \$this->source);\n")
+                         ->outdent()
+@@ -232,7 +270,11 @@ protected function compileConstructor(Compiler $compiler)
+                         ->string($key)
+                         ->raw(\sprintf(']; unset($_trait_%s_blocks[', $i))
+                         ->string($key)
+-                        ->raw("]);\n\n")
++                        ->raw(']); $this->traitAliases[')
++                        ->subcompile($value)
++                        ->raw('] = ')
++                        ->string($key)
++                        ->raw(";\n\n")
+                     ;
+                 }
+             }
+@@ -303,10 +345,13 @@ protected function compileConstructor(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileDisplay(Compiler $compiler)
+     {
+         $compiler
+-            ->write("protected function doDisplay(array \$context, array \$blocks = [])\n", "{\n")
++            ->write("protected function doDisplay(array \$context, array \$blocks = []): iterable\n", "{\n")
+             ->indent()
+             ->write("\$macros = \$this->macros;\n")
+             ->subcompile($this->getNode('display_start'))
+@@ -319,11 +364,9 @@ protected function compileDisplay(Compiler $compiler)
+             $compiler->addDebugInfo($parent);
+             if ($parent instanceof ConstantExpression) {
+                 $compiler
+-                    ->write('$this->parent = $this->loadTemplate(')
++                    ->write('$this->parent = $this->load(')
+                     ->subcompile($parent)
+                     ->raw(', ')
+-                    ->repr($this->getSourceContext()->getName())
+-                    ->raw(', ')
+                     ->repr($parent->getTemplateLine())
+                     ->raw(");\n")
+                 ;
+@@ -341,7 +384,7 @@ protected function compileDisplay(Compiler $compiler)
+         $compiler->subcompile($this->getNode('display_end'));
+ 
+         if (!$this->hasNode('parent')) {
+-            $compiler->write("return; yield '';\n"); // ensure at least one yield call even for templates with no output
++            $compiler->write("yield from [];\n");
+         }
+ 
+         $compiler
+@@ -350,6 +393,9 @@ protected function compileDisplay(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileClassFooter(Compiler $compiler)
+     {
+         $compiler
+@@ -359,18 +405,24 @@ protected function compileClassFooter(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileMacros(Compiler $compiler)
+     {
+         $compiler->subcompile($this->getNode('macros'));
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileGetTemplateName(Compiler $compiler)
+     {
+         $compiler
+             ->write("/**\n")
+             ->write(" * @codeCoverageIgnore\n")
+             ->write(" */\n")
+-            ->write("public function getTemplateName()\n", "{\n")
++            ->write("public function getTemplateName(): string\n", "{\n")
+             ->indent()
+             ->write('return ')
+             ->repr($this->getSourceContext()->getName())
+@@ -380,6 +432,9 @@ protected function compileGetTemplateName(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileIsTraitable(Compiler $compiler)
+     {
+         // A template can be used as a trait if:
+@@ -398,7 +453,7 @@ protected function compileIsTraitable(Compiler $compiler)
+             }
+ 
+             if (!\count($nodes)) {
+-                $nodes = new Node([$nodes]);
++                $nodes = new Nodes([$nodes]);
+             }
+ 
+             foreach ($nodes as $node) {
+@@ -406,14 +461,6 @@ protected function compileIsTraitable(Compiler $compiler)
+                     continue;
+                 }
+ 
+-                if ($node instanceof TextNode && ctype_space($node->getAttribute('data'))) {
+-                    continue;
+-                }
+-
+-                if ($node instanceof BlockReferenceNode) {
+-                    continue;
+-                }
+-
+                 $traitable = false;
+                 break;
+             }
+@@ -427,7 +474,7 @@ protected function compileIsTraitable(Compiler $compiler)
+             ->write("/**\n")
+             ->write(" * @codeCoverageIgnore\n")
+             ->write(" */\n")
+-            ->write("public function isTraitable()\n", "{\n")
++            ->write("public function isTraitable(): bool\n", "{\n")
+             ->indent()
+             ->write("return false;\n")
+             ->outdent()
+@@ -435,13 +482,16 @@ protected function compileIsTraitable(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileDebugInfo(Compiler $compiler)
+     {
+         $compiler
+             ->write("/**\n")
+             ->write(" * @codeCoverageIgnore\n")
+             ->write(" */\n")
+-            ->write("public function getDebugInfo()\n", "{\n")
++            ->write("public function getDebugInfo(): array\n", "{\n")
+             ->indent()
+             ->write(\sprintf("return %s;\n", str_replace("\n", '', var_export(array_reverse($compiler->getDebugInfo(), true), true))))
+             ->outdent()
+@@ -449,10 +499,13 @@ protected function compileDebugInfo(Compiler $compiler)
+         ;
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function compileGetSourceContext(Compiler $compiler)
+     {
+         $compiler
+-            ->write("public function getSourceContext()\n", "{\n")
++            ->write("public function getSourceContext(): Source\n", "{\n")
+             ->indent()
+             ->write('return new Source(')
+             ->string($compiler->getEnvironment()->isDebug() ? $this->getSourceContext()->getCode() : '')
+@@ -465,36 +518,4 @@ protected function compileGetSourceContext(Compiler $compiler)
+             ->write("}\n")
+         ;
+     }
+-
+-    protected function compileLoadTemplate(Compiler $compiler, $node, $var)
+-    {
+-        if ($node instanceof ConstantExpression) {
+-            $compiler
+-                ->write(\sprintf('%s = $this->loadTemplate(', $var))
+-                ->subcompile($node)
+-                ->raw(', ')
+-                ->repr($node->getTemplateName())
+-                ->raw(', ')
+-                ->repr($node->getTemplateLine())
+-                ->raw(");\n")
+-            ;
+-        } else {
+-            throw new \LogicException('Trait templates can only be constant nodes.');
+-        }
+-    }
+-
+-    private function hasNodeOutputNodes(Node $node): bool
+-    {
+-        if ($node instanceof NodeOutputInterface) {
+-            return true;
+-        }
+-
+-        foreach ($node as $child) {
+-            if ($this->hasNodeOutputNodes($child)) {
+-                return true;
+-            }
+-        }
+-
+-        return false;
+-    }
+ }
+diff --git a/src/Node/Node.php b/src/Node/Node.php
+index 5ef661f5e37..dcf912c2198 100644
+--- a/src/Node/Node.php
++++ b/src/Node/Node.php
+@@ -20,10 +20,15 @@
+  * Represents a node in the AST.
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @implements \IteratorAggregate<int|string, Node>
+  */
+ #[YieldReady]
+ class Node implements \Countable, \IteratorAggregate
+ {
++    /**
++     * @var array<string|int, Node>
++     */
+     protected $nodes;
+     protected $attributes;
+     protected $lineno;
+@@ -36,50 +41,75 @@ class Node implements \Countable, \IteratorAggregate
+     private $attributeNameDeprecations = [];
+ 
+     /**
+-     * @param array  $nodes      An array of named nodes
+-     * @param array  $attributes An array of attributes (should not be nodes)
+-     * @param int    $lineno     The line number
+-     * @param string $tag        The tag name associated with the Node
++     * @param array<string|int, Node> $nodes      An array of named nodes
++     * @param array                   $attributes An array of attributes (should not be nodes)
++     * @param int                     $lineno     The line number
+      */
+-    public function __construct(array $nodes = [], array $attributes = [], int $lineno = 0, ?string $tag = null)
++    public function __construct(array $nodes = [], array $attributes = [], int $lineno = 0)
+     {
++        if (self::class === static::class) {
++            trigger_deprecation('twig/twig', '3.15', \sprintf('Instantiating "%s" directly is deprecated; the class will become abstract in 4.0.', self::class));
++        }
++
+         foreach ($nodes as $name => $node) {
+             if (!$node instanceof self) {
+-                throw new \InvalidArgumentException(\sprintf('Using "%s" for the value of node "%s" of "%s" is not supported. You must pass a \Twig\Node\Node instance.', \is_object($node) ? \get_class($node) : (null === $node ? 'null' : \gettype($node)), $name, static::class));
++                throw new \InvalidArgumentException(\sprintf('Using "%s" for the value of node "%s" of "%s" is not supported. You must pass a \Twig\Node\Node instance.', get_debug_type($node), $name, static::class));
+             }
+         }
+         $this->nodes = $nodes;
+         $this->attributes = $attributes;
+         $this->lineno = $lineno;
+-        $this->tag = $tag;
++
++        if (\func_num_args() > 3) {
++            trigger_deprecation('twig/twig', '3.12', \sprintf('The "tag" constructor argument of the "%s" class is deprecated and ignored (check which TokenParser class set it to "%s"), the tag is now automatically set by the Parser when needed.', static::class, func_get_arg(3) ?: 'null'));
++        }
+     }
+ 
+-    public function __toString()
++    public function __toString(): string
+     {
++        $repr = static::class;
++
++        if ($this->tag) {
++            $repr .= \sprintf("\n  tag: %s", $this->tag);
++        }
++
+         $attributes = [];
+         foreach ($this->attributes as $name => $value) {
+-            $attributes[] = \sprintf('%s: %s', $name, \is_callable($value) ? '\Closure' : str_replace("\n", '', var_export($value, true)));
++            if (\is_callable($value)) {
++                $v = '\Closure';
++            } elseif ($value instanceof \Stringable) {
++                $v = (string) $value;
++            } else {
++                $v = str_replace("\n", '', var_export($value, true));
++            }
++            $attributes[] = \sprintf('%s: %s', $name, $v);
+         }
+ 
+-        $repr = [static::class.'('.implode(', ', $attributes)];
++        if ($attributes) {
++            $repr .= \sprintf("\n  attributes:\n    %s", implode("\n    ", $attributes));
++        }
+ 
+         if (\count($this->nodes)) {
++            $repr .= "\n  nodes:";
+             foreach ($this->nodes as $name => $node) {
+-                $len = \strlen($name) + 4;
++                $len = \strlen($name) + 6;
+                 $noderepr = [];
+                 foreach (explode("\n", (string) $node) as $line) {
+                     $noderepr[] = str_repeat(' ', $len).$line;
+                 }
+ 
+-                $repr[] = \sprintf('  %s: %s', $name, ltrim(implode("\n", $noderepr)));
++                $repr .= \sprintf("\n    %s: %s", $name, ltrim(implode("\n", $noderepr)));
+             }
+-
+-            $repr[] = ')';
+-        } else {
+-            $repr[0] .= ')';
+         }
+ 
+-        return implode("\n", $repr);
++        return $repr;
++    }
++
++    public function __clone()
++    {
++        foreach ($this->nodes as $name => $node) {
++            $this->nodes[$name] = clone $node;
++        }
+     }
+ 
+     /**
+@@ -102,6 +132,18 @@ public function getNodeTag(): ?string
+         return $this->tag;
+     }
+ 
++    /**
++     * @internal
++     */
++    public function setNodeTag(string $tag): void
++    {
++        if ($this->tag) {
++            throw new \LogicException('The tag of a node can only be set once.');
++        }
++
++        $this->tag = $tag;
++    }
++
+     public function hasAttribute(string $name): bool
+     {
+         return \array_key_exists($name, $this->attributes);
+@@ -151,11 +193,17 @@ public function removeAttribute(string $name): void
+         unset($this->attributes[$name]);
+     }
+ 
++    /**
++     * @param string|int $name
++     */
+     public function hasNode(string $name): bool
+     {
+         return isset($this->nodes[$name]);
+     }
+ 
++    /**
++     * @param string|int $name
++     */
+     public function getNode(string $name): self
+     {
+         if (!isset($this->nodes[$name])) {
+@@ -175,6 +223,9 @@ public function getNode(string $name): self
+         return $this->nodes[$name];
+     }
+ 
++    /**
++     * @param string|int $name
++     */
+     public function setNode(string $name, self $node): void
+     {
+         $triggerDeprecation = \func_num_args() > 2 ? func_get_arg(2) : true;
+@@ -193,11 +244,17 @@ public function setNode(string $name, self $node): void
+         $this->nodes[$name] = $node;
+     }
+ 
++    /**
++     * @param string|int $name
++     */
+     public function removeNode(string $name): void
+     {
+         unset($this->nodes[$name]);
+     }
+ 
++    /**
++     * @param string|int $name
++     */
+     public function deprecateNode(string $name, NameDeprecation $dep): void
+     {
+         $this->nodeNameDeprecations[$name] = $dep;
+diff --git a/src/Node/Nodes.php b/src/Node/Nodes.php
+new file mode 100644
+index 00000000000..bd67053abe1
+--- /dev/null
++++ b/src/Node/Nodes.php
+@@ -0,0 +1,28 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node;
++
++use Twig\Attribute\YieldReady;
++
++/**
++ * Represents a list of nodes.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ */
++#[YieldReady]
++final class Nodes extends Node
++{
++    public function __construct(array $nodes = [], int $lineno = 0)
++    {
++        parent::__construct($nodes, [], $lineno);
++    }
++}
+diff --git a/src/Node/PrintNode.php b/src/Node/PrintNode.php
+index da442d85207..da94ab4685d 100644
+--- a/src/Node/PrintNode.php
++++ b/src/Node/PrintNode.php
+@@ -22,11 +22,11 @@
+  * @author Fabien Potencier <fabien@symfony.com>
+  */
+ #[YieldReady]
+-class PrintNode extends Node implements NodeOutputInterface
++class PrintNode extends Node implements NodeOutputInterface, CoercesChildrenToStringInterface
+ {
+-    public function __construct(AbstractExpression $expr, int $lineno, ?string $tag = null)
++    public function __construct(AbstractExpression $expr, int $lineno)
+     {
+-        parent::__construct(['expr' => $expr], [], $lineno, $tag);
++        parent::__construct(['expr' => $expr], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -41,4 +41,9 @@ public function compile(Compiler $compiler): void
+             ->raw(";\n")
+         ;
+     }
++
++    public function getStringCoercedChildNames(): array
++    {
++        return ['expr'];
++    }
+ }
+diff --git a/src/Node/SandboxNode.php b/src/Node/SandboxNode.php
+index 80aecbdba36..d51cea44b48 100644
+--- a/src/Node/SandboxNode.php
++++ b/src/Node/SandboxNode.php
+@@ -22,9 +22,9 @@
+ #[YieldReady]
+ class SandboxNode extends Node
+ {
+-    public function __construct(Node $body, int $lineno, ?string $tag = null)
++    public function __construct(Node $body, int $lineno)
+     {
+-        parent::__construct(['body' => $body], [], $lineno, $tag);
++        parent::__construct(['body' => $body], [], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+diff --git a/src/Node/SetNode.php b/src/Node/SetNode.php
+index 0900f1542a9..7b063b00b2a 100644
+--- a/src/Node/SetNode.php
++++ b/src/Node/SetNode.php
+@@ -23,7 +23,7 @@
+ #[YieldReady]
+ class SetNode extends Node implements NodeCaptureInterface
+ {
+-    public function __construct(bool $capture, Node $names, Node $values, int $lineno, ?string $tag = null)
++    public function __construct(bool $capture, Node $names, Node $values, int $lineno)
+     {
+         /*
+          * Optimizes the node when capture is used for a large block of text.
+@@ -33,15 +33,22 @@ public function __construct(bool $capture, Node $names, Node $values, int $linen
+         $safe = false;
+         if ($capture) {
+             $safe = true;
+-            if ($values instanceof TextNode) {
++            // Node::class === get_class($values) should be removed in Twig 4.0
++            if (($values instanceof Nodes || Node::class === $values::class) && !\count($values)) {
++                $values = new ConstantExpression('', $values->getTemplateLine());
++                $capture = false;
++            } elseif ($values instanceof TextNode) {
+                 $values = new ConstantExpression($values->getAttribute('data'), $values->getTemplateLine());
+                 $capture = false;
++            } elseif ($values instanceof PrintNode && $values->getNode('expr') instanceof ConstantExpression) {
++                $values = $values->getNode('expr');
++                $capture = false;
+             } else {
+                 $values = new CaptureNode($values, $values->getTemplateLine());
+             }
+         }
+ 
+-        parent::__construct(['names' => $names, 'values' => $values], ['capture' => $capture, 'safe' => $safe], $lineno, $tag);
++        parent::__construct(['names' => $names, 'values' => $values], ['capture' => $capture, 'safe' => $safe], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -78,11 +85,23 @@ public function compile(Compiler $compiler): void
+                 $compiler->raw(']');
+             } else {
+                 if ($this->getAttribute('safe')) {
+-                    $compiler
+-                        ->raw("('' === \$tmp = ")
+-                        ->subcompile($this->getNode('values'))
+-                        ->raw(") ? '' : new Markup(\$tmp, \$this->env->getCharset())")
+-                    ;
++                    if ($this->getNode('values') instanceof ConstantExpression) {
++                        if ('' === $this->getNode('values')->getAttribute('value')) {
++                            $compiler->raw('""');
++                        } else {
++                            $compiler
++                                ->raw('new Markup(')
++                                ->subcompile($this->getNode('values'))
++                                ->raw(', $this->env->getCharset())')
++                            ;
++                        }
++                    } else {
++                        $compiler
++                            ->raw("('' === \$tmp = ")
++                            ->subcompile($this->getNode('values'))
++                            ->raw(") ? '' : new Markup(\$tmp, \$this->env->getCharset())")
++                        ;
++                    }
+                 } else {
+                     $compiler->subcompile($this->getNode('values'));
+                 }
+diff --git a/src/Node/TypesNode.php b/src/Node/TypesNode.php
+new file mode 100644
+index 00000000000..a1828808385
+--- /dev/null
++++ b/src/Node/TypesNode.php
+@@ -0,0 +1,40 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Node;
++
++use Twig\Attribute\YieldReady;
++use Twig\Compiler;
++
++/**
++ * Represents a types node.
++ *
++ * @author Jeroen Versteeg <jeroen@alisqi.com>
++ */
++#[YieldReady]
++class TypesNode extends Node
++{
++    /**
++     * @param array<string, array{type: string, optional: bool}> $types
++     */
++    public function __construct(array $types, int $lineno)
++    {
++        parent::__construct([], ['mapping' => $types], $lineno);
++    }
++
++    /**
++     * @return void
++     */
++    public function compile(Compiler $compiler)
++    {
++        // Don't compile anything.
++    }
++}
+diff --git a/src/Node/WithNode.php b/src/Node/WithNode.php
+index a7b7e70d9dd..487e2800bfd 100644
+--- a/src/Node/WithNode.php
++++ b/src/Node/WithNode.php
+@@ -22,14 +22,14 @@
+ #[YieldReady]
+ class WithNode extends Node
+ {
+-    public function __construct(Node $body, ?Node $variables, bool $only, int $lineno, ?string $tag = null)
++    public function __construct(Node $body, ?Node $variables, bool $only, int $lineno)
+     {
+         $nodes = ['body' => $body];
+         if (null !== $variables) {
+             $nodes['variables'] = $variables;
+         }
+ 
+-        parent::__construct($nodes, ['only' => $only], $lineno, $tag);
++        parent::__construct($nodes, ['only' => $only], $lineno);
+     }
+ 
+     public function compile(Compiler $compiler): void
+@@ -61,7 +61,7 @@ public function compile(Compiler $compiler): void
+                 $compiler->write("\$context = [];\n");
+             }
+ 
+-            $compiler->write(\sprintf("\$context = \$this->env->mergeGlobals(array_merge(\$context, \$%s));\n", $varsName));
++            $compiler->write(\sprintf("\$context = \$%s + \$context + \$this->env->getGlobals();\n", $varsName));
+         }
+ 
+         $compiler
+diff --git a/src/NodeVisitor/AbstractNodeVisitor.php b/src/NodeVisitor/AbstractNodeVisitor.php
+index 5de35fd096a..38b1ec9d04f 100644
+--- a/src/NodeVisitor/AbstractNodeVisitor.php
++++ b/src/NodeVisitor/AbstractNodeVisitor.php
+@@ -19,7 +19,7 @@
+  *
+  * @author Fabien Potencier <fabien@symfony.com>
+  *
+- * @deprecated since 3.9 (to be removed in 4.0)
++ * @deprecated since Twig 3.9 (to be removed in 4.0)
+  */
+ abstract class AbstractNodeVisitor implements NodeVisitorInterface
+ {
+diff --git a/src/NodeVisitor/EscaperNodeVisitor.php b/src/NodeVisitor/EscaperNodeVisitor.php
+index 91e2ea89392..a9f829770a2 100644
+--- a/src/NodeVisitor/EscaperNodeVisitor.php
++++ b/src/NodeVisitor/EscaperNodeVisitor.php
+@@ -16,14 +16,14 @@
+ use Twig\Node\AutoEscapeNode;
+ use Twig\Node\BlockNode;
+ use Twig\Node\BlockReferenceNode;
+-use Twig\Node\DoNode;
+-use Twig\Node\Expression\ConditionalExpression;
++use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Expression\FilterExpression;
+-use Twig\Node\Expression\InlinePrint;
++use Twig\Node\Expression\OperatorEscapeInterface;
+ use Twig\Node\ImportNode;
+ use Twig\Node\ModuleNode;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Node\PrintNode;
+ use Twig\NodeTraverser;
+ 
+@@ -59,7 +59,7 @@ public function enterNode(Node $node, Environment $env): Node
+         } elseif ($node instanceof BlockNode) {
+             $this->statusStack[] = $this->blocks[$node->getAttribute('name')] ?? $this->needEscaping();
+         } elseif ($node instanceof ImportNode) {
+-            $this->safeVars[] = $node->getNode('var')->getAttribute('name');
++            $this->safeVars[] = $node->getNode('var')->getNode('var')->getAttribute('name');
+         }
+ 
+         return $node;
+@@ -75,11 +75,13 @@ public function leaveNode(Node $node, Environment $env): ?Node
+             return $this->preEscapeFilterNode($node, $env);
+         } elseif ($node instanceof PrintNode && false !== $type = $this->needEscaping()) {
+             $expression = $node->getNode('expr');
+-            if ($expression instanceof ConditionalExpression && $this->shouldUnwrapConditional($expression, $env, $type)) {
+-                return new DoNode($this->unwrapConditional($expression, $env, $type), $expression->getTemplateLine());
++            if ($expression instanceof OperatorEscapeInterface) {
++                $this->escapeConditional($expression, $env, $type);
++            } else {
++                $node->setNode('expr', $this->escapeExpression($expression, $env, $type));
+             }
+ 
+-            return $this->escapePrintNode($node, $env, $type);
++            return $node;
+         }
+ 
+         if ($node instanceof AutoEscapeNode || $node instanceof BlockNode) {
+@@ -91,81 +93,57 @@ public function leaveNode(Node $node, Environment $env): ?Node
+         return $node;
+     }
+ 
+-    private function shouldUnwrapConditional(ConditionalExpression $expression, Environment $env, string $type): bool
+-    {
+-        $expr2Safe = $this->isSafeFor($type, $expression->getNode('expr2'), $env);
+-        $expr3Safe = $this->isSafeFor($type, $expression->getNode('expr3'), $env);
+-
+-        return $expr2Safe !== $expr3Safe;
+-    }
+-
+-    private function unwrapConditional(ConditionalExpression $expression, Environment $env, string $type): ConditionalExpression
+-    {
+-        // convert "echo a ? b : c" to "a ? echo b : echo c" recursively
+-        $expr2 = $expression->getNode('expr2');
+-        if ($expr2 instanceof ConditionalExpression && $this->shouldUnwrapConditional($expr2, $env, $type)) {
+-            $expr2 = $this->unwrapConditional($expr2, $env, $type);
+-        } else {
+-            $expr2 = $this->escapeInlinePrintNode(new InlinePrint($expr2, $expr2->getTemplateLine()), $env, $type);
+-        }
+-        $expr3 = $expression->getNode('expr3');
+-        if ($expr3 instanceof ConditionalExpression && $this->shouldUnwrapConditional($expr3, $env, $type)) {
+-            $expr3 = $this->unwrapConditional($expr3, $env, $type);
+-        } else {
+-            $expr3 = $this->escapeInlinePrintNode(new InlinePrint($expr3, $expr3->getTemplateLine()), $env, $type);
+-        }
+-
+-        return new ConditionalExpression($expression->getNode('expr1'), $expr2, $expr3, $expression->getTemplateLine());
+-    }
+-
+-    private function escapeInlinePrintNode(InlinePrint $node, Environment $env, string $type): Node
++    /**
++     * @param AbstractExpression&OperatorEscapeInterface $expression
++     */
++    private function escapeConditional($expression, Environment $env, string $type): void
+     {
+-        $expression = $node->getNode('node');
+-
+-        if ($this->isSafeFor($type, $expression, $env)) {
+-            return $node;
++        foreach ($expression->getOperandNamesToEscape() as $name) {
++            /** @var AbstractExpression $operand */
++            $operand = $expression->getNode($name);
++            if ($operand instanceof OperatorEscapeInterface) {
++                $this->escapeConditional($operand, $env, $type);
++            } else {
++                $expression->setNode($name, $this->escapeExpression($operand, $env, $type));
++            }
+         }
+-
+-        return new InlinePrint($this->getEscaperFilter($type, $expression), $node->getTemplateLine());
+     }
+ 
+-    private function escapePrintNode(PrintNode $node, Environment $env, string $type): Node
++    private function escapeExpression(AbstractExpression $expression, Environment $env, string $type): AbstractExpression
+     {
+-        $expression = $node->getNode('expr');
+-
+-        if ($this->isSafeFor($type, $expression, $env)) {
+-            return $node;
+-        }
+-
+-        $class = \get_class($node);
+-
+-        return new $class($this->getEscaperFilter($type, $expression), $node->getTemplateLine());
++        return $this->isSafeFor($type, $expression, $env) ? $expression : $this->getEscaperFilter($env, $type, $expression);
+     }
+ 
+     private function preEscapeFilterNode(FilterExpression $filter, Environment $env): FilterExpression
+     {
+-        $name = $filter->getNode('filter')->getAttribute('value');
++        if ($filter->hasAttribute('twig_callable')) {
++            $type = $filter->getAttribute('twig_callable')->getPreEscape();
++        } else {
++            // legacy
++            $name = $filter->getNode('filter', false)->getAttribute('value');
++            $type = $env->getFilter($name)->getPreEscape();
++        }
+ 
+-        $type = $env->getFilter($name)->getPreEscape();
+         if (null === $type) {
+             return $filter;
+         }
+ 
++        /** @var AbstractExpression $node */
+         $node = $filter->getNode('node');
+         if ($this->isSafeFor($type, $node, $env)) {
+             return $filter;
+         }
+ 
+-        $filter->setNode('node', $this->getEscaperFilter($type, $node));
++        $filter->setNode('node', $this->getEscaperFilter($env, $type, $node));
+ 
+         return $filter;
+     }
+ 
+-    private function isSafeFor(string $type, Node $expression, Environment $env): bool
++    private function isSafeFor(string $type, AbstractExpression $expression, Environment $env): bool
+     {
+         $safe = $this->safeAnalysis->getSafe($expression);
+ 
+-        if (null === $safe) {
++        if (!$safe) {
+             if (null === $this->traverser) {
+                 $this->traverser = new NodeTraverser($env, [$this->safeAnalysis]);
+             }
+@@ -176,10 +154,13 @@ private function isSafeFor(string $type, Node $expression, Environment $env): bo
+             $safe = $this->safeAnalysis->getSafe($expression);
+         }
+ 
+-        return \in_array($type, $safe) || \in_array('all', $safe);
++        return \in_array($type, $safe, true) || \in_array('all', $safe, true);
+     }
+ 
+-    private function needEscaping()
++    /**
++     * @return string|false
++     */
++    private function needEscaping(): string|bool
+     {
+         if (\count($this->statusStack)) {
+             return $this->statusStack[\count($this->statusStack) - 1];
+@@ -188,13 +169,13 @@ private function needEscaping()
+         return $this->defaultStrategy ?: false;
+     }
+ 
+-    private function getEscaperFilter(string $type, Node $node): FilterExpression
++    private function getEscaperFilter(Environment $env, string $type, AbstractExpression $node): FilterExpression
+     {
+         $line = $node->getTemplateLine();
+-        $name = new ConstantExpression('escape', $line);
+-        $args = new Node([new ConstantExpression($type, $line), new ConstantExpression(null, $line), new ConstantExpression(true, $line)]);
++        $filter = $env->getFilter('escape');
++        $args = new Nodes([new ConstantExpression($type, $line), new ConstantExpression(null, $line), new ConstantExpression(true, $line)]);
+ 
+-        return new FilterExpression($node, $name, $args, $line);
++        return new FilterExpression($node, $filter, $args, $line);
+     }
+ 
+     public function getPriority(): int
+diff --git a/src/NodeVisitor/MacroAutoImportNodeVisitor.php b/src/NodeVisitor/MacroAutoImportNodeVisitor.php
+deleted file mode 100644
+index d6a7781ba27..00000000000
+--- a/src/NodeVisitor/MacroAutoImportNodeVisitor.php
++++ /dev/null
+@@ -1,74 +0,0 @@
+-<?php
+-
+-/*
+- * This file is part of Twig.
+- *
+- * (c) Fabien Potencier
+- *
+- * For the full copyright and license information, please view the LICENSE
+- * file that was distributed with this source code.
+- */
+-
+-namespace Twig\NodeVisitor;
+-
+-use Twig\Environment;
+-use Twig\Node\Expression\AssignNameExpression;
+-use Twig\Node\Expression\ConstantExpression;
+-use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\MethodCallExpression;
+-use Twig\Node\Expression\NameExpression;
+-use Twig\Node\ImportNode;
+-use Twig\Node\ModuleNode;
+-use Twig\Node\Node;
+-
+-/**
+- * @author Fabien Potencier <fabien@symfony.com>
+- *
+- * @internal
+- */
+-final class MacroAutoImportNodeVisitor implements NodeVisitorInterface
+-{
+-    private $inAModule = false;
+-    private $hasMacroCalls = false;
+-
+-    public function enterNode(Node $node, Environment $env): Node
+-    {
+-        if ($node instanceof ModuleNode) {
+-            $this->inAModule = true;
+-            $this->hasMacroCalls = false;
+-        }
+-
+-        return $node;
+-    }
+-
+-    public function leaveNode(Node $node, Environment $env): Node
+-    {
+-        if ($node instanceof ModuleNode) {
+-            $this->inAModule = false;
+-            if ($this->hasMacroCalls) {
+-                $node->getNode('constructor_end')->setNode('_auto_macro_import', new ImportNode(new NameExpression('_self', 0), new AssignNameExpression('_self', 0), 0, 'import', true));
+-            }
+-        } elseif ($this->inAModule) {
+-            if (
+-                $node instanceof GetAttrExpression
+-                && $node->getNode('node') instanceof NameExpression
+-                && '_self' === $node->getNode('node')->getAttribute('name')
+-                && $node->getNode('attribute') instanceof ConstantExpression
+-            ) {
+-                $this->hasMacroCalls = true;
+-
+-                $name = $node->getNode('attribute')->getAttribute('value');
+-                $node = new MethodCallExpression($node->getNode('node'), 'macro_'.$name, $node->getNode('arguments'), $node->getTemplateLine());
+-                $node->setAttribute('safe', true);
+-            }
+-        }
+-
+-        return $node;
+-    }
+-
+-    public function getPriority(): int
+-    {
+-        // we must be ran before auto-escaping
+-        return -10;
+-    }
+-}
+diff --git a/src/NodeVisitor/OptimizerNodeVisitor.php b/src/NodeVisitor/OptimizerNodeVisitor.php
+index 55f5d6eb960..b778ba40efa 100644
+--- a/src/NodeVisitor/OptimizerNodeVisitor.php
++++ b/src/NodeVisitor/OptimizerNodeVisitor.php
+@@ -17,8 +17,8 @@
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Expression\FunctionExpression;
+ use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\NameExpression;
+ use Twig\Node\Expression\ParentExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\ForNode;
+ use Twig\Node\IncludeNode;
+ use Twig\Node\Node;
+@@ -47,13 +47,13 @@ final class OptimizerNodeVisitor implements NodeVisitorInterface
+ 
+     private $loops = [];
+     private $loopsTargets = [];
+-    private $optimizers;
+ 
+     /**
+      * @param int $optimizers The optimizer mode
+      */
+-    public function __construct(int $optimizers = -1)
+-    {
++    public function __construct(
++        private int $optimizers = -1,
++    ) {
+         if ($optimizers > (self::OPTIMIZE_FOR | self::OPTIMIZE_RAW_FILTER | self::OPTIMIZE_TEXT_NODES)) {
+             throw new \InvalidArgumentException(\sprintf('Optimizer mode "%s" is not valid.', $optimizers));
+         }
+@@ -62,7 +62,9 @@ public function __construct(int $optimizers = -1)
+             trigger_deprecation('twig/twig', '3.11', 'The "Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_RAW_FILTER" option is deprecated and does nothing.');
+         }
+ 
+-        $this->optimizers = $optimizers;
++        if (-1 !== $optimizers && self::OPTIMIZE_TEXT_NODES === (self::OPTIMIZE_TEXT_NODES & $optimizers)) {
++            trigger_deprecation('twig/twig', '3.12', 'The "Twig\NodeVisitor\OptimizerNodeVisitor::OPTIMIZE_TEXT_NODES" option is deprecated and does nothing.');
++        }
+     }
+ 
+     public function enterNode(Node $node, Environment $env): Node
+@@ -82,42 +84,6 @@ public function leaveNode(Node $node, Environment $env): ?Node
+ 
+         $node = $this->optimizePrintNode($node);
+ 
+-        if (self::OPTIMIZE_TEXT_NODES === (self::OPTIMIZE_TEXT_NODES & $this->optimizers)) {
+-            $node = $this->mergeTextNodeCalls($node);
+-        }
+-
+-        return $node;
+-    }
+-
+-    private function mergeTextNodeCalls(Node $node): Node
+-    {
+-        $text = '';
+-        $names = [];
+-        foreach ($node as $k => $n) {
+-            if (!$n instanceof TextNode) {
+-                return $node;
+-            }
+-
+-            $text .= $n->getAttribute('data');
+-            $names[] = $k;
+-        }
+-
+-        if (!$text) {
+-            return $node;
+-        }
+-
+-        if (Node::class === \get_class($node)) {
+-            return new TextNode($text, $node->getTemplateLine());
+-        }
+-
+-        foreach ($names as $i => $name) {
+-            if (0 === $i) {
+-                $node->setNode($name, new TextNode($text, $node->getTemplateLine()));
+-            } else {
+-                $node->removeNode($name);
+-            }
+-        }
+-
+         return $node;
+     }
+ 
+@@ -171,13 +137,13 @@ private function enterOptimizeFor(Node $node): void
+         // when do we need to add the loop variable back?
+ 
+         // the loop variable is referenced for the current loop
+-        elseif ($node instanceof NameExpression && 'loop' === $node->getAttribute('name')) {
++        elseif ($node instanceof ContextVariable && 'loop' === $node->getAttribute('name')) {
+             $node->setAttribute('always_defined', true);
+             $this->addLoopToCurrent();
+         }
+ 
+         // optimize access to loop targets
+-        elseif ($node instanceof NameExpression && \in_array($node->getAttribute('name'), $this->loopsTargets)) {
++        elseif ($node instanceof ContextVariable && \in_array($node->getAttribute('name'), $this->loopsTargets, true)) {
+             $node->setAttribute('always_defined', true);
+         }
+ 
+@@ -207,7 +173,7 @@ private function enterOptimizeFor(Node $node): void
+                 || 'parent' === $node->getNode('attribute')->getAttribute('value')
+             )
+             && (true === $this->loops[0]->getAttribute('with_loop')
+-             || ($node->getNode('node') instanceof NameExpression
++             || ($node->getNode('node') instanceof ContextVariable
+                  && 'loop' === $node->getNode('node')->getAttribute('name')
+              )
+             )
+diff --git a/src/NodeVisitor/SafeAnalysisNodeVisitor.php b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+index 6df046e1c7b..b1aea0f361d 100644
+--- a/src/NodeVisitor/SafeAnalysisNodeVisitor.php
++++ b/src/NodeVisitor/SafeAnalysisNodeVisitor.php
+@@ -13,14 +13,15 @@
+ 
+ use Twig\Environment;
+ use Twig\Node\Expression\BlockReferenceExpression;
+-use Twig\Node\Expression\ConditionalExpression;
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Expression\FilterExpression;
+ use Twig\Node\Expression\FunctionExpression;
+ use Twig\Node\Expression\GetAttrExpression;
++use Twig\Node\Expression\MacroReferenceExpression;
+ use Twig\Node\Expression\MethodCallExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\OperatorEscapeInterface;
+ use Twig\Node\Expression\ParentExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
+ 
+ /**
+@@ -36,11 +37,14 @@ public function setSafeVars(array $safeVars): void
+         $this->safeVars = $safeVars;
+     }
+ 
++    /**
++     * @return array
++     */
+     public function getSafe(Node $node)
+     {
+-        $hash = spl_object_hash($node);
++        $hash = spl_object_id($node);
+         if (!isset($this->data[$hash])) {
+-            return;
++            return [];
+         }
+ 
+         foreach ($this->data[$hash] as $bucket) {
+@@ -48,17 +52,24 @@ public function getSafe(Node $node)
+                 continue;
+             }
+ 
+-            if (\in_array('html_attr', $bucket['value'])) {
++            if (\in_array('html_attr', $bucket['value'], true)) {
++                $bucket['value'][] = 'html';
++                $bucket['value'][] = 'html_attr_relaxed';
++            }
++
++            if (\in_array('html_attr_relaxed', $bucket['value'], true)) {
+                 $bucket['value'][] = 'html';
+             }
+ 
+             return $bucket['value'];
+         }
++
++        return [];
+     }
+ 
+     private function setSafe(Node $node, array $safe): void
+     {
+-        $hash = spl_object_hash($node);
++        $hash = spl_object_id($node);
+         if (isset($this->data[$hash])) {
+             foreach ($this->data[$hash] as &$bucket) {
+                 if ($bucket['key'] === $node) {
+@@ -90,63 +101,77 @@ public function leaveNode(Node $node, Environment $env): ?Node
+         } elseif ($node instanceof ParentExpression) {
+             // parent block is safe by definition
+             $this->setSafe($node, ['all']);
+-        } elseif ($node instanceof ConditionalExpression) {
+-            // intersect safeness of both operands
+-            $safe = $this->intersectSafe($this->getSafe($node->getNode('expr2')), $this->getSafe($node->getNode('expr3')));
+-            $this->setSafe($node, $safe);
++        } elseif ($node instanceof OperatorEscapeInterface) {
++            // intersect safeness of operands
++            $operands = $node->getOperandNamesToEscape();
++            if (2 < \count($operands)) {
++                throw new \LogicException(\sprintf('Operators with more than 2 operands are not supported yet, got %d.', \count($operands)));
++            } elseif (2 === \count($operands)) {
++                $safe = $this->intersectSafe($this->getSafe($node->getNode($operands[0])), $this->getSafe($node->getNode($operands[1])));
++                $this->setSafe($node, $safe);
++            }
+         } elseif ($node instanceof FilterExpression) {
+             // filter expression is safe when the filter is safe
+-            $name = $node->getNode('filter')->getAttribute('value');
+-            $args = $node->getNode('arguments');
+-            if ($filter = $env->getFilter($name)) {
+-                $safe = $filter->getSafe($args);
++            if ($node->hasAttribute('twig_callable')) {
++                $filter = $node->getAttribute('twig_callable');
++            } else {
++                // legacy
++                $filter = $env->getFilter($node->getAttribute('name'));
++            }
++
++            if ($filter) {
++                $safe = $filter->getSafe($node->getNode('arguments'));
+                 if (null === $safe) {
++                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', $filter::class);
++                    $safe = [];
++                }
++
++                if (!$safe) {
+                     $safe = $this->intersectSafe($this->getSafe($node->getNode('node')), $filter->getPreservesSafety());
+                 }
+                 $this->setSafe($node, $safe);
+-            } else {
+-                $this->setSafe($node, []);
+             }
+         } elseif ($node instanceof FunctionExpression) {
+             // function expression is safe when the function is safe
+-            $name = $node->getAttribute('name');
+-            $args = $node->getNode('arguments');
+-            if ($function = $env->getFunction($name)) {
+-                $this->setSafe($node, $function->getSafe($args));
++            if ($node->hasAttribute('twig_callable')) {
++                $function = $node->getAttribute('twig_callable');
+             } else {
+-                $this->setSafe($node, []);
++                // legacy
++                $function = $env->getFunction($node->getAttribute('name'));
+             }
+-        } elseif ($node instanceof MethodCallExpression) {
+-            if ($node->getAttribute('safe')) {
+-                $this->setSafe($node, ['all']);
+-            } else {
+-                $this->setSafe($node, []);
++
++            if ($function) {
++                $safe = $function->getSafe($node->getNode('arguments'));
++                if (null === $safe) {
++                    trigger_deprecation('twig/twig', '3.16', 'The "%s::getSafe()" method should not return "null" anymore, return "[]" instead.', $function::class);
++                    $safe = [];
++                }
++                $this->setSafe($node, $safe);
+             }
+-        } elseif ($node instanceof GetAttrExpression && $node->getNode('node') instanceof NameExpression) {
++        } elseif ($node instanceof MethodCallExpression || $node instanceof MacroReferenceExpression) {
++            // all macro calls are safe
++            $this->setSafe($node, ['all']);
++        } elseif ($node instanceof GetAttrExpression && $node->getNode('node') instanceof ContextVariable) {
+             $name = $node->getNode('node')->getAttribute('name');
+-            if (\in_array($name, $this->safeVars)) {
++            if (\in_array($name, $this->safeVars, true)) {
+                 $this->setSafe($node, ['all']);
+-            } else {
+-                $this->setSafe($node, []);
+             }
+-        } else {
+-            $this->setSafe($node, []);
+         }
+ 
+         return $node;
+     }
+ 
+-    private function intersectSafe(?array $a = null, ?array $b = null): array
++    private function intersectSafe(array $a, array $b): array
+     {
+-        if (null === $a || null === $b) {
++        if (!$a || !$b) {
+             return [];
+         }
+ 
+-        if (\in_array('all', $a)) {
++        if (\in_array('all', $a, true)) {
+             return $b;
+         }
+ 
+-        if (\in_array('all', $b)) {
++        if (\in_array('all', $b, true)) {
+             return $a;
+         }
+ 
+diff --git a/src/NodeVisitor/SandboxNodeVisitor.php b/src/NodeVisitor/SandboxNodeVisitor.php
+index 7cc1c2e9f66..65667c2ffc9 100644
+--- a/src/NodeVisitor/SandboxNodeVisitor.php
++++ b/src/NodeVisitor/SandboxNodeVisitor.php
+@@ -15,18 +15,18 @@
+ use Twig\Node\CheckSecurityCallNode;
+ use Twig\Node\CheckSecurityNode;
+ use Twig\Node\CheckToStringNode;
++use Twig\Node\CoercesChildrenToStringInterface;
+ use Twig\Node\Expression\ArrayExpression;
+-use Twig\Node\Expression\Binary\ConcatBinary;
+ use Twig\Node\Expression\Binary\RangeBinary;
+ use Twig\Node\Expression\FilterExpression;
+ use Twig\Node\Expression\FunctionExpression;
+ use Twig\Node\Expression\GetAttrExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\OperatorEscapeInterface;
+ use Twig\Node\Expression\Unary\SpreadUnary;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\ModuleNode;
+ use Twig\Node\Node;
+-use Twig\Node\PrintNode;
+-use Twig\Node\SetNode;
++use Twig\Node\Nodes;
+ 
+ /**
+  * @author Fabien Potencier <fabien@symfony.com>
+@@ -42,7 +42,6 @@ final class SandboxNodeVisitor implements NodeVisitorInterface
+     private $filters;
+     /** @var array<string, int> */
+     private $functions;
+-    private $needsToStringWrap = false;
+ 
+     public function enterNode(Node $node, Environment $env): Node
+     {
+@@ -51,8 +50,6 @@ public function enterNode(Node $node, Environment $env): Node
+             $this->tags = [];
+             $this->filters = [];
+             $this->functions = [];
+-
+-            return $node;
+         } elseif ($this->inAModule) {
+             // look for tags
+             if ($node->getNodeTag() && !isset($this->tags[$node->getNodeTag()])) {
+@@ -60,8 +57,8 @@ public function enterNode(Node $node, Environment $env): Node
+             }
+ 
+             // look for filters
+-            if ($node instanceof FilterExpression && !isset($this->filters[$node->getNode('filter')->getAttribute('value')])) {
+-                $this->filters[$node->getNode('filter')->getAttribute('value')] = $node->getTemplateLine();
++            if ($node instanceof FilterExpression && !isset($this->filters[$node->getAttribute('name')])) {
++                $this->filters[$node->getAttribute('name')] = $node->getTemplateLine();
+             }
+ 
+             // look for functions
+@@ -69,33 +66,27 @@ public function enterNode(Node $node, Environment $env): Node
+                 $this->functions[$node->getAttribute('name')] = $node->getTemplateLine();
+             }
+ 
++            // look for functions whose parser callable replaced the FunctionExpression
++            // with a specialized node (e.g. `parent`, `block`, `attribute`); the
++            // original function name was stashed by FunctionExpressionParser.
++            if ($node->hasAttribute('sandboxed_function_name')) {
++                $name = $node->getAttribute('sandboxed_function_name');
++                if (!isset($this->functions[$name])) {
++                    $this->functions[$name] = $node->getTemplateLine();
++                }
++            }
++
+             // the .. operator is equivalent to the range() function
+             if ($node instanceof RangeBinary && !isset($this->functions['range'])) {
+                 $this->functions['range'] = $node->getTemplateLine();
+             }
++        }
+ 
+-            if ($node instanceof PrintNode) {
+-                $this->needsToStringWrap = true;
+-                $this->wrapNode($node, 'expr');
+-            }
+-
+-            if ($node instanceof SetNode && !$node->getAttribute('capture')) {
+-                $this->needsToStringWrap = true;
+-            }
+-
+-            // wrap outer nodes that can implicitly call __toString()
+-            if ($this->needsToStringWrap) {
+-                if ($node instanceof ConcatBinary) {
+-                    $this->wrapNode($node, 'left');
+-                    $this->wrapNode($node, 'right');
+-                }
+-                if ($node instanceof FilterExpression) {
+-                    $this->wrapNode($node, 'node');
+-                    $this->wrapArrayNode($node, 'arguments');
+-                }
+-                if ($node instanceof FunctionExpression) {
+-                    $this->wrapArrayNode($node, 'arguments');
+-                }
++        // wrap children that the node itself will string-coerce at runtime;
++        // applies to ModuleNode (`parent` slot for {% extends %}) too
++        if ($this->inAModule && $node instanceof CoercesChildrenToStringInterface) {
++            foreach ($node->getStringCoercedChildNames() as $childName) {
++                $this->wrapNode($node, $childName);
+             }
+         }
+ 
+@@ -107,12 +98,8 @@ public function leaveNode(Node $node, Environment $env): ?Node
+         if ($node instanceof ModuleNode) {
+             $this->inAModule = false;
+ 
+-            $node->setNode('constructor_end', new Node([new CheckSecurityCallNode(), $node->getNode('constructor_end')]));
+-            $node->setNode('class_end', new Node([new CheckSecurityNode($this->filters, $this->tags, $this->functions), $node->getNode('class_end')]));
+-        } elseif ($this->inAModule) {
+-            if ($node instanceof PrintNode || $node instanceof SetNode) {
+-                $this->needsToStringWrap = false;
+-            }
++            $node->setNode('constructor_end', new Nodes([new CheckSecurityCallNode(), $node->getNode('constructor_end')]));
++            $node->setNode('class_end', new Nodes([new CheckSecurityNode($this->filters, $this->tags, $this->functions), $node->getNode('class_end')]));
+         }
+ 
+         return $node;
+@@ -121,27 +108,24 @@ public function leaveNode(Node $node, Environment $env): ?Node
+     private function wrapNode(Node $node, string $name): void
+     {
+         $expr = $node->getNode($name);
+-        if (($expr instanceof NameExpression || $expr instanceof GetAttrExpression) && !$expr->isGenerator()) {
+-            // Simplify in 4.0 as the spread attribute has been removed there
+-            $new = new CheckToStringNode($expr);
+-            if ($expr->hasAttribute('spread')) {
+-                $new->setAttribute('spread', $expr->getAttribute('spread'));
+-            }
+-            $node->setNode($name, $new);
++        // `_self` is internal: it compiles to `$this->getTemplateName()` and is always a string
++        if ($expr instanceof ContextVariable && '_self' === $expr->getAttribute('name')) {
++            return;
++        }
++        if (($expr instanceof ContextVariable || $expr instanceof GetAttrExpression) && !$expr->isGenerator()) {
++            $node->setNode($name, new CheckToStringNode($expr));
+         } elseif ($expr instanceof SpreadUnary) {
+-            $this->wrapNode($expr, 'node');
+-        } elseif ($expr instanceof ArrayExpression) {
++            $expr->setNode('node', new CheckToStringNode($expr->getNode('node'), true));
++        } elseif ($expr instanceof ArrayExpression || $expr instanceof Nodes) {
+             foreach ($expr as $name => $_) {
+                 $this->wrapNode($expr, $name);
+             }
+-        }
+-    }
+-
+-    private function wrapArrayNode(Node $node, string $name): void
+-    {
+-        $args = $node->getNode($name);
+-        foreach ($args as $name => $_) {
+-            $this->wrapNode($args, $name);
++        } elseif ($expr instanceof OperatorEscapeInterface) {
++            foreach ($expr->getOperandNamesToEscape() as $operandName) {
++                $this->wrapNode($expr, $operandName);
++            }
++        } elseif ($expr instanceof FilterExpression || $expr instanceof FunctionExpression) {
++            $node->setNode($name, new CheckToStringNode($expr));
+         }
+     }
+ 
+diff --git a/src/NodeVisitor/YieldNotReadyNodeVisitor.php b/src/NodeVisitor/YieldNotReadyNodeVisitor.php
+index 6470bdabc86..4d6cf60a0ae 100644
+--- a/src/NodeVisitor/YieldNotReadyNodeVisitor.php
++++ b/src/NodeVisitor/YieldNotReadyNodeVisitor.php
+@@ -21,17 +21,16 @@
+  */
+ final class YieldNotReadyNodeVisitor implements NodeVisitorInterface
+ {
+-    private $useYield;
+     private $yieldReadyNodes = [];
+ 
+-    public function __construct(bool $useYield)
+-    {
+-        $this->useYield = $useYield;
++    public function __construct(
++        private bool $useYield,
++    ) {
+     }
+ 
+     public function enterNode(Node $node, Environment $env): Node
+     {
+-        $class = \get_class($node);
++        $class = $node::class;
+ 
+         if ($node instanceof AbstractExpression || isset($this->yieldReadyNodes[$class])) {
+             return $node;
+@@ -39,10 +38,10 @@ public function enterNode(Node $node, Environment $env): Node
+ 
+         if (!$this->yieldReadyNodes[$class] = (bool) (new \ReflectionClass($class))->getAttributes(YieldReady::class)) {
+             if ($this->useYield) {
+-                throw new \LogicException(\sprintf('You cannot enable the "use_yield" option of Twig as node "%s" is not marked as ready for it; please make it ready and then flag it with the #[YieldReady] attribute.', $class));
++                throw new \LogicException(\sprintf('You cannot enable the "use_yield" option of Twig as node "%s" is not marked as ready for it; please make it ready and then flag it with the #[\Twig\Attribute\YieldReady] attribute.', $class));
+             }
+ 
+-            trigger_deprecation('twig/twig', '3.9', 'Twig node "%s" is not marked as ready for using "yield" instead of "echo"; please make it ready and then flag it with the #[YieldReady] attribute.', $class);
++            trigger_deprecation('twig/twig', '3.9', 'Twig node "%s" is not marked as ready for using "yield" instead of "echo"; please make it ready and then flag it with the #[\Twig\Attribute\YieldReady] attribute.', $class);
+         }
+ 
+         return $node;
+diff --git a/src/OperatorPrecedenceChange.php b/src/OperatorPrecedenceChange.php
+new file mode 100644
+index 00000000000..31ebaef48cb
+--- /dev/null
++++ b/src/OperatorPrecedenceChange.php
+@@ -0,0 +1,34 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig;
++
++use Twig\ExpressionParser\PrecedenceChange;
++
++/**
++ * Represents a precedence change.
++ *
++ * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @deprecated since Twig 1.20 Use Twig\ExpressionParser\PrecedenceChange instead
++ */
++class OperatorPrecedenceChange extends PrecedenceChange
++{
++    public function __construct(
++        private string $package,
++        private string $version,
++        private int $newPrecedence,
++    ) {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s" class is deprecated since Twig 3.21. Use "%s" instead.', self::class, PrecedenceChange::class);
++
++        parent::__construct($package, $version, $newPrecedence);
++    }
++}
+diff --git a/src/Parser.php b/src/Parser.php
+index 7cfc2058c01..62f14ebf5fd 100644
+--- a/src/Parser.php
++++ b/src/Parser.php
+@@ -13,15 +13,25 @@
+ namespace Twig;
+ 
+ use Twig\Error\SyntaxError;
++use Twig\ExpressionParser\ExpressionParserInterface;
++use Twig\ExpressionParser\ExpressionParsers;
++use Twig\ExpressionParser\ExpressionParserType;
++use Twig\ExpressionParser\InfixExpressionParserInterface;
++use Twig\ExpressionParser\Prefix\LiteralExpressionParser;
++use Twig\ExpressionParser\PrefixExpressionParserInterface;
+ use Twig\Node\BlockNode;
+ use Twig\Node\BlockReferenceNode;
+ use Twig\Node\BodyNode;
++use Twig\Node\EmptyNode;
+ use Twig\Node\Expression\AbstractExpression;
++use Twig\Node\Expression\Variable\AssignTemplateVariable;
++use Twig\Node\Expression\Variable\TemplateVariable;
+ use Twig\Node\MacroNode;
+ use Twig\Node\ModuleNode;
+ use Twig\Node\Node;
+ use Twig\Node\NodeCaptureInterface;
+ use Twig\Node\NodeOutputInterface;
++use Twig\Node\Nodes;
+ use Twig\Node\PrintNode;
+ use Twig\Node\TextNode;
+ use Twig\TokenParser\TokenParserInterface;
+@@ -33,6 +43,7 @@
+ class Parser
+ {
+     private $stack = [];
++    private ?\WeakMap $expressionRefs = null;
+     private $stream;
+     private $parent;
+     private $visitors;
+@@ -40,26 +51,44 @@ class Parser
+     private $blocks;
+     private $blockStack;
+     private $macros;
+-    private $env;
+     private $importedSymbols;
+     private $traits;
+     private $embeddedTemplates = [];
++    private int $lastEmbedIndex = 0;
+     private $varNameSalt = 0;
++    private $ignoreUnknownTwigCallables = false;
++    private ExpressionParsers $parsers;
+ 
+-    public function __construct(Environment $env)
++    public function __construct(
++        private Environment $env,
++    ) {
++        $this->parsers = $env->getExpressionParsers();
++    }
++
++    public function getEnvironment(): Environment
+     {
+-        $this->env = $env;
++        return $this->env;
+     }
+ 
+     public function getVarName(): string
+     {
++        trigger_deprecation('twig/twig', '3.15', 'The "%s()" method is deprecated.', __METHOD__);
++
+         return \sprintf('__internal_parse_%d', $this->varNameSalt++);
+     }
+ 
++    /**
++     * @throws SyntaxError
++     */
+     public function parse(TokenStream $stream, $test = null, bool $dropNeedle = false): ModuleNode
+     {
++        // reset on root parse() calls only, so the counter spans nested/reentrant parses
++        if (!$this->stack) {
++            $this->lastEmbedIndex = 0;
++        }
++
+         $vars = get_object_vars($this);
+-        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames'], $vars['varNameSalt']);
++        unset($vars['stack'], $vars['env'], $vars['handlers'], $vars['visitors'], $vars['expressionParser'], $vars['reservedMacroNames'], $vars['lastEmbedIndex'], $vars['varNameSalt']);
+         $this->stack[] = $vars;
+ 
+         // node visitors
+@@ -67,10 +96,6 @@ public function parse(TokenStream $stream, $test = null, bool $dropNeedle = fals
+             $this->visitors = $this->env->getNodeVisitors();
+         }
+ 
+-        if (null === $this->expressionParser) {
+-            $this->expressionParser = new ExpressionParser($this, $this->env);
+-        }
+-
+         $this->stream = $stream;
+         $this->parent = null;
+         $this->blocks = [];
+@@ -79,12 +104,13 @@ public function parse(TokenStream $stream, $test = null, bool $dropNeedle = fals
+         $this->blockStack = [];
+         $this->importedSymbols = [[]];
+         $this->embeddedTemplates = [];
++        $this->expressionRefs = new \WeakMap();
+ 
+         try {
+             $body = $this->subparse($test, $dropNeedle);
+ 
+             if (null !== $this->parent && null === $body = $this->filterBodyNodes($body)) {
+-                $body = new Node();
++                $body = new EmptyNode();
+             }
+         } catch (SyntaxError $e) {
+             if (!$e->getSourceContext()) {
+@@ -92,13 +118,23 @@ public function parse(TokenStream $stream, $test = null, bool $dropNeedle = fals
+             }
+ 
+             if (!$e->getTemplateLine()) {
+-                $e->setTemplateLine($this->stream->getCurrent()->getLine());
++                $e->setTemplateLine($this->getCurrentToken()->getLine());
+             }
+ 
+             throw $e;
++        } finally {
++            $this->expressionRefs = null;
+         }
+ 
+-        $node = new ModuleNode(new BodyNode([$body]), $this->parent, new Node($this->blocks), new Node($this->macros), new Node($this->traits), $this->embeddedTemplates, $stream->getSourceContext());
++        $node = new ModuleNode(
++            new BodyNode([$body]),
++            $this->parent,
++            $this->blocks ? new Nodes($this->blocks) : new EmptyNode(),
++            $this->macros ? new Nodes($this->macros) : new EmptyNode(),
++            $this->traits ? new Nodes($this->traits) : new EmptyNode(),
++            $this->embeddedTemplates ? new Nodes($this->embeddedTemplates) : new EmptyNode(),
++            $stream->getSourceContext(),
++        );
+ 
+         $traverser = new NodeTraverser($this->env, $this->visitors);
+ 
+@@ -115,29 +151,48 @@ public function parse(TokenStream $stream, $test = null, bool $dropNeedle = fals
+         return $node;
+     }
+ 
++    public function shouldIgnoreUnknownTwigCallables(): bool
++    {
++        return $this->ignoreUnknownTwigCallables;
++    }
++
++    public function subparseIgnoreUnknownTwigCallables($test, bool $dropNeedle = false): void
++    {
++        $previous = $this->ignoreUnknownTwigCallables;
++        $this->ignoreUnknownTwigCallables = true;
++        try {
++            $this->subparse($test, $dropNeedle);
++        } finally {
++            $this->ignoreUnknownTwigCallables = $previous;
++        }
++    }
++
++    /**
++     * @throws SyntaxError
++     */
+     public function subparse($test, bool $dropNeedle = false): Node
+     {
+         $lineno = $this->getCurrentToken()->getLine();
+         $rv = [];
+         while (!$this->stream->isEOF()) {
+-            switch ($this->getCurrentToken()->getType()) {
+-                case /* Token::TEXT_TYPE */ 0:
++            switch (true) {
++                case $this->stream->getCurrent()->test(Token::TEXT_TYPE):
+                     $token = $this->stream->next();
+                     $rv[] = new TextNode($token->getValue(), $token->getLine());
+                     break;
+ 
+-                case /* Token::VAR_START_TYPE */ 2:
++                case $this->stream->getCurrent()->test(Token::VAR_START_TYPE):
+                     $token = $this->stream->next();
+-                    $expr = $this->expressionParser->parseExpression();
+-                    $this->stream->expect(/* Token::VAR_END_TYPE */ 4);
++                    $expr = $this->parseExpression();
++                    $this->stream->expect(Token::VAR_END_TYPE);
+                     $rv[] = new PrintNode($expr, $token->getLine());
+                     break;
+ 
+-                case /* Token::BLOCK_START_TYPE */ 1:
++                case $this->stream->getCurrent()->test(Token::BLOCK_START_TYPE):
+                     $this->stream->next();
+                     $token = $this->getCurrentToken();
+ 
+-                    if (/* Token::NAME_TYPE */ 5 !== $token->getType()) {
++                    if (!$token->test(Token::NAME_TYPE)) {
+                         throw new SyntaxError('A block must start with a tag name.', $token->getLine(), $this->stream->getSourceContext());
+                     }
+ 
+@@ -150,14 +205,14 @@ public function subparse($test, bool $dropNeedle = false): Node
+                             return $rv[0];
+                         }
+ 
+-                        return new Node($rv, [], $lineno);
++                        return new Nodes($rv, $lineno);
+                     }
+ 
+                     if (!$subparser = $this->env->getTokenParser($token->getValue())) {
+                         if (null !== $test) {
+                             $e = new SyntaxError(\sprintf('Unexpected "%s" tag', $token->getValue()), $token->getLine(), $this->stream->getSourceContext());
+ 
+-                            $callable = (new ReflectionCallable($test))->getCallable();
++                            $callable = (new ReflectionCallable(new TwigTest('decision', $test)))->getCallable();
+                             if (\is_array($callable) && $callable[0] instanceof TokenParserInterface) {
+                                 $e->appendMessage(\sprintf(' (expecting closing tag for the "%s" tag defined near line %s).', $callable[0]->getTag(), $lineno));
+                             }
+@@ -173,13 +228,16 @@ public function subparse($test, bool $dropNeedle = false): Node
+ 
+                     $subparser->setParser($this);
+                     $node = $subparser->parse($token);
+-                    if (null !== $node) {
++                    if (!$node) {
++                        trigger_deprecation('twig/twig', '3.12', 'Returning "null" from "%s" is deprecated and forbidden by "TokenParserInterface".', $subparser::class);
++                    } else {
++                        $node->setNodeTag($subparser->getTag());
+                         $rv[] = $node;
+                     }
+                     break;
+ 
+                 default:
+-                    throw new SyntaxError('Lexer or parser ended up in unsupported state.', $this->getCurrentToken()->getLine(), $this->stream->getSourceContext());
++                    throw new SyntaxError('The lexer or the parser ended up in an unsupported state.', $this->getCurrentToken()->getLine(), $this->stream->getSourceContext());
+             }
+         }
+ 
+@@ -187,14 +245,19 @@ public function subparse($test, bool $dropNeedle = false): Node
+             return $rv[0];
+         }
+ 
+-        return new Node($rv, [], $lineno);
++        return new Nodes($rv, $lineno);
+     }
+ 
+     public function getBlockStack(): array
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return $this->blockStack;
+     }
+ 
++    /**
++     * @return string|null
++     */
+     public function peekBlockStack()
+     {
+         return $this->blockStack[\count($this->blockStack) - 1] ?? null;
+@@ -212,21 +275,31 @@ public function pushBlockStack($name): void
+ 
+     public function hasBlock(string $name): bool
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return isset($this->blocks[$name]);
+     }
+ 
+     public function getBlock(string $name): Node
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return $this->blocks[$name];
+     }
+ 
+     public function setBlock(string $name, BlockNode $value): void
+     {
++        if (isset($this->blocks[$name])) {
++            throw new SyntaxError(\sprintf("The block '%s' has already been defined line %d.", $name, $this->blocks[$name]->getTemplateLine()), $this->getCurrentToken()->getLine(), $this->blocks[$name]->getSourceContext());
++        }
++
+         $this->blocks[$name] = new BodyNode([$value], [], $value->getTemplateLine());
+     }
+ 
+     public function hasMacro(string $name): bool
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return isset($this->macros[$name]);
+     }
+ 
+@@ -242,21 +315,35 @@ public function addTrait($trait): void
+ 
+     public function hasTraits(): bool
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return \count($this->traits) > 0;
+     }
+ 
++    /**
++     * @return void
++     */
+     public function embedTemplate(ModuleNode $template)
+     {
+-        $template->setIndex(mt_rand());
++        $template->setIndex(++$this->lastEmbedIndex);
+ 
+         $this->embeddedTemplates[] = $template;
+     }
+ 
+-    public function addImportedSymbol(string $type, string $alias, ?string $name = null, ?AbstractExpression $node = null): void
++    public function addImportedSymbol(string $type, string $alias, ?string $name = null, AbstractExpression|AssignTemplateVariable|null $internalRef = null): void
+     {
+-        $this->importedSymbols[0][$type][$alias] = ['name' => $name, 'node' => $node];
++        if ($internalRef && !$internalRef instanceof AssignTemplateVariable) {
++            trigger_deprecation('twig/twig', '3.15', 'Not passing a "%s" instance as an internal reference is deprecated ("%s" given).', __METHOD__, AssignTemplateVariable::class, $internalRef::class);
++
++            $internalRef = new AssignTemplateVariable(new TemplateVariable($internalRef->getAttribute('name'), $internalRef->getTemplateLine()), $internalRef->getAttribute('global'));
++        }
++
++        $this->importedSymbols[0][$type][$alias] = ['name' => $name, 'node' => $internalRef];
+     }
+ 
++    /**
++     * @return array{name: string, node: AssignTemplateVariable|null}|null
++     */
+     public function getImportedSymbol(string $type, string $alias)
+     {
+         // if the symbol does not exist in the current scope (0), try in the main/global scope (last index)
+@@ -278,18 +365,71 @@ public function popLocalScope(): void
+         array_shift($this->importedSymbols);
+     }
+ 
++    /**
++     * @deprecated since Twig 3.21
++     */
+     public function getExpressionParser(): ExpressionParser
+     {
++        trigger_deprecation('twig/twig', '3.21', 'Method "%s()" is deprecated, use "parseExpression()" instead.', __METHOD__);
++
++        if (null === $this->expressionParser) {
++            $this->expressionParser = new ExpressionParser($this, $this->env);
++        }
++
+         return $this->expressionParser;
+     }
+ 
++    public function parseExpression(int $precedence = 0): AbstractExpression
++    {
++        $token = $this->getCurrentToken();
++        if ($token->test(Token::OPERATOR_TYPE) && $ep = $this->parsers->getByName(PrefixExpressionParserInterface::class, $token->getValue())) {
++            $this->getStream()->next();
++            $expr = $ep->parse($this, $token);
++            $this->checkPrecedenceDeprecations($ep, $expr);
++        } else {
++            $expr = $this->parsers->getByClass(LiteralExpressionParser::class)->parse($this, $token);
++        }
++
++        $token = $this->getCurrentToken();
++        while ($token->test(Token::OPERATOR_TYPE) && ($ep = $this->parsers->getByName(InfixExpressionParserInterface::class, $token->getValue())) && $ep->getPrecedence() >= $precedence) {
++            $this->getStream()->next();
++            $expr = $ep->parse($this, $expr, $token);
++            $this->checkPrecedenceDeprecations($ep, $expr);
++            $token = $this->getCurrentToken();
++        }
++
++        return $expr;
++    }
++
+     public function getParent(): ?Node
+     {
++        trigger_deprecation('twig/twig', '3.12', 'Method "%s()" is deprecated.', __METHOD__);
++
+         return $this->parent;
+     }
+ 
++    /**
++     * @return bool
++     */
++    public function hasInheritance()
++    {
++        return $this->parent || 0 < \count($this->traits);
++    }
++
+     public function setParent(?Node $parent): void
+     {
++        if (null === $parent) {
++            trigger_deprecation('twig/twig', '3.12', 'Passing "null" to "%s()" is deprecated.', __METHOD__);
++        }
++
++        if (null !== $parent && !$parent instanceof AbstractExpression) {
++            trigger_deprecation('twig/twig', '3.24', 'Passing a "%s" instance to "%s()" is deprecated, pass an "AbstractExpression" instance instead.', $parent::class, __METHOD__);
++        }
++
++        if (null !== $this->parent) {
++            throw new SyntaxError('Multiple extends tags are forbidden.', $parent->getTemplateLine(), $parent->getSourceContext());
++        }
++
+         $this->parent = $parent;
+     }
+ 
+@@ -303,6 +443,113 @@ public function getCurrentToken(): Token
+         return $this->stream->getCurrent();
+     }
+ 
++    public function getFunction(string $name, int $line): TwigFunction
++    {
++        try {
++            $function = $this->env->getFunction($name);
++        } catch (SyntaxError $e) {
++            if (!$this->shouldIgnoreUnknownTwigCallables()) {
++                throw $e;
++            }
++
++            $function = null;
++        }
++
++        if (!$function) {
++            if ($this->shouldIgnoreUnknownTwigCallables()) {
++                return new TwigFunction($name, static fn () => '');
++            }
++            $e = new SyntaxError(\sprintf('Unknown "%s" function.', $name), $line, $this->stream->getSourceContext());
++            $e->addSuggestions($name, array_keys($this->env->getFunctions()));
++
++            throw $e;
++        }
++
++        if ($function->isDeprecated()) {
++            $src = $this->stream->getSourceContext();
++            $function->triggerDeprecation($src->getPath() ?: $src->getName(), $line);
++        }
++
++        return $function;
++    }
++
++    public function getFilter(string $name, int $line): TwigFilter
++    {
++        try {
++            $filter = $this->env->getFilter($name);
++        } catch (SyntaxError $e) {
++            if (!$this->shouldIgnoreUnknownTwigCallables()) {
++                throw $e;
++            }
++
++            $filter = null;
++        }
++        if (!$filter) {
++            if ($this->shouldIgnoreUnknownTwigCallables()) {
++                return new TwigFilter($name, static fn () => '');
++            }
++            $e = new SyntaxError(\sprintf('Unknown "%s" filter.', $name), $line, $this->stream->getSourceContext());
++            $e->addSuggestions($name, array_keys($this->env->getFilters()));
++
++            throw $e;
++        }
++
++        if ($filter->isDeprecated()) {
++            $src = $this->stream->getSourceContext();
++            $filter->triggerDeprecation($src->getPath() ?: $src->getName(), $line);
++        }
++
++        return $filter;
++    }
++
++    public function getTest(int $line): TwigTest
++    {
++        $name = $this->stream->expect(Token::NAME_TYPE)->getValue();
++
++        if ($this->stream->test(Token::NAME_TYPE)) {
++            // try 2-words tests
++            $name = $name.' '.$this->getCurrentToken()->getValue();
++
++            try {
++                $test = $this->env->getTest($name);
++            } catch (SyntaxError $e) {
++                if (!$this->shouldIgnoreUnknownTwigCallables()) {
++                    throw $e;
++                }
++
++                $test = null;
++            }
++            $this->stream->next();
++        } else {
++            try {
++                $test = $this->env->getTest($name);
++            } catch (SyntaxError $e) {
++                if (!$this->shouldIgnoreUnknownTwigCallables()) {
++                    throw $e;
++                }
++
++                $test = null;
++            }
++        }
++
++        if (!$test) {
++            if ($this->shouldIgnoreUnknownTwigCallables()) {
++                return new TwigTest($name, static fn () => '');
++            }
++            $e = new SyntaxError(\sprintf('Unknown "%s" test.', $name), $line, $this->stream->getSourceContext());
++            $e->addSuggestions($name, array_keys($this->env->getTests()));
++
++            throw $e;
++        }
++
++        if ($test->isDeprecated()) {
++            $src = $this->stream->getSourceContext();
++            $test->triggerDeprecation($src->getPath() ?: $src->getName(), $this->stream->getCurrent()->getLine());
++        }
++
++        return $test;
++    }
++
+     private function filterBodyNodes(Node $node, bool $nested = false): ?Node
+     {
+         // check that the body does not contain non-empty output nodes
+@@ -340,7 +587,8 @@ private function filterBodyNodes(Node $node, bool $nested = false): ?Node
+ 
+         // here, $nested means "being at the root level of a child template"
+         // we need to discard the wrapping "Node" for the "body" node
+-        $nested = $nested || Node::class !== \get_class($node);
++        // Node::class !== \get_class($node) should be removed in Twig 4.0
++        $nested = $nested || (Node::class !== $node::class && !$node instanceof Nodes);
+         foreach ($node as $k => $n) {
+             if (null !== $n && null === $this->filterBodyNodes($n, $nested)) {
+                 $node->removeNode($k);
+@@ -349,4 +597,43 @@ private function filterBodyNodes(Node $node, bool $nested = false): ?Node
+ 
+         return $node;
+     }
++
++    private function checkPrecedenceDeprecations(ExpressionParserInterface $expressionParser, AbstractExpression $expr)
++    {
++        $this->expressionRefs[$expr] = $expressionParser;
++        $precedenceChanges = $this->parsers->getPrecedenceChanges();
++
++        // Check that the all nodes that are between the 2 precedences have explicit parentheses
++        if (!isset($precedenceChanges[$expressionParser])) {
++            return;
++        }
++
++        if ($expr->hasExplicitParentheses()) {
++            return;
++        }
++
++        if ($expressionParser instanceof PrefixExpressionParserInterface) {
++            /** @var AbstractExpression $node */
++            $node = $expr->getNode('node');
++            foreach ($precedenceChanges as $ep => $changes) {
++                if (!\in_array($expressionParser, $changes, true)) {
++                    continue;
++                }
++                if (isset($this->expressionRefs[$node]) && $ep === $this->expressionRefs[$node]) {
++                    $change = $expressionParser->getPrecedenceChange();
++                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $expressionParser->getName(), ExpressionParserType::getType($expressionParser)->value, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
++                }
++            }
++        }
++
++        foreach ($precedenceChanges[$expressionParser] as $ep) {
++            foreach ($expr as $node) {
++                /** @var AbstractExpression $node */
++                if (isset($this->expressionRefs[$node]) && $ep === $this->expressionRefs[$node] && !$node->hasExplicitParentheses()) {
++                    $change = $ep->getPrecedenceChange();
++                    trigger_deprecation($change->getPackage(), $change->getVersion(), \sprintf('As the "%s" %s operator will change its precedence in the next major version, add explicit parentheses to avoid behavior change in "%s" at line %d.', $ep->getName(), ExpressionParserType::getType($ep)->value, $this->getStream()->getSourceContext()->getName(), $node->getTemplateLine()));
++                }
++            }
++        }
++    }
+ }
+diff --git a/src/Profiler/Dumper/BaseDumper.php b/src/Profiler/Dumper/BaseDumper.php
+index 267718c1f5f..06bf4b888a7 100644
+--- a/src/Profiler/Dumper/BaseDumper.php
++++ b/src/Profiler/Dumper/BaseDumper.php
+@@ -31,11 +31,16 @@ abstract protected function formatNonTemplate(Profile $profile, $prefix): string
+ 
+     abstract protected function formatTime(Profile $profile, $percent): string;
+ 
++    protected function formatRoot(Profile $profile): string
++    {
++        return $profile->getName();
++    }
++
+     private function dumpProfile(Profile $profile, $prefix = '', $sibling = false): string
+     {
+         if ($profile->isRoot()) {
+             $this->root = $profile->getDuration();
+-            $start = $profile->getName();
++            $start = $this->formatRoot($profile);
+         } else {
+             if ($profile->isTemplate()) {
+                 $start = $this->formatTemplate($profile, $prefix);
+diff --git a/src/Profiler/Dumper/BlackfireDumper.php b/src/Profiler/Dumper/BlackfireDumper.php
+index bb3fbb52a2a..7cfae16f1c6 100644
+--- a/src/Profiler/Dumper/BlackfireDumper.php
++++ b/src/Profiler/Dumper/BlackfireDumper.php
+@@ -40,7 +40,7 @@ public function dump(Profile $profile): string
+         return $str;
+     }
+ 
+-    private function dumpChildren(string $parent, Profile $profile, &$data)
++    private function dumpChildren(string $parent, Profile $profile, &$data): void
+     {
+         foreach ($profile as $p) {
+             if ($p->isTemplate()) {
+@@ -53,7 +53,7 @@ private function dumpChildren(string $parent, Profile $profile, &$data)
+         }
+     }
+ 
+-    private function dumpProfile(string $edge, Profile $profile, &$data)
++    private function dumpProfile(string $edge, Profile $profile, &$data): void
+     {
+         if (isset($data[$edge])) {
+             ++$data[$edge]['ct'];
+diff --git a/src/Profiler/Dumper/HtmlDumper.php b/src/Profiler/Dumper/HtmlDumper.php
+index cdab2de5953..1bfd81b0ea6 100644
+--- a/src/Profiler/Dumper/HtmlDumper.php
++++ b/src/Profiler/Dumper/HtmlDumper.php
+@@ -30,18 +30,28 @@ public function dump(Profile $profile): string
+         return '<pre>'.parent::dump($profile).'</pre>';
+     }
+ 
++    protected function formatRoot(Profile $profile): string
++    {
++        return self::escape($profile->getName());
++    }
++
+     protected function formatTemplate(Profile $profile, $prefix): string
+     {
+-        return \sprintf('%s└ <span style="background-color: %s">%s</span>', $prefix, self::$colors['template'], $profile->getTemplate());
++        return \sprintf('%s└ <span style="background-color: %s">%s</span>', $prefix, self::$colors['template'], self::escape($profile->getTemplate()));
+     }
+ 
+     protected function formatNonTemplate(Profile $profile, $prefix): string
+     {
+-        return \sprintf('%s└ %s::%s(<span style="background-color: %s">%s</span>)', $prefix, $profile->getTemplate(), $profile->getType(), self::$colors[$profile->getType()] ?? 'auto', $profile->getName());
++        return \sprintf('%s└ %s::%s(<span style="background-color: %s">%s</span>)', $prefix, self::escape($profile->getTemplate()), $profile->getType(), self::$colors[$profile->getType()] ?? 'auto', self::escape($profile->getName()));
+     }
+ 
+     protected function formatTime(Profile $profile, $percent): string
+     {
+         return \sprintf('<span style="color: %s">%.2fms/%.0f%%</span>', $percent > 20 ? self::$colors['big'] : 'auto', $profile->getDuration() * 1000, $percent);
+     }
++
++    private static function escape(string $value): string
++    {
++        return htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
++    }
+ }
+diff --git a/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php b/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
+index 4d2a581054b..4c5c2005d21 100644
+--- a/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
++++ b/src/Profiler/NodeVisitor/ProfilerNodeVisitor.php
+@@ -17,6 +17,7 @@
+ use Twig\Node\MacroNode;
+ use Twig\Node\ModuleNode;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\NodeVisitor\NodeVisitorInterface;
+ use Twig\Profiler\Node\EnterProfileNode;
+ use Twig\Profiler\Node\LeaveProfileNode;
+@@ -27,12 +28,11 @@
+  */
+ final class ProfilerNodeVisitor implements NodeVisitorInterface
+ {
+-    private $extensionName;
+     private $varName;
+ 
+-    public function __construct(string $extensionName)
+-    {
+-        $this->extensionName = $extensionName;
++    public function __construct(
++        private string $extensionName,
++    ) {
+         $this->varName = \sprintf('__internal_%s', hash(\PHP_VERSION_ID < 80100 ? 'sha256' : 'xxh128', $extensionName));
+     }
+ 
+@@ -44,8 +44,8 @@ public function enterNode(Node $node, Environment $env): Node
+     public function leaveNode(Node $node, Environment $env): ?Node
+     {
+         if ($node instanceof ModuleNode) {
+-            $node->setNode('display_start', new Node([new EnterProfileNode($this->extensionName, Profile::TEMPLATE, $node->getTemplateName(), $this->varName), $node->getNode('display_start')]));
+-            $node->setNode('display_end', new Node([new LeaveProfileNode($this->varName), $node->getNode('display_end')]));
++            $node->setNode('display_start', new Nodes([new EnterProfileNode($this->extensionName, Profile::TEMPLATE, $node->getTemplateName(), $this->varName), $node->getNode('display_start')]));
++            $node->setNode('display_end', new Nodes([new LeaveProfileNode($this->varName), $node->getNode('display_end')]));
+         } elseif ($node instanceof BlockNode) {
+             $node->setNode('body', new BodyNode([
+                 new EnterProfileNode($this->extensionName, Profile::BLOCK, $node->getAttribute('name'), $this->varName),
+diff --git a/src/Profiler/Profile.php b/src/Profiler/Profile.php
+index 72506b7c8da..63861d653e0 100644
+--- a/src/Profiler/Profile.php
++++ b/src/Profiler/Profile.php
+@@ -20,18 +20,15 @@ final class Profile implements \IteratorAggregate, \Serializable
+     public const BLOCK = 'block';
+     public const TEMPLATE = 'template';
+     public const MACRO = 'macro';
+-
+-    private $template;
+-    private $name;
+-    private $type;
+     private $starts = [];
+     private $ends = [];
+     private $profiles = [];
+ 
+-    public function __construct(string $template = 'main', string $type = self::ROOT, string $name = 'main')
+-    {
+-        $this->template = $template;
+-        $this->type = $type;
++    public function __construct(
++        private string $template = 'main',
++        private string $type = self::ROOT,
++        private string $name = 'main',
++    ) {
+         $this->name = str_starts_with($name, '__internal_') ? 'INTERNAL' : $name;
+         $this->enter();
+     }
+@@ -102,6 +99,22 @@ public function getDuration(): float
+         return isset($this->ends['wt']) && isset($this->starts['wt']) ? $this->ends['wt'] - $this->starts['wt'] : 0;
+     }
+ 
++    /**
++     * Returns the start time in microseconds.
++     */
++    public function getStartTime(): float
++    {
++        return $this->starts['wt'] ?? 0.0;
++    }
++
++    /**
++     * Returns the end time in microseconds.
++     */
++    public function getEndTime(): float
++    {
++        return $this->ends['wt'] ?? 0.0;
++    }
++
+     /**
+      * Returns the memory usage in bytes.
+      */
+@@ -160,7 +173,7 @@ public function serialize(): string
+ 
+     public function unserialize($data): void
+     {
+-        $this->__unserialize(unserialize($data));
++        $this->__unserialize(unserialize($data, ['allowed_classes' => [self::class]]));
+     }
+ 
+     /**
+diff --git a/src/Resources/core.php b/src/Resources/core.php
+index e5372cda492..80f62cf6989 100644
+--- a/src/Resources/core.php
++++ b/src/Resources/core.php
+@@ -11,6 +11,9 @@
+ 
+ use Twig\Environment;
+ use Twig\Extension\CoreExtension;
++use Twig\Extension\SandboxExtension;
++use Twig\Source;
++use Twig\Template;
+ 
+ /**
+  * @internal
+@@ -237,7 +240,7 @@ function twig_sort_filter(Environment $env, $array, $arrow = null)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::sort($env, $array, $arrow);
++    return CoreExtension::sort($env, twig_resolve_is_sandboxed($env), $array, $arrow);
+ }
+ 
+ /**
+@@ -441,7 +444,7 @@ function twig_constant_is_defined($constant, $object = null)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::constantIsDefined($constant, $object);
++    return CoreExtension::constant($constant, $object, true);
+ }
+ 
+ /**
+@@ -461,11 +464,11 @@ function twig_array_batch($items, $size, $fill = null, $preserveKeys = true)
+  *
+  * @deprecated since Twig 3.9
+  */
+-function twig_array_column($array, $name, $index = null): array
++function twig_array_column(Environment $env, $array, $name, $index = null): array
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::column($array, $name, $index);
++    return CoreExtension::column($env, twig_resolve_is_sandboxed($env), $array, $name, $index);
+ }
+ 
+ /**
+@@ -477,7 +480,7 @@ function twig_array_filter(Environment $env, $array, $arrow)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::filter($env, $array, $arrow);
++    return CoreExtension::filter($env, twig_resolve_is_sandboxed($env), $array, $arrow);
+ }
+ 
+ /**
+@@ -489,7 +492,7 @@ function twig_array_map(Environment $env, $array, $arrow)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::map($env, $array, $arrow);
++    return CoreExtension::map($env, twig_resolve_is_sandboxed($env), $array, $arrow);
+ }
+ 
+ /**
+@@ -501,7 +504,7 @@ function twig_array_reduce(Environment $env, $array, $arrow, $initial = null)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::reduce($env, $array, $arrow, $initial);
++    return CoreExtension::reduce($env, twig_resolve_is_sandboxed($env), $array, $arrow, $initial);
+ }
+ 
+ /**
+@@ -513,7 +516,7 @@ function twig_array_some(Environment $env, $array, $arrow)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::arraySome($env, $array, $arrow);
++    return CoreExtension::arraySome($env, $array, $arrow, twig_resolve_is_sandboxed($env));
+ }
+ 
+ /**
+@@ -525,7 +528,7 @@ function twig_array_every(Environment $env, $array, $arrow)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::arrayEvery($env, $array, $arrow);
++    return CoreExtension::arrayEvery($env, $array, $arrow, twig_resolve_is_sandboxed($env));
+ }
+ 
+ /**
+@@ -537,5 +540,33 @@ function twig_check_arrow_in_sandbox(Environment $env, $arrow, $thing, $type)
+ {
+     trigger_deprecation('twig/twig', '3.9', 'Using the internal "%s" function is deprecated.', __FUNCTION__);
+ 
+-    return CoreExtension::checkArrowInSandbox($env, $arrow, $thing, $type);
++    CoreExtension::checkArrow(twig_resolve_is_sandboxed($env), $arrow, $thing, $type);
++}
++
++/**
++ * Recovers the calling Template's Source by walking the PHP backtrace.
++ *
++ * @internal
++ */
++function twig_resolve_caller_source(): ?Source
++{
++    foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS) as $trace) {
++        if (isset($trace['object']) && $trace['object'] instanceof Template) {
++            return $trace['object']->getSourceContext();
++        }
++    }
++
++    return null;
++}
++
++/**
++ * @internal
++ */
++function twig_resolve_is_sandboxed(Environment $env): bool
++{
++    if (!$env->hasExtension(SandboxExtension::class)) {
++        return false;
++    }
++
++    return $env->getExtension(SandboxExtension::class)->isSandboxed(twig_resolve_caller_source());
+ }
+diff --git a/src/Resources/debug.php b/src/Resources/debug.php
+index 104b4f4e0d2..a0392ff513b 100644
+--- a/src/Resources/debug.php
++++ b/src/Resources/debug.php
+@@ -1,9 +1,9 @@
+ <?php
+ 
+ /*
+- * This file is part of the Symfony package.
++ * This file is part of Twig.
+  *
+- * (c) Fabien Potencier <fabien@symfony.com>
++ * (c) Fabien Potencier
+  *
+  * For the full copyright and license information, please view the LICENSE
+  * file that was distributed with this source code.
+diff --git a/src/Resources/string_loader.php b/src/Resources/string_loader.php
+index 8f0e6492aab..c499e5ec2b0 100644
+--- a/src/Resources/string_loader.php
++++ b/src/Resources/string_loader.php
+@@ -1,9 +1,9 @@
+ <?php
+ 
+ /*
+- * This file is part of the Symfony package.
++ * This file is part of Twig.
+  *
+- * (c) Fabien Potencier <fabien@symfony.com>
++ * (c) Fabien Potencier
+  *
+  * For the full copyright and license information, please view the LICENSE
+  * file that was distributed with this source code.
+diff --git a/src/Runtime/EscaperRuntime.php b/src/Runtime/EscaperRuntime.php
+index b1dac964022..f4a7023c7a7 100644
+--- a/src/Runtime/EscaperRuntime.php
++++ b/src/Runtime/EscaperRuntime.php
+@@ -17,7 +17,7 @@
+ 
+ final class EscaperRuntime implements RuntimeExtensionInterface
+ {
+-    /** @var array<string, callable(string $string, string $charset): string> */
++    /** @var array<string, callable(string, string): string> */
+     private $escapers = [];
+ 
+     /** @internal */
+@@ -26,11 +26,9 @@ final class EscaperRuntime implements RuntimeExtensionInterface
+     /** @internal */
+     public $safeLookup = [];
+ 
+-    private $charset;
+-
+-    public function __construct($charset = 'UTF-8')
+-    {
+-        $this->charset = $charset;
++    public function __construct(
++        private $charset = 'UTF-8',
++    ) {
+     }
+ 
+     /**
+@@ -38,6 +36,8 @@ public function __construct($charset = 'UTF-8')
+      *
+      * @param string                                            $strategy The strategy name that should be used as a strategy in the escape call
+      * @param callable(string $string, string $charset): string $callable A valid PHP callable
++     *
++     * @return void
+      */
+     public function setEscaper($strategy, callable $callable)
+     {
+@@ -54,6 +54,11 @@ public function getEscapers()
+         return $this->escapers;
+     }
+ 
++    /**
++     * @param array<class-string<\Stringable>, string[]> $safeClasses
++     *
++     * @return void
++     */
+     public function setSafeClasses(array $safeClasses = [])
+     {
+         $this->safeClasses = [];
+@@ -63,6 +68,12 @@ public function setSafeClasses(array $safeClasses = [])
+         }
+     }
+ 
++    /**
++     * @param class-string<\Stringable> $class
++     * @param string[]                  $strategies
++     *
++     * @return void
++     */
+     public function addSafeClass(string $class, array $strategies)
+     {
+         $class = ltrim($class, '\\');
+@@ -93,9 +104,9 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+         }
+ 
+         if (!\is_string($string)) {
+-            if (\is_object($string) && method_exists($string, '__toString')) {
++            if ($string instanceof \Stringable) {
+                 if ($autoescape) {
+-                    $c = \get_class($string);
++                    $c = $string::class;
+                     if (!isset($this->safeClasses[$c])) {
+                         $this->safeClasses[$c] = [];
+                         foreach (class_parents($string) + class_implements($string) as $class) {
+@@ -113,7 +124,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                 }
+ 
+                 $string = (string) $string;
+-            } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'url'])) {
++            } elseif (\in_array($strategy, ['html', 'js', 'css', 'html_attr', 'html_attr_relaxed', 'url'], true)) {
+                 // we return the input as is (which can be of any type)
+                 return $string;
+             }
+@@ -129,6 +140,10 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+             case 'html':
+                 // see https://www.php.net/htmlspecialchars
+ 
++                if ('UTF-8' === $charset) {
++                    return htmlspecialchars($string, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
++                }
++
+                 // Using a static variable to avoid initializing the array
+                 // each time the function is called. Moving the declaration on the
+                 // top of the function slow downs other escaping strategies.
+@@ -176,7 +191,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                     throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+                 }
+ 
+-                $string = preg_replace_callback('#[^a-zA-Z0-9,\._]#Su', function ($matches) {
++                $string = preg_replace_callback('#[^a-zA-Z0-9,\._]#Su', static function ($matches) {
+                     $char = $matches[0];
+ 
+                     /*
+@@ -184,7 +199,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                     * Escape sequences supported only by JavaScript, not JSON, are omitted.
+                     * \" is also supported but omitted, because the resulting string is not HTML safe.
+                     */
+-                    static $shortMap = [
++                    $short = match ($char) {
+                         '\\' => '\\\\',
+                         '/' => '\\/',
+                         "\x08" => '\b',
+@@ -192,10 +207,11 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                         "\x0A" => '\n',
+                         "\x0D" => '\r',
+                         "\x09" => '\t',
+-                    ];
++                        default => false,
++                    };
+ 
+-                    if (isset($shortMap[$char])) {
+-                        return $shortMap[$char];
++                    if ($short) {
++                        return $short;
+                     }
+ 
+                     $codepoint = mb_ord($char, 'UTF-8');
+@@ -227,7 +243,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                     throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+                 }
+ 
+-                $string = preg_replace_callback('#[^a-zA-Z0-9]#Su', function ($matches) {
++                $string = preg_replace_callback('#[^a-zA-Z0-9]#Su', static function ($matches) {
+                     $char = $matches[0];
+ 
+                     return \sprintf('\\%X ', 1 === \strlen($char) ? \ord($char) : mb_ord($char, 'UTF-8'));
+@@ -240,6 +256,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                 return $string;
+ 
+             case 'html_attr':
++            case 'html_attr_relaxed':
+                 if ('UTF-8' !== $charset) {
+                     $string = $this->convertEncoding($string, 'UTF-8', $charset);
+                 }
+@@ -248,7 +265,12 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                     throw new RuntimeError('The string to escape is not a valid UTF-8 string.');
+                 }
+ 
+-                $string = preg_replace_callback('#[^a-zA-Z0-9,\.\-_]#Su', function ($matches) {
++                $regex = match ($strategy) {
++                    'html_attr' => '#[^a-zA-Z0-9,\.\-_]#Su',
++                    'html_attr_relaxed' => '#[^a-zA-Z0-9,\.\-_:@\[\]]#Su',
++                };
++
++                $string = preg_replace_callback($regex, static function ($matches) {
+                     /**
+                      * This function is adapted from code coming from Zend Framework.
+                      *
+@@ -256,7 +278,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                      * @license   https://framework.zend.com/license/new-bsd New BSD License
+                      */
+                     $chr = $matches[0];
+-                    $ord = \ord($chr);
++                    $ord = \ord($chr[0]);
+ 
+                     /*
+                     * The following replaces characters undefined in HTML with the
+@@ -277,18 +299,13 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                         * entities that XML supports. Using HTML entities would result in this error:
+                         *     XML Parsing Error: undefined entity
+                         */
+-                        static $entityMap = [
++                        return match ($ord) {
+                             34 => '&quot;', /* quotation mark */
+                             38 => '&amp;',  /* ampersand */
+                             60 => '&lt;',   /* less-than sign */
+                             62 => '&gt;',   /* greater-than sign */
+-                        ];
+-
+-                        if (isset($entityMap[$ord])) {
+-                            return $entityMap[$ord];
+-                        }
+-
+-                        return \sprintf('&#x%02X;', $ord);
++                            default => \sprintf('&#x%02X;', $ord),
++                        };
+                     }
+ 
+                     /*
+@@ -312,7 +329,7 @@ public function escape($string, string $strategy = 'html', ?string $charset = nu
+                     return $this->escapers[$strategy]($string, $charset);
+                 }
+ 
+-                $validStrategies = implode('", "', array_merge(['html', 'js', 'url', 'css', 'html_attr'], array_keys($this->escapers)));
++                $validStrategies = implode('", "', array_merge(['html', 'js', 'url', 'css', 'html_attr', 'html_attr_relaxed'], array_keys($this->escapers)));
+ 
+                 throw new RuntimeError(\sprintf('Invalid escaping strategy "%s" (valid ones: "%s").', $strategy, $validStrategies));
+         }
+diff --git a/src/RuntimeLoader/ContainerRuntimeLoader.php b/src/RuntimeLoader/ContainerRuntimeLoader.php
+index b360d7beaf1..05106680c4f 100644
+--- a/src/RuntimeLoader/ContainerRuntimeLoader.php
++++ b/src/RuntimeLoader/ContainerRuntimeLoader.php
+@@ -23,11 +23,9 @@
+  */
+ class ContainerRuntimeLoader implements RuntimeLoaderInterface
+ {
+-    private $container;
+-
+-    public function __construct(ContainerInterface $container)
+-    {
+-        $this->container = $container;
++    public function __construct(
++        private ContainerInterface $container,
++    ) {
+     }
+ 
+     public function load(string $class)
+diff --git a/src/RuntimeLoader/FactoryRuntimeLoader.php b/src/RuntimeLoader/FactoryRuntimeLoader.php
+index 13064839267..5d4e70b921d 100644
+--- a/src/RuntimeLoader/FactoryRuntimeLoader.php
++++ b/src/RuntimeLoader/FactoryRuntimeLoader.php
+@@ -18,14 +18,12 @@
+  */
+ class FactoryRuntimeLoader implements RuntimeLoaderInterface
+ {
+-    private $map;
+-
+     /**
+      * @param array $map An array where keys are class names and values factory callables
+      */
+-    public function __construct(array $map = [])
+-    {
+-        $this->map = $map;
++    public function __construct(
++        private array $map = [],
++    ) {
+     }
+ 
+     public function load(string $class)
+diff --git a/src/Sandbox/SecurityNotAllowedFilterError.php b/src/Sandbox/SecurityNotAllowedFilterError.php
+index 02d306360ba..9293a3f0b93 100644
+--- a/src/Sandbox/SecurityNotAllowedFilterError.php
++++ b/src/Sandbox/SecurityNotAllowedFilterError.php
+@@ -18,7 +18,7 @@
+  */
+ final class SecurityNotAllowedFilterError extends SecurityError
+ {
+-    private $filterName;
++    private string $filterName;
+ 
+     public function __construct(string $message, string $functionName)
+     {
+diff --git a/src/Sandbox/SecurityNotAllowedFunctionError.php b/src/Sandbox/SecurityNotAllowedFunctionError.php
+index 4f76dc6ece4..71c9f02bc5b 100644
+--- a/src/Sandbox/SecurityNotAllowedFunctionError.php
++++ b/src/Sandbox/SecurityNotAllowedFunctionError.php
+@@ -18,7 +18,7 @@
+  */
+ final class SecurityNotAllowedFunctionError extends SecurityError
+ {
+-    private $functionName;
++    private string $functionName;
+ 
+     public function __construct(string $message, string $functionName)
+     {
+diff --git a/src/Sandbox/SecurityNotAllowedMethodError.php b/src/Sandbox/SecurityNotAllowedMethodError.php
+index 8df9d0baa96..98e8e434d93 100644
+--- a/src/Sandbox/SecurityNotAllowedMethodError.php
++++ b/src/Sandbox/SecurityNotAllowedMethodError.php
+@@ -18,8 +18,8 @@
+  */
+ final class SecurityNotAllowedMethodError extends SecurityError
+ {
+-    private $className;
+-    private $methodName;
++    private string $className;
++    private string $methodName;
+ 
+     public function __construct(string $message, string $className, string $methodName)
+     {
+@@ -33,7 +33,7 @@ public function getClassName(): string
+         return $this->className;
+     }
+ 
+-    public function getMethodName()
++    public function getMethodName(): string
+     {
+         return $this->methodName;
+     }
+diff --git a/src/Sandbox/SecurityNotAllowedPropertyError.php b/src/Sandbox/SecurityNotAllowedPropertyError.php
+index 42ec4f38694..e74ffeddb25 100644
+--- a/src/Sandbox/SecurityNotAllowedPropertyError.php
++++ b/src/Sandbox/SecurityNotAllowedPropertyError.php
+@@ -18,8 +18,8 @@
+  */
+ final class SecurityNotAllowedPropertyError extends SecurityError
+ {
+-    private $className;
+-    private $propertyName;
++    private string $className;
++    private string $propertyName;
+ 
+     public function __construct(string $message, string $className, string $propertyName)
+     {
+@@ -33,7 +33,7 @@ public function getClassName(): string
+         return $this->className;
+     }
+ 
+-    public function getPropertyName()
++    public function getPropertyName(): string
+     {
+         return $this->propertyName;
+     }
+diff --git a/src/Sandbox/SecurityNotAllowedTagError.php b/src/Sandbox/SecurityNotAllowedTagError.php
+index 4522150e1b7..f9cd625b4c0 100644
+--- a/src/Sandbox/SecurityNotAllowedTagError.php
++++ b/src/Sandbox/SecurityNotAllowedTagError.php
+@@ -18,7 +18,7 @@
+  */
+ final class SecurityNotAllowedTagError extends SecurityError
+ {
+-    private $tagName;
++    private string $tagName;
+ 
+     public function __construct(string $message, string $tagName)
+     {
+diff --git a/src/Sandbox/SecurityPolicy.php b/src/Sandbox/SecurityPolicy.php
+index 417d38a8d4e..061b7974dfc 100644
+--- a/src/Sandbox/SecurityPolicy.php
++++ b/src/Sandbox/SecurityPolicy.php
+@@ -26,6 +26,7 @@ final class SecurityPolicy implements SecurityPolicyInterface
+     private $allowedMethods;
+     private $allowedProperties;
+     private $allowedFunctions;
++    private bool $strict = false;
+ 
+     public function __construct(array $allowedTags = [], array $allowedFilters = [], array $allowedMethods = [], array $allowedProperties = [], array $allowedFunctions = [])
+     {
+@@ -50,7 +51,7 @@ public function setAllowedMethods(array $methods): void
+     {
+         $this->allowedMethods = [];
+         foreach ($methods as $class => $m) {
+-            $this->allowedMethods[$class] = array_map(function ($value) { return strtr($value, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'); }, \is_array($m) ? $m : [$m]);
++            $this->allowedMethods[$class] = array_map('strtolower', \is_array($m) ? $m : [$m]);
+         }
+     }
+ 
+@@ -64,23 +65,51 @@ public function setAllowedFunctions(array $functions): void
+         $this->allowedFunctions = $functions;
+     }
+ 
++    /**
++     * Toggles strict mode.
++     *
++     * In strict mode, the tags and functions that are historically always allowed in a
++     * sandbox (the ``extends`` and ``use`` tags, the ``parent``, ``block``, and
++     * ``attribute`` functions) are no longer implicitly allowed and must be added to the
++     * relevant allow-list to be usable. Use this flag in 3.x to opt-in to the forthcoming
++     * 4.0 behavior and silence the related deprecations.
++     */
++    public function setStrict(bool $strict): void
++    {
++        $this->strict = $strict;
++    }
++
+     public function checkSecurity($tags, $filters, $functions): void
+     {
+         foreach ($tags as $tag) {
+-            if (!\in_array($tag, $this->allowedTags)) {
+-                throw new SecurityNotAllowedTagError(\sprintf('Tag "%s" is not allowed.', $tag), $tag);
++            if (!\in_array($tag, $this->allowedTags, true)) {
++                if (!$this->strict && 'extends' === $tag) {
++                    trigger_deprecation('twig/twig', '3.12', 'The "extends" tag is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed (or enable strict mode on the security policy to opt-in to the 4.0 behavior now).');
++                } elseif (!$this->strict && 'use' === $tag) {
++                    trigger_deprecation('twig/twig', '3.12', 'The "use" tag is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed (or enable strict mode on the security policy to opt-in to the 4.0 behavior now).');
++                } else {
++                    throw new SecurityNotAllowedTagError(\sprintf('Tag "%s" is not allowed.', $tag), $tag);
++                }
+             }
+         }
+ 
+         foreach ($filters as $filter) {
+-            if (!\in_array($filter, $this->allowedFilters)) {
++            if (!\in_array($filter, $this->allowedFilters, true)) {
+                 throw new SecurityNotAllowedFilterError(\sprintf('Filter "%s" is not allowed.', $filter), $filter);
+             }
+         }
+ 
+         foreach ($functions as $function) {
+-            if (!\in_array($function, $this->allowedFunctions)) {
+-                throw new SecurityNotAllowedFunctionError(\sprintf('Function "%s" is not allowed.', $function), $function);
++            if (!\in_array($function, $this->allowedFunctions, true)) {
++                if (!$this->strict && 'parent' === $function) {
++                    trigger_deprecation('twig/twig', '3.27', 'The "parent" function is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed (or enable strict mode on the security policy to opt-in to the 4.0 behavior now).');
++                } elseif (!$this->strict && 'block' === $function) {
++                    trigger_deprecation('twig/twig', '3.27', 'The "block" function is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed (or enable strict mode on the security policy to opt-in to the 4.0 behavior now).');
++                } elseif (!$this->strict && 'attribute' === $function) {
++                    trigger_deprecation('twig/twig', '3.27', 'The "attribute" function is always allowed in sandboxes, but won\'t be in 4.0, please enable it explicitly in your sandbox policy if needed (or enable strict mode on the security policy to opt-in to the 4.0 behavior now).');
++                } else {
++                    throw new SecurityNotAllowedFunctionError(\sprintf('Function "%s" is not allowed.', $function), $function);
++                }
+             }
+         }
+     }
+@@ -92,16 +121,16 @@ public function checkMethodAllowed($obj, $method): void
+         }
+ 
+         $allowed = false;
+-        $method = strtr($method, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
++        $method = strtolower($method);
+         foreach ($this->allowedMethods as $class => $methods) {
+-            if ($obj instanceof $class && \in_array($method, $methods)) {
++            if ($obj instanceof $class && \in_array($method, $methods, true)) {
+                 $allowed = true;
+                 break;
+             }
+         }
+ 
+         if (!$allowed) {
+-            $class = \get_class($obj);
++            $class = $obj::class;
+             throw new SecurityNotAllowedMethodError(\sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, $class), $class, $method);
+         }
+     }
+@@ -110,14 +139,14 @@ public function checkPropertyAllowed($obj, $property): void
+     {
+         $allowed = false;
+         foreach ($this->allowedProperties as $class => $properties) {
+-            if ($obj instanceof $class && \in_array($property, \is_array($properties) ? $properties : [$properties])) {
++            if ($obj instanceof $class && \in_array($property, \is_array($properties) ? $properties : [$properties], true)) {
+                 $allowed = true;
+                 break;
+             }
+         }
+ 
+         if (!$allowed) {
+-            $class = \get_class($obj);
++            $class = $obj::class;
+             throw new SecurityNotAllowedPropertyError(\sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, $class), $class, $property);
+         }
+     }
+diff --git a/src/Sandbox/SourcePolicyInterface.php b/src/Sandbox/SourcePolicyInterface.php
+index b952f1ea6fa..1b29608559a 100644
+--- a/src/Sandbox/SourcePolicyInterface.php
++++ b/src/Sandbox/SourcePolicyInterface.php
+@@ -17,6 +17,8 @@
+  * Interface for a class that can optionally enable the sandbox mode based on a template's Twig\Source.
+  *
+  * @author Yaakov Saxon
++ *
++ * @deprecated since Twig 3.27.0 with no replacement
+  */
+ interface SourcePolicyInterface
+ {
+diff --git a/src/Source.php b/src/Source.php
+index 3cb02403c1a..0f626b62d37 100644
+--- a/src/Source.php
++++ b/src/Source.php
+@@ -18,20 +18,16 @@
+  */
+ final class Source
+ {
+-    private $code;
+-    private $name;
+-    private $path;
+-
+     /**
+      * @param string $code The template source code
+      * @param string $name The template logical name
+      * @param string $path The filesystem path of the template if any
+      */
+-    public function __construct(string $code, string $name, string $path = '')
+-    {
+-        $this->code = $code;
+-        $this->name = $name;
+-        $this->path = $path;
++    public function __construct(
++        private string $code,
++        private string $name,
++        private string $path = '',
++    ) {
+     }
+ 
+     public function getCode(): string
+diff --git a/src/Template.php b/src/Template.php
+index 04c530cc9c8..e32c85d0f30 100644
+--- a/src/Template.php
++++ b/src/Template.php
+@@ -13,7 +13,6 @@
+ namespace Twig;
+ 
+ use Twig\Error\Error;
+-use Twig\Error\LoaderError;
+ use Twig\Error\RuntimeError;
+ 
+ /**
+@@ -35,41 +34,37 @@ abstract class Template
+ 
+     protected $parent;
+     protected $parents = [];
+-    protected $env;
+     protected $blocks = [];
+     protected $traits = [];
++    protected $traitAliases = [];
+     protected $extensions = [];
+     protected $sandbox;
+ 
+     private $useYield;
+ 
+-    public function __construct(Environment $env)
+-    {
+-        $this->env = $env;
++    public function __construct(
++        protected Environment $env,
++    ) {
+         $this->useYield = $env->useYield();
+         $this->extensions = $env->getExtensions();
+     }
+ 
+     /**
+      * Returns the template name.
+-     *
+-     * @return string The template name
+      */
+-    abstract public function getTemplateName();
++    abstract public function getTemplateName(): string;
+ 
+     /**
+      * Returns debug information about the template.
+      *
+-     * @return array Debug information
++     * @return array<int, int> Debug information
+      */
+-    abstract public function getDebugInfo();
++    abstract public function getDebugInfo(): array;
+ 
+     /**
+      * Returns information about the original template source code.
+-     *
+-     * @return Source
+      */
+-    abstract public function getSourceContext();
++    abstract public function getSourceContext(): Source;
+ 
+     /**
+      * Returns the parent template.
+@@ -79,40 +74,41 @@ abstract public function getSourceContext();
+      *
+      * @return self|TemplateWrapper|false The parent template or false if there is no parent
+      */
+-    public function getParent(array $context)
++    public function getParent(array $context): self|TemplateWrapper|false
+     {
+         if (null !== $this->parent) {
+             return $this->parent;
+         }
+ 
+-        try {
+-            if (!$parent = $this->doGetParent($context)) {
+-                return false;
+-            }
++        // The compiled doGetParent() may evaluate user expressions (filters,
++        // functions, method calls) when the parent name is dynamic. Make sure
++        // the sandbox security check runs first so those expressions cannot
++        // bypass the allow-list when getParent() is reached before the first
++        // ensureSecurityChecked() call on this template (e.g. via
++        // getTemplateForMacro() or yieldBlock() into a pre-warmed instance).
++        $this->ensureSecurityChecked();
+ 
+-            if ($parent instanceof self || $parent instanceof TemplateWrapper) {
+-                return $this->parents[$parent->getSourceContext()->getName()] = $parent;
+-            }
++        if (!$parent = $this->doGetParent($context)) {
++            return false;
++        }
+ 
+-            if (!isset($this->parents[$parent])) {
+-                $this->parents[$parent] = $this->loadTemplate($parent);
+-            }
+-        } catch (LoaderError $e) {
+-            $e->setSourceContext(null);
+-            $e->guess();
++        if ($parent instanceof self || $parent instanceof TemplateWrapper) {
++            return $this->parents[$parent->getSourceContext()->getName()] = $parent;
++        }
+ 
+-            throw $e;
++        if (!isset($this->parents[$parent])) {
++            $this->parents[$parent] = $this->load($parent, -1);
+         }
+ 
+         return $this->parents[$parent];
+     }
+ 
+-    protected function doGetParent(array $context)
++    protected function doGetParent(array $context): bool|string|self|TemplateWrapper
+     {
+         return false;
+     }
+ 
+-    public function isTraitable()
++    public function isTraitable(): bool
+     {
+         return true;
+     }
+@@ -127,7 +123,7 @@ public function isTraitable()
+      * @param array  $context The context
+      * @param array  $blocks  The current set of blocks
+      */
+-    public function displayParentBlock($name, array $context, array $blocks = [])
++    public function displayParentBlock($name, array $context, array $blocks = []): void
+     {
+         foreach ($this->yieldParentBlock($name, $context, $blocks) as $data) {
+             echo $data;
+@@ -145,7 +141,7 @@ public function displayParentBlock($name, array $context, array $blocks = [])
+      * @param array  $blocks    The current set of blocks
+      * @param bool   $useBlocks Whether to use the current set of blocks
+      */
+-    public function displayBlock($name, array $context, array $blocks = [], $useBlocks = true, ?self $templateContext = null)
++    public function displayBlock($name, array $context, array $blocks = [], $useBlocks = true, ?self $templateContext = null): void
+     {
+         foreach ($this->yieldBlock($name, $context, $blocks, $useBlocks, $templateContext) as $data) {
+             echo $data;
+@@ -164,8 +160,19 @@ public function displayBlock($name, array $context, array $blocks = [], $useBloc
+      *
+      * @return string The rendered block
+      */
+-    public function renderParentBlock($name, array $context, array $blocks = [])
++    public function renderParentBlock($name, array $context, array $blocks = []): string
+     {
++        if (!$this->useYield) {
++            if ($this->env->isDebug()) {
++                ob_start();
++            } else {
++                ob_start(static function () { return ''; });
++            }
++            $this->displayParentBlock($name, $context, $blocks);
++
++            return ob_get_clean();
++        }
++
+         $content = '';
+         foreach ($this->yieldParentBlock($name, $context, $blocks) as $data) {
+             $content .= $data;
+@@ -187,8 +194,28 @@ public function renderParentBlock($name, array $context, array $blocks = [])
+      *
+      * @return string The rendered block
+      */
+-    public function renderBlock($name, array $context, array $blocks = [], $useBlocks = true)
++    public function renderBlock($name, array $context, array $blocks = [], $useBlocks = true): string
+     {
++        if (!$this->useYield) {
++            $level = ob_get_level();
++            if ($this->env->isDebug()) {
++                ob_start();
++            } else {
++                ob_start(static function () { return ''; });
++            }
++            try {
++                $this->displayBlock($name, $context, $blocks, $useBlocks);
++            } catch (\Throwable $e) {
++                while (ob_get_level() > $level) {
++                    ob_end_clean();
++                }
++
++                throw $e;
++            }
++
++            return ob_get_clean();
++        }
++
+         $content = '';
+         foreach ($this->yieldBlock($name, $context, $blocks, $useBlocks) as $data) {
+             $content .= $data;
+@@ -209,7 +236,7 @@ public function renderBlock($name, array $context, array $blocks = [], $useBlock
+      *
+      * @return bool true if the block exists, false otherwise
+      */
+-    public function hasBlock($name, array $context, array $blocks = [])
++    public function hasBlock($name, array $context, array $blocks = []): bool
+     {
+         if (isset($blocks[$name])) {
+             return $blocks[$name][0] instanceof self;
+@@ -235,9 +262,9 @@ public function hasBlock($name, array $context, array $blocks = [])
+      * @param array $context The context
+      * @param array $blocks  The current set of blocks
+      *
+-     * @return array An array of block names
++     * @return array<string> An array of block names
+      */
+-    public function getBlockNames(array $context, array $blocks = [])
++    public function getBlockNames(array $context, array $blocks = []): array
+     {
+         $names = array_merge(array_keys($blocks), array_keys($this->blocks));
+ 
+@@ -250,24 +277,16 @@ public function getBlockNames(array $context, array $blocks = [])
+ 
+     /**
+      * @param string|TemplateWrapper|array<string|TemplateWrapper> $template
+-     *
+-     * @return self|TemplateWrapper
+      */
+-    protected function loadTemplate($template, $templateName = null, $line = null, $index = null)
++    protected function load(string|TemplateWrapper|array $template, int $line, ?int $index = null): self
+     {
+         try {
+             if (\is_array($template)) {
+-                return $this->env->resolveTemplate($template);
++                return $this->env->resolveTemplate($template)->unwrap();
+             }
+ 
+             if ($template instanceof TemplateWrapper) {
+-                return $template;
+-            }
+-
+-            if ($template instanceof self) {
+-                trigger_deprecation('twig/twig', '3.9', 'Passing a "%s" instance to "%s" is deprecated.', self::class, __METHOD__);
+-
+-                return $template;
++                return $template->unwrap();
+             }
+ 
+             if ($template === $this->getTemplateName()) {
+@@ -282,14 +301,14 @@ protected function loadTemplate($template, $templateName = null, $line = null, $
+             return $this->env->loadTemplate($class, $template, $index);
+         } catch (Error $e) {
+             if (!$e->getSourceContext()) {
+-                $e->setSourceContext($templateName ? new Source('', $templateName) : $this->getSourceContext());
++                $e->setSourceContext($this->getSourceContext());
+             }
+ 
+             if ($e->getTemplateLine() > 0) {
+                 throw $e;
+             }
+ 
+-            if (!$line) {
++            if (-1 === $line) {
+                 $e->guess();
+             } else {
+                 $e->setTemplateLine($line);
+@@ -299,12 +318,32 @@ protected function loadTemplate($template, $templateName = null, $line = null, $
+         }
+     }
+ 
++    /**
++     * @param string|TemplateWrapper|array<string|TemplateWrapper> $template
++     *
++     * @deprecated since Twig 3.21 and will be removed in 4.0. Use Template::load() instead.
++     */
++    protected function loadTemplate($template, $templateName = null, ?int $line = null, ?int $index = null): self|TemplateWrapper
++    {
++        trigger_deprecation('twig/twig', '3.21', 'The "%s" method is deprecated.', __METHOD__);
++
++        if (null === $line) {
++            $line = -1;
++        }
++
++        if ($template instanceof self) {
++            return $template;
++        }
++
++        return $this->load($template, $line, $index);
++    }
++
+     /**
+      * @internal
+      *
+-     * @return self
++     * @return $this
+      */
+-    public function unwrap()
++    public function unwrap(): self
+     {
+         return $this;
+     }
+@@ -317,7 +356,7 @@ public function unwrap()
+      *
+      * @return array An array of blocks
+      */
+-    public function getBlocks()
++    public function getBlocks(): array
+     {
+         return $this->blocks;
+     }
+@@ -331,6 +370,26 @@ public function display(array $context, array $blocks = []): void
+ 
+     public function render(array $context): string
+     {
++        if (!$this->useYield) {
++            $level = ob_get_level();
++            if ($this->env->isDebug()) {
++                ob_start();
++            } else {
++                ob_start(static function () { return ''; });
++            }
++            try {
++                $this->display($context);
++            } catch (\Throwable $e) {
++                while (ob_get_level() > $level) {
++                    ob_end_clean();
++                }
++
++                throw $e;
++            }
++
++            return ob_get_clean();
++        }
++
+         $content = '';
+         foreach ($this->yield($context) as $data) {
+             $content .= $data;
+@@ -340,35 +399,16 @@ public function render(array $context): string
+     }
+ 
+     /**
+-     * @return iterable<string>
++     * @return iterable<scalar|\Stringable|null>
+      */
+     public function yield(array $context, array $blocks = []): iterable
+     {
+-        $context = $this->env->mergeGlobals($context);
++        $context += $this->env->getGlobals();
+         $blocks = array_merge($this->blocks, $blocks);
+ 
+         try {
+-            if ($this->useYield) {
+-                yield from $this->doDisplay($context, $blocks);
+-
+-                return;
+-            }
+-
+-            $level = ob_get_level();
+-            ob_start();
+-
+-            foreach ($this->doDisplay($context, $blocks) as $data) {
+-                if (ob_get_length()) {
+-                    $data = ob_get_clean().$data;
+-                    ob_start();
+-                }
+-
+-                yield $data;
+-            }
+-
+-            if (ob_get_length()) {
+-                yield ob_get_clean();
+-            }
++            $this->ensureSecurityChecked();
++            yield from $this->doDisplay($context, $blocks);
+         } catch (Error $e) {
+             if (!$e->getSourceContext()) {
+                 $e->setSourceContext($this->getSourceContext());
+@@ -386,19 +426,13 @@ public function yield(array $context, array $blocks = []): iterable
+             $e->guess();
+ 
+             throw $e;
+-        } finally {
+-            if (!$this->useYield) {
+-                while (ob_get_level() > $level) {
+-                    ob_end_clean();
+-                }
+-            }
+         }
+     }
+ 
+     /**
+-     * @return iterable<string>
++     * @return iterable<scalar|\Stringable|null>
+      */
+-    public function yieldBlock($name, array $context, array $blocks = [], $useBlocks = true, ?self $templateContext = null)
++    public function yieldBlock($name, array $context, array $blocks = [], $useBlocks = true, ?self $templateContext = null): iterable
+     {
+         if ($useBlocks && isset($blocks[$name])) {
+             $template = $blocks[$name][0];
+@@ -418,27 +452,8 @@ public function yieldBlock($name, array $context, array $blocks = [], $useBlocks
+ 
+         if (null !== $template) {
+             try {
+-                if ($this->useYield) {
+-                    yield from $template->$block($context, $blocks);
+-
+-                    return;
+-                }
+-
+-                $level = ob_get_level();
+-                ob_start();
+-
+-                foreach ($template->$block($context, $blocks) as $data) {
+-                    if (ob_get_length()) {
+-                        $data = ob_get_clean().$data;
+-                        ob_start();
+-                    }
+-
+-                    yield $data;
+-                }
+-
+-                if (ob_get_length()) {
+-                    yield ob_get_clean();
+-                }
++                $template->ensureSecurityChecked();
++                yield from $template->$block($context, $blocks);
+             } catch (Error $e) {
+                 if (!$e->getSourceContext()) {
+                     $e->setSourceContext($template->getSourceContext());
+@@ -456,12 +471,6 @@ public function yieldBlock($name, array $context, array $blocks = [], $useBlocks
+                 $e->guess();
+ 
+                 throw $e;
+-            } finally {
+-                if (!$this->useYield) {
+-                    while (ob_get_level() > $level) {
+-                        ob_end_clean();
+-                    }
+-                }
+             }
+         } elseif ($parent = $this->getParent($context)) {
+             yield from $parent->unwrap()->yieldBlock($name, $context, array_merge($this->blocks, $blocks), false, $templateContext ?? $this);
+@@ -482,12 +491,12 @@ public function yieldBlock($name, array $context, array $blocks = [], $useBlocks
+      * @param array  $context The context
+      * @param array  $blocks  The current set of blocks
+      *
+-     * @return iterable<string>
++     * @return iterable<scalar|\Stringable|null>
+      */
+-    public function yieldParentBlock($name, array $context, array $blocks = [])
++    public function yieldParentBlock($name, array $context, array $blocks = []): iterable
+     {
+         if (isset($this->traits[$name])) {
+-            yield from $this->traits[$name][0]->yieldBlock($name, $context, $blocks, false);
++            yield from $this->traits[$name][0]->yieldBlock($this->traitAliases[$name] ?? $name, $context, $blocks, false);
+         } elseif ($parent = $this->getParent($context)) {
+             yield from $parent->unwrap()->yieldBlock($name, $context, $blocks, false);
+         } else {
+@@ -495,11 +504,55 @@ public function yieldParentBlock($name, array $context, array $blocks = [])
+         }
+     }
+ 
++    protected function hasMacro(string $name, array $context): bool
++    {
++        if (method_exists($this, $name)) {
++            return true;
++        }
++
++        if (!$parent = $this->getParent($context)) {
++            return false;
++        }
++
++        return $parent->hasMacro($name, $context);
++    }
++
++    protected function getTemplateForMacro(string $name, array $context, int $line, Source $source): self
++    {
++        if (method_exists($this, $name)) {
++            $this->ensureSecurityChecked();
++
++            return $this;
++        }
++
++        $parent = $this;
++        while ($parent = $parent->getParent($context)) {
++            if (method_exists($parent, $name)) {
++                $parent->ensureSecurityChecked();
++
++                return $parent;
++            }
++        }
++
++        throw new RuntimeError(\sprintf('Macro "%s" is not defined in template "%s".', substr($name, \strlen('macro_')), $this->getTemplateName()), $line, $source);
++    }
++
++    /**
++     * Runs the sandbox security check against the current sandbox state.
++     *
++     * @internal
++     */
++    public function ensureSecurityChecked(): void
++    {
++    }
++
+     /**
+      * Auto-generated method to display the template with the given context.
+      *
+      * @param array $context An array of parameters to pass to the template
+      * @param array $blocks  An array of blocks to pass to the template
++     *
++     * @return iterable<scalar|\Stringable|null>
+      */
+-    abstract protected function doDisplay(array $context, array $blocks = []);
++    abstract protected function doDisplay(array $context, array $blocks = []): iterable;
+ }
+diff --git a/src/TemplateWrapper.php b/src/TemplateWrapper.php
+index fcfb070c799..265ce3e1ccc 100644
+--- a/src/TemplateWrapper.php
++++ b/src/TemplateWrapper.php
+@@ -18,19 +18,32 @@
+  */
+ final class TemplateWrapper
+ {
+-    private $env;
+-    private $template;
+-
+     /**
+      * This method is for internal use only and should never be called
+      * directly (use Twig\Environment::load() instead).
+      *
+      * @internal
+      */
+-    public function __construct(Environment $env, Template $template)
++    public function __construct(
++        private Environment $env,
++        private Template $template,
++    ) {
++    }
++
++    /**
++     * @return iterable<scalar|\Stringable|null>
++     */
++    public function stream(array $context = []): iterable
++    {
++        yield from $this->template->yield($context);
++    }
++
++    /**
++     * @return iterable<scalar|\Stringable|null>
++     */
++    public function streamBlock(string $name, array $context = []): iterable
+     {
+-        $this->env = $env;
+-        $this->template = $template;
++        yield from $this->template->yieldBlock($name, $context);
+     }
+ 
+     public function render(array $context = []): string
+@@ -38,6 +51,9 @@ public function render(array $context = []): string
+         return $this->template->render($context);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function display(array $context = [])
+     {
+         // using func_get_args() allows to not expose the blocks argument
+@@ -60,12 +76,15 @@ public function getBlockNames(array $context = []): array
+ 
+     public function renderBlock(string $name, array $context = []): string
+     {
+-        return $this->template->renderBlock($name, $this->env->mergeGlobals($context));
++        return $this->template->renderBlock($name, $context + $this->env->getGlobals());
+     }
+ 
++    /**
++     * @return void
++     */
+     public function displayBlock(string $name, array $context = [])
+     {
+-        $context = $this->env->mergeGlobals($context);
++        $context += $this->env->getGlobals();
+         foreach ($this->template->yieldBlock($name, $context) as $data) {
+             echo $data;
+         }
+diff --git a/src/Test/IntegrationTestCase.php b/src/Test/IntegrationTestCase.php
+index 5519dd0a99f..d995c6a032c 100644
+--- a/src/Test/IntegrationTestCase.php
++++ b/src/Test/IntegrationTestCase.php
+@@ -17,6 +17,7 @@
+ use Twig\Extension\ExtensionInterface;
+ use Twig\Loader\ArrayLoader;
+ use Twig\RuntimeLoader\RuntimeLoaderInterface;
++use Twig\TokenParser\TokenParserInterface;
+ use Twig\TwigFilter;
+ use Twig\TwigFunction;
+ use Twig\TwigTest;
+@@ -30,9 +31,19 @@
+ abstract class IntegrationTestCase extends TestCase
+ {
+     /**
++     * @deprecated since Twig 3.13, use getFixturesDirectory() instead.
++     *
+      * @return string
+      */
+-    abstract protected function getFixturesDir();
++    protected function getFixturesDir()
++    {
++        throw new \BadMethodCallException('Not implemented.');
++    }
++
++    protected static function getFixturesDirectory(): string
++    {
++        throw new \BadMethodCallException('Not implemented.');
++    }
+ 
+     /**
+      * @return RuntimeLoaderInterface[]
+@@ -74,8 +85,42 @@ protected function getTwigTests()
+         return [];
+     }
+ 
++    /**
++     * @return array<callable(string): (TwigFilter|false)>
++     */
++    protected function getUndefinedFilterCallbacks(): array
++    {
++        return [];
++    }
++
++    /**
++     * @return array<callable(string): (TwigFunction|false)>
++     */
++    protected function getUndefinedFunctionCallbacks(): array
++    {
++        return [];
++    }
++
++    /**
++     * @return array<callable(string): (TwigTest|false)>
++     */
++    protected function getUndefinedTestCallbacks(): array
++    {
++        return [];
++    }
++
++    /**
++     * @return array<callable(string): (TokenParserInterface|false)>
++     */
++    protected function getUndefinedTokenParserCallbacks(): array
++    {
++        return [];
++    }
++
+     /**
+      * @dataProvider getTests
++     *
++     * @return void
+      */
+     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
+     {
+@@ -86,15 +131,29 @@ public function testIntegration($file, $message, $condition, $templates, $except
+      * @dataProvider getLegacyTests
+      *
+      * @group legacy
++     *
++     * @return void
+      */
+     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
+     {
+         $this->doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation);
+     }
+ 
++    /**
++     * @return iterable
++     *
++     * @final since Twig 3.13
++     */
+     public function getTests($name, $legacyTests = false)
+     {
+-        $fixturesDir = realpath($this->getFixturesDir());
++        try {
++            $fixturesDir = static::getFixturesDirectory();
++        } catch (\BadMethodCallException) {
++            trigger_deprecation('twig/twig', '3.13', 'Not overriding "%s::getFixturesDirectory()" in "%s" is deprecated. This method will be abstract in 4.0.', self::class, static::class);
++            $fixturesDir = $this->getFixturesDir();
++        }
++
++        $fixturesDir = realpath($fixturesDir);
+         $tests = [];
+ 
+         foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+@@ -126,10 +185,10 @@ public function getTests($name, $legacyTests = false)
+                 throw new \InvalidArgumentException(\sprintf('Test "%s" is not valid.', str_replace($fixturesDir.'/', '', $file)));
+             }
+ 
+-            $tests[] = [str_replace($fixturesDir.'/', '', $file), $message, $condition, $templates, $exception, $outputs, $deprecation];
++            $tests[str_replace($fixturesDir.'/', '', $file)] = [str_replace($fixturesDir.'/', '', $file), $message, $condition, $templates, $exception, $outputs, $deprecation];
+         }
+ 
+-        if ($legacyTests && empty($tests)) {
++        if ($legacyTests && !$tests) {
+             // add a dummy test to avoid a PHPUnit message
+             return [['not', '-', '', [], '', []]];
+         }
+@@ -137,11 +196,19 @@ public function getTests($name, $legacyTests = false)
+         return $tests;
+     }
+ 
++    /**
++     * @final since Twig 3.13
++     *
++     * @return iterable
++     */
+     public function getLegacyTests()
+     {
+         return $this->getTests('testLegacyIntegration', true);
+     }
+ 
++    /**
++     * @return void
++     */
+     protected function doIntegrationTest($file, $message, $condition, $templates, $exception, $outputs, $deprecation = '')
+     {
+         if (!$outputs) {
+@@ -156,13 +223,16 @@ protected function doIntegrationTest($file, $message, $condition, $templates, $e
+             }
+         }
+ 
+-        $loader = new ArrayLoader($templates);
+-
+         foreach ($outputs as $i => $match) {
+             $config = array_merge([
+                 'cache' => false,
+                 'strict_variables' => true,
+             ], $match[2] ? eval($match[2].';') : []);
++            // make sure that template are always compiled even if they are the same (useful when testing with more than one data/expect sections)
++            foreach ($templates as $j => $template) {
++                $templates[$j] = $template.str_repeat(' ', $i);
++            }
++            $loader = new ArrayLoader($templates);
+             $twig = new Environment($loader, $config);
+             $twig->addGlobal('global', 'global');
+             foreach ($this->getRuntimeLoaders() as $runtimeLoader) {
+@@ -185,9 +255,25 @@ protected function doIntegrationTest($file, $message, $condition, $templates, $e
+                 $twig->addFunction($function);
+             }
+ 
++            foreach ($this->getUndefinedFilterCallbacks() as $callback) {
++                $twig->registerUndefinedFilterCallback($callback);
++            }
++
++            foreach ($this->getUndefinedFunctionCallbacks() as $callback) {
++                $twig->registerUndefinedFunctionCallback($callback);
++            }
++
++            foreach ($this->getUndefinedTestCallbacks() as $callback) {
++                $twig->registerUndefinedTestCallback($callback);
++            }
++
++            foreach ($this->getUndefinedTokenParserCallbacks() as $callback) {
++                $twig->registerUndefinedTokenParserCallback($callback);
++            }
++
+             $deprecations = [];
+             try {
+-                $prevHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$deprecations, &$prevHandler) {
++                $prevHandler = set_error_handler(static function ($type, $msg, $file, $line, $context = []) use (&$deprecations, &$prevHandler) {
+                     if (\E_USER_DEPRECATED === $type) {
+                         $deprecations[] = $msg;
+ 
+@@ -201,14 +287,14 @@ protected function doIntegrationTest($file, $message, $condition, $templates, $e
+             } catch (\Exception $e) {
+                 if (false !== $exception) {
+                     $message = $e->getMessage();
+-                    $this->assertSame(trim($exception), trim(\sprintf('%s: %s', \get_class($e), $message)));
++                    $this->assertSame(trim($exception), trim(\sprintf('%s: %s', $e::class, $message)));
+                     $last = substr($message, \strlen($message) - 1);
+                     $this->assertTrue('.' === $last || '?' === $last, 'Exception message must end with a dot or a question mark.');
+ 
+                     return;
+                 }
+ 
+-                throw new Error(\sprintf('%s: %s', \get_class($e), $e->getMessage()), -1, null, $e);
++                throw new Error(\sprintf('%s: %s', $e::class, $e->getMessage()), -1, null, $e);
+             } finally {
+                 restore_error_handler();
+             }
+@@ -219,14 +305,14 @@ protected function doIntegrationTest($file, $message, $condition, $templates, $e
+                 $output = trim($template->render(eval($match[1].';')), "\n ");
+             } catch (\Exception $e) {
+                 if (false !== $exception) {
+-                    $this->assertSame(trim($exception), trim(\sprintf('%s: %s', \get_class($e), $e->getMessage())));
++                    $this->assertStringMatchesFormat(trim($exception), trim(\sprintf('%s: %s', $e::class, $e->getMessage())));
+ 
+                     return;
+                 }
+ 
+-                $e = new Error(\sprintf('%s: %s', \get_class($e), $e->getMessage()), -1, null, $e);
++                $e = new Error(\sprintf('%s: %s', $e::class, $e->getMessage()), -1, null, $e);
+ 
+-                $output = trim(\sprintf('%s: %s', \get_class($e), $e->getMessage()));
++                $output = trim(\sprintf('%s: %s', $e::class, $e->getMessage()));
+             }
+ 
+             if (false !== $exception) {
+@@ -249,6 +335,9 @@ protected function doIntegrationTest($file, $message, $condition, $templates, $e
+         }
+     }
+ 
++    /**
++     * @return array<string, string>
++     */
+     protected static function parseTemplates($test)
+     {
+         $templates = [];
+diff --git a/src/Test/NodeTestCase.php b/src/Test/NodeTestCase.php
+index 4046f08cdc9..0cb5b2fab05 100644
+--- a/src/Test/NodeTestCase.php
++++ b/src/Test/NodeTestCase.php
+@@ -11,6 +11,8 @@
+ 
+ namespace Twig\Test;
+ 
++use PHPUnit\Framework\Attributes\BeforeClass;
++use PHPUnit\Framework\Attributes\DataProvider;
+ use PHPUnit\Framework\TestCase;
+ use Twig\Compiler;
+ use Twig\Environment;
+@@ -24,16 +26,39 @@ abstract class NodeTestCase extends TestCase
+      */
+     private $currentEnv;
+ 
+-    abstract public function getTests();
++    /**
++     * @return iterable<array{0: Node, 1: string, 2?: Environment|null, 3?: bool}>
++     */
++    public function getTests()
++    {
++        return [];
++    }
++
++    /**
++     * @return iterable<array{0: Node, 1: string, 2?: Environment|null, 3?: bool}>
++     */
++    public static function provideTests(): iterable
++    {
++        trigger_deprecation('twig/twig', '3.13', 'Not implementing "%s()" in "%s" is deprecated. This method will be abstract in 4.0.', __METHOD__, static::class);
++
++        return [];
++    }
+ 
+     /**
+      * @dataProvider getTests
++     * @dataProvider provideTests
++     *
++     * @return void
+      */
++    #[DataProvider('getTests'), DataProvider('provideTests')]
+     public function testCompile($node, $source, $environment = null, $isPattern = false)
+     {
+         $this->assertNodeCompilation($source, $node, $environment, $isPattern);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function assertNodeCompilation($source, Node $node, ?Environment $environment = null, $isPattern = false)
+     {
+         $compiler = $this->getCompiler($environment);
+@@ -46,29 +71,72 @@ public function assertNodeCompilation($source, Node $node, ?Environment $environ
+         }
+     }
+ 
++    /**
++     * @return Compiler
++     */
+     protected function getCompiler(?Environment $environment = null)
+     {
+         return new Compiler($environment ?? $this->getEnvironment());
+     }
+ 
++    /**
++     * @return Environment
++     *
++     * @final since Twig 3.13
++     */
+     protected function getEnvironment()
+     {
+-        if (!$this->currentEnv) {
+-            $this->currentEnv = new Environment(new ArrayLoader());
+-        }
++        return $this->currentEnv ??= static::createEnvironment();
++    }
+ 
+-        return $this->currentEnv;
++    protected static function createEnvironment(): Environment
++    {
++        return new Environment(new ArrayLoader());
+     }
+ 
++    /**
++     * @return string
++     *
++     * @deprecated since Twig 3.13, use createVariableGetter() instead.
++     */
+     protected function getVariableGetter($name, $line = false)
++    {
++        trigger_deprecation('twig/twig', '3.13', 'Method "%s()" is deprecated, use "createVariableGetter()" instead.', __METHOD__);
++
++        return self::createVariableGetter($name, $line);
++    }
++
++    final protected static function createVariableGetter(string $name, bool $line = false): string
+     {
+         $line = $line > 0 ? "// line $line\n" : '';
+ 
+         return \sprintf('%s($context["%s"] ?? null)', $line, $name);
+     }
+ 
++    /**
++     * @return string
++     *
++     * @deprecated since Twig 3.13, use createAttributeGetter() instead.
++     */
+     protected function getAttributeGetter()
++    {
++        trigger_deprecation('twig/twig', '3.13', 'Method "%s()" is deprecated, use "createAttributeGetter()" instead.', __METHOD__);
++
++        return self::createAttributeGetter();
++    }
++
++    final protected static function createAttributeGetter(): string
+     {
+         return 'CoreExtension::getAttribute($this->env, $this->source, ';
+     }
++
++    /** @beforeClass */
++    #[BeforeClass]
++    final public static function checkDataProvider(): void
++    {
++        $r = new \ReflectionMethod(static::class, 'getTests');
++        if (self::class !== $r->getDeclaringClass()->getName()) {
++            trigger_deprecation('twig/twig', '3.13', 'Implementing "%s::getTests()" in "%s" is deprecated, implement "provideTests()" instead.', self::class, static::class);
++        }
++    }
+ }
+diff --git a/src/Token.php b/src/Token.php
+index 5be39bdc7ee..823c7738769 100644
+--- a/src/Token.php
++++ b/src/Token.php
+@@ -17,10 +17,6 @@
+  */
+ final class Token
+ {
+-    private $value;
+-    private $type;
+-    private $lineno;
+-
+     public const EOF_TYPE = -1;
+     public const TEXT_TYPE = 0;
+     public const BLOCK_START_TYPE = 1;
+@@ -34,17 +30,29 @@ final class Token
+     public const PUNCTUATION_TYPE = 9;
+     public const INTERPOLATION_START_TYPE = 10;
+     public const INTERPOLATION_END_TYPE = 11;
++    /**
++     * @deprecated since Twig 3.21, "arrow" is now an operator
++     */
+     public const ARROW_TYPE = 12;
++    /**
++     * @deprecated since Twig 3.21, "spread" is now an operator
++     */
+     public const SPREAD_TYPE = 13;
+ 
+-    public function __construct(int $type, $value, int $lineno)
+-    {
+-        $this->type = $type;
+-        $this->value = $value;
+-        $this->lineno = $lineno;
++    public function __construct(
++        private int $type,
++        private $value,
++        private int $lineno,
++    ) {
++        if (self::ARROW_TYPE === $type) {
++            trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "arrow" is now an operator.', self::ARROW_TYPE);
++        }
++        if (self::SPREAD_TYPE === $type) {
++            trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "spread" is now an operator.', self::SPREAD_TYPE);
++        }
+     }
+ 
+-    public function __toString()
++    public function __toString(): string
+     {
+         return \sprintf('%s(%s)', self::typeToString($this->type, true), $this->value);
+     }
+@@ -67,9 +75,46 @@ public function test($type, $values = null): bool
+             $type = self::NAME_TYPE;
+         }
+ 
+-        return ($this->type === $type) && (
++        if (self::ARROW_TYPE === $type) {
++            trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "arrow" is now an operator.', self::typeToEnglish(self::ARROW_TYPE));
++
++            return self::OPERATOR_TYPE === $this->type && '=>' === $this->value;
++        }
++        if (self::SPREAD_TYPE === $type) {
++            trigger_deprecation('twig/twig', '3.21', 'The "%s" token type is deprecated, "spread" is now an operator.', self::typeToEnglish(self::SPREAD_TYPE));
++
++            return self::OPERATOR_TYPE === $this->type && '...' === $this->value;
++        }
++
++        $typeMatches = $this->type === $type;
++        if ($typeMatches && self::PUNCTUATION_TYPE === $type && \in_array($this->value, ['(', '[', '|', '.', '?', '?:'], true) && $values) {
++            foreach ((array) $values as $value) {
++                if (\in_array($value, ['(', '[', '|', '.', '?', '?:'], true)) {
++                    trigger_deprecation('twig/twig', '3.21', 'The "%s" token is now an "%s" token instead of a "%s" one.', $this->value, self::typeToEnglish(self::OPERATOR_TYPE), $this->toEnglish());
++
++                    break;
++                }
++            }
++        }
++        if (!$typeMatches) {
++            if (self::OPERATOR_TYPE === $type && self::PUNCTUATION_TYPE === $this->type) {
++                if ($values) {
++                    foreach ((array) $values as $value) {
++                        if (\in_array($value, ['(', '[', '|', '.', '?', '?:'], true)) {
++                            $typeMatches = true;
++
++                            break;
++                        }
++                    }
++                } else {
++                    $typeMatches = true;
++                }
++            }
++        }
++
++        return $typeMatches && (
+             null === $values
+-            || (\is_array($values) && \in_array($this->value, $values))
++            || (\is_array($values) && \in_array($this->value, $values, true))
+             || $this->value == $values
+         );
+     }
+@@ -79,8 +124,13 @@ public function getLine(): int
+         return $this->lineno;
+     }
+ 
++    /**
++     * @deprecated since Twig 3.19
++     */
+     public function getType(): int
+     {
++        trigger_deprecation('twig/twig', '3.19', \sprintf('The "%s()" method is deprecated.', __METHOD__));
++
+         return $this->type;
+     }
+ 
+@@ -89,6 +139,11 @@ public function getValue()
+         return $this->value;
+     }
+ 
++    public function toEnglish(): string
++    {
++        return self::typeToEnglish($this->type);
++    }
++
+     public static function typeToString(int $type, bool $short = false): string
+     {
+         switch ($type) {
+diff --git a/src/TokenParser/AbstractTokenParser.php b/src/TokenParser/AbstractTokenParser.php
+index 720ea676283..8acaa6f56e9 100644
+--- a/src/TokenParser/AbstractTokenParser.php
++++ b/src/TokenParser/AbstractTokenParser.php
+@@ -11,7 +11,11 @@
+ 
+ namespace Twig\TokenParser;
+ 
++use Twig\Lexer;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Nodes;
+ use Twig\Parser;
++use Twig\Token;
+ 
+ /**
+  * Base class for all token parsers.
+@@ -29,4 +33,29 @@ public function setParser(Parser $parser): void
+     {
+         $this->parser = $parser;
+     }
++
++    /**
++     * Parses an assignment expression like "a, b".
++     */
++    protected function parseAssignmentExpression(): Nodes
++    {
++        $stream = $this->parser->getStream();
++        $targets = [];
++        while (true) {
++            $token = $stream->getCurrent();
++            if ($stream->test(Token::OPERATOR_TYPE) && preg_match(Lexer::REGEX_NAME, $token->getValue())) {
++                // in this context, string operators are variable names
++                $stream->next();
++            } else {
++                $stream->expect(Token::NAME_TYPE, null, 'Only variables can be assigned to');
++            }
++            $targets[] = new AssignContextVariable($token->getValue(), $token->getLine());
++
++            if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
++                break;
++            }
++        }
++
++        return new Nodes($targets);
++    }
+ }
+diff --git a/src/TokenParser/ApplyTokenParser.php b/src/TokenParser/ApplyTokenParser.php
+index 4dbf30406b0..5b560e74916 100644
+--- a/src/TokenParser/ApplyTokenParser.php
++++ b/src/TokenParser/ApplyTokenParser.php
+@@ -11,8 +11,10 @@
+ 
+ namespace Twig\TokenParser;
+ 
+-use Twig\Node\Expression\TempNameExpression;
++use Twig\ExpressionParser\Infix\FilterExpressionParser;
++use Twig\Node\Expression\Variable\LocalVariable;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Node\PrintNode;
+ use Twig\Node\SetNode;
+ use Twig\Token;
+@@ -31,21 +33,25 @@ final class ApplyTokenParser extends AbstractTokenParser
+     public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+-        $name = $this->parser->getVarName();
+-
+-        $ref = new TempNameExpression($name, $lineno);
+-        $ref->setAttribute('always_defined', true);
+-
+-        $filter = $this->parser->getExpressionParser()->parseFilterExpressionRaw($ref, $this->getTag());
++        $ref = new LocalVariable(null, $lineno);
++        $filter = $ref;
++        $op = $this->parser->getEnvironment()->getExpressionParsers()->getByClass(FilterExpressionParser::class);
++        while (true) {
++            $filter = $op->parse($this->parser, $filter, $this->parser->getCurrentToken());
++            if (!$this->parser->getStream()->test(Token::OPERATOR_TYPE, '|')) {
++                break;
++            }
++            $this->parser->getStream()->next();
++        }
+ 
+         $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+         $body = $this->parser->subparse([$this, 'decideApplyEnd'], true);
+         $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new Node([
+-            new SetNode(true, $ref, $body, $lineno, $this->getTag()),
+-            new PrintNode($filter, $lineno, $this->getTag()),
+-        ]);
++        return new Nodes([
++            new SetNode(true, $ref, $body, $lineno),
++            new PrintNode($filter, $lineno),
++        ], $lineno);
+     }
+ 
+     public function decideApplyEnd(Token $token): bool
+diff --git a/src/TokenParser/AutoEscapeTokenParser.php b/src/TokenParser/AutoEscapeTokenParser.php
+index b674bea4ab0..86feb27e621 100644
+--- a/src/TokenParser/AutoEscapeTokenParser.php
++++ b/src/TokenParser/AutoEscapeTokenParser.php
+@@ -29,21 +29,21 @@ public function parse(Token $token): Node
+         $lineno = $token->getLine();
+         $stream = $this->parser->getStream();
+ 
+-        if ($stream->test(/* Token::BLOCK_END_TYPE */ 3)) {
++        if ($stream->test(Token::BLOCK_END_TYPE)) {
+             $value = 'html';
+         } else {
+-            $expr = $this->parser->getExpressionParser()->parseExpression();
++            $expr = $this->parser->parseExpression();
+             if (!$expr instanceof ConstantExpression) {
+                 throw new SyntaxError('An escaping strategy must be a string or false.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+             }
+             $value = $expr->getAttribute('value');
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new AutoEscapeNode($value, $body, $lineno, $this->getTag());
++        return new AutoEscapeNode($value, $body, $lineno);
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+diff --git a/src/TokenParser/BlockTokenParser.php b/src/TokenParser/BlockTokenParser.php
+index c654d31f940..452b323e533 100644
+--- a/src/TokenParser/BlockTokenParser.php
++++ b/src/TokenParser/BlockTokenParser.php
+@@ -15,7 +15,9 @@
+ use Twig\Error\SyntaxError;
+ use Twig\Node\BlockNode;
+ use Twig\Node\BlockReferenceNode;
++use Twig\Node\EmptyNode;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Node\PrintNode;
+ use Twig\Token;
+ 
+@@ -35,17 +37,14 @@ public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+         $stream = $this->parser->getStream();
+-        $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
+-        if ($this->parser->hasBlock($name)) {
+-            throw new SyntaxError(\sprintf("The block '%s' has already been defined line %d.", $name, $this->parser->getBlock($name)->getTemplateLine()), $stream->getCurrent()->getLine(), $stream->getSourceContext());
+-        }
+-        $this->parser->setBlock($name, $block = new BlockNode($name, new Node([]), $lineno));
++        $name = $stream->expect(Token::NAME_TYPE)->getValue();
++        $this->parser->setBlock($name, $block = new BlockNode($name, new EmptyNode(), $lineno));
+         $this->parser->pushLocalScope();
+         $this->parser->pushBlockStack($name);
+ 
+-        if ($stream->nextIf(/* Token::BLOCK_END_TYPE */ 3)) {
++        if ($stream->nextIf(Token::BLOCK_END_TYPE)) {
+             $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+-            if ($token = $stream->nextIf(/* Token::NAME_TYPE */ 5)) {
++            if ($token = $stream->nextIf(Token::NAME_TYPE)) {
+                 $value = $token->getValue();
+ 
+                 if ($value != $name) {
+@@ -53,17 +52,17 @@ public function parse(Token $token): Node
+                 }
+             }
+         } else {
+-            $body = new Node([
+-                new PrintNode($this->parser->getExpressionParser()->parseExpression(), $lineno),
++            $body = new Nodes([
++                new PrintNode($this->parser->parseExpression(), $lineno),
+             ]);
+         }
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+         $block->setNode('body', $body);
+         $this->parser->popBlockStack();
+         $this->parser->popLocalScope();
+ 
+-        return new BlockReferenceNode($name, $lineno, $this->getTag());
++        return new BlockReferenceNode($name, $lineno);
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+diff --git a/src/TokenParser/DeprecatedTokenParser.php b/src/TokenParser/DeprecatedTokenParser.php
+index c17c4aadc29..df1ba381f44 100644
+--- a/src/TokenParser/DeprecatedTokenParser.php
++++ b/src/TokenParser/DeprecatedTokenParser.php
+@@ -33,9 +33,8 @@ final class DeprecatedTokenParser extends AbstractTokenParser
+     public function parse(Token $token): Node
+     {
+         $stream = $this->parser->getStream();
+-        $expressionParser = $this->parser->getExpressionParser();
+-        $expr = $expressionParser->parseExpression();
+-        $node = new DeprecatedNode($expr, $token->getLine(), $this->getTag());
++        $expr = $this->parser->parseExpression();
++        $node = new DeprecatedNode($expr, $token->getLine());
+ 
+         while ($stream->test(Token::NAME_TYPE)) {
+             $k = $stream->getCurrent()->getValue();
+@@ -44,10 +43,10 @@ public function parse(Token $token): Node
+ 
+             switch ($k) {
+                 case 'package':
+-                    $node->setNode('package', $expressionParser->parseExpression());
++                    $node->setNode('package', $this->parser->parseExpression());
+                     break;
+                 case 'version':
+-                    $node->setNode('version', $expressionParser->parseExpression());
++                    $node->setNode('version', $this->parser->parseExpression());
+                     break;
+                 default:
+                     throw new SyntaxError(\sprintf('Unknown "%s" option.', $k), $stream->getCurrent()->getLine(), $stream->getSourceContext());
+diff --git a/src/TokenParser/DoTokenParser.php b/src/TokenParser/DoTokenParser.php
+index 32c8f12ff86..ca9d03d454f 100644
+--- a/src/TokenParser/DoTokenParser.php
++++ b/src/TokenParser/DoTokenParser.php
+@@ -24,11 +24,11 @@ final class DoTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $expr = $this->parser->getExpressionParser()->parseExpression();
++        $expr = $this->parser->parseExpression();
+ 
+-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new DoNode($expr, $token->getLine(), $this->getTag());
++        return new DoNode($expr, $token->getLine());
+     }
+ 
+     public function getTag(): string
+diff --git a/src/TokenParser/EmbedTokenParser.php b/src/TokenParser/EmbedTokenParser.php
+index adf683cc19e..fa279104614 100644
+--- a/src/TokenParser/EmbedTokenParser.php
++++ b/src/TokenParser/EmbedTokenParser.php
+@@ -13,7 +13,7 @@
+ 
+ use Twig\Node\EmbedNode;
+ use Twig\Node\Expression\ConstantExpression;
+-use Twig\Node\Expression\NameExpression;
++use Twig\Node\Expression\Variable\ContextVariable;
+ use Twig\Node\Node;
+ use Twig\Token;
+ 
+@@ -28,23 +28,23 @@ public function parse(Token $token): Node
+     {
+         $stream = $this->parser->getStream();
+ 
+-        $parent = $this->parser->getExpressionParser()->parseExpression();
++        $parent = $this->parser->parseExpression();
+ 
+         [$variables, $only, $ignoreMissing] = $this->parseArguments();
+ 
+-        $parentToken = $fakeParentToken = new Token(/* Token::STRING_TYPE */ 7, '__parent__', $token->getLine());
++        $parentToken = $fakeParentToken = new Token(Token::STRING_TYPE, '__parent__', $token->getLine());
+         if ($parent instanceof ConstantExpression) {
+-            $parentToken = new Token(/* Token::STRING_TYPE */ 7, $parent->getAttribute('value'), $token->getLine());
+-        } elseif ($parent instanceof NameExpression) {
+-            $parentToken = new Token(/* Token::NAME_TYPE */ 5, $parent->getAttribute('name'), $token->getLine());
++            $parentToken = new Token(Token::STRING_TYPE, $parent->getAttribute('value'), $token->getLine());
++        } elseif ($parent instanceof ContextVariable) {
++            $parentToken = new Token(Token::NAME_TYPE, $parent->getAttribute('name'), $token->getLine());
+         }
+ 
+         // inject a fake parent to make the parent() function work
+         $stream->injectTokens([
+-            new Token(/* Token::BLOCK_START_TYPE */ 1, '', $token->getLine()),
+-            new Token(/* Token::NAME_TYPE */ 5, 'extends', $token->getLine()),
++            new Token(Token::BLOCK_START_TYPE, '', $token->getLine()),
++            new Token(Token::NAME_TYPE, 'extends', $token->getLine()),
+             $parentToken,
+-            new Token(/* Token::BLOCK_END_TYPE */ 3, '', $token->getLine()),
++            new Token(Token::BLOCK_END_TYPE, '', $token->getLine()),
+         ]);
+ 
+         $module = $this->parser->parse($stream, [$this, 'decideBlockEnd'], true);
+@@ -56,9 +56,9 @@ public function parse(Token $token): Node
+ 
+         $this->parser->embedTemplate($module);
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new EmbedNode($module->getTemplateName(), $module->getAttribute('index'), $variables, $only, $ignoreMissing, $token->getLine(), $this->getTag());
++        return new EmbedNode($module->getTemplateName(), $module->getAttribute('index'), $variables, $only, $ignoreMissing, $token->getLine());
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+diff --git a/src/TokenParser/ExtendsTokenParser.php b/src/TokenParser/ExtendsTokenParser.php
+index 0ca46dd29f7..8f64698187d 100644
+--- a/src/TokenParser/ExtendsTokenParser.php
++++ b/src/TokenParser/ExtendsTokenParser.php
+@@ -13,6 +13,7 @@
+ namespace Twig\TokenParser;
+ 
+ use Twig\Error\SyntaxError;
++use Twig\Node\EmptyNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+ 
+@@ -35,14 +36,11 @@ public function parse(Token $token): Node
+             throw new SyntaxError('Cannot use "extend" in a macro.', $token->getLine(), $stream->getSourceContext());
+         }
+ 
+-        if (null !== $this->parser->getParent()) {
+-            throw new SyntaxError('Multiple extends tags are forbidden.', $token->getLine(), $stream->getSourceContext());
+-        }
+-        $this->parser->setParent($this->parser->getExpressionParser()->parseExpression());
++        $this->parser->setParent($this->parser->parseExpression());
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new Node();
++        return new EmptyNode($token->getLine());
+     }
+ 
+     public function getTag(): string
+diff --git a/src/TokenParser/FlushTokenParser.php b/src/TokenParser/FlushTokenParser.php
+index 02c74aa134b..0d238874579 100644
+--- a/src/TokenParser/FlushTokenParser.php
++++ b/src/TokenParser/FlushTokenParser.php
+@@ -26,9 +26,9 @@ final class FlushTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new FlushNode($token->getLine(), $this->getTag());
++        return new FlushNode($token->getLine());
+     }
+ 
+     public function getTag(): string
+diff --git a/src/TokenParser/ForTokenParser.php b/src/TokenParser/ForTokenParser.php
+index 1af6da8fde5..21166fc1fab 100644
+--- a/src/TokenParser/ForTokenParser.php
++++ b/src/TokenParser/ForTokenParser.php
+@@ -12,7 +12,8 @@
+ 
+ namespace Twig\TokenParser;
+ 
+-use Twig\Node\Expression\AssignNameExpression;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\ForElseNode;
+ use Twig\Node\ForNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+@@ -34,31 +35,32 @@ public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+         $stream = $this->parser->getStream();
+-        $targets = $this->parser->getExpressionParser()->parseAssignmentExpression();
+-        $stream->expect(/* Token::OPERATOR_TYPE */ 8, 'in');
+-        $seq = $this->parser->getExpressionParser()->parseExpression();
++        $targets = $this->parseAssignmentExpression();
++        $stream->expect(Token::OPERATOR_TYPE, 'in');
++        $seq = $this->parser->parseExpression();
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+         $body = $this->parser->subparse([$this, 'decideForFork']);
+         if ('else' == $stream->next()->getValue()) {
+-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
+-            $else = $this->parser->subparse([$this, 'decideForEnd'], true);
++            $elseLineno = $stream->getCurrent()->getLine();
++            $stream->expect(Token::BLOCK_END_TYPE);
++            $else = new ForElseNode($this->parser->subparse([$this, 'decideForEnd'], true), $elseLineno);
+         } else {
+             $else = null;
+         }
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+         if (\count($targets) > 1) {
+             $keyTarget = $targets->getNode('0');
+-            $keyTarget = new AssignNameExpression($keyTarget->getAttribute('name'), $keyTarget->getTemplateLine());
++            $keyTarget = new AssignContextVariable($keyTarget->getAttribute('name'), $keyTarget->getTemplateLine());
+             $valueTarget = $targets->getNode('1');
+         } else {
+-            $keyTarget = new AssignNameExpression('_key', $lineno);
++            $keyTarget = new AssignContextVariable('_key', $lineno);
+             $valueTarget = $targets->getNode('0');
+         }
+-        $valueTarget = new AssignNameExpression($valueTarget->getAttribute('name'), $valueTarget->getTemplateLine());
++        $valueTarget = new AssignContextVariable($valueTarget->getAttribute('name'), $valueTarget->getTemplateLine());
+ 
+-        return new ForNode($keyTarget, $valueTarget, $seq, null, $body, $else, $lineno, $this->getTag());
++        return new ForNode($keyTarget, $valueTarget, $seq, null, $body, $else, $lineno);
+     }
+ 
+     public function decideForFork(Token $token): bool
+diff --git a/src/TokenParser/FromTokenParser.php b/src/TokenParser/FromTokenParser.php
+index 31b6cde4148..1c80a171777 100644
+--- a/src/TokenParser/FromTokenParser.php
++++ b/src/TokenParser/FromTokenParser.php
+@@ -11,7 +11,9 @@
+ 
+ namespace Twig\TokenParser;
+ 
+-use Twig\Node\Expression\AssignNameExpression;
++use Twig\Node\Expression\Variable\AssignContextVariable;
++use Twig\Node\Expression\Variable\AssignTemplateVariable;
++use Twig\Node\Expression\Variable\TemplateVariable;
+ use Twig\Node\ImportNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+@@ -19,7 +21,7 @@
+ /**
+  * Imports macros.
+  *
+- *   {% from 'forms.html' import forms %}
++ *   {% from 'forms.html.twig' import forms %}
+  *
+  * @internal
+  */
+@@ -27,33 +29,34 @@ final class FromTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $macro = $this->parser->getExpressionParser()->parseExpression();
++        $macro = $this->parser->parseExpression();
+         $stream = $this->parser->getStream();
+-        $stream->expect(/* Token::NAME_TYPE */ 5, 'import');
++        $stream->expect(Token::NAME_TYPE, 'import');
+ 
+         $targets = [];
+         while (true) {
+-            $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
++            $name = $stream->expect(Token::NAME_TYPE)->getValue();
+ 
+-            $alias = $name;
+             if ($stream->nextIf('as')) {
+-                $alias = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
++                $alias = new AssignContextVariable($stream->expect(Token::NAME_TYPE)->getValue(), $token->getLine());
++            } else {
++                $alias = new AssignContextVariable($name, $token->getLine());
+             }
+ 
+             $targets[$name] = $alias;
+ 
+-            if (!$stream->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
++            if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
+                 break;
+             }
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        $var = new AssignNameExpression($this->parser->getVarName(), $token->getLine());
+-        $node = new ImportNode($macro, $var, $token->getLine(), $this->getTag(), $this->parser->isMainScope());
++        $internalRef = new AssignTemplateVariable(new TemplateVariable(null, $token->getLine()), $this->parser->isMainScope());
++        $node = new ImportNode($macro, $internalRef, $token->getLine());
+ 
+         foreach ($targets as $name => $alias) {
+-            $this->parser->addImportedSymbol('function', $alias, 'macro_'.$name, $var);
++            $this->parser->addImportedSymbol('function', $alias->getAttribute('name'), 'macro_'.$name, $internalRef);
+         }
+ 
+         return $node;
+diff --git a/src/TokenParser/GuardTokenParser.php b/src/TokenParser/GuardTokenParser.php
+new file mode 100644
+index 00000000000..eb48865795c
+--- /dev/null
++++ b/src/TokenParser/GuardTokenParser.php
+@@ -0,0 +1,79 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\TokenParser;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\EmptyNode;
++use Twig\Node\Node;
++use Twig\Node\Nodes;
++use Twig\Token;
++
++/**
++ * @internal
++ */
++final class GuardTokenParser extends AbstractTokenParser
++{
++    public function parse(Token $token): Node
++    {
++        $stream = $this->parser->getStream();
++        $typeToken = $stream->expect(Token::NAME_TYPE);
++        if (!\in_array($typeToken->getValue(), ['function', 'filter', 'test'], true)) {
++            throw new SyntaxError(\sprintf('Supported guard types are function, filter and test, "%s" given.', $typeToken->getValue()), $typeToken->getLine(), $stream->getSourceContext());
++        }
++        $method = 'get'.$typeToken->getValue();
++
++        $nameToken = $stream->expect(Token::NAME_TYPE);
++        $name = $nameToken->getValue();
++        if ('test' === $typeToken->getValue() && $stream->test(Token::NAME_TYPE)) {
++            // try 2-words tests
++            $name .= ' '.$stream->getCurrent()->getValue();
++            $stream->next();
++        }
++
++        try {
++            $exists = null !== $this->parser->getEnvironment()->$method($name);
++        } catch (SyntaxError) {
++            $exists = false;
++        }
++
++        $stream->expect(Token::BLOCK_END_TYPE);
++        if ($exists) {
++            $body = $this->parser->subparse([$this, 'decideGuardFork']);
++        } else {
++            $body = new EmptyNode();
++            $this->parser->subparseIgnoreUnknownTwigCallables([$this, 'decideGuardFork']);
++        }
++        $else = new EmptyNode();
++        if ('else' === $stream->next()->getValue()) {
++            $stream->expect(Token::BLOCK_END_TYPE);
++            $else = $this->parser->subparse([$this, 'decideGuardEnd'], true);
++        }
++        $stream->expect(Token::BLOCK_END_TYPE);
++
++        return new Nodes([$exists ? $body : $else]);
++    }
++
++    public function decideGuardFork(Token $token): bool
++    {
++        return $token->test(['else', 'endguard']);
++    }
++
++    public function decideGuardEnd(Token $token): bool
++    {
++        return $token->test(['endguard']);
++    }
++
++    public function getTag(): string
++    {
++        return 'guard';
++    }
++}
+diff --git a/src/TokenParser/IfTokenParser.php b/src/TokenParser/IfTokenParser.php
+index 569ccfaf11a..4e3588e5be5 100644
+--- a/src/TokenParser/IfTokenParser.php
++++ b/src/TokenParser/IfTokenParser.php
+@@ -15,6 +15,7 @@
+ use Twig\Error\SyntaxError;
+ use Twig\Node\IfNode;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Token;
+ 
+ /**
+@@ -35,9 +36,9 @@ final class IfTokenParser extends AbstractTokenParser
+     public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+-        $expr = $this->parser->getExpressionParser()->parseExpression();
++        $expr = $this->parser->parseExpression();
+         $stream = $this->parser->getStream();
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+         $body = $this->parser->subparse([$this, 'decideIfFork']);
+         $tests = [$expr, $body];
+         $else = null;
+@@ -46,13 +47,13 @@ public function parse(Token $token): Node
+         while (!$end) {
+             switch ($stream->next()->getValue()) {
+                 case 'else':
+-                    $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++                    $stream->expect(Token::BLOCK_END_TYPE);
+                     $else = $this->parser->subparse([$this, 'decideIfEnd']);
+                     break;
+ 
+                 case 'elseif':
+-                    $expr = $this->parser->getExpressionParser()->parseExpression();
+-                    $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++                    $expr = $this->parser->parseExpression();
++                    $stream->expect(Token::BLOCK_END_TYPE);
+                     $body = $this->parser->subparse([$this, 'decideIfFork']);
+                     $tests[] = $expr;
+                     $tests[] = $body;
+@@ -67,9 +68,9 @@ public function parse(Token $token): Node
+             }
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new IfNode(new Node($tests), $else, $lineno, $this->getTag());
++        return new IfNode(new Nodes($tests), $else, $lineno);
+     }
+ 
+     public function decideIfFork(Token $token): bool
+diff --git a/src/TokenParser/ImportTokenParser.php b/src/TokenParser/ImportTokenParser.php
+index 44cb4dad79d..6dcb7662cbf 100644
+--- a/src/TokenParser/ImportTokenParser.php
++++ b/src/TokenParser/ImportTokenParser.php
+@@ -11,7 +11,8 @@
+ 
+ namespace Twig\TokenParser;
+ 
+-use Twig\Node\Expression\AssignNameExpression;
++use Twig\Node\Expression\Variable\AssignTemplateVariable;
++use Twig\Node\Expression\Variable\TemplateVariable;
+ use Twig\Node\ImportNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+@@ -19,7 +20,7 @@
+ /**
+  * Imports macros.
+  *
+- *   {% import 'forms.html' as forms %}
++ *   {% import 'forms.html.twig' as forms %}
+  *
+  * @internal
+  */
+@@ -27,14 +28,14 @@ final class ImportTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $macro = $this->parser->getExpressionParser()->parseExpression();
+-        $this->parser->getStream()->expect(/* Token::NAME_TYPE */ 5, 'as');
+-        $var = new AssignNameExpression($this->parser->getStream()->expect(/* Token::NAME_TYPE */ 5)->getValue(), $token->getLine());
+-        $this->parser->getStream()->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $macro = $this->parser->parseExpression();
++        $this->parser->getStream()->expect(Token::NAME_TYPE, 'as');
++        $name = $this->parser->getStream()->expect(Token::NAME_TYPE)->getValue();
++        $var = new AssignTemplateVariable(new TemplateVariable($name, $token->getLine()), $this->parser->isMainScope());
++        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
++        $this->parser->addImportedSymbol('template', $name);
+ 
+-        $this->parser->addImportedSymbol('template', $var->getAttribute('name'));
+-
+-        return new ImportNode($macro, $var, $token->getLine(), $this->getTag(), $this->parser->isMainScope());
++        return new ImportNode($macro, $var, $token->getLine());
+     }
+ 
+     public function getTag(): string
+diff --git a/src/TokenParser/IncludeTokenParser.php b/src/TokenParser/IncludeTokenParser.php
+index fda5bfd8c0a..55ac1516c4e 100644
+--- a/src/TokenParser/IncludeTokenParser.php
++++ b/src/TokenParser/IncludeTokenParser.php
+@@ -12,6 +12,7 @@
+ 
+ namespace Twig\TokenParser;
+ 
++use Twig\Node\Expression\AbstractExpression;
+ use Twig\Node\IncludeNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+@@ -19,9 +20,9 @@
+ /**
+  * Includes a template.
+  *
+- *   {% include 'header.html' %}
++ *   {% include 'header.html.twig' %}
+  *     Body
+- *   {% include 'footer.html' %}
++ *   {% include 'footer.html.twig' %}
+  *
+  * @internal
+  */
+@@ -29,35 +30,38 @@ class IncludeTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $expr = $this->parser->getExpressionParser()->parseExpression();
++        $expr = $this->parser->parseExpression();
+ 
+         [$variables, $only, $ignoreMissing] = $this->parseArguments();
+ 
+-        return new IncludeNode($expr, $variables, $only, $ignoreMissing, $token->getLine(), $this->getTag());
++        return new IncludeNode($expr, $variables, $only, $ignoreMissing, $token->getLine());
+     }
+ 
++    /**
++     * @return array{0: ?AbstractExpression, 1: bool, 2: bool}
++     */
+     protected function parseArguments()
+     {
+         $stream = $this->parser->getStream();
+ 
+         $ignoreMissing = false;
+-        if ($stream->nextIf(/* Token::NAME_TYPE */ 5, 'ignore')) {
+-            $stream->expect(/* Token::NAME_TYPE */ 5, 'missing');
++        if ($stream->nextIf(Token::NAME_TYPE, 'ignore')) {
++            $stream->expect(Token::NAME_TYPE, 'missing');
+ 
+             $ignoreMissing = true;
+         }
+ 
+         $variables = null;
+-        if ($stream->nextIf(/* Token::NAME_TYPE */ 5, 'with')) {
+-            $variables = $this->parser->getExpressionParser()->parseExpression();
++        if ($stream->nextIf(Token::NAME_TYPE, 'with')) {
++            $variables = $this->parser->parseExpression();
+         }
+ 
+         $only = false;
+-        if ($stream->nextIf(/* Token::NAME_TYPE */ 5, 'only')) {
++        if ($stream->nextIf(Token::NAME_TYPE, 'only')) {
+             $only = true;
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+         return [$variables, $only, $ignoreMissing];
+     }
+diff --git a/src/TokenParser/MacroTokenParser.php b/src/TokenParser/MacroTokenParser.php
+index 1f0e3e97fd1..38e66c81073 100644
+--- a/src/TokenParser/MacroTokenParser.php
++++ b/src/TokenParser/MacroTokenParser.php
+@@ -13,6 +13,12 @@
+ 
+ use Twig\Error\SyntaxError;
+ use Twig\Node\BodyNode;
++use Twig\Node\EmptyNode;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\Unary\NegUnary;
++use Twig\Node\Expression\Unary\PosUnary;
++use Twig\Node\Expression\Variable\LocalVariable;
+ use Twig\Node\MacroNode;
+ use Twig\Node\Node;
+ use Twig\Token;
+@@ -32,14 +38,13 @@ public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+         $stream = $this->parser->getStream();
+-        $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
++        $name = $stream->expect(Token::NAME_TYPE)->getValue();
++        $arguments = $this->parseDefinition();
+ 
+-        $arguments = $this->parser->getExpressionParser()->parseArguments(true, true);
+-
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+         $this->parser->pushLocalScope();
+         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+-        if ($token = $stream->nextIf(/* Token::NAME_TYPE */ 5)) {
++        if ($token = $stream->nextIf(Token::NAME_TYPE)) {
+             $value = $token->getValue();
+ 
+             if ($value != $name) {
+@@ -47,11 +52,11 @@ public function parse(Token $token): Node
+             }
+         }
+         $this->parser->popLocalScope();
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        $this->parser->setMacro($name, new MacroNode($name, new BodyNode([$body]), $arguments, $lineno, $this->getTag()));
++        $this->parser->setMacro($name, new MacroNode($name, new BodyNode([$body]), $arguments, $lineno));
+ 
+-        return new Node();
++        return new EmptyNode($lineno);
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+@@ -63,4 +68,56 @@ public function getTag(): string
+     {
+         return 'macro';
+     }
++
++    private function parseDefinition(): ArrayExpression
++    {
++        $arguments = new ArrayExpression([], $this->parser->getCurrentToken()->getLine());
++        $stream = $this->parser->getStream();
++        $stream->expect(Token::OPERATOR_TYPE, '(', 'A list of arguments must begin with an opening parenthesis');
++        while (!$stream->test(Token::PUNCTUATION_TYPE, ')')) {
++            if (\count($arguments)) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'Arguments must be separated by a comma');
++
++                // if the comma above was a trailing comma, early exit the argument parse loop
++                if ($stream->test(Token::PUNCTUATION_TYPE, ')')) {
++                    break;
++                }
++            }
++
++            $token = $stream->expect(Token::NAME_TYPE, null, 'An argument must be a name');
++            $name = new LocalVariable($token->getValue(), $this->parser->getCurrentToken()->getLine());
++            if ($token = $stream->nextIf(Token::OPERATOR_TYPE, '=')) {
++                $default = $this->parser->parseExpression();
++            } else {
++                $default = new ConstantExpression(null, $this->parser->getCurrentToken()->getLine());
++                $default->setAttribute('is_implicit', true);
++            }
++
++            if (!$this->checkConstantExpression($default)) {
++                throw new SyntaxError('A default value for an argument must be a constant (a boolean, a string, a number, a sequence, or a mapping).', $token->getLine(), $stream->getSourceContext());
++            }
++            $arguments->addElement($default, $name);
++        }
++        $stream->expect(Token::PUNCTUATION_TYPE, ')', 'A list of arguments must be closed by a parenthesis');
++
++        return $arguments;
++    }
++
++    // checks that the node only contains "constant" elements
++    private function checkConstantExpression(Node $node): bool
++    {
++        if (!($node instanceof ConstantExpression || $node instanceof ArrayExpression
++            || $node instanceof NegUnary || $node instanceof PosUnary
++        )) {
++            return false;
++        }
++
++        foreach ($node as $n) {
++            if (!$this->checkConstantExpression($n)) {
++                return false;
++            }
++        }
++
++        return true;
++    }
+ }
+diff --git a/src/TokenParser/SandboxTokenParser.php b/src/TokenParser/SandboxTokenParser.php
+index c919556eccb..e6f4a63f363 100644
+--- a/src/TokenParser/SandboxTokenParser.php
++++ b/src/TokenParser/SandboxTokenParser.php
+@@ -22,7 +22,7 @@
+  * Marks a section of a template as untrusted code that must be evaluated in the sandbox mode.
+  *
+  *    {% sandbox %}
+- *        {% include 'user.html' %}
++ *        {% include 'user.html.twig' %}
+  *    {% endsandbox %}
+  *
+  * @see https://twig.symfony.com/doc/api.html#sandbox-extension for details
+@@ -34,12 +34,16 @@ final class SandboxTokenParser extends AbstractTokenParser
+     public function parse(Token $token): Node
+     {
+         $stream = $this->parser->getStream();
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        trigger_deprecation('twig/twig', '3.15', \sprintf('The "sandbox" tag is deprecated in "%s" at line %d.', $stream->getSourceContext()->getName(), $token->getLine()));
++
++        $stream->expect(Token::BLOCK_END_TYPE);
+         $body = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+         // in a sandbox tag, only include tags are allowed
+-        if (!$body instanceof IncludeNode) {
++        if ($body instanceof IncludeNode) {
++            $body->setAttribute('sandboxed', true);
++        } else {
+             foreach ($body as $node) {
+                 if ($node instanceof TextNode && ctype_space($node->getAttribute('data'))) {
+                     continue;
+@@ -48,10 +52,12 @@ public function parse(Token $token): Node
+                 if (!$node instanceof IncludeNode) {
+                     throw new SyntaxError('Only "include" tags are allowed within a "sandbox" section.', $node->getTemplateLine(), $stream->getSourceContext());
+                 }
++
++                $node->setAttribute('sandboxed', true);
+             }
+         }
+ 
+-        return new SandboxNode($body, $token->getLine(), $this->getTag());
++        return new SandboxNode($body, $token->getLine());
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+diff --git a/src/TokenParser/SetTokenParser.php b/src/TokenParser/SetTokenParser.php
+index 2fbdfe0901f..1aabbf582b1 100644
+--- a/src/TokenParser/SetTokenParser.php
++++ b/src/TokenParser/SetTokenParser.php
+@@ -13,6 +13,7 @@
+ 
+ use Twig\Error\SyntaxError;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Node\SetNode;
+ use Twig\Token;
+ 
+@@ -34,13 +35,13 @@ public function parse(Token $token): Node
+     {
+         $lineno = $token->getLine();
+         $stream = $this->parser->getStream();
+-        $names = $this->parser->getExpressionParser()->parseAssignmentExpression();
++        $names = $this->parseAssignmentExpression();
+ 
+         $capture = false;
+-        if ($stream->nextIf(/* Token::OPERATOR_TYPE */ 8, '=')) {
+-            $values = $this->parser->getExpressionParser()->parseMultitargetExpression();
++        if ($stream->nextIf(Token::OPERATOR_TYPE, '=')) {
++            $values = $this->parseMultitargetExpression();
+ 
+-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++            $stream->expect(Token::BLOCK_END_TYPE);
+ 
+             if (\count($names) !== \count($values)) {
+                 throw new SyntaxError('When using set, you must have the same number of variables and assignments.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+@@ -52,13 +53,13 @@ public function parse(Token $token): Node
+                 throw new SyntaxError('When using set with a block, you cannot have a multi-target.', $stream->getCurrent()->getLine(), $stream->getSourceContext());
+             }
+ 
+-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++            $stream->expect(Token::BLOCK_END_TYPE);
+ 
+             $values = $this->parser->subparse([$this, 'decideBlockEnd'], true);
+-            $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++            $stream->expect(Token::BLOCK_END_TYPE);
+         }
+ 
+-        return new SetNode($capture, $names, $values, $lineno, $this->getTag());
++        return new SetNode($capture, $names, $values, $lineno);
+     }
+ 
+     public function decideBlockEnd(Token $token): bool
+@@ -70,4 +71,17 @@ public function getTag(): string
+     {
+         return 'set';
+     }
++
++    private function parseMultitargetExpression(): Nodes
++    {
++        $targets = [];
++        while (true) {
++            $targets[] = $this->parser->parseExpression();
++            if (!$this->parser->getStream()->nextIf(Token::PUNCTUATION_TYPE, ',')) {
++                break;
++            }
++        }
++
++        return new Nodes($targets);
++    }
+ }
+diff --git a/src/TokenParser/TypesTokenParser.php b/src/TokenParser/TypesTokenParser.php
+new file mode 100644
+index 00000000000..2c7b77c024b
+--- /dev/null
++++ b/src/TokenParser/TypesTokenParser.php
+@@ -0,0 +1,89 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\TokenParser;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\Node;
++use Twig\Node\TypesNode;
++use Twig\Token;
++use Twig\TokenStream;
++
++/**
++ * Declare variable types.
++ *
++ *  {% types {foo: 'number', bar?: 'string'} %}
++ *
++ * @author Jeroen Versteeg <jeroen@alisqi.com>
++ *
++ * @internal
++ */
++final class TypesTokenParser extends AbstractTokenParser
++{
++    public function parse(Token $token): Node
++    {
++        $stream = $this->parser->getStream();
++        $types = $this->parseSimpleMappingExpression($stream);
++        $stream->expect(Token::BLOCK_END_TYPE);
++
++        return new TypesNode($types, $token->getLine());
++    }
++
++    /**
++     * @return array<string, array{type: string, optional: bool}>
++     *
++     * @throws SyntaxError
++     */
++    private function parseSimpleMappingExpression(TokenStream $stream): array
++    {
++        $enclosed = null !== $stream->nextIf(Token::PUNCTUATION_TYPE, '{');
++        $types = [];
++        $first = true;
++        while (!($stream->test(Token::PUNCTUATION_TYPE, '}') || $stream->test(Token::BLOCK_END_TYPE))) {
++            if (!$first) {
++                $stream->expect(Token::PUNCTUATION_TYPE, ',', 'A type string must be followed by a comma');
++
++                // trailing ,?
++                if ($stream->test(Token::PUNCTUATION_TYPE, '}') || $stream->test(Token::BLOCK_END_TYPE)) {
++                    break;
++                }
++            }
++            $first = false;
++
++            $nameToken = $stream->expect(Token::NAME_TYPE);
++
++            if ($stream->nextIf(Token::OPERATOR_TYPE, '?:')) {
++                $isOptional = true;
++            } else {
++                $isOptional = null !== $stream->nextIf(Token::OPERATOR_TYPE, '?');
++                $stream->expect(Token::PUNCTUATION_TYPE, ':', 'A type name must be followed by a colon (:)');
++            }
++
++            $valueToken = $stream->expect(Token::STRING_TYPE);
++
++            $types[$nameToken->getValue()] = [
++                'type' => $valueToken->getValue(),
++                'optional' => $isOptional,
++            ];
++        }
++
++        if ($enclosed) {
++            $stream->expect(Token::PUNCTUATION_TYPE, '}', 'An opened mapping is not properly closed');
++        }
++
++        return $types;
++    }
++
++    public function getTag(): string
++    {
++        return 'types';
++    }
++}
+diff --git a/src/TokenParser/UseTokenParser.php b/src/TokenParser/UseTokenParser.php
+index 3cdbb98ad01..41386c8b479 100644
+--- a/src/TokenParser/UseTokenParser.php
++++ b/src/TokenParser/UseTokenParser.php
+@@ -12,8 +12,10 @@
+ namespace Twig\TokenParser;
+ 
+ use Twig\Error\SyntaxError;
++use Twig\Node\EmptyNode;
+ use Twig\Node\Expression\ConstantExpression;
+ use Twig\Node\Node;
++use Twig\Node\Nodes;
+ use Twig\Token;
+ 
+ /**
+@@ -34,7 +36,7 @@ final class UseTokenParser extends AbstractTokenParser
+ {
+     public function parse(Token $token): Node
+     {
+-        $template = $this->parser->getExpressionParser()->parseExpression();
++        $template = $this->parser->parseExpression();
+         $stream = $this->parser->getStream();
+ 
+         if (!$template instanceof ConstantExpression) {
+@@ -44,26 +46,26 @@ public function parse(Token $token): Node
+         $targets = [];
+         if ($stream->nextIf('with')) {
+             while (true) {
+-                $name = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
++                $name = $stream->expect(Token::NAME_TYPE)->getValue();
+ 
+                 $alias = $name;
+                 if ($stream->nextIf('as')) {
+-                    $alias = $stream->expect(/* Token::NAME_TYPE */ 5)->getValue();
++                    $alias = $stream->expect(Token::NAME_TYPE)->getValue();
+                 }
+ 
+                 $targets[$name] = new ConstantExpression($alias, -1);
+ 
+-                if (!$stream->nextIf(/* Token::PUNCTUATION_TYPE */ 9, ',')) {
++                if (!$stream->nextIf(Token::PUNCTUATION_TYPE, ',')) {
+                     break;
+                 }
+             }
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        $this->parser->addTrait(new Node(['template' => $template, 'targets' => new Node($targets)]));
++        $this->parser->addTrait(new Nodes(['template' => $template, 'targets' => new Nodes($targets)]));
+ 
+-        return new Node();
++        return new EmptyNode($token->getLine());
+     }
+ 
+     public function getTag(): string
+diff --git a/src/TokenParser/WithTokenParser.php b/src/TokenParser/WithTokenParser.php
+index 7d8cbe26165..83470d8651f 100644
+--- a/src/TokenParser/WithTokenParser.php
++++ b/src/TokenParser/WithTokenParser.php
+@@ -30,18 +30,18 @@ public function parse(Token $token): Node
+ 
+         $variables = null;
+         $only = false;
+-        if (!$stream->test(/* Token::BLOCK_END_TYPE */ 3)) {
+-            $variables = $this->parser->getExpressionParser()->parseExpression();
+-            $only = (bool) $stream->nextIf(/* Token::NAME_TYPE */ 5, 'only');
++        if (!$stream->test(Token::BLOCK_END_TYPE)) {
++            $variables = $this->parser->parseExpression();
++            $only = (bool) $stream->nextIf(Token::NAME_TYPE, 'only');
+         }
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+         $body = $this->parser->subparse([$this, 'decideWithEnd'], true);
+ 
+-        $stream->expect(/* Token::BLOCK_END_TYPE */ 3);
++        $stream->expect(Token::BLOCK_END_TYPE);
+ 
+-        return new WithNode($body, $variables, $only, $token->getLine(), $this->getTag());
++        return new WithNode($body, $variables, $only, $token->getLine());
+     }
+ 
+     public function decideWithEnd(Token $token): bool
+diff --git a/src/TokenStream.php b/src/TokenStream.php
+index 9921f788d88..7ee7539f1a3 100644
+--- a/src/TokenStream.php
++++ b/src/TokenStream.php
+@@ -21,21 +21,27 @@
+  */
+ final class TokenStream
+ {
+-    private $tokens;
+     private $current = 0;
+-    private $source;
+ 
+-    public function __construct(array $tokens, ?Source $source = null)
+-    {
+-        $this->tokens = $tokens;
+-        $this->source = $source ?: new Source('', '');
++    public function __construct(
++        private array $tokens,
++        private ?Source $source = null,
++    ) {
++        if (null === $this->source) {
++            trigger_deprecation('twig/twig', '3.16', \sprintf('Not passing a "%s" object to "%s" constructor is deprecated.', Source::class, __CLASS__));
++
++            $this->source = new Source('', '');
++        }
+     }
+ 
+-    public function __toString()
++    public function __toString(): string
+     {
+         return implode("\n", $this->tokens);
+     }
+ 
++    /**
++     * @return void
++     */
+     public function injectTokens(array $tokens)
+     {
+         $this->tokens = array_merge(\array_slice($this->tokens, 0, $this->current), $tokens, \array_slice($this->tokens, $this->current));
+@@ -73,7 +79,7 @@ public function expect($type, $value = null, ?string $message = null): Token
+             $line = $token->getLine();
+             throw new SyntaxError(\sprintf('%sUnexpected token "%s"%s ("%s" expected%s).',
+                 $message ? $message.'. ' : '',
+-                Token::typeToEnglish($token->getType()),
++                $token->toEnglish(),
+                 $token->getValue() ? \sprintf(' of value "%s"', $token->getValue()) : '',
+                 Token::typeToEnglish($type), $value ? \sprintf(' with value "%s"', $value) : ''),
+                 $line,
+@@ -110,7 +116,7 @@ public function test($primary, $secondary = null): bool
+      */
+     public function isEOF(): bool
+     {
+-        return /* Token::EOF_TYPE */ -1 === $this->tokens[$this->current]->getType();
++        return $this->tokens[$this->current]->test(Token::EOF_TYPE);
+     }
+ 
+     public function getCurrent(): Token
+@@ -118,11 +124,6 @@ public function getCurrent(): Token
+         return $this->tokens[$this->current];
+     }
+ 
+-    /**
+-     * Gets the source associated with this stream.
+-     *
+-     * @internal
+-     */
+     public function getSourceContext(): Source
+     {
+         return $this->source;
+diff --git a/src/TwigCallableInterface.php b/src/TwigCallableInterface.php
+new file mode 100644
+index 00000000000..4279b643029
+--- /dev/null
++++ b/src/TwigCallableInterface.php
+@@ -0,0 +1,55 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @method bool needsIsSandboxed() Whether the callable needs the current sandbox state passed as an argument. Not implementing this method is deprecated since Twig 3.25, it will be required in 4.0.
++ */
++interface TwigCallableInterface extends \Stringable
++{
++    public function getName(): string;
++
++    public function getType(): string;
++
++    public function getDynamicName(): string;
++
++    /**
++     * @return callable|array{class-string, string}|null
++     */
++    public function getCallable();
++
++    public function getNodeClass(): string;
++
++    public function needsCharset(): bool;
++
++    public function needsEnvironment(): bool;
++
++    public function needsContext(): bool;
++
++    public function withDynamicArguments(string $name, string $dynamicName, array $arguments): self;
++
++    public function getArguments(): array;
++
++    public function isVariadic(): bool;
++
++    public function isDeprecated(): bool;
++
++    public function getDeprecatingPackage(): string;
++
++    public function getDeprecatedVersion(): string;
++
++    public function getAlternative(): ?string;
++
++    public function getMinimalNumberOfRequiredArguments(): int;
++}
+diff --git a/src/TwigFilter.php b/src/TwigFilter.php
+index 2b80df9399b..dece5184355 100644
+--- a/src/TwigFilter.php
++++ b/src/TwigFilter.php
+@@ -21,79 +21,27 @@
+  *
+  * @see https://twig.symfony.com/doc/templates.html#filters
+  */
+-final class TwigFilter
++final class TwigFilter extends AbstractTwigCallable
+ {
+-    private $name;
+-    private $callable;
+-    private $options;
+-    private $arguments = [];
+-
+     /**
+      * @param callable|array{class-string, string}|null $callable A callable implementing the filter. If null, you need to overwrite the "node_class" option to customize compilation.
+      */
+     public function __construct(string $name, $callable = null, array $options = [])
+     {
+-        $this->name = $name;
+-        $this->callable = $callable;
++        parent::__construct($name, $callable, $options);
++
+         $this->options = array_merge([
+-            'needs_environment' => false,
+-            'needs_context' => false,
+-            'needs_charset' => false,
+-            'is_variadic' => false,
+             'is_safe' => null,
+             'is_safe_callback' => null,
+             'pre_escape' => null,
+             'preserves_safety' => null,
+             'node_class' => FilterExpression::class,
+-            'deprecated' => false,
+-            'deprecating_package' => '',
+-            'alternative' => null,
+-        ], $options);
+-    }
+-
+-    public function getName(): string
+-    {
+-        return $this->name;
+-    }
+-
+-    /**
+-     * Returns the callable to execute for this filter.
+-     *
+-     * @return callable|array{class-string, string}|null
+-     */
+-    public function getCallable()
+-    {
+-        return $this->callable;
+-    }
+-
+-    public function getNodeClass(): string
+-    {
+-        return $this->options['node_class'];
+-    }
+-
+-    public function setArguments(array $arguments): void
+-    {
+-        $this->arguments = $arguments;
+-    }
+-
+-    public function getArguments(): array
+-    {
+-        return $this->arguments;
++        ], $this->options);
+     }
+ 
+-    public function needsCharset(): bool
++    public function getType(): string
+     {
+-        return $this->options['needs_charset'];
+-    }
+-
+-    public function needsEnvironment(): bool
+-    {
+-        return $this->options['needs_environment'];
+-    }
+-
+-    public function needsContext(): bool
+-    {
+-        return $this->options['needs_context'];
++        return 'filter';
+     }
+ 
+     public function getSafe(Node $filterArgs): ?array
+@@ -106,12 +54,12 @@ public function getSafe(Node $filterArgs): ?array
+             return $this->options['is_safe_callback']($filterArgs);
+         }
+ 
+-        return null;
++        return [];
+     }
+ 
+-    public function getPreservesSafety(): ?array
++    public function getPreservesSafety(): array
+     {
+-        return $this->options['preserves_safety'];
++        return $this->options['preserves_safety'] ?? [];
+     }
+ 
+     public function getPreEscape(): ?string
+@@ -119,28 +67,8 @@ public function getPreEscape(): ?string
+         return $this->options['pre_escape'];
+     }
+ 
+-    public function isVariadic(): bool
+-    {
+-        return $this->options['is_variadic'];
+-    }
+-
+-    public function isDeprecated(): bool
+-    {
+-        return (bool) $this->options['deprecated'];
+-    }
+-
+-    public function getDeprecatingPackage(): string
+-    {
+-        return $this->options['deprecating_package'];
+-    }
+-
+-    public function getDeprecatedVersion(): string
+-    {
+-        return \is_bool($this->options['deprecated']) ? '' : $this->options['deprecated'];
+-    }
+-
+-    public function getAlternative(): ?string
++    public function getMinimalNumberOfRequiredArguments(): int
+     {
+-        return $this->options['alternative'];
++        return parent::getMinimalNumberOfRequiredArguments() + 1;
+     }
+ }
+diff --git a/src/TwigFunction.php b/src/TwigFunction.php
+index bfee7eb87e0..4a10df95e65 100644
+--- a/src/TwigFunction.php
++++ b/src/TwigFunction.php
+@@ -21,77 +21,31 @@
+  *
+  * @see https://twig.symfony.com/doc/templates.html#functions
+  */
+-final class TwigFunction
++final class TwigFunction extends AbstractTwigCallable
+ {
+-    private $name;
+-    private $callable;
+-    private $options;
+-    private $arguments = [];
+-
+     /**
+      * @param callable|array{class-string, string}|null $callable A callable implementing the function. If null, you need to overwrite the "node_class" option to customize compilation.
+      */
+     public function __construct(string $name, $callable = null, array $options = [])
+     {
+-        $this->name = $name;
+-        $this->callable = $callable;
++        parent::__construct($name, $callable, $options);
++
+         $this->options = array_merge([
+-            'needs_environment' => false,
+-            'needs_context' => false,
+-            'needs_charset' => false,
+-            'is_variadic' => false,
+             'is_safe' => null,
+             'is_safe_callback' => null,
+             'node_class' => FunctionExpression::class,
+-            'deprecated' => false,
+-            'deprecating_package' => '',
+-            'alternative' => null,
+-        ], $options);
+-    }
+-
+-    public function getName(): string
+-    {
+-        return $this->name;
+-    }
+-
+-    /**
+-     * Returns the callable to execute for this function.
+-     *
+-     * @return callable|array{class-string, string}|null
+-     */
+-    public function getCallable()
+-    {
+-        return $this->callable;
+-    }
+-
+-    public function getNodeClass(): string
+-    {
+-        return $this->options['node_class'];
+-    }
+-
+-    public function setArguments(array $arguments): void
+-    {
+-        $this->arguments = $arguments;
+-    }
+-
+-    public function getArguments(): array
+-    {
+-        return $this->arguments;
++            'parser_callable' => null,
++        ], $this->options);
+     }
+ 
+-    public function needsCharset(): bool
++    public function getType(): string
+     {
+-        return $this->options['needs_charset'];
++        return 'function';
+     }
+ 
+-    public function needsEnvironment(): bool
++    public function getParserCallable(): ?callable
+     {
+-        return $this->options['needs_environment'];
+-    }
+-
+-    public function needsContext(): bool
+-    {
+-        return $this->options['needs_context'];
++        return $this->options['parser_callable'];
+     }
+ 
+     public function getSafe(Node $functionArgs): ?array
+@@ -106,29 +60,4 @@ public function getSafe(Node $functionArgs): ?array
+ 
+         return [];
+     }
+-
+-    public function isVariadic(): bool
+-    {
+-        return (bool) $this->options['is_variadic'];
+-    }
+-
+-    public function isDeprecated(): bool
+-    {
+-        return (bool) $this->options['deprecated'];
+-    }
+-
+-    public function getDeprecatingPackage(): string
+-    {
+-        return $this->options['deprecating_package'];
+-    }
+-
+-    public function getDeprecatedVersion(): string
+-    {
+-        return \is_bool($this->options['deprecated']) ? '' : $this->options['deprecated'];
+-    }
+-
+-    public function getAlternative(): ?string
+-    {
+-        return $this->options['alternative'];
+-    }
+ }
+diff --git a/src/TwigTest.php b/src/TwigTest.php
+index 0b43a284906..5e58ad8b0e8 100644
+--- a/src/TwigTest.php
++++ b/src/TwigTest.php
+@@ -20,87 +20,48 @@
+  *
+  * @see https://twig.symfony.com/doc/templates.html#test-operator
+  */
+-final class TwigTest
++final class TwigTest extends AbstractTwigCallable
+ {
+-    private $name;
+-    private $callable;
+-    private $options;
+-    private $arguments = [];
+-
+     /**
+      * @param callable|array{class-string, string}|null $callable A callable implementing the test. If null, you need to overwrite the "node_class" option to customize compilation.
+      */
+     public function __construct(string $name, $callable = null, array $options = [])
+     {
+-        $this->name = $name;
+-        $this->callable = $callable;
++        parent::__construct($name, $callable, $options);
++
+         $this->options = array_merge([
+-            'is_variadic' => false,
+             'node_class' => TestExpression::class,
+-            'deprecated' => false,
+-            'deprecating_package' => '',
+-            'alternative' => null,
+             'one_mandatory_argument' => false,
+-        ], $options);
+-    }
+-
+-    public function getName(): string
+-    {
+-        return $this->name;
+-    }
+-
+-    /**
+-     * Returns the callable to execute for this test.
+-     *
+-     * @return callable|array{class-string, string}|null
+-     */
+-    public function getCallable()
+-    {
+-        return $this->callable;
++        ], $this->options);
+     }
+ 
+-    public function getNodeClass(): string
++    public function getType(): string
+     {
+-        return $this->options['node_class'];
++        return 'test';
+     }
+ 
+-    public function setArguments(array $arguments): void
++    public function needsCharset(): bool
+     {
+-        $this->arguments = $arguments;
++        return false;
+     }
+ 
+-    public function getArguments(): array
++    public function needsEnvironment(): bool
+     {
+-        return $this->arguments;
++        return false;
+     }
+ 
+-    public function isVariadic(): bool
++    public function needsContext(): bool
+     {
+-        return (bool) $this->options['is_variadic'];
++        return false;
+     }
+ 
+-    public function isDeprecated(): bool
+-    {
+-        return (bool) $this->options['deprecated'];
+-    }
+-
+-    public function getDeprecatingPackage(): string
+-    {
+-        return $this->options['deprecating_package'];
+-    }
+-
+-    public function getDeprecatedVersion(): string
+-    {
+-        return \is_bool($this->options['deprecated']) ? '' : $this->options['deprecated'];
+-    }
+-
+-    public function getAlternative(): ?string
++    public function hasOneMandatoryArgument(): bool
+     {
+-        return $this->options['alternative'];
++        return (bool) $this->options['one_mandatory_argument'];
+     }
+ 
+-    public function hasOneMandatoryArgument(): bool
++    public function getMinimalNumberOfRequiredArguments(): int
+     {
+-        return (bool) $this->options['one_mandatory_argument'];
++        return parent::getMinimalNumberOfRequiredArguments() + 1;
+     }
+ }
+diff --git a/src/Util/CallableArgumentsExtractor.php b/src/Util/CallableArgumentsExtractor.php
+new file mode 100644
+index 00000000000..c7bf5408891
+--- /dev/null
++++ b/src/Util/CallableArgumentsExtractor.php
+@@ -0,0 +1,223 @@
++<?php
++
++/*
++ * This file is part of Twig.
++ *
++ * (c) Fabien Potencier
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Twig\Util;
++
++use Twig\Error\SyntaxError;
++use Twig\Node\Expression\ArrayExpression;
++use Twig\Node\Expression\CallExpression;
++use Twig\Node\Expression\ConstantExpression;
++use Twig\Node\Expression\VariadicExpression;
++use Twig\Node\Node;
++use Twig\TwigCallableInterface;
++
++/**
++ * @author Fabien Potencier <fabien@symfony.com>
++ *
++ * @internal
++ */
++final class CallableArgumentsExtractor
++{
++    private ReflectionCallable $rc;
++
++    public function __construct(
++        private Node $node,
++        private TwigCallableInterface $twigCallable,
++    ) {
++        $this->rc = new ReflectionCallable($twigCallable);
++    }
++
++    /**
++     * @return array<Node>
++     */
++    public function extractArguments(Node $arguments): array
++    {
++        $extractedArguments = [];
++        $extractedArgumentNameMap = [];
++        $named = false;
++        foreach ($arguments as $name => $node) {
++            if (!\is_int($name)) {
++                $named = true;
++            } elseif ($named) {
++                throw new SyntaxError(\sprintf('Positional arguments cannot be used after named arguments for %s "%s".', $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
++            }
++
++            $extractedArguments[$normalizedName = $this->normalizeName($name)] = $node;
++            $extractedArgumentNameMap[$normalizedName] = $name;
++        }
++
++        if (!$named && !$this->twigCallable->isVariadic()) {
++            $min = $this->twigCallable->getMinimalNumberOfRequiredArguments();
++            if (\count($extractedArguments) < $this->rc->getReflector()->getNumberOfRequiredParameters() - $min) {
++                $argName = $this->toSnakeCase($this->rc->getReflector()->getParameters()[$min + \count($extractedArguments)]->getName());
++
++                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $argName, $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
++            }
++
++            return $extractedArguments;
++        }
++
++        if (!$callable = $this->twigCallable->getCallable()) {
++            if ($named) {
++                throw new SyntaxError(\sprintf('Named arguments are not supported for %s "%s".', $this->twigCallable->getType(), $this->twigCallable->getName()));
++            }
++
++            throw new SyntaxError(\sprintf('Arbitrary positional arguments are not supported for %s "%s".', $this->twigCallable->getType(), $this->twigCallable->getName()));
++        }
++
++        [$callableParameters, $isPhpVariadic] = $this->getCallableParameters();
++        $arguments = [];
++        $callableParameterNames = [];
++        $missingArguments = [];
++        $optionalArguments = [];
++        $pos = 0;
++        foreach ($callableParameters as $callableParameter) {
++            $callableParameterName = $callableParameter->name;
++            if (\PHP_VERSION_ID >= 80000 && 'range' === $callable) {
++                if ('start' === $callableParameterName) {
++                    $callableParameterName = 'low';
++                } elseif ('end' === $callableParameterName) {
++                    $callableParameterName = 'high';
++                }
++            }
++
++            $callableParameterNames[] = $callableParameterName;
++            $normalizedCallableParameterName = $this->normalizeName($callableParameterName);
++
++            if (\array_key_exists($normalizedCallableParameterName, $extractedArguments)) {
++                if (\array_key_exists($pos, $extractedArguments)) {
++                    throw new SyntaxError(\sprintf('Argument "%s" is defined twice for %s "%s".', $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
++                }
++
++                if (\count($missingArguments)) {
++                    throw new SyntaxError(\sprintf(
++                        'Argument "%s" could not be assigned for %s "%s(%s)" because it is mapped to an internal PHP function which cannot determine default value for optional argument%s "%s".',
++                        $callableParameterName, $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', array_map([$this, 'toSnakeCase'], $callableParameterNames)), \count($missingArguments) > 1 ? 's' : '', implode('", "', $missingArguments)
++                    ), $this->node->getTemplateLine(), $this->node->getSourceContext());
++                }
++
++                $arguments = array_merge($arguments, $optionalArguments);
++                $arguments[] = $extractedArguments[$normalizedCallableParameterName];
++                unset($extractedArguments[$normalizedCallableParameterName]);
++                $optionalArguments = [];
++            } elseif (\array_key_exists($pos, $extractedArguments)) {
++                $arguments = array_merge($arguments, $optionalArguments);
++                $arguments[] = $extractedArguments[$pos];
++                unset($extractedArguments[$pos]);
++                $optionalArguments = [];
++                ++$pos;
++            } elseif ($callableParameter->isDefaultValueAvailable()) {
++                $optionalArguments[] = new ConstantExpression($callableParameter->getDefaultValue(), $this->node->getTemplateLine());
++            } elseif ($callableParameter->isOptional()) {
++                if (!$extractedArguments) {
++                    break;
++                }
++
++                $missingArguments[] = $callableParameterName;
++            } else {
++                throw new SyntaxError(\sprintf('Value for argument "%s" is required for %s "%s".', $this->toSnakeCase($callableParameterName), $this->twigCallable->getType(), $this->twigCallable->getName()), $this->node->getTemplateLine(), $this->node->getSourceContext());
++            }
++        }
++
++        if ($this->twigCallable->isVariadic()) {
++            $arbitraryArguments = $isPhpVariadic ? new VariadicExpression([], $this->node->getTemplateLine()) : new ArrayExpression([], $this->node->getTemplateLine());
++            foreach ($extractedArguments as $key => $value) {
++                if (\is_int($key)) {
++                    $arbitraryArguments->addElement($value);
++                } else {
++                    $originalKey = $extractedArgumentNameMap[$key];
++                    if ($originalKey !== $this->toSnakeCase($originalKey)) {
++                        trigger_deprecation('twig/twig', '3.15', \sprintf('Using "snake_case" for variadic arguments is required for a smooth upgrade with Twig 4.0; rename "%s" to "%s" in "%s" at line %d.', $originalKey, $this->toSnakeCase($originalKey), $this->node->getSourceContext()->getName(), $this->node->getTemplateLine()));
++                    }
++                    $arbitraryArguments->addElement($value, new ConstantExpression($this->toSnakeCase($originalKey), $this->node->getTemplateLine()));
++                    // I Twig 4.0, don't convert the key:
++                    // $arbitraryArguments->addElement($value, new ConstantExpression($originalKey, $this->node->getTemplateLine()));
++                }
++                unset($extractedArguments[$key]);
++            }
++
++            if ($arbitraryArguments->count()) {
++                $arguments = array_merge($arguments, $optionalArguments);
++                $arguments[] = $arbitraryArguments;
++            }
++        }
++
++        if ($extractedArguments) {
++            $unknownArgument = null;
++            foreach ($extractedArguments as $extractedArgument) {
++                if ($extractedArgument instanceof Node) {
++                    $unknownArgument = $extractedArgument;
++                    break;
++                }
++            }
++
++            throw new SyntaxError(
++                \sprintf(
++                    'Unknown argument%s "%s" for %s "%s(%s)".',
++                    \count($extractedArguments) > 1 ? 's' : '', implode('", "', array_keys($extractedArguments)), $this->twigCallable->getType(), $this->twigCallable->getName(), implode(', ', array_map([$this, 'toSnakeCase'], $callableParameterNames))
++                ),
++                $unknownArgument ? $unknownArgument->getTemplateLine() : $this->node->getTemplateLine(),
++                $unknownArgument ? $unknownArgument->getSourceContext() : $this->node->getSourceContext()
++            );
++        }
++
++        return $arguments;
++    }
++
++    private function normalizeName(string $name): string
++    {
++        return strtolower(str_replace('_', '', $name));
++    }
++
++    private function toSnakeCase(string $name): string
++    {
++        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z0-9])([A-Z])/'], '\1_\2', $name));
++    }
++
++    private function getCallableParameters(): array
++    {
++        $parameters = $this->rc->getReflector()->getParameters();
++        if ($this->node->hasNode('node')) {
++            array_shift($parameters);
++        }
++        if ($this->twigCallable->needsCharset()) {
++            array_shift($parameters);
++        }
++        if ($this->twigCallable->needsEnvironment()) {
++            array_shift($parameters);
++        }
++        if ($this->twigCallable->needsContext()) {
++            array_shift($parameters);
++        }
++        if (CallExpression::needsIsSandboxed($this->twigCallable)) {
++            array_shift($parameters);
++        }
++        foreach ($this->twigCallable->getArguments() as $argument) {
++            array_shift($parameters);
++        }
++
++        $isPhpVariadic = false;
++        if ($this->twigCallable->isVariadic()) {
++            $argument = end($parameters);
++            $isArray = $argument && $argument->hasType() && $argument->getType() instanceof \ReflectionNamedType && 'array' === $argument->getType()->getName();
++            if ($isArray && $argument->isDefaultValueAvailable() && [] === $argument->getDefaultValue()) {
++                array_pop($parameters);
++            } elseif ($argument && $argument->isVariadic()) {
++                array_pop($parameters);
++                $isPhpVariadic = true;
++            } else {
++                throw new SyntaxError(\sprintf('The last parameter of "%s" for %s "%s" must be an array with default value, eg. "array $arg = []".', $this->rc->getName(), $this->twigCallable->getType(), $this->twigCallable->getName()));
++            }
++        }
++
++        return [$parameters, $isPhpVariadic];
++    }
++}
+diff --git a/src/Util/DeprecationCollector.php b/src/Util/DeprecationCollector.php
+index ad531061716..64cbba5a3f8 100644
+--- a/src/Util/DeprecationCollector.php
++++ b/src/Util/DeprecationCollector.php
+@@ -20,11 +20,9 @@
+  */
+ final class DeprecationCollector
+ {
+-    private $twig;
+-
+-    public function __construct(Environment $twig)
+-    {
+-        $this->twig = $twig;
++    public function __construct(
++        private Environment $twig,
++    ) {
+     }
+ 
+     /**
+@@ -56,7 +54,7 @@ public function collectDir(string $dir, string $ext = '.twig'): array
+     public function collect(\Traversable $iterator): array
+     {
+         $deprecations = [];
+-        set_error_handler(function ($type, $msg) use (&$deprecations) {
++        set_error_handler(static function ($type, $msg) use (&$deprecations) {
+             if (\E_USER_DEPRECATED === $type) {
+                 $deprecations[] = $msg;
+             }
+diff --git a/src/Util/ReflectionCallable.php b/src/Util/ReflectionCallable.php
+index 54384e14bd8..0298e291de3 100644
+--- a/src/Util/ReflectionCallable.php
++++ b/src/Util/ReflectionCallable.php
+@@ -11,6 +11,8 @@
+ 
+ namespace Twig\Util;
+ 
++use Twig\TwigCallableInterface;
++
+ /**
+  * @author Fabien Potencier <fabien@symfony.com>
+  *
+@@ -19,11 +21,13 @@
+ final class ReflectionCallable
+ {
+     private $reflector;
+-    private $callable = null;
++    private $callable;
+     private $name;
+ 
+-    public function __construct($callable, string $debugType = 'unknown', string $debugName = 'unknown')
+-    {
++    public function __construct(
++        TwigCallableInterface $twigCallable,
++    ) {
++        $callable = $twigCallable->getCallable();
+         if (\is_string($callable) && false !== $pos = strpos($callable, '::')) {
+             $callable = [substr($callable, 0, $pos), substr($callable, 2 + $pos)];
+         }
+@@ -40,7 +44,7 @@ public function __construct($callable, string $debugType = 'unknown', string $de
+         try {
+             $closure = \Closure::fromCallable($callable);
+         } catch (\TypeError $e) {
+-            throw new \LogicException(\sprintf('Callback for %s "%s" is not callable in the current scope.', $debugType, $debugName), 0, $e);
++            throw new \LogicException(\sprintf('Callback for %s "%s" is not callable in the current scope.', $twigCallable->getType(), $twigCallable->getName()), 0, $e);
+         }
+         $this->reflector = $r = new \ReflectionFunction($closure);
+ 
+@@ -76,6 +80,9 @@ public function getReflector(): \ReflectionFunctionAbstract
+         return $this->reflector;
+     }
+ 
++    /**
++     * @return callable
++     */
+     public function getCallable()
+     {
+         return $this->callable;
+diff --git a/src/Util/TemplateDirIterator.php b/src/Util/TemplateDirIterator.php
+index 3bef14beec3..d739b285f2c 100644
+--- a/src/Util/TemplateDirIterator.php
++++ b/src/Util/TemplateDirIterator.php
+@@ -17,7 +17,7 @@
+ class TemplateDirIterator extends \IteratorIterator
+ {
+     /**
+-     * @return mixed
++     * @return string
+      */
+     #[\ReturnTypeWillChange]
+     public function current()
+@@ -26,7 +26,7 @@ public function current()
+     }
+ 
+     /**
+-     * @return mixed
++     * @return string
+      */
+     #[\ReturnTypeWillChange]
+     public function key()


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

1) Some symfony component have been. Since they remain in the 5.4.x version, no compatibility issue is expected.

2) Some npm dependencies have been updated. Considering they respect the semver, no compatibility issue is expected.

3) Twig get critical security fixes in the v3.26 and the v3.27 versions, but the PHP 7.4 support has been dropped a long time ago. To be able to upgrade, I create 2 patches. The first apply all the code changes from the v3.11.3 to the v3.27.0 version. This diff has been generated from Github ans is supposed to be reliable. The second patch correspond to changes made manually to make the code compatible with PHP 7.4, maynly replacing enums by scalar values, replacing match by switch, and replace promoted constructor parmeters to properties. Also, I had to install the `benmorel/weakmap-polyfill` polyfill library.
Not including twig fixes does not seems a good option. The only viable alternative solution, IMHO, is to drop the support of PHP 7.4 and 8.1 versions in GLPI 10.0, but I am pretty sure it will trigger complains from some customers and community users.