### PR TITLE
Drop FancyTree (Old jQuery UI component)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ The present file will list all changes made to the project; according to the
 - `hotkeys-js` JS library
 - `jquery-prettytextdiff` JS library
 - `jquery.rateit` JS library
+- `jquery.fancytree` JS library. Use `Wunderbaum` instead.
 - `Forms/FaIconSelector` JS module
 - `Knowbase` JS module
 - `league/csv` PHP library. Use `phpoffice/phpspreadsheet` instead.

--- a/css/includes/components/_browser_tree.scss
+++ b/css/includes/components/_browser_tree.scss
@@ -32,27 +32,16 @@
  */
 
 #tree_browse {
-    display: flex;
-    align-items: stretch;
+    display: grid;
+    grid-template-columns: 250px 1fr;
 
     .browser_tree {
-        flex-basis: 250px;
-        flex-shrink: 0;
         padding-right: 10px;
         padding-left: 2px;
 
         .browser-tree-container {
             overflow-x: hidden;
             overflow-y: auto;
-            flex: 1;
-
-            .fancytree-container {
-                overflow-y: auto;
-
-                i.fa.sub_items {
-                    color: #787878;
-                }
-            }
         }
 
         .browser_tree_search {

--- a/css/includes/components/_browser_tree.scss
+++ b/css/includes/components/_browser_tree.scss
@@ -34,15 +34,16 @@
 #tree_browse {
     display: grid;
     grid-template-columns: 250px 1fr;
+
     --wb-border-color: var(--tblr-border-color);
     --wb-focus-border-color: var(--tblr-focus-ring-color);
     --wb-background-color: var(--tblr-card-bg);
     --wb-node-text-color: var(--tblr-body-color);
-    --wb-active-color-grayscale: rgba(var(--tblr-secondary-rgb), 0.08);
-    --wb-active-color: rgba(var(--tblr-secondary-rgb), 0.08);
-    --wb-hover-color: rgba(var(--tblr-secondary-rgb), 0.08);
-    --wb-active-hover-color-grayscale: rgba(var(--tblr-secondary-rgb), 0.08);
-    --wb-active-hover-color: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-color-grayscale: rgb(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-color: rgb(var(--tblr-secondary-rgb), 0.08);
+    --wb-hover-color: rgb(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-hover-color-grayscale: rgb(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-hover-color: rgb(var(--tblr-secondary-rgb), 0.08);
     --wb-active-border-color-grayscale: var(--tblr-border-color);
     --wb-active-border-color: var(--tblr-border-color);
 

--- a/css/includes/components/_browser_tree.scss
+++ b/css/includes/components/_browser_tree.scss
@@ -34,6 +34,10 @@
 #tree_browse {
     display: grid;
     grid-template-columns: 250px 1fr;
+    --wb-border-color: var(--tblr-border-color);
+    --wb-focus-border-color: var(--tblr-focus-ring-color);
+    --wb-background-color: var(--tblr-card-bg);
+    --wb-node-text-color: var(--tblr-body-color);
 
     .browser_tree {
         padding-right: 10px;

--- a/css/includes/components/_browser_tree.scss
+++ b/css/includes/components/_browser_tree.scss
@@ -38,6 +38,13 @@
     --wb-focus-border-color: var(--tblr-focus-ring-color);
     --wb-background-color: var(--tblr-card-bg);
     --wb-node-text-color: var(--tblr-body-color);
+    --wb-active-color-grayscale: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-color: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-hover-color: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-hover-color-grayscale: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-hover-color: rgba(var(--tblr-secondary-rgb), 0.08);
+    --wb-active-border-color-grayscale: var(--tblr-border-color);
+    --wb-active-border-color: var(--tblr-border-color);
 
     .browser_tree {
         padding-right: 10px;

--- a/lib/bundles/base.js
+++ b/lib/bundles/base.js
@@ -59,12 +59,8 @@ require('jquery-ui/ui/scroll-parent');
 require('jquery-ui/ui/unique-id');
 
 // jQuery fancttree
-require('jquery.fancytree');
-require('jquery.fancytree/dist/modules/jquery.fancytree.grid');
-require('jquery.fancytree/dist/modules/jquery.fancytree.filter');
-require('jquery.fancytree/dist/modules/jquery.fancytree.glyph');
-require('jquery.fancytree/dist/modules/jquery.fancytree.persist');
-import 'jquery.fancytree/dist/skin-awesome/ui.fancytree.css';
+require('wunderbaum/dist/wunderbaum.css');
+window.Wunderbaum = require('wunderbaum');
 
 // Tabler
 import {bootstrap} from '@tabler/core';

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
                 "jquery": "^3.7.1",
                 "jquery-migrate": "^3.6.0",
                 "jquery-ui": "^1.14.2",
-                "jquery.fancytree": "^2.38.5",
                 "leaflet": "^1.9.4",
                 "leaflet-control-geocoder": "^3.3.1",
                 "leaflet-fullscreen": "^1.0.2",
@@ -76,7 +75,8 @@
                 "tinycolor2": "^1.6.0",
                 "tinymce": "^8.6.0",
                 "tinymce-i18n": "^26.5.18",
-                "vue": "^3.5.35"
+                "vue": "^3.5.35",
+                "wunderbaum": "^0.14.1"
             },
             "devDependencies": {
                 "@axe-core/playwright": "^4.11.3",
@@ -9201,15 +9201,6 @@
                 "jquery": ">=1.12.0 <5.0.0"
             }
         },
-        "node_modules/jquery.fancytree": {
-            "version": "2.38.5",
-            "resolved": "https://registry.npmjs.org/jquery.fancytree/-/jquery.fancytree-2.38.5.tgz",
-            "integrity": "sha512-6ntTplhfYKWz74GLpeeE9B62VqhsF+bd80gLZRDD1gl7Vv9WTqqQrCsrGMMu0PB6JLhNOXhf17xIcYpARG+N3g==",
-            "license": "MIT",
-            "peerDependencies": {
-                "jquery": ">=1.9"
-            }
-        },
         "node_modules/js-beautify": {
             "version": "1.14.9",
             "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
@@ -15106,6 +15097,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/wunderbaum": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/wunderbaum/-/wunderbaum-0.14.1.tgz",
+            "integrity": "sha512-RCpQxfmJLs87xqHxqI6gXW3hhRCMEQOeUkVlXykBtKNuXLUG6yjU31tmE7uUy27R7WcyHs/ZiDquZTkqstEIdA==",
+            "license": "MIT"
         },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "jquery": "^3.7.1",
         "jquery-migrate": "^3.6.0",
         "jquery-ui": "^1.14.2",
-        "jquery.fancytree": "^2.38.5",
         "leaflet": "^1.9.4",
         "leaflet-control-geocoder": "^3.3.1",
         "leaflet-fullscreen": "^1.0.2",
@@ -76,7 +75,8 @@
         "tinycolor2": "^1.6.0",
         "tinymce": "^8.6.0",
         "tinymce-i18n": "^26.5.18",
-        "vue": "^3.5.35"
+        "vue": "^3.5.35",
+        "wunderbaum": "^0.14.1"
     },
     "scripts": {
         "build:pack": "webpack --config .webpack.config.js",

--- a/src/Glpi/Features/TreeBrowse.php
+++ b/src/Glpi/Features/TreeBrowse.php
@@ -109,7 +109,8 @@ JAVASCRIPT;
 
         if ($update) {
             $JS .= <<<JAVASCRIPT
-                $('#tree_category').fancytree('option', 'source', {$category_list});
+                Wunderbaum.Wunderbaum.getTree('#tree_category').setOption('source', {$category_list});
+                Wunderbaum.Wunderbaum.getTree('#tree_category').reload();
 JAVASCRIPT;
 
             $params['criteria'][] = $_SESSION['treebrowse'][$itemtype];
@@ -121,56 +122,82 @@ JAVASCRIPT;
 
             $JS .= <<<JAVASCRIPT
             $(function() {
-                $('#tree_category').fancytree({
-                    // load plugins
-                    extensions: ['filter', 'glyph', 'persist'],
-
-                    // Scroll node into visible area, when focused by keyboard
-                    autoScroll: true,
-
-                    // enable font-awesome icons
-                    glyph: {
-                        preset: "awesome5",
-                        map: {}
-                    },
-
-                    persist: {
-                        cookiePrefix: '$js_itemtype',
-                        expandLazy: true,
-                        overrideSource: true,
-                        store: "auto"
-                    },
-
-                    // load json data
+                function saveState(tree) {
+                    const state = {
+                        active: tree.activeNode ? tree.activeNode.key : null,
+                        expanded: tree.findAll((n) => n.expanded).map(node => node.key),
+                    };
+                    localStorage.setItem('wunderbaum-state-$js_itemtype', JSON.stringify(state));
+                }
+                function restoreState(tree) {
+                    let persistedState = localStorage.getItem('wunderbaum-state-$js_itemtype');
+                    if (persistedState) {
+                        persistedState = JSON.parse(persistedState);
+                        if (persistedState.active) {
+                            const activeNode = tree.findKey(persistedState.active);
+                            if (activeNode) {
+                                activeNode.setActive(true, {
+                                    scroll: true,
+                                });
+                            }
+                        }
+                        if (persistedState.expanded) {
+                            if (!Array.isArray(persistedState.expanded)) {
+                                persistedState.expanded = [persistedState.expanded];
+                            }
+                            persistedState.expanded.forEach(key => {
+                                const node = tree.findKey(key);
+                                if (node) {
+                                    node.setExpanded(true);
+                                }
+                            });
+                        }
+                    }
+                }
+                const tree = new Wunderbaum.Wunderbaum({
+                    element: document.getElementById('tree_category'),
                     source: {$category_list},
-
-                    // filter plugin options
-                    filter: {
-                        mode: "hide", // remove unmatched nodes
-                        autoExpand: true, // if results found in children, auto-expand parent
-                        nodata: '{$no_cat_found}', // message when no data found
+                    render: (e) => {
+                        e.nodeElem.querySelector('.wb-title').innerHTML = e.node.title;
                     },
-
-                    // events
-                    activate: function(event, data) {
-                        var node = data.node;
-                        var key  = node.key;
-
-                        window.loadNode(key);
+                    iconMap: {
+                        error: "ti ti-alert-triangle",
+                        noData: "ti ti-help",
+                        expanderExpanded: "ti ti-chevron-down",
+                        expanderCollapsed: "ti ti-chevron-right",
+                        checkChecked: "ti ti-square-check",
+                        checkUnchecked: "ti ti-square",
+                        checkUnknown: "ti ti-square-minus",
+                        folder: "ti ti-folder",
+                        folderOpen: "ti ti-folder-open",
+                        folderLazy: "ti ti-folder-symlink",
+                        doc: "ti ti-file",
                     },
-
+                    init: () => {
+                        if ($initial_cat_id !== -1) {
+                            tree.findKey($initial_cat_id).setActive(true, {
+                                scroll: true,
+                            });
+                        } else if (localStorage.getItem('wunderbaum-state-$js_itemtype')) {
+                            restoreState(tree);
+                        } else {
+                            tree.findKey(-1).setActive(true, {
+                                scroll: true,
+                            });
+                        }
+                    },
+                    activate: (e) => {
+                        window.loadNode(e.node.key);
+                        saveState(e.tree);
+                    },
+                    expand: () => {
+                        saveState(tree);
+                    }
                 });
 
-                var tree = $.ui.fancytree.getTree("#tree_category")
-                if ($initial_cat_id !== -1) {
-                    // URL parameter takes precedence over persisted state
-                    tree.activateKey($initial_cat_id);
-                } else if (tree.activeNode === null) {
-                    tree.activateKey(-1);
-                }
-                $(document).on('keyup', '#browser_tree_search', function() {
-                    var search_text = $(this).val();
-                    $.ui.fancytree.getTree("#tree_category").filterNodes(search_text);
+                document.getElementById('browser_tree_search').addEventListener('keyup', function() {
+                    const searchText = this.value;
+                    tree.filterNodes(searchText, { mode: "hide", autoExpand: true, nodata: '$no_cat_found' });
                 });
             });
 

--- a/src/Glpi/Features/TreeBrowseInterface.php
+++ b/src/Glpi/Features/TreeBrowseInterface.php
@@ -48,7 +48,7 @@ interface TreeBrowseInterface
     public static function showBrowseView(string $itemtype, array $params, $update = false);
 
     /**
-     * Get list of document categories in fancytree format.
+     * Get list of document categories in Wunderbaum (fancytree) format.
      *
      * @param class-string<CommonDBTM> $itemtype
      * @param array $params

--- a/tests/e2e/specs/Knowbase/tree_browse.spec.ts
+++ b/tests/e2e/specs/Knowbase/tree_browse.spec.ts
@@ -58,7 +58,7 @@ test('tree browse selects category from URL parameter', async ({ page, profile, 
     );
 
     // eslint-disable-next-line playwright/no-raw-locators
-    const active_node = page.locator('#tree_category .fancytree-active .fancytree-title');
+    const active_node = page.locator('#tree_category .wb-row.wb-active .wb-title');
     await expect(active_node).toContainText(category_name);
 });
 
@@ -68,6 +68,6 @@ test('tree browse defaults to "Without Category" when no URL parameter', async (
     await page.goto('/front/knowbaseitem.php?browse=1&forcetab=Knowbase$2');
 
     // eslint-disable-next-line playwright/no-raw-locators
-    const active_node = page.locator('#tree_category .fancytree-active .fancytree-title');
+    const active_node = page.locator('#tree_category .wb-row.wb-active .wb-title');
     await expect(active_node).toContainText('Without Category');
 });


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Replace FancyTree with modern rewrite Wunderbaum which has no reliance on jQuery/jQuery UI. Wunderbaum is from the same author and the API remained fairly consistent, at least for our very limited needs. As a bonus, I've also removed the reliance on FontAwesome by specifying an iconMap for the icons we need to use Tabler.

Only thing missing was the persistence functionality, but it was trivial to implement.