### PR TITLE
Avoid calling getSearchURL(false) twice when building the device menu.

### DIFF
--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -169,11 +169,13 @@ abstract class CommonDevice extends CommonDropdown
                 /** @var class-string $key */
                 foreach ($tab as $key => $val) {
                     if ($tmp = getItemForItemtype($key)) {
+                        $search_url = $tmp::getSearchURL(false);
+
                         $menu['options'][$key] = [
                             'title' => $val,
-                            'page'  => $tmp::getSearchURL(false),
+                            'page' => $search_url,
                             'links' => [
-                                'search' => $tmp::getSearchURL(false),
+                                'search' => $search_url,
                             ],
                         ];
                         if ($tmp::canCreate()) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

- The search URL is deterministic for a given item type during menu generation, so storing it in a local variable avoids duplicated method calls without changing the generated menu structure or permissions logic.


