### PR TITLE
Add 'Assign: equipment by name' action in CommonITILObjects buisness rules

### DIFF
--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -400,6 +400,7 @@ class RuleAction extends CommonDBChild
             'affectbyip'          => __('Assign: equipment by IP address'),
             'affectbyfqdn'        => __('Assign: equipment by name + domain'),
             'affectbymac'         => __('Assign: equipment by MAC address'),
+            'affectbyname'        => __('Assign: equipment by name'),
             'compute'             => __('Recalculate'),
             'delete'              => __('Delete'),
             'do_not_compute'      => __('Do not calculate'),

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -433,6 +433,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                     case "affectbyip":
                     case "affectbyfqdn":
                     case "affectbymac":
+                    case "affectbyname":
                         if (!isset($output["entities_id"])) {
                             $output["entities_id"] = $params["entities_id"];
                         }
@@ -462,6 +463,13 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
 
                             case "affectbymac":
                                 $result = NetworkPortInstantiation::getUniqueItemByMac(
+                                    $regexvalue,
+                                    $output["entities_id"]
+                                );
+                                break;
+
+                            case "affectbyname":
+                                $result = self::getUniqueItemByName(
                                     $regexvalue,
                                     $output["entities_id"]
                                 );
@@ -966,9 +974,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
         // assign an object
         $actions['affectobject']['name']                            = _n('Associated element', 'Associated elements', Session::getPluralNumber());
         $actions['affectobject']['type']                            = 'text';
-        $actions['affectobject']['force_actions']                   = ['affectbyip', 'affectbyfqdn',
-            'affectbymac',
-        ];
+        $actions['affectobject']['force_actions']                   = ['affectbyip', 'affectbyfqdn', 'affectbymac', 'affectbyname'];
 
         // assign an appliance
         $actions['assign_appliance']['name']                        = _n('Associated element', 'Associated elements', Session::getPluralNumber()) . " : " . Appliance::getTypeName(1);
@@ -1088,5 +1094,42 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
     {
         $itemtype = static::getItemtype();
         return $itemtype::getIcon();
+    }
+
+    /**
+     * Find the first non-deleted, non-template asset whose name matches $name
+     * within $entity, searching across all ticket-assignable item types.
+     *
+     * @param string $name   Asset name to look for
+     * @param int    $entity Entity ID to restrict the search
+     * @return array{id: int, itemtype: class-string}|array{} Empty array when nothing found
+     */
+    public static function getUniqueItemByName(string $name, int $entity): array
+    {
+        global $CFG_GLPI;
+
+        foreach ($CFG_GLPI['ticket_types'] as $itemtype) {
+            $item = getItemForItemtype($itemtype);
+            if (!$item) {
+                continue;
+            }
+
+            $criteria = ['name' => $name];
+            if ($item->isEntityAssign()) {
+                $criteria['entities_id'] = $entity;
+            }
+            if ($item->maybeDeleted()) {
+                $criteria['is_deleted'] = 0;
+            }
+            if ($item->maybeTemplate()) {
+                $criteria['is_template'] = 0;
+            }
+
+            if ($item->getFromDBByCrit($criteria)) {
+                return ['id' => $item->getID(), 'itemtype' => $itemtype];
+            }
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes 44430!
- Add a new business rule action ("Assign: equipment by name")  for `CommonITILObjects`  that allows associating the object with the first item whose name matches the specified value (including regular expression support).