### PR TITLE
Entity selector keyboard control

### DIFF
--- a/js/src/vue/EntitySelector/EntitySelector.vue
+++ b/js/src/vue/EntitySelector/EntitySelector.vue
@@ -36,8 +36,8 @@
         tree_data,
         loadTreeData,
         changeFullStructure: doChangeFullStructure,
-        changeEntity: doChangeEntity
-    } = useEntitySelector();
+        changeEntity
+    } = useEntitySelector(useTemplateRef('entity_selector'));
 
     /**
      * Function for enumerating tree data and performing an action on each node.
@@ -208,20 +208,10 @@
             }
         });
     }
-
-    function changeEntity(entity_id, is_recursive) {
-        doChangeEntity(entity_id, is_recursive).then(response => {
-            if (response.ok) {
-                window.location.reload();
-            } else {
-                window.glpi_toast_error(__('An error occurred while changing the entity. Please try again.'));
-            }
-        });
-    }
 </script>
 
 <template>
-    <div>
+    <div ref="entity_selector">
         <a ref="entity_dropdown_toggle" href="#" class="dropdown-item dropdown-toggle entity-dropdown-toggle" data-bs-toggle="dropdown"
            data-bs-auto-close="outside" :title="current_entity" :aria-label="__('Select the desired entity')">
             <i class="fa-fw ti ti-stack"></i>
@@ -247,12 +237,18 @@
             <div v-if="!loading" class="flexbox-item-grow mt-2 position-relative" :style="`height: calc(30px + ${32 * max_items}px)`">
                 <div class="w-100 h-100 overflow-x-auto overflow-y-hidden">
                     <ul class="w-100 list-group rounded-0" @wheel.prevent.stop="onListScroll">
-                        <li v-for="node in visible_in_dom" :key="node.key" :class="`list-group-item p-0 border-0 cursor-pointer`" :style="`${node.selected ? 'background-color: var(--tblr-primary)' : ''}`">
-                            <div :style="{paddingLeft: node.level * indent_size + 'px'}" :data-node-id="node.key" class="text-nowrap d-flex align-items-center pt-1">
+                        <li v-for="node in visible_in_dom" :key="node.key" :class="`list-group-item p-0 border-0 cursor-pointer`"
+                            :style="`${node.selected ? 'background-color: var(--tblr-primary)' : ''}`"
+                            tabindex="0" :data-node-level="node.level" :data-has-children="node.children.length > 0"
+                            :data-key="node.key"
+                            :aria-expanded="node.children.length > 0 ? node.expanded : undefined"
+                            >
+                            <div :style="{paddingLeft: node.level * indent_size + 'px'}" class="text-nowrap d-flex align-items-center pt-1">
                                 <button v-if="node.children.length" :title="node.expanded ? __('Collapse') : __('Expand')"
                                         :aria-label="node.expanded ? __('Collapse') : __('Expand')"
                                         class="btn btn-ghost-secondary btn-sm btn-icon p-1 cursor-pointer collapse-item"
-                                        @click.prevent.stop="onExpandToggleClick(node)">
+                                        @click.prevent.stop="onExpandToggleClick(node)"
+                                        tabindex="-1" aria-hidden="true">
                                     <i :class="node.expanded ? 'ti ti-chevron-down' : 'ti ti-chevron-right'"></i>
                                 </button>
                                 <div v-else style="width: 25px"></div>
@@ -264,7 +260,8 @@
                                 <button v-if="node.children.length" class="btn btn-ghost-secondary btn-sm btn-icon p-1"
                                         :title="__('Select this entity and all its children')"
                                         :aria-label="__('Select this entity and all its children')"
-                                        @click.prevent.stop="changeEntity(node.key, true)" data-bs-toggle="tooltip" data-bs-placement="top">
+                                        @click.prevent.stop="changeEntity(node.key, true)" data-bs-toggle="tooltip" data-bs-placement="top"
+                                        tabindex="-1" aria-hidden="true">
                                     <i class="ti ti-chevrons-down"></i>
                                 </button>
                             </div>

--- a/js/src/vue/EntitySelector/useEntitySelector.js
+++ b/js/src/vue/EntitySelector/useEntitySelector.js
@@ -30,15 +30,85 @@
  * ---------------------------------------------------------------------
  */
 
-import { ref } from 'vue';
+import {nextTick, onMounted, ref} from 'vue';
 
-export function useEntitySelector()
+export function useEntitySelector(container_el)
 {
     const loading = ref(false);
     const tree_data = ref([]);
 
-    function loadTreeData()
-    {
+    onMounted(() => {
+        container_el.value.addEventListener('shown.bs.dropdown', () => {
+            container_el.value.querySelector('input[name="entsearchtext"]').focus();
+        });
+        // Add key listeners for navigating the tree with the keyboard
+        container_el.value.addEventListener('keyup', (event) => {
+            const list_item = event.target.closest('li');
+            if (!list_item) {
+                return;
+            }
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                // Focus the next visible list item
+                let next = list_item.nextElementSibling;
+                while (next && next.offsetParent === null) {
+                    next = next.nextElementSibling;
+                }
+                if (next) {
+                    next.focus();
+                }
+            } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                // Focus the previous visible list item
+                let prev = list_item.previousElementSibling;
+                while (prev && prev.offsetParent === null) {
+                    prev = prev.previousElementSibling;
+                }
+                if (prev) {
+                    prev.focus();
+                }
+            } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                if (list_item.dataset.hasChildren === 'true' && list_item.ariaExpanded === 'false') {
+                    list_item.querySelector('.collapse-item').click();
+                    // Need to wait for DOM changes since child items are not in the DOM until the parent is expanded
+                    nextTick().then(() => {
+                        let next = list_item.nextElementSibling;
+                        while (next && next.offsetParent === null) {
+                            next = next.nextElementSibling;
+                        }
+                        if (next && parseInt(next.dataset.nodeLevel) > parseInt(list_item.dataset.nodeLevel)) {
+                            next.focus();
+                        }
+                    });
+                }
+            } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                if (list_item.dataset.hasChildren === 'true' && list_item.ariaExpanded === 'true') {
+                    list_item.querySelector('.collapse-item').click();
+                } else {
+                    // Focus the parent list item
+                    const level = parseInt(list_item.dataset.nodeLevel);
+                    if (level > 0) {
+                        let prev = list_item.previousElementSibling;
+                        while (prev && (prev.offsetParent === null || parseInt(prev.dataset.nodeLevel) >= level)) {
+                            prev = prev.previousElementSibling;
+                        }
+                        if (prev) {
+                            prev.focus();
+                        }
+                    }
+                }
+            } else if (event.key === 'Enter') {
+                const select_children = event.metaKey || event.ctrlKey; // Allow selecting an entity and all its children by holding Ctrl or Cmd
+                event.preventDefault();
+                event.stopPropagation();
+                changeEntity(list_item.dataset.key, select_children);
+            }
+        });
+    });
+
+    function loadTreeData() {
         loading.value = true;
         return fetch(`${window.CFG_GLPI.root_doc}/ajax/entitytreesons.php`, {
             method: 'GET',
@@ -73,8 +143,7 @@ export function useEntitySelector()
     /**
      * Change entity to "Full structure" which means access to all of the user's entities.
      */
-    function changeFullStructure()
-    {
+    function changeFullStructure() {
         return fetch(`${window.CFG_GLPI.root_doc}/Session/ChangeEntity`, {
             method: 'POST',
             headers: {
@@ -87,8 +156,7 @@ export function useEntitySelector()
         });
     }
 
-    function changeEntity(entity_id, is_recursive)
-    {
+    function changeEntity(entity_id, is_recursive) {
         return fetch(`${window.CFG_GLPI.root_doc}/Session/ChangeEntity`, {
             method: 'POST',
             headers: {
@@ -99,6 +167,12 @@ export function useEntitySelector()
                 id: entity_id,
                 is_recursive: is_recursive,
             }),
+        }).then(response => {
+            if (response.ok) {
+                window.location.reload();
+            } else {
+                window.glpi_toast_error(__('An error occurred while changing the entity. Please try again.'));
+            }
         });
     }
 

--- a/js/src/vue/EntitySelector/useEntitySelector.js
+++ b/js/src/vue/EntitySelector/useEntitySelector.js
@@ -50,20 +50,14 @@ export function useEntitySelector(container_el)
             if (event.key === 'ArrowDown') {
                 event.preventDefault();
                 // Focus the next visible list item
-                let next = list_item.nextElementSibling;
-                while (next && next.offsetParent === null) {
-                    next = next.nextElementSibling;
-                }
+                const next = list_item.nextElementSibling;
                 if (next) {
                     next.focus();
                 }
             } else if (event.key === 'ArrowUp') {
                 event.preventDefault();
                 // Focus the previous visible list item
-                let prev = list_item.previousElementSibling;
-                while (prev && prev.offsetParent === null) {
-                    prev = prev.previousElementSibling;
-                }
+                const prev = list_item.previousElementSibling;
                 if (prev) {
                     prev.focus();
                 }
@@ -73,10 +67,7 @@ export function useEntitySelector(container_el)
                     list_item.querySelector('.collapse-item').click();
                     // Need to wait for DOM changes since child items are not in the DOM until the parent is expanded
                     nextTick().then(() => {
-                        let next = list_item.nextElementSibling;
-                        while (next && next.offsetParent === null) {
-                            next = next.nextElementSibling;
-                        }
+                        const next = list_item.nextElementSibling;
                         if (next && parseInt(next.dataset.nodeLevel) > parseInt(list_item.dataset.nodeLevel)) {
                             next.focus();
                         }
@@ -91,7 +82,7 @@ export function useEntitySelector(container_el)
                     const level = parseInt(list_item.dataset.nodeLevel);
                     if (level > 0) {
                         let prev = list_item.previousElementSibling;
-                        while (prev && (prev.offsetParent === null || parseInt(prev.dataset.nodeLevel) >= level)) {
+                        while (prev && parseInt(prev.dataset.nodeLevel) >= level) {
                             prev = prev.previousElementSibling;
                         }
                         if (prev) {

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -204,7 +204,10 @@ export class GlpiPage
         entity_name: string
     ): Promise<void> {
         // eslint-disable-next-line playwright/no-raw-locators
-        await this.getButton(entity_name).locator('//ancestor::li').getByRole('button', { name: 'Select this entity and all its children' }).click();
+        await this.getButton(entity_name).locator('//ancestor::li').getByRole('button', {
+            name: 'Select this entity and all its children',
+            includeHidden: true, // Button is hidden in the accessibility tree because it is replaced by keyboard controls.
+        }).click();
     }
 
     public async doSwitchToEntityWithoutRecursion(

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -153,27 +153,3 @@ test('Can switch to another entity without sub entities', async ({ page, profile
         'Root entity'
     );
 });
-
-test('Keyboard navigation in entity selector', async ({ page, profile }) => {
-    await page.goto('/front/preference.php');
-    await profile.set(Profiles.SuperAdmin);
-    const glpi_page = new GlpiPage(page);
-
-    await glpi_page.doOpenEntitySelector();
-    const entity_04 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 04' });
-    const entity_05 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 05' });
-
-    await page.getByRole('listitem').filter({ hasText: 'E2E worker entity 04' }).first().focus();
-
-    await page.keyboard.press('ArrowDown');
-    await expect(entity_05).toBeFocused();
-
-    await page.keyboard.press('ArrowUp');
-    await expect(entity_04).toBeFocused();
-
-    await page.keyboard.press('Enter');
-
-    await expect(glpi_page.active_entity).toHaveText(
-        'E2E worker entity 04'
-    );
-});

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -160,8 +160,8 @@ test('Keyboard navigation in entity selector', async ({ page, profile }) => {
     const glpi_page = new GlpiPage(page);
 
     await glpi_page.doOpenEntitySelector();
-    const entity_04 = glpi_page.getEntityFromTree("E2E worker entity 04");
-    const entity_05 = glpi_page.getEntityFromTree("E2E worker entity 05");
+    const entity_04 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 04' });
+    const entity_05 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 05' });
 
     await page.getByRole('listitem').filter({ hasText: 'Root entity' }).first().focus();
 

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -153,3 +153,27 @@ test('Can switch to another entity without sub entities', async ({ page, profile
         'Root entity'
     );
 });
+
+test('Keyboard navigation in entity selector', async ({ page, profile }) => {
+    await page.goto('/front/preference.php');
+    await profile.set(Profiles.SuperAdmin);
+    const glpi_page = new GlpiPage(page);
+
+    await glpi_page.doOpenEntitySelector();
+    const entity_04 = glpi_page.getEntityFromTree("E2E worker entity 04");
+    const entity_05 = glpi_page.getEntityFromTree("E2E worker entity 05");
+
+    await page.getByRole('listitem').filter({ hasText: 'Root entity' }).first().focus();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(entity_04).toBeFocused();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(entity_05).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    await expect(glpi_page.active_entity).toHaveText(
+        'E2E worker entity 05'
+    );
+});

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -163,17 +163,17 @@ test('Keyboard navigation in entity selector', async ({ page, profile }) => {
     const entity_04 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 04' });
     const entity_05 = page.getByRole('listitem').filter({ hasText: 'E2E worker entity 05' });
 
-    await page.getByRole('listitem').filter({ hasText: 'Root entity' }).first().focus();
-
-    await page.keyboard.press('ArrowDown');
-    await expect(entity_04).toBeFocused();
+    await page.getByRole('listitem').filter({ hasText: 'E2E worker entity 04' }).first().focus();
 
     await page.keyboard.press('ArrowDown');
     await expect(entity_05).toBeFocused();
 
+    await page.keyboard.press('ArrowUp');
+    await expect(entity_04).toBeFocused();
+
     await page.keyboard.press('Enter');
 
     await expect(glpi_page.active_entity).toHaveText(
-        'E2E worker entity 05'
+        'E2E worker entity 04'
     );
 });

--- a/tests/js/vue/EntitySelector/EntitySelector.spec.js
+++ b/tests/js/vue/EntitySelector/EntitySelector.spec.js
@@ -1,0 +1,251 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import '/build/vue/app.js';
+import EntitySelector from '/js/src/vue/EntitySelector/EntitySelector.vue';
+import '/lib/fuzzy.js';
+import {enableAutoUnmount, flushPromises, mount} from "@vue/test-utils";
+
+enableAutoUnmount(afterEach);
+
+describe('EntitySelector Vue Component', () => {
+    beforeEach(() => {
+       window.hotkeys.unbind();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.resetAllMocks();
+    });
+
+    test('component in global components list', async () => {
+        expect(window.Vue.components['EntitySelector/EntitySelector']).toBeDefined();
+        expect(window.Vue.components['EntitySelector/EntitySelector'].component).toHaveProperty('name', 'AsyncComponentWrapper');
+    });
+
+    const mockEntityTreeData = [
+        {
+            "key": 0,
+            "label": "Root entity",
+            "children": [
+                {
+                    "key": 101117,
+                    "label": "HQ",
+                    "children": []
+                },
+                {
+                    "key": 101118,
+                    "label": "Remote Office A",
+                    "children": [
+                        {
+                            "key": 101120,
+                            "label": "HR",
+                            "children": []
+                        },
+                        {
+                            "key": 101119,
+                            "label": "IT",
+                            "children": []
+                        },
+                        {
+                            "key": 101121,
+                            "label": "Maintenance",
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "key": 101122,
+                    "label": "Remote Office B",
+                    "children": [
+                        {
+                            "key": 101124,
+                            "label": "HR",
+                            "children": []
+                        },
+                        {
+                            "key": 101123,
+                            "label": "IT",
+                            "children": []
+                        }
+                    ]
+                }
+            ],
+            "expanded": true,
+            "selected": true
+        }
+    ];
+
+    async function mountEntitySelector() {
+        const wrapper = mount(EntitySelector, {
+            attachTo: document.body,//'#entity-tree-dropdown',
+            props: {
+                current_entity: 'Root entity',
+                current_entity_short: 'Root',
+            },
+            global: {
+                mocks: {
+                    __: (msg) => msg,
+                }
+            }
+        });
+        await flushPromises();
+        return wrapper;
+    }
+
+    test('mounts', async () => {
+        const wrapper = await mountEntitySelector();
+
+        expect(wrapper.find('a').attributes()).toHaveProperty('title', 'Root entity');
+        expect(wrapper.find('a').text()).toBe('Root');
+        expect(wrapper.find('input[name="entsearchtext"]').exists()).toBe(true);
+    });
+
+    test('hotkeys', async () => {
+        const wrapper = await mountEntitySelector();
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => mockEntityTreeData,
+        });
+
+        const event = new KeyboardEvent('keydown', {ctrlKey: true, altKey: true, key: 'e'});
+        document.dispatchEvent(event);
+        await flushPromises();
+        vi.advanceTimersByTime(1500);
+        await flushPromises();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        wrapper.unmount();
+
+        await mountEntitySelector();
+        const macEvent = new KeyboardEvent('keydown', {metaKey: true, altKey: true, key: 'e'});
+        document.dispatchEvent(macEvent);
+        await flushPromises();
+        vi.advanceTimersByTime(1500);
+        await flushPromises();
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('keyboard navigation', async () => {
+        const wrapper = await mountEntitySelector();
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+            ok: true,
+            json: async () => mockEntityTreeData,
+        });
+
+        const event = new KeyboardEvent('keydown', {ctrlKey: true, altKey: true, key: 'e'});
+        document.dispatchEvent(event);
+        await flushPromises();
+        vi.advanceTimersByTime(1500);
+        await flushPromises();
+
+        // JSDOM does not support tabbing so we will manually focus the first list item before starting keyboard navigation tests
+        const firstListItem = wrapper.find('li');
+        firstListItem.element.focus();
+        // Should be the Root entity
+        expect(document.activeElement).toBe(firstListItem.element);
+        expect(firstListItem.text()).toBe('Root entity');
+
+        // Press ArrowDown to navigate to the next item
+        firstListItem.element.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowDown', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('HQ');
+
+        // Press ArrowDown again to navigate to the next item
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowDown', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('Remote Office A');
+
+        // ArrowRight should expand Remote Office A and focus on the first child (HR)
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowRight', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('HR');
+
+        // ArrowDown should navigate to the next sibling (IT)
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowDown', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('IT');
+
+        // ArrowLeft should focus Remote Office A without collapsing it
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowLeft', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('Remote Office A');
+        // Check "HR" is still visible to ensure it did not collapse
+        expect(wrapper.find('li[data-key="101120"]').exists()).toBe(true);
+
+        // ArrowLeft again should collapse Remote Office A and keep it focused
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowLeft', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('Remote Office A');
+        // Check "HR" is not visible to ensure it collapsed
+        expect(wrapper.find('li[data-key="101120"]').exists()).toBe(false);
+
+        // Arrow up should navigate back to HQ
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'ArrowUp', bubbles: true}));
+        await flushPromises();
+        expect(document.activeElement.textContent.trim()).toBe('HQ');
+
+        // Enter key should trigger the change to HQ entity without selecting children
+        fetchMock.mockClear();
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({}),
+        });
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'Enter', bubbles: true}));
+        await flushPromises();
+        let request_body = new URLSearchParams(fetchMock.mock.calls[0][1].body);
+        expect(request_body.get('id')).toBe('101117');
+        expect(request_body.get('is_recursive')).toBe('false');
+        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/Session/ChangeEntity'), expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-Requested-With': 'XMLHttpRequest',
+            })
+        }));
+
+        // Ctrl+Enter should trigger the change to HQ entity with selecting children
+        fetchMock.mockClear();
+        document.activeElement.dispatchEvent(new KeyboardEvent('keyup', {key: 'Enter', ctrlKey: true, bubbles: true}));
+        await flushPromises();
+        request_body = new URLSearchParams(fetchMock.mock.calls[0][1].body);
+        expect(request_body.get('id')).toBe('101117');
+        expect(request_body.get('is_recursive')).toBe('true');
+        expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/Session/ChangeEntity'), expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-Requested-With': 'XMLHttpRequest',
+            })
+        }));
+    });
+});


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes https://github.com/glpi-project/roadmap/issues/308

Entity Selector now auto-focuses the search input when shown.
Keyboard controls (mostly standard):
- Up/Down - Move to previous/next visible node (including children)
- Left - If a leaf node, moves to the parent. If a parent node, collapses the node and moves to the next parent.
- Right - If a parent node, expands the node.
- Enter - Selects the current entity
- Enter + Ctrl/Command - Selects the current entity and its children