### PR TITLE
FIX / Add entity and child entities search options to SLM and SLA/OLA list views

### DIFF
--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -801,7 +801,8 @@ final class SearchOption implements ArrayAccess
         ) {
             if ($itemtype !== AllAssets::getType()) {
                 $entity_opt = self::getOptionNumber($itemtype, 'completename', 'Entity');
-                if ($entity_opt > 0) {
+                $options = self::getOptionsForItemtype($itemtype);
+                if ($entity_opt > 0 && empty($options[$entity_opt]['nodefaultcolumn'])) {
                     $toview[] = $entity_opt;
                 }
             } else {

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -801,8 +801,7 @@ final class SearchOption implements ArrayAccess
         ) {
             if ($itemtype !== AllAssets::getType()) {
                 $entity_opt = self::getOptionNumber($itemtype, 'completename', 'Entity');
-                $options = self::getOptionsForItemtype($itemtype);
-                if ($entity_opt > 0 && empty($options[$entity_opt]['nodefaultcolumn'])) {
+                if ($entity_opt > 0) {
                     $toview[] = $entity_opt;
                 }
             } else {

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -627,6 +627,25 @@ TWIG, $twig_params);
             'datatype'           => 'text',
         ];
 
+        $tab[] = [
+            'id'              => '80',
+            'table'           => Entity::getTable(),
+            'field'           => 'completename',
+            'name'            => Entity::getTypeName(1),
+            'massiveaction'   => false,
+            'datatype'        => 'dropdown',
+            'nodefaultcolumn' => true,
+        ];
+
+        $tab[] = [
+            'id'            => '86',
+            'table'         => static::getTable(),
+            'field'         => 'is_recursive',
+            'name'          => __('Child entities'),
+            'datatype'      => 'bool',
+            'massiveaction' => false,
+        ];
+
         return $tab;
     }
 

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -634,7 +634,6 @@ TWIG, $twig_params);
             'name'            => Entity::getTypeName(1),
             'massiveaction'   => false,
             'datatype'        => 'dropdown',
-            'nodefaultcolumn' => true,
         ];
 
         $tab[] = [

--- a/src/SLM.php
+++ b/src/SLM.php
@@ -174,7 +174,7 @@ class SLM extends CommonDBTM
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% extends 'generic_show_form.html.twig' %}
             {% import 'components/form/fields_macros.html.twig' as fields %}
-            
+
             {% block more_fields %}
                 {{ fields.dropdownField('Calendar', 'calendars_id', item.fields['use_ticket_calendar'] ? -1 : item.fields['calendars_id'], 'Calendar'|itemtype_name(1), {
                     emptylabel: empty_label,
@@ -237,7 +237,6 @@ TWIG, $twig_params);
             'name'            => Entity::getTypeName(1),
             'massiveaction'   => false,
             'datatype'        => 'dropdown',
-            'nodefaultcolumn' => true,
         ];
 
         $tab[] = [

--- a/src/SLM.php
+++ b/src/SLM.php
@@ -174,7 +174,6 @@ class SLM extends CommonDBTM
         echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
             {% extends 'generic_show_form.html.twig' %}
             {% import 'components/form/fields_macros.html.twig' as fields %}
-
             {% block more_fields %}
                 {{ fields.dropdownField('Calendar', 'calendars_id', item.fields['use_ticket_calendar'] ? -1 : item.fields['calendars_id'], 'Calendar'|itemtype_name(1), {
                     emptylabel: empty_label,

--- a/src/SLM.php
+++ b/src/SLM.php
@@ -230,6 +230,25 @@ TWIG, $twig_params);
             'datatype'           => 'text',
         ];
 
+        $tab[] = [
+            'id'              => '80',
+            'table'           => Entity::getTable(),
+            'field'           => 'completename',
+            'name'            => Entity::getTypeName(1),
+            'massiveaction'   => false,
+            'datatype'        => 'dropdown',
+            'nodefaultcolumn' => true,
+        ];
+
+        $tab[] = [
+            'id'            => '86',
+            'table'         => static::getTable(),
+            'field'         => 'is_recursive',
+            'name'          => __('Child entities'),
+            'datatype'      => 'bool',
+            'massiveaction' => false,
+        ];
+
         return $tab;
     }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44494
- Entity and child-entities colums were missing from the SLM, SLA and OLA search option definitions even though the underlying tables (`glpi_slms`, `glpi_slas`, `glpi_olas`) have had `entities_id` and `is_recursive` columns since the feature was introduced. Users had to open each record individually to find out which entity it belonged to. So this PR add **Entity** (id 80) and **Child entities** (id 86) search options.

Before : 

<img width="721" height="743" alt="image_paste3310980" src="https://github.com/user-attachments/assets/1796b7e9-3a55-4c12-817b-a7d8e5ed5117" />

After : 

<img width="760" height="803" alt="Capture d’écran du 2026-06-16 10-21-23" src="https://github.com/user-attachments/assets/acccbfdd-5bf5-439d-8c90-7fe53de079e0" />




