### PR TITLE
Fix clear orphan test

### DIFF
--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -1060,10 +1060,15 @@ class Inventory
         $existing_types = glob(GLPI_INVENTORY_DIR . '/*', GLOB_ONLYDIR);
 
         foreach ($existing_types as $existing_type) {
-            /** @var class-string<CommonDBTM> $itemtype */
             $itemtype = str_replace(GLPI_INVENTORY_DIR . '/', '', $existing_type);
             // use `getItemForItemtype` to fix classname case (i.e. `refusedequipement` -> `RefusedEquipement`)
-            $itemtype = getItemForItemtype($itemtype)::getType();
+            $item = getItemForItemtype($itemtype);
+            if ($item === false) {
+                // Class might not exist if it refer to a deleted custom asset type
+                continue;
+            }
+            /** @var class-string<CommonDBTM> $itemtype */
+            $itemtype = $item::getType();
             $inventory_files = new RegexIterator(
                 new RecursiveIteratorIterator(
                     new RecursiveDirectoryIterator($existing_type)


### PR DESCRIPTION
Fix this failure: 

<img width="1057" height="546" alt="image" src="https://github.com/user-attachments/assets/822be415-0bb5-47c5-a891-741d69d24cb4" />

The test was sometime referring to a custom asset that not longer existed.

Note that it occurs during a test on documents because `CronTask::launch(-2, 5, 'cleanorphans')` run both Document::cleanorphans and Inventory::cleanorphans.

Possible improvement (won't be included in this PR): clear the inventory folders when a custom asset definition is deleted?