### PR TITLE
Fix deprecation message for SMTP modes and error text

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -407,7 +407,7 @@ class Config extends CommonDBTM
 
         if (array_key_exists('smtp_mode', $input) && in_array($input['smtp_mode'], [MAIL_SMTPSSL, MAIL_SMTPTLS], true)) {
             $input['smtp_mode'] = MAIL_SMTP;
-            Toolbox::deprecated('Usage of "MAIL_SMTPTLS" and "MAIL_SMTPTLS" SMTP mode is deprecated. Switch to "MAIL_SMTP" mode.');
+            Toolbox::deprecated('Usage of "MAIL_SMTPSSL" and "MAIL_SMTPTLS" SMTP mode is deprecated. Switch to "MAIL_SMTP" mode.');
         }
 
         if (array_key_exists('smtp_mode', $input) && (int) $input['smtp_mode'] === MAIL_SMTPOAUTH) {
@@ -1965,7 +1965,7 @@ class Config extends CommonDBTM
 
         // No valid email was found
         trigger_error(
-            'No email address is not defined in configuration.',
+            'No email address is defined in configuration.',
             E_USER_WARNING
         );
 


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

This PR fixes two warning messages in Config.php.

Fix the deprecated SMTP mode warning to correctly reference both MAIL_SMTPSSL and MAIL_SMTPTLS.
Fix the email configuration warning message grammar.

These changes do not modify any behavior and only improve the accuracy and readability of warning messages displayed to administrators.