### PR TITLE
Add(RuleCommonITILObject.php): add 'Assign: equipment by name' action

### DIFF
--- a/src/RuleAction.php
+++ b/src/RuleAction.php
@@ -400,6 +400,7 @@ class RuleAction extends CommonDBChild
             'affectbyip'          => __('Assign: equipment by IP address'),
             'affectbyfqdn'        => __('Assign: equipment by name + domain'),
             'affectbymac'         => __('Assign: equipment by MAC address'),
+            'affectbyname'        => __('Assign: equipment by name'),
             'compute'             => __('Recalculate'),
             'delete'              => __('Delete'),
             'do_not_compute'      => __('Do not calculate'),

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -1114,6 +1114,11 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                 continue;
             }
 
+            $item_has_name_field = $item->isField('name');
+            if (!$item_has_name_field) {
+                continue;
+            }
+
             $criteria = ['name' => $name];
             if ($item->isEntityAssign()) {
                 $criteria['entities_id'] = $entity;
@@ -1125,8 +1130,8 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                 $criteria['is_template'] = 0;
             }
 
-            if ($item->getFromDBByCrit($criteria)) {
-                return ['id' => $item->getID(), 'itemtype' => $itemtype];
+            foreach ($item->getSeveralFromDBByCrit($criteria, [], 1) as $first_item) {
+                return ['id' => $first_item->getID(), 'itemtype' => $itemtype];
             }
         }
 

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -433,6 +433,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                     case "affectbyip":
                     case "affectbyfqdn":
                     case "affectbymac":
+                    case "affectbyname":
                         if (!isset($output["entities_id"])) {
                             $output["entities_id"] = $params["entities_id"];
                         }
@@ -462,6 +463,13 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
 
                             case "affectbymac":
                                 $result = NetworkPortInstantiation::getUniqueItemByMac(
+                                    $regexvalue,
+                                    $output["entities_id"]
+                                );
+                                break;
+
+                            case "affectbyname":
+                                $result = self::getUniqueItemByName(
                                     $regexvalue,
                                     $output["entities_id"]
                                 );
@@ -966,9 +974,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
         // assign an object
         $actions['affectobject']['name']                            = _n('Associated element', 'Associated elements', Session::getPluralNumber());
         $actions['affectobject']['type']                            = 'text';
-        $actions['affectobject']['force_actions']                   = ['affectbyip', 'affectbyfqdn',
-            'affectbymac',
-        ];
+        $actions['affectobject']['force_actions']                   = ['affectbyip', 'affectbyfqdn', 'affectbymac', 'affectbyname'];
 
         // assign an appliance
         $actions['assign_appliance']['name']                        = _n('Associated element', 'Associated elements', Session::getPluralNumber()) . " : " . Appliance::getTypeName(1);
@@ -1088,5 +1094,42 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
     {
         $itemtype = static::getItemtype();
         return $itemtype::getIcon();
+    }
+
+    /**
+     * Find the first non-deleted, non-template asset whose name matches $name
+     * within $entity, searching across all ticket-assignable item types.
+     *
+     * @param string $name   Asset name to look for
+     * @param int    $entity Entity ID to restrict the search
+     * @return array{id: int, itemtype: class-string}|array{} Empty array when nothing found
+     */
+    public static function getUniqueItemByName(string $name, int $entity): array
+    {
+        global $CFG_GLPI;
+
+        foreach ($CFG_GLPI['ticket_types'] as $itemtype) {
+            $item = getItemForItemtype($itemtype);
+            if (!$item) {
+                continue;
+            }
+
+            $criteria = ['name' => $name];
+            if ($item->isEntityAssign()) {
+                $criteria['entities_id'] = $entity;
+            }
+            if ($item->maybeDeleted()) {
+                $criteria['is_deleted'] = 0;
+            }
+            if ($item->maybeTemplate()) {
+                $criteria['is_template'] = 0;
+            }
+
+            if ($item->getFromDBByCrit($criteria)) {
+                return ['id' => $item->getID(), 'itemtype' => $itemtype];
+            }
+        }
+
+        return [];
     }
 }

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -1114,8 +1114,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                 continue;
             }
 
-            $item_has_name_field = $item->isField('name');
-            if (!$item_has_name_field) {
+            if (!$item->isField('name')) {
                 continue;
             }
 

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -3652,22 +3652,15 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
         $itil_class = $this->getITILObjectClass();
         $itil_fk = $itil_class::getForeignKeyField();
-        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+        $itil_item_class = $this->getITILLinkClass('Item');
+        $itil_item_table =  $itil_item_class::getTable();
 
-        $computer = $this->createItem(\Computer::class, [
-            'name'        => 'affectbyname-test-create',
-            'entities_id' => $entity_id,
-        ]);
+        $rule_action_name = 'affectbyname-test-create';
+        $rule_criteria_name = 'affectbyname-trigger';
 
-        //add a seconde computer
+        //add a computer who's name doesn't match the rule action
         $this->createItem(\Computer::class, [
             'name'        => 'server-2',
-            'entities_id' => $entity_id,
-        ]);
-
-        //add another ticket type item that is set after Computer in the list of ticket types
-        $this->createItem(\Monitor::class, [
-            'name'        => 'affectbyname-test-create',
             'entities_id' => $entity_id,
         ]);
 
@@ -3675,28 +3668,57 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $rule_builder
             ->setCondtion(RuleCommonITILObject::ONADD)
             ->setEntity($entity_id)
-            ->addCriteria('name', Rule::PATTERN_CONTAIN, 'affectbyname-trigger')
-            ->addAction('affectbyname', 'affectobject', 'affectbyname-test-create');
+            ->addCriteria('name', Rule::PATTERN_CONTAIN, $rule_criteria_name)
+            ->addAction('affectbyname', 'affectobject', $rule_action_name);
         $this->createRule($rule_builder);
 
+        //test before creating an item with the name used in the rule action.
         $itil = $this->createItem($itil_class, [
-            'name'        => 'affectbyname-trigger ticket',
+            'name'        => $rule_criteria_name,
             'content'     => 'test',
             'entities_id' => $entity_id,
         ]);
 
-        //only the first computer should be linked to the ITIL object (first item found)
+        //No item should be linked
         $this->assertEquals(
-            1,
+            0,
             countElementsInTable(
                 $itil_item_table,
                 [
-                    'itemtype' => \Computer::class,
-                    'items_id' => $computer->getID(),
                     $itil_fk   => $itil->getID(),
                 ]
             ),
         );
+
+        //Now add 2 items who's names matche the rule action
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->createItem(\Monitor::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        //create the ITIL item again to trigger the rule
+        $itil = $this->createItem($itil_class, [
+            'name'        => $rule_criteria_name,
+            'content'     => 'test',
+            'entities_id' => $entity_id,
+        ]);
+
+        $linked_items = iterator_to_array(
+            $itil_item_class::getSeveralFromDBByCrit([
+                $itil_fk => $itil->getID(),
+            ])
+        );
+        $this->assertCount(1, $linked_items);
+
+        //Only the computer is linked (first item)
+        $item_link = array_pop($linked_items);
+        $this->assertEquals(\Computer::class, $item_link->fields['itemtype']);
+        $this->assertEquals($computer->getID(), $item_link->fields['items_id']);
     }
 
     public function testAffectEquipmentByNameOnUpdate(): void
@@ -3706,22 +3728,15 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
         $itil_class = $this->getITILObjectClass();
         $itil_fk = $itil_class::getForeignKeyField();
-        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+        $itil_item_class = $this->getITILLinkClass('Item');
+        $itil_item_table = $itil_item_class::getTable();
 
-        $computer = $this->createItem(\Computer::class, [
-            'name'        => 'affectbyname-test-update',
-            'entities_id' => $entity_id,
-        ]);
+        $rule_action_name = 'affectbyname-test-update';
+        $rule_criteria_name = 'affectbyname-trigger';
 
-        //add a seconde computer
+        //add an item who's name doesn't match the rule action
         $this->createItem(\Computer::class, [
             'name'        => 'server-2',
-            'entities_id' => $entity_id,
-        ]);
-
-        //add another ticket type item that is set after Computer in the list of ticket types
-        $this->createItem(\Monitor::class, [
-            'name'        => 'affectbyname-test-update',
             'entities_id' => $entity_id,
         ]);
 
@@ -3729,12 +3744,12 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $rule_builder
             ->setCondtion(RuleCommonITILObject::ONUPDATE)
             ->setEntity($entity_id)
-            ->addCriteria('name', Rule::PATTERN_CONTAIN, 'affectbyname-trigger')
-            ->addAction('affectbyname', 'affectobject', 'affectbyname-test-update');
+            ->addCriteria('name', Rule::PATTERN_CONTAIN, $rule_criteria_name)
+            ->addAction('affectbyname', 'affectobject', $rule_action_name);
         $this->createRule($rule_builder);
 
         $itil = $this->createItem($itil_class, [
-            'name'        => 'no match yet',
+            'name'        => $rule_criteria_name . ' (before update)',
             'content'     => 'test',
             'entities_id' => $entity_id,
         ]);
@@ -3745,26 +3760,49 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
             countElementsInTable(
                 $itil_item_table,
                 [
-                    'itemtype' => \Computer::class,
-                    'items_id' => $computer->getID(),
                     $itil_fk => $itil->getID(),
                 ]
             )
         );
 
-        $this->updateItem($itil_class, $itil->getID(), ['name' => 'affectbyname-trigger updated']);
+        //test update beofore creating an item with the name used in the rule action.
+        $this->updateItem($itil_class, $itil->getID(), ['name' => $rule_criteria_name . ' (after update)']);
 
+        //no link should be created since no item matches the rule action name
         $this->assertEquals(
-            1,
+            0,
             countElementsInTable(
                 $itil_item_table,
                 [
-                    'itemtype' => \Computer::class,
-                    'items_id' => $computer->getID(),
                     $itil_fk   => $itil->getID(),
                 ]
             ),
         );
+
+        //create 2 items who's name matches the rule action
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->createItem(\Monitor::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->updateItem($itil_class, $itil->getID(), ['name' => $rule_criteria_name . ' (after update 2)']);
+
+        $linked_items = iterator_to_array(
+            $itil_item_class::getSeveralFromDBByCrit([
+                $itil_fk => $itil->getID(),
+            ])
+        );
+        $this->assertCount(1, $linked_items);
+
+        //Only the computer is linked (first item)
+        $item_link = array_pop($linked_items);
+        $this->assertEquals(\Computer::class, $item_link->fields['itemtype']);
+        $this->assertEquals($computer->getID(), $item_link->fields['items_id']);
     }
 
     public function testAffectEquipmentByNameWithRegex(): void
@@ -3774,22 +3812,14 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
         $itil_class = $this->getITILObjectClass();
         $itil_fk = $itil_class::getForeignKeyField();
-        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+        $itil_item_class = $this->getITILLinkClass('Item');
+        $itil_item_table = $itil_item_class::getTable();
 
-        $computer = $this->createItem(\Computer::class, [
-            'name'        => 'regex-test-target',
-            'entities_id' => $entity_id,
-        ]);
+        $rule_action_name = 'regex-test-target';
 
-        //add a seconde computer
+        //create an item with a name that matches the regex
         $this->createItem(\Computer::class, [
             'name'        => 'server-2',
-            'entities_id' => $entity_id,
-        ]);
-
-        //add another ticket type item that is set after Computer in the list of ticket types
-        $this->createItem(\Monitor::class, [
-            'name'        => 'regex-test-target',
             'entities_id' => $entity_id,
         ]);
 
@@ -3797,26 +3827,55 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         $rule_builder
             ->setCondtion(RuleCommonITILObject::ONADD)
             ->setEntity($entity_id)
-            ->addCriteria('content', Rule::REGEX_MATCH, '/(regex-test-target)/')
+            ->addCriteria('content', Rule::REGEX_MATCH, '/(' . $rule_action_name . ')/')
             ->addAction('affectbyname', 'affectobject', '#0');
         $this->createRule($rule_builder);
 
         $itil = $this->createItem($itil_class, [
             'name'        => 'ticket with regex equipment assignment',
-            'content'     => 'please assign regex-test-target to this ticket',
+            'content'     => 'please assign ' . $rule_action_name . ' to this ticket',
             'entities_id' => $entity_id,
         ]);
 
+        //No item should be linked since no item matches the rule action name
         $this->assertEquals(
-            1,
+            0,
             countElementsInTable(
                 $itil_item_table,
                 [
-                    'itemtype' => \Computer::class,
-                    'items_id' => $computer->getID(),
                     $itil_fk   => $itil->getID(),
                 ]
             ),
         );
+
+        //create 2 items who's name matches the rule action
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->createItem(\Monitor::class, [
+            'name'        => $rule_action_name,
+            'entities_id' => $entity_id,
+        ]);
+
+        // create the ITIL item again to trigger the rule
+        $itil = $this->createItem($itil_class, [
+            'name'        => 'ticket with regex equipment assignment',
+            'content'     => 'please assign ' . $rule_action_name . ' to this ticket',
+            'entities_id' => $entity_id,
+        ]);
+
+        $linked_items = iterator_to_array(
+            $itil_item_class::getSeveralFromDBByCrit([
+                $itil_fk => $itil->getID(),
+            ])
+        );
+        $this->assertCount(1, $linked_items);
+
+        //Only the computer is linked (first item)
+        $item_link = array_pop($linked_items);
+        $this->assertEquals(\Computer::class, $item_link->fields['itemtype']);
+        $this->assertEquals($computer->getID(), $item_link->fields['items_id']);
     }
 }

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -3555,7 +3555,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
             'entities_id' => $entity_id,
         ]);
 
-        //add a seconde computer
+        //add a second computer
         $this->createItem(\Computer::class, [
             'name'        => 'server-2',
             'entities_id' => $entity_id,
@@ -3582,7 +3582,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
         $result = RuleCommonITILObject::getUniqueItemByName('nonexistent-asset-xyz-' . mt_rand(), $entity_id);
 
-        $this->assertEmpty($result);
+        $this->assertSame([], $result);
 
         //create a non ticket type item with the same name, it should not be returned
         $this->createItem(Entity::class, [
@@ -3591,7 +3591,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
         ]);
 
         $result = RuleCommonITILObject::getUniqueItemByName('test-entity', $entity_id);
-        $this->assertEmpty($result);
+        $this->assertSame([], $result);
     }
 
     public function testGetUniqueItemByNameExcludesNonValidItems(): void
@@ -3621,7 +3621,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
         $result = RuleCommonITILObject::getUniqueItemByName('template-server-findme', $entity_id);
 
-        $this->assertEmpty($result);
+        $this->assertSame([], $result);
     }
 
     public function testGetUniqueItemByNameRestrictsToEntity(): void
@@ -3638,7 +3638,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
 
         $result = RuleCommonITILObject::getUniqueItemByName('entity-restricted-server', $root_entity);
 
-        $this->assertEmpty($result);
+        $this->assertSame([], $result);
 
         $result = RuleCommonITILObject::getUniqueItemByName('entity-restricted-server', $child_entity);
 
@@ -3765,7 +3765,7 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
             )
         );
 
-        //test update beofore creating an item with the name used in the rule action.
+        //test update before creating an item with the name used in the rule action.
         $this->updateItem($itil_class, $itil->getID(), ['name' => $rule_criteria_name . ' (after update)']);
 
         //no link should be created since no item matches the rule action name

--- a/tests/src/RuleCommonITILObjectTest.php
+++ b/tests/src/RuleCommonITILObjectTest.php
@@ -3544,4 +3544,279 @@ abstract class RuleCommonITILObjectTest extends DbTestCase
     }
 
 
+    public function testGetUniqueItemByNameReturnsMatchingItem(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'affectbyname-test-create',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add a seconde computer
+        $this->createItem(\Computer::class, [
+            'name'        => 'server-2',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add another ticket type item that is set after Computer in the list of ticket types
+        $this->createItem(\Monitor::class, [
+            'name'        => 'affectbyname-test-create',
+            'entities_id' => $entity_id,
+        ]);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('affectbyname-test-create', $entity_id);
+
+        //only the computer should be returned (first item found)
+        $this->assertEquals($computer->getID(), $result['id']);
+        $this->assertEquals(\Computer::class, $result['itemtype']);
+    }
+
+    public function testGetUniqueItemByNameReturnsEmptyWhenNotFound(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('nonexistent-asset-xyz-' . mt_rand(), $entity_id);
+
+        $this->assertEmpty($result);
+
+        //create a non ticket type item with the same name, it should not be returned
+        $this->createItem(Entity::class, [
+            'name'        => 'test-entity',
+            'entities_id' => $entity_id,
+        ]);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('test-entity', $entity_id);
+        $this->assertEmpty($result);
+    }
+
+    public function testGetUniqueItemByNameExcludesNonValidItems(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+
+        //Test with a deleted item
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'deleted-server-findme',
+            'entities_id' => $entity_id,
+        ]);
+        $this->assertTrue((new \Computer())->delete(['id' => $computer->getID()]));
+
+        $result = RuleCommonITILObject::getUniqueItemByName('deleted-server-findme', $entity_id);
+
+        $this->assertSame([], $result);
+
+        //Test with a template
+
+        $this->createItem(\Computer::class, [
+            'name'        => 'template-server-findme',
+            'entities_id' => $entity_id,
+            'is_template' => 1,
+        ]);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('template-server-findme', $entity_id);
+
+        $this->assertEmpty($result);
+    }
+
+    public function testGetUniqueItemByNameRestrictsToEntity(): void
+    {
+        $this->login();
+
+        $root_entity   = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $child_entity  = getItemByTypeName(Entity::class, '_test_child_1', true);
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'entity-restricted-server',
+            'entities_id' => $child_entity,
+        ]);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('entity-restricted-server', $root_entity);
+
+        $this->assertEmpty($result);
+
+        $result = RuleCommonITILObject::getUniqueItemByName('entity-restricted-server', $child_entity);
+
+        $this->assertSame($computer->getID(), $result['id']);
+    }
+
+    public function testAffectEquipmentByNameOnCreate(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $itil_class = $this->getITILObjectClass();
+        $itil_fk = $itil_class::getForeignKeyField();
+        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'affectbyname-test-create',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add a seconde computer
+        $this->createItem(\Computer::class, [
+            'name'        => 'server-2',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add another ticket type item that is set after Computer in the list of ticket types
+        $this->createItem(\Monitor::class, [
+            'name'        => 'affectbyname-test-create',
+            'entities_id' => $entity_id,
+        ]);
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, $this->getTestedClass());
+        $rule_builder
+            ->setCondtion(RuleCommonITILObject::ONADD)
+            ->setEntity($entity_id)
+            ->addCriteria('name', Rule::PATTERN_CONTAIN, 'affectbyname-trigger')
+            ->addAction('affectbyname', 'affectobject', 'affectbyname-test-create');
+        $this->createRule($rule_builder);
+
+        $itil = $this->createItem($itil_class, [
+            'name'        => 'affectbyname-trigger ticket',
+            'content'     => 'test',
+            'entities_id' => $entity_id,
+        ]);
+
+        //only the first computer should be linked to the ITIL object (first item found)
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                $itil_item_table,
+                [
+                    'itemtype' => \Computer::class,
+                    'items_id' => $computer->getID(),
+                    $itil_fk   => $itil->getID(),
+                ]
+            ),
+        );
+    }
+
+    public function testAffectEquipmentByNameOnUpdate(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $itil_class = $this->getITILObjectClass();
+        $itil_fk = $itil_class::getForeignKeyField();
+        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'affectbyname-test-update',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add a seconde computer
+        $this->createItem(\Computer::class, [
+            'name'        => 'server-2',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add another ticket type item that is set after Computer in the list of ticket types
+        $this->createItem(\Monitor::class, [
+            'name'        => 'affectbyname-test-update',
+            'entities_id' => $entity_id,
+        ]);
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, $this->getTestedClass());
+        $rule_builder
+            ->setCondtion(RuleCommonITILObject::ONUPDATE)
+            ->setEntity($entity_id)
+            ->addCriteria('name', Rule::PATTERN_CONTAIN, 'affectbyname-trigger')
+            ->addAction('affectbyname', 'affectobject', 'affectbyname-test-update');
+        $this->createRule($rule_builder);
+
+        $itil = $this->createItem($itil_class, [
+            'name'        => 'no match yet',
+            'content'     => 'test',
+            'entities_id' => $entity_id,
+        ]);
+
+        // No link before update
+        $this->assertEquals(
+            0,
+            countElementsInTable(
+                $itil_item_table,
+                [
+                    'itemtype' => \Computer::class,
+                    'items_id' => $computer->getID(),
+                    $itil_fk => $itil->getID(),
+                ]
+            )
+        );
+
+        $this->updateItem($itil_class, $itil->getID(), ['name' => 'affectbyname-trigger updated']);
+
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                $itil_item_table,
+                [
+                    'itemtype' => \Computer::class,
+                    'items_id' => $computer->getID(),
+                    $itil_fk   => $itil->getID(),
+                ]
+            ),
+        );
+    }
+
+    public function testAffectEquipmentByNameWithRegex(): void
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName(Entity::class, '_test_root_entity', true);
+        $itil_class = $this->getITILObjectClass();
+        $itil_fk = $itil_class::getForeignKeyField();
+        $itil_item_table = $this->getITILLinkClass('Item')::getTable();
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => 'regex-test-target',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add a seconde computer
+        $this->createItem(\Computer::class, [
+            'name'        => 'server-2',
+            'entities_id' => $entity_id,
+        ]);
+
+        //add another ticket type item that is set after Computer in the list of ticket types
+        $this->createItem(\Monitor::class, [
+            'name'        => 'regex-test-target',
+            'entities_id' => $entity_id,
+        ]);
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, $this->getTestedClass());
+        $rule_builder
+            ->setCondtion(RuleCommonITILObject::ONADD)
+            ->setEntity($entity_id)
+            ->addCriteria('content', Rule::REGEX_MATCH, '/(regex-test-target)/')
+            ->addAction('affectbyname', 'affectobject', '#0');
+        $this->createRule($rule_builder);
+
+        $itil = $this->createItem($itil_class, [
+            'name'        => 'ticket with regex equipment assignment',
+            'content'     => 'please assign regex-test-target to this ticket',
+            'entities_id' => $entity_id,
+        ]);
+
+        $this->assertEquals(
+            1,
+            countElementsInTable(
+                $itil_item_table,
+                [
+                    'itemtype' => \Computer::class,
+                    'items_id' => $computer->getID(),
+                    $itil_fk   => $itil->getID(),
+                ]
+            ),
+        );
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes 44430!
- Add a new business rule action ("Assign: equipment by name") for `CommonITILObjects` that allows associating the object with the first item whose name matches the specified value (including regular expression support).