### PR TITLE
fix(forms): apply AND-over-OR precedence when evaluating conditions

### DIFF
--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -315,36 +315,45 @@ final class Engine
      */
     private function computeConditions(array $conditions, array &$result_per_condition = []): bool
     {
-        $conditions_result = null;
+        // Evaluate each condition individually and collect its logic operator.
+        $evaluated = [];
+        $operators = [];
         foreach ($conditions as $condition) {
             if (empty($condition->getItemUuid())) {
                 continue;
             }
-
-            // Apply condition (item + value operator + value)
             $condition_result = $this->computeCondition($condition);
             $result_per_condition[spl_object_id($condition)] = $condition_result;
+            $evaluated[] = $condition_result;
+            $operators[] = $condition->getLogicOperator();
+        }
 
-            // Apply logic operator
-            if ($conditions_result === null) {
-                // This was the first condition, ignore operator.
-                $conditions_result = $condition_result;
+        if (empty($evaluated)) {
+            return false;
+        }
+
+        // Apply AND-over-OR operator precedence (matching legacy formcreator behavior):
+        // operators[0] is the first condition's operator and is always ignored.
+        // operators[i] (i > 0) is the operator connecting evaluated[i-1] to evaluated[i].
+        // We split on OR boundaries into AND-groups, then OR-reduce across groups.
+        $or_groups = [];
+        $current_group = [$evaluated[0]];
+        for ($i = 1, $count = count($evaluated); $i < $count; $i++) {
+            if ($operators[$i] === LogicOperator::OR) {
+                $or_groups[] = $current_group;
+                $current_group = [$evaluated[$i]];
             } else {
-                // Merge result with previous result using the defined operator.
-                $operator = $condition->getLogicOperator();
-                $conditions_result = $operator->apply(
-                    $conditions_result,
-                    $condition_result,
-                );
+                $current_group[] = $evaluated[$i];
             }
         }
+        $or_groups[] = $current_group;
 
-        // No conditions are defined, we consider the result to be false
-        if ($conditions_result === null) {
-            $conditions_result = false;
+        foreach ($or_groups as $group) {
+            if (!in_array(false, $group, true)) {
+                return true; // all conditions in this AND-group are true
+            }
         }
-
-        return $conditions_result;
+        return false;
     }
 
     private function computeCondition(ConditionData $condition): bool

--- a/src/Glpi/Form/Condition/Engine.php
+++ b/src/Glpi/Form/Condition/Engine.php
@@ -328,7 +328,7 @@ final class Engine
             $operators[] = $condition->getLogicOperator();
         }
 
-        if (empty($evaluated)) {
+        if ($evaluated === []) {
             return false;
         }
 

--- a/tests/functional/Glpi/Form/Condition/EngineTest.php
+++ b/tests/functional/Glpi/Form/Condition/EngineTest.php
@@ -972,6 +972,119 @@ final class EngineTest extends DbTestCase
         ];
     }
 
+    public static function conditionsWithMixedAndOrOperators(): iterable
+    {
+        // Verifies AND-over-OR operator precedence, matching legacy formcreator behavior.
+        // Expression: Q1=a AND Q2=b OR Q3=c AND Q4=d
+        // Correct evaluation (AND binds tighter): (Q1=a AND Q2=b) OR (Q3=c AND Q4=d)
+        // Broken left-fold evaluation: ((Q1=a AND Q2=b) OR Q3=c) AND Q4=d
+        $form = new FormBuilder();
+        $form->addQuestion("Question 1", QuestionTypeShortText::class);
+        $form->addQuestion("Question 2", QuestionTypeShortText::class);
+        $form->addQuestion("Question 3", QuestionTypeShortText::class);
+        $form->addQuestion("Question 4", QuestionTypeShortText::class);
+        $form->addQuestion("Target Question", QuestionTypeShortText::class);
+        $form->setQuestionVisibility(
+            "Target Question",
+            VisibilityStrategy::VISIBLE_IF,
+            [
+                [
+                    'logic_operator' => LogicOperator::AND, // first condition: operator ignored
+                    'item_name'      => "Question 1",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => "a",
+                ],
+                [
+                    'logic_operator' => LogicOperator::AND, // Q1=a AND Q2=b
+                    'item_name'      => "Question 2",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => "b",
+                ],
+                [
+                    'logic_operator' => LogicOperator::OR, // (Q1=a AND Q2=b) OR (...)
+                    'item_name'      => "Question 3",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => "c",
+                ],
+                [
+                    'logic_operator' => LogicOperator::AND, // Q3=c AND Q4=d
+                    'item_name'      => "Question 4",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => "d",
+                ],
+            ]
+        );
+
+        // First AND-group matches: (T AND T) OR (F AND F) = TRUE
+        // Broken left-fold: ((T AND T) OR F) AND F = FALSE
+        yield 'first AND group matches' => [
+            'form'  => $form,
+            'input' => [
+                'answers' => [
+                    'Question 1' => "a",
+                    'Question 2' => "b",
+                    'Question 3' => "wrong",
+                    'Question 4' => "wrong",
+                ],
+            ],
+            'expected_output' => [
+                'questions' => ['Target Question' => true],
+            ],
+        ];
+
+        // Second AND-group matches: (F AND F) OR (T AND T) = TRUE
+        yield 'second AND group matches' => [
+            'form'  => $form,
+            'input' => [
+                'answers' => [
+                    'Question 1' => "wrong",
+                    'Question 2' => "wrong",
+                    'Question 3' => "c",
+                    'Question 4' => "d",
+                ],
+            ],
+            'expected_output' => [
+                'questions' => ['Target Question' => true],
+            ],
+        ];
+
+        // Neither group matches: (F AND F) OR (F AND F) = FALSE
+        yield 'neither AND group matches' => [
+            'form'  => $form,
+            'input' => [
+                'answers' => [
+                    'Question 1' => "wrong",
+                    'Question 2' => "wrong",
+                    'Question 3' => "wrong",
+                    'Question 4' => "wrong",
+                ],
+            ],
+            'expected_output' => [
+                'questions' => ['Target Question' => false],
+            ],
+        ];
+
+        // Partial first group match: (T AND F) OR (F AND F) = FALSE
+        yield 'partial first AND group match' => [
+            'form'  => $form,
+            'input' => [
+                'answers' => [
+                    'Question 1' => "a",
+                    'Question 2' => "wrong",
+                    'Question 3' => "wrong",
+                    'Question 4' => "wrong",
+                ],
+            ],
+            'expected_output' => [
+                'questions' => ['Target Question' => false],
+            ],
+        ];
+    }
+
     #[DataProvider('conditionsOnForm')]
     #[DataProvider('conditionsOnQuestions')]
     #[DataProvider('conditionsOnComments')]
@@ -982,6 +1095,7 @@ final class EngineTest extends DbTestCase
     #[DataProvider('conditionsWithEmptyOperatorOnNullAnswer')]
     #[DataProvider('conditionsWithEmptyOperatorOnNotVisibleQuestionAsSource')]
     #[DataProvider('conditionsOnChildBlocksWithParentSectionHidden')]
+    #[DataProvider('conditionsWithMixedAndOrOperators')]
     public function testComputation(
         FormBuilder $form,
         array $input,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !44202

When a form item had conditions mixing AND and OR operators (e.g. A AND B OR C AND D), the engine evaluated them left-to-right without precedence, producing different results than the legacy formcreator plugin. This restores the expected boolean algebra behavior where AND binds tighter than OR, matching formcreator's implementation.


