### PR TITLE
fix(entity): move satisfaction survey search options to helpdesk section

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1489,61 +1489,6 @@ class Entity extends CommonTreeDropdown implements
         ];
 
         $tab[] = [
-            'id'                 => 'assets',
-            'name'               => _n('Asset', 'Assets', Session::getPluralNumber()),
-        ];
-
-        $tab[] = [
-            'id'                 => '38',
-            'table'              => static::getTable(),
-            'field'              => 'autofill_buy_date',
-            'name'               => __('Date of purchase'),
-            'massiveaction'      => false,
-            'nosearch'           => true,
-            'datatype'           => 'specific',
-        ];
-
-        $tab[] = [
-            'id'                 => '39',
-            'table'              => static::getTable(),
-            'field'              => 'autofill_order_date',
-            'name'               => __('Order date'),
-            'massiveaction'      => false,
-            'nosearch'           => true,
-            'datatype'           => 'specific',
-        ];
-
-        $tab[] = [
-            'id'                 => '40',
-            'table'              => static::getTable(),
-            'field'              => 'autofill_delivery_date',
-            'name'               => __('Delivery date'),
-            'massiveaction'      => false,
-            'nosearch'           => true,
-            'datatype'           => 'specific',
-        ];
-
-        $tab[] = [
-            'id'                 => '41',
-            'table'              => static::getTable(),
-            'field'              => 'autofill_use_date',
-            'name'               => __('Startup date'),
-            'massiveaction'      => false,
-            'nosearch'           => true,
-            'datatype'           => 'specific',
-        ];
-
-        $tab[] = [
-            'id'                 => '42',
-            'table'              => static::getTable(),
-            'field'              => 'autofill_warranty_date',
-            'name'               => __('Start date of warranty'),
-            'massiveaction'      => false,
-            'nosearch'           => true,
-            'datatype'           => 'specific',
-        ];
-
-        $tab[] = [
             'id'                 => '43',
             'table'              => static::getTable(),
             'field'              => 'inquest_config',
@@ -1615,6 +1560,61 @@ class Entity extends CommonTreeDropdown implements
             'name'               => sprintf(__('Satisfaction survey URL (%s)'), Change::getTypeName(1)),
             'massiveaction'      => false,
             'datatype'           => 'string',
+        ];
+
+        $tab[] = [
+            'id'                 => 'assets',
+            'name'               => _n('Asset', 'Assets', Session::getPluralNumber()),
+        ];
+
+        $tab[] = [
+            'id'                 => '38',
+            'table'              => static::getTable(),
+            'field'              => 'autofill_buy_date',
+            'name'               => __('Date of purchase'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'datatype'           => 'specific',
+        ];
+
+        $tab[] = [
+            'id'                 => '39',
+            'table'              => static::getTable(),
+            'field'              => 'autofill_order_date',
+            'name'               => __('Order date'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'datatype'           => 'specific',
+        ];
+
+        $tab[] = [
+            'id'                 => '40',
+            'table'              => static::getTable(),
+            'field'              => 'autofill_delivery_date',
+            'name'               => __('Delivery date'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'datatype'           => 'specific',
+        ];
+
+        $tab[] = [
+            'id'                 => '41',
+            'table'              => static::getTable(),
+            'field'              => 'autofill_use_date',
+            'name'               => __('Startup date'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'datatype'           => 'specific',
+        ];
+
+        $tab[] = [
+            'id'                 => '42',
+            'table'              => static::getTable(),
+            'field'              => 'autofill_warranty_date',
+            'name'               => __('Start date of warranty'),
+            'massiveaction'      => false,
+            'nosearch'           => true,
+            'datatype'           => 'specific',
         ];
 
         $tab[] = [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44356
- the satisfaction survey fields ticket and change, were grouped under the assets section instead of the helpdesk section.

## Screenshots (if appropriate):

<img width="1439" height="87" alt="image" src="https://github.com/user-attachments/assets/45227085-be8e-4103-ba35-4c0bd74cef29" />
