### PR TITLE
fix wrong right check on front/logviewer.php

### DIFF
--- a/front/logs.php
+++ b/front/logs.php
@@ -37,7 +37,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\System\Log\LogViewer;
 
-Session::checkRight("system_logs", READ);
+Session::checkRight(LogViewer::$rightname, READ);
 
 Html::header(
     LogViewer::getTypeName(Session::getPluralNumber()),

--- a/front/logviewer.php
+++ b/front/logviewer.php
@@ -58,11 +58,11 @@ if (($_GET['action'] ?? '') === 'download_log_file') {
     $logparser = new LogParser();
     $logparser->download($filepath);
 } elseif (($_POST['action'] ?? '') === 'empty') {
-    Session::checkRight('config', UPDATE);
+    Session::checkRight(Config::$rightname, UPDATE); // no UPDATE right for LogViewer -> Config::$rightname used
     $logparser->empty($filepath);
     Html::back();
 } elseif (($_POST['action'] ?? '') === 'delete') {
-    Session::checkRight('config', UPDATE);
+    Session::checkRight(Config::$rightname, UPDATE);
     $logparser->delete($filepath);
     Html::redirect($CFG_GLPI["root_doc"] . "/front/logs.php");
 } else {

--- a/front/logviewer.php
+++ b/front/logviewer.php
@@ -41,7 +41,7 @@ use Glpi\System\Log\LogViewer;
 
 global $CFG_GLPI;
 
-Session::checkRight("logs", READ);
+Session::checkRight(LogViewer::$rightname, READ);
 
 $filepath = $_REQUEST['filepath'] ?? null;
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- **fix wrong right check on front/logviewer.php**
- **replace hardcoded right names with $rightname variable (logs/logsviewer).**

* right 'logs' - \Log::$rightname - is for reading items logs (ticket updated, etc).
* 'system_logs' - \Glpi\System\Log\LogViewer::$rightname - is for system logs (php errors, crons, etc)
