### PR TITLE
A11Y : 2fa setup

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -496,6 +496,22 @@ body .toast {
     outline: none !important;
 }
 
+.totp-code-input {
+    --otp-cell: 2ch;
+
+    width: calc(var(--otp-digits, 6) * var(--otp-cell) + 1px);
+    padding-inline: 0.5ch 0;
+    font-family: var(--tblr-font-monospace, monospace);
+    font-size: 1.75em;
+    font-weight: 700;
+    letter-spacing: 1ch;
+    background-image: repeating-linear-gradient(
+        90deg,
+        transparent 0 calc(var(--otp-cell) - 1px),
+        var(--tblr-border-color) calc(var(--otp-cell) - 1px) var(--otp-cell)
+    );
+}
+
 .tooltip {
     --tblr-tooltip-color: var(--tblr-body-bg); /* Text color */
     --tblr-tooltip-bg: var(--tblr-body-color); /* Background color */

--- a/src/Glpi/Controller/Security/MFAController.php
+++ b/src/Glpi/Controller/Security/MFAController.php
@@ -104,7 +104,7 @@ final class MFAController extends AbstractController
         }
         $totp = new TOTPManager();
         $backup_code = $request->request->get('backup_code');
-        $totp_code = implode('', $request->request->all('totp_code'));
+        $totp_code = preg_replace('/\s+/', '', $request->request->getString('totp_code')) ?? '';
         $secret = $request->request->get('secret');
         $algorithm = null;
 

--- a/src/Glpi/Controller/Security/MFAController.php
+++ b/src/Glpi/Controller/Security/MFAController.php
@@ -48,6 +48,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
+use function Safe\preg_replace;
+
 final class MFAController extends AbstractController
 {
     #[Route(
@@ -104,7 +106,7 @@ final class MFAController extends AbstractController
         }
         $totp = new TOTPManager();
         $backup_code = $request->request->get('backup_code');
-        $totp_code = preg_replace('/\s+/', '', $request->request->getString('totp_code')) ?? '';
+        $totp_code = preg_replace('/\s+/', '', $request->request->getString('totp_code'));
         $secret = $request->request->get('secret');
         $algorithm = null;
 

--- a/templates/pages/2fa/2fa_request.html.twig
+++ b/templates/pages/2fa/2fa_request.html.twig
@@ -55,7 +55,7 @@
                     if (form.attr('data-code-type') === 'code') {
                         // Switch to backup code
                         form.attr('data-code-type', 'backup_code');
-                        $('input[name="totp_code[]"]')
+                        $('input[name="totp_code"]')
                             .attr('disabled', 'disabled')
                             .addClass('d-none');
                         $('input[name="backup_code"]')
@@ -69,7 +69,7 @@
                         $('input[name="backup_code"]')
                             .attr('disabled', 'disabled')
                             .toggleClass('d-none');
-                        $('input[name="totp_code[]"]')
+                        $('input[name="totp_code"]')
                             .removeAttr('disabled')
                             .removeClass('d-none');
                         btn.text('{{ __('Use a backup code') }}');

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -33,11 +33,11 @@
 {% macro tfa_code_input(digits = 6) %}
    <div class="d-flex justify-content-center" dir="ltr">
       <input type="text" id="totp_code" name="totp_code"
-             class="form-control text-center fw-bold"
+             class="form-control totp-code-input"
              maxlength="{{ digits }}" pattern="[0-9]{{ '{' ~ digits ~ '}' }}"
              inputmode="numeric" autocomplete="one-time-code" required
              aria-label="{{ __('Authentication code') }}"
-             style="max-width: 12em; font-size: 1.5em; letter-spacing: 0.3em">
+             style="--otp-digits: {{ digits }}">
    </div>
    <script>
        $(document).ready(function() {

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -32,58 +32,23 @@
 
 {% macro tfa_code_input(digits = 6) %}
    <div class="d-flex justify-content-center" dir="ltr">
-      {% for i in 1..digits %}
-         <input type="text" class="form-control text-center {{ i != 1 ? 'ms-2' : '' }} fw-bold" name="totp_code[]"
-             maxlength="1" pattern="[0-9]" inputmode="numeric" required style="width: 2.5em; font-size: 1.5em"
-             aria-label="{{ __('2FA code digit %s of %s')|format(i, digits) }}">
-      {% endfor %}
+      <input type="text" id="totp_code" name="totp_code"
+             class="form-control text-center fw-bold"
+             maxlength="{{ digits }}" pattern="[0-9]{{ '{' ~ digits ~ '}' }}"
+             inputmode="numeric" autocomplete="one-time-code" required
+             aria-label="{{ __('Authentication code') }}"
+             style="max-width: 12em; font-size: 1.5em; letter-spacing: 0.3em">
    </div>
    <script>
        $(document).ready(function() {
-           const input_fields = $('input[name="totp_code[]"]');
-           input_fields.first().focus();
-           input_fields.parent().on('keyup', 'input[name="totp_code[]"]', function(e) {
-               if (e.which === 8) {
-                   return;
-               }
-               if ($(this).val().length === 1) {
-                   const next = $(this).next();
-                   if (next.length === 0) {
-                       $(this).closest('form').find('button[name="continue"]').click();
-                       input_fields.prop('disabled', true);
-                   }
+           const field = $('#totp_code');
+           field.trigger('focus');
+           // Auto-submit once the full code is entered (parity with previous UX)
+           field.on('input', function() {
+               if (this.value.length === {{ digits }}) {
+                   $(this).closest('form').find('button[name="continue"]').trigger('click');
                }
            });
-           input_fields.parent().on('keydown', 'input[name="totp_code[]"]', function(e) {
-               if (e.which === 8) {
-                   $(this).prev().focus();
-               }
-               if ($(this).val().length === 1) {
-                   // Move to the next input if there is one, otherwise submit the form
-                   const next = $(this).next();
-                   if (next.length) {
-                       next.focus();
-                   } else {
-                       $(this).closest('form').find('button[name="continue"]').click();
-                       input_fields.prop('disabled', true);
-                   }
-               }
-           });
-           // Pasting in any of the fields will fill all of them
-           input_fields.on('paste', function(e) {
-              const pasted_data = e.originalEvent.clipboardData.getData('text');
-              // Clear all fields
-              input_fields.val('');
-              let last_filled = 0;
-              input_fields.each(function(index) {
-                 if (pasted_data[index]) {
-                    $(this).val(pasted_data[index]);
-                    last_filled = index;
-                 }
-              });
-              // focus on the field after the last one filled (or the last if all filled)
-              input_fields.eq(Math.min(input_fields.length, last_filled + 1)).focus();
-          });
        });
    </script>
 {% endmacro %}
@@ -99,39 +64,43 @@
             {% endif %}
          </div>
          <div class="card-body">
-            <div class="col">
-               <div>{{ __('1. Install an authenticator app on your mobile device such as Google Authenticator or Authy.') }}</div>
-               <div class="mt-2">{{ __('2. Scan the following QR code or enter the code shown into your authenticator app.') }}</div>
-               <div class="col-md-6 mx-auto">
-                  <div class="text-center">
-                     <img src="{{ qrcode }}" alt="{{ __('QR Code') }}" />
-                  </div>
-               </div>
-               <div class="mx-auto">
-                  <div>
-                     <div class="btn-group d-flex">
-                        <input class="form-control" alt="{{ __('2FA secret') }}" value="{{ secret }}" aria-label="{{ __('2FA secret') }}" />
-                        <button type="button" class="btn btn-icon flex-grow-0 flex-shrink-0" name="copy_secret" data-clipboard-text="{{ secret }}">
-                           <i class="ti ti-clipboard-copy"></i>
-                        </button>
-                        <script>
-                           $(document).ready(function() {
-                               $('button[name="copy_secret"]').on('click', function() {
-                                   navigator.clipboard.writeText($(this).data('clipboard-text'));
-                               });
-                           });
-                        </script>
+            <ol class="col mb-0">
+               <li>{{ __('Install an authenticator app on your mobile device such as Google Authenticator or Authy.') }}</li>
+               <li class="mt-2">
+                  {{ __('Scan the following QR code or enter the code shown into your authenticator app.') }}
+                  <div class="col-md-6 mx-auto">
+                     <div class="text-center">
+                        <img src="{{ qrcode }}" alt="{{ __('QR Code') }}" />
                      </div>
-                     <input type="hidden" name="secret" value="{{ secret }}" />
-                     <input type="hidden" name="_idor_token" value="{{ idor_token('', {'secret': secret}) }}" />
                   </div>
-               </div>
-               <div class="mt-3">{{ __('3. After entering the code into your authenticator, enter the code shown in the app to finish the setup') }}</div>
-               <div class="col-md-6 mx-auto mt-2">
-                  {# Show code input here to verify it is set correctly #}
-                  {{ _self.tfa_code_input() }}
-               </div>
-            </div>
+                  <div class="mx-auto">
+                     <div>
+                        <div class="btn-group d-flex">
+                           <input class="form-control" alt="{{ __('2FA secret') }}" value="{{ secret }}" aria-label="{{ __('2FA secret') }}" />
+                           <button type="button" class="btn btn-icon flex-grow-0 flex-shrink-0" name="copy_secret" data-clipboard-text="{{ secret }}">
+                              <i class="ti ti-clipboard-copy"></i>
+                           </button>
+                           <script>
+                              $(document).ready(function() {
+                                  $('button[name="copy_secret"]').on('click', function() {
+                                      navigator.clipboard.writeText($(this).data('clipboard-text'));
+                                  });
+                              });
+                           </script>
+                        </div>
+                        <input type="hidden" name="secret" value="{{ secret }}" />
+                        <input type="hidden" name="_idor_token" value="{{ idor_token('', {'secret': secret}) }}" />
+                     </div>
+                  </div>
+               </li>
+               <li class="mt-3">
+                  {{ __('After entering the code into your authenticator, enter the code shown in the app to finish the setup') }}
+                  <div class="col-md-6 mx-auto mt-2">
+                     {# Show code input here to verify it is set correctly #}
+                     {{ _self.tfa_code_input() }}
+                  </div>
+               </li>
+            </ol>
          </div>
          <div class="card-footer d-flex flex-wrap">
             {% if enforced and in_grace_period %}

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -41,14 +41,7 @@
    </div>
    <script>
        $(document).ready(function() {
-           const field = $('#totp_code');
-           field.trigger('focus');
-           // Auto-submit once the full code is entered (parity with previous UX)
-           field.on('input', function() {
-               if (this.value.length === {{ digits }}) {
-                   $(this).closest('form').find('button[name="continue"]').trigger('click');
-               }
-           });
+           $('#totp_code').trigger('focus');
        });
    </script>
 {% endmacro %}

--- a/tests/e2e/pages/LoginPage.ts
+++ b/tests/e2e/pages/LoginPage.ts
@@ -134,9 +134,7 @@ export class LoginPage extends GlpiPage
 
     public async doFillTotpCode(token: string): Promise<void>
     {
-        for (let i = 0; i < 6; i++) {
-            await this.page.getByRole('textbox', { name: `2FA code digit ${i + 1} of 6` }).fill(token[i]);
-        }
+        await this.page.getByRole('textbox', { name: 'Authentication code' }).fill(token);
         await this.page.getByRole('button', { name: 'Verify' }).click();
     }
 }

--- a/tests/e2e/specs/Security/session.spec.ts
+++ b/tests/e2e/specs/Security/session.spec.ts
@@ -167,4 +167,43 @@ test.describe('Session', () => {
 
         await expect(anonymousPage).toHaveURL(/\/front\/central\.php/);
     });
+
+    test('2FA setup screen has accessible structure', async ({ anonymousPage, api }) => {
+        test.slow();
+
+        const username = `e2e_tests_2fa${Date.now()}`;
+        const user_id = await api.createItem('User', {
+            name: username,
+            login: username,
+            password: 'glpi',
+            password2: 'glpi',
+            _profiles_id: Profiles.SuperAdmin,
+        });
+        const group_id = await api.createItem('Group', {
+            name: `e2e_tests_group_2fa${Date.now()}`,
+            entities_id: 0,
+            '2fa_enforced': 1,
+        });
+        await api.createItem('Group_User', {
+            groups_id: group_id,
+            users_id: user_id,
+        });
+
+        await anonymousPage.setExtraHTTPHeaders({ 'Accept-Language': 'en-GB,en;q=0.9' });
+        const login_page = new LoginPage(anonymousPage);
+        await login_page.goto();
+        await login_page.doLogin(username, 'glpi');
+        await expect(anonymousPage).toHaveURL(/\/MFA\/Setup/);
+
+        // Setup instructions are a semantic ordered list of 3 steps (criterion 9.3)
+        await expect(anonymousPage.getByRole('list').getByRole('listitem')).toHaveCount(3);
+
+        // The code entry is a single accessible field, not the former 6 per-digit inputs
+        await expect(anonymousPage.getByRole('textbox', { name: 'Authentication code' })).toBeVisible();
+        await expect(anonymousPage.getByRole('textbox', { name: /digit \d of \d/ })).toHaveCount(0);
+
+        const secret = await anonymousPage.getByRole('textbox', { name: '2FA secret' }).inputValue();
+        await login_page.doFillTotpCode(authenticator.generate(secret));
+        await expect(anonymousPage).toHaveURL(/\/MFA\/ShowBackupCodes/);
+    });
 });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/316
- Here is a brief description of what this PR does : 

- Setup steps (1/2/3) are now a semantic ordered list instead of plain divs.
- The six single-character code fields, whose buggy focus JS left keyboard users stuck after two digits : are replaced by one labelled code input (native paste & keyboard, shared with the login prompt).
- Submission stays explicit via "Verify" ([no change of context on input)](https://www.w3.org/TR/WCAG21/#dfn-change-of-context).

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.3
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.3

E2E coverage added as we have a behaviour change.

Note: ol used rather than ul since the steps are a numbered procedure.

<img width="845" height="649" alt="image" src="https://github.com/user-attachments/assets/c4978bc3-311a-4017-add5-af96ce6523f5" />



