### PR TITLE
Cache profile rights by language

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1171,7 +1171,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                 ];
                 $GLPI_CACHE->set($cache_key, $all_rights);
             }
-            $all_rights = $all_rights ?? $GLPI_CACHE->get($cache_key);
+            $all_rights ??= $GLPI_CACHE->get($cache_key);
 
             // Add rights for custom assets
             $definitions = AssetDefinitionManager::getInstance()->getDefinitions(only_active: true);

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -832,6 +832,8 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
     {
         global $GLPI_CACHE;
 
+        $cache_key = 'profile_rights_core_' . (Session::getLanguage() ?? '');
+
         /**
          * Helper function to streamline rights definition
          * @param class-string<CommonDBTM>|null $itemtype
@@ -861,7 +863,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             $dropdown_rights = (new Profile())->getRights();
             unset($dropdown_rights[DELETE], $dropdown_rights[UNLOCK]);
 
-            if (!$GLPI_CACHE->has('profile_rights_core')) {
+            if (!$GLPI_CACHE->has($cache_key)) {
                 $all_rights = [
                     'central' => [
                         'tracking' => [
@@ -1167,9 +1169,9 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                         ],
                     ],
                 ];
-                $GLPI_CACHE->set('profile_rights_core', $all_rights);
+                $GLPI_CACHE->set($cache_key, $all_rights);
             }
-            $all_rights = $GLPI_CACHE->get('profile_rights_core');
+            $all_rights = $all_rights ?? $GLPI_CACHE->get($cache_key);
 
             // Add rights for custom assets
             $definitions = AssetDefinitionManager::getInstance()->getDefinitions(only_active: true);


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #24363

Profile rights were cached in 11.0.7 because they took over 100ms to compute and this was being done for every GraphQL request or any other time the full API schema was needed. By caching, it reduced the time spent to under 10ms for this part. Unfortunately, I didn't take into account the fact the labels were part of this data. This PR fixes the issue by considering the language in the cache key.