### PR TITLE
Fix: Prevent negative password history validation length

### DIFF
--- a/src/PasswordHistory.php
+++ b/src/PasswordHistory.php
@@ -194,6 +194,7 @@ final class PasswordHistory
     private function getPasswordHistoryLengthToValidate(): int
     {
         global $CFG_GLPI;
-        return max(0, ($CFG_GLPI['non_reusable_passwords_count'] ?? 1) - 1);
+        $password_count = (int) ($CFG_GLPI['non_reusable_passwords_count'] ?? 1);
+        return max(0, $password_count - 1);
     }
 }

--- a/src/PasswordHistory.php
+++ b/src/PasswordHistory.php
@@ -194,6 +194,6 @@ final class PasswordHistory
     private function getPasswordHistoryLengthToValidate(): int
     {
         global $CFG_GLPI;
-        return ($CFG_GLPI['non_reusable_passwords_count'] ?? 1) - 1;
+        return max(0, ($CFG_GLPI['non_reusable_passwords_count'] ?? 1) - 1);
     }
 }

--- a/tests/functional/PasswordHistoryTest.php
+++ b/tests/functional/PasswordHistoryTest.php
@@ -91,6 +91,14 @@ final class PasswordHistoryTest extends DbTestCase
             'expected' => true,
         ];
 
+        // Try to reuse old password 1 with password history fully disabled
+        $CFG_GLPI['non_reusable_passwords_count'] = 0;
+        yield [
+            'user'     => $tu_user,
+            'password' => "old password 1",
+            'expected' => true,
+        ];
+
         // Try to reuse current old password 1 with history enabled (length = 2)
         $CFG_GLPI['non_reusable_passwords_count'] = 3;
         yield [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

It fixes PasswordHistory::getPasswordHistoryLengthToValidate() subtracts 1 from
non_reusable_passwords_count because the current password is checked
separately from password_history.

If the configuration value is 0, the method currently returns -1. Since
validatePassword() only skips history checks when the length is exactly 0,
a negative value causes the full password history to be checked instead of
skipping it.

This change clamps the computed history length to 0 to avoid unexpected
password history validation when the configured count does not require it.