### PR TITLE
Fix: item link dropdown stuck on searching... with many entities

### DIFF
--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -75,8 +75,11 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         $p['valuename'] = $_POST['valuename'];
     }
     if (isset($_POST['entity_restrict'])) {
-        $p['entity_restrict']           = $_POST['entity_restrict'];
-        $idor_params['entity_restrict'] = $_POST['entity_restrict'];
+        $entity_restrict = is_array($_POST['entity_restrict'])
+            ? json_encode(array_values($_POST['entity_restrict']))
+            : $_POST['entity_restrict'];
+        $p['entity_restrict']           = $entity_restrict;
+        $idor_params['entity_restrict'] = $entity_restrict;
     }
     if (isset($_POST['condition'])) {
         $p['condition']           = $_POST['condition'];

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use function Safe\json_encode;
+
 global $CFG_GLPI;
 
 header("Content-Type: text/html; charset=UTF-8");

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -121,7 +121,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
         $params = ['items_id' => '__VALUE__',
             'itemtype' => $_POST["idtable"],
         ];
-        if (isset($_POST['entity_restrict'])) {
+        if (isset($entity_restrict)) {
             $params['entity_restrict'] = $entity_restrict;
         }
 

--- a/ajax/dropdownAllItems.php
+++ b/ajax/dropdownAllItems.php
@@ -122,7 +122,7 @@ if ($_POST["idtable"] && class_exists($_POST["idtable"])) {
             'itemtype' => $_POST["idtable"],
         ];
         if (isset($_POST['entity_restrict'])) {
-            $params['entity_restrict'] = $_POST['entity_restrict'];
+            $params['entity_restrict'] = $entity_restrict;
         }
 
         $id = 'showItemSpecificity_' . $_POST['name'] . $rand;

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -3089,4 +3089,33 @@ HTML;
 
         $this->assertContains($project->getID(), $ids);
     }
+
+    public function testDropdownAllItemsEntityRestrictIsStringInJsConfig(): void
+    {
+        $this->login();
+
+        // A JS array causes jQuery to expand entity_restrict into N POST params, exhausting
+        // max_input_vars and silently truncating _idor_token.
+        $_POST['idtable']             = 'Ticket';
+        $_POST['name']                = 'items_id_2';
+        $_POST['display_emptychoice'] = 1;
+        $_POST['entity_restrict']     = [0, 1, 2];
+
+        ob_start();
+        include GLPI_ROOT . '/ajax/dropdownAllItems.php';
+        $output = ob_get_clean();
+
+        unset($_POST['idtable'], $_POST['name'], $_POST['display_emptychoice'], $_POST['entity_restrict']);
+
+        $this->assertMatchesRegularExpression(
+            '/"entity_restrict"\s*:\s*"[^"]*"/',
+            $output,
+            'entity_restrict must be a JSON string in the Select2 config, not a JS array'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/"entity_restrict"\s*:\s*\[/',
+            $output,
+            'entity_restrict must not be a JS array (would cause N POST params per entity)'
+        );
+    }
 }

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -77,6 +77,11 @@ use Toolbox;
 use User;
 use UserTitle;
 
+use function Safe\json_decode;
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+use function Safe\preg_match;
+
 /* Test for inc/dropdown.class.php */
 
 class DropdownTest extends DbTestCase
@@ -3114,6 +3119,42 @@ HTML;
         );
         $this->assertDoesNotMatchRegularExpression(
             '/"entity_restrict"\s*:\s*\[/',
+            $output,
+            'entity_restrict must not be a JS array (would cause N POST params per entity)'
+        );
+    }
+
+    public function testDropdownAllItemsEntityRestrictIsStringInShowItemSpecificity(): void
+    {
+        $this->login();
+
+        // Same array-expansion risk as testDropdownAllItemsEntityRestrictIsStringInJsConfig,
+        // but on the showItemSpecificity ajax call params.
+        $_POST['idtable']             = 'Ticket';
+        $_POST['name']                = 'items_id_2';
+        $_POST['display_emptychoice'] = 1;
+        $_POST['entity_restrict']     = [0, 1, 2];
+        $_POST['showItemSpecificity'] = 'ajax/dummy.php';
+
+        ob_start();
+        include GLPI_ROOT . '/ajax/dropdownAllItems.php';
+        $output = ob_get_clean();
+
+        unset(
+            $_POST['idtable'],
+            $_POST['name'],
+            $_POST['display_emptychoice'],
+            $_POST['entity_restrict'],
+            $_POST['showItemSpecificity']
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/entity_restrict:"[^"]*"/',
+            $output,
+            'entity_restrict must be a JSON string in the showItemSpecificity call, not a JS array'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/entity_restrict:\[/',
             $output,
             'entity_restrict must not be a JS array (would cause N POST params per entity)'
         );


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44239

When a user has access to many entities, the "Link Ticket - Tickets" search field gets stuck on "Searching..." and never returns results.

`ajax/dropdownAllItems.php` was passing `entity_restrict` as a PHP array to `jsAjaxDropdown()`, which embeds it as a JS array in the Select2 config. jQuery then serializes it as one POST variable per entity (`entity_restrict[]=1&entity_restrict[]=2&...`).
With enough entities this exceeds PHP's `max_input_vars` limit (default 1000), silently truncating the `_idor_token` POST variable. IDOR validation then fails and `getDropdownValue.php` returns an empty body.

The fix JSON-encodes `entity_restrict` before embedding it in the config (matching the pattern already used in `Dropdown::show()`), so jQuery always sends it as a single POST parameter regardless of how many entities the user has access to.

## Screenshots (if appropriate):
