### PR TITLE
fix (planning reservation) : preserve current date in calendar after saving a reservation

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1112,30 +1112,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/front/report.networking.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Binary operation "\\." between array\\|int\\|string and \'\\?\' results in an error\\.$#',
-	'identifier' => 'binaryOp.invalid',
-	'count' => 1,
-	'path' => __DIR__ . '/front/reservation.form.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$haystack of function str_contains expects string, string\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/front/reservation.form.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$string of function parse_str expects string, array\\|int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/front/reservation.form.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$url of function Safe\\\\parse_url expects string, string\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 2,
-	'path' => __DIR__ . '/front/reservation.form.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$id of method CommonGLPI\\:\\:getFormURLWithID\\(\\) expects int, int\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -36,6 +36,7 @@
 require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\Event;
+use Safe\DateTime;
 
 use function Safe\parse_url;
 use function Safe\strtotime;
@@ -124,7 +125,7 @@ if (isset($_POST["update"])) {
         );
     }
 
-    $fn_redirect_back((new \DateTime($rr->fields["begin"]))->format('Y-m-d'));
+    $fn_redirect_back((new DateTime($rr->fields["begin"]))->format('Y-m-d'));
 } elseif (isset($_POST["add"])) {
     Reservation::handleAddForm($_POST);
     $fn_redirect_back();

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -124,7 +124,7 @@ if (isset($_POST["update"])) {
         );
     }
 
-    $fn_redirect_back(substr($rr->fields["begin"], 0, 10));
+    $fn_redirect_back((new \DateTime($rr->fields["begin"]))->format('Y-m-d'));
 } elseif (isset($_POST["add"])) {
     Reservation::handleAddForm($_POST);
     $fn_redirect_back();

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -38,6 +38,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 use Glpi\Event;
 
 use function Safe\parse_url;
+use function Safe\strtotime;
 
 global $CFG_GLPI;
 
@@ -49,17 +50,14 @@ if (Session::getCurrentInterface() == "helpdesk") {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }
 
-$fn_redirect_back = static function ($begin_year = null, $begin_month = null) {
+$fn_redirect_back = static function ($begin_date = null) {
     $back_url = Html::getBackUrl();
-    if ($begin_year === null && $begin_month === null) {
+    if ($begin_date === null) {
         // Try to get from POST data
         if (isset($_POST['resa']["begin"])) {
-            $begin = $_POST['resa']["begin"];
-            [$begin_year, $begin_month] = explode("-", $begin);
+            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]));
         } else {
-            // Default to current month/year
-            $begin_year  = date('Y');
-            $begin_month = date('m');
+            $begin_date = date('Y-m-d');
         }
     }
 
@@ -73,14 +71,12 @@ $fn_redirect_back = static function ($begin_year = null, $begin_month = null) {
     }
     if (str_contains($back_url, 'front/reservation.php')) {
         $back_url .= (!str_contains($back_url, '?') ? '?' : '&') . Toolbox::append_params([
-            'month' => $begin_month,
-            'year' => $begin_year,
+            'defaultDate' => $begin_date,
         ]);
     } else {
         $back_url .= (!str_contains($back_url, '?') ? '?' : '&') . Toolbox::append_params([
             'tab_params' => [
-                'month' => $begin_month,
-                'year' => $begin_year,
+                'defaultDate' => $begin_date,
             ],
         ]);
     }
@@ -128,8 +124,7 @@ if (isset($_POST["update"])) {
         );
     }
 
-    [$begin_year, $begin_month] = explode("-", $rr->fields["begin"]);
-    $fn_redirect_back($begin_year, $begin_month);
+    $fn_redirect_back(substr($rr->fields["begin"], 0, 10));
 } elseif (isset($_POST["add"])) {
     Reservation::handleAddForm($_POST);
     $fn_redirect_back();

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -55,7 +55,7 @@ $fn_redirect_back = static function ($begin_date = null) {
     if ($begin_date === null) {
         // Try to get from POST data
         if (isset($_POST['resa']["begin"])) {
-            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]));
+            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]) ?: time());
         } else {
             $begin_date = date('Y-m-d');
         }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -55,8 +55,13 @@ $fn_redirect_back = static function ($begin_date = null) {
     $back_url = Html::getBackUrl() ?: '';
     if ($begin_date === null) {
         // Try to get from POST data
+        try {
+            $date = strtotime($_POST['resa']["begin"]);
+        } catch (Exception) {
+            $date = time();
+        }
         if (isset($_POST['resa']["begin"])) {
-            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]) ?: time());
+            $begin_date = date('Y-m-d', $date);
         } else {
             $begin_date = date('Y-m-d');
         }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -56,13 +56,9 @@ $fn_redirect_back = static function ($begin_date = null) {
     if ($begin_date === null) {
         // Try to get from POST data
         try {
-            $date = strtotime($_POST['resa']["begin"]);
-        } catch (Exception) {
-            $date = time();
-        }
-        if (isset($_POST['resa']["begin"])) {
+            $date = isset($_POST['resa']["begin"]) ? strtotime($_POST['resa']["begin"]) : time();
             $begin_date = date('Y-m-d', $date);
-        } else {
+        } catch (Exception) {
             $begin_date = date('Y-m-d');
         }
     }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -39,6 +39,7 @@ use Glpi\Event;
 use Safe\DateTime;
 
 use function Safe\parse_url;
+use function Safe\strtotime;
 
 global $CFG_GLPI;
 
@@ -51,11 +52,11 @@ if (Session::getCurrentInterface() == "helpdesk") {
 }
 
 $fn_redirect_back = static function ($begin_date = null) {
-    $back_url = Html::getBackUrl();
+    $back_url = Html::getBackUrl() ?: '';
     if ($begin_date === null) {
         // Try to get from POST data
         if (isset($_POST['resa']["begin"])) {
-            $begin_date = date('Y-m-d', \strtotime($_POST['resa']["begin"]) ?: time());
+            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]) ?: time());
         } else {
             $begin_date = date('Y-m-d');
         }
@@ -63,8 +64,10 @@ $fn_redirect_back = static function ($begin_date = null) {
 
     // Remove old month/year params
     $back_url_params = [];
-    $back_url_base = parse_url($back_url, PHP_URL_PATH) ?? '';
-    parse_str(parse_url($back_url, PHP_URL_QUERY) ?? '', $back_url_params);
+    $path_result = parse_url($back_url, PHP_URL_PATH);
+    $back_url_base = is_string($path_result) ? $path_result : '';
+    $query_result = parse_url($back_url, PHP_URL_QUERY);
+    parse_str(is_string($query_result) ? $query_result : '', $back_url_params);
     unset($back_url_params['month'], $back_url_params['year'], $back_url_params['tab_params']);
     $back_url = $back_url_params !== []
         ? $back_url_base . '?' . Toolbox::append_params($back_url_params)

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -39,7 +39,6 @@ use Glpi\Event;
 use Safe\DateTime;
 
 use function Safe\parse_url;
-use function Safe\strtotime;
 
 global $CFG_GLPI;
 
@@ -56,7 +55,7 @@ $fn_redirect_back = static function ($begin_date = null) {
     if ($begin_date === null) {
         // Try to get from POST data
         if (isset($_POST['resa']["begin"])) {
-            $begin_date = date('Y-m-d', strtotime($_POST['resa']["begin"]) ?: time());
+            $begin_date = date('Y-m-d', \strtotime($_POST['resa']["begin"]) ?: time());
         } else {
             $begin_date = date('Y-m-d');
         }
@@ -67,9 +66,9 @@ $fn_redirect_back = static function ($begin_date = null) {
     $back_url_base = parse_url($back_url, PHP_URL_PATH) ?? '';
     parse_str(parse_url($back_url, PHP_URL_QUERY) ?? '', $back_url_params);
     unset($back_url_params['month'], $back_url_params['year'], $back_url_params['tab_params']);
-    if ($back_url_params !== []) {
-        $back_url = $back_url_base . '?' . Toolbox::append_params($back_url_params);
-    }
+    $back_url = $back_url_params !== []
+        ? $back_url_base . '?' . Toolbox::append_params($back_url_params)
+        : $back_url_base;
     if (str_contains($back_url, 'front/reservation.php')) {
         $back_url .= (!str_contains($back_url, '?') ? '?' : '&') . Toolbox::append_params([
             'defaultDate' => $begin_date,

--- a/tests/cypress/e2e/Tools/reservations.cy.js
+++ b/tests/cypress/e2e/Tools/reservations.cy.js
@@ -105,7 +105,7 @@ describe('Reservations', () => {
 
         function checkOctober2024() {
             cy.get('.fc-header-toolbar .fc-center').contains('October 2024').should('exist');
-            cy.url().should('match', /(month=10(&|$))|(tab_params%5Bmonth%5D=10(&|$))/);
+            cy.url().should('match', /(defaultDate=2024-10-)|(tab_params%5BdefaultDate%5D=2024-10-)/);
         }
 
         function addReservation() {

--- a/tests/cypress/e2e/Tools/reservations.cy.js
+++ b/tests/cypress/e2e/Tools/reservations.cy.js
@@ -105,7 +105,7 @@ describe('Reservations', () => {
 
         function checkOctober2024() {
             cy.get('.fc-header-toolbar .fc-center').contains('October 2024').should('exist');
-            cy.url().should('match', /(defaultDate=2024-10-)|(tab_params%5BdefaultDate%5D=2024-10-)/);
+            cy.url().should('match', /(defaultDate=2024-10-\d{2}(&|$))|(tab_params%5BdefaultDate%5D=2024-10-\d{2}(&|$))/);
         }
 
         function addReservation() {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44551

- After adding, modifying, or deleting a reservation, the calendar would jump back to the first day of the month instead of staying on the date being viewed.
The fn redirect_back function only returned the year and month in the return URL, so the day was set to 1. The fix passes a date to preserve the exact date of the reservation.

## Screenshots (if appropriate):


