### PR TITLE
fix(targets): Fix missing sub-entities in Entity visibility target dropdown (KB, RSS Feeds, Reminders)

### DIFF
--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -60,15 +60,18 @@ if (
         case 'User':
             $params = [
                 'right' => isset($_POST['allusers']) ? 'all' : $_POST['right'],
-                'name' => $prefix . 'users_id' . $suffix,
+                'name'  => $prefix . 'users_id' . $suffix,
+                'used'  => $_POST['used']['User'] ?? [],
             ];
             User::dropdown($params);
             $display = true;
             break;
 
         case 'Group':
-            $params             = ['rand' => $rand,
+            $params             = [
+                'rand' => $rand,
                 'name' => $prefix . 'groups_id' . $suffix,
+                'used' => $_POST['used']['Group'] ?? [],
             ];
             $params['toupdate'] = ['value_fieldname'
                                                   => 'value',
@@ -87,8 +90,10 @@ if (
 
         case 'Entity':
             Entity::dropdown([
-                'value' => $_SESSION['glpiactive_entity'],
+                'display_emptychoice' => true,
+                'value' => -1,
                 'name'  => $prefix . 'entities_id' . $suffix,
+                'used'  => $_POST['used']['Entity'] ?? [],
             ]);
             echo '<div class="ms-3">' . __s('Child entities') . '</div>';
             Dropdown::showYesNo($prefix . 'is_recursive' . $suffix);
@@ -105,6 +110,7 @@ if (
             $params             = [
                 'rand'      => $rand,
                 'name'      => $prefix . 'profiles_id' . $suffix,
+                'used'      => $_POST['used']['Profile'] ?? [],
                 'condition' => [
                     'glpi_profilerights.name'     => $righttocheck,
                     'glpi_profilerights.rights'   => ['&', $checkright],

--- a/ajax/visibility.php
+++ b/ajax/visibility.php
@@ -87,10 +87,8 @@ if (
 
         case 'Entity':
             Entity::dropdown([
-                'value'       => $_SESSION['glpiactive_entity'],
-                'name'        => $prefix . 'entities_id' . $suffix,
-                'entity'      => $_POST['entity'] ?? -1,
-                'entity_sons' => $_POST['is_recursive'] ?? false,
+                'value' => $_SESSION['glpiactive_entity'],
+                'name'  => $prefix . 'entities_id' . $suffix,
             ]);
             echo '<div class="ms-3">' . __s('Child entities') . '</div>';
             Dropdown::showYesNo($prefix . 'is_recursive' . $suffix);

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -344,6 +344,12 @@ abstract class CommonDBVisible extends CommonDBTM
         if (isset($this->fields['is_recursive'])) {
             $params['is_recursive'] = $this->fields['is_recursive'];
         }
+        $params['used'] = [
+            'User'    => array_keys($this->users ?? []),
+            'Entity'  => array_keys($this->entities ?? []),
+            'Group'   => array_keys($this->groups ?? []),
+            'Profile' => array_keys($this->profiles ?? []),
+        ];
         return $params;
     }
 }

--- a/src/CommonDBVisible.php
+++ b/src/CommonDBVisible.php
@@ -345,10 +345,10 @@ abstract class CommonDBVisible extends CommonDBTM
             $params['is_recursive'] = $this->fields['is_recursive'];
         }
         $params['used'] = [
-            'User'    => array_keys($this->users ?? []),
-            'Entity'  => array_keys($this->entities ?? []),
-            'Group'   => array_keys($this->groups ?? []),
-            'Profile' => array_keys($this->profiles ?? []),
+            'User'    => array_keys($this->users),
+            'Entity'  => array_keys($this->entities),
+            'Group'   => array_keys($this->groups),
+            'Profile' => array_keys($this->profiles),
         ];
         return $params;
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

There is a UI inconsistency when configuring visibility targets (**Knowledge Base** articles, **Reminders**, **RSS Feeds**). When a user clicks **Add a Target** and selects the **Entity** target type, the subsequent "Entity" dropdown fails to display sub-entities if the current item is not set to recursive. However, when creating a new KB article, the exact same **Target** dropdown correctly shows the full entity tree (including sub-entities). 

Additionally, the dropdowns across all target types (User, Group, Profile, Entity) fail to filter out targets that have already been assigned to the item, allowing for confusing duplicate selections. Specifically for Entities, the active entity (such as the Root Entity) was immune to any filtering and would stubbornly remain in the dropdown even when already assigned.

## Root Cause

1. **Missing Sub-entities**: When adding an Entity target to an existing item, `ajax/visibility.php` artificially restricted the `Entity::dropdown` by passing the item's current `entities_id` and `is_recursive` flag into the dropdown options. Because of this, if the base article was not recursive, the dropdown was hard-filtered to only show the article's specific entity, completely omitting the sub-entities from the selection list.
    * Visibility in GLPI (`CommonDBVisible` classes) allows targets to grant cross-entity access (e.g. creating an article in **Entity A** but adding a target to explicitly grant visibility to **Entity B**)—namely Knowledge Base articles, RSS Feeds, and Reminders. These modules use auxiliary tables (like `glpi_entities_knowbaseitems`, `glpi_entities_reminders`, etc.) to grant target access. Because visibility logic supports cross-entity access via these tables, the artificial restriction was preventing users from adding perfectly valid targets.
    * The **Group** and **Profile** target types (handled via `ajax/subvisibility.php`) do not apply this restriction; they correctly allow the user to select from any entity they have access to.
    * When creating a new article, the dropdown bypassed the restriction and showed the sub-entities simply because `$_POST['entity']` wasn't populated yet, resulting in the `-1` fallback.

2. **Duplicate Target Assignments**: The `ajax/visibility.php` script was never provided with the context of which targets were already tied to the item, so it couldn't utilize the standard `used` parameter to properly filter them out of the dropdown choices.

3. **Persistent Root Entity**: Even when the `used` parameter was introduced to filter out duplicates, the core `Dropdown::show` behavior forcibly pre-selects the user's active entity. If a dropdown option is the currently selected `value` (e.g., `0` for the Root Entity), GLPI intentionally removes it from the `used` array so the option isn't hidden. This caused the Root Entity to always show up.

## Solution

This PR implements three fixes:

1. Aligns the Entity target behavior in `ajax/visibility.php` with the logic used by **Group** and **Profile** targets in `ajax/subvisibility.php`. By removing the artificial `entity` and `entity_sons` filtering, the **Entity** dropdown now consistently allows the user to see and select from the full entity tree when adding visibility targets.
2. Updates `CommonDBVisible::getShowVisibilityDropdownParams()` to extract all currently assigned targets (`$this->users`, `$this->entities`, `$this->groups`, and `$this->profiles`) and passes them down to `ajax/visibility.php` via a `used` array. The target dropdowns now ingest this array to dynamically exclude previously assigned items.
3. Explicitly sets `display_emptychoice => true` and `value => -1` for the Entity dropdown inside `ajax/visibility.php`. By defaulting to the `-----` empty choice instead of forcefully pre-selecting the active entity, the dropdown can now successfully filter out the Root Entity if it has already been used.

## Screenshots (if appropriate):

<img width="917" height="160" alt="image" src="https://github.com/user-attachments/assets/8fb5305b-c029-4d2d-bd61-c6efd8920cce" />
