### PR TITLE
fix defaultFIlter ignoring is_active flag

### DIFF
--- a/src/DefaultFilter.php
+++ b/src/DefaultFilter.php
@@ -149,7 +149,8 @@ class DefaultFilter extends CommonDBTM implements FilterableInterface
                 ],
             ],
             'WHERE' => [
-                "$default_table.itemtype" => $itemtype,
+                "$default_table.itemtype"   => $itemtype,
+                "$default_table.is_active"  => 1,
                 "NOT" => [
                     "$filter_table.search_criteria" => null,
                 ],

--- a/tests/functional/DefaultFilterTest.php
+++ b/tests/functional/DefaultFilterTest.php
@@ -66,11 +66,30 @@ class DefaultFilterTest extends DbTestCase
 
         $this->assertNotNull($result);
         $this->assertArrayHasKey('search_criteria', $result);
+        $this->assertSame('AND', $result['search_criteria']['link']);
+        $this->assertNotEmpty($result['search_criteria']['criteria']);
     }
 
     public function testGetSearchCriteriaReturnsNullWhenInactive(): void
     {
         $this->createDefaultFilterWithCriteria(false);
+
+        $this->assertNull(\DefaultFilter::getSearchCriteria(\Ticket::class));
+    }
+
+    private function createActiveFilterWithoutCriteria(): \DefaultFilter
+    {
+        return $this->createItem(\DefaultFilter::class, [
+            'name'      => 'Test filter without criteria',
+            'itemtype'  => \Ticket::class,
+            'is_active' => 1,
+        ]);
+    }
+
+    // Verify if a filter exists where no criteria are saved
+    public function testGetSearchCriteriaReturnsNullWhenActiveWithoutCriteria(): void
+    {
+        $this->createActiveFilterWithoutCriteria();
 
         $this->assertNull(\DefaultFilter::getSearchCriteria(\Ticket::class));
     }

--- a/tests/functional/DefaultFilterTest.php
+++ b/tests/functional/DefaultFilterTest.php
@@ -40,14 +40,11 @@ class DefaultFilterTest extends DbTestCase
 {
     private function createDefaultFilterWithCriteria(bool $is_active): \DefaultFilter
     {
-        $filter = new \DefaultFilter();
-        $id = $filter->add([
+        $filter = $this->createItem(\DefaultFilter::class, [
             'name'      => 'Test filter',
             'itemtype'  => \Ticket::class,
             'is_active' => (int) $is_active,
         ]);
-        $this->assertGreaterThan(0, $id);
-        $this->assertTrue($filter->getFromDB($id));
 
         $filter->saveFilter([
             ['link' => 'AND', 'field' => 12, 'searchtype' => 'equals', 'value' => 'notold'],

--- a/tests/functional/DefaultFilterTest.php
+++ b/tests/functional/DefaultFilterTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\DbTestCase;
+
+class DefaultFilterTest extends DbTestCase
+{
+    private function createDefaultFilterWithCriteria(bool $is_active): \DefaultFilter
+    {
+        $filter = new \DefaultFilter();
+        $id = $filter->add([
+            'name'      => 'Test filter',
+            'itemtype'  => \Ticket::class,
+            'is_active' => (int) $is_active,
+        ]);
+        $this->assertGreaterThan(0, $id);
+        $this->assertTrue($filter->getFromDB($id));
+
+        $filter->saveFilter([
+            ['link' => 'AND', 'field' => 12, 'searchtype' => 'equals', 'value' => 'notold'],
+        ]);
+
+        return $filter;
+    }
+
+    public function testGetSearchCriteriaReturnsNullWhenNoFilter(): void
+    {
+        $this->assertNull(\DefaultFilter::getSearchCriteria(\Ticket::class));
+    }
+
+    public function testGetSearchCriteriaReturnsDataWhenActive(): void
+    {
+        $this->createDefaultFilterWithCriteria(true);
+
+        $result = \DefaultFilter::getSearchCriteria(\Ticket::class);
+
+        $this->assertNotNull($result);
+        $this->assertArrayHasKey('search_criteria', $result);
+    }
+
+    public function testGetSearchCriteriaReturnsNullWhenInactive(): void
+    {
+        $this->createDefaultFilterWithCriteria(false);
+
+        $this->assertNull(\DefaultFilter::getSearchCriteria(\Ticket::class));
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44489
-  When a default filter was disabled, it continued to be applied to list views. “is_active = 1” was added to the WHERE clause so that disabled filters would be ignored.

## Screenshots (if appropriate):

<img width="716" height="152" alt="image" src="https://github.com/user-attachments/assets/b610b58c-9653-43e0-a6ca-01d7f860b85f" />

