### PR TITLE
reuse finfo instance for mime check in Toolbox::getFileAsResponse

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -15224,12 +15224,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/MailCollector.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$subject of function Safe\\\\preg_match expects string, bool\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/MailCollector.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#4 \\$subject of method MailCollector\\:\\:getRecursiveAttached\\(\\) expects string, string\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -19967,12 +19961,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$string of function stripslashes expects string, array\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Toolbox.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$string of function strtolower expects string, string\\|false\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Toolbox.php',
 ];
 $ignoreErrors[] = [

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -607,16 +607,18 @@ class Toolbox
         }
 
         $can_be_inlined = false;
-        if (
-            str_starts_with(strtolower($mime), 'image/')
-            && strtolower($mime) !== 'image/svg+xml'
-        ) {
-            // images files can be inlined
-            // except for svg (vector of attack, see https://github.com/glpi-project/glpi/issues/3873)
-            $can_be_inlined = true;
-        } elseif (strtolower($mime) === 'application/pdf') {
-            // PDF files can be inlined
-            $can_be_inlined = true;
+        if ($mime !== null) {
+            if (
+                str_starts_with(strtolower($mime), 'image/')
+                && strtolower($mime) !== 'image/svg+xml'
+            ) {
+                // images files can be inlined
+                // except for svg (vector of attack, see https://github.com/glpi-project/glpi/issues/3873)
+                $can_be_inlined = true;
+            } elseif (strtolower($mime) === 'application/pdf') {
+                // PDF files can be inlined
+                $can_be_inlined = true;
+            }
         }
         $attachment = $can_be_inlined === false ? ' attachment;' : '';
 
@@ -2421,10 +2423,10 @@ class Toolbox
      * @since 0.85.5
      *
      * @param string         $file  path of the file
-     * @param bool|string $type  check if $file is the correct type (only matches with the first part of the mime like "image" for "image/png)
+     * @param false|string $type  check if $file is the correct type (only matches with the first part of the mime like "image" for "image/png)
      *
      * @return bool|string (if $type not given) else boolean
-     *
+     * @phpstan-return ($type is false ? string : bool)
      **/
     public static function getMime($file, $type = false)
     {

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -603,9 +603,7 @@ class Toolbox
 
         // if $mime is defined, ignore mime type by extension
         if ($mime === null && preg_match('/\.(...)$/', $path)) {
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $mime = finfo_file($finfo, $path);
-            unset($finfo);
+            $mime = self::getMime($path);
         }
 
         $can_be_inlined = false;
@@ -2423,7 +2421,7 @@ class Toolbox
      * @since 0.85.5
      *
      * @param string         $file  path of the file
-     * @param bool|string $type  check if $file is the correct type
+     * @param bool|string $type  check if $file is the correct type (only matches with the first part of the mime like "image" for "image/png)
      *
      * @return bool|string (if $type not given) else boolean
      *

--- a/src/Toolbox.php
+++ b/src/Toolbox.php
@@ -81,7 +81,6 @@ use function Safe\curl_init;
 use function Safe\error_log;
 use function Safe\fclose;
 use function Safe\filemtime;
-use function Safe\finfo_open;
 use function Safe\fopen;
 use function Safe\fread;
 use function Safe\fwrite;


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Not a fix and has no performance implications. *May* improve maintainability.

Reuses `Toolbox::getMime` function for checking the mime inside `Toolbox::getFileAsResponse`.
I also clarified the `$type` parameter of `Toolbox::getMime` as it only matches against the first part of a mime which may not be expected by developers.
Some PHPStan error fixes.

closes #24395


