### PR TITLE
fix ui: Add missing icons to Notification menu entries

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -196,6 +196,7 @@ class Notification extends CommonDBTM implements FilterableInterface
             $menu['icon']                                       = self::getIcon();
             $menu['options'][Notification::class]['title']           = _n('Notification', 'Notifications', Session::getPluralNumber());
             $menu['options'][Notification::class]['page']            = Notification::getSearchURL(false);
+            $menu['options'][Notification::class]['icon']            = Notification::getIcon();
             $menu['options'][Notification::class]['links']['add']    = Notification::getFormURL(false);
             $menu['options'][Notification::class]['links']['search'] = Notification::getSearchURL(false);
             //saved search list
@@ -206,6 +207,8 @@ class Notification extends CommonDBTM implements FilterableInterface
                         = _n('Notification template', 'Notification templates', Session::getPluralNumber());
             $menu['options'][NotificationTemplate::class]['page']
                         = NotificationTemplate::getSearchURL(false);
+            $menu['options'][NotificationTemplate::class]['icon']
+                        = NotificationTemplate::getIcon();
             $menu['options'][NotificationTemplate::class]['links']['add']
                         = NotificationTemplate::getFormURL(false);
             $menu['options'][NotificationTemplate::class]['links']['search']


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

- It fixes Notification-related pages display the correct icons in the left menu, but the corresponding breadcrumb entries do not show any icon.

This happens because the menu entries created in Notification::getMenuContent() define their title and page, but do not define an icon property.

Since breadcrumb rendering relies on the menu definition stored in the session, the icon is missing when navigating to Notification and Notification Template pages.

This change adds the corresponding icon definitions to the affected menu entries.

## Screenshots (if appropriate):
<img width="562" height="73" alt="image" src="https://github.com/user-attachments/assets/5b5e9fcc-fcf2-4533-ba3b-467194a60711" />

