### PR TITLE
Display web tests errors

### DIFF
--- a/tests/web/APIRestTest.php
+++ b/tests/web/APIRestTest.php
@@ -118,7 +118,8 @@ class APIRestTest extends TestCase
     public function tearDown(): void
     {
         // Check that no errors occurred on the test server
-        $this->assertEmpty(file_get_contents($this->getLogFilePath()));
+        $errors = file_get_contents($this->getLogFilePath());
+        $this->assertEmpty($errors, $errors);
         parent::tearDown();
     }
 


### PR DESCRIPTION
Since `setUp()` method empty logs files; it's not possible to upload them.
Using file contents as error message would display valuable information to fix.

(follows #24500)