### PR TITLE
Fix SMTP password cleanup when switching to SMTP OAuth

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -456,12 +456,14 @@ class Config extends CommonDBTM
 
         if (isset($input["_blank_smtp_passwd"]) && $input["_blank_smtp_passwd"]) {
             $input['smtp_passwd'] = '';
-        } elseif (
-            isset($input['smtp_passwd'])
-            && empty($input['smtp_passwd'])
-            && (!isset($input['smtp_mode']) || (int) $input['smtp_mode'] !== MAIL_SMTPOAUTH)
-        ) {
+        }
+
+        if (isset($input['smtp_passwd']) && empty($input['smtp_passwd'])) {
             unset($input['smtp_passwd']);
+        }
+
+        if (($input['smtp_mode'] ?? null) === MAIL_SMTPOAUTH) {
+            $input['smtp_passwd'] = '';
         }
 
         return $input;

--- a/src/Config.php
+++ b/src/Config.php
@@ -454,11 +454,14 @@ class Config extends CommonDBTM
             $input['smtp_oauth_refresh_token'] = '';
         }
 
-        if (isset($input['smtp_passwd']) && empty($input['smtp_passwd'])) {
-            unset($input['smtp_passwd']);
-        }
         if (isset($input["_blank_smtp_passwd"]) && $input["_blank_smtp_passwd"]) {
             $input['smtp_passwd'] = '';
+        } elseif (
+            isset($input['smtp_passwd'])
+            && empty($input['smtp_passwd'])
+            && (!isset($input['smtp_mode']) || (int) $input['smtp_mode'] !== MAIL_SMTPOAUTH)
+        ) {
+            unset($input['smtp_passwd']);
         }
 
         return $input;

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -568,6 +568,36 @@ class ConfigTest extends DbTestCase
     }
 
     /**
+     * Test that the legacy SMTP password is cleared when switching to SMTP OAuth.
+     *
+     * SMTP OAuth does not use `smtp_passwd`. When changing the SMTP mode to OAuth,
+     * the previous SMTP password must be overwritten with an empty value instead of
+     * being kept in the database.
+     */
+    public function testSmtpPasswordIsClearedWhenSwitchingToSmtpOauth(): void
+    {
+        $conf = new Config();
+
+        Config::setConfigurationValues('core', [
+            'smtp_mode'   => MAIL_SMTP,
+            'smtp_passwd' => 'old-password',
+        ]);
+
+        $conf->update([
+            'id'        => 1,
+            'smtp_mode' => MAIL_SMTPOAUTH,
+        ]);
+
+        $values = Config::getConfigurationValues('core', [
+            'smtp_mode',
+            'smtp_passwd',
+        ]);
+
+        $this->assertSame(MAIL_SMTPOAUTH, (int) $values['smtp_mode']);
+        $this->assertSame('', $values['smtp_passwd']);
+    }
+
+    /**
      * Test password expiration delay configuration update.
      */
     public function testPasswordExpirationDelayUpdate()


### PR DESCRIPTION
## Checklist before requesting a review

- [X] I have read the CONTRIBUTING document.

## Description

- It fixes #19835

When switching the mail notification configuration from SMTP authentication to SMTP OAuth, GLPI attempts to clear the legacy SMTP password by setting `smtp_passwd` to an empty string.

However, the generic empty password handling later removes `smtp_passwd` from the input, preventing the empty value from being saved. As a result, the previous SMTP password remains stored in the configuration.

This patch preserves the empty `smtp_passwd` value when the selected SMTP mode is OAuth, while keeping the existing behavior for standard SMTP authentication.

### Changes

* Preserve empty `smtp_passwd` when switching to `MAIL_SMTPOAUTH`.
* Keep existing empty-password handling for non-OAuth SMTP modes.
* Add a functional test covering the migration from SMTP authentication to SMTP OAuth.

### Steps to reproduce

1. Configure email notifications using SMTP authentication.
2. Save a valid SMTP username and password.
3. Switch the SMTP mode to OAuth.
4. Save the configuration.
5. Check the stored mail configuration.

### Current behavior

The previously configured SMTP password remains stored.

### Expected behavior

The legacy SMTP password should be cleared when SMTP OAuth is enabled.

### Regression test

Added `testSmtpPasswordIsClearedWhenSwitchingToSmtpOauth()` to ensure that switching from SMTP authentication to SMTP OAuth removes any previously stored SMTP password.