### PR TITLE
Fix: Avoid generating unused IDOR tokens for projects and tasks in Central

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -507,7 +507,6 @@ class Central extends CommonGLPI
                 ],
             ];
         }
-        
         if (Session::haveRight("projecttask", ProjectTask::READMY)) {
             $idor = Session::getNewIDORToken(ProjectTask::class);
             $twig_params['cards'][] = [

--- a/src/Central.php
+++ b/src/Central.php
@@ -496,8 +496,8 @@ class Central extends CommonGLPI
             ];
         }
 
-        $idor = Session::getNewIDORToken(Project::class);
         if (Session::haveRight("project", Project::READMY)) {
+            $idor = Session::getNewIDORToken(Project::class);
             $twig_params['cards'][] = [
                 'itemtype'  => Project::class,
                 'widget'    => 'central_list',
@@ -507,8 +507,9 @@ class Central extends CommonGLPI
                 ],
             ];
         }
-        $idor = Session::getNewIDORToken(ProjectTask::class);
+        
         if (Session::haveRight("projecttask", ProjectTask::READMY)) {
+            $idor = Session::getNewIDORToken(ProjectTask::class);
             $twig_params['cards'][] = [
                 'itemtype'  => ProjectTask::class,
                 'widget'    => 'central_list',
@@ -521,7 +522,6 @@ class Central extends CommonGLPI
 
         TemplateRenderer::getInstance()->display('central/widget_tab.html.twig', $twig_params);
     }
-
 
     private static function getMessages(): array
     {
@@ -663,7 +663,6 @@ class Central extends CommonGLPI
 
         return $messages;
     }
-
 
     /**
      * @return void


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

-  Small performance cleanup, no behavior change
Avoids generating IDOR tokens fbefore checking user rights.

## Screenshots (if appropriate):


