### PR TITLE
add: Plugin uninstall in CLI for plugin dev

### DIFF
--- a/PluginsMakefile.mk
+++ b/PluginsMakefile.mk
@@ -80,6 +80,10 @@ test-setup: ## Setup the plugin for tests
 	@$(CONSOLE) plugin:enable --env=testing $(PLUGIN_DIR)
 .PHONY: test-setup
 
+test-uninstall: ## Uninstall the plugin in test env
+	@$(CONSOLE) plugin:uninstall --env=testing $(PLUGIN_DIR) -q
+.PHONY: uninstall
+
 test-e2e-setup: ## Setup the plugin for end-to-end tests
 	@$(CONSOLE) plugin:install --env=e2e_testing $(PLUGIN_DIR) -u glpi --force
 	@$(CONSOLE) plugin:enable --env=e2e_testing $(PLUGIN_DIR)


### PR DESCRIPTION
When developing a plugin, it could be useful to also be able to uninstall it, currently only having `test-setup`