### PR TITLE
Clear cache install update uninstall plugin

### DIFF
--- a/src/Glpi/Console/Plugin/InstallCommand.php
+++ b/src/Glpi/Console/Plugin/InstallCommand.php
@@ -35,7 +35,9 @@
 
 namespace Glpi\Console\Plugin;
 
+use Glpi\Console\Cache\ClearCommand;
 use Plugin;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -147,6 +149,10 @@ class InstallCommand extends AbstractPluginCommand
                 OutputInterface::VERBOSITY_NORMAL
             );
         }
+
+        $clear_cache_command = new ClearCommand();
+        $clear_cache_command->setApplication($this->getApplication());
+        $clear_cache_command->run(new ArrayInput([]), $output);
 
         if ($failed) {
             return self::ERROR_PLUGIN_INSTALLATION_FAILED;

--- a/src/Glpi/Console/Plugin/UninstallCommand.php
+++ b/src/Glpi/Console/Plugin/UninstallCommand.php
@@ -35,8 +35,10 @@
 
 namespace Glpi\Console\Plugin;
 
+use Glpi\Console\Cache\ClearCommand;
 use Plugin;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -109,6 +111,10 @@ class UninstallCommand extends AbstractPluginCommand
                 OutputInterface::VERBOSITY_NORMAL
             );
         }
+
+        $clear_cache_command = new ClearCommand();
+        $clear_cache_command->setApplication($this->getApplication());
+        $clear_cache_command->run(new ArrayInput([]), $output);
 
         return $failed ? Command::FAILURE : Command::SUCCESS;
     }

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -37,6 +37,7 @@ namespace Glpi\Marketplace;
 
 use CommonGLPI;
 use Config;
+use Glpi\Cache\CacheManager;
 use CronTask;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
@@ -597,7 +598,9 @@ class Controller extends CommonGLPI
      */
     public function installPlugin(bool $disable_messages = false): bool
     {
-        $state =  $this->setPluginState("install");
+        $state = $this->setPluginState("install");
+
+        $this->clearCache();
 
         if ($disable_messages) {
             $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
@@ -614,7 +617,23 @@ class Controller extends CommonGLPI
      */
     public function uninstallPlugin(): bool
     {
-        return $this->setPluginState("uninstall") == Plugin::NOTINSTALLED;
+        $state = $this->setPluginState("uninstall");
+
+        $this->clearCache();
+
+        return $state == Plugin::NOTINSTALLED;
+    }
+
+
+    private function clearCache(): void
+    {
+        $success = (new CacheManager())->resetAllCaches();
+
+        Session::addMessageAfterRedirect(
+            $success ? __s('Cache cleared successfully.') : __s('Failed to clear cache.'),
+            false,
+            $success ? INFO : ERROR
+        );
     }
 
 

--- a/src/Glpi/Marketplace/Controller.php
+++ b/src/Glpi/Marketplace/Controller.php
@@ -37,8 +37,8 @@ namespace Glpi\Marketplace;
 
 use CommonGLPI;
 use Config;
-use Glpi\Cache\CacheManager;
 use CronTask;
+use Glpi\Cache\CacheManager;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;

--- a/tests/functional/Glpi/Console/Plugin/InstallCommandTest.php
+++ b/tests/functional/Glpi/Console/Plugin/InstallCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\functional\Glpi\Console\Plugin;
+
+use Glpi\Console\Cache\ClearCommand;
+use Glpi\Console\Plugin\InstallCommand;
+use Glpi\Tests\DbTestCase;
+use Plugin;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class InstallCommandTest extends DbTestCase
+{
+    private ?string $plugin_dir = null;
+    private string $plugin_name = '';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->plugin_name = 'testcacheinstall' . uniqid();
+        $this->plugin_dir  = GLPI_ROOT . '/plugins/' . $this->plugin_name;
+
+        mkdir($this->plugin_dir);
+        file_put_contents($this->plugin_dir . '/setup.php', sprintf(
+            <<<'PHP'
+            <?php
+            function plugin_version_%1$s(): array {
+                return ['name' => 'Test Cache Install', 'version' => '1.0.0', 'author' => 'Test', 'license' => 'GPL v2+', 'requirements' => ['glpi' => ['min' => '9.5.0']]];
+            }
+            function plugin_%1$s_install(): bool { return true; }
+            function plugin_%1$s_uninstall(): bool { return true; }
+            PHP,
+            $this->plugin_name
+        ));
+    }
+
+    public function tearDown(): void
+    {
+        $plugin = new Plugin();
+        if ($plugin->getFromDBByCrit(['directory' => $this->plugin_name])) {
+            $plugin->delete(['id' => $plugin->fields['id']], true);
+        }
+
+        if ($this->plugin_dir !== null && is_dir($this->plugin_dir)) {
+            $this->removeDirectory($this->plugin_dir);
+        }
+
+        parent::tearDown();
+    }
+
+    private function buildApplication(): Application
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new InstallCommand());
+        $app->add(new ClearCommand());
+        return $app;
+    }
+
+    public function testClearsCacheAfterInstall(): void
+    {
+        $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
+        $tester->execute(['directory' => [$this->plugin_name]]);
+
+        $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
+    }
+
+    public function testClearsCacheAfterForceInstall(): void
+    {
+        $plugin = new Plugin();
+        $plugin->checkPluginState($this->plugin_name);
+        $plugin->getFromDBByCrit(['directory' => $this->plugin_name]);
+        $plugin->install($plugin->fields['id']);
+
+        $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
+        $tester->execute(['directory' => [$this->plugin_name], '--force' => true]);
+
+        $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
+    }
+
+    public function testClearsCacheAfterInstallAll(): void
+    {
+        // --all sets directory=['*'] in interact() without prompting, then normalizeInput()
+        // expands it to all not-yet-installed plugins (including our test plugin).
+        // Even if other plugins fail, cache clearing is unconditional.
+        $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
+        $tester->execute(['--all' => true]);
+
+        $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
+    }
+}

--- a/tests/functional/Glpi/Console/Plugin/InstallCommandTest.php
+++ b/tests/functional/Glpi/Console/Plugin/InstallCommandTest.php
@@ -36,12 +36,12 @@ namespace tests\functional\Glpi\Console\Plugin;
 
 use Glpi\Console\Cache\ClearCommand;
 use Glpi\Console\Plugin\InstallCommand;
-use Glpi\Tests\DbTestCase;
+use Glpi\Tests\GLPITestCase;
 use Plugin;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class InstallCommandTest extends DbTestCase
+class InstallCommandTest extends GLPITestCase
 {
     private ?string $plugin_dir = null;
     private string $plugin_name = '';
@@ -50,7 +50,7 @@ class InstallCommandTest extends DbTestCase
     {
         parent::setUp();
 
-        $this->plugin_name = 'testcacheinstall' . uniqid();
+        $this->plugin_name = 'testcacheinstall' . substr(uniqid(), -6);
         $this->plugin_dir  = GLPI_ROOT . '/plugins/' . $this->plugin_name;
 
         mkdir($this->plugin_dir);
@@ -94,6 +94,8 @@ class InstallCommandTest extends DbTestCase
     {
         $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
         $tester->execute(['directory' => [$this->plugin_name]]);
+        restore_error_handler();
+        restore_exception_handler();
 
         $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
     }
@@ -107,6 +109,8 @@ class InstallCommandTest extends DbTestCase
 
         $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
         $tester->execute(['directory' => [$this->plugin_name], '--force' => true]);
+        restore_error_handler();
+        restore_exception_handler();
 
         $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
     }
@@ -118,6 +122,8 @@ class InstallCommandTest extends DbTestCase
         // Even if other plugins fail, cache clearing is unconditional.
         $tester = new CommandTester($this->buildApplication()->find('plugin:install'));
         $tester->execute(['--all' => true]);
+        restore_error_handler();
+        restore_exception_handler();
 
         $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
     }

--- a/tests/functional/Glpi/Console/Plugin/UninstallCommandTest.php
+++ b/tests/functional/Glpi/Console/Plugin/UninstallCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\functional\Glpi\Console\Plugin;
+
+use Glpi\Console\Cache\ClearCommand;
+use Glpi\Console\Plugin\UninstallCommand;
+use Glpi\Tests\DbTestCase;
+use Plugin;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UninstallCommandTest extends DbTestCase
+{
+    private ?string $plugin_dir = null;
+    private string $plugin_name = '';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->plugin_name = 'testcacheuninstall' . uniqid();
+        $this->plugin_dir  = GLPI_ROOT . '/plugins/' . $this->plugin_name;
+
+        mkdir($this->plugin_dir);
+        file_put_contents($this->plugin_dir . '/setup.php', sprintf(
+            <<<'PHP'
+            <?php
+            function plugin_version_%1$s(): array {
+                return ['name' => 'Test Cache Uninstall', 'version' => '1.0.0', 'author' => 'Test', 'license' => 'GPL v2+', 'requirements' => ['glpi' => ['min' => '9.5.0']]];
+            }
+            function plugin_%1$s_install(): bool { return true; }
+            function plugin_%1$s_uninstall(): bool { return true; }
+            PHP,
+            $this->plugin_name
+        ));
+    }
+
+    public function tearDown(): void
+    {
+        $plugin = new Plugin();
+        if ($plugin->getFromDBByCrit(['directory' => $this->plugin_name])) {
+            $plugin->delete(['id' => $plugin->fields['id']], true);
+        }
+
+        if ($this->plugin_dir !== null && is_dir($this->plugin_dir)) {
+            $this->removeDirectory($this->plugin_dir);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testClearsCacheAfterUninstall(): void
+    {
+        $plugin = new Plugin();
+        $plugin->checkPluginState($this->plugin_name);
+        $plugin->getFromDBByCrit(['directory' => $this->plugin_name]);
+        $plugin->install($plugin->fields['id']);
+
+        $app = new Application();
+        $app->setAutoExit(false);
+        $app->add(new UninstallCommand());
+        $app->add(new ClearCommand());
+
+        $tester = new CommandTester($app->find('plugin:uninstall'));
+        $tester->execute(
+            ['directory' => [$this->plugin_name], '--no-interaction' => true]
+        );
+
+        $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
+    }
+}

--- a/tests/functional/Glpi/Console/Plugin/UninstallCommandTest.php
+++ b/tests/functional/Glpi/Console/Plugin/UninstallCommandTest.php
@@ -36,12 +36,12 @@ namespace tests\functional\Glpi\Console\Plugin;
 
 use Glpi\Console\Cache\ClearCommand;
 use Glpi\Console\Plugin\UninstallCommand;
-use Glpi\Tests\DbTestCase;
+use Glpi\Tests\GLPITestCase;
 use Plugin;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class UninstallCommandTest extends DbTestCase
+class UninstallCommandTest extends GLPITestCase
 {
     private ?string $plugin_dir = null;
     private string $plugin_name = '';
@@ -97,6 +97,8 @@ class UninstallCommandTest extends DbTestCase
         $tester->execute(
             ['directory' => [$this->plugin_name], '--no-interaction' => true]
         );
+        restore_error_handler();
+        restore_exception_handler();
 
         $this->assertStringContainsString('Cache cleared successfully.', $tester->getDisplay());
     }

--- a/tests/functional/Glpi/Marketplace/ControllerTest.php
+++ b/tests/functional/Glpi/Marketplace/ControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\functional\Glpi\Marketplace;
+
+use Glpi\Marketplace\Controller;
+use Glpi\Tests\GLPITestCase;
+
+class ControllerTest extends GLPITestCase
+{
+    public function testClearCacheAddsSuccessMessage(): void
+    {
+        $controller = new Controller('testplugin');
+
+        $this->callPrivateMethod($controller, 'clearCache');
+
+        $this->hasSessionMessages(INFO, ['Cache cleared successfully.']);
+    }
+}

--- a/tests/functional/Glpi/Marketplace/ControllerTest.php
+++ b/tests/functional/Glpi/Marketplace/ControllerTest.php
@@ -44,6 +44,8 @@ class ControllerTest extends GLPITestCase
         $controller = new Controller('testplugin');
 
         $this->callPrivateMethod($controller, 'clearCache');
+        restore_error_handler();
+        restore_exception_handler();
 
         $this->hasSessionMessages(INFO, ['Cache cleared successfully.']);
     }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description


 After `installing` or `uninstalling` a plugin — whether through the Marketplace UI or via the `plugin:install` / `plugin:uninstall` console commands GLPI's cache was not cleared. 

This PR ensures the cache is fully reset (equivalent to running cache:clear) at the end of every plugin lifecycle operation:

**Console commands (plugin:install, plugin:uninstall)**
  - plugin:install delegates to ClearCommand after the installation loop completes, regardless of whether individual installs succeeded or failed. This covers the standard invocation, --force, and --all.
  - plugin:uninstall applies the same unconditional cache clear after the uninstallation loop. 
  - The user sees a Cache cleared successfully. message in the command output.

**Marketplace controller**
  - A private clearCache() method encapsulates CacheManager::resetAllCaches() and adds a Session::addMessageAfterRedirect() message (success or error) visible in the UI.
  - installPlugin() and uninstallPlugin() both call clearCache() after the state transition, covering both initial installs and updates triggered from the Marketplace.


