### PR TITLE
Avoid calling itemAffinity() twice in CommonDevice::getHTMLTableHeader()

### DIFF
--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -420,7 +420,9 @@ abstract class CommonDevice extends CommonDropdown
         }
 
         $linktype = static::getItem_DeviceType();
-        if (in_array($itemtype, $linktype::itemAffinity()) || in_array('*', $linktype::itemAffinity())) {
+        $affinity = $linktype::itemAffinity();
+
+        if (in_array($itemtype, $affinity, true) || in_array('*', $affinity, true)) {
             $column = $base->addHeader('device', $content, $super, $father);
             $column->setItemType(
                 static::class,


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

- The affinity list does not need to be recomputed for both checks. Storing it in a local variable keeps the same behavior while reducing duplicate work during table rendering.


