### PR TITLE
A11Y (followup/tests) repair broken test suite after hotkeys-js removal

### DIFF
--- a/js/src/vue/EntitySelector/EntitySelector.vue
+++ b/js/src/vue/EntitySelector/EntitySelector.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import {computed, onMounted, ref, useTemplateRef, watch, useId, onUnmounted} from "vue";
+    import {computed, onMounted, ref, useTemplateRef, watch, useId, onBeforeUnmount} from "vue";
     import {useEntitySelector} from "./useEntitySelector.js";
 
     const props = defineProps({
@@ -201,7 +201,7 @@
         document.addEventListener('keydown', hotkey_listener);
     });
 
-    onUnmounted(() => {
+    onBeforeUnmount(() => {
         entity_dropdown_toggle.value.removeEventListener('show.bs.dropdown', onShowSelector);
         document.removeEventListener('keydown', hotkey_listener);
     });

--- a/tests/js/vue/EntitySelector/EntitySelector.spec.js
+++ b/tests/js/vue/EntitySelector/EntitySelector.spec.js
@@ -39,7 +39,6 @@ enableAutoUnmount(afterEach);
 
 describe('EntitySelector Vue Component', () => {
     beforeEach(() => {
-       window.hotkeys.unbind();
         vi.useFakeTimers();
     });
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The Entity Selector test suite is red on `main`. #24554 was branched off a base predating the hotkeys-js removal and merged over it without the JS tests being re-run, leaving two regressions (https://github.com/glpi-project/glpi/actions/runs/27751104397/job/82101549271?pr=24601) :

1. The test teardown still relied on the removed hotkeys-js library, throwing in setup.
2. The component cleanup ran too late in the unmount cycle, after the template refs were already cleared, which left a global keyboard listener attached and cascaded into the other tests.


Relates to #24554.


<img width="981" height="503" alt="image" src="https://github.com/user-attachments/assets/77268cd9-b368-4d0e-90e7-d7f8c184dd66" />


