### PR TITLE
fix: prevent search filters dropdown from closing when navigating calendar

### DIFF
--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -67,6 +67,16 @@ $(function() {
             locale:          getFlatPickerLocale("{{ locale['language']|e('js') }}", "{{ locale['region']|e('js') }}"),
             minuteIncrement: {{ timestep }},
             allowInput:      true,
+            onReady:         function(dates, str, instance) {
+                // The calendar is appended to <body>, so its clicks never bubble
+                // through the search filters dropdown. Stop them from reaching the
+                // document so Bootstrap's dropdown auto-close (a document 'click'
+                // listener) doesn't treat calendar navigation (month arrows, etc.)
+                // as an outside click and close the panel.
+                instance.calendarContainer.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                });
+            },
             onClose:         function(dates, str, picker) {
                 picker.setDate(picker.altInput.value, true, picker.config.altFormat);
             },

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -49,6 +49,7 @@
         <span class="form-check-label text-secondary small">{{ __('Specify a time') }}</span>
     </label>
 </div>
+
 <script>
 $(function() {
     function buildFp(hasTime, defaultDate) {

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -49,7 +49,6 @@
         <span class="form-check-label text-secondary small">{{ __('Specify a time') }}</span>
     </label>
 </div>
-
 <script>
 $(function() {
     function buildFp(hasTime, defaultDate) {

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -361,6 +361,50 @@ $(document).ready(function() {
       refreshSearchResults();
    });
 
+    // Keep flatpickr calendars inside the search panel's dropdown-menu so Bootstrap's
+    // composedPath() check treats calendar interactions as "inside" the dropdown,
+    // preventing it from closing without needing e.preventDefault().
+    // Flatpickr calls positionCalendar() internally via a closure so overriding the
+    // instance property does nothing — the `position` config function is the correct
+    // hook. getBoundingClientRect() accounts for Popper transforms so the formula
+    // (inputBounds - dropdownRect) gives correct container-relative coordinates.
+    const _flatpickrOrig = $.fn.flatpickr;
+    $.fn.flatpickr = function (config) {
+        const dropdown = $(this).closest('.dropdown-menu-card')[0];
+        if (dropdown) {
+            config = Object.assign({}, config, {
+                appendTo: dropdown,
+                position(fpInstance, positionElement) {
+                    const input = (positionElement || fpInstance._positionElement).getBoundingClientRect();
+                    const cal = fpInstance.calendarContainer;
+                    const r = dropdown.getBoundingClientRect();
+                    const showOnTop = window.innerHeight - input.bottom < cal.offsetHeight
+                        && input.top > cal.offsetHeight;
+                    cal.style.top = (showOnTop
+                        ? input.top - r.top - cal.offsetHeight - 2
+                        : input.bottom - r.top + 2) + 'px';
+                    cal.style.left = Math.max(0, input.left - r.left) + 'px';
+                    cal.style.right = 'auto';
+                    cal.classList.toggle('arrowTop', !showOnTop);
+                    cal.classList.toggle('arrowBottom', showOnTop);
+                },
+            });
+
+            // Because the calendar is now appended inside the search <form>, flatpickr's
+            // purely-visual number inputs (year, hour, minute) become part of the form's
+            // HTML5 constraint validation. The minute input carries a "step" (time_step), so
+            // a value such as ":11" is reported invalid and form.checkValidity() returns
+            // false — which silently blocks the "Search" button. Detach those inputs from the
+            // form (they are never submitted) so they can no longer affect its validity.
+            config.onReady = [].concat(config.onReady || [], function (selectedDates, dateStr, instance) {
+                instance.calendarContainer.querySelectorAll('input').forEach(function (input) {
+                    input.setAttribute('form', 'flatpickr-no-form');
+                });
+            });
+        }
+        return _flatpickrOrig.call(this, config);
+    };
+
    $('.default-filter').change(function(event) {
       const search_params = new URLSearchParams(window.location.search);
       if (!$(this).is(":checked")) {

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -361,50 +361,6 @@ $(document).ready(function() {
       refreshSearchResults();
    });
 
-    // Keep flatpickr calendars inside the search panel's dropdown-menu so Bootstrap's
-    // composedPath() check treats calendar interactions as "inside" the dropdown,
-    // preventing it from closing without needing e.preventDefault().
-    // Flatpickr calls positionCalendar() internally via a closure so overriding the
-    // instance property does nothing — the `position` config function is the correct
-    // hook. getBoundingClientRect() accounts for Popper transforms so the formula
-    // (inputBounds - dropdownRect) gives correct container-relative coordinates.
-    const _flatpickrOrig = $.fn.flatpickr;
-    $.fn.flatpickr = function (config) {
-        const dropdown = $(this).closest('.dropdown-menu-card')[0];
-        if (dropdown) {
-            config = Object.assign({}, config, {
-                appendTo: dropdown,
-                position(fpInstance, positionElement) {
-                    const input = (positionElement || fpInstance._positionElement).getBoundingClientRect();
-                    const cal = fpInstance.calendarContainer;
-                    const r = dropdown.getBoundingClientRect();
-                    const showOnTop = window.innerHeight - input.bottom < cal.offsetHeight
-                        && input.top > cal.offsetHeight;
-                    cal.style.top = (showOnTop
-                        ? input.top - r.top - cal.offsetHeight - 2
-                        : input.bottom - r.top + 2) + 'px';
-                    cal.style.left = Math.max(0, input.left - r.left) + 'px';
-                    cal.style.right = 'auto';
-                    cal.classList.toggle('arrowTop', !showOnTop);
-                    cal.classList.toggle('arrowBottom', showOnTop);
-                },
-            });
-
-            // Because the calendar is now appended inside the search <form>, flatpickr's
-            // purely-visual number inputs (year, hour, minute) become part of the form's
-            // HTML5 constraint validation. The minute input carries a "step" (time_step), so
-            // a value such as ":11" is reported invalid and form.checkValidity() returns
-            // false — which silently blocks the "Search" button. Detach those inputs from the
-            // form (they are never submitted) so they can no longer affect its validity.
-            config.onReady = [].concat(config.onReady || [], function (selectedDates, dateStr, instance) {
-                instance.calendarContainer.querySelectorAll('input').forEach(function (input) {
-                    input.setAttribute('form', 'flatpickr-no-form');
-                });
-            });
-        }
-        return _flatpickrOrig.call(this, config);
-    };
-
    $('.default-filter').change(function(event) {
       const search_params = new URLSearchParams(window.location.search);
       if (!$(this).is(":checked")) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44463
- When using a date filter with the specify a date option in the search panel, clicking the month arrows in the calendar would cause the search panel to close while the calendar remained visible on the page. This has been fixed by intercerpting hide.bs.dropdown and canceling it as long as the calendar is open.

## Screenshots (if appropriate):
<img width="525" height="315" alt="Capture d’écran du 2026-06-04 09-32-06" src="https://github.com/user-attachments/assets/6993a002-2e10-4888-b1fe-0e87b33a3c34" />


