### PR TITLE
Fix: Toolbox::isJSON() handling of boolean literals

### DIFF
--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -2771,11 +2771,8 @@ class Toolbox
         }
 
         // "true" and "false" are valid JSON strings.
-        if ('true' === $json) {
+        if (in_array($json, ['true', 'false'], true)) {
             return true;
-        }
-        if ('false' === $json) {
-            return false;
         }
 
         // Any other JSON string has to be wrapped in {}, [] or "".

--- a/tests/functional/ToolboxTest.php
+++ b/tests/functional/ToolboxTest.php
@@ -243,28 +243,44 @@ class ToolboxTest extends DbTestCase
             [
                 '{"validJson":true}',
                 true,
-            ], [
+            ],
+            [
                 '{"invalidJson":true',
                 false,
-            ], [
+            ],
+            [
                 '"valid"',
                 true,
-            ], [
+            ],
+            [
                 'null',
                 true,
-            ], [
+            ],
+            [
+                'true',
+                true,
+            ],
+            [
+                'false',
+                true,
+            ],
+            [
                 1000,
                 true,
-            ], [
+            ],
+            [
                 [1, 2, 3],
                 false,
-            ], [
+            ],
+            [
                 (object) ['json' => true],
                 false,
-            ], [
+            ],
+            [
                 '{ bad content',
                 false,
-            ], [
+            ],
+            [
                 file_get_contents(GLPI_ROOT . '/vendor/glpi-project/inventory_format/examples/computer_1.json'),
                 true,
             ],


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #24393
- Toolbox::isJSON() documents that both "true" and "false" are valid JSON literals, but the implementation handled them inconsistently.

While "true" correctly returned true, "false" returned false, causing the method to reject a valid JSON literal.

This change simplifies the logic by handling both boolean literals with a single strict condition and returning true for both values.

According to RFC 7159 / ECMA-404, JSON boolean literals are:

- true
- false

The current implementation already special-cases these values before running json_decode(), but only "true" is accepted while "false" is rejected.

As a result:

Toolbox::isJSON('true')  === true
Toolbox::isJSON('false') === false

even though both are valid JSON literals.

This patch fixes the inconsistency and aligns the implementation with both the existing comment and JSON specification.

## Screenshots (if appropriate):