### PR TITLE
A11y : missing help links

### DIFF
--- a/src/Glpi/Application/View/Extension/ConfigExtension.php
+++ b/src/Glpi/Application/View/Extension/ConfigExtension.php
@@ -36,6 +36,7 @@
 namespace Glpi\Application\View\Extension;
 
 use Entity;
+use Html;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -49,7 +50,18 @@ class ConfigExtension extends AbstractExtension
         return [
             new TwigFunction('config', [$this, 'config']),
             new TwigFunction('entity_config', [$this, 'getEntityConfig']),
+            new TwigFunction('help_url', [$this, 'helpUrl']),
         ];
+    }
+
+    /**
+     * Get the help/documentation URL for the current interface.
+     *
+     * @return string
+     */
+    public function helpUrl(): string
+    {
+        return Html::getHelpURL();
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -1453,6 +1453,25 @@ TWIG,
     }
 
     /**
+     * Returns the help/documentation URL for the current interface.
+     *
+     * @return string
+     */
+    public static function getHelpURL(): string
+    {
+        global $CFG_GLPI;
+
+        $help_url_key = Session::getCurrentInterface() === 'central'
+            ? 'central_doc_url'
+            : 'helpdesk_doc_url';
+        $help_url = !empty($CFG_GLPI[$help_url_key])
+            ? $CFG_GLPI[$help_url_key]
+            : 'https://glpi-project.org/documentation';
+
+        return URL::sanitizeURL($help_url);
+    }
+
+    /**
      * Returns template variables that can be used for page header in any context.
      *
      * @return array
@@ -1485,20 +1504,13 @@ TWIG,
             // may remove this header for security reasons.
         }
 
-        $help_url_key = Session::getCurrentInterface() === 'central'
-            ? 'central_doc_url'
-            : 'helpdesk_doc_url';
-        $help_url = !empty($CFG_GLPI[$help_url_key])
-            ? $CFG_GLPI[$help_url_key]
-            : 'https://glpi-project.org/documentation';
-
         return [
             'is_debug_active'       => $_SESSION['glpi_use_mode'] == Session::DEBUG_MODE,
             'is_impersonate_active' => Session::isImpersonateActive(),
             'found_new_version'   => $found_new_version,
             'user'                  => $user instanceof User ? $user : null,
             'platform'              => $platform,
-            'help_url'              => URL::sanitizeURL($help_url),
+            'help_url'              => self::getHelpURL(),
         ];
     }
 

--- a/templates/layout/page_card_notlogged.html.twig
+++ b/templates/layout/page_card_notlogged.html.twig
@@ -94,6 +94,13 @@
             <div class="text-center text-muted mt-3">
                {% block footer_block %}{% endblock %}
             </div>
+
+            <div class="text-center mt-3">
+               <a href="{{ help_url() }}">
+                  <i class="ti ti-help" aria-hidden="true"></i>
+                  {{ __('Help') }}
+               </a>
+            </div>
          </div>
       </div>
    </div>

--- a/tests/e2e/specs/Layout/anonymous_help_link.spec.ts
+++ b/tests/e2e/specs/Layout/anonymous_help_link.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect } from '@playwright/test';
+import { authenticator } from 'otplib';
+import { test } from '../../fixtures/glpi_fixture';
+import { LoginPage } from '../../pages/LoginPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerLogin } from '../../utils/WorkerEntities';
+
+// Seeded OAuth client (see tests/e2e/specs/Security/oauth_authcode.spec.ts).
+const OAUTH_CLIENT_ID    = 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+const OAUTH_SCOPE        = 'api user';
+const OAUTH_REDIRECT_URI = '/api.php/oauth2/redirection';
+
+// RAWeb criterion 16: the help link must be available from every page, including
+// the anonymous pages that share the page_card_notlogged layout. The login and
+// lost-password pages are trivial to reach; this spec covers the
+// hard-to-reproduce ones (OAuth consent and the 2FA prompts) where a silent
+// layout regression would otherwise go unnoticed.
+test.describe('Anonymous help link', () => {
+    test('is available on the OAuth authorization page', async ({ anonymousPage }) => {
+        await anonymousPage.setExtraHTTPHeaders({ 'Accept-Language': 'en-GB,en;q=0.9' });
+
+        const oauth_page = new LoginPage(anonymousPage);
+        await oauth_page.gotoOauthAuthorize(OAUTH_CLIENT_ID, OAUTH_SCOPE, OAUTH_REDIRECT_URI);
+
+        const worker_login = getWorkerLogin();
+        await oauth_page.doLogin(worker_login, worker_login);
+
+        await expect(oauth_page.oauth_authorization_heading).toBeVisible();
+        await expect(anonymousPage.getByRole('link', { name: 'Help' })).toBeVisible();
+    });
+
+    test('is available on the 2FA setup and prompt pages', async ({ anonymousPage, api }) => {
+        // Heavy fixture setup (user + enforced-2FA group) plus two full login flows.
+        test.slow();
+        await anonymousPage.setExtraHTTPHeaders({ 'Accept-Language': 'en-GB,en;q=0.9' });
+
+        const username = `e2e_tests_help_2fa${Date.now()}`;
+        const user_id = await api.createItem('User', {
+            name: username,
+            login: username,
+            password: 'glpi',
+            password2: 'glpi',
+            _profiles_id: Profiles.SuperAdmin,
+        });
+        const group_id = await api.createItem('Group', {
+            name: `e2e_tests_help_group_2fa${Date.now()}`,
+            entities_id: 0,
+            '2fa_enforced': 1,
+        });
+        await api.createItem('Group_User', {
+            groups_id: group_id,
+            users_id: user_id,
+        });
+
+        const login_page = new LoginPage(anonymousPage);
+        await login_page.goto();
+        await login_page.doLogin(username, 'glpi');
+
+        // Enforced 2FA setup page.
+        await expect(anonymousPage).toHaveURL(/\/MFA\/Setup/);
+        await expect(anonymousPage.getByRole('link', { name: 'Help' })).toBeVisible();
+
+        // Complete the setup so 2FA is required on the next login.
+        const secret = await anonymousPage.getByRole('textbox', { name: '2FA secret' }).inputValue();
+        await login_page.doFillTotpCode(authenticator.generate(secret));
+        await expect(anonymousPage).toHaveURL(/\/MFA\/ShowBackupCodes/);
+        await anonymousPage.getByRole('button', { name: 'Continue' }).click();
+
+        await login_page.doLogout();
+
+        // 2FA code prompt shown on the next login.
+        await login_page.goto();
+        await login_page.doLogin(username, 'glpi');
+        await expect(anonymousPage).toHaveURL(/\/MFA\/Prompt/);
+        await expect(anonymousPage.getByRole('link', { name: 'Help' })).toBeVisible();
+    });
+});


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/307
- Here is a brief description of what this PR does : 

RAWeb criterion 16 : the support/help link must be reachable from every page.
It was only present in the authenticated user menu, missing from all anonymous pages (login, lost password, 2FA, OAuth consent, maintenance, install…).

- Extract the interface-aware help URL logic into `Html::getHelpURL()` (single source, sanitized) ; `getPageHeaderTplVars()` now consumes it.
- New `help_url()` Twig function delegating to it.
- Render the help link in the shared `page_card_notlogged` layout : covers the 9 anonymous pages at once.

Same tab (parity with the user menu), decorative icon `aria-hidden`, "Help" as accessible name.

E2e coverage for the hard-to-reproduce pages (OAuth consent + 2FA setup/prompt).

## Screenshots : 

<img width="521" height="476" alt="image" src="https://github.com/user-attachments/assets/a9188e91-90e7-41e4-9327-0ae62391732b" />

