### PR TITLE
Check email key existence before validity check

### DIFF
--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -308,7 +308,7 @@ class UserEmail extends CommonDBChild
 
     public function prepareInputForUpdate($input)
     {
-        if (!$this->checkInputEmailValidity($input)) {
+        if (array_key_exists('email', $input) && !$this->checkInputEmailValidity($input)) {
             return false;
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [ X I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

Fix UserEmail partial updates by validating the email address only when the email field is part of the update payload.

## Rationale

`prepareInputForUpdate()` currently calls `checkInputEmailValidity()` unconditionally.
This rejects valid partial updates, such as updating only `is_default`, because `checkInputEmailValidity()` requires the `email` key to be present.

This change keeps the existing validation behavior when the email address is actually updated, while allowing unrelated fields to be updated normally.

## Changes

- Only validate `email` during update when the `email` field is present in the input.
- No behavior change for add operations.
- No behavior change for invalid email updates.