### PR TITLE
fix(planning): unlpan task and remove event

### DIFF
--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -70,8 +70,14 @@ if (($_POST["action"] ?? null) == "clone_event") {
 }
 
 if (($_POST["action"] ?? null) == "delete_event") {
-    $extevent->check((int) $_POST['event']['items_id'], DELETE);
-    echo Planning::deleteEvent($_POST['event']);
+    $event = $_POST['event'];
+    if (!is_null($event['itemtype']) && is_a($event['itemtype'], PlanningExternalEvent::class, true)) {
+        if (is_null($event['items_id'])) {
+            throw new InvalidArgumentException("Missing items_id for external event");
+        }
+        $extevent->check((int) $event['items_id'], DELETE);
+    }
+    echo Planning::deleteEvent($event);
     return;
 }
 

--- a/ajax/planning.php
+++ b/ajax/planning.php
@@ -71,12 +71,7 @@ if (($_POST["action"] ?? null) == "clone_event") {
 
 if (($_POST["action"] ?? null) == "delete_event") {
     $event = $_POST['event'];
-    if (!is_null($event['itemtype']) && is_a($event['itemtype'], PlanningExternalEvent::class, true)) {
-        if (is_null($event['items_id'])) {
-            throw new InvalidArgumentException("Missing items_id for external event");
-        }
-        $extevent->check((int) $event['items_id'], DELETE);
-    }
+    // rights check is done inside `Planning::deleteEvent()`, depending on the event itemtype
     echo Planning::deleteEvent($event);
     return;
 }

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1497,7 +1497,8 @@ TWIG, $twig_params);
 
         $item = getItemForItemtype($event['itemtype']);
 
-        if (!$item->can((int) $event['items_id'], $item->maybeDeleted() ? DELETE : PURGE)) {
+        $required_right = ($item instanceof CommonITILTask) ? UPDATE : ($item->maybeDeleted() ? DELETE : PURGE);
+        if (!$item->can((int) $event['items_id'], $required_right)) {
             return false;
         }
 
@@ -1507,6 +1508,12 @@ TWIG, $twig_params);
             && method_exists($item, "deleteInstance")
         ) {
             return $item->deleteInstance((int) $event['items_id'], $event['day']);
+        }
+
+        // For tasks linked to tickets/changes/problems, only unschedule (clear planning
+        // dates) instead of deleting the task record entirely.
+        if ($item instanceof CommonITILTask) {
+            return $item->unplan();
         }
 
         return $item->delete([


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- It fixes #24259

- !43130

Requires a documentation update if it previously stated that deleting a "task" type event completely deleted the task, as it now only unschedules it.

