### PR TITLE
FIX KB / relink embedded document URLs when creating KB article from ticket (v10 backport)

### DIFF
--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -1606,7 +1606,7 @@ HTML
         ]);
 
         $doc_url = '/front/document.send.php?docid=' . $document->getID()
-            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
+            . '&itemtype=Ticket&items_id=' . $ticket->getID();
 
         $kb = $this->createItem(\KnowbaseItem::class, [
             'name'          => __FUNCTION__,
@@ -1657,8 +1657,18 @@ HTML
         $profile = $this->createItem(\Profile::class, [
             'name'      => __FUNCTION__,
             'interface' => 'central',
-            'knowbase'  => \KnowbaseItem::PUBLISHFAQ | CREATE,
-            'ticket'    => 0,
+        ]);
+
+        $this->createItem(\ProfileRight::class, [
+            'profiles_id' => $profile->getID(),
+            'name'        => 'knowbase',
+            'rights'      => \KnowbaseItem::PUBLISHFAQ | CREATE,
+        ]);
+
+        $this->createItem(\ProfileRight::class, [
+            'profiles_id' => $profile->getID(),
+            'name'        => 'ticket',
+            'rights'      => 0,
         ]);
 
         $user = $this->createItem(\User::class, [
@@ -1672,7 +1682,7 @@ HTML
         $this->login($user->fields['name'], 'testpassword');
 
         $doc_url = '/front/document.send.php?docid=' . $document->getID()
-            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
+            . '&itemtype=Ticket&items_id=' . $ticket->getID();
 
         $kb = $this->createItem(\KnowbaseItem::class, [
             'name'          => __FUNCTION__,

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -1589,126 +1589,113 @@ HTML
     {
         $this->login();
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem(\Ticket::class, [
             'name'    => __FUNCTION__,
             'content' => __FUNCTION__,
         ]);
-        $this->integer($ticket_id)->isGreaterThan(0);
 
-        $document = new \Document();
-        $document_id = $document->add([
+        $document = $this->createItem(\Document::class, [
             'name'     => __FUNCTION__,
             'filename' => 'test.txt',
         ]);
-        $this->integer($document_id)->isGreaterThan(0);
 
-        $document_item = new \Document_Item();
-        $this->integer($document_item->add([
-            'documents_id' => $document_id,
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
             'itemtype'     => \Ticket::class,
-            'items_id'     => $ticket_id,
-        ]))->isGreaterThan(0);
+            'items_id'     => $ticket->getID(),
+        ]);
 
-        $doc_url = '/front/document.send.php?docid=' . $document_id
-            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket_id;
+        $doc_url = '/front/document.send.php?docid=' . $document->getID()
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
 
-        $kb = new \KnowbaseItem();
-        $kb_id = $kb->add([
+        $kb = $this->createItem(\KnowbaseItem::class, [
             'name'          => __FUNCTION__,
             'answer'        => '<p><a href="' . $doc_url . '">doc</a></p>',
             'is_faq'        => 0,
             'users_id'      => \Session::getLoginUserID(),
             '_itemtype'     => \Ticket::class,
-            '_items_id'     => $ticket_id,
+            '_items_id'     => $ticket->getID(),
             '_do_item_link' => false,
-        ]);
-        $this->integer($kb_id)->isGreaterThan(0);
-        $this->boolean($kb->getFromDB($kb_id))->isTrue();
+        ], ['answer']);
 
-        $this->string($kb->fields['answer'])->contains('itemtype=KnowbaseItem');
-        $this->string($kb->fields['answer'])->contains('items_id=' . $kb_id);
-        $this->string($kb->fields['answer'])->notContains('itemtype=Ticket');
+        $this->assertTrue($kb->getFromDB($kb->getID()));
 
-        $this->integer(countElementsInTable(\Document_Item::getTable(), [
-            'documents_id' => $document_id,
-            'itemtype'     => \KnowbaseItem::class,
-            'items_id'     => $kb_id,
-        ]))->isEqualTo(1);
+        $this->assertStringContainsString('itemtype=KnowbaseItem', $kb->fields['answer']);
+        $this->assertStringContainsString('items_id=' . $kb->getID(), $kb->fields['answer']);
+        $this->assertStringNotContainsString('itemtype=Ticket', $kb->fields['answer']);
+
+        $this->assertEquals(
+            1,
+            countElementsInTable(\Document_Item::getTable(), [
+                'documents_id' => $document->getID(),
+                'itemtype'     => \KnowbaseItem::class,
+                'items_id'     => $kb->getID(),
+            ])
+        );
     }
 
     public function testRelinkEmbeddedDocumentsBlockedWithoutSourceAccess(): void
     {
         $this->login();
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem(\Ticket::class, [
             'name'    => __FUNCTION__,
             'content' => __FUNCTION__,
         ]);
-        $this->integer($ticket_id)->isGreaterThan(0);
 
-        $document = new \Document();
-        $document_id = $document->add([
+        $document = $this->createItem(\Document::class, [
             'name'     => __FUNCTION__,
             'filename' => 'test.txt',
         ]);
-        $this->integer($document_id)->isGreaterThan(0);
 
-        $document_item = new \Document_Item();
-        $this->integer($document_item->add([
-            'documents_id' => $document_id,
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
             'itemtype'     => \Ticket::class,
-            'items_id'     => $ticket_id,
-        ]))->isGreaterThan(0);
+            'items_id'     => $ticket->getID(),
+        ]);
 
-        $profile = new \Profile();
-        $profile_id = $profile->add([
+        $profile = $this->createItem(\Profile::class, [
             'name'      => __FUNCTION__,
             'interface' => 'central',
+            'knowbase'  => \KnowbaseItem::PUBLISHFAQ | CREATE,
+            'ticket'    => 0,
         ]);
-        $this->integer($profile_id)->isGreaterThan(0);
 
-        // Droits : KB publish + create, aucun droit ticket
-        $DB->update(\Profile::getTable(), [
-            'knowbase' => \KnowbaseItem::PUBLISHFAQ | CREATE,
-        ], ['id' => $profile_id]);
-
-        $user = new \User();
-        $user_id = $user->add([
+        $user = $this->createItem(\User::class, [
             'name'         => __FUNCTION__,
             'password'     => 'testpassword',
             'password2'    => 'testpassword',
-            '_profiles_id' => $profile_id,
+            '_profiles_id' => $profile->getID(),
             '_entities_id' => 0,
-        ]);
-        $this->integer($user_id)->isGreaterThan(0);
+        ], ['password', 'password2']);
 
-        $this->login(__FUNCTION__, 'testpassword');
+        $this->login($user->fields['name'], 'testpassword');
 
-        $doc_url = '/front/document.send.php?docid=' . $document_id
-            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket_id;
+        $doc_url = '/front/document.send.php?docid=' . $document->getID()
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket->getID();
 
-        $kb = new \KnowbaseItem();
-        $kb_id = $kb->add([
+        $kb = $this->createItem(\KnowbaseItem::class, [
             'name'          => __FUNCTION__,
             'answer'        => '<p><a href="' . $doc_url . '">doc</a></p>',
             'is_faq'        => 1,
-            'users_id'      => $user_id,
+            'users_id'      => $user->getID(),
             '_itemtype'     => \Ticket::class,
-            '_items_id'     => $ticket_id,
+            '_items_id'     => $ticket->getID(),
             '_do_item_link' => false,
-        ]);
-        $this->integer($kb_id)->isGreaterThan(0);
-        $this->boolean($kb->getFromDB($kb_id))->isTrue();
+        ], ['answer']);
 
-        $this->string($kb->fields['answer'])->notContains('itemtype=KnowbaseItem');
-        $this->string($kb->fields['answer'])->contains('itemtype=Ticket');
+        $this->assertTrue($kb->getFromDB($kb->getID()));
 
-        $this->integer(countElementsInTable(\Document_Item::getTable(), [
-            'documents_id' => $document_id,
-            'itemtype'     => \KnowbaseItem::class,
-            'items_id'     => $kb_id,
-        ]))->isEqualTo(0);
+        $this->assertStringNotContainsString('itemtype=KnowbaseItem', $kb->fields['answer']);
+        $this->assertStringContainsString('itemtype=Ticket', $kb->fields['answer']);
+
+        $this->assertEquals(
+            0,
+            countElementsInTable(\Document_Item::getTable(), [
+                'documents_id' => $document->getID(),
+                'itemtype'     => \KnowbaseItem::class,
+                'items_id'     => $kb->getID(),
+            ])
+        );
     }
 }

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -1659,16 +1659,9 @@ HTML
             'interface' => 'central',
         ]);
 
-        $this->createItem(\ProfileRight::class, [
-            'profiles_id' => $profile->getID(),
-            'name'        => 'knowbase',
-            'rights'      => \KnowbaseItem::PUBLISHFAQ | CREATE,
-        ]);
-
-        $this->createItem(\ProfileRight::class, [
-            'profiles_id' => $profile->getID(),
-            'name'        => 'ticket',
-            'rights'      => 0,
+        \ProfileRight::updateProfileRights($profile->getID(), [
+            'knowbase' => \KnowbaseItem::PUBLISHFAQ | CREATE,
+            'ticket'   => 0,
         ]);
 
         $user = $this->createItem(\User::class, [

--- a/phpunit/functional/KnowbaseItemTest.php
+++ b/phpunit/functional/KnowbaseItemTest.php
@@ -1584,4 +1584,131 @@ HTML
         ]);
         $this->assertTrue($fn_can_tech_see_kb());
     }
+
+    public function testRelinkEmbeddedDocumentsFromTicketSolution(): void
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name'    => __FUNCTION__,
+            'content' => __FUNCTION__,
+        ]);
+        $this->integer($ticket_id)->isGreaterThan(0);
+
+        $document = new \Document();
+        $document_id = $document->add([
+            'name'     => __FUNCTION__,
+            'filename' => 'test.txt',
+        ]);
+        $this->integer($document_id)->isGreaterThan(0);
+
+        $document_item = new \Document_Item();
+        $this->integer($document_item->add([
+            'documents_id' => $document_id,
+            'itemtype'     => \Ticket::class,
+            'items_id'     => $ticket_id,
+        ]))->isGreaterThan(0);
+
+        $doc_url = '/front/document.send.php?docid=' . $document_id
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket_id;
+
+        $kb = new \KnowbaseItem();
+        $kb_id = $kb->add([
+            'name'          => __FUNCTION__,
+            'answer'        => '<p><a href="' . $doc_url . '">doc</a></p>',
+            'is_faq'        => 0,
+            'users_id'      => \Session::getLoginUserID(),
+            '_itemtype'     => \Ticket::class,
+            '_items_id'     => $ticket_id,
+            '_do_item_link' => false,
+        ]);
+        $this->integer($kb_id)->isGreaterThan(0);
+        $this->boolean($kb->getFromDB($kb_id))->isTrue();
+
+        $this->string($kb->fields['answer'])->contains('itemtype=KnowbaseItem');
+        $this->string($kb->fields['answer'])->contains('items_id=' . $kb_id);
+        $this->string($kb->fields['answer'])->notContains('itemtype=Ticket');
+
+        $this->integer(countElementsInTable(\Document_Item::getTable(), [
+            'documents_id' => $document_id,
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $kb_id,
+        ]))->isEqualTo(1);
+    }
+
+    public function testRelinkEmbeddedDocumentsBlockedWithoutSourceAccess(): void
+    {
+        $this->login();
+
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name'    => __FUNCTION__,
+            'content' => __FUNCTION__,
+        ]);
+        $this->integer($ticket_id)->isGreaterThan(0);
+
+        $document = new \Document();
+        $document_id = $document->add([
+            'name'     => __FUNCTION__,
+            'filename' => 'test.txt',
+        ]);
+        $this->integer($document_id)->isGreaterThan(0);
+
+        $document_item = new \Document_Item();
+        $this->integer($document_item->add([
+            'documents_id' => $document_id,
+            'itemtype'     => \Ticket::class,
+            'items_id'     => $ticket_id,
+        ]))->isGreaterThan(0);
+
+        $profile = new \Profile();
+        $profile_id = $profile->add([
+            'name'      => __FUNCTION__,
+            'interface' => 'central',
+        ]);
+        $this->integer($profile_id)->isGreaterThan(0);
+
+        // Droits : KB publish + create, aucun droit ticket
+        $DB->update(\Profile::getTable(), [
+            'knowbase' => \KnowbaseItem::PUBLISHFAQ | CREATE,
+        ], ['id' => $profile_id]);
+
+        $user = new \User();
+        $user_id = $user->add([
+            'name'         => __FUNCTION__,
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => $profile_id,
+            '_entities_id' => 0,
+        ]);
+        $this->integer($user_id)->isGreaterThan(0);
+
+        $this->login(__FUNCTION__, 'testpassword');
+
+        $doc_url = '/front/document.send.php?docid=' . $document_id
+            . '&amp;itemtype=Ticket&amp;items_id=' . $ticket_id;
+
+        $kb = new \KnowbaseItem();
+        $kb_id = $kb->add([
+            'name'          => __FUNCTION__,
+            'answer'        => '<p><a href="' . $doc_url . '">doc</a></p>',
+            'is_faq'        => 1,
+            'users_id'      => $user_id,
+            '_itemtype'     => \Ticket::class,
+            '_items_id'     => $ticket_id,
+            '_do_item_link' => false,
+        ]);
+        $this->integer($kb_id)->isGreaterThan(0);
+        $this->boolean($kb->getFromDB($kb_id))->isTrue();
+
+        $this->string($kb->fields['answer'])->notContains('itemtype=KnowbaseItem');
+        $this->string($kb->fields['answer'])->contains('itemtype=Ticket');
+
+        $this->integer(countElementsInTable(\Document_Item::getTable(), [
+            'documents_id' => $document_id,
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $kb_id,
+        ]))->isEqualTo(0);
+    }
 }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -335,6 +335,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
      **/
     public function post_addItem()
     {
+        // Relink embedded document URLs from source item context before addFiles saves to DB
+        $relinked_answer = $this->relinkEmbeddedDocumentsFromLinkedItemContext(
+            $this->input['answer'] ?? $this->fields['answer'] ?? null
+        );
+        if ($relinked_answer !== null) {
+            $this->input['answer'] = $relinked_answer;
+        }
+
         // Handle rich-text images and uploaded documents
         $this->input = $this->addFiles(
             $this->input,
@@ -425,8 +433,6 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
      * @param ?string $answer
      *
      * @return ?string
-     *
-     * @phpstan-ignore method.unused
      */
     private function relinkEmbeddedDocumentsFromLinkedItemContext(?string $answer): ?string
     {

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -336,11 +336,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     public function post_addItem()
     {
         // Relink embedded document URLs from source item context before addFiles saves to DB
-        $relinked_answer = $this->relinkEmbeddedDocumentsFromLinkedItemContext(
-            $this->input['answer'] ?? $this->fields['answer'] ?? null
-        );
-        if ($relinked_answer !== null) {
+        $original_answer = $this->input['answer'] ?? $this->fields['answer'] ?? null;
+        $relinked_answer = $this->relinkEmbeddedDocumentsFromLinkedItemContext($original_answer);
+        if ($relinked_answer !== null && $relinked_answer !== $original_answer) {
             $this->input['answer'] = $relinked_answer;
+            $this->fields['answer'] = $relinked_answer;
+            $this->updateInDB(['answer']);
         }
 
         // Handle rich-text images and uploaded documents

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -425,9 +425,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
      * @param ?string $answer
      *
      * @return ?string
+     *
+     * @phpstan-ignore method.unused
      */
     private function relinkEmbeddedDocumentsFromLinkedItemContext(?string $answer): ?string
     {
+        /** @var \DBmysql $DB */
         global $DB;
 
         if ($answer === null || $answer === '') {
@@ -519,6 +522,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         string $source_itemtype,
         int $source_items_id
     ): bool {
+        /** @var \DBmysql $DB */
         global $DB;
 
         $source_link = $DB->request([

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -419,6 +419,133 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
         $this->update1NTableData(KnowbaseItem_KnowbaseItemCategory::class, "_categories");
     }
 
+    /**
+     * Recontextualize embedded document URLs from source item to current KnowbaseItem.
+     *
+     * @param ?string $answer
+     *
+     * @return ?string
+     */
+    private function relinkEmbeddedDocumentsFromLinkedItemContext(?string $answer): ?string
+    {
+        global $DB;
+
+    if ($answer === null || $answer === '') {
+        return $answer;
+    }
+
+    $source_itemtype = $this->input['_itemtype'] ?? null;
+    $source_items_id = $this->input['_items_id'] ?? null;
+    if (
+        !is_string($source_itemtype)
+        || !is_a($source_itemtype, CommonDBTM::class, true)
+        || !is_numeric($source_items_id)
+        || (int) $source_items_id <= 0
+    ) {
+        return $answer;
+    }
+    $source_items_id = (int) $source_items_id;
+
+    $decoded_answer = html_entity_decode(
+        html_entity_decode($answer, ENT_QUOTES | ENT_HTML5),
+        ENT_QUOTES | ENT_HTML5
+    );
+
+    $matches = [];
+    preg_match_all('/(?:https?:\/\/[^"\'\s<>]+)?\/front\/document\.send\.php\?[^"\'\s<>]+/i', $decoded_answer, $matches);
+    if (count($matches[0]) === 0) {
+        return $answer;
+    }
+
+    $document_item = new Document_Item();
+    foreach (array_unique($matches[0]) as $document_url) {
+        if (!is_string($document_url) || $document_url === '') {
+            continue;
+        }
+
+        $query = parse_url($document_url, PHP_URL_QUERY);
+        if (!is_string($query)) {
+            continue;
+        }
+
+        parse_str($query, $params);
+        $document_id = (int) ($params['docid'] ?? 0);
+        if (
+            $document_id <= 0
+            || ($params['itemtype'] ?? null) !== $source_itemtype
+            || (int) ($params['items_id'] ?? 0) !== $source_items_id
+        ) {
+            continue;
+        }
+
+        if (!$this->canRelinkEmbeddedDocumentFromSourceContext($document_id, $source_itemtype, $source_items_id)) {
+            continue;
+        }
+
+        $target_link = [
+            'documents_id' => $document_id,
+            'itemtype'     => self::class,
+            'items_id'     => $this->getID(),
+        ];
+        if (!$document_item->alreadyExists($target_link)) {
+            $document_item->add($target_link);
+        }
+
+        $params['itemtype'] = self::class;
+        $params['items_id'] = $this->getID();
+        $base_url = strtok($document_url, '?');
+        if ($base_url === false) {
+            continue;
+        }
+
+        $updated_url = $base_url . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        $decoded_answer = str_replace($document_url, $updated_url, $decoded_answer);
+    }
+
+    return htmlspecialchars($decoded_answer, ENT_QUOTES | ENT_HTML5);
+}
+
+    /**
+     * Ensure a document can be safely re-linked from a source context.
+     *
+     * @param int    $document_id
+     * @param string $source_itemtype
+     * @param int    $source_items_id
+     *
+     * @return bool
+     */
+    private function canRelinkEmbeddedDocumentFromSourceContext(
+        int $document_id,
+        string $source_itemtype,
+        int $source_items_id
+    ): bool {
+        global $DB;
+
+        $source_link = $DB->request([
+            'FROM'  => Document_Item::getTable(),
+            'COUNT' => 'cpt',
+            'WHERE' => [
+                'documents_id' => $document_id,
+                'itemtype'     => $source_itemtype,
+                'items_id'     => $source_items_id,
+            ],
+            'LIMIT' => 1,
+        ])->current();
+
+        if (
+            (int) ($source_link['cpt'] ?? 0) <= 0
+            && !is_a($source_itemtype, CommonITILObject::class, true)
+        ) {
+            return false;
+        }
+
+        $document = new Document();
+        return $document->getFromDB($document_id)
+            && $document->canViewFile([
+                'itemtype' => $source_itemtype,
+                'items_id' => $source_items_id,
+            ]);
+    }
 
     /**
      * @since 0.83

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -430,80 +430,80 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria
     {
         global $DB;
 
-    if ($answer === null || $answer === '') {
-        return $answer;
-    }
-
-    $source_itemtype = $this->input['_itemtype'] ?? null;
-    $source_items_id = $this->input['_items_id'] ?? null;
-    if (
-        !is_string($source_itemtype)
-        || !is_a($source_itemtype, CommonDBTM::class, true)
-        || !is_numeric($source_items_id)
-        || (int) $source_items_id <= 0
-    ) {
-        return $answer;
-    }
-    $source_items_id = (int) $source_items_id;
-
-    $decoded_answer = html_entity_decode(
-        html_entity_decode($answer, ENT_QUOTES | ENT_HTML5),
-        ENT_QUOTES | ENT_HTML5
-    );
-
-    $matches = [];
-    preg_match_all('/(?:https?:\/\/[^"\'\s<>]+)?\/front\/document\.send\.php\?[^"\'\s<>]+/i', $decoded_answer, $matches);
-    if (count($matches[0]) === 0) {
-        return $answer;
-    }
-
-    $document_item = new Document_Item();
-    foreach (array_unique($matches[0]) as $document_url) {
-        if (!is_string($document_url) || $document_url === '') {
-            continue;
+        if ($answer === null || $answer === '') {
+            return $answer;
         }
 
-        $query = parse_url($document_url, PHP_URL_QUERY);
-        if (!is_string($query)) {
-            continue;
-        }
-
-        parse_str($query, $params);
-        $document_id = (int) ($params['docid'] ?? 0);
+        $source_itemtype = $this->input['_itemtype'] ?? null;
+        $source_items_id = $this->input['_items_id'] ?? null;
         if (
-            $document_id <= 0
-            || ($params['itemtype'] ?? null) !== $source_itemtype
-            || (int) ($params['items_id'] ?? 0) !== $source_items_id
+            !is_string($source_itemtype)
+            || !is_a($source_itemtype, CommonDBTM::class, true)
+            || !is_numeric($source_items_id)
+            || (int) $source_items_id <= 0
         ) {
-            continue;
+            return $answer;
+        }
+        $source_items_id = (int) $source_items_id;
+
+        $decoded_answer = html_entity_decode(
+            html_entity_decode($answer, ENT_QUOTES | ENT_HTML5),
+            ENT_QUOTES | ENT_HTML5
+        );
+
+        $matches = [];
+        preg_match_all('/(?:https?:\/\/[^"\'\s<>]+)?\/front\/document\.send\.php\?[^"\'\s<>]+/i', $decoded_answer, $matches);
+        if (count($matches[0]) === 0) {
+            return $answer;
         }
 
-        if (!$this->canRelinkEmbeddedDocumentFromSourceContext($document_id, $source_itemtype, $source_items_id)) {
-            continue;
+        $document_item = new Document_Item();
+        foreach (array_unique($matches[0]) as $document_url) {
+            if (!is_string($document_url) || $document_url === '') {
+                continue;
+            }
+
+            $query = parse_url($document_url, PHP_URL_QUERY);
+            if (!is_string($query)) {
+                continue;
+            }
+
+            parse_str($query, $params);
+            $document_id = (int) ($params['docid'] ?? 0);
+            if (
+                $document_id <= 0
+                || ($params['itemtype'] ?? null) !== $source_itemtype
+                || (int) ($params['items_id'] ?? 0) !== $source_items_id
+            ) {
+                continue;
+            }
+
+            if (!$this->canRelinkEmbeddedDocumentFromSourceContext($document_id, $source_itemtype, $source_items_id)) {
+                continue;
+            }
+
+            $target_link = [
+                'documents_id' => $document_id,
+                'itemtype'     => self::class,
+                'items_id'     => $this->getID(),
+            ];
+            if (!$document_item->alreadyExists($target_link)) {
+                $document_item->add($target_link);
+            }
+
+            $params['itemtype'] = self::class;
+            $params['items_id'] = $this->getID();
+            $base_url = strtok($document_url, '?');
+            if ($base_url === false) {
+                continue;
+            }
+
+            $updated_url = $base_url . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+            $decoded_answer = str_replace($document_url, $updated_url, $decoded_answer);
         }
 
-        $target_link = [
-            'documents_id' => $document_id,
-            'itemtype'     => self::class,
-            'items_id'     => $this->getID(),
-        ];
-        if (!$document_item->alreadyExists($target_link)) {
-            $document_item->add($target_link);
-        }
-
-        $params['itemtype'] = self::class;
-        $params['items_id'] = $this->getID();
-        $base_url = strtok($document_url, '?');
-        if ($base_url === false) {
-            continue;
-        }
-
-        $updated_url = $base_url . '?' . http_build_query($params, '', '&', PHP_QUERY_RFC3986);
-        $decoded_answer = str_replace($document_url, $updated_url, $decoded_answer);
+        return htmlspecialchars($decoded_answer, ENT_QUOTES | ENT_HTML5);
     }
-
-    return htmlspecialchars($decoded_answer, ENT_QUOTES | ENT_HTML5);
-}
 
     /**
      * Ensure a document can be safely re-linked from a source context.


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR is a backport of #23982 , with specific adaptation to V10 version : 

- Replaced `htmlescape()` (v11 only) with `htmlspecialchars()`
- Added double `html_entity_decode` pass before URL matching, as GLPI v10 sanitizes rich-text content through `Sanitizer`, causing double-encoded entities (`&` → `&amp;` → `&#38;amp;`) that would prevent the regex from matching embedded document URLs.


