### PR TITLE
[HLAPI] fix handling content-type header with parameters

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -638,8 +638,9 @@ EOT;
         $request = $request->withQueryParams(array_merge($request->getQueryParams(), $_GET));
 
         // Handle potential JSON request body
-        $content_types = $request->getHeader('Content-Type');
-        if (in_array('application/json', $content_types, true)) {
+        $content_type = $request->getHeaderLine('Content-Type');
+        $content_type = explode(';', $content_type)[0];
+        if ($content_type === 'application/json') {
             $body = $request->getBody()->getContents();
             try {
                 $body = json_decode($body, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/functional/Glpi/Api/HL/RouterTest.php
+++ b/tests/functional/Glpi/Api/HL/RouterTest.php
@@ -279,6 +279,13 @@ class RouterTest extends GLPITestCase
         $this->assertArrayHasKey('field1', $schema['properties']);
         $this->assertArrayHasKey('field2', $schema['properties']);
     }
+
+    public function testContentTypeWithCharset()
+    {
+        $router = TestRouter::getInstance();
+        $router->handleRequest(new Request('POST', '/test', ['Content-Type' => 'application/json; charset=utf-8'], json_encode(['test' => 'value'])));
+        $this->assertEquals('value', $router->getOriginalRequest()->getParameter('test'));
+    }
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Content-Type check for JSON was checking the entire header string and would fail if it contained extra parameters like charset. This would cause the request parameters to have none of the data from the input body.
