### PR TITLE
A11Y : rework headings hierarchy in preferences screens

### DIFF
--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -54,13 +54,15 @@
    </div>
 {% endmacro %}
 
-{% macro smallTitle(label, icon = '', helper = '', id = '') %}
+{% macro smallTitle(label, icon = '', helper = '', id = '', level = 4) %}
    {% set margins = 'mt-2 mb-2' %}
    {% set id = id != '' ? id : 'formsection' ~ random() %}
+   {% set level = level in [1, 2, 3, 4, 5, 6] ? level : 4 %}
 
    <div class="card border-0 shadow-none p-0 m-0 {{ margins }}">
       <div id="{{ id }}" class="card-header mb-1 p-0 ps-3 py-1">
-         <h4 class="card-subtitle {{ icon|length ? 'ms-4' : '' }}">
+         {# fs-4 keeps the visual size constant regardless of the heading level #}
+         <h{{ level }} class="card-subtitle fs-4 {{ icon|length ? 'ms-4' : '' }}">
             {% if icon|length %}
                <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
                   <i class="fs-2x {{ icon }}"></i>
@@ -71,7 +73,7 @@
                <span class="form-help" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true"
                      data-bs-title="{{ helper }}">?</span>
             {% endif %}
-         </h4>
+         </h{{ level }}>
       </div>
    </div>
 {% endmacro %}

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -335,7 +335,7 @@
    <div class="hr-text my-3">
       <i class="ti ti-palette"></i>
       {# heading rather than span: adds this divider label to the heading outline (RGAA 9.1) #}
-      <h6 class="m-0 fs-5 fw-medium">{{ __('Priority colors') }}</h6>
+      <h5 class="m-0 fs-5 fw-medium">{{ __('Priority colors') }}</h5>
    </div>
    {{ fields.htmlField('', priority_colors, '', field_options|merge({
       input_class: 'col-12',

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -253,7 +253,7 @@
    {{ fields.dropdownYesNo('search_pagination_on_top', config['search_pagination_on_top'], __('Show search pagination above results'), field_options) }}
 
    {% if get_current_interface() == 'central' %}
-      {{ fields.smallTitle(__('Assistance'), 'ti ti-headset') }}
+      {{ fields.smallTitle(__('Assistance'), 'ti ti-headset', level = 5) }}
 
       {{ fields.dropdownYesNo('followup_private', config['followup_private'], __('Private followups by default'), field_options) }}
       {% if has_profile_right('ticket', constant('Ticket::READMY')) or has_profile_right('ticket', constant('Ticket::READALL')) or has_profile_right('ticket', constant('Ticket::READASSIGN')) %}
@@ -334,14 +334,15 @@
    {% endset %}
    <div class="hr-text my-3">
       <i class="ti ti-palette"></i>
-      <span>{{ __('Priority colors') }}</span>
+      {# heading rather than span: adds this divider label to the heading outline (RGAA 9.1) #}
+      <h6 class="m-0 fs-5 fw-medium">{{ __('Priority colors') }}</h6>
    </div>
    {{ fields.htmlField('', priority_colors, '', field_options|merge({
       input_class: 'col-12',
       field_class: 'col-12'
    })) }}
 
-   {{ fields.smallTitle(__('Due date progression'), 'ti ti-clock-play') }}
+   {{ fields.smallTitle(__('Due date progression'), 'ti ti-clock-play', level = 5) }}
    {% set unit_options = {
       '%': '%',
       'hours': _n('Hour', 'Hours', get_plural_number()),
@@ -377,7 +378,7 @@
    })) }}
 
    {% if get_current_interface() == 'central' and config('lock_use_lock_item') %}
-      {{ fields.smallTitle(__('Item locks'), 'ti ti-lock') }}
+      {{ fields.smallTitle(__('Item locks'), 'ti ti-lock', level = 5) }}
       {{ fields.dropdownYesNo('lock_autolock_mode', config['lock_autolock_mode'], __('Auto-lock Mode'), field_options) }}
       {{ fields.dropdownYesNo(
          'lock_directunlock_notification',
@@ -388,7 +389,7 @@
    {% endif %}
 
    {% if call('\\Glpi\\Dashboard\\Grid::canViewOneDashboard') %}
-      {{ fields.smallTitle(__('Dashboards'), call('Glpi\\Dashboard\\Dashboard::getIcon'), '', 'section-dashboards') }}
+      {{ fields.smallTitle(__('Dashboards'), call('Glpi\\Dashboard\\Dashboard::getIcon'), '', 'section-dashboards', level = 5) }}
       {% macro dropdownDashboard(name, config, thecontext = "core", disabled_option = false) %}
          {% do call('\\Glpi\\Dashboard\\Grid::dropdownDashboard', [name, {
             value: config[name],
@@ -423,7 +424,7 @@
       ) }}
    {% endif %}
 
-   {{ fields.smallTitle(_n('Notification', 'Notifications', get_plural_number()), 'ti ti-bell') }}
+   {{ fields.smallTitle(_n('Notification', 'Notifications', get_plural_number()), 'ti ti-bell', level = 5) }}
    {% set enable_notif_helper %}
       • {{ __('Disable notifications by default on ITIL objects actor configuration, with ability to derogate to it.') }}
       • {{ __('Disable all notifications on all other objects, without ability to derogate to it.') }}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/315
- Here is a brief description of what this PR does :

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.1

On the Preferences page, subsections shared the same h4 level as their parent section, and "Priority colors" was not a heading at all.

- The subtitle component now takes an optional heading level (default unchanged, so no impact on other pages).
- Subsections now nest as h5 under their h4 section, and "Priority colors" becomes an h6 heading.
- CSS workaround: since dropping to h5/h6 shrinks the font, the subtitle is pinned to the fs-4 size so the visual rendering stays identical regardless of the heading level.

Out of scope (separate issues suggested) : inconsistent modal-title levels across the app, and the missing h1 on the page (transverse layout concern).



