### PR TITLE
fix: self-service user assigned to a ticket when adding a mail followup

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -492,8 +492,14 @@ class ITILFollowup extends CommonDBChild
 
         $itemtype = $input['itemtype'];
 
-        if ($itemtype == Ticket::class && $_SESSION['glpiset_followup_tech'] && !$input['is_private']) {
-            Ticket::assignToMe($this->input["items_id"], $input["users_id"]);
+        if ($itemtype == Ticket::class && !$input['is_private'] && $input["users_id"] > 0) {
+            $followup_author = new User();
+            if ($followup_author->getFromDB((int) $input["users_id"])) {
+                $followup_author->computePreferences();
+                if ($followup_author->fields['set_followup_tech']) {
+                    Ticket::assignToMe($this->input["items_id"], $input["users_id"]);
+                }
+            }
         }
 
         // Only calculate timeline_position if not already specified in the input

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -168,7 +168,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
     {
 
         if (
-           $this->isDeletedOrClosed()
+            $this->isDeletedOrClosed()
         ) {
             return false;
         }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -180,6 +180,34 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
 
     /**
+     * Check whether a specific user has the right to assign themselves to this ticket,
+     * based on their own profile rights rather than the current session.
+     *
+     * @param int $user_id
+     *
+     * @return bool
+     */
+    public function canAssignToUser(int $user_id): bool
+    {
+        if (
+            isset($this->fields['is_deleted']) && $this->fields['is_deleted'] == 1
+            || isset($this->fields['status']) && in_array($this->fields['status'], static::getClosedStatusArray())
+        ) {
+            return false;
+        }
+
+        $entity_id = $this->fields['entities_id'] ?? 0;
+
+        return (
+            Profile::haveUserRight($user_id, self::$rightname, self::STEAL, $entity_id)
+            || (
+                Profile::haveUserRight($user_id, self::$rightname, self::OWN, $entity_id)
+                && $this->countUsers(CommonITILActor::ASSIGN) == 0
+            )
+        );
+    }
+
+    /**
      * @param int $ticket_id
      * @param int $user_id
      *
@@ -194,7 +222,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                 'tickets_id' => $ticket_id,
                 'users_id'   => $user_id,
             ]);
-            if (!count($ticket_user) && $ticket->canAssignToMe()) {
+            if (!count($ticket_user) && $ticket->canAssignToUser($user_id)) {
                 $ticket->update([
                     'id' => $ticket_id,
                     '_users_id_assign' => $user_id,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -168,8 +168,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
     {
 
         if (
-            isset($this->fields['is_deleted']) && $this->fields['is_deleted'] == 1
-            || isset($this->fields['status']) && in_array($this->fields['status'], static::getClosedStatusArray())
+           $this->isDeletedOrClosed()
         ) {
             return false;
         }
@@ -190,8 +189,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
     public function canAssignToUser(int $user_id): bool
     {
         if (
-            isset($this->fields['is_deleted']) && $this->fields['is_deleted'] == 1
-            || isset($this->fields['status']) && in_array($this->fields['status'], static::getClosedStatusArray())
+            $this->isDeletedOrClosed()
         ) {
             return false;
         }
@@ -205,6 +203,12 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                 && $this->countUsers(CommonITILActor::ASSIGN) == 0
             )
         );
+    }
+
+    private function isDeletedOrClosed(): bool
+    {
+        return (isset($this->fields['is_deleted']) && $this->fields['is_deleted'] == 1
+            || isset($this->fields['status']) && in_array($this->fields['status'], static::getClosedStatusArray()));
     }
 
     /**

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -182,6 +182,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
      * Check whether a specific user has the right to assign themselves to this ticket,
      * based on their own profile rights rather than the current session.
      *
+     * @since 11.0.8
      * @param int $user_id
      *
      * @return bool

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7157,6 +7157,8 @@ HTML,
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
         $this->assertCount(1, $actors);
+        $this->assertSame(User::class, array_values($actors)[0]['itemtype']);
+        $this->assertSame($tech_user->getID(), (int) array_values($actors)[0]['items_id']);
 
         //add a solution to the ticket and assign to me
         $this->login('glpi', 'glpi');
@@ -7174,6 +7176,8 @@ HTML,
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
         $this->assertCount(2, $actors);
+        $this->assertSame(User::class, array_values($actors)[1]['itemtype']);
+        $this->assertSame($glpi_user->getID(), (int) array_values($actors)[1]['items_id']);
 
         //create a new ticket
         $ticket = $this->createItem(
@@ -7205,6 +7209,8 @@ HTML,
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
         $this->assertCount(0, $actors);
 
+        $requester_id = getItemByTypeName('User', 'glpi', true);
+
         //create a new ticket
         $ticket = $this->createItem(
             Ticket::class,
@@ -7213,7 +7219,7 @@ HTML,
                 'content'               => __METHOD__,
                 'entities_id'           => $entity_id,
                 '_skip_auto_assign'     => true,
-                '_users_id_requester'   => getItemByTypeName('User', 'glpi', true),
+                '_users_id_requester'   => $requester_id,
                 '_users_id_observer'    => getItemByTypeName('User', 'tech', true),
             ]
         );
@@ -7221,6 +7227,8 @@ HTML,
 
         $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
         $this->assertCount(1, $actors);
+        $this->assertSame(User::class, array_values($actors)[0]['itemtype']);
+        $this->assertSame($requester_id, (int) array_values($actors)[0]['items_id']);
 
         //add a followup to the ticket without assigning to me
         $this->login('glpi', 'glpi');
@@ -7367,6 +7375,10 @@ HTML,
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
         $this->assertCount($expected_actors_count, $actors);
+        if ($expected_actors_count > 0) {
+            $this->assertSame(User::class, array_values($actors)[0]['itemtype']);
+            $this->assertSame($from_user_id, (int) array_values($actors)[0]['items_id']);
+        }
     }
 
     public function testNotificationDisabled()

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7096,33 +7096,29 @@ HTML,
         $entity_id = 0;
 
         $ticket = new Ticket();
-        $fup = new ITILFollowup();
-        $sol = new ITILSolution();
 
         //create a ticket
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem(Ticket::class, [
             'name'                  => __METHOD__,
             'content'               => __METHOD__,
             'entities_id'           => $entity_id,
             '_skip_auto_assign'     => true,
             '_users_id_requester'   => getItemByTypeName('User', 'normal', true),
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         //add a followup to the ticket without assigning to me (tech)
         $this->login('tech', 'tech');
-        $tech_user = new User();
-        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
-        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_followup_tech' => 0]);
         $tech_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $fup->add([
+        $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
                 'users_id'  => $tech_user->getID(),
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7130,18 +7126,17 @@ HTML,
         $this->assertCount(0, $actors);
 
         //add a private followup to the ticket and NOT assign to me (tech)
-        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
-        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_followup_tech' => 1]);
         $tech_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $fup->add([
+        $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype'      => 'Ticket',
                 'items_id'      => $ticket_id,
                 'content'       => 'A simple followup',
                 'is_private'    => 1,
                 'users_id'      => $tech_user->getID(),
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7149,14 +7144,14 @@ HTML,
         $this->assertCount(0, $actors);
 
         //add a followup to the ticket and assign to me (tech)
-        $this->assertGreaterThan(
-            0,
-            (int) $fup->add([
+        $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
                 'users_id'  => $tech_user->getID(),
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7165,17 +7160,15 @@ HTML,
 
         //add a solution to the ticket and assign to me
         $this->login('glpi', 'glpi');
-        $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 1]);
-        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_solution_tech' => 1]);
         $glpi_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $sol->add([
+        $this->createItem(
+            ITILSolution::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple solution',
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7183,28 +7176,29 @@ HTML,
         $this->assertCount(2, $actors);
 
         //create a new ticket
-        $ticket_id = $ticket->add([
-            'name'                  => __METHOD__,
-            'content'               => __METHOD__,
-            'entities_id'           => $entity_id,
-            '_skip_auto_assign'     => true,
-            '_users_id_requester'   => getItemByTypeName('User', 'normal', true),
-        ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket = $this->createItem(
+            Ticket::class,
+            [
+                'name'                  => __METHOD__,
+                'content'               => __METHOD__,
+                'entities_id'           => $entity_id,
+                '_skip_auto_assign'     => true,
+                '_users_id_requester'   => getItemByTypeName('User', 'normal', true),
+            ]
+        );
+        $ticket_id = $ticket->getID();
 
         //add a solution to the ticket without assigning to me
         $this->login('tech', 'tech');
-        $tech_user = new User();
-        $tech_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 0]);
-        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_solution_tech' => 0]);
         $tech_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $sol->add([
+        $this->createItem(
+            ITILSolution::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple solution',
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7212,49 +7206,48 @@ HTML,
         $this->assertCount(0, $actors);
 
         //create a new ticket
-        $ticket_id = $ticket->add([
-            'name'                  => __METHOD__,
-            'content'               => __METHOD__,
-            'entities_id'           => $entity_id,
-            '_skip_auto_assign'     => true,
-            '_users_id_requester'   => getItemByTypeName('User', 'glpi', true),
-            '_users_id_observer'    => getItemByTypeName('User', 'tech', true),
-        ]);
-        $this->assertGreaterThan(0, $ticket_id);
-        $ticket->getFromDB($ticket_id);
+        $ticket = $this->createItem(
+            Ticket::class,
+            [
+                'name'                  => __METHOD__,
+                'content'               => __METHOD__,
+                'entities_id'           => $entity_id,
+                '_skip_auto_assign'     => true,
+                '_users_id_requester'   => getItemByTypeName('User', 'glpi', true),
+                '_users_id_observer'    => getItemByTypeName('User', 'tech', true),
+            ]
+        );
+        $ticket_id = $ticket->getID();
+
         $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
         $this->assertCount(1, $actors);
 
         //add a followup to the ticket without assigning to me
         $this->login('glpi', 'glpi');
-        $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
-        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_followup_tech' => 1]);
         $glpi_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $fup->add([
+        $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
                 'users_id'  => $glpi_user->getID(),
-            ])
+            ]
         );
 
         //add a followup to the ticket without assigning to me
         $this->login('tech', 'tech');
-        $tech_user = new User();
-        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
-        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_followup_tech' => 1]);
         $tech_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $fup->add([
+        $this->createItem(
+            ITILFollowup::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
                 'users_id'  => $tech_user->getID(),
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);
@@ -7263,17 +7256,15 @@ HTML,
 
         //add a solution to the ticket without assigning to me
         $this->login('glpi', 'glpi');
-        $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 1]);
-        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_solution_tech' => 1]);
         $glpi_user->loadPreferencesInSession();
-        $this->assertGreaterThan(
-            0,
-            (int) $sol->add([
+        $this->createItem(
+            ITILSolution::class,
+            [
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple solution',
-            ])
+            ]
         );
 
         $ticket->getFromDB($ticket_id);

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7108,13 +7108,17 @@ HTML,
 
         //add a followup to the ticket without assigning to me (tech)
         $this->login('tech', 'tech');
-        $_SESSION['glpiset_followup_tech'] = 0;
+        $tech_user = new User();
+        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
+        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
+                'users_id'  => $tech_user->getID(),
             ])
         );
 
@@ -7123,7 +7127,9 @@ HTML,
         $this->assertCount(0, $actors);
 
         //add a private followup to the ticket and NOT assign to me (tech)
-        $_SESSION['glpiset_followup_tech'] = 1;
+        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
+        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
@@ -7131,6 +7137,7 @@ HTML,
                 'items_id'      => $ticket_id,
                 'content'       => 'A simple followup',
                 'is_private'    => 1,
+                'users_id'      => $tech_user->getID(),
             ])
         );
 
@@ -7145,6 +7152,7 @@ HTML,
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
+                'users_id'  => $tech_user->getID(),
             ])
         );
 
@@ -7154,7 +7162,10 @@ HTML,
 
         //add a solution to the ticket and assign to me
         $this->login('glpi', 'glpi');
-        $_SESSION['glpiset_solution_tech'] = 1;
+        $glpi_user = new User();
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 1]);
+        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $sol->add([
@@ -7180,7 +7191,10 @@ HTML,
 
         //add a solution to the ticket without assigning to me
         $this->login('tech', 'tech');
-        $_SESSION['glpiset_solution_tech'] = 0;
+        $tech_user = new User();
+        $tech_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 0]);
+        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $sol->add([
@@ -7210,25 +7224,33 @@ HTML,
 
         //add a followup to the ticket without assigning to me
         $this->login('glpi', 'glpi');
-        $_SESSION['glpiset_followup_tech'] = 1;
+        $glpi_user = new User();
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
+        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
+                'users_id'  => $glpi_user->getID(),
             ])
         );
 
         //add a followup to the ticket without assigning to me
         $this->login('tech', 'tech');
-        $_SESSION['glpiset_followup_tech'] = 1;
+        $tech_user = new User();
+        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
+        $tech_user->getFromDB(Session::getLoginUserID());
+        $tech_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $fup->add([
                 'itemtype'  => 'Ticket',
                 'items_id'  => $ticket_id,
                 'content'   => 'A simple followup',
+                'users_id'  => $tech_user->getID(),
             ])
         );
 
@@ -7238,7 +7260,10 @@ HTML,
 
         //add a solution to the ticket without assigning to me
         $this->login('glpi', 'glpi');
-        $_SESSION['glpiset_solution_tech'] = 1;
+        $glpi_user = new User();
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 0]);
+        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user->loadPreferencesInSession();
         $this->assertGreaterThan(
             0,
             (int) $sol->add([

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7316,7 +7316,6 @@ HTML,
 
         // Associate an email address with the sender so MailCollector can resolve them
         $sender_email = $from_user . '@test.glpi.com';
-        $user_email = new UserEmail();
         $this->createItem(
             UserEmail::class,
             ['users_id' => $from_user_id, 'is_default' => 1, 'email' => $sender_email]

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -9376,7 +9376,7 @@ HTML,
             'pattern' => 'ITILsolution',
         ]);
 
-        $this->createItem(\UserEmail::class, [
+        $this->createItem(UserEmail::class, [
             'users_id' => $user->getID(),
             'is_default' => 1,
             'email' => 'tech@tech.tech',

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -57,6 +57,8 @@ use ITILCategory;
 use ITILFollowup;
 use ITILReminder;
 use ITILSolution;
+use Laminas\Mail\Storage\Message as MailMessage;
+use MailCollector;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Profile;
 use Profile_User;
@@ -79,6 +81,7 @@ use TicketTemplate;
 use TicketTemplateMandatoryField;
 use TicketValidation;
 use User;
+use UserEmail;
 
 /* Test for inc/ticket.class.php */
 
@@ -7276,6 +7279,104 @@ HTML,
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
         $this->assertCount(0, $actors);
+    }
+
+    public static function mailCollectorFollowupNotAssignedProvider(): array
+    {
+        return [
+            'self_service_user_has_no_tech_rights' => [
+                'from_user'        => 'normal',
+                'set_followup_tech' => 1,
+            ],
+            'tech_user_disabled_preference' => [
+                'from_user'        => 'tech',
+                'set_followup_tech' => 0,
+            ],
+            'tech_user_enabled_preference' => [
+                'from_user'        => 'tech',
+                'set_followup_tech' => 1,
+            ],
+        ];
+    }
+
+    #[DataProvider('mailCollectorFollowupNotAssignedProvider')]
+    public function testMailCollectorFollowupDoesNotAssignUser(string $from_user, int $set_followup_tech): void
+    {
+        // Log in as glpi and enable "assign me" preference to simulate the mail collector's
+        // own session
+        $this->login();
+        $glpi_user = new User();
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
+        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user->loadPreferencesInSession();
+
+        // Set the followup author's own preference in the database
+        $from_user_id = getItemByTypeName('User', $from_user, true);
+        $user = new User();
+        $user->update(['id' => $from_user_id, 'set_followup_tech' => $set_followup_tech]);
+
+        // Associate an email address with the sender so MailCollector can resolve them
+        $sender_email = $from_user . '@test.glpi.com';
+        $user_email = new UserEmail();
+        $this->assertGreaterThan(
+            0,
+            (int) $user_email->add(['users_id' => $from_user_id, 'is_default' => 1, 'email' => $sender_email])
+        );
+
+        //create mail collector
+        $collector = new MailCollector();
+        $mailgate_id = $collector->add([
+            'name'            => 'test-collector',
+            'is_active'       => 1,
+            'filesize_max'    => 2097152,
+            'requester_field' => MailCollector::REQUESTER_FIELD_FROM,
+            'mail_server'      => 'imap.test.glpi.com',
+            'server_type'      => '/imap',
+        ]);
+        $this->assertGreaterThan(0, $mailgate_id);
+        $collector->getFromDB($mailgate_id);
+
+        // Create a ticket with no assignee
+        $ticket = new Ticket();
+        $ticket_id = $ticket->add([
+            'name'              => __METHOD__,
+            'content'           => __METHOD__,
+            'entities_id'       => 0,
+            '_skip_auto_assign' => true,
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        // Build a raw email from the sender replying to the ticket (linked via subject line)
+        $raw = implode("\r\n", [
+            "From: {$from_user} <{$sender_email}>",
+            "To: helpdesk@glpi.com",
+            "Subject: Re: [GLPI #{$ticket_id}]",
+            "Message-ID: <test-{$from_user}-followup@glpi-test.com>",
+            "Date: Mon, 01 Jan 2024 12:00:00 +0000",
+            "",
+            "This is a test followup sent via email.",
+        ]);
+        $message = new MailMessage(['raw' => $raw]);
+
+        $tkt = $collector->buildTicket(1, $message, ['mailgates_id' => $mailgate_id, 'play_rules' => false]);
+
+        $this->assertFalse($tkt['_blacklisted']);
+        $this->assertArrayHasKey('tickets_id', $tkt);
+        $this->assertSame($ticket_id, $tkt['tickets_id']);
+        $this->assertSame($from_user_id, $tkt['users_id']);
+
+        // Replicate the followup-creation logic from MailCollector::collect()
+        $fup_input             = $tkt;
+        $fup_input['itemtype'] = Ticket::class;
+        $fup_input['items_id'] = $fup_input['tickets_id'];
+        unset($fup_input['tickets_id']);
+
+        $fup = new ITILFollowup();
+        $this->assertGreaterThan(0, (int) $fup->add($fup_input));
+
+        $ticket->getFromDB($ticket_id);
+        $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
+        $this->assertCount($set_followup_tech, $actors);
     }
 
     public function testNotificationDisabled()

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7281,7 +7281,7 @@ HTML,
         $this->assertCount(0, $actors);
     }
 
-    public static function mailCollectorFollowupNotAssignedProvider(): array
+    public static function mailCollectorFollowupSetAssigneeProvider(): array
     {
         return [
             'self_service_user_has_no_tech_rights' => [
@@ -7299,8 +7299,8 @@ HTML,
         ];
     }
 
-    #[DataProvider('mailCollectorFollowupNotAssignedProvider')]
-    public function testMailCollectorFollowupDoesNotAssignUser(string $from_user, int $set_followup_tech): void
+    #[DataProvider('mailCollectorFollowupSetAssigneeProvider')]
+    public function testMailCollectorFollowupSetAssignee(string $from_user, int $set_followup_tech): void
     {
         // Log in as glpi and enable "assign me" preference to simulate the mail collector's
         // own session

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7225,7 +7225,7 @@ HTML,
         //add a followup to the ticket without assigning to me
         $this->login('glpi', 'glpi');
         $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
         $glpi_user->getFromDB(Session::getLoginUserID());
         $glpi_user->loadPreferencesInSession();
         $this->assertGreaterThan(
@@ -7241,7 +7241,7 @@ HTML,
         //add a followup to the ticket without assigning to me
         $this->login('tech', 'tech');
         $tech_user = new User();
-        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 0]);
+        $tech_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
         $tech_user->getFromDB(Session::getLoginUserID());
         $tech_user->loadPreferencesInSession();
         $this->assertGreaterThan(
@@ -7261,7 +7261,7 @@ HTML,
         //add a solution to the ticket without assigning to me
         $this->login('glpi', 'glpi');
         $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 0]);
+        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_solution_tech' => 1]);
         $glpi_user->getFromDB(Session::getLoginUserID());
         $glpi_user->loadPreferencesInSession();
         $this->assertGreaterThan(

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7308,46 +7308,43 @@ HTML,
         // Log in as glpi and enable "assign me" preference to simulate the mail collector's
         // own session
         $this->login();
-        $glpi_user = new User();
-        $glpi_user->update(['id' => Session::getLoginUserID(), 'set_followup_tech' => 1]);
-        $glpi_user->getFromDB(Session::getLoginUserID());
+        $glpi_user = $this->updateItem(User::class, Session::getLoginUserID(), ['set_followup_tech' => 1]);
         $glpi_user->loadPreferencesInSession();
 
         // Set the followup author's own preference in the database
         $from_user_id = getItemByTypeName('User', $from_user, true);
-        $user = new User();
-        $user->update(['id' => $from_user_id, 'set_followup_tech' => $set_followup_tech]);
+        $this->updateItem(User::class, $from_user_id, ['set_followup_tech' => $set_followup_tech]);
 
         // Associate an email address with the sender so MailCollector can resolve them
         $sender_email = $from_user . '@test.glpi.com';
         $user_email = new UserEmail();
-        $this->assertGreaterThan(
-            0,
-            (int) $user_email->add(['users_id' => $from_user_id, 'is_default' => 1, 'email' => $sender_email])
+        $this->createItem(
+            UserEmail::class,
+            ['users_id' => $from_user_id, 'is_default' => 1, 'email' => $sender_email]
         );
 
-        //create mail collector
-        $collector = new MailCollector();
-        $mailgate_id = $collector->add([
-            'name'            => 'test-collector',
-            'is_active'       => 1,
-            'filesize_max'    => 2097152,
-            'requester_field' => MailCollector::REQUESTER_FIELD_FROM,
-            'mail_server'      => 'imap.test.glpi.com',
-            'server_type'      => '/imap',
-        ]);
-        $this->assertGreaterThan(0, $mailgate_id);
-        $collector->getFromDB($mailgate_id);
+        $collector = $this->createItem(
+            MailCollector::class,
+            [
+                'name'             => 'test-collector',
+                'is_active'        => 1,
+                'filesize_max'     => 2097152,
+                'requester_field'  => MailCollector::REQUESTER_FIELD_FROM,
+                'mail_server'      => 'imap.test.glpi.com',
+                'server_type'      => '/imap',
+            ],
+            ['mail_server', 'server_type']
+        );
+        $mailgate_id = $collector->getID();
 
         // Create a ticket with no assignee
-        $ticket = new Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem(Ticket::class, [
             'name'              => __METHOD__,
             'content'           => __METHOD__,
             'entities_id'       => 0,
             '_skip_auto_assign' => true,
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         // Build a raw email from the sender replying to the ticket (linked via subject line)
         $raw = implode("\r\n", [
@@ -7374,8 +7371,7 @@ HTML,
         $fup_input['items_id'] = $fup_input['tickets_id'];
         unset($fup_input['tickets_id']);
 
-        $fup = new ITILFollowup();
-        $this->assertGreaterThan(0, (int) $fup->add($fup_input));
+        $this->createItem(ITILFollowup::class, $fup_input, ['name', 'add_reopen']);
 
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -7285,22 +7285,25 @@ HTML,
     {
         return [
             'self_service_user_has_no_tech_rights' => [
-                'from_user'        => 'normal',
+                'from_user'        => 'post-only',
                 'set_followup_tech' => 1,
+                'expected_actors_count' => 0,
             ],
             'tech_user_disabled_preference' => [
                 'from_user'        => 'tech',
                 'set_followup_tech' => 0,
+                'expected_actors_count' => 0,
             ],
             'tech_user_enabled_preference' => [
                 'from_user'        => 'tech',
                 'set_followup_tech' => 1,
+                'expected_actors_count' => 1,
             ],
         ];
     }
 
     #[DataProvider('mailCollectorFollowupSetAssigneeProvider')]
-    public function testMailCollectorFollowupSetAssignee(string $from_user, int $set_followup_tech): void
+    public function testMailCollectorFollowupSetAssignee(string $from_user, int $set_followup_tech, int $expected_actors_count): void
     {
         // Log in as glpi and enable "assign me" preference to simulate the mail collector's
         // own session
@@ -7376,7 +7379,7 @@ HTML,
 
         $ticket->getFromDB($ticket_id);
         $actors = $ticket->getActorsForType(CommonITILActor::ASSIGN);
-        $this->assertCount($set_followup_tech, $actors);
+        $this->assertCount($expected_actors_count, $actors);
     }
 
     public function testNotificationDisabled()


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.

## Description

- Fixes !43852
- When the global configuration option "Add me as a technician when adding a ticket follow-up" is set to "yes", a user who adds a follow-up through the mail collector is always assigned as a technician on the ticket, even if their personal preference is set to "No" or if they do not have the required rights (for example, a Self-Service user).
- This happened because the code checked the option value and permissions stored in the current session instead of those of the user actually adding the follow-up.
- Fix: check the personal preference and permissions of the user adding the follow-up rather than the values stored in the current session.