### PR TITLE
Take port into account for CRSF host/origin comparison

### DIFF
--- a/src/Glpi/Kernel/Listener/ControllerListener/CheckCsrfListener.php
+++ b/src/Glpi/Kernel/Listener/ControllerListener/CheckCsrfListener.php
@@ -36,6 +36,7 @@ namespace Glpi\Kernel\Listener\ControllerListener;
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Http\SessionManager;
+use RuntimeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -101,7 +102,19 @@ final readonly class CheckCsrfListener implements EventSubscriberInterface
         $origin = $request->headers->get('Origin');
         $host = $request->headers->get('Host');
         if ($origin !== null && $host !== null) {
-            return parse_url($origin, PHP_URL_HOST) === $host;
+            $origin_host = parse_url($origin, PHP_URL_HOST);
+            if (!is_string($origin_host) || $origin_host === "") {
+                // Likely impossible, just here to make phpstan happy
+                throw new RuntimeException('Failed to parse host from origin');
+            }
+
+            // Port is optional, use it only if specified
+            $origin_port = parse_url($origin, PHP_URL_PORT);
+            if (is_int($origin_port)) {
+                return "$origin_host:$origin_port" === $host;
+            }
+
+            return $origin_host === $host;
         }
 
         // If both 'Sec-Fetch-Site' and 'Origin' are missing then the request

--- a/tests/e2e/specs/Security/csrf.spec.ts
+++ b/tests/e2e/specs/Security/csrf.spec.ts
@@ -36,6 +36,7 @@ import { getWorkerEntityId } from '../../utils/WorkerEntities';
 
 const external_origin = "https://not-my-origin.com";
 const same_origin = "https://my-origin.com";
+const same_origin_with_port = "https://my-origin.com:12345";
 
 const post_cases = [
     // Test all possible "Sec-Fetch-Site" values
@@ -48,6 +49,7 @@ const post_cases = [
     // Demonstrate "Origin" fallback
     { sec_fetch_site: null, origin: external_origin, expected: 403 },
     { sec_fetch_site: null, origin: same_origin, expected: 200 },
+    { sec_fetch_site: null, origin: same_origin_with_port, expected: 200 },
 
     // Demonstrate that "Sec-Fetch-Site" take precedence over "Origin"
     { sec_fetch_site: "same-origin", origin: external_origin, expected: 200 },
@@ -113,8 +115,8 @@ function configHeaders(
         'Origin'?: string,
         'Host': string,
     } = {
-        // Host is always set by the browser.
-        Host: "my-origin.com",
+        // Host is always set by the browser. Insert port if needed.
+        Host: origin && origin.split(':').length > 2 ? "my-origin.com:12345" : "my-origin.com",
     };
 
     if (sec_fetch_site !== null) {


### PR DESCRIPTION
I found a small issue with the new CSRF checks.

When connecting from `http://1.111.111.111:12000`, the headers would be:
```
Host: "1.111.111.111:12000"
Origin: "https://1.111.111.111:12000
```

Then, our code would extract only the url part from `Origin`, thus getting `1.111.111.111`.
It would then compare it to the host and the comparison would fail since host is `1.111.111.111:12000`.

The fix is simple: we must also extract the port from the `Origin` header and use it in our comparison if needed.
