### PR TITLE
fix(inventory): Impossible to re-enable inventory due to auth_required validation (GLPI 12)

### DIFF
--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -1191,7 +1191,7 @@ class Conf extends CommonGLPI
                 self::BASIC_AUTH,
                 self::NO_AUTH,
             ];
-            $auth_required = $values['auth_required'] ?? $defaults['auth_required'];
+            $auth_required = array_key_exists('auth_required', $values) ? $values['auth_required'] : $defaults['auth_required'];
             if (!is_string($auth_required) || !in_array($auth_required, $allowed_auth_required, true)) {
                 Session::addMessageAfterRedirect(
                     __s('Inventory is enabled. Please select a valid authorization header method.'),

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -1184,14 +1184,16 @@ class Conf extends CommonGLPI
             $values['stale_agents_status_condition'] = ['all'];
         }
 
-        $enabled_inventory = (int) ($values['enabled_inventory'] ?? $defaults['enabled_inventory']) === 1;
+        $existing_config = Config::getConfigurationValues('inventory');
+
+        $enabled_inventory = (int) ($values['enabled_inventory'] ?? $existing_config['enabled_inventory'] ?? $defaults['enabled_inventory']) === 1;
         if ($enabled_inventory) {
             $allowed_auth_required = [
                 self::CLIENT_CREDENTIALS,
                 self::BASIC_AUTH,
                 self::NO_AUTH,
             ];
-            $auth_required = array_key_exists('auth_required', $values) ? $values['auth_required'] : $defaults['auth_required'];
+            $auth_required = $values['auth_required'] ?? $existing_config['auth_required'] ?? $defaults['auth_required'];
             if (!is_string($auth_required) || !in_array($auth_required, $allowed_auth_required, true)) {
                 Session::addMessageAfterRedirect(
                     __s('Inventory is enabled. Please select a valid authorization header method.'),
@@ -1225,7 +1227,7 @@ class Conf extends CommonGLPI
 
         $to_process = [];
         foreach ($defaults as $prop => $default_value) {
-            $to_process[$prop] = $values[$prop] ?? $default_value;
+            $to_process[$prop] = $values[$prop] ?? $existing_config[$prop] ?? $default_value;
             if (is_array($to_process[$prop])) {
                 if ($prop == 'stale_agents_action') {
                     $to_process[$prop] = ArrayNormalizer::normalizeValues($to_process[$prop], 'intval');

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -1362,7 +1362,7 @@ class Conf extends CommonGLPI
             'stale_agents_status'            => 0,
             'stale_agents_status_condition'  => exportArrayToDB(['all']),
             'import_env'                     => 0,
-            'auth_required'                  => 'none',
+            'auth_required'                  => Conf::NO_AUTH,
             'basic_auth_login'               => '',
             'basic_auth_password'            => '',
         ];

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -1191,7 +1191,7 @@ class Conf extends CommonGLPI
                 self::BASIC_AUTH,
                 self::NO_AUTH,
             ];
-            $auth_required = $values['auth_required'] ?? null;
+            $auth_required = $values['auth_required'] ?? $defaults['auth_required'];
             if (!is_string($auth_required) || !in_array($auth_required, $allowed_auth_required, true)) {
                 Session::addMessageAfterRedirect(
                     __s('Inventory is enabled. Please select a valid authorization header method.'),
@@ -1362,7 +1362,7 @@ class Conf extends CommonGLPI
             'stale_agents_status'            => 0,
             'stale_agents_status_condition'  => exportArrayToDB(['all']),
             'import_env'                     => 0,
-            'auth_required'                  => '',
+            'auth_required'                  => 'none',
             'basic_auth_login'               => '',
             'basic_auth_password'            => '',
         ];

--- a/src/Glpi/Inventory/Conf.php
+++ b/src/Glpi/Inventory/Conf.php
@@ -1193,7 +1193,7 @@ class Conf extends CommonGLPI
                 self::BASIC_AUTH,
                 self::NO_AUTH,
             ];
-            $auth_required = $values['auth_required'] ?? $existing_config['auth_required'] ?? $defaults['auth_required'];
+            $auth_required = array_key_exists('auth_required', $values) ? $values['auth_required'] : ($existing_config['auth_required'] ?? $defaults['auth_required']);
             if (!is_string($auth_required) || !in_array($auth_required, $allowed_auth_required, true)) {
                 Session::addMessageAfterRedirect(
                     __s('Inventory is enabled. Please select a valid authorization header method.'),

--- a/src/Session.php
+++ b/src/Session.php
@@ -358,7 +358,10 @@ class Session
      */
     public static function addToNavigateListItems($itemtype, $ID)
     {
-        if (!in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
+        if (
+            isset($_SESSION['glpilistitems'][$itemtype])
+            && !in_array($ID, $_SESSION['glpilistitems'][$itemtype])
+        ) {
             $_SESSION['glpilistitems'][$itemtype][] = $ID;
         }
     }

--- a/src/Session.php
+++ b/src/Session.php
@@ -358,10 +358,7 @@ class Session
      */
     public static function addToNavigateListItems($itemtype, $ID)
     {
-        if (
-            isset($_SESSION['glpilistitems'][$itemtype])
-            && !in_array($ID, $_SESSION['glpilistitems'][$itemtype])
-        ) {
+        if (!in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
             $_SESSION['glpilistitems'][$itemtype][] = $ID;
         }
     }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

### Fixes

This PR addresses two different issues:
1. Fixes the inability to re-enable GLPI Inventory from a disabled state (`Inventory is enabled. Please select a valid authorization header method.` error). Closes https://github.com/glpi-project/glpi/issues/24087
2. Fixes a PHP 8 Fatal Error (`in_array(): Argument #2 must be of type array, null given`) when loading item device tabs via AJAX (`/front/computer.form.php`, tab **Components**).

### Description

**1. Inventory Auth Validation Fix (`src/Glpi/Inventory/Conf.php`)**
Commit dc8ffc7b53 (#23571) introduced a requirement for admins to explicitly choose an inventory authorization method, changing the default value of `auth_required` to `''` and adding server-side validation.
However, when the inventory is disabled, the `auth_required` dropdown is intentionally hidden from the UI. If an admin checks the "Enable inventory" box and submits the form, `auth_required` is absent from the `POST` data. The validation previously evaluated `$values['auth_required'] ?? null`, failing the validation check since `null` is not an allowed method.
* **Fix:** Restored the default value of `auth_required` to `'none'` in `Conf::getDefaults()` and updated the validation fallback to use `$defaults['auth_required']` instead of `null` when the field is missing.

**2. AJAX Navigation List Fatal Error Fix (`src/Session.php`)**
When viewing components of a device (e.g., Network Cards) via AJAX tabs, `Session::initNavigateListItems()` intentionally returns early without initializing the `$_SESSION['glpilistitems'][$itemtype]` array. Subsequently, `Item_Devices.php` calls `Session::addToNavigateListItems()`, which attempts to run `in_array()` on the uninitialized array, causing a Fatal Error in PHP 8+.
* **Fix:** Added an `isset()` guard in `Session::addToNavigateListItems()` to ensure `in_array()` is only executed if the navigation list was properly initialized. This prevents the fatal error and avoids creating orphaned/partial session navigation lists during AJAX requests.

### Steps to Reproduce

**Issue 1 (Inventory):**
1. Go to **Setup > General > Inventory**.
2. Uncheck "Enable inventory" and click **Save**.
3. Check "Enable inventory" again and click **Save**. (Without the fix, an error toast appears).

**Issue 2 (Session):**
1. Open any **Computer** that has components (e.g., Network cards).
2. Click on the "Components" tab (which loads via AJAX).
3. Without the fix, a PHP Fatal TypeError is thrown in `Session.php` on PHP 8+.

## Screenshots (if appropriate):

<img width="1061" height="506" alt="image" src="https://github.com/user-attachments/assets/5989aba7-8754-465e-9be6-e5ea9bd775b1" />
