### PR TITLE
let plugins define a default dashboard for reset

### DIFF
--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -39,6 +39,8 @@ use CommonDBTM;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\Exception\TooManyResultsException;
+use Glpi\Plugin\Hooks;
+use Plugin;
 use Ramsey\Uuid\Uuid;
 use Session;
 use Toolbox;
@@ -750,7 +752,7 @@ class Dashboard extends CommonDBTM
      */
     public static function getDefaults(): array
     {
-        return [
+        $default_dashboards = [
             [
                 'key' => 'central',
                 'name' => __('Central'),
@@ -1660,5 +1662,28 @@ class Dashboard extends CommonDBTM
                 ],
             ],
         ];
+
+        $more_dashboards = Plugin::doHookFunction(Hooks::DASHBOARD_DEFAULTS);
+        if (is_array($more_dashboards)) {
+            $default_dashboards = array_merge($default_dashboards, $more_dashboards);
+        }
+
+        /**
+         * @var list<array{
+         *   key: string,
+         *   name: string,
+         *   context: string,
+         *   items: list<array{
+         *     x: int,
+         *     y: int,
+         *     width: int,
+         *     height: int,
+         *     gridstack_id: string,
+         *     card_id: string,
+         *     card_options: array{color: string, widgettype: string}
+         *   }>
+         * }>
+         */
+        return $default_dashboards;
     }
 }

--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -47,6 +47,22 @@ use Toolbox;
 
 use function Safe\json_decode;
 
+/**
+ * @phpstan-type DashboardConfigDescription list<array{
+ *   key: string,
+ *   name: string,
+ *   context: string,
+ *   items: list<array{
+ *     x: int,
+ *     y: int,
+ *     width: int,
+ *     height: int,
+ *     gridstack_id: string,
+ *     card_id: string,
+ *     card_options: array{color: string, widgettype: string}
+ *   }>
+ * }>
+ */
 class Dashboard extends CommonDBTM
 {
     /** @var int */
@@ -732,23 +748,7 @@ class Dashboard extends CommonDBTM
     /**
      * Return default dashboards data.
      *
-     * @return list<array{
-     *   key: string,
-     *   name: string,
-     *   context: string,
-     *   items: list<array{
-     *     x: int,
-     *     y: int,
-     *     width: int,
-     *     height: int,
-     *     gridstack_id: string,
-     *     card_id: string,
-     *     card_options: array{
-     *       color: string,
-     *       widgettype: string,
-     *     },
-     *   }>,
-     * }>
+     * @return DashboardConfigDescription
      */
     public static function getDefaults(): array
     {
@@ -1665,25 +1665,10 @@ class Dashboard extends CommonDBTM
 
         $more_dashboards = Plugin::doHookFunction(Hooks::DASHBOARD_DEFAULTS);
         if (is_array($more_dashboards)) {
+            /** @var DashboardConfigDescription $more_dashboards */
             $default_dashboards = array_merge($default_dashboards, $more_dashboards);
         }
 
-        /**
-         * @var list<array{
-         *   key: string,
-         *   name: string,
-         *   context: string,
-         *   items: list<array{
-         *     x: int,
-         *     y: int,
-         *     width: int,
-         *     height: int,
-         *     gridstack_id: string,
-         *     card_id: string,
-         *     card_options: array{color: string, widgettype: string}
-         *   }>
-         * }>
-         */
         return $default_dashboards;
     }
 }

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -1044,6 +1044,28 @@ class Hooks
      */
     public const DASHBOARD_TYPES    = 'dashboard_types';
 
+    /**
+     * Register a function to define default dashboard setup
+     * The function is called with no parameters.
+     * The function is expected to return an array of arrays describing default dashboard setups with the following properties
+     * - 'key' => the key of a dashboard
+     * - 'name' => the name of the dashboard
+     * - 'context' => the context of the dashboard
+     * - 'items' => an array of cards (see lines below)
+     *    - 'x' => x position of the card
+     *    - 'y' => y position of the card
+     *    - 'width'  => 'the width of the card
+     *    - 'height' => 'the height of the card
+     *    - 'gridstack_id' => the ID of the card in the gridstack
+     *    - 'card_id' => the ID of the card
+     *    - 'card_options' => options of the card (see lines below)
+     *      - 'color' => HTML color
+     *      - 'widgettype' => type of widget
+     *      - 'use_gradient => 1 for true, 0 for false
+     *      - 'limit' => limit of elements displayed in the card
+     */
+    public const DASHBOARD_DEFAULTS = 'dashboard_defaults';
+
     // HL API hooks
     /**
      * The hook function to call to redefine schemas.


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- Create a new hook to let a plugin describe additional dashboards for reset use case

This allows plugins (like Carbon) to restore default configuration for its dashboard, or let plugins propose pre configured dashboards anywhere.

## Screenshots (if appropriate):

#### Dialog to reset the dashboard 

Example with the plugin Carbon

<img width="1486" height="613" alt="image" src="https://github.com/user-attachments/assets/caebdd41-04f4-47c1-8b4e-ee3b197940f0" />

#### After the reset 

<img width="1580" height="818" alt="image" src="https://github.com/user-attachments/assets/b6ee0eab-d9f8-4193-910b-b1dcbf989e42" />

