### PR TITLE
A11Y : add autocomplete hints

### DIFF
--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -57,7 +57,7 @@ class UserEmail extends CommonDBChild
 
     /**
      * Whether the e-mail inputs are rendered on the current user's own profile.
-     * When true, the editable input exposes an `autocomplete="email"` hint (RGAA 11.13).
+     * When true, editable inputs expose an `autocomplete="email"` hint (RGAA 11.13).
      */
     private static bool $render_for_current_user = false;
 
@@ -195,10 +195,12 @@ class UserEmail extends CommonDBChild
         // only appended (no client-side removal); revisit if a remove control is added.
         $position_expr = "'+(document.querySelectorAll('[name^=" . $field_name . "]').length + 1)+'";
 
+        $autocomplete = self::$render_for_current_user ? " autocomplete='email'" : "";
+
         $html = "<div class='d-flex' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>"
             . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . htmlescape(sprintf(__('Set %s email as default'), '__LABEL_POS__')) . "'>"
             . "&nbsp;"
-            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . htmlescape(sprintf(__('Email address %s'), '__LABEL_POS__')) . "'>"
+            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'$autocomplete aria-label='" . htmlescape(sprintf(__('Email address %s'), '__LABEL_POS__')) . "'>"
             . "</div>";
 
         // The label placeholders are replaced after jsescape() so the counting expression
@@ -323,7 +325,14 @@ class UserEmail extends CommonDBChild
             }
         }
 
-        parent::showAddChildButtonForItemForm($user, '_useremails', $canedit);
+        // Scoped to this render (reset below) so no later caller inherits a stale state.
+        self::$render_for_current_user = $users_id == Session::getLoginUserID();
+
+        try {
+            parent::showAddChildButtonForItemForm($user, '_useremails', $canedit);
+        } finally {
+            self::$render_for_current_user = false;
+        }
     }
 
 

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -55,6 +55,12 @@ class UserEmail extends CommonDBChild
      */
     private static int $display_index = 0;
 
+    /**
+     * Whether the e-mail inputs are rendered on the current user's own profile.
+     * When true, the editable input exposes an `autocomplete="email"` hint (RGAA 11.13).
+     */
+    private static bool $render_for_current_user = false;
+
 
     public static function getTypeName($nb = 0)
     {
@@ -239,7 +245,8 @@ class UserEmail extends CommonDBChild
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));
         } else {
-            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . htmlescape(sprintf(__('Email address %s'), $position)) . "'>";
+            $autocomplete = self::$render_for_current_user ? " autocomplete='email'" : "";
+            $result .= "<input type='text' class='form-control' name='$field_name' value='$value'$autocomplete aria-label='" . htmlescape(sprintf(__('Email address %s'), $position)) . "'>";
         }
         $result .= "</div>";
 
@@ -281,7 +288,15 @@ class UserEmail extends CommonDBChild
         }
 
         self::$display_index = 0; // restart the per-render numbering used for aria-labels
-        parent::showChildsForItemForm($user, '_useremails', $canedit);
+
+        // Scoped to this render (reset below) so no later caller inherits a stale state.
+        self::$render_for_current_user = $users_id == Session::getLoginUserID();
+
+        try {
+            parent::showChildsForItemForm($user, '_useremails', $canedit);
+        } finally {
+            self::$render_for_current_user = false;
+        }
     }
 
 

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -101,6 +101,7 @@
                             }) }}
                             {{ fields.textField('middlename', item.fields['middlename'], __('Middle name / Patronymic'), {
                                 readonly: external_auth,
+                                additional_attributes: is_preference_form ? {autocomplete: 'additional-name'} : {},
                             }) }}
 
                             {% if use_timezones %}
@@ -263,7 +264,7 @@
                                 additional_attributes: is_preference_form ? {autocomplete: 'tel'} : {},
                             }) }}
                             {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone'), {
-                                additional_attributes: is_preference_form ? {autocomplete: 'tel'} : {},
+                                additional_attributes: is_preference_form ? {autocomplete: 'mobile tel'} : {},
                             }) }}
                             {% if not simple_form %}
                                 {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2'), {

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -93,9 +93,11 @@
 
                             {{ fields.textField('realname', item.fields['realname'], __('Surname'), {
                                 readonly: external_auth,
+                                additional_attributes: is_preference_form ? {autocomplete: 'family-name'} : {},
                             }) }}
                             {{ fields.textField('firstname', item.fields['firstname'], __('First name'), {
                                 readonly: external_auth,
+                                additional_attributes: is_preference_form ? {autocomplete: 'given-name'} : {},
                             }) }}
                             {{ fields.textField('middlename', item.fields['middlename'], __('Middle name / Patronymic'), {
                                 readonly: external_auth,
@@ -257,10 +259,16 @@
                                 {{ call('UserEmail::showAddEmailButton', [item]) }}
                             {% endset %}
                             {{ fields.htmlField('_useremails', emails_field, _n('Email', 'Emails', get_plural_number())) }}
-                            {{ fields.textField('phone', item.fields['phone'], 'Phone'|itemtype_name(1)) }}
-                            {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone')) }}
+                            {{ fields.textField('phone', item.fields['phone'], 'Phone'|itemtype_name(1), {
+                                additional_attributes: is_preference_form ? {autocomplete: 'tel'} : {},
+                            }) }}
+                            {{ fields.textField('mobile', item.fields['mobile'], __('Mobile phone'), {
+                                additional_attributes: is_preference_form ? {autocomplete: 'tel'} : {},
+                            }) }}
                             {% if not simple_form %}
-                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2')) }}
+                                {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2'), {
+                                    additional_attributes: is_preference_form ? {autocomplete: 'tel'} : {},
+                                }) }}
                             {% endif %}
                             </div>
 

--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -33,7 +33,7 @@
 {% extends 'layout/page_card_notlogged.html.twig' %}
 
 {% block content_block %}
-    <form action="{{ path('front/login.php') }}" method="post" autocomplete="off" data-submit-once>
+    <form action="{{ path('front/login.php') }}" method="post" data-submit-once>
         <input type="hidden" name="noAUTO" value="{{ noAuto }}"/>
         <input type="hidden" name="redirect" value="{{ redirect }}"/>
         {% if text_login|length > 0 %}
@@ -48,7 +48,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="login_name">{{ __('Login') }}</label>
-                    <input type="text" class="form-control" id="login_name" name="login_name" placeholder=""/>
+                    <input type="text" class="form-control" id="login_name" name="login_name" placeholder="" autocomplete="username"/>
                 </div>
                 <div class="mb-4">
                     <div class="d-flex">
@@ -56,7 +56,7 @@
                             {{ __('Password') }}
                         </label>
                     </div>
-                    <input type="password" class="form-control" id="login_password" name="login_password" placeholder="" autocomplete="off"/>
+                    <input type="password" class="form-control" id="login_password" name="login_password" placeholder="" autocomplete="current-password"/>
                 </div>
 
                 {% if config('display_login_source') %}

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -42,7 +42,7 @@
 {% elseif messages_only is defined %}
     {{ include('components/messages_after_redirect_alerts.html.twig') }}
 {% else %}
-    <form action="{{ target }}" method="post" autocomplete="off" data-submit-once>
+    <form action="{{ target }}" method="post" data-submit-once>
         <h2 class="card-title text-center mb-4">{{ title }}</h2>
 
         {% if type == 'update' %}
@@ -107,6 +107,9 @@
                 {{ fields.emailField('email', '', _n('Email', 'Emails', 1), {
                     full_width: true,
                     required: true,
+                    additional_attributes: {
+                        autocomplete: 'email',
+                    },
                 }) }}
             </div>
             {% set save_button = '<i class="ti ti-mail" aria-hidden="true"></i><span>' ~ __('Send') ~ '<span>' %}

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -51,7 +51,7 @@
                 readonly: true,
                 full_width: true,
                 additional_attributes: {
-                    autocomplete: 'off',
+                    autocomplete: 'username',
                 }
             }) }}
             {{ fields.passwordField('current_password', '', __('Current password'), {

--- a/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
+++ b/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
@@ -32,8 +32,13 @@
 
 import { test, expect } from '../../fixtures/glpi_fixture';
 import { LoginPage } from '../../pages/LoginPage';
+import { UserPage } from '../../pages/UserPage';
 import { Profiles } from '../../utils/Profiles';
 import AxeBuilder from '@axe-core/playwright';
+
+// Main tab of the preference page, and of the admin user form.
+const PREFERENCE_TAB = 'User$1';
+const USER_FORM_TAB = 'User$main';
 
 // Login page, logged-out.
 test('login fields expose autocomplete tokens', async ({ anonymousPage }) => {
@@ -52,12 +57,13 @@ test('login fields expose autocomplete tokens', async ({ anonymousPage }) => {
 });
 
 // Lost-password "forget" email also carries autocomplete="email", but its form only renders
-// with password-recovery notifications enabled (off in e2e) — verified manually instead.
+// with password-recovery notifications enabled (off in e2e), so it is verified manually.
 
 // Preference page: tokens emitted only in the preference context.
 test('profile identity fields expose autocomplete tokens when editing own profile', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
-    await page.goto('/front/preference.php');
+    const user_page = new UserPage(page);
+    await user_page.gotoPreferences(PREFERENCE_TAB);
 
     await expect(page.getByLabel('Surname', { exact: true })).toHaveAttribute('autocomplete', 'family-name');
     await expect(page.getByLabel('First name', { exact: true })).toHaveAttribute('autocomplete', 'given-name');
@@ -69,24 +75,35 @@ test('profile identity fields expose autocomplete tokens when editing own profil
 // Guard: the admin user form (outside the preference context) must NOT emit personal tokens.
 test('admin user form does not expose personal autocomplete tokens (guard)', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
-    await page.goto('/front/user.form.php');
+    await page.goto(`/front/user.form.php?forcetab=${USER_FORM_TAB}`);
 
     await expect(page.getByLabel('Surname', { exact: true })).not.toHaveAttribute('autocomplete', 'family-name');
 });
 
-// User's own e-mail input on the profile page.
-test('profile email input exposes autocomplete=email when editing own profile', async ({ page, profile }) => {
+// User's own e-mail inputs on the profile page, server-rendered and client-added alike.
+test('profile email inputs expose autocomplete=email when editing own profile', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
-    await page.goto('/front/preference.php');
+    const user_page = new UserPage(page);
+    await user_page.gotoPreferences(PREFERENCE_TAB);
 
-    await expect(page.getByLabel('Email address').first())
-        .toHaveAttribute('autocomplete', 'email');
+    const emails = user_page.getEmailFields();
+    await expect(emails.first()).toHaveAttribute('autocomplete', 'email');
+
+    // The "+" button builds its row from JS, which is a distinct render path.
+    const initial_count = await emails.count();
+    await user_page.doAddNewEmailField();
+    await expect(emails).toHaveCount(initial_count + 1);
+    await expect(emails.last()).toHaveAttribute('autocomplete', 'email');
 });
 
 // Regression: no invalid autocomplete tokens anywhere on the profile form.
 test('profile form has no invalid autocomplete tokens', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
-    await page.goto('/front/preference.php');
+    const user_page = new UserPage(page);
+    await user_page.gotoPreferences(PREFERENCE_TAB);
+
+    // The tab loads over AJAX; without this axe would scan an empty page.
+    await expect(page.getByLabel('Surname', { exact: true })).toBeVisible();
 
     const a11y = await new AxeBuilder({ page })
         .include('form')

--- a/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
+++ b/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
@@ -67,17 +67,23 @@ test('profile identity fields expose autocomplete tokens when editing own profil
 
     await expect(page.getByLabel('Surname', { exact: true })).toHaveAttribute('autocomplete', 'family-name');
     await expect(page.getByLabel('First name', { exact: true })).toHaveAttribute('autocomplete', 'given-name');
+    await expect(page.getByLabel('Middle name / Patronymic', { exact: true })).toHaveAttribute('autocomplete', 'additional-name');
     await expect(page.getByLabel('Phone', { exact: true })).toHaveAttribute('autocomplete', 'tel');
-    await expect(page.getByLabel('Mobile phone', { exact: true })).toHaveAttribute('autocomplete', 'tel');
+    // Qualified so autofill does not treat it as the same field as `phone`.
+    await expect(page.getByLabel('Mobile phone', { exact: true })).toHaveAttribute('autocomplete', 'mobile tel');
     await expect(page.getByLabel('Phone 2', { exact: true })).toHaveAttribute('autocomplete', 'tel');
 });
 
 // Guard: the admin user form (outside the preference context) must NOT emit personal tokens.
 test('admin user form does not expose personal autocomplete tokens (guard)', async ({ page, profile }) => {
     await profile.set(Profiles.SuperAdmin);
+    const user_page = new UserPage(page);
     await page.goto(`/front/user.form.php?forcetab=${USER_FORM_TAB}`);
 
     await expect(page.getByLabel('Surname', { exact: true })).not.toHaveAttribute('autocomplete', 'family-name');
+
+    // Email rows are built in PHP, so they carry their own guard.
+    await expect(user_page.getEmailFields().first()).not.toHaveAttribute('autocomplete');
 });
 
 // User's own e-mail inputs on the profile page, server-rendered and client-added alike.

--- a/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
+++ b/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
@@ -34,6 +34,7 @@ import { test, expect } from '../../fixtures/glpi_fixture';
 import { LoginPage } from '../../pages/LoginPage';
 import { UserPage } from '../../pages/UserPage';
 import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
 import AxeBuilder from '@axe-core/playwright';
 
 // Main tab of the preference page, and of the admin user form.
@@ -74,16 +75,49 @@ test('profile identity fields expose autocomplete tokens when editing own profil
     await expect(page.getByLabel('Phone 2', { exact: true })).toHaveAttribute('autocomplete', 'tel');
 });
 
-// Guard: the admin user form (outside the preference context) must NOT emit personal tokens.
-test('admin user form does not expose personal autocomplete tokens (guard)', async ({ page, profile }) => {
+// Guard: an admin editing someone else's profile must not be offered their own data.
+test('admin user form does not expose personal autocomplete tokens (guard)', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
+
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const user_id = await api.createItem('User', {
+        name: `autocomplete_guard_${suffix}`,
+    });
+    // A lower profile keeps the user visible and its e-mail rows editable.
+    await api.createItem('Profile_User', {
+        users_id: user_id,
+        profiles_id: Profiles.SelfService,
+        entities_id: getWorkerEntityId(),
+        is_recursive: 1,
+    });
+    await api.createItem('UserEmail', {
+        users_id: user_id,
+        email: `autocomplete_guard_${suffix}@example.com`,
+    });
+
     const user_page = new UserPage(page);
-    await page.goto(`/front/user.form.php?forcetab=${USER_FORM_TAB}`);
+    await user_page.gotoUserForm(user_id, USER_FORM_TAB);
 
-    await expect(page.getByLabel('Surname', { exact: true })).not.toHaveAttribute('autocomplete', 'family-name');
+    const labels = [
+        'Surname',
+        'First name',
+        'Middle name / Patronymic',
+        'Phone',
+        'Mobile phone',
+        'Phone 2',
+    ];
+    for (const label of labels) {
+        await expect(page.getByLabel(label, { exact: true })).not.toHaveAttribute('autocomplete');
+    }
 
-    // Email rows are built in PHP, so they carry their own guard.
-    await expect(user_page.getEmailFields().first()).not.toHaveAttribute('autocomplete');
+    const emails = user_page.getEmailFields();
+    await expect(emails.first()).not.toHaveAttribute('autocomplete');
+
+    // Email rows are built in PHP, so the JS-added row carries its own guard.
+    const initial_count = await emails.count();
+    await user_page.doAddNewEmailField();
+    await expect(emails).toHaveCount(initial_count + 1);
+    await expect(emails.last()).not.toHaveAttribute('autocomplete');
 });
 
 // User's own e-mail inputs on the profile page, server-rendered and client-added alike.

--- a/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
+++ b/tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { test, expect } from '../../fixtures/glpi_fixture';
+import { LoginPage } from '../../pages/LoginPage';
+import { Profiles } from '../../utils/Profiles';
+import AxeBuilder from '@axe-core/playwright';
+
+// Login page, logged-out.
+test('login fields expose autocomplete tokens', async ({ anonymousPage }) => {
+    const login = new LoginPage(anonymousPage);
+    await login.goto();
+
+    await expect(login.login_input).toHaveAttribute('autocomplete', 'username');
+    await expect(login.password_input).toHaveAttribute('autocomplete', 'current-password');
+
+    const a11y = await new AxeBuilder({ page: anonymousPage })
+        .include('form')
+        .withTags(['wcag135'])
+        .analyze()
+    ;
+    expect(a11y.violations).toEqual([]);
+});
+
+// Lost-password "forget" email also carries autocomplete="email", but its form only renders
+// with password-recovery notifications enabled (off in e2e) — verified manually instead.
+
+// Preference page: tokens emitted only in the preference context.
+test('profile identity fields expose autocomplete tokens when editing own profile', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await page.goto('/front/preference.php');
+
+    await expect(page.getByLabel('Surname', { exact: true })).toHaveAttribute('autocomplete', 'family-name');
+    await expect(page.getByLabel('First name', { exact: true })).toHaveAttribute('autocomplete', 'given-name');
+    await expect(page.getByLabel('Phone', { exact: true })).toHaveAttribute('autocomplete', 'tel');
+    await expect(page.getByLabel('Mobile phone', { exact: true })).toHaveAttribute('autocomplete', 'tel');
+    await expect(page.getByLabel('Phone 2', { exact: true })).toHaveAttribute('autocomplete', 'tel');
+});
+
+// Guard: the admin user form (outside the preference context) must NOT emit personal tokens.
+test('admin user form does not expose personal autocomplete tokens (guard)', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await page.goto('/front/user.form.php');
+
+    await expect(page.getByLabel('Surname', { exact: true })).not.toHaveAttribute('autocomplete', 'family-name');
+});
+
+// User's own e-mail input on the profile page.
+test('profile email input exposes autocomplete=email when editing own profile', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await page.goto('/front/preference.php');
+
+    await expect(page.getByLabel('Email address').first())
+        .toHaveAttribute('autocomplete', 'email');
+});
+
+// Regression: no invalid autocomplete tokens anywhere on the profile form.
+test('profile form has no invalid autocomplete tokens', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+    await page.goto('/front/preference.php');
+
+    const a11y = await new AxeBuilder({ page })
+        .include('form')
+        .withTags(['wcag135'])
+        .analyze()
+    ;
+    expect(a11y.violations).toEqual([]);
+});


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/306
- Here is a brief description of what this PR does : 

- Login: username + current-password (removed the form-level `autocomplete="off"`, which was cancelling field tokens in some browsers).
- Lost password: email.
- Profile (`user.html.twig`): family-name, given-name, tel, emitted only in the personal-profile context (`is_preference_form`), so the admin user form is left untouched.
- Profile emails (`UserEmail`): email, restricted to the current user's own profile.

**Tests:** 
introduces Playwright's a11y tooling ([@axe-core/playwright](https://playwright.dev/docs/accessibility-testing)) via a new spec `tests/e2e/specs/Accessibility/autocomplete_hints.spec.ts`, combining explicit token presence/value assertions with an axe wcag135 scan (validity), plus a guard test (no tokens leak onto the admin form).

_Out of scope: profile Login field (read-only), Select2 comboboxes (frozen by #310), the JS add-email template (static, no user context). The lost-password field is verified manually (form is gated behind enabled notifications)._


