### PR TITLE
Fix: Invalid HTML in Toolbox::shortenNumber()

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3121,12 +3121,12 @@ class Toolbox
         }
 
         if ($html) {
-        $formatted = '
-            <span class="formatted-number" data-precision="' . htmlescape($precision) . '">
-                <span class="number">' . htmlescape($formatted) . '</span>
-                <span class="suffix">' . htmlescape($suffix) . '</span>
-            </span>
-        ';
+            $formatted = '
+                <span class="formatted-number" data-precision="' . htmlescape($precision) . '">
+                    <span class="number">' . htmlescape($formatted) . '</span>
+                    <span class="suffix">' . htmlescape($suffix) . '</span>
+                </span>
+            ';
         } else {
             $formatted .= $suffix;
         }

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -3121,14 +3121,12 @@ class Toolbox
         }
 
         if ($html) {
-            $formatted = '
-                <span "
-                      class="formatted-number"
-                      data-precision="' . htmlescape($precision) . '">
-                    <span class="number">' . htmlescape($formatted) . '</span>
-                    <span class="suffix">' . htmlescape($suffix) . '</span>
-                </span>
-            ';
+        $formatted = '
+            <span class="formatted-number" data-precision="' . htmlescape($precision) . '">
+                <span class="number">' . htmlescape($formatted) . '</span>
+                <span class="suffix">' . htmlescape($suffix) . '</span>
+            </span>
+        ';
         } else {
             $formatted .= $suffix;
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Toolbox::shortenNumber() generates invalid HTML due to an extra quote after the opening span tag.
- This removes the stray quote without changing the generated structure or behavior.

## Screenshots (if appropriate):


