### PR TITLE
Fix reverse relation lookup in CommonDBRelation massive removal

### DIFF
--- a/src/CommonDBRelation.php
+++ b/src/CommonDBRelation.php
@@ -1725,7 +1725,7 @@ abstract class CommonDBRelation extends CommonDBConnexity
                         ) {
                             $ORWHERE = [
                                 static::$items_id_1 => $item_2->getID(),
-                                static::$items_id_2 => $item_2->getID(),
+                                static::$items_id_2 => $item_1->getID(),
                             ];
                             if (preg_match('/^itemtype/', static::$itemtype_1)) {
                                 $ORWHERE[static::$itemtype_1] = $item_2->getType();

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -430,34 +430,34 @@ class CommonDBRelationTest extends DbTestCase
             'name'        => __FUNCTION__ . '_1',
             'entities_id' => 0,
         ]);
-    
+
         $computer_2 = $this->createItem(\Computer::class, [
             'name'        => __FUNCTION__ . '_2',
             'entities_id' => 0,
         ]);
-    
+
         $port_1 = $this->createItem(\NetworkPort::class, [
             'itemtype'           => \Computer::class,
             'items_id'           => $computer_1->getID(),
             'name'               => __FUNCTION__ . '_port_1',
             'instantiation_type' => 'NetworkPortEthernet',
         ]);
-    
+
         $port_2 = $this->createItem(\NetworkPort::class, [
             'itemtype'           => \Computer::class,
             'items_id'           => $computer_2->getID(),
             'name'               => __FUNCTION__ . '_port_2',
             'instantiation_type' => 'NetworkPortEthernet',
         ]);
-    
+
         // Store relation in reverse order: port_2 -> port_1.
         $relation = new CommonDBRelationTest_SameTypeRelation();
-    
+
         $this->assertGreaterThan(0, $relation->add([
             'networkports_id_1' => $port_2->getID(),
             'networkports_id_2' => $port_1->getID(),
         ]));
-    
+
         $this->assertSame(
             1,
             countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [
@@ -465,18 +465,18 @@ class CommonDBRelationTest extends DbTestCase
                 'networkports_id_2' => $port_1->getID(),
             ])
         );
-    
+
         $ma = $this->getMockBuilder(MassiveAction::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getAction', 'addMessage', 'getInput', 'itemDone'])
             ->getMock();
-    
+
         $ma->method('getAction')->willReturn('remove');
         $ma->method('addMessage')->willReturn(null);
         $ma->method('getInput')->willReturn([
             'peer_networkports_id_2' => $port_2->getID(),
         ]);
-    
+
         $ma->expects($this->once())
             ->method('itemDone')
             ->with(
@@ -484,13 +484,13 @@ class CommonDBRelationTest extends DbTestCase
                 $port_1->getID(),
                 MassiveAction::ACTION_OK
             );
-    
+
         CommonDBRelationTest_SameTypeRelation::processMassiveActionsForOneItemtype(
             $ma,
             new \NetworkPort(),
             [$port_1->getID()]
         );
-    
+
         $this->assertSame(
             0,
             countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -35,9 +35,31 @@
 namespace tests\units;
 
 use CommonDBRelation;
+use MassiveAction;
+use NetworkPort_NetworkPort;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\ItemLinkException;
 use Glpi\Tests\DbTestCase;
+
+/**
+ * Test-only relation used to exercise same-type reverse lookup logic
+ * in CommonDBRelation massive actions.
+ */
+class CommonDBRelationTest_SameTypeRelation extends NetworkPort_NetworkPort
+{
+    public static function getRelationMassiveActionsSpecificities()
+    {
+        $specificities = parent::getRelationMassiveActionsSpecificities();
+        $specificities['check_both_items_if_same_type'] = true;
+
+        return $specificities;
+    }
+
+    public function can($ID, $right, ?array &$input = null)
+    {
+        return true;
+    }
+}
 
 class CommonDBRelationTest extends DbTestCase
 {
@@ -413,5 +435,95 @@ class CommonDBRelationTest extends DbTestCase
             ]
         );
         /** /Entity with items_id = 0 is valid (root entity) */
+    }
+
+    /**
+     * Verify that massive remove actions can find and delete
+     * same-type relations stored in reverse order.
+     *
+     * This specifically exercises the
+     * `check_both_items_if_same_type` reverse lookup branch.
+     */
+    public function testMassiveActionRemoveFindsReverseSameTypeRelation(): void
+    {
+        // Create two computers.
+        $computer_1 = $this->createItem(\Computer::class, [
+            'name'        => __FUNCTION__ . '_1',
+            'entities_id' => 0,
+        ]);
+    
+        $computer_2 = $this->createItem(\Computer::class, [
+            'name'        => __FUNCTION__ . '_2',
+            'entities_id' => 0,
+        ]);
+    
+        // Create one network port for each computer.
+        $port_1 = $this->createItem(\NetworkPort::class, [
+            'itemtype'           => \Computer::class,
+            'items_id'           => $computer_1->getID(),
+            'name'               => __FUNCTION__ . '_port_1',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]);
+    
+        $port_2 = $this->createItem(\NetworkPort::class, [
+            'itemtype'           => \Computer::class,
+            'items_id'           => $computer_2->getID(),
+            'name'               => __FUNCTION__ . '_port_2',
+            'instantiation_type' => 'NetworkPortEthernet',
+        ]);
+    
+        // Store relation in reverse order:
+        // port_2 -> port_1.
+        $relation = new CommonDBRelationTest_SameTypeRelation();
+    
+        $this->assertGreaterThan(0, $relation->add([
+            'networkports_id_1' => $port_2->getID(),
+            'networkports_id_2' => $port_1->getID(),
+        ]));
+    
+        // Ensure relation exists before massive action removal.
+        $this->assertSame(
+            1,
+            countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [
+                'networkports_id_1' => $port_2->getID(),
+                'networkports_id_2' => $port_1->getID(),
+            ])
+        );
+    
+        // Mock a massive action removing port_2 from port_1.
+        $ma = $this->getMockBuilder(MassiveAction::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAction', 'addMessage', 'getInput', 'itemDone'])
+            ->getMock();
+    
+        $ma->method('getAction')->willReturn('remove');
+        $ma->method('addMessage')->willReturn(null);
+        $ma->method('getInput')->willReturn([
+            'peer_networkports_id_2' => $port_2->getID(),
+        ]);
+    
+        // The relation should be found through the reverse lookup and removed.
+        $ma->expects($this->once())
+            ->method('itemDone')
+            ->with(
+                \NetworkPort::class,
+                $port_1->getID(),
+                MassiveAction::ACTION_OK
+            );
+    
+        CommonDBRelationTest_SameTypeRelation::processMassiveActionsForOneItemtype(
+            $ma,
+            new \NetworkPort(),
+            [$port_1->getID()]
+        );
+    
+        // Relation should no longer exist.
+        $this->assertSame(
+            0,
+            countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [
+                'networkports_id_1' => $port_2->getID(),
+                'networkports_id_2' => $port_1->getID(),
+            ])
+        );
     }
 }

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -35,11 +35,11 @@
 namespace tests\units;
 
 use CommonDBRelation;
-use MassiveAction;
-use NetworkPort_NetworkPort;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\ItemLinkException;
 use Glpi\Tests\DbTestCase;
+use MassiveAction;
+use NetworkPort_NetworkPort;
 
 class CommonDBRelationTest extends DbTestCase
 {

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -509,7 +509,7 @@ class CommonDBRelationTest_SameTypeRelation extends NetworkPort_NetworkPort
 {
     public static function getTable($classname = null): string
     {
-        return \NetworkPort_NetworkPort::getTable();
+        return NetworkPort_NetworkPort::getTable();
     }
 
     public static function getRelationMassiveActionsSpecificities(): array

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -505,18 +505,14 @@ class CommonDBRelationTest extends DbTestCase
  * Test-only relation used to exercise same-type reverse lookup logic
  * in CommonDBRelation massive actions.
  */
-/**
- * Test-only relation used to exercise same-type reverse lookup logic
- * in CommonDBRelation massive actions.
- */
 class CommonDBRelationTest_SameTypeRelation extends \NetworkPort_NetworkPort
 {
-    public static function getTable($classname = null)
+    public static function getTable($classname = null): string
     {
         return \NetworkPort_NetworkPort::getTable();
     }
 
-    public static function getRelationMassiveActionsSpecificities()
+    public static function getRelationMassiveActionsSpecificities(): array
     {
         $specificities = parent::getRelationMassiveActionsSpecificities();
         $specificities['check_both_items_if_same_type'] = true;

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -41,26 +41,6 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\ItemLinkException;
 use Glpi\Tests\DbTestCase;
 
-/**
- * Test-only relation used to exercise same-type reverse lookup logic
- * in CommonDBRelation massive actions.
- */
-class CommonDBRelationTest_SameTypeRelation extends NetworkPort_NetworkPort
-{
-    public static function getRelationMassiveActionsSpecificities()
-    {
-        $specificities = parent::getRelationMassiveActionsSpecificities();
-        $specificities['check_both_items_if_same_type'] = true;
-
-        return $specificities;
-    }
-
-    public function can($ID, $right, ?array &$input = null)
-    {
-        return true;
-    }
-}
-
 class CommonDBRelationTest extends DbTestCase
 {
     public function testCreateCheck(): void
@@ -446,7 +426,6 @@ class CommonDBRelationTest extends DbTestCase
      */
     public function testMassiveActionRemoveFindsReverseSameTypeRelation(): void
     {
-        // Create two computers.
         $computer_1 = $this->createItem(\Computer::class, [
             'name'        => __FUNCTION__ . '_1',
             'entities_id' => 0,
@@ -457,7 +436,6 @@ class CommonDBRelationTest extends DbTestCase
             'entities_id' => 0,
         ]);
     
-        // Create one network port for each computer.
         $port_1 = $this->createItem(\NetworkPort::class, [
             'itemtype'           => \Computer::class,
             'items_id'           => $computer_1->getID(),
@@ -472,8 +450,7 @@ class CommonDBRelationTest extends DbTestCase
             'instantiation_type' => 'NetworkPortEthernet',
         ]);
     
-        // Store relation in reverse order:
-        // port_2 -> port_1.
+        // Store relation in reverse order: port_2 -> port_1.
         $relation = new CommonDBRelationTest_SameTypeRelation();
     
         $this->assertGreaterThan(0, $relation->add([
@@ -481,7 +458,6 @@ class CommonDBRelationTest extends DbTestCase
             'networkports_id_2' => $port_1->getID(),
         ]));
     
-        // Ensure relation exists before massive action removal.
         $this->assertSame(
             1,
             countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [
@@ -490,7 +466,6 @@ class CommonDBRelationTest extends DbTestCase
             ])
         );
     
-        // Mock a massive action removing port_2 from port_1.
         $ma = $this->getMockBuilder(MassiveAction::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getAction', 'addMessage', 'getInput', 'itemDone'])
@@ -502,7 +477,6 @@ class CommonDBRelationTest extends DbTestCase
             'peer_networkports_id_2' => $port_2->getID(),
         ]);
     
-        // The relation should be found through the reverse lookup and removed.
         $ma->expects($this->once())
             ->method('itemDone')
             ->with(
@@ -517,7 +491,6 @@ class CommonDBRelationTest extends DbTestCase
             [$port_1->getID()]
         );
     
-        // Relation should no longer exist.
         $this->assertSame(
             0,
             countElementsInTable(CommonDBRelationTest_SameTypeRelation::getTable(), [
@@ -525,5 +498,34 @@ class CommonDBRelationTest extends DbTestCase
                 'networkports_id_2' => $port_1->getID(),
             ])
         );
+    }
+}
+
+/**
+ * Test-only relation used to exercise same-type reverse lookup logic
+ * in CommonDBRelation massive actions.
+ */
+/**
+ * Test-only relation used to exercise same-type reverse lookup logic
+ * in CommonDBRelation massive actions.
+ */
+class CommonDBRelationTest_SameTypeRelation extends \NetworkPort_NetworkPort
+{
+    public static function getTable($classname = null)
+    {
+        return \NetworkPort_NetworkPort::getTable();
+    }
+
+    public static function getRelationMassiveActionsSpecificities()
+    {
+        $specificities = parent::getRelationMassiveActionsSpecificities();
+        $specificities['check_both_items_if_same_type'] = true;
+
+        return $specificities;
+    }
+
+    public function can($ID, $right, ?array &$input = null): bool
+    {
+        return true;
     }
 }

--- a/tests/functional/CommonDBRelationTest.php
+++ b/tests/functional/CommonDBRelationTest.php
@@ -505,7 +505,7 @@ class CommonDBRelationTest extends DbTestCase
  * Test-only relation used to exercise same-type reverse lookup logic
  * in CommonDBRelation massive actions.
  */
-class CommonDBRelationTest_SameTypeRelation extends \NetworkPort_NetworkPort
+class CommonDBRelationTest_SameTypeRelation extends NetworkPort_NetworkPort
 {
     public static function getTable($classname = null): string
     {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- When removing relations through `processMassiveActionsForOneItemtype()` with `check_both_items_if_same_type` enabled, the reverse lookup does not correctly mirror the relation.

The normal lookup checks:

item_1 -> item_2

but the reverse lookup currently uses:

item_2 -> item_2

instead of:

item_2 -> item_1

This makes the reverse condition inconsistent with the relation handling logic already used elsewhere in `CommonDBRelation`, including `add()`, which properly checks both directions when relations may be stored in either order.

As a result, some same-type relations may not be found during massive removal when stored in reverse order.

This change only fixes the reverse lookup condition and does not modify relation semantics or introduce behavioral changes outside of the incorrect lookup case.

## Screenshots (if appropriate):
