### PR TITLE
A11Y : add hints for color picking fields

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -171,10 +171,16 @@
         id: name ~ '_' ~ (options.rand ?? random()),
     }|merge(options) %}
 
+    {% set describedby = options.id ~ '_format' %}
     {{ _self.input(name, value, options|merge({
         'type': 'text',
         'input_addclass': 'rounded-0',
+        'additional_attributes': (options.additional_attributes ?? {})|merge({
+            'placeholder': '#RRGGBB',
+            'aria-describedby': describedby,
+        }),
     })) }}
+    <span id="{{ describedby }}" class="visually-hidden">{{ __('Expected format: a hexadecimal color code, for example #FF0000.') }}</span>
     <script>
         $(function () {
             $("#{{ options.id|e('css')|e('js') }}").spectrum({


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes [#322](https://github.com/glpi-project/roadmap/issues/322)
- Here is a brief description of what this PR does

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.10

 Color picker fields gave no indication of the expected input format and no example.

- The shared color input now exposes a visible #RRGGBB placeholder and a programmatic description (via aria-describedby) stating the expected hexadecimal format with an example, so screen reader and keyboard users know what to type.
- No blocking validation is added, so existing stored values keep saving and the Spectrum picker still sanitizes manual input.


