### PR TITLE
Fix: Avoid generating unused IDOR tokens in Central my view

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -285,7 +285,7 @@ class Central extends CommonGLPI
         $twig_params = [
             'cards' => [],
         ];
-        
+
         foreach ($lists as $list) {
             $card_params = [
                 'start'              => 0,
@@ -305,7 +305,7 @@ class Central extends CommonGLPI
         $card_params = [
             'who' => Session::getLoginUserID(),
         ];
-        
+
         $idor = Session::getNewIDORToken(Planning::class, $card_params);
         $twig_params['cards'][] = [
             'itemtype'  => Planning::class,
@@ -323,12 +323,12 @@ class Central extends CommonGLPI
                 '_idor_token'  => $idor,
             ],
         ];
-        
+
         if (Session::haveRight("reminder_public", READ)) {
             $idor = Session::getNewIDORToken(Reminder::class, [
                 'personal' => 'false',
             ]);
-        
+
             $twig_params['cards'][] = [
                 'itemtype' => Reminder::class,
                 'widget' => 'central_list',
@@ -338,10 +338,10 @@ class Central extends CommonGLPI
                 ],
             ];
         }
-        
+
         if (Session::haveRight("project", Project::READMY)) {
             $idor = Session::getNewIDORToken(Project::class);
-        
+
             $twig_params['cards'][] = [
                 'itemtype' => Project::class,
                 'widget' => 'central_list',
@@ -350,10 +350,10 @@ class Central extends CommonGLPI
                 ],
             ];
         }
-        
+
         if (Session::haveRight("projecttask", ProjectTask::READMY)) {
             $idor = Session::getNewIDORToken(ProjectTask::class);
-        
+
             $twig_params['cards'][] = [
                 'itemtype' => ProjectTask::class,
                 'widget' => 'central_list',

--- a/src/Central.php
+++ b/src/Central.php
@@ -285,6 +285,7 @@ class Central extends CommonGLPI
         $twig_params = [
             'cards' => [],
         ];
+        
         foreach ($lists as $list) {
             $card_params = [
                 'start'              => 0,
@@ -304,6 +305,7 @@ class Central extends CommonGLPI
         $card_params = [
             'who' => Session::getLoginUserID(),
         ];
+        
         $idor = Session::getNewIDORToken(Planning::class, $card_params);
         $twig_params['cards'][] = [
             'itemtype'  => Planning::class,
@@ -321,38 +323,42 @@ class Central extends CommonGLPI
                 '_idor_token'  => $idor,
             ],
         ];
-        $idor = Session::getNewIDORToken(Reminder::class, [
-            'personal'  => 'false',
-        ]);
+        
         if (Session::haveRight("reminder_public", READ)) {
+            $idor = Session::getNewIDORToken(Reminder::class, [
+                'personal' => 'false',
+            ]);
+        
             $twig_params['cards'][] = [
-                'itemtype'  => Reminder::class,
-                'widget'    => 'central_list',
-                'params'    => [
-                    'personal'     => 'false',
-                    '_idor_token'  => $idor,
+                'itemtype' => Reminder::class,
+                'widget' => 'central_list',
+                'params' => [
+                    'personal' => 'false',
+                    '_idor_token' => $idor,
                 ],
             ];
         }
-        $idor = Session::getNewIDORToken(Project::class);
+        
         if (Session::haveRight("project", Project::READMY)) {
+            $idor = Session::getNewIDORToken(Project::class);
+        
             $twig_params['cards'][] = [
-                'itemtype'  => Project::class,
-                'widget'    => 'central_list',
-                'params'    => $card_params + [
-                    'itemtype'      => User::getType(),
-                    '_idor_token'  => $idor,
+                'itemtype' => Project::class,
+                'widget' => 'central_list',
+                'params' => [
+                    '_idor_token' => $idor,
                 ],
             ];
         }
-        $idor = Session::getNewIDORToken(ProjectTask::class);
+        
         if (Session::haveRight("projecttask", ProjectTask::READMY)) {
+            $idor = Session::getNewIDORToken(ProjectTask::class);
+        
             $twig_params['cards'][] = [
-                'itemtype'  => ProjectTask::class,
-                'widget'    => 'central_list',
-                'params'    => $card_params + [
-                    'itemtype'      => User::getType(),
-                    '_idor_token'  => $idor,
+                'itemtype' => ProjectTask::class,
+                'widget' => 'central_list',
+                'params' => [
+                    '_idor_token' => $idor,
                 ],
             ];
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- This avoids generating IDOR tokens for central widgets before checking user rights.

The behavior is unchanged: tokens are still generated when the corresponding widget is visible. For users without the required rights, unnecessary token generation is skipped.

## Screenshots (if appropriate):


