### PR TITLE
fix(ui): Empty icons in Breadcrumbs for all Device components

### DIFF
--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -172,6 +172,7 @@ abstract class CommonDevice extends CommonDropdown
                         $menu['options'][$key] = [
                             'title' => $val,
                             'page'  => $tmp::getSearchURL(false),
+                            'icon'  => $key::getIcon(),
                             'links' => [
                                 'search' => $tmp::getSearchURL(false),
                             ],
@@ -196,6 +197,7 @@ abstract class CommonDevice extends CommonDropdown
                             $menu['options'][$item_device_key] = [
                                 'title' => $itemTypeName,
                                 'page'  => $item_device_search_url,
+                                'icon'  => $itemClass::getIcon(),
                                 'links' => [
                                     'search' => $item_device_search_url,
                                 ],

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -172,7 +172,7 @@ abstract class CommonDevice extends CommonDropdown
                         $menu['options'][$key] = [
                             'title' => $val,
                             'page'  => $tmp::getSearchURL(false),
-                            'icon'  => $key::getIcon(),
+                            'icon'  => $tmp::getIcon(),
                             'links' => [
                                 'search' => $tmp::getSearchURL(false),
                             ],


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does:

The breadcrumbs for all device components (Network cards, Memory, Motherboards, etc.) were displaying empty icons (`<i class=""></i>`) because the `icon` attribute was not being injected into the menu array generated by `CommonDevice::getMenuContent()`.

> **Note:** Because the menu structure is cached in the PHP Session (`$_SESSION['glpimenu']`), you must **logout and login again** into GLPI after applying this patch to see the breadcrumb icons correctly. A simple page refresh (Ctrl+F5) will not rebuild the session cache.

(Moved from #24471)

## Screenshots (if appropriate):

Before: 

<img width="416" height="43" alt="image" src="https://github.com/user-attachments/assets/0fef6ead-e11d-4061-b006-64f1c1eeb814" />

After: 

<img width="442" height="39" alt="image" src="https://github.com/user-attachments/assets/48a76f2a-a63e-439b-a660-b9ba7085878d" />

Observe the Breadcrumb on the top of the page; the icon should now be displayed correctly for Network Cards (`ti ti-network`), as well as for any other component (Memory, Processors, etc.).
