### PR TITLE
A11Y : group preference form fields

### DIFF
--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -175,7 +175,7 @@ class UserEmail extends CommonDBChild
     #[Override()]
     public static function getJSCodeToAddForItemChild($field_name, $child_count_js_var)
     {
-        $html = "<div class='d-flex'>"
+        $html = "<div class='d-flex' role='group' aria-label='" . __s('Email') . "'>"
             . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . __s('Set as default email') . "'>"
             . "&nbsp;"
             . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . __s('Email address') . "'>"
@@ -206,7 +206,7 @@ class UserEmail extends CommonDBChild
         }
         $result = "";
         $field_name = htmlescape($field_name . "[$id]");
-        $result .= "<div class='d-flex align-items-center'>";
+        $result .= "<div class='d-flex align-items-center' role='group' aria-label='" . __s('Email') . "'>";
         $result .= "<input title='" . __s('Default email') . "' type='radio' name='_default_email'
              value='" . htmlescape($this->getID()) . "'";
         if (!$canedit) {

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -178,7 +178,7 @@ class UserEmail extends CommonDBChild
         $html = "<div class='d-flex' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>"
             . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . __s('Set as default email') . "'>"
             . "&nbsp;"
-            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . _sn('Email address', 'Email addresses', 1) . "'>"
+            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . __s('Email address') . "'>"
             . "</div>";
 
         return str_replace(
@@ -220,7 +220,7 @@ class UserEmail extends CommonDBChild
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));
         } else {
-            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . _sn('Email address', 'Email addresses', 1) . "'>";
+            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . __s('Email address') . "'>";
         }
         $result .= "</div>";
 

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -175,10 +175,10 @@ class UserEmail extends CommonDBChild
     #[Override()]
     public static function getJSCodeToAddForItemChild($field_name, $child_count_js_var)
     {
-        $html = "<div class='d-flex' role='group' aria-label='" . __s('Email') . "'>"
+        $html = "<div class='d-flex' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>"
             . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . __s('Set as default email') . "'>"
             . "&nbsp;"
-            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . __s('Email address') . "'>"
+            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . _sn('Email address', 'Email addresses', 1) . "'>"
             . "</div>";
 
         return str_replace(
@@ -206,7 +206,7 @@ class UserEmail extends CommonDBChild
         }
         $result = "";
         $field_name = htmlescape($field_name . "[$id]");
-        $result .= "<div class='d-flex align-items-center' role='group' aria-label='" . __s('Email') . "'>";
+        $result .= "<div class='d-flex align-items-center' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>";
         $result .= "<input title='" . __s('Default email') . "' type='radio' name='_default_email'
              value='" . htmlescape($this->getID()) . "'";
         if (!$canedit) {
@@ -220,7 +220,7 @@ class UserEmail extends CommonDBChild
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));
         } else {
-            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . __s('Email address') . "'>";
+            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . _sn('Email address', 'Email addresses', 1) . "'>";
         }
         $result .= "</div>";
 

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -247,7 +247,8 @@
                                 {% endif %}
                             {% endif %}
 
-                            {{ fields.smallTitle(__('Contact information')) }}
+                            <div role="group" aria-labelledby="pref_section_contact">
+                            {{ fields.smallTitle(__('Contact information'), '', '', 'pref_section_contact') }}
                             {% set emails_field %}
                                 {{ call('UserEmail::showForUser', [item]) }}
                                 {{ call('UserEmail::showAddEmailButton', [item]) }}
@@ -258,9 +259,11 @@
                             {% if not simple_form %}
                                 {{ fields.textField('phone2', item.fields['phone2'], __('Phone 2')) }}
                             {% endif %}
+                            </div>
 
                             {% if not item.isNewItem() and ((caneditpassword ?? false) or is_preference_form) %}
-                                {{ fields.smallTitle(__('Passwords and access keys')) }}
+                                <div role="group" aria-labelledby="pref_section_passwords">
+                                {{ fields.smallTitle(__('Passwords and access keys'), '', '', 'pref_section_passwords') }}
                                 {{ fields.passwordField('api_token', item.fields['api_token']|decrypt, __('API token'), {
                                     can_regenerate: true,
                                     is_disclosable: true,
@@ -311,11 +314,14 @@
                                     {% endset %}
                                     {{ fields.htmlField('_change_pw', change_pw_field, __('Password')) }}
                                 {% endif %}
+                                </div>
                             {% endif %}
                             {% if item.isNewItem() %}
-                                {{ fields.smallTitle(__('Passwords and access keys')) }}
+                                <div role="group" aria-labelledby="pref_section_passwords">
+                                {{ fields.smallTitle(__('Passwords and access keys'), '', '', 'pref_section_passwords') }}
                                 <div>
                                     {{ include('pages/admin/user/change_other_password.html.twig') }}
+                                </div>
                                 </div>
                             {% endif %}
                         </div>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/321
- Here is a brief description of what this PR does : 

[RGAA criterion 11.5](https://rgaa-checker.com/guide/11.5) : fields of the same nature must be grouped. On the references form, the "Contact information" and "Passwords and access keys" sections and each email row (field + "default" radio) were not grouped.

- Wrap both sections in `role="group"` + `aria-labelledby` (reusing the smallTitle id), matching the existing core pattern in entity/assistance.
- Add `role="group"` + `aria-label` to each email row in `UserEmail` (server-rendered + JS add-email template).

`role=group` + `aria-labelledby` is RGAA-11.5-conformant on par with fieldset/legend.

Minor visual changes / side effect on the phone edition on central / helpdesk profile edition / creation : Phone fields are now stacked on the same column as they share the same parent : 

<img width="814" height="293" alt="image" src="https://github.com/user-attachments/assets/a7447073-9548-49dc-b20d-8df7fc447f6f" />

<img width="828" height="823" alt="image" src="https://github.com/user-attachments/assets/2ed33e49-2c12-47e8-b98d-54e81e972200" />

If needed i can make a workaround for this.








