### PR TITLE
fix(planning): delete instance error

### DIFF
--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -335,11 +335,11 @@ trait PlanningEvent
      * @param string $day
      *
      * @see addInstanceException
-     * @return void
+     * @return bool
      */
-    public function deleteInstance(int $id = 0, string $day = "")
+    public function deleteInstance(int $id = 0, string $day = ""): bool
     {
-        $this->addInstanceException($id, $day);
+        return $this->addInstanceException($id, $day);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

To reproduce:

- Create a recurring event in the planign
- Try to delete a single occurrence with right-click instead of the entire series > the error is triggered in the logs

The event is deleted from the database, but the page must be refreshed (F5) to see it removed from the calendar.

```txt
glpi.CRITICAL:   *** Uncaught PHP Exception TypeError: "Planning::deleteEvent(): Return value must be of type bool, null returned" at Planning.php line 1509
  Backtrace :
  ./src/Planning.php:1509                            
  ./ajax/planning.php:74                             Planning::deleteEvent()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```
