### PR TITLE
Reset dashboards cache during PHPUnit tests

### DIFF
--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -52,6 +52,8 @@ use Dropdown;
 use Entity;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Cache\CacheManager;
+use Glpi\Dashboard\Dashboard;
+use Glpi\Dashboard\Grid;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Search\SearchOption;
 use Glpi\Tests\Log\TestHandler;
@@ -122,6 +124,10 @@ class GLPITestCase extends TestCase
         $PHPLOGGER->setHandlers([$this->log_handler]);
 
         vfsStreamWrapper::register();
+
+        // Reset dashboard caches
+        Grid::$all_dashboards = [];
+        Dashboard::$all_dashboards = [];
 
         // Make sure the tester plugin is never deactived by a test as it would
         // impact others tests that depend on it.


### PR DESCRIPTION
#24373 seems to have made some phpunit tests flaky:

<img width="757" height="252" alt="image" src="https://github.com/user-attachments/assets/84710c51-d8e8-4aa5-a9af-6dc8f06f2cbb" />

The static variable storing all dashboards should probably be reset between each tests to avoid issues like this.
