### PR TITLE
fix(softwarelicense): child entities checkbox always unchecked when editing

### DIFF
--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -289,24 +289,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         return true;
     }
 
-    /**
-     * Is the license may be recursive
-     *
-     * @return bool
-     **/
-    public function maybeRecursive()
-    {
-        $soft = new Software();
-        if (
-            isset($this->fields["softwares_id"])
-            && $soft->getFromDB($this->fields["softwares_id"])
-        ) {
-            return $soft->isRecursive();
-        }
-
-        return true;
-    }
-
     public function rawSearchOptions()
     {
         $tab = [];

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -307,24 +307,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         return true;
     }
 
-    /**
-     * Is the license recursive ?
-     *
-     * @return bool
-     **/
-    public function isRecursive()
-    {
-        $soft = new Software();
-        if (
-            isset($this->fields["softwares_id"])
-            && $soft->getFromDB($this->fields["softwares_id"])
-        ) {
-            return $soft->isRecursive();
-        }
-
-        return false;
-    }
-
     public function rawSearchOptions()
     {
         $tab = [];

--- a/tests/functional/SoftwareLicenseTest.php
+++ b/tests/functional/SoftwareLicenseTest.php
@@ -381,7 +381,7 @@ class SoftwareLicenseTest extends DbTestCase
         $this->assertEquals($initial_total + 1, $total_after_computer);
 
         $user = getItemByTypeName('User', TU_USER);
-        $user_license_id = $this->createItem(\SoftwareLicense_User::class, [
+        $this->createItem(\SoftwareLicense_User::class, [
             'softwarelicenses_id' => $license_id,
             'users_id' => $user->getID(),
         ])->getID();
@@ -498,7 +498,7 @@ class SoftwareLicenseTest extends DbTestCase
 
         // Add a computer to this license to reach the limit
         $computer = getItemByTypeName('Computer', '_test_pc01');
-        $item_license_id = $this->createItem(\Item_SoftwareLicense::class, [
+        $this->createItem(\Item_SoftwareLicense::class, [
             'softwarelicenses_id' => $license_id,
             'items_id' => $computer->getID(),
             'itemtype' => 'Computer',
@@ -525,7 +525,7 @@ class SoftwareLicenseTest extends DbTestCase
         $this->assertTrue($license2->getFromDB($license2_id));
 
         // Add a computer to this license to reach the limit
-        $item_license2_id = $this->createItem(\Item_SoftwareLicense::class, [
+        $this->createItem(\Item_SoftwareLicense::class, [
             'softwarelicenses_id' => $license2_id,
             'items_id' => $computer->getID(),
             'itemtype' => 'Computer',
@@ -622,4 +622,34 @@ class SoftwareLicenseTest extends DbTestCase
         $count_after_second = \SoftwareLicense_User::countForLicense($license_id);
         $this->assertEquals(1, $count_after_second);
     }
+
+
+    public function testIsRecursiveReflectsLicenseOwnField(): void
+    {
+        $this->login();
+
+        // Software must be recursive so that maybeRecursive() returns true for the license
+        $software_id = $this->createItem(\Software::class, [
+            'name'         => 'Recursive software ' . $this->getUniqueString(),
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ])->getID();
+
+        $recursive_license = $this->createItem(\SoftwareLicense::class, [
+            'name'         => 'Recursive license',
+            'softwares_id' => $software_id,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertTrue($recursive_license->isRecursive());
+
+        $non_recursive_license = $this->createItem(\SoftwareLicense::class, [
+            'name'         => 'Non-recursive license',
+            'softwares_id' => $software_id,
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+        ]);
+        $this->assertFalse($non_recursive_license->isRecursive());
+    }
+
 }

--- a/tests/functional/SoftwareLicenseTest.php
+++ b/tests/functional/SoftwareLicenseTest.php
@@ -652,4 +652,33 @@ class SoftwareLicenseTest extends DbTestCase
         $this->assertFalse($non_recursive_license->isRecursive());
     }
 
+    public function testIsRecursiveWithNonRecursiveSoftware(): void
+    {
+        $this->login();
+
+        $software_id = $this->createItem(\Software::class, [
+            'name'         => 'Non-recursive software ' . $this->getUniqueString(),
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+        ])->getID();
+
+        // Even when the software is not recursive, the “is_recursive” field in the license must be used
+        // The software is not recursive, but the license is recursive
+        $recursive_license = $this->createItem(\SoftwareLicense::class, [
+            'name'         => 'Recursive license',
+            'softwares_id' => $software_id,
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertTrue($recursive_license->isRecursive());
+
+        $non_recursive_license = $this->createItem(\SoftwareLicense::class, [
+            'name'         => 'Non-recursive license',
+            'softwares_id' => $software_id,
+            'entities_id'  => 0,
+            'is_recursive' => 0,
+        ]);
+        $this->assertFalse($non_recursive_license->isRecursive());
+    }
+
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44612
- In SoftwareLicences, the isRecursive() function was overridden and always returned $soft->isRecursive() (the value of the parent software), completely ignoring the is_recursive field of the license itself. As a result, the "Child Entities" checkbox was always displayed as unchecked when opening an existing record. 

## Screenshots (if appropriate):


