### PR TITLE
Fix alert filtering in displayLastAlert()

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -277,12 +277,14 @@ class Alert extends CommonDBTM
 
         if ($items_id) {
             $iter = $DB->request([
-                'FROM'     => self::getTable(),
-                'FIELDS'   => 'date',
-                'ORDER'    => 'date DESC',
-                'LIMIT'    => 1,
-                'itemtype' => $itemtype,
-                'items_id' => $items_id,
+                'FROM'   => self::getTable(),
+                'FIELDS' => 'date',
+                'WHERE'  => [
+                    'itemtype' => $itemtype,
+                    'items_id' => $items_id,
+                ],
+                'ORDER'  => 'date DESC',
+                'LIMIT'  => 1,
             ]);
             if ($row = $iter->current()) {
                 //TRANS: %s is the date


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.

## Description

This fixes the query used by Alert::displayLastAlert().

The itemtype and items_id filters were passed at the root level of the DB request options instead of being placed inside the WHERE clause.

This could prevent the query from being correctly filtered and may display the last alert from another item.

The change moves these filters into the WHERE clause, matching the expected DB request format.