### PR TITLE
Trigger validation_answer notifications only when answered

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -539,10 +539,12 @@ abstract class CommonITILValidation extends CommonDBChild
 
         // -- notifications
         if (
-            count($this->updates)
+            in_array('status', $this->updates)
+            && (int) $this->fields["status"] !== self::WAITING
             && $donotif
         ) {
-            $options  = ['validation_id'     => $this->fields["id"],
+            $options  = [
+                'validation_id'     => $this->fields["id"],
                 'validation_status' => $this->fields["status"],
             ];
             NotificationEvent::raiseEvent('validation_answer', $this->getItem(), $options, $this);

--- a/tests/functional/TicketValidationTest.php
+++ b/tests/functional/TicketValidationTest.php
@@ -34,6 +34,45 @@
 
 namespace tests\units;
 
+use CommonITILValidation;
 use Glpi\Tests\CommonITILValidationTest;
+use QueuedNotification;
 
-class TicketValidationTest extends CommonITILValidationTest {}
+class TicketValidationTest extends CommonITILValidationTest
+{
+    public function testValidationAnswerNotification(): void
+    {
+        global $CFG_GLPI;
+
+        $this->login();
+        $itil = $this->createItem($this->getITILClassname(), [
+            'name' => 'Test Notification Recipients',
+            'content' => 'Test Notification Recipients',
+        ]);
+        $validation = $this->createItem($this->getValidationClassname(), [
+            $itil::getForeignKeyField() => $itil->getID(),
+            'itemtype_target' => 'User',
+            'items_id_target' => $_SESSION['glpiID'],
+        ]);
+        $queued_notification = new QueuedNotification();
+
+        $CFG_GLPI["use_notifications"] = true;
+        $CFG_GLPI['notifications_mailing'] = true;
+
+        $this->assertEquals(0, countElementsInTable($queued_notification::getTable(), ['event' => 'validation_answer']));
+
+        // Updating the submission comment should not trigger the validation_answer notification
+        $validation->update([
+            'id' => $validation->getID(),
+            'comment_submission' => 'This is a comment.',
+        ]);
+        $this->assertEquals(0, countElementsInTable($queued_notification::getTable(), ['event' => 'validation_answer']));
+
+        $validation->update([
+            'id' => $validation->getID(),
+            'status' => CommonITILValidation::ACCEPTED,
+        ]);
+        // Administrator + Approver
+        $this->assertEquals(2, countElementsInTable($queued_notification::getTable(), ['event' => 'validation_answer']));
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

fixes #24498 
`validation_answer` notifications were triggered for any update on an approval rather than just when it received an answer.