### PR TITLE
fix(Session): prevent PHP error in addToNavigateListItems when session key is unset

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -366,7 +366,7 @@ class Session
      */
     public static function addToNavigateListItems($itemtype, $ID)
     {
-        if (!in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
+        if (empty($_SESSION['glpilistitems'][$itemtype]) || !in_array($ID, $_SESSION['glpilistitems'][$itemtype])) {
             $_SESSION['glpilistitems'][$itemtype][] = $ID;
         }
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Improve fix #24236
- Added a check for the existence of $_SESSION['glpilistitems'][$itemtype]

## Screenshots (if appropriate):
<img width="1183" height="441" alt="image" src="https://github.com/user-attachments/assets/6b888524-79d5-4552-a93a-e29c205104d6" />


