### PR TITLE
fix(Impact.php): respect READ_ASSIGNED and READ_OWNED rights in asset search

### DIFF
--- a/src/Impact.php
+++ b/src/Impact.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Features\AssignableItemInterface;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\SearchEngine;
 use Glpi\Search\SearchOption;
@@ -926,7 +927,7 @@ HTML;
         }
 
         // Return empty result if the user doesn't have READ rights
-        if (!Session::haveRight($itemtype::$rightname, READ)) {
+        if (!Session::haveRightsOr($itemtype::$rightname, [READ, READ_ASSIGNED, READ_OWNED])) {
             return [
                 "items" => [],
                 "total" => 0,
@@ -960,6 +961,11 @@ HTML;
                 $base_request,
                 $itemtype::getVisibilityCriteria()
             );
+        }
+
+        // Add assignable criteria if the item is assignable
+        if (is_subclass_of($itemtype, AssignableItemInterface::class, true)) {
+            $base_request['WHERE'][] = $itemtype::getAssignableVisiblityCriteria();
         }
 
         $item = new $itemtype();
@@ -1047,7 +1053,7 @@ HTML;
         foreach ($itemtypes as $itemtype) {
             /** @var class-string $itemtype */
             // Do not display this itemtype if the user doesn't have READ rights
-            if (!Session::haveRight($itemtype::$rightname, READ)) {
+            if (!Session::haveRightsOr($itemtype::$rightname, [READ, READ_ASSIGNED, READ_OWNED])) {
                 continue;
             }
 

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -963,12 +963,16 @@ HTML;
             );
         }
 
+        $item = new $itemtype();
+
         // Add assignable criteria if the item is assignable
-        if (is_subclass_of($itemtype, AssignableItemInterface::class, true)) {
-            $base_request['WHERE'][] = $itemtype::getAssignableVisiblityCriteria();
+        if ($item instanceof AssignableItemInterface) {
+            $visibility_criteria = $item->getAssignableVisiblityCriteria();
+            if (count($visibility_criteria)) {
+                $base_request['WHERE'][] = $visibility_criteria;
+            }
         }
 
-        $item = new $itemtype();
         if ($item->isEntityAssign()) {
             $base_request['WHERE'] = array_merge_recursive(
                 $base_request['WHERE'],

--- a/tests/functional/ImpactTest.php
+++ b/tests/functional/ImpactTest.php
@@ -38,14 +38,14 @@ use CommonDBTM;
 use Computer;
 use Glpi\Plugin\Hooks;
 use Glpi\Tests\DbTestCase;
+use Group;
+use Group_Item;
+use Group_User;
 use ImpactCompound;
 use ImpactItem;
 use ImpactRelation;
 use Item_Ticket;
 use Ticket;
-use Group;
-use Group_Item;
-use Group_User;
 
 class ImpactTest extends DbTestCase
 {

--- a/tests/functional/ImpactTest.php
+++ b/tests/functional/ImpactTest.php
@@ -602,19 +602,27 @@ class ImpactTest extends DbTestCase
     {
         $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
         $this->login();
+        $assigned_user_id = getItemByTypeName('User', 'normal', true);
 
         $c1 = $this->createItem(Computer::class, ['name' => 'impact-test-read-1', 'entities_id' => $entity_id]);
         $c2 = $this->createItem(Computer::class, ['name' => 'impact-test-read-2', 'entities_id' => $entity_id]);
+        $c3 = $this->createItem(Computer::class, [
+            'name' => 'impact-test-read-3',
+            'entities_id' => $entity_id,
+            'users_id_tech' => $assigned_user_id,
+        ]);
+
 
         $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
 
         $result = \Impact::searchAsset(Computer::class, [], 'impact-test-read');
 
-        $this->assertSame(2, $result['total']);
+        $this->assertSame(3, $result['total']);
 
         $ids = array_column($result['items'], 'id');
         $this->assertContains($c1->getID(), $ids);
         $this->assertContains($c2->getID(), $ids);
+        $this->assertContains($c3->getID(), $ids);
     }
 
     public function testSearchAssetReadAssignedRight(): void

--- a/tests/functional/ImpactTest.php
+++ b/tests/functional/ImpactTest.php
@@ -43,6 +43,9 @@ use ImpactItem;
 use ImpactRelation;
 use Item_Ticket;
 use Ticket;
+use Group;
+use Group_Item;
+use Group_User;
 
 class ImpactTest extends DbTestCase
 {
@@ -579,5 +582,125 @@ class ImpactTest extends DbTestCase
 
             $this->assertSame($root_doc . '/pics/impact/default.png', \Impact::getImpactIcon('PluginTesterAnotherAsset'));
         }
+    }
+
+    public function testSearchAssetNoRights(): void
+    {
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $this->login();
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = 0;
+
+        $this->createItem(Computer::class, ['name' => 'impact-test-norights-1', 'entities_id' => $entity_id]);
+        $this->createItem(Computer::class, ['name' => 'impact-test-norights-2', 'entities_id' => $entity_id]);
+
+        $result = \Impact::searchAsset(Computer::class, [], 'impact-test-norights');
+        $this->assertSame([], $result['items']);
+        $this->assertSame(0, $result['total']);
+    }
+
+    public function testSearchAssetReadRight(): void
+    {
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $this->login();
+
+        $c1 = $this->createItem(Computer::class, ['name' => 'impact-test-read-1', 'entities_id' => $entity_id]);
+        $c2 = $this->createItem(Computer::class, ['name' => 'impact-test-read-2', 'entities_id' => $entity_id]);
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
+
+        $result = \Impact::searchAsset(Computer::class, [], 'impact-test-read');
+
+        $this->assertSame(2, $result['total']);
+
+        $ids = array_column($result['items'], 'id');
+        $this->assertContains($c1->getID(), $ids);
+        $this->assertContains($c2->getID(), $ids);
+    }
+
+    public function testSearchAssetReadAssignedRight(): void
+    {
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $this->login();
+        $user_id = $_SESSION['glpiID'];
+
+        // Direct user assignment
+        $assigned = $this->createItem(Computer::class, [
+            'name'          => 'impact-test-assigned-yes',
+            'entities_id'   => $entity_id,
+            'users_id_tech' => $user_id,
+        ]);
+        $not_assigned = $this->createItem(Computer::class, [
+            'name'        => 'impact-test-assigned-no',
+            'entities_id' => $entity_id,
+        ]);
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ_ASSIGNED;
+
+        $result = \Impact::searchAsset(Computer::class, [], 'impact-test-assigned');
+        $this->assertSame(1, $result['total']);
+        $ids = array_column($result['items'], 'id');
+        $this->assertContains($assigned->getID(), $ids);
+        $this->assertNotContains($not_assigned->getID(), $ids);
+
+        // Group-based tech assignment
+        $group = $this->createItem(Group::class, [
+            'name'        => 'impact-test-tech-group',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Add user to the group and reflect in session
+        $this->createItem(Group_User::class, [
+            'groups_id' => $group->getID(),
+            'users_id'  => $user_id,
+        ]);
+        $_SESSION['glpigroups'][] = $group->getID();
+
+        $group_assigned = $this->createItem(Computer::class, [
+            'name'        => 'impact-test-group-assigned-yes',
+            'entities_id' => $entity_id,
+        ]);
+        $group_not_assigned = $this->createItem(Computer::class, [
+            'name'        => 'impact-test-group-assigned-no',
+            'entities_id' => $entity_id,
+        ]);
+
+        // Link computer to the tech group
+        $this->createItem(Group_Item::class, [
+            'groups_id' => $group->getID(),
+            'items_id'  => $group_assigned->getID(),
+            'itemtype'  => Computer::class,
+            'type'      => Group_Item::GROUP_TYPE_TECH,
+        ]);
+
+        $result = \Impact::searchAsset(Computer::class, [], 'impact-test-group-assigned');
+        $this->assertSame(1, $result['total']);
+        $ids = array_column($result['items'], 'id');
+        $this->assertContains($group_assigned->getID(), $ids);
+        $this->assertNotContains($group_not_assigned->getID(), $ids);
+    }
+
+    public function testSearchAssetReadOwnedRight(): void
+    {
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $this->login();
+        $user_id = $_SESSION['glpiID'];
+
+        $owned = $this->createItem(Computer::class, [
+            'name'        => 'impact-test-owned-yes',
+            'entities_id' => $entity_id,
+            'users_id'    => $user_id,
+        ]);
+        $not_owned = $this->createItem(Computer::class, [
+            'name'        => 'impact-test-owned-no',
+            'entities_id' => $entity_id,
+        ]);
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ_OWNED;
+
+        $result = \Impact::searchAsset(Computer::class, [], 'impact-test-owned');
+        $this->assertSame(1, $result['total']);
+        $ids = array_column($result['items'], 'id');
+        $this->assertContains($owned->getID(), $ids);
+        $this->assertNotContains($not_owned->getID(), $ids);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44694
- Previously, `Impact::searchAsset() ` and the impact itemtype selector both required the full `READ` right on an item type. Users with only `READ_ASSIGNED` (view assigned) or `READ_OWNED` (view owned) couldn't view any of their assigned/owned items in the impact graph.
- This change replaces `haveRight(READ)` checks by `haveRightsOr([READ, READ_ASSIGNED, READ_OWNED])` and injects the `AssignableItemInterface::getAssignableVisiblityCriteria()` SQL filter when the item type is assignable, so the returned list is automatically scoped to what the current user is allowed to see,  matching the same filtering already applied by the main Search engine.