### PR TITLE
Fix satisfaction survey display in entity list

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2701,7 +2701,7 @@ class Entity extends CommonTreeDropdown implements
                     //TRANS: %d is the percentage. %% to display %
                     $inherit .= sprintf(__s('%d%%'), $inquest_rate);
 
-                    if ((int) $values[$field] === 2) {
+                    if ((int) $values[$field] === CommonITILSatisfaction::TYPE_EXTERNAL) {
                         $url = self::getUsedConfig(
                             $field,
                             $entity_id,

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -1551,6 +1551,7 @@ class Entity extends CommonTreeDropdown implements
             'massiveaction'      => false,
             'nosearch'           => true,
             'datatype'           => 'specific',
+            'additionalfields'   => ['id'],
         ];
 
         $tab[] = [
@@ -1588,6 +1589,7 @@ class Entity extends CommonTreeDropdown implements
             'massiveaction'      => false,
             'nosearch'           => true,
             'datatype'           => 'specific',
+            'additionalfields'   => ['id'],
         ];
 
         $tab[] = [
@@ -2673,23 +2675,24 @@ class Entity extends CommonTreeDropdown implements
 
             case 'inquest_config':
             case 'inquest_config_change':
-                if ($values[$field] === self::CONFIG_PARENT) {
+                if ((int) $values[$field] === self::CONFIG_PARENT) {
                     return __s('Inheritance of the parent entity');
                 }
                 $inherit = '';
+                $entity_id = (int) ($values['id'] ?? 0);
                 $inquest_rate = self::getUsedConfig(
                     $field,
-                    $options['entity']->fields['entities_id'],
+                    $entity_id,
                     str_replace('config', 'rate', $field)
                 );
                 $inherit .= '<br>';
-                if ($inquest_rate === 0) {
+                if ((int) $inquest_rate === 0) {
                     $inherit .= __s('Disabled');
                 } else {
                     $inherit .= htmlescape(CommonITILSatisfaction::getTypeInquestName($values[$field])) . '<br>';
                     $inqconf = self::getUsedConfig(
                         $field,
-                        $options['entity']->fields['entities_id'],
+                        $entity_id,
                         str_replace('config', 'delay', $field)
                     );
 
@@ -2698,13 +2701,17 @@ class Entity extends CommonTreeDropdown implements
                     //TRANS: %d is the percentage. %% to display %
                     $inherit .= sprintf(__s('%d%%'), $inquest_rate);
 
-                    if ($values[$field] === 2) {
-                        $inherit .= "<br>";
-                        $inherit .= htmlescape(self::getUsedConfig(
+                    if ((int) $values[$field] === 2) {
+                        $url = self::getUsedConfig(
                             $field,
-                            $options['entity']->fields['entities_id'],
-                            str_replace('config', 'URL', $field)
-                        ));
+                            $entity_id,
+                            str_replace('config', 'URL', $field),
+                            ''
+                        );
+                        if ($url !== '') {
+                            $inherit .= "<br>";
+                            $inherit .= '<a href="' . htmlescape($url) . '" target="_blank">' . htmlescape($url) . '</a>';
+                        }
                     }
                 }
                 return $inherit;

--- a/tests/functional/EntityTest.php
+++ b/tests/functional/EntityTest.php
@@ -1385,7 +1385,7 @@ class EntityTest extends DbTestCase
     {
         $this->login();
 
-        $old_entity = $this->createItem(
+        $this->createItem(
             'Entity',
             [
                 'name'        => 'Existing entity',
@@ -1548,12 +1548,10 @@ class EntityTest extends DbTestCase
 
         $this->login();
 
-        $fn_get_current_entities = static function () use ($DB) {
-            return iterator_to_array($DB->request([
-                'SELECT' => ['id', 'name', 'entities_id'],
-                'FROM' => 'glpi_entities',
-            ]));
-        };
+        $fn_get_current_entities = (static fn() => iterator_to_array($DB->request([
+            'SELECT' => ['id', 'name', 'entities_id'],
+            'FROM' => 'glpi_entities',
+        ])));
 
         $fn_find_entities_in_selector = static function ($selector, $entities, $parent_id = 0, &$found = []) use (&$fn_find_entities_in_selector) {
             foreach ($selector as $item) {
@@ -2251,5 +2249,93 @@ class EntityTest extends DbTestCase
 
         // Assert
         $this->assertEquals($expected_strategy, $actual_strategy);
+    }
+
+    /** @return iterable<string, array{inquest_config: int, inquest_rate: int, inquest_delay: int, inquest_URL: string|null, contains: array<string>, not_contains: array<string>}> */
+    public static function inquestConfigDisplayProvider(): iterable
+    {
+        yield 'CONFIG_PARENT shows inheritance label' => [
+            'inquest_config' => Entity::CONFIG_PARENT,
+            'inquest_rate'   => 0,
+            'inquest_delay'  => 0,
+            'inquest_URL'    => null,
+            'contains'       => ['Inheritance of the parent entity'],
+            'not_contains'   => [],
+        ];
+
+        yield 'internal survey, rate disabled' => [
+            'inquest_config' => \CommonITILSatisfaction::TYPE_INTERNAL,
+            'inquest_rate'   => 0,
+            'inquest_delay'  => 0,
+            'inquest_URL'    => null,
+            'contains'       => ['Disabled'],
+            'not_contains'   => ['-2'],
+        ];
+
+        yield 'internal survey, rate set' => [
+            'inquest_config' => \CommonITILSatisfaction::TYPE_INTERNAL,
+            'inquest_rate'   => 50,
+            'inquest_delay'  => 3,
+            'inquest_URL'    => null,
+            'contains'       => ['Internal survey', '3', '50%'],
+            'not_contains'   => ['-2'],
+        ];
+
+        yield 'external survey with URL' => [
+            'inquest_config' => \CommonITILSatisfaction::TYPE_EXTERNAL,
+            'inquest_rate'   => 100,
+            'inquest_delay'  => 1,
+            'inquest_URL'    => 'https://example.com/survey',
+            'contains'       => ['External survey', 'https://example.com/survey', '<a href='],
+            'not_contains'   => ['-2'],
+        ];
+
+        yield 'external survey without URL shows no -2' => [
+            'inquest_config' => \CommonITILSatisfaction::TYPE_EXTERNAL,
+            'inquest_rate'   => 100,
+            'inquest_delay'  => 1,
+            'inquest_URL'    => null,
+            'contains'       => ['External survey'],
+            'not_contains'   => ['-2', '<a href='],
+        ];
+    }
+
+    /**
+     * @param array<string> $contains
+     * @param array<string> $not_contains
+     */
+    #[DataProvider('inquestConfigDisplayProvider')]
+    public function testInquestConfigSpecificValueToDisplay(
+        int $inquest_config,
+        int $inquest_rate,
+        int $inquest_delay,
+        ?string $inquest_URL,
+        array $contains,
+        array $not_contains
+    ): void {
+        $this->login();
+
+        $entity = $this->createItem(Entity::class, [
+            'name'           => 'Test inquest display',
+            'entities_id'    => getItemByTypeName('Entity', '_test_root_entity', true),
+            'inquest_config' => $inquest_config,
+            'inquest_rate'   => $inquest_rate,
+            'inquest_delay'  => $inquest_delay,
+            'inquest_URL'    => $inquest_URL ?? '',
+        ]);
+
+        $result = Entity::getSpecificValueToDisplay(
+            'inquest_config',
+            ['inquest_config' => $inquest_config, 'id' => $entity->getID()],
+            ['html' => true]
+        );
+
+        foreach ($contains as $expected) {
+            $this->assertStringContainsString($expected, $result);
+        }
+
+        foreach ($not_contains as $unexpected) {
+            $this->assertStringNotContainsString($unexpected, $result);
+        }
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44356
- The satisfaction survey configuration columns in the entity list were displaying "-2 days / -2%" instead of the actual configured values. The external survey URL was also showing "-2" when not set, and was displayed as plain text instead of a clickable link.

## Screenshots (if appropriate):

Before (survey deactivate)

<img width="1588" height="433" alt="image" src="https://github.com/user-attachments/assets/f61db4bf-7666-4f0b-8f6e-a7c5fa6cedcb" />


After 

<img width="1588" height="433" alt="Capture d’écran du 2026-06-16 15-04-18" src="https://github.com/user-attachments/assets/a39febfe-76d7-46d2-b652-6d9160667920" />



