### PR TITLE
Fix positions not reset between rack items when checking model update

### DIFF
--- a/src/CommonDCModelDropdown.php
+++ b/src/CommonDCModelDropdown.php
@@ -329,7 +329,6 @@ abstract class CommonDCModelDropdown extends CommonDropdown
         // If so, check whether the new units required fit into the rack without modifying the positions
         $hasIssues = false;
         $itemtype = $this->getItemtypeForModel();
-        $positionsToCheck = [];
         foreach ($this->getItemsRackForModel() as $item_rack) {
             $rack = Rack::getById($item_rack['racks_id']);
             $filled = $rack->getFilled($itemtype, $item_rack['items_id']);
@@ -339,6 +338,7 @@ abstract class CommonDCModelDropdown extends CommonDropdown
             $depth = $input['depth'] ?? $this->fields['depth'];
 
             // Collect the positions to check
+            $positionsToCheck = [];
             for ($i = 0; $i < $requiredUnits; $i++) {
                 $positionsToCheck[] = $item_rack['position'] + $i;
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44135
- When updating a DC model's required_units, $positionsToCheck was initialized outside the foreach loop, causing positions from previous rack items to accumulate and trigger false-positive conflicts on unrelated racks. Moving the initialization inside the loop ensures each rack item is checked independently.


