### PR TITLE
[HLAPI] Use 201 status for created responses

### DIFF
--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -226,7 +226,7 @@ abstract class AbstractController
             return self::getCRUDErrorResponse(self::CRUD_ACTION_CREATE);
         }
 
-        return self::getItemLinkResponse($new_id, $api_path);
+        return self::getItemLinkResponse($new_id, $api_path, 201);
     }
 
     /**

--- a/tests/src/HLAPITestCase.php
+++ b/tests/src/HLAPITestCase.php
@@ -394,7 +394,9 @@ final class HLAPIHelper
         $this->call($request, function ($call) use ($extra_options, &$new_item_location, $endpoint) {
             /** @var HLAPICallAsserter $call */
             $call->response
-                ->isOK()
+                ->status(function ($status) use ($endpoint) {
+                    $this->test->assertEquals(201, $status, 'The POST route path of endpoint "' . $endpoint . '" does not return a 201 status code');
+                })
                 ->jsonContent(function ($content) use ($extra_options, $endpoint) {
                     $this->test->assertArrayHasKey('id', $content, 'The response for the POST route path of endpoint "' . $endpoint . '" does not have an "id" field');
                     $this->test->assertGreaterThan(0, $content['id'], 'The response for the POST route path of endpoint "' . $endpoint . '" has an "id" field that is not valid');


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

Responses for created resources were mistakenly using the default 200 status code instead of 201.
