### PR TITLE
Fix import of inactive genericobject items

### DIFF
--- a/src/Glpi/Features/State.php
+++ b/src/Glpi/Features/State.php
@@ -36,27 +36,20 @@
 namespace Glpi\Features;
 
 use DropdownVisibility;
-use LogicException;
+use Glpi\DBAL\QueryExpression;
 
 trait State
 {
     /**
      * Check if itemtype class is present in configuration array
      *
-     * @return void
+     * @return bool
      */
-    private function checkSetup(): void
+    private function hasStates(): bool
     {
         global $CFG_GLPI;
 
-        if (!in_array(static::class, $CFG_GLPI['state_types'])) {
-            throw new LogicException(
-                sprintf(
-                    'Class %s must be present in $CFG_GLPI[\'state_types\']',
-                    static::class
-                )
-            );
-        }
+        return in_array(static::class, $CFG_GLPI['state_types']);
     }
 
     /**
@@ -64,7 +57,10 @@ trait State
      */
     public function isStateVisible(int $id): bool
     {
-        $this->checkSetup();
+        if (!$this->hasStates()) {
+            return false;
+        }
+
         $dropdownVisibility = new DropdownVisibility();
         return $dropdownVisibility->getFromDBByCrit([
             'itemtype' => \State::getType(),
@@ -79,7 +75,12 @@ trait State
      */
     public function getStateVisibilityCriteria(): array
     {
-        $this->checkSetup();
+        if (!$this->hasStates()) {
+            return [
+                'WHERE' => [new QueryExpression('false')],
+            ];
+        }
+
         return [
             'LEFT JOIN' => [
                 DropdownVisibility::getTable() => [

--- a/templates/components/form/item_device.html.twig
+++ b/templates/components/form/item_device.html.twig
@@ -181,7 +181,7 @@
                      ) }}
                   {% endif %}
 
-                  {% if item.isField('states_id') and item is usingtrait('Glpi\\Features\\State') %}
+                  {% if item.isField('states_id') and get_class(item) in config('state_types') %}
                      {{ fields.dropdownField(
                         'State',
                         'states_id',

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -74,7 +74,7 @@
                               {{ fields.autoNameField('template_name', item, __('Template name'), 0, specific_field_options) }}
                           {% elseif item.isField('is_active') and field is same as '_template_is_active' and withtemplate >= 1 %}
                               {{ fields.hiddenField('is_active', item.fields['is_active']) }}
-                          {% elseif field is same as 'states_id' and item is usingtrait('Glpi\\Features\\State') %}
+                          {% elseif field is same as 'states_id' and get_class(item) in config('state_types') %}
                               {{ fields.dropdownField(
                                   'State',
                                   'states_id',

--- a/tests/fixtures/genericobject-migration/genericobject-db.sql
+++ b/tests/fixtures/genericobject-migration/genericobject-db.sql
@@ -190,6 +190,9 @@ CREATE TABLE `glpi_plugin_genericobject_inactives` (
   KEY `date_mod` (`date_mod`),
   KEY `date_creation` (`date_creation`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+INSERT INTO `glpi_plugin_genericobject_inactives` (`id`, `entities_id`, `name`, `comment`, `date_mod`, `date_creation`) VALUES
+(1, 0, 'Inactive 1', '', '2025-01-13 08:47:23', '2025-01-13 08:47:23'),
+(2, 0, 'Inactive 2', '', '2025-02-24 17:43:01', '2025-02-26 14:12:17');
 
 CREATE TABLE `glpi_plugin_genericobject_smartphones` (
   `id` INT UNSIGNED AUTO_INCREMENT NOT NULL,

--- a/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
+++ b/tests/functional/Glpi/Migration/GenericobjectPluginMigrationTest.php
@@ -66,6 +66,8 @@ class GenericobjectPluginMigrationTest extends DbTestCase
 
         parent::setUpBeforeClass();
 
+        self::clearDb();
+
         // Load it once for the whole class.
         // This will create new tables, therefore cannot be executed inside the test DB transaction.
         $queries = $DB->getQueriesFromFile(sprintf('%s/tests/fixtures/genericobject-migration/genericobject-db.sql', GLPI_ROOT));
@@ -76,6 +78,13 @@ class GenericobjectPluginMigrationTest extends DbTestCase
 
     public static function tearDownAfterClass(): void
     {
+        self::clearDb();
+
+        parent::tearDownAfterClass();
+    }
+
+    private static function clearDb(): void
+    {
         global $DB;
 
         $tables = $DB->listTables('glpi\_plugin\_genericobject\_%');
@@ -84,7 +93,6 @@ class GenericobjectPluginMigrationTest extends DbTestCase
         }
 
         $DB->clearSchemaCache();
-        parent::tearDownAfterClass();
     }
 
     public function setUp(): void

--- a/tests/functional/StateTest.php
+++ b/tests/functional/StateTest.php
@@ -258,8 +258,7 @@ class StateTest extends DbTestCase
         unset($CFG_GLPI['state_types'][0]);
         $this->assertTrue(method_exists($itemtype, 'isStateVisible'), $itemtype . ' misses isStateVisible() method!');
 
-        $this->expectExceptionMessage(sprintf('Class %s must be present in $CFG_GLPI[\'state_types\']', $itemtype));
-        $this->assertTrue($item->isStateVisible($states_id));
+        $this->assertFalse($item->isStateVisible($states_id));
     }
 
     public function testGetStateVisibilityCriteria(): void


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes #24255.

When importing inactive items from the `genericobject`, the corresponding generic asset class is not added to the `$CFG_GLPI` entries because it is inactive. The `Glpi\Features\State` trait is still used, because, to prevent having to render on-the-fly too much code, we do not condition its usage to the active state of the asset definition.

Instead of throwing an exception when the `Glpi\Features\State` trait is used on a class that is not present in `$CFG_GLPI['state_types']`, I propose to make the feature unavailable.