### PR TITLE
Improve performance of helpdesk loading by skipping dashboard loading

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -707,7 +707,7 @@ TWIG,
             //Remove huge memory waste by loading dashboard and related libraries (looking at you echarts...)
             //on pages when there is no right to view dashboards (mainly for simplified interface users)
             if (!Grid::canViewOneDashboard()) {
-                $jslibs = array_diff($jslibs, ['dashboard']);
+                $jslibs = array_filter($jslibs, static fn($lib) => $lib !== 'dashboard');
             }
 
             if (in_array('dashboard', $jslibs)) {

--- a/src/Html.php
+++ b/src/Html.php
@@ -702,6 +702,14 @@ TWIG,
                 }
             }
 
+            //TODO Stop using sector-based JS loading
+
+            //Remove huge memory waste by loading dashboard and related libraries (looking at you echarts...)
+            //on pages when there is no right to view dashboards (mainly for simplified interface users)
+            if (!Grid::canViewOneDashboard()) {
+                $jslibs = array_diff($jslibs, ['dashboard']);
+            }
+
             if (in_array('dashboard', $jslibs)) {
                 // include more js libs for dashboard case
                 $jslibs = array_merge($jslibs, [

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -621,7 +621,7 @@ $CFG_GLPI['javascript'] = [
     'preference'   => ['clipboard'],
     'self-service' => $reservations_libs,
     'reservation'   => $reservations_libs,
-    'helpdesk-home' => ['home-scss-file', 'gridstack', 'dashboard'],
+    'helpdesk-home' => ['home-scss-file', 'dashboard'],
 ];
 
 // push reservations libs to reservations itemtypes (they shoul in asset sector)


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Also other pages that use sector-based loading of the dashboard JS and related libraries even when the user has no permission to view dashboards.

Despite my years-long desire to kill sector-based JS loading, that won't happen for GLPI 12. This hack to try preventing the loading of the large amount of JS for dashboards when they would never be used is fairly useful. We can mainly blame the loading of the entire `echarts` library. I kept it for `main` in case there is a missed case where the dashboard JS is needed without actually relying on dashboard permissions. If that happens, we could add a condition to only remove the JS loading for the "homedesk-home" sector.

Loading times are the time for network requests to finish and I took the quickest times seen. JS memory usage was taken after a garbage collection action. No XDebug or debug mode and GLPI was in production mode.

| | Loading Time | Resources Loaded | Memory Usage |
| - | ------------------ | ------------------------- | -------------------- |
| Original | 620ms | 18 MB | 79.4 MB |
| This PR | 450ms | 14.2 MB | 68 MB |

IMO these metrics are still not good but at least an improvement.

Other large memory hogs on the helpdesk home according to Chrome's Coverage tool (reports memory usage by file and amount memory usage of unused parts):
- TinyMCE (72% unused. 4.6 MB total): Not sure this is needed at all but it is globally loaded everywhere
- Tabler CSS (94% unused. 960 KB total): This is just the main Tabler CSS and Bootstrap. It is very bloated.
- GLPI CSS (99% unused. 900kb). Also very bloated. Honestly not even sure how we ended up with so much custom CSS when we are supposed to rely on Tabler + Bootstrap.

In total, the helpdesk home coverage with this PR is 3.2 MB used of resources of 10.9MB (71% unused).

In other news, I just found out about the Coverage tool so I have that to be more annoying about performance now... Sorry.