### PR TITLE
Fix - Multiple dropdown conditions not evaluated when option count exceeds 50

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -117,41 +117,7 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implemen
     #[Override]
     protected function getFormInlineScript(): string
     {
-        // language=Twig
-        $js = <<<TWIG
-            import("/js/modules/Forms/QuestionDropdown.js").then((m) => {
-                {% if question is not null %}
-                    const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
-                    container.data(
-                        'manager',
-                        new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)
-                    );
-                {% else %}
-                    $(document).on('glpi-form-editor-question-type-changed', function(e, question, type) {
-                        if (type === '{{ question_type|escape('js') }}') {
-                            const container = question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            container.data(
-                                'manager',
-                                new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container, true)
-                            );
-                        }
-                    });
-
-                    $(document).on('glpi-form-editor-question-duplicated', function(e, question, new_question) {
-                        const question_type = question.find('input[data-glpi-form-editor-original-name="type"]').val();
-                        if (question_type === '{{ question_type|escape('js') }}') {
-                            const container = new_question.find('div[data-glpi-form-editor-selectable-question-options]');
-                            container.data(
-                                'manager',
-                                new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container, true)
-                            );
-                        }
-                    });
-                {% endif %}
-            });
-TWIG;
-
-        return $js;
+        return "{% include 'pages/admin/form/question_type/dropdown/form_inline_script.html.twig' %}";
     }
 
     #[Override]
@@ -163,48 +129,8 @@ TWIG;
     #[Override]
     public function renderAdministrationTemplate(?Question $question): string
     {
-        $template = <<<TWIG
-        {% import 'components/form/fields_macros.html.twig' as fields %}
-
-        <div data-glpi-form-editor-preview-dropdown>
-            {{ fields.dropdownArrayField(
-                'default_value',
-                checked_values|first,
-                values,
-                '',
-                {
-                    'init': init,
-                    'no_label': true,
-                    'multiple': false,
-                    'disabled': is_multiple_dropdown,
-                    'display_emptychoice': true,
-                    'field_class': 'single-preview-dropdown col-12' ~ (is_multiple_dropdown ? ' d-none' : ''),
-                    'mb': '',
-                    'aria_label': default_option_label
-                }
-            ) }}
-            {{ fields.dropdownArrayField(
-                'default_value',
-                '',
-                values,
-                '',
-                {
-                    'init': init,
-                    'no_label': true,
-                    'multiple': true,
-                    'disabled': not is_multiple_dropdown,
-                    'values': checked_values,
-                    'field_class': 'multiple-preview-dropdown col-12' ~ (not is_multiple_dropdown ? ' d-none' : ''),
-                    'mb': '',
-                    'aria_label': default_options_label
-                }
-            ) }}
-        </div>
-TWIG;
-
         $parent = parent::renderAdministrationTemplate($question);
 
-        $twig = TemplateRenderer::getInstance();
         $values = array_combine(
             array_map(fn($option) => $option['uuid'], $this->getValues($question)),
             array_map(fn($option) => $option['value'], $this->getValues($question))
@@ -213,66 +139,37 @@ TWIG;
             fn($option) => $option['uuid'],
             array_filter($this->getValues($question), fn($option) => $option['checked'])
         );
-        return $twig->renderFromStringTemplate($template, [
-            'question'              => $question,
-            'init'                  => $question != null,
-            'values'                => $values,
-            'checked_values'        => $checked_values,
-            'is_multiple_dropdown'  => $this->isMultipleDropdown($question),
-            'default_option_label'  => __('Default option'),
-            'default_options_label' => __('Default options'),
-        ]) . $parent;
+
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/form/question_type/dropdown/administration_template.html.twig',
+            [
+                'question'              => $question,
+                'init'                  => $question != null,
+                'values'                => $values,
+                'checked_values'        => $checked_values,
+                'is_multiple_dropdown'  => $this->isMultipleDropdown($question),
+                'default_option_label'  => __('Default option'),
+                'default_options_label' => __('Default options'),
+            ]
+        ) . $parent;
     }
 
     #[Override]
     public function renderAdministrationOptionsTemplate(?Question $question): string
     {
-        $template = <<<TWIG
-            {% set rand = random() %}
-
-            <div class="d-flex gap-2">
-                <label class="form-check form-switch mb-0">
-                    <input type="hidden" name="is_multiple_dropdown" value="0"
-                    data-glpi-form-editor-specific-question-extra-data>
-                    <input class="form-check-input" type="checkbox" name="is_multiple_dropdown"
-                        value="1" {{ is_multiple_dropdown ? 'checked' : '' }}
-                        data-glpi-form-editor-specific-question-extra-data>
-                    <span class="form-check-label">{{ is_multiple_dropdown_label }}</span>
-                </label>
-            </div>
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
-        return $twig->renderFromStringTemplate($template, [
-            'is_multiple_dropdown'       => $this->isMultipleDropdown($question),
-            'is_multiple_dropdown_label' => __('Allow multiple options'),
-        ]);
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/form/question_type/dropdown/administration_options.html.twig',
+            [
+                'is_multiple_dropdown'       => $this->isMultipleDropdown($question),
+                'is_multiple_dropdown_label' => __('Allow multiple options'),
+            ]
+        );
     }
 
     #[Override]
     public function renderEndUserTemplate(
         Question $question,
     ): string {
-        $template = <<<TWIG
-            {% import 'components/form/fields_macros.html.twig' as fields %}
-
-            {{ fields.dropdownArrayField(
-                question.getEndUserInputName(),
-                not is_multiple ? checked_values|first : '',
-                values,
-                '',
-                {
-                    'no_label'           : true,
-                    'values'             : checked_values,
-                    'multiple'           : is_multiple,
-                    'mb'                 : '',
-                    'aria_label'         : label,
-                    'display_emptychoice': checked_values|length == 0,
-                }
-            ) }}
-TWIG;
-
-        $twig = TemplateRenderer::getInstance();
         $checked_values = array_map(
             fn($option) => $option['uuid'],
             array_filter($this->getValues($question), fn($option) => $option['checked'])
@@ -289,13 +186,16 @@ TWIG;
             $translated_options[$uuid] = FormTranslation::translate($question, $key) ?? $option;
         }
 
-        return $twig->renderFromStringTemplate($template, [
-            'question'       => $question,
-            'label'          => $question->fields['name'],
-            'values'         => $translated_options,
-            'checked_values' => $checked_values,
-            'is_multiple'    => $this->isMultipleDropdown($question),
-        ]);
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/form/question_type/dropdown/end_user_template.html.twig',
+            [
+                'question'       => $question,
+                'label'          => $question->fields['name'],
+                'values'         => $translated_options,
+                'checked_values' => $checked_values,
+                'is_multiple'    => $this->isMultipleDropdown($question),
+            ]
+        );
     }
 
     /**
@@ -311,53 +211,6 @@ TWIG;
     ): string {
         global $CFG_GLPI;
 
-        $template = <<<TWIG
-            {% set rand = random() %}
-
-            <div class="col-12 mb-0">
-                <select
-                    id="dropdown_{{ rand }}"
-                    name="{{ input_name }}"
-                    class="form-select select2"
-                    aria-label="{{ label }}"
-                    {{ is_multiple ? 'multiple' : '' }}
-                >
-                    {% for uuid, text in initial_values %}
-                        <option value="{{ uuid }}" selected>{{ text }}</option>
-                    {% endfor %}
-                </select>
-            </div>
-
-            <script>
-            (function() {
-                var el = $('#dropdown_{{ rand }}');
-                el.select2({
-                    ajax: {
-                        url:      '{{ ajax_url|e('js') }}',
-                        type:     'POST',
-                        dataType: 'json',
-                        delay:    250,
-                        data: function(params) {
-                            return {
-                                searchText:  params.term || '',
-                                page:        params.page || 1,
-                                page_limit:  50,
-                                question_id: '{{ question_id|e('js') }}',
-                            };
-                        },
-                        processResults: function(data) {
-                            return { results: data.results, pagination: data.pagination };
-                        },
-                    },
-                    allowClear:  true,
-                    placeholder: '',
-                    width:       '100%',
-                    multiple:    {{ is_multiple ? 'true' : 'false' }},
-                });
-            })();
-            </script>
-TWIG;
-
         $initial_values = [];
         foreach ($checked_values as $uuid) {
             if (isset($options[$uuid])) {
@@ -366,14 +219,17 @@ TWIG;
             }
         }
 
-        return TemplateRenderer::getInstance()->renderFromStringTemplate($template, [
-            'label'          => $question->fields['name'],
-            'input_name'     => $question->getEndUserInputName(),
-            'question_id'    => $question->fields['id'],
-            'ajax_url'       => $CFG_GLPI['root_doc'] . '/Form/Question/DropdownValues',
-            'initial_values' => $initial_values,
-            'is_multiple'    => $this->isMultipleDropdown($question),
-        ]);
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/form/question_type/dropdown/end_user_template_ajax.html.twig',
+            [
+                'label'          => $question->fields['name'],
+                'input_name'     => $question->getEndUserInputName(),
+                'question_id'    => $question->fields['id'],
+                'ajax_url'       => $CFG_GLPI['root_doc'] . '/Form/Question/DropdownValues',
+                'initial_values' => $initial_values,
+                'is_multiple'    => $this->isMultipleDropdown($question),
+            ]
+        );
     }
 
     #[Override]

--- a/templates/pages/admin/form/question_type/dropdown/administration_options.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/administration_options.html.twig
@@ -1,0 +1,42 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<div class="d-flex gap-2">
+    <label class="form-check form-switch mb-0">
+        <input type="hidden" name="is_multiple_dropdown" value="0"
+            data-glpi-form-editor-specific-question-extra-data>
+        <input class="form-check-input" type="checkbox" name="is_multiple_dropdown"
+            value="1" {{ is_multiple_dropdown ? 'checked' : '' }}
+            data-glpi-form-editor-specific-question-extra-data>
+        <span class="form-check-label">{{ is_multiple_dropdown_label }}</span>
+    </label>
+</div>

--- a/templates/pages/admin/form/question_type/dropdown/administration_template.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/administration_template.html.twig
@@ -1,0 +1,68 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div data-glpi-form-editor-preview-dropdown>
+    {{ fields.dropdownArrayField(
+        'default_value',
+        checked_values|first,
+        values,
+        '',
+        {
+            'init': init,
+            'no_label': true,
+            'multiple': false,
+            'disabled': is_multiple_dropdown,
+            'display_emptychoice': true,
+            'field_class': 'single-preview-dropdown col-12' ~ (is_multiple_dropdown ? ' d-none' : ''),
+            'mb': '',
+            'aria_label': default_option_label
+        }
+    ) }}
+    {{ fields.dropdownArrayField(
+        'default_value',
+        '',
+        values,
+        '',
+        {
+            'init': init,
+            'no_label': true,
+            'multiple': true,
+            'disabled': not is_multiple_dropdown,
+            'values': checked_values,
+            'field_class': 'multiple-preview-dropdown col-12' ~ (not is_multiple_dropdown ? ' d-none' : ''),
+            'mb': '',
+            'aria_label': default_options_label
+        }
+    ) }}
+</div>

--- a/templates/pages/admin/form/question_type/dropdown/end_user_template.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/end_user_template.html.twig
@@ -1,0 +1,48 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{{ fields.dropdownArrayField(
+    question.getEndUserInputName(),
+    not is_multiple ? checked_values|first : '',
+    values,
+    '',
+    {
+        'no_label'           : true,
+        'values'             : checked_values,
+        'multiple'           : is_multiple,
+        'mb'                 : '',
+        'aria_label'         : label,
+        'display_emptychoice': checked_values|length == 0,
+    }
+) }}

--- a/templates/pages/admin/form/question_type/dropdown/end_user_template_ajax.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/end_user_template_ajax.html.twig
@@ -35,7 +35,7 @@
 <div class="col-12 mb-0">
     <select
         id="dropdown_{{ rand }}"
-        name="{{ input_name }}{% if is_multiple %}[]{% endif %}"
+        name="{{ input_name }}{{ is_multiple ? '[]' : '' }}"
         class="form-select select2"
         aria-label="{{ label }}"
         {{ is_multiple ? 'multiple' : '' }}

--- a/templates/pages/admin/form/question_type/dropdown/end_user_template_ajax.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/end_user_template_ajax.html.twig
@@ -1,0 +1,76 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% set rand = random() %}
+
+<div class="col-12 mb-0">
+    <select
+        id="dropdown_{{ rand }}"
+        name="{{ input_name }}{% if is_multiple %}[]{% endif %}"
+        class="form-select select2"
+        aria-label="{{ label }}"
+        {{ is_multiple ? 'multiple' : '' }}
+    >
+        {% for uuid, text in initial_values %}
+            <option value="{{ uuid }}" selected>{{ text }}</option>
+        {% endfor %}
+    </select>
+</div>
+
+<script>
+(function() {
+    var el = $('#dropdown_{{ rand }}');
+    el.select2({
+        ajax: {
+            url:      '{{ ajax_url|e('js') }}',
+            type:     'POST',
+            dataType: 'json',
+            delay:    250,
+            data: function(params) {
+                return {
+                    searchText:  params.term || '',
+                    page:        params.page || 1,
+                    page_limit:  50,
+                    question_id: '{{ question_id|e('js') }}',
+                };
+            },
+            processResults: function(data) {
+                return { results: data.results, pagination: data.pagination };
+            },
+        },
+        allowClear:  true,
+        placeholder: '',
+        width:       '100%',
+        multiple:    {{ is_multiple ? 'true' : 'false' }},
+    });
+})();
+</script>

--- a/templates/pages/admin/form/question_type/dropdown/form_inline_script.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/form_inline_script.html.twig
@@ -1,0 +1,62 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+import("/js/modules/Forms/QuestionDropdown.js").then((m) => {
+    {% if question is not null %}
+        const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
+        container.data(
+            'manager',
+            new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)
+        );
+    {% else %}
+        $(document).on('glpi-form-editor-question-type-changed', function(e, question, type) {
+            if (type === '{{ question_type|escape('js') }}') {
+                const container = question.find('div[data-glpi-form-editor-selectable-question-options]');
+                container.data(
+                    'manager',
+                    new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container, true)
+                );
+            }
+        });
+
+        $(document).on('glpi-form-editor-question-duplicated', function(e, question, new_question) {
+            const question_type = question.find('input[data-glpi-form-editor-original-name="type"]').val();
+            if (question_type === '{{ question_type|escape('js') }}') {
+                const container = new_question.find('div[data-glpi-form-editor-selectable-question-options]');
+                container.data(
+                    'manager',
+                    new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container, true)
+                );
+            }
+        });
+    {% endif %}
+});

--- a/templates/pages/admin/form/question_type/dropdown/form_inline_script.html.twig
+++ b/templates/pages/admin/form/question_type/dropdown/form_inline_script.html.twig
@@ -32,7 +32,7 @@
 
 import("/js/modules/Forms/QuestionDropdown.js").then((m) => {
     {% if question is not null %}
-        const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand }}"]');
+        const container = $('div[data-glpi-form-editor-selectable-question-options="{{ rand|e('css')|e('js') }}"]');
         container.data(
             'manager',
             new m.GlpiFormQuestionTypeDropdown('{{ input_type|escape('js') }}', container)

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
@@ -112,7 +112,7 @@ final class QuestionTypeDropdownTest extends DbTestCase
             $html,
             'Multiple dropdown with >50 options must use array name (answers_X[]) so all selected values are submitted and the condition engine receives an array'
         );
-        $this->assertStringContainsString('multiple', $html);
+        $this->assertMatchesRegularExpression('/<select[^>]+\bmultiple\b/', $html);
         $this->assertStringContainsString('DropdownValues', $html, 'Should use the AJAX template');
     }
 

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeDropdown;
 use Glpi\Form\QuestionType\QuestionTypeDropdownExtraDataConfig;
 use Glpi\Tests\DbTestCase;
@@ -94,5 +95,78 @@ final class QuestionTypeDropdownTest extends DbTestCase
             "1) Your favorite colors: Red, Yellow",
             strip_tags($ticket->fields['content']),
         );
+    }
+
+    public function testMultipleDropdownWithMoreThan50OptionsRendersSelectWithArrayName(): void
+    {
+        $question = $this->createDropdownQuestion(
+            option_count: 51,
+            is_multiple: true,
+        );
+
+        $html = (new QuestionTypeDropdown())->renderEndUserTemplate($question);
+
+        $input_name = $question->getEndUserInputName();
+        $this->assertStringContainsString(
+            sprintf('name="%s[]"', $input_name),
+            $html,
+            'Multiple dropdown with >50 options must use array name (answers_X[]) so all selected values are submitted and the condition engine receives an array'
+        );
+        $this->assertStringContainsString('multiple', $html);
+        $this->assertStringContainsString('DropdownValues', $html, 'Should use the AJAX template');
+    }
+
+    public function testSingleDropdownWithMoreThan50OptionsRendersSelectWithoutArrayName(): void
+    {
+        $question = $this->createDropdownQuestion(
+            option_count: 51,
+            is_multiple: false,
+        );
+
+        $html = (new QuestionTypeDropdown())->renderEndUserTemplate($question);
+
+        $input_name = $question->getEndUserInputName();
+        $this->assertStringContainsString(
+            sprintf('name="%s"', $input_name),
+            $html,
+        );
+        $this->assertStringNotContainsString(
+            sprintf('name="%s[]"', $input_name),
+            $html,
+        );
+        $this->assertStringContainsString('DropdownValues', $html, 'Should use the AJAX template');
+    }
+
+    public function testDropdownWithAtMost50OptionsRendersStandardTemplate(): void
+    {
+        $question = $this->createDropdownQuestion(
+            option_count: 50,
+            is_multiple: true,
+        );
+
+        $html = (new QuestionTypeDropdown())->renderEndUserTemplate($question);
+
+        $this->assertStringNotContainsString('DropdownValues', $html, 'Should use the standard template, not AJAX');
+    }
+
+    private function createDropdownQuestion(int $option_count, bool $is_multiple): Question
+    {
+        $options = [];
+        for ($i = 1; $i <= $option_count; $i++) {
+            $options["option_$i"] = "Option $i";
+        }
+
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Pick options",
+            type: QuestionTypeDropdown::class,
+            extra_data: json_encode(new QuestionTypeDropdownExtraDataConfig(
+                options: $options,
+                is_multiple_dropdown: $is_multiple,
+            ))
+        );
+        $form = $this->createForm($builder);
+
+        return Question::getById($this->getQuestionId($form, "Pick options"));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44745
- Here is a brief description of what this PR does

### Problem

When a multiple-select dropdown question has more than 50 options, the conditions depending on its answer were never evaluated. The root cause is in the AJAX rendering path (triggered when `count > 50`): the `<select>` element was rendered with `name="answers_X"` instead of `name="answers_X[]"`. Without the array suffix, PHP only retains the last submitted value, so the condition engine always received a scalar instead of an array.

This bug was introduced in #23970.

### Fix

Add `{% if is_multiple %}[]{% endif %}` to the `name` attribute in the AJAX template (`end_user_template_ajax.html.twig`).

### Refactor

All inline Twig templates (PHP heredocs) in `QuestionTypeDropdown` have been extracted to dedicated `.html.twig` files under `templates/pages/admin/form/question_type/dropdown/`. No behavior change, cleaner separation of concerns.

### Tests

Three test cases added to `QuestionTypeDropdownTest`:

- multiple dropdown >50 options renders `name="answers_X[]"` (regression)
- single dropdown >50 options renders `name="answers_X"` (no array suffix)
- dropdown ≤50 options uses the standard template (not AJAX)