### PR TITLE
fix approval template form accessed before initialization error

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -1808,12 +1808,20 @@ HTML;
     {
         global $CFG_GLPI;
 
+        $default_right = 'validate';
+        if (static::class === self::class) {
+            // Impossible to know the itemtype the validation is for (probably from the approval template form)
+            $default_right = ['validate_request', 'validate_incident', 'validate'];
+        } elseif (static::$itemtype == Ticket::class) {
+            $default_right = ['validate_request', 'validate_incident'];
+        }
+
         $params = [
             'prefix'             => null,
             'id'                 => 0,
             'parents_id'         => null,
             'entity'             => $_SESSION['glpiactive_entity'],
-            'right'              => static::$itemtype == Ticket::class ? ['validate_request', 'validate_incident'] : 'validate',
+            'right'              => $default_right,
             'groups_id'          => 0,
             'itemtype_target'    => '',
             'items_id_target'    => 0,


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #24402

It looks like the original work in the PR that added approval templates had added a field to restrict the types the approval template could be used with (Ticket or Change), but that was removed before merge. At this point, it is impossible to know what users can be approvers in the template since Tickets and Changes use separate rights and even with Tickets, the right changes depending on if it is a request or incident. The only thing we can do is show users with any of the validation rights.