### PR TITLE
fix(PlanningExternalEvent): SQL error when a duplicate document is added

### DIFF
--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -153,7 +153,7 @@ class Document_Item extends CommonDBRelation
             'documents_id'      => $input['documents_id'],
             'itemtype'          => $input['itemtype'],
             'items_id'          => $input['items_id'],
-            'timeline_position' => $input['timeline_position'] ?? null,
+            'timeline_position' => $input['timeline_position'] ?? 0,
         ];
         if (array_key_exists('timeline_position', $input) && !empty($input['timeline_position'])) {
             $criteria['timeline_position'] = $input['timeline_position'];

--- a/tests/functional/PlanningExternalEventTest.php
+++ b/tests/functional/PlanningExternalEventTest.php
@@ -423,4 +423,61 @@ class PlanningExternalEventTest extends AbstractPlanningEventTest
         }
         $this->assertTrue($found, 'The created event should be in guest\'s vCalendars');
     }
+
+    /**
+     * Test that documents can be uploaded and attached to a PlanningExternalEvent, and that duplicates are not created
+     */
+    public function testUploadDocuments()
+    {
+        $this->login();
+
+        $doc_item = new \Document_Item();
+        $filename = '5e5e92ffd9bd91.11111111' . 'foo.txt';
+
+        // Create event with document
+        $planning_event = $this->createItem(PlanningExternalEvent::class, [
+            'name' => 'Event with document',
+            'users_id' => Session::getLoginUserID(),
+            'plan' => [
+                'begin' => '2025-01-15 10:00:00',
+                'end' => '2025-01-15 12:00:00',
+            ],
+            '_filename' => [
+                0 => $filename,
+            ],
+        ], ['plan']);
+        copy(FIXTURE_DIR . '/uploads/foo.txt', GLPI_TMP_DIR . '/' . $filename);
+        $documents = $doc_item->find([
+            'itemtype' => PlanningExternalEvent::class,
+            'items_id' => $planning_event->getID(),
+        ]);
+        $this->assertCount(1, $documents, 'One document should be attached to the event');
+
+        // Try to attach the same document again
+        $this->updateItem(PlanningExternalEvent::class, $planning_event->getID(), [
+            '_filename' => [
+                0 => $filename,
+            ],
+        ]);
+        $documents = $doc_item->find([
+            'itemtype' => PlanningExternalEvent::class,
+            'items_id' => $planning_event->getID(),
+        ]);
+        $this->assertCount(1, $documents, 'Duplicate document should not be attached to the event');
+
+        // Attach a second document
+        $filename2 = '5e5e92ffd9bd91.44444444bar.txt';
+        $this->updateItem(PlanningExternalEvent::class, $planning_event->getID(), [
+            '_filename' => [
+                0 => $filename,
+                1 => $filename2,
+            ],
+        ]);
+        copy(FIXTURE_DIR . '/uploads/bar.txt', GLPI_TMP_DIR . '/' . $filename2);
+        $documents = $doc_item->find([
+            'itemtype' => PlanningExternalEvent::class,
+            'items_id' => $planning_event->getID(),
+        ]);
+        $this->assertCount(2, $documents, 'Second document should be attached to the event');
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44658
- If a user adds a document that is already linked to an external event in the calendar, the “Save” button remains disabled and an error appears in the logs. The `timeline_position` column is non-nullable and has a default value of 0.

```
[2026-06-11 12:36:47] glpi.CRITICAL:   *** Uncaught PHP Exception RuntimeException: "MySQL query error: Duplicate entry '2-PlanningExternalEvent-1-0' for key 'unicity' (1062) in SQL query "INSERT INTO `glpi_documents_items` (`documents_id`, `itemtype`, `items_id`, `date`, `users_id`, `entities_id`, `is_recursive`, `date_creation`, `date_mod`) VALUES ('2', 'PlanningExternalEvent', '1', '2026-06-11 12:36:47', '2', '0', '1', '2026-06-11 12:36:47', '2026-06-11 12:36:47')"." at DBmysql.php line 416
  Backtrace :
  ./src/DBmysql.php:416                              
  ./src/DBmysql.php:1377                             DBmysql->doQuery()
  ./src/CommonDBTM.php:780                           DBmysql->insert()
  ./src/CommonDBTM.php:1384                          CommonDBTM->addToDB()
  ./src/CommonDBTM.php:5658                          CommonDBTM->add()
  ./src/Glpi/Features/PlanningEvent.php:244          CommonDBTM->addFiles()
  ./src/CommonDBTM.php:1678                          PlanningExternalEvent->prepareInputForUpdate()
  ./front/planningexternalevent.form.php:84          CommonDBTM->update()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:208        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:71                              Symfony\Component\HttpKernel\Kernel->handle()
```

## Screenshots (if appropriate):

<img width="865" height="998" alt="image" src="https://github.com/user-attachments/assets/bb2b78cf-2ca8-4123-a391-79dac393f109" />



