### PR TITLE
Fix: Avoids unnecessary object instantiation when checking dashboard visibility in Central.php

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -79,8 +79,7 @@ class Central extends CommonGLPI
                 4 => self::createTabEntry(_n('RSS feed', 'RSS feeds', Session::getPluralNumber()), 0, null, RSSFeed::getIcon()),
             ];
 
-            $grid = new Grid('central');
-            if ($grid::canViewOneDashboard()) {
+            if (Grid::canViewOneDashboard()) {
                 array_unshift($tabs, self::createTabEntry(__('Dashboard'), 0, null, Dashboard::getIcon()));
             }
 


### PR DESCRIPTION
avoids unnecessary object instantiation when checking dashboard visibility.

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- avoids unnecessary object instantiation when checking dashboard visibility.

## Screenshots (if appropriate):


