### PR TITLE
fix(forms): Group questions and comments by section to avoid confusion caused by identical names

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -3048,6 +3048,7 @@ export class GlpiFormEditorController
                     'name': this.#getItemInput($(question), "name"),
                     'type': this.#getItemInput($(question), "type"),
                     'extra_data': this.#getQuestionExtraData(question),
+                    'forms_sections_uuid': this.#getItemInput($(question), "forms_sections_uuid"),
                 });
             })
         ;
@@ -3072,6 +3073,7 @@ export class GlpiFormEditorController
                 comments.push({
                     'uuid': this.#getItemInput($(comment), "uuid"),
                     'name': this.#getItemInput($(comment), "name"),
+                    'forms_sections_uuid': this.#getItemInput($(comment), "forms_sections_uuid"),
                 });
             })
         ;

--- a/src/Glpi/Form/Condition/CommentData.php
+++ b/src/Glpi/Form/Condition/CommentData.php
@@ -39,6 +39,7 @@ final class CommentData
     public function __construct(
         private string $uuid,
         private string $name,
+        private ?string $section_uuid = null,
     ) {}
 
     public function getName(): string
@@ -49,5 +50,10 @@ final class CommentData
     public function getUuid(): string
     {
         return $this->uuid;
+    }
+
+    public function getSectionUuid(): ?string
+    {
+        return $this->section_uuid;
     }
 }

--- a/src/Glpi/Form/Condition/EditorManager.php
+++ b/src/Glpi/Form/Condition/EditorManager.php
@@ -91,54 +91,111 @@ final class EditorManager
         foreach ($sections_data as $section_data) {
             // Ignore the section that is currently selected as a condition can't
             // be used as a criteria for its own visiblity.
-            if (
-                $this->form_data->getSelectedItemType() == Type::SECTION->value
-                && $section_data->getUuid() == $this->form_data->getSelectedItemUuid()
-            ) {
+            if ($this->isSelectedItem(Type::SECTION, $section_data->getUuid())) {
                 continue;
             }
 
             // Format itemtype + uuid into a single key to allow selected both
             // with a simple dropdown.
             $key = Type::SECTION->value . '-' . $section_data->getUuid();
-            $dropdown_values[Section::getTypeName(Session::getPluralNumber())][$key] = $section_data->getName();
+            $dropdown_values[Section::getTypeName(Session::getPluralNumber())][$key] = $this->getSectionLabel($section_data);
         }
 
         $questions_data = $this->form_data->getQuestionsData();
+        $comments_data = $this->form_data->getCommentsData();
+
+        // Questions and comments are grouped under their parent section so that
+        // items sharing the same name (a common case across sections) can be
+        // told apart, just like in GLPI 10.
+        //
+        // This is only useful when the form has more than one section: with a
+        // single section, its header is hidden in the editor, so grouping by
+        // section would only add visual noise. In that case (or when no section
+        // information is available), fall back to a flat grouping by type.
+        $group_by_section = count($sections_data) > 1;
+
+        // Index of known section uuids, used both to label the groups and to
+        // detect items whose parent section can't be resolved.
+        $section_names = [];
+        foreach ($sections_data as $section_data) {
+            $section_names[$section_data->getUuid()] = $section_data->getName();
+        }
+
+        // Build the per-section groups in section order so that questions and
+        // comments appear under their section, in the form's order.
+        if ($group_by_section) {
+            foreach ($sections_data as $section_data) {
+                $group = $this->getSectionLabel($section_data);
+
+                foreach ($questions_data as $question_data) {
+                    if (
+                        $question_data->getSectionUuid() === $section_data->getUuid()
+                        && !$this->isSelectedItem(Type::QUESTION, $question_data->getUuid())
+                    ) {
+                        $key = Type::QUESTION->value . '-' . $question_data->getUuid();
+                        $dropdown_values[$group][$key] = $question_data->getName();
+                    }
+                }
+
+                foreach ($comments_data as $comment_data) {
+                    if (
+                        $comment_data->getSectionUuid() === $section_data->getUuid()
+                        && !$this->isSelectedItem(Type::COMMENT, $comment_data->getUuid())
+                    ) {
+                        $key = Type::COMMENT->value . '-' . $comment_data->getUuid();
+                        $dropdown_values[$group][$key] = $comment_data->getName();
+                    }
+                }
+            }
+        }
+
+        // Items that are not grouped by section (single-section form, or items
+        // whose parent section is unknown) keep their former generic grouping
+        // by type.
         foreach ($questions_data as $question_data) {
-            // Ignore the question that is currently selected as a condition can't
-            // be used as a criteria for its own visiblity.
-            if (
-                $this->form_data->getSelectedItemType() == Type::QUESTION->value
-                && $question_data->getUuid() == $this->form_data->getSelectedItemUuid()
-            ) {
+            if ($group_by_section && !empty($question_data->getSectionUuid()) && isset($section_names[$question_data->getSectionUuid()])) {
+                continue;
+            }
+            if ($this->isSelectedItem(Type::QUESTION, $question_data->getUuid())) {
                 continue;
             }
 
-            // Format itemtype + uuid into a single key to allow selected both
-            // with a simple dropdown.
             $key = Type::QUESTION->value . '-' . $question_data->getUuid();
             $dropdown_values[Question::getTypeName(Session::getPluralNumber())][$key] = $question_data->getName();
         }
 
-        $comments_data = $this->form_data->getCommentsData();
         foreach ($comments_data as $comment_data) {
-            // Ignore the comment that is currently selected as a condition can't
-            // be used as a criteria for its own visiblity.
-            if (
-                $this->form_data->getSelectedItemType() == Type::COMMENT->value
-                && $comment_data->getUuid() == $this->form_data->getSelectedItemUuid()
-            ) {
+            if ($group_by_section && !empty($comment_data->getSectionUuid()) && isset($section_names[$comment_data->getSectionUuid()])) {
+                continue;
+            }
+            if ($this->isSelectedItem(Type::COMMENT, $comment_data->getUuid())) {
                 continue;
             }
 
-            // Format itemtype + uuid into a single key to allow selected both
-            // with a simple dropdown.
             $key = Type::COMMENT->value . '-' . $comment_data->getUuid();
             $dropdown_values[Comment::getTypeName(Session::getPluralNumber())][$key] = $comment_data->getName();
         }
 
         return $dropdown_values;
+    }
+
+    /**
+     * Check whether the given item is the one currently selected, as a condition
+     * can't be used as a criteria for its own visibility.
+     */
+    private function isSelectedItem(Type $type, string $uuid): bool
+    {
+        return $this->form_data->getSelectedItemType() == $type->value
+            && $uuid == $this->form_data->getSelectedItemUuid();
+    }
+
+    /**
+     * Get the label to display for a section, falling back to the same
+     * placeholder as the editor when the section has no name.
+     */
+    private function getSectionLabel(SectionData $section): string
+    {
+        return $section->getName() !== '' ? $section->getName() : __('New section');
     }
 
     /**

--- a/src/Glpi/Form/Condition/FormData.php
+++ b/src/Glpi/Form/Condition/FormData.php
@@ -74,7 +74,11 @@ final class FormData
         $questions_data = [];
         $comments_data = [];
 
+        // Map section ids to their uuid so questions and comments can reference
+        // their parent section without triggering a database load per item.
+        $section_uuids = [];
         foreach ($form->getSections() as $section) {
+            $section_uuids[$section->getID()] = $section->fields['uuid'];
             $sections_data[] = [
                 'uuid' => $section->fields['uuid'],
                 'name' => $section->fields['name'],
@@ -83,17 +87,19 @@ final class FormData
 
         foreach ($form->getQuestions() as $question) {
             $questions_data[] = [
-                'uuid'       => $question->fields['uuid'],
-                'name'       => $question->fields['name'],
-                'type'       => $question->getQuestionType(),
-                'extra_data' => json_decode($question->fields['extra_data'] ?? '{}', true),
+                'uuid'                => $question->fields['uuid'],
+                'name'                => $question->fields['name'],
+                'type'                => $question->getQuestionType(),
+                'extra_data'          => json_decode($question->fields['extra_data'] ?? '{}', true),
+                'forms_sections_uuid' => $section_uuids[$question->fields['forms_sections_id']] ?? null,
             ];
         }
 
         foreach ($form->getFormComments() as $comment) {
             $comments_data[] = [
-                'uuid' => $comment->fields['uuid'],
-                'name' => $comment->fields['name'],
+                'uuid'                => $comment->fields['uuid'],
+                'name'                => $comment->fields['name'],
+                'forms_sections_uuid' => $section_uuids[$comment->fields['forms_sections_id']] ?? null,
             ];
         }
 
@@ -168,6 +174,7 @@ final class FormData
                 name: $question_data['name'],
                 type: new $type(),
                 extra_data: $question_data['extra_data'] ?? null,
+                section_uuid: $question_data['forms_sections_uuid'] ?? null,
             );
         }
     }
@@ -178,6 +185,7 @@ final class FormData
             $this->comments_data[] = new CommentData(
                 uuid: $comment_data['uuid'],
                 name: $comment_data['name'],
+                section_uuid: $comment_data['forms_sections_uuid'] ?? null,
             );
         }
     }

--- a/src/Glpi/Form/Condition/QuestionData.php
+++ b/src/Glpi/Form/Condition/QuestionData.php
@@ -43,6 +43,7 @@ final class QuestionData
         private string $name,
         private QuestionTypeInterface $type,
         private ?array $extra_data,
+        private ?string $section_uuid = null,
     ) {}
 
     public function getName(): string
@@ -63,5 +64,10 @@ final class QuestionData
     public function getExtraData(): ?array
     {
         return $this->extra_data;
+    }
+
+    public function getSectionUuid(): ?string
+    {
+        return $this->section_uuid;
     }
 }

--- a/tests/e2e/specs/Form/conditions_editor.spec.ts
+++ b/tests/e2e/specs/Form/conditions_editor.spec.ts
@@ -350,7 +350,7 @@ test(`Can use the editor to add or delete conditions on a section`, async ({
 
     const conditions = form.getVisibleConditions();
     await expect(form.getConditionTarget(conditions.nth(0)))
-        .toHaveText("Questions - My second question");
+        .toHaveText("First section - My second question");
     await expect(form.getConditionValueOperator(conditions.nth(0)))
         .toHaveText("Do not contains");
     await expect(form.getTextConditionValue(conditions.nth(0)))
@@ -359,7 +359,7 @@ test(`Can use the editor to add or delete conditions on a section`, async ({
     await expect(form.getConditionLogicOperator(conditions.nth(1)))
         .toHaveText("Or");
     await expect(form.getConditionTarget(conditions.nth(1)))
-        .toHaveText("Questions - My first question");
+        .toHaveText("First section - My first question");
     await expect(form.getConditionValueOperator(conditions.nth(1)))
         .toHaveText("Contains");
     await expect(form.getTextConditionValue(conditions.nth(1)))
@@ -368,7 +368,7 @@ test(`Can use the editor to add or delete conditions on a section`, async ({
     // Delete the first condition
     await form.doDeleteCondition(0);
     await expect(form.getConditionTarget(conditions.nth(0)))
-        .toHaveText("Questions - My first question");
+        .toHaveText("First section - My first question");
     await expect(form.getConditionValueOperator(conditions.nth(0)))
         .toHaveText("Contains");
     await expect(form.getTextConditionValue(conditions.nth(0)))
@@ -381,7 +381,7 @@ test(`Can use the editor to add or delete conditions on a section`, async ({
 
     const final_conditions = form.getVisibleConditions();
     await expect(form.getConditionTarget(final_conditions.nth(0)))
-        .toHaveText("Questions - My first question");
+        .toHaveText("First section - My first question");
     await expect(form.getConditionValueOperator(final_conditions.nth(0)))
         .toHaveText("Contains");
     await expect(form.getTextConditionValue(final_conditions.nth(0)))

--- a/tests/functional/Glpi/Form/Condition/EditorManagerTest.php
+++ b/tests/functional/Glpi/Form/Condition/EditorManagerTest.php
@@ -203,6 +203,183 @@ final class EditorManagerTest extends GLPITestCase
         ]);
     }
 
+    public function testQuestionsAndCommentsAreGroupedBySection(): void
+    {
+        // Arrange: two sections, each holding questions (some sharing the same
+        // name) and a comment, all referencing their parent section.
+        $form_data = new FormData([
+            'sections' => [
+                ['uuid' => 's1', 'name' => 'Section 1'],
+                ['uuid' => 's2', 'name' => 'Section 2'],
+            ],
+            'questions' => [
+                [
+                    'uuid' => 1,
+                    'name' => 'Name',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's1',
+                ],
+                [
+                    'uuid' => 2,
+                    'name' => 'Email',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's1',
+                ],
+                [
+                    'uuid' => 3,
+                    'name' => 'Name',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's2',
+                ],
+            ],
+            'comments' => [
+                ['uuid' => 1, 'name' => 'My comment', 'forms_sections_uuid' => 's2'],
+            ],
+        ]);
+        $editor_manager = $this->getManagerWithData($form_data);
+
+        // Act: get the dropdown values
+        $dropdown_values = $editor_manager->getItemsDropdownValues();
+
+        // Assert: questions and comments are grouped under their section name,
+        // letting homonymous questions be told apart.
+        $this->assertEquals([
+            'Sections' => [
+                'section-s1' => 'Section 1',
+                'section-s2' => 'Section 2',
+            ],
+            'Section 1' => [
+                'question-1' => 'Name',
+                'question-2' => 'Email',
+            ],
+            'Section 2' => [
+                'question-3' => 'Name',
+                'comment-1' => 'My comment',
+            ],
+        ], $dropdown_values);
+    }
+
+    public function testEmptySectionNameFallsBackToPlaceholder(): void
+    {
+        // Arrange: two sections, one of them without a name.
+        $form_data = new FormData([
+            'sections' => [
+                ['uuid' => 's1', 'name' => 'Section 1'],
+                ['uuid' => 's2', 'name' => ''],
+            ],
+            'questions' => [
+                [
+                    'uuid' => 1,
+                    'name' => 'Name',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's1',
+                ],
+                [
+                    'uuid' => 2,
+                    'name' => 'Email',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's2',
+                ],
+            ],
+        ]);
+        $editor_manager = $this->getManagerWithData($form_data);
+
+        // Act: get the dropdown values
+        $dropdown_values = $editor_manager->getItemsDropdownValues();
+
+        // Assert: the unnamed section uses the editor's placeholder, both as a
+        // selectable item and as the group label.
+        $this->assertEquals([
+            'Sections' => [
+                'section-s1' => 'Section 1',
+                'section-s2' => __('New section'),
+            ],
+            'Section 1' => [
+                'question-1' => 'Name',
+            ],
+            __('New section') => [
+                'question-2' => 'Email',
+            ],
+        ], $dropdown_values);
+    }
+
+    public function testSingleSectionDisablesGrouping(): void
+    {
+        // Arrange: a single section (its header is hidden in the editor) holding
+        // questions and a comment.
+        $form_data = new FormData([
+            'sections' => [
+                ['uuid' => 's1', 'name' => 'Section 1'],
+            ],
+            'questions' => [
+                [
+                    'uuid' => 1,
+                    'name' => 'Name',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's1',
+                ],
+                [
+                    'uuid' => 2,
+                    'name' => 'Email',
+                    'type' => QuestionTypeShortText::class,
+                    'forms_sections_uuid' => 's1',
+                ],
+            ],
+            'comments' => [
+                ['uuid' => 1, 'name' => 'My comment', 'forms_sections_uuid' => 's1'],
+            ],
+        ]);
+        $editor_manager = $this->getManagerWithData($form_data);
+
+        // Act: get the dropdown values
+        $dropdown_values = $editor_manager->getItemsDropdownValues();
+
+        // Assert: grouping is cancelled, items keep the flat grouping by type.
+        $this->assertEquals([
+            'Sections' => [
+                'section-s1' => 'Section 1',
+            ],
+            'Questions' => [
+                'question-1' => 'Name',
+                'question-2' => 'Email',
+            ],
+            'Comments' => [
+                'comment-1' => 'My comment',
+            ],
+        ], $dropdown_values);
+    }
+
+    public function testItemsWithUnknownSectionFallBackToGenericGroups(): void
+    {
+        // Arrange: a question and a comment without any resolvable parent section.
+        $form_data = new FormData([
+            'questions' => [
+                [
+                    'uuid' => 1,
+                    'name' => 'Question 1',
+                    'type' => QuestionTypeShortText::class,
+                ],
+            ],
+            'comments' => [
+                ['uuid' => 1, 'name' => 'Comment 1'],
+            ],
+        ]);
+        $editor_manager = $this->getManagerWithData($form_data);
+
+        // Act: get the dropdown values
+        $dropdown_values = $editor_manager->getItemsDropdownValues();
+
+        // Assert: items keep their former generic grouping by type.
+        $this->assertEquals([
+            'Questions' => [
+                'question-1' => 'Question 1',
+            ],
+            'Comments' => [
+                'comment-1' => 'Comment 1',
+            ],
+        ], $dropdown_values);
+    }
+
     public static function provideSelectedFormElementIsExcludedFromDropdownValues(): iterable
     {
         yield 'section' => [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review


- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !44336

This PR introduces improvements to how form questions and comments are grouped and displayed in the conditions editor, making it easier to distinguish items with the same name across different sections. The main focus is on grouping questions and comments under their parent section in dropdowns, with sensible fallbacks for single-section forms or items with unknown sections.

## Screenshots (if appropriate):

### Before
<img width="726" height="377" alt="image" src="https://github.com/user-attachments/assets/7817e5e9-f948-48f5-92bb-e85c095a1eac" />

### After
<img width="726" height="377" alt="image" src="https://github.com/user-attachments/assets/b6d1e87f-3894-4b2d-9de4-42c3ca0a98aa" />
