### PR TITLE
fix (planning) priority color category event

### DIFF
--- a/css/legacy/includes/_planning.scss
+++ b/css/legacy/includes/_planning.scss
@@ -251,6 +251,7 @@
 
          .fc-content {
             margin-right: 8px;
+            margin-left: 8px;
          }
 
          .fc-time {
@@ -289,6 +290,15 @@
             bottom: 0;
             top: 0;
             right: 0;
+         }
+
+         .event_category {
+            position: absolute;
+            width: 7px;
+            bottom: 0;
+            top: 0;
+            left: 0;
+            z-index: 3;
          }
       }
 

--- a/js/planning.js
+++ b/js/planning.js
@@ -179,6 +179,10 @@ var GLPIPlanning  = {
                 var eventtype_marker = `<span class="event_type" style="background-color: ${_.escape(extProps.typeColor)}"></span>`;
                 element.append(eventtype_marker);
 
+                if (extProps.catColor) {
+                    element.append(`<span class="event_category" style="background-color: ${_.escape(extProps.catColor)}"></span>`);
+                }
+
                 var content = extProps.content;
                 var tooltip = extProps.tooltip;
                 if (view.type !== 'dayGridMonth'

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -807,7 +807,7 @@ class Group_User extends CommonDBRelation
 
             // add the planning for the user
             $plannings['plannings'][$planning_k]['users']['user_' . $this->fields['users_id']] = [
-                'color'   => Planning::getPaletteColor('bg', $nb_users),
+                'color'   => Planning::getPaletteColor($nb_users),
                 'display' => true,
                 'type'    => 'user',
             ];

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1750,7 +1750,7 @@ TWIG, $twig_params);
                              && !$_SESSION['glpi_plannings']['filters']['OnlyBgEvents']['display']
                               ? 'background'
                               : '',
-                'color'       => $actor_color,
+                'color'       => !empty($event['color']) ? $event['color'] : $actor_color,
                 'borderColor' => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1777,7 +1777,7 @@ TWIG, $twig_params);
             if (!$event['editable']) {
                 $new_event['editable'] = false;
             }
-            
+
             // Recompute text color based on the final background color for readability
             $new_event['textColor'] = Toolbox::getFgColor($new_event['color'], 100);
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -61,24 +61,6 @@ class Planning extends CommonGLPI
     public static $rightname = 'planning';
 
     /** @var string[]  */
-    public static $palette_bg = ['#FFEEC4', '#D4EDFB', '#E1D0E1', '#CDD7A9', '#F8C8D2',
-        '#D6CACA', '#D3D6ED', '#C8E5E3', '#FBD5BF', '#E9EBA2',
-        '#E8E5E5', '#DBECDF', '#FCE7F2', '#E9D3D3', '#D2DBDC',
-    ];
-
-    /** @var string[]  */
-    public static $palette_fg = ['#57544D', '#59707E', '#5B3B5B', '#3A431A', '#58242F',
-        '#3B2727', '#272D59', '#2E4645', '#6F4831', '#46481B',
-        '#4E4E4E', '#274C30', '#6A535F', '#473232', '#454545',
-    ];
-
-    /** @var string[]  */
-    public static $palette_ev = ['#E94A31', '#5174F2', '#51C9F2', '#FFCC29', '#20C646',
-        '#364959', '#8C5344', '#FF8100', '#F600C4', '#0017FF',
-        '#000000', '#FFFFFF', '#005800', '#925EFF',
-    ];
-
-    /** @var string[]  */
     public static $directgroup_itemtype = ['PlanningExternalEvent', 'ProjectTask', 'TicketTask', 'ProblemTask', 'ChangeTask'];
 
     public const READMY    =    1;
@@ -618,40 +600,20 @@ JAVASCRIPT;
     }
 
     /**
-     * Return a palette array (for example self::$palette_bg)
-     * @param  string $palette_name  the short name for palette (bg, fg, ev)
-     * @return mixed                 the palette array or false
+     * Return a deterministic hexa color for a given index.
+     * @param  int     $color_index
+     * @return string                 color in hexa (ex: #FFFFFF)
      *
      * @since  9.1.1
      */
-    public static function getPalette($palette_name = 'bg')
+    public static function getPaletteColor(int $color_index = 0): string
     {
-        if (in_array($palette_name, ['bg', 'fg', 'ev'])) {
-            return self::${"palette_$palette_name"};
-        }
-
-        return false;
-    }
-
-    /**
-     * Return an hexa color from a palette
-     * @param  string  $palette_name the short name for palette (bg, fg, ev)
-     * @param  int $color_index  The color index in this palette
-     * @return mixed                 the color in hexa (ex: #FFFFFF) or false
-     *
-     * @since  9.1.1
-     */
-    public static function getPaletteColor($palette_name = 'bg', $color_index = 0)
-    {
-        if ($palette = self::getPalette($palette_name)) {
-            if ($color_index >= count($palette)) {
-                $color_index %= count($palette);
-            }
-
-            return $palette[$color_index];
-        }
-
-        return false;
+        $colors = [
+            '#FFEEC4', '#D4EDBC', '#C4D7ED', '#E8C4ED', '#C4EDE8',
+            '#EDD4C4', '#D4C4ED', '#EDE8C4', '#C4EDD4', '#EDC4D4',
+            '#C4C4ED', '#EDE4C4', '#C4EDDE', '#E4C4ED', '#C4E4ED',
+        ];
+        return $colors[$color_index % count($colors)];
     }
 
     /**
@@ -684,7 +646,7 @@ JAVASCRIPT;
         if (!isset($_SESSION['glpi_plannings']['filters'])) {
             $_SESSION['glpi_plannings']['filters']   = [];
             $_SESSION['glpi_plannings']['plannings'] = ['user_' . $_SESSION['glpiID'] => [
-                'color'   => self::getPaletteColor('bg', 0),
+                'color'   => self::getPaletteColor(0),
                 'display' => true,
                 'type'    => 'user',
             ],
@@ -698,7 +660,7 @@ JAVASCRIPT;
             if (in_array($planning_type, ['NotPlanned', 'OnlyBgEvents', 'StateDone']) || $planning_type::canView()) {
                 if (!isset($filters[$planning_type])) {
                     $filters[$planning_type] = [
-                        'color'   => self::getPaletteColor('ev', $index_color),
+                        'color'   => self::getPaletteColor($index_color),
                         'display' => !in_array($planning_type, ['NotPlanned', 'OnlyBgEvents']),
                         'type'    => 'event_filter',
                     ];
@@ -826,7 +788,7 @@ JAVASCRIPT;
             $color = $filter_data['color'];
         } else {
             $params['filter_color_index']++;
-            $color = self::getPaletteColor('bg', $params['filter_color_index']);
+            $color = self::getPaletteColor($params['filter_color_index']);
         }
 
         $login_user = null;
@@ -973,7 +935,7 @@ TWIG, $twig_params);
             return;
         }
         $_SESSION['glpi_plannings']['plannings']["user_" . $params['users_id']]
-         = ['color'   => self::getPaletteColor('bg', $_SESSION['glpi_plannings_color_index']),
+         = ['color'   => self::getPaletteColor($_SESSION['glpi_plannings_color_index']),
              'display' => true,
              'type'    => 'user',
          ];
@@ -1053,7 +1015,7 @@ TWIG, $twig_params);
 
         foreach ($users as $user_data) {
             $current_group['users']['user_' . $user_data['id']] = [
-                'color'   => self::getPaletteColor('bg', $_SESSION['glpi_plannings_color_index']),
+                'color'   => self::getPaletteColor($_SESSION['glpi_plannings_color_index']),
                 'display' => true,
                 'type'    => 'user',
             ];
@@ -1152,8 +1114,7 @@ TWIG, $twig_params);
         }
         $_SESSION['glpi_plannings']['plannings']["group_" . $params['groups_id']]
          = ['color'   => self::getPaletteColor(
-             'bg',
-             $_SESSION['glpi_plannings_color_index']
+            $_SESSION['glpi_plannings_color_index']
          ),
              'display' => true,
              'type'    => 'group',
@@ -1215,7 +1176,7 @@ TWIG, $twig_params);
         }
 
         $_SESSION['glpi_plannings']['plannings']['external_' . md5($params['url'])] = [
-            'color'   => self::getPaletteColor('bg', $_SESSION['glpi_plannings_color_index']),
+            'color'   => self::getPaletteColor($_SESSION['glpi_plannings_color_index']),
             'display' => true,
             'type'    => 'external',
             'name'    => $params['name'],
@@ -1733,9 +1694,8 @@ TWIG, $twig_params);
             // get duration in milliseconds
             $ms_duration = (strtotime($end) - strtotime($begin)) * 1000;
 
-            $index_color = array_search("user_$users_id", array_keys($_SESSION['glpi_plannings']['plannings']));
             $actor_color = $_SESSION['glpi_plannings']['plannings']["user_$users_id"]['color']
-                ?? self::$palette_bg[$index_color ?: 0];
+                ?? Toolbox::getFgColor('index_color', 100);
             $new_event = [
                 'title'       => $event['name'],
                 'content'     => $content,
@@ -1752,10 +1712,10 @@ TWIG, $twig_params);
                               : '',
                 'color'       => !empty($event['color']) ? $event['color'] : $actor_color,
                 'borderColor' => (empty($event['event_type_color'])
-                              ? self::getPaletteColor('ev', $event['itemtype'])
+                              ? self::getPaletteColor($event['itemtype'])
                               : $event['event_type_color']),
                 'typeColor'   => (empty($event['event_type_color'])
-                              ? self::getPaletteColor('ev', $event['itemtype'])
+                              ? self::getPaletteColor($event['itemtype'])
                               : $event['event_type_color']),
                 'catColor'    => $event['event_cat_color'] ?? "",
                 'url'         => $event['url'] ?? "",

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1754,7 +1754,6 @@ TWIG, $twig_params);
                 'borderColor' => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),
-                'textColor'   => self::$palette_fg[$index_color ?: 0],
                 'typeColor'   => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),
@@ -1782,6 +1781,9 @@ TWIG, $twig_params);
             if (!empty($event['event_cat_color'])) {
                 $new_event['color'] = $event['event_cat_color'];
             }
+
+            // Recompute text color based on the final background color for readability
+            $new_event['textColor'] = Toolbox::getFgColor($new_event['color'], 100);
 
             // manage reccurent events
             if (isset($event['rrule']) && count($event['rrule'])) {

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1733,7 +1733,9 @@ TWIG, $twig_params);
             // get duration in milliseconds
             $ms_duration = (strtotime($end) - strtotime($begin)) * 1000;
 
-            $index_color = array_search("user_$users_id", array_keys($_SESSION['glpi_plannings']));
+            $index_color = array_search("user_$users_id", array_keys($_SESSION['glpi_plannings']['plannings']));
+            $actor_color = $_SESSION['glpi_plannings']['plannings']["user_$users_id"]['color']
+                ?? self::$palette_bg[$index_color ?: 0];
             $new_event = [
                 'title'       => $event['name'],
                 'content'     => $content,
@@ -1748,13 +1750,11 @@ TWIG, $twig_params);
                              && !$_SESSION['glpi_plannings']['filters']['OnlyBgEvents']['display']
                               ? 'background'
                               : '',
-                'color'       => (empty($event['color'])
-                              ? self::$palette_bg[$index_color]
-                              : $event['color']),
+                'color'       => $actor_color,
                 'borderColor' => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),
-                'textColor'   => self::$palette_fg[$index_color],
+                'textColor'   => self::$palette_fg[$index_color ?: 0],
                 'typeColor'   => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),
@@ -1778,12 +1778,8 @@ TWIG, $twig_params);
                 $new_event['editable'] = false;
             }
 
-            // override color if view is ressource and category color exists
-            // maybe we need a better way for displaying categories color
-            if (
-                $param['view_name'] === "resourceWeek"
-                && !empty($event['event_cat_color'])
-            ) {
+            // Category color has highest priority, then user calendar color
+            if (!empty($event['event_cat_color'])) {
                 $new_event['color'] = $event['event_cat_color'];
             }
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -1757,6 +1757,7 @@ TWIG, $twig_params);
                 'typeColor'   => (empty($event['event_type_color'])
                               ? self::getPaletteColor('ev', $event['itemtype'])
                               : $event['event_type_color']),
+                'catColor'    => $event['event_cat_color'] ?? "",
                 'url'         => $event['url'] ?? "",
                 'ajaxurl'     => $event['ajaxurl'] ?? "",
                 'itemtype'    => $event['itemtype'] ?? "",
@@ -1776,12 +1777,7 @@ TWIG, $twig_params);
             if (!$event['editable']) {
                 $new_event['editable'] = false;
             }
-
-            // Category color has highest priority, then user calendar color
-            if (!empty($event['event_cat_color'])) {
-                $new_event['color'] = $event['event_cat_color'];
-            }
-
+            
             // Recompute text color based on the final background color for readability
             $new_event['textColor'] = Toolbox::getFgColor($new_event['color'], 100);
 

--- a/tests/functional/PlanningTest.php
+++ b/tests/functional/PlanningTest.php
@@ -183,31 +183,6 @@ class PlanningTest extends DbTestCase
         }
     }
 
-    public static function getPaletteColorProvider()
-    {
-        $palettes = [];
-        $properties = (new \ReflectionClass(\Planning::class))->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_STATIC);
-        foreach ($properties as $property) {
-            if (str_starts_with($property->getName(), 'palette_')) {
-                // Add palette (without the 'palette_' prefix)
-                $palettes[] = substr($property->getName(), 8);
-            }
-        }
-        $result = [];
-        foreach ($palettes as $palette) {
-            for ($i = 0; $i < 20; $i++) {
-                $result[] = [$palette, $i];
-            }
-        }
-        return $result;
-    }
-
-    #[DataProvider('getPaletteColorProvider')]
-    public function testGetPaletteColor(string $palette_name, int $index)
-    {
-        $color = \Planning::getPaletteColor($palette_name, $index);
-        $this->assertMatchesRegularExpression('/#[0-9A-F]{6}/', $color);
-    }
 
     public function testUpdateEventTimesAllowed()
     {

--- a/tests/functional/PlanningTest.php
+++ b/tests/functional/PlanningTest.php
@@ -470,7 +470,8 @@ class PlanningTest extends DbTestCase
         }
     }
 
-    //The category color takes precedence over the actor color, if no category is specified, the user swatch color is used
+    // Background color priority: event-specific color (external calendars) > actor/user swatch color
+    // Category color is never used as background — it is exposed in catColor for the left band indicator
     public function testEventColorPriority(): void
     {
         $this->login();
@@ -515,8 +516,10 @@ class PlanningTest extends DbTestCase
         $with_cat    = current(array_filter($events, fn($e) => $e['title'] === 'event with category'));
         $without_cat = current(array_filter($events, fn($e) => $e['title'] === 'event without category'));
 
-        $this->assertEquals($category_color, $with_cat['color'], 'category color override actor_color');
-        $this->assertEquals($actor_color, $without_cat['color'], 'actor_color if no category');
+        $this->assertEquals($actor_color, $with_cat['color'], 'actor color is used as background even with a category');
+        $this->assertEquals($actor_color, $without_cat['color'], 'actor color is used as background when no category');
+        $this->assertEquals($category_color, $with_cat['catColor'], 'category color is exposed in catColor for the band');
+        $this->assertEmpty($without_cat['catColor'], 'catColor is empty when no category');
 
         // event-specific color ext override actor color
         $event_specific_color = '#AABBCC';

--- a/tests/functional/PlanningTest.php
+++ b/tests/functional/PlanningTest.php
@@ -168,7 +168,7 @@ class PlanningTest extends DbTestCase
         $_SESSION['glpi_plannings'] = $session_backup;
 
         foreach ($expected_events_keys as $list_var => $events_keys) {
-            $events_list = $$list_var;
+            $events_list = ${$list_var};
             $this->assertCount(count($events_keys), $events_list);
             foreach ($events_keys as $index => $evt_key) {
                 $event_data = $expected_events_data[$evt_key];
@@ -334,7 +334,7 @@ class PlanningTest extends DbTestCase
         $this->assertEmpty($event->encodeRRule(["freq" => '']));
     }
 
-    public static function checkAlreadyPlannedProvider()
+    public static function checkAlreadyPlannedProvider(): iterable
     {
         $begin_task = '2025-05-13 00:00:00';
         $end_task   = '2025-05-13 01:00:00';
@@ -468,5 +468,54 @@ class PlanningTest extends DbTestCase
         } else {
             $this->hasNoSessionMessages([WARNING]);
         }
+    }
+
+    //The category color takes precedence over the actor color, if no category is specified, the user swatch color is used
+    public function testEventColorPriority(): void
+    {
+        $this->login();
+        \Planning::initSessionForCurrentUser();
+        $actor_color = '#D757FF';
+        $category_color = '#8600FF';
+        $users_id = $_SESSION['glpiID'];
+        $_SESSION['glpi_plannings']['plannings']["user_$users_id"]['color'] = $actor_color;
+
+        $category = $this->createItem('PlanningEventCategory', [
+            'name'  => 'categorie with color',
+            'color' => $category_color,
+        ]);
+
+        $this->createItem('PlanningExternalEvent', [
+            'name'                      => 'event with categorie',
+            'users_id'                  => $users_id,
+            'planningeventcategories_id' => $category->getID(),
+            'plan' => [
+                'begin' => '2027-01-01 08:00:00',
+                'end'   => '2027-01-01 09:00:00',
+            ],
+        ], ['plan']); //'plan'  tells `createItem` not to check this field among the fields returned by the db (virtual field)
+
+        $this->createItem('PlanningExternalEvent', [
+            'name'     => 'event without categorie',
+            'users_id' => $users_id,
+            'plan' => [
+                'begin' => '2027-01-01 10:00:00',
+                'end'   => '2027-01-01 11:00:00',
+            ],
+        ], ['plan']);
+
+        $events = \Planning::constructEventsArray([
+            'start'            => '2027-01-01 00:00:00',
+            'end'              => '2027-01-01 23:59:59',
+            'force_all_events' => true, // `force_all_events`  get all events within a date range without applying any filters
+        ]);
+
+        $this->assertCount(2, $events);
+
+        $with_cat    = current(array_filter($events, fn($e) => $e['title'] === 'event with categorie'));
+        $without_cat = current(array_filter($events, fn($e) => $e['title'] === 'event without categorie'));
+
+        $this->assertEquals($category_color, $with_cat['color'], 'category color override actor_color');
+        $this->assertEquals($actor_color, $without_cat['color'], 'actor_color if no category');
     }
 }

--- a/tests/functional/PlanningTest.php
+++ b/tests/functional/PlanningTest.php
@@ -517,5 +517,30 @@ class PlanningTest extends DbTestCase
 
         $this->assertEquals($category_color, $with_cat['color'], 'category color override actor_color');
         $this->assertEquals($actor_color, $without_cat['color'], 'actor_color if no category');
+
+        // event-specific color ext override actor color
+        $event_specific_color = '#AABBCC';
+        $plannings_backup = $_SESSION['glpi_plannings']['plannings'];
+        $_SESSION['glpi_plannings']['plannings'] = [
+            "user_$users_id" => ['color' => $actor_color, 'display' => true, 'type' => 'user'],
+            'external_test'  => [
+                'color'   => $event_specific_color,
+                'display' => true,
+                'type'    => 'external',
+                'name'    => 'Test external',
+                'url'     => 'file://' . realpath(GLPI_ROOT . '/tests/fixtures/ical/sample_2.ics'),
+            ],
+        ];
+
+        $ext_events = \Planning::constructEventsArray([
+            'start' => '2019-11-01 00:00:00',
+            'end'   => '2019-11-30 23:59:59',
+        ]);
+
+        $_SESSION['glpi_plannings']['plannings'] = $plannings_backup;
+
+        $ext_event = current(array_filter($ext_events, fn($e) => $e['title'] === 'Another event'));
+        $this->assertNotFalse($ext_event, 'External event "Another event" should be found in sample_2.ics');
+        $this->assertEquals($event_specific_color, $ext_event['color'], 'event-specific color overrides actor color');
     }
 }

--- a/tests/functional/PlanningTest.php
+++ b/tests/functional/PlanningTest.php
@@ -481,12 +481,12 @@ class PlanningTest extends DbTestCase
         $_SESSION['glpi_plannings']['plannings']["user_$users_id"]['color'] = $actor_color;
 
         $category = $this->createItem('PlanningEventCategory', [
-            'name'  => 'categorie with color',
+            'name'  => 'category with color',
             'color' => $category_color,
         ]);
 
         $this->createItem('PlanningExternalEvent', [
-            'name'                      => 'event with categorie',
+            'name'                      => 'event with category',
             'users_id'                  => $users_id,
             'planningeventcategories_id' => $category->getID(),
             'plan' => [
@@ -496,7 +496,7 @@ class PlanningTest extends DbTestCase
         ], ['plan']); //'plan'  tells `createItem` not to check this field among the fields returned by the db (virtual field)
 
         $this->createItem('PlanningExternalEvent', [
-            'name'     => 'event without categorie',
+            'name'     => 'event without category',
             'users_id' => $users_id,
             'plan' => [
                 'begin' => '2027-01-01 10:00:00',
@@ -512,8 +512,8 @@ class PlanningTest extends DbTestCase
 
         $this->assertCount(2, $events);
 
-        $with_cat    = current(array_filter($events, fn($e) => $e['title'] === 'event with categorie'));
-        $without_cat = current(array_filter($events, fn($e) => $e['title'] === 'event without categorie'));
+        $with_cat    = current(array_filter($events, fn($e) => $e['title'] === 'event with category'));
+        $without_cat = current(array_filter($events, fn($e) => $e['title'] === 'event without category'));
 
         $this->assertEquals($category_color, $with_cat['color'], 'category color override actor_color');
         $this->assertEquals($actor_color, $without_cat['color'], 'actor_color if no category');


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44466
- Event category colors were previously only visible in the timeline view. They are now displayed throughout the application, following this priority order:
Background color priority: event-specific color (external calendars) > actor/user swatch color
Category color is never used as background — it is exposed in catColor for the left band indicator

## Screenshots (if appropriate):

<img width="720" height="240" alt="image" src="https://github.com/user-attachments/assets/55a1122b-a1e6-41de-b5fc-28f01a973d5d" />

