### PR TITLE
Fix(REcurrentItem): Fix recurring item duplication when creation time equals session start time

### DIFF
--- a/phpunit/abstracts/CommonITILRecurrentTest.php
+++ b/phpunit/abstracts/CommonITILRecurrentTest.php
@@ -401,6 +401,22 @@ abstract class CommonITILRecurrentTest extends DbTestCase
             'expected_value' => date('Y-m-d H:i:s', $next_time),
         ];
 
+        // Regression: creation_time equal to session time must advance to the next period.
+        // When begin_date - create_before lands exactly on the current time, the old strict-<
+        // loop condition would exit without advancing, storing a next_creation_date identical
+        // to the frozen PHP session time. MySQL NOW() being slightly ahead would then select
+        // the item again the next day, producing a J+1 duplicate.
+        $data[] = [
+            'begin_date'     => '2026-06-11 13:37:00', // begin_date - 7 days = 2026-06-04 13:37:00
+            'end_date'       => '2028-01-01 00:00:00',
+            'periodicity'    => '1YEAR',
+            'create_before'  => DAY_TIMESTAMP * 7,
+            'calendars_id'   => 0,
+            'expected_value' => '2027-06-04 13:37:00', // must advance past current_date, never return it
+            'messages'       => null,
+            'current_date'   => '2026-06-04 13:37:00',
+        ];
+
         // Special case: calendar where monday to friday are full working days
         $calendar_id = $calendar->add(['name' => $this->getChildClass() . ' testing calendar 2']);
         $this->assertGreaterThan(0, $calendar_id);
@@ -530,6 +546,28 @@ abstract class CommonITILRecurrentTest extends DbTestCase
                 $this->hasSessionMessages(ERROR, $messages);
             }
         }
+    }
+
+    public function testNextCreationDateNeverEqualsCurrentTime(): void
+    {
+        // When begin_date - create_before lands exactly on the current session time,
+        // next_creation_date must advance to the next period, not return the current time.
+        // Returning the current time causes a J+1 duplicate: MySQL NOW() is a few ms
+        // ahead of the frozen session time, so the item is reselected by the next cron run.
+        $_SESSION['glpi_currenttime'] = '2026-06-04 13:37:00';
+
+        $child_class = $this->getChildClass();
+        $recurrent   = new $child_class();
+
+        $result = $recurrent->computeNextCreationDate(
+            '2026-06-11 13:37:00', // begin_date - 7 days = 2026-06-04 13:37:00 (= session time)
+            '2028-01-01 00:00:00',
+            '1YEAR',
+            DAY_TIMESTAMP * 7,
+            0
+        );
+
+        $this->assertSame('2027-06-04 13:37:00', $result);
     }
 
     /**

--- a/src/CommonITILRecurrent.php
+++ b/src/CommonITILRecurrent.php
@@ -443,8 +443,10 @@ abstract class CommonITILRecurrent extends CommonDropdown
             $occurence_time = strtotime($begin_date);
             $creation_time  = $occurence_time - $create_before;
 
-            // Add steps while creation time is in past
-            while ($creation_time < $now) {
+            // Add steps while creation time is in past or equal to now.
+            // Using <= prevents returning a next_creation_date identical to the session
+            // start time, which MySQL NOW() would already exceed, causing a J+1 duplicate.
+            while ($creation_time <= $now) {
                 $creation_time  = strtotime("+ $periodicity_as_interval", $creation_time);
                 $occurence_time = $creation_time + $create_before;
 
@@ -500,7 +502,7 @@ abstract class CommonITILRecurrent extends CommonDropdown
             $occurence_time = strtotime($occurence_date);
             $creation_time  = $occurence_time - $create_before;
 
-            while ($creation_time < $now) {
+            while ($creation_time <= $now) {
                 $occurence_date = $calendar->computeEndDate(
                     date('Y-m-d H:i:s', $occurence_time),
                     $periodicity_in_seconds,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !42469

`computeNextCreationDate()` uses `Session::getCurrentTime()` (frozen at PHP
process start) as `$now`. The loop condition `while ($creation_time < $now)`
exits when `creation_time >= $now`, including when they are equal.

When `begin_date − create_before` produces a timestamp that is exactly equal
to the session start time, the loop exits without advancing: `next_creation_date`
is stored as the current session time. Because MySQL `NOW()` at the time of the
cron query is a few milliseconds ahead of the frozen session time, the item is
immediately eligible for reprocessing. The next daily cron run finds
`next_creation_date` in the past and creates a second item (J+1 duplicate).
The bug self-heals after the second run because the following day's session time
has advanced past the stuck sequence value.

The fix changes the loop condition from `<` to `<=` in both branches of the
function (no-calendar path and calendar-with-daily-or-longer-periodicity path),
ensuring the returned value is always strictly greater than `$now`.

A regression test `testNextCreationDateNeverEqualsCurrentTime` is added,
covering the exact edge case: `begin_date − create_before = session time`
must return the next yearly occurrence, never the current time.



## Screenshots (if appropriate):


