### PR TITLE
fix(CommonITILRecurrent.php): fix Periodicity and Preliminary creation dropdown values

### DIFF
--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -256,12 +256,28 @@ abstract class CommonITILRecurrent extends CommonDropdown
     /**
      * Display periodicity field
      * The displayed dropdown offer the following options:
-     *    1 to 24 hours
+     *    1 to 23 hours
      *    1 to 30 days
      *    1 to 11 months
      *    1 to 10 years
      */
     public function displayPeriodicityInput(): void
+    {
+        Dropdown::showFromArray('periodicity', static::getPeriodicityPossibleValues(), [
+            'value' => $this->fields['periodicity'],
+        ]);
+    }
+
+    /**
+     * Get all possible periodicity values:
+     *    1 to 23 hours
+     *    1 to 30 days
+     *    1 to 11 months
+     *    1 to 10 years
+     *
+     * @return array<int|string, string>
+     */
+    public static function getPeriodicityPossibleValues(): array
     {
         $possible_values = [];
 
@@ -285,9 +301,21 @@ abstract class CommonITILRecurrent extends CommonDropdown
             $possible_values[$i . 'YEAR'] = sprintf(_n('%d year', '%d years', $i), $i);
         }
 
-        Dropdown::showFromArray('periodicity', $possible_values, [
-            'value' => $this->fields['periodicity'],
-        ]);
+        return $possible_values;
+    }
+
+    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
+    {
+        if (!is_array($values)) {
+            $values = [$field => $values];
+        }
+        $options['display'] = false;
+        switch ($field) {
+            case 'periodicity':
+                $options['value'] = $values[$field];
+                return (string) Dropdown::showFromArray($name, static::getPeriodicityPossibleValues(), $options);
+        }
+        return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }
 
     public function rawSearchOptions()
@@ -340,6 +368,8 @@ abstract class CommonITILRecurrent extends CommonDropdown
             'field'    => 'create_before',
             'name'     => __('Preliminary creation'),
             'datatype' => 'timestamp',
+            'max'      => 2 * WEEK_TIMESTAMP,
+            'step'     => HOUR_TIMESTAMP,
         ];
 
         $tab[] = [

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -310,10 +310,9 @@ abstract class CommonITILRecurrent extends CommonDropdown
             $values = [$field => $values];
         }
         $options['display'] = false;
-        switch ($field) {
-            case 'periodicity':
-                $options['value'] = $values[$field];
-                return (string) Dropdown::showFromArray($name, static::getPeriodicityPossibleValues(), $options);
+        if ($field === 'periodicity') {
+            $options['value'] = $values[$field];
+            return (string) Dropdown::showFromArray($name, static::getPeriodicityPossibleValues(), $options);
         }
         return parent::getSpecificValueToSelect($field, $name, $values, $options);
     }


### PR DESCRIPTION


## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44581
The massive action "Update" for recurring tickets/changes showed incorrect options for the Periodicity and Preliminary creation fields:
- Periodicity was a manual input field, while in the form, it's a dropdown.
- Preliminary creation max value was 1 day, while the form offers up to 2 weeks in 1-hour steps.

Changes:
- Extract `getPeriodicityPossibleValues()` static helper to avoid duplicating the hours/days/months/years option list.
- Use `getPeriodicityPossibleValues()` to render the dropdown in both `displayPeriodicityInput()` (used for the normal form) and in `getSpecificValueToSelect()` (used for the massive action form).
- Add `max => 2 * WEEK_TIMESTAMP` and `step => HOUR_TIMESTAMP` to the `create_before` search option so `Dropdown::showTimeStamp()` uses the same range as the normal form.

## Screenshots (if appropriate):

before : 

<img width="1166" height="508" alt="before_1" src="https://github.com/user-attachments/assets/b13c6cb8-35de-4576-904e-acda6433c99b" />

<img width="1166" height="508" alt="before_2" src="https://github.com/user-attachments/assets/7803abe7-9fa8-4fe9-8729-53d340c6106b" />

After : 

<img width="1166" height="508" alt="after_1" src="https://github.com/user-attachments/assets/e223ec82-5d39-41a3-8b1b-bf9df443fe5b" />

<img width="1166" height="508" alt="after_2" src="https://github.com/user-attachments/assets/f50ef445-b06f-472f-b1bb-58ef7f9f2992" />