### PR TITLE
Feat: read display name from SCSS comment in custom themes

### DIFF
--- a/src/Glpi/UI/ThemeManager.php
+++ b/src/Glpi/UI/ThemeManager.php
@@ -170,7 +170,12 @@ class ThemeManager
                     // Guess dark mode based on if the file contains "$is-dark: true;"
                     $file_content = file_get_contents($file);
                     $is_dark = preg_match('/^\s*\$is-dark:\s*true;\s*$/im', $file_content) === 1;
-                    $theme_name = ucfirst(str_replace('_', ' ', $file_name));
+                    $name_matches = [];
+                    if (preg_match('/^\/\*\s*theme-name:\s*(.+?)\s*\*\//m', $file_content, $name_matches) === 1) {
+                        $theme_name = $name_matches[1];
+                    } else {
+                        $theme_name = ucfirst(str_replace('_', ' ', $file_name));
+                    }
                     $this->custom_themes[] = new Theme($file_name, $theme_name, $is_dark, true);
                 }
             }

--- a/src/Glpi/UI/ThemeManager.php
+++ b/src/Glpi/UI/ThemeManager.php
@@ -171,11 +171,8 @@ class ThemeManager
                     $file_content = file_get_contents($file);
                     $is_dark = preg_match('/^\s*\$is-dark:\s*true;\s*$/im', $file_content) === 1;
                     $name_matches = [];
-                    if (preg_match('/^\/\*\s*theme-name:\s*(.+?)\s*\*\//m', $file_content, $name_matches) === 1) {
-                        $theme_name = $name_matches[1];
-                    } else {
-                        $theme_name = ucfirst(str_replace('_', ' ', $file_name));
-                    }
+                    preg_match('/^\/\*\s*theme-name:\s*(.+?)\s*\*\//m', $file_content, $name_matches);
+                    $theme_name = $name_matches[1] ?? ucfirst(str_replace('_', ' ', $file_name));
                     $this->custom_themes[] = new Theme($file_name, $theme_name, $is_dark, true);
                 }
             }

--- a/tests/functional/Glpi/UI/ThemeTest.php
+++ b/tests/functional/Glpi/UI/ThemeTest.php
@@ -76,6 +76,26 @@ SCSS,
         $this->assertSame('My dark theme', $my_dark_theme->getName());
     }
 
+    public function testGetCustomThemesUsesThemeNameComment(): void
+    {
+        vfsStream::setup('custom_themes', null, [
+            'plugin_branding_1.scss' => '/* theme-name: My Brand Palette */' . "\n" . ':root[data-glpi-theme="plugin_branding_1"] {}',
+            'plugin_branding_2.scss' => ':root[data-glpi-theme="plugin_branding_2"] {}',
+        ]);
+        $theme_manager = $this->getMockBuilder(ThemeManager::class)
+            ->onlyMethods(['getCustomThemesDirectory'])
+            ->getMock();
+        $theme_manager->method('getCustomThemesDirectory')->willReturn(vfsStream::url('custom_themes'));
+
+        $named = $theme_manager->getTheme('plugin_branding_1');
+        $this->assertNotNull($named);
+        $this->assertSame('My Brand Palette', $named->getName());
+
+        $fallback = $theme_manager->getTheme('plugin_branding_2');
+        $this->assertNotNull($fallback);
+        $this->assertSame('Plugin branding 2', $fallback->getName());
+    }
+
     public function testGetAllThemes(): void
     {
         $themes = ThemeManager::getInstance()->getCoreThemes();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44409
- Custom theme SCSS files can now embed a `/* theme-name: My Name */` comment on their first line to control the label shown in the theme picker.
- Without the comment, the existing fallback behavior (name derived from the filename) applies unchanged, so no existing theme is affected.
- This lets plugins that generate theme files with non-descriptive filenames (e.g. `plugin_branding_1.scss`) expose a proper human-readable name instead of "Plugin branding 1".


## Screenshots (if appropriate):


