### PR TITLE
Avoid unnecessary ORDER BY clauses in relation count queries

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -2066,7 +2066,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
         global $DB;
 
         $params = static::getListForItemParams($item);
-        unset($params['SELECT']);
+        unset($params['SELECT'], $params['ORDER']);
         $params['COUNT'] = 'cpt';
         $iterator = $DB->request($params);
 
@@ -2099,7 +2099,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
             }
 
             $params = static::getTypeItemsQueryParams($item->fields['id'], $data['itemtype']);
-            unset($params['SELECT']);
+            unset($params['SELECT'], $params['ORDER']);
             $params['COUNT'] = 'cpt';
             $iterator = $DB->request($params);
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- These count queries do not return ordered rows, so keeping ORDER BY clauses is unnecessary. Removing them avoids extra work for supported database engines while preserving the exact same result.

## Screenshots (if appropriate):


