### PR TITLE
Fix sql error 'Unknown column name' during transfer

### DIFF
--- a/src/Transfer.php
+++ b/src/Transfer.php
@@ -4219,14 +4219,20 @@ final class Transfer extends CommonDBTM
                 if (!empty($tab)) {
                     $table = $itemtype::getTable();
                     $name_field = $itemtype::getNameField();
-                    $table_name_field = sprintf('%1$s.%2$s', $table, $name_field);
+                    $has_name_field = $DB->fieldExists($table, $name_field);
+                    $table_name_field = $has_name_field ? sprintf('%1$s.%2$s', $table, $name_field) : null;
+
+                    $select = [
+                        "$table.id",
+                        'entities.completename AS entname',
+                        'entities.id AS entID',
+                    ];
+                    if ($table_name_field !== null) {
+                        $select[] = $table_name_field;
+                    }
+
                     $iterator = $DB->request([
-                        'SELECT' => [
-                            "$table.id",
-                            $table_name_field,
-                            'entities.completename AS entname',
-                            'entities.id AS entID',
-                        ],
+                        'SELECT' => $select,
                         'FROM' => $table,
                         'LEFT JOIN' => [
                             'glpi_entities AS entities' => [
@@ -4237,7 +4243,7 @@ final class Transfer extends CommonDBTM
                             ],
                         ],
                         'WHERE' => ["$table.id" => $tab],
-                        'ORDERBY' => ['entname', $table_name_field],
+                        'ORDERBY' => $table_name_field !== null ? ['entname', $table_name_field] : ['entname'],
                     ]);
 
                     foreach ($iterator as $data) {

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1412,9 +1412,9 @@ class TransferTest extends DbTestCase
         } catch (\Throwable $e) {
             ob_end_clean();
             throw $e;
+        } finally {
+            unset($_SESSION['glpitransfer_list']);
         }
-
-        unset($_SESSION['glpitransfer_list']);
 
         $this->assertNotEmpty($output);
     }

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1377,6 +1377,48 @@ class TransferTest extends DbTestCase
         unset($_SESSION['glpitransfer_list']);
     }
 
+    public function testShowTransferListWithItemDevicesDoesNotFailOnMissingNameField(): void
+    {
+        $this->login();
+
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'Transfer test computer',
+            'entities_id' => $entity_id,
+        ]);
+
+        $soundcard = $this->createItem(\DeviceSoundCard::class, [
+            'designation' => 'Transfer test soundcard',
+            'entities_id' => $entity_id,
+        ]);
+
+        $item_soundcard = $this->createItem(\Item_DeviceSoundCard::class, [
+            'itemtype'            => \Computer::class,
+            'items_id'            => $computer->getID(),
+            'devicesoundcards_id' => $soundcard->getID(),
+            'entities_id'         => $entity_id,
+        ]);
+
+        $_SESSION['glpitransfer_list'] = [
+            \Item_DeviceSoundCard::class => [$item_soundcard->getID() => $item_soundcard->getID()],
+        ];
+
+        $transfer = new \Transfer();
+        ob_start();
+        try {
+            $transfer->showTransferList();
+            $output = ob_get_clean();
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
+
+        unset($_SESSION['glpitransfer_list']);
+
+        $this->assertNotEmpty($output);
+    }
+
     private function createMassiveActionMock(string $action): \MassiveAction
     {
         $ma = $this->getMockBuilder(\MassiveAction::class)

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1383,7 +1383,7 @@ class TransferTest extends DbTestCase
 
         $entity_id = $this->getTestRootEntity(only_id: true);
 
-        $computer = $this->createItem(\Computer::class, [
+        $computer = $this->createItem(Computer::class, [
             'name'        => 'Transfer test computer',
             'entities_id' => $entity_id,
         ]);
@@ -1394,7 +1394,7 @@ class TransferTest extends DbTestCase
         ]);
 
         $item_soundcard = $this->createItem(\Item_DeviceSoundCard::class, [
-            'itemtype'            => \Computer::class,
+            'itemtype'            => Computer::class,
             'items_id'            => $computer->getID(),
             'devicesoundcards_id' => $soundcard->getID(),
             'entities_id'         => $entity_id,

--- a/tests/functional/TransferTest.php
+++ b/tests/functional/TransferTest.php
@@ -1416,7 +1416,12 @@ class TransferTest extends DbTestCase
             unset($_SESSION['glpitransfer_list']);
         }
 
-        $this->assertNotEmpty($output);
+        $this->assertStringContainsString('<tbody>', $output);
+
+        $this->assertStringContainsString(
+            sprintf('(%d)', $item_soundcard->getID()),
+            $output
+        );
     }
 
     private function createMassiveActionMock(string $action): \MassiveAction


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44422
- Here is a brief description of what this PR does

When transferring an item from one entity to another, the SQL query was accessing the “name” field without checking whether it existed. So I added a check before including the field in the query.
## Screenshots (if appropriate):
<img width="1121" height="268" alt="image" src="https://github.com/user-attachments/assets/f263d7a7-3c77-416b-8978-dc2e72f1c8ce" />
<img width="1121" height="268" alt="image" src="https://github.com/user-attachments/assets/6d26a192-32b0-4404-9de9-544353167415" />


