### PR TITLE
Fix ui: Incomplete breadcrumbs for notification setting pages

### DIFF
--- a/front/notificationajaxsetting.form.php
+++ b/front/notificationajaxsetting.form.php
@@ -53,6 +53,6 @@ if (!empty($_POST["test_ajax_send"])) {
     Html::back();
 }
 
-$menus = ["config", "notification", "config"];
+$menus = ["config", "notification", NotificationAjaxSetting::class];
 $config_id = Config::getConfigIDForContext('core');
 NotificationAjaxSetting::displayFullPageForItem($config_id, $menus);

--- a/front/notificationmailingsetting.form.php
+++ b/front/notificationmailingsetting.form.php
@@ -75,6 +75,6 @@ if (isset($_POST["update"])) {
     Html::back();
 }
 
-$menus = ["config", "notification", "config"];
+$menus = ["config", "notification", NotificationMailingSetting::class];
 $config_id = Config::getConfigIDForContext('core');
 NotificationMailingSetting::displayFullPageForItem($config_id, $menus);

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -213,6 +213,14 @@ class Notification extends CommonDBTM implements FilterableInterface
             //saved search list
             $menu['options'][NotificationTemplate::class]['links']['lists']  = "";
             $menu['options'][NotificationTemplate::class]['lists_itemtype']  = NotificationTemplate::getType();
+
+            $menu['options'][NotificationMailingSetting::class]['title'] = NotificationMailingSetting::getTypeName();
+            $menu['options'][NotificationMailingSetting::class]['page']  = NotificationMailingSetting::getFormURL(false);
+            $menu['options'][NotificationMailingSetting::class]['icon']  = NotificationMailingSetting::getIcon();
+
+            $menu['options'][NotificationAjaxSetting::class]['title'] = NotificationAjaxSetting::getTypeName();
+            $menu['options'][NotificationAjaxSetting::class]['page']  = NotificationAjaxSetting::getFormURL(false);
+            $menu['options'][NotificationAjaxSetting::class]['icon']  = NotificationAjaxSetting::getIcon();
         }
         if (count($menu)) {
             return $menu;


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

It fixes Notification mailing and browser settings pages use a generic breadcrumb path (["config", "notification", "config"]), so the last breadcrumb entry is not resolved to the actual notification setting page.

Registering these setting pages in Notification::getMenuContent() and using their itemtype in the $menus array makes the breadcrumb consistent with the notification submenu entries.

## Screenshots (if appropriate):
<img width="926" height="395" alt="image" src="https://github.com/user-attachments/assets/f037fe22-7ca5-49a3-b9f7-c09e416c095c" />
<img width="538" height="305" alt="image" src="https://github.com/user-attachments/assets/ec1aaf27-c394-4061-83bd-0f98acf83580" />
<img width="521" height="221" alt="image" src="https://github.com/user-attachments/assets/b4711b47-5a8b-4ea8-8b25-b3145022a404" />