### PR TITLE
A11Y : make disclose/copy buttons keyboard-accessible and labelled

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1577,7 +1577,7 @@ function toggleDisclosablePasswordField(button, item) {
 /**
  * Converts a disclosable password field to a normal text field
  * @param {string} item The ID of the field to be shown
- * @deprecated Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
+ * @deprecated 12.0 Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
  */
 function showDisclosablePasswordField(item) {
     $("#" + CSS.escape(item)).prop("type", "text");
@@ -1586,7 +1586,7 @@ function showDisclosablePasswordField(item) {
 /**
  * Converts a normal text field to a password field
  * @param {string} item The ID of the field to be hidden
- * @deprecated Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
+ * @deprecated 12.0 Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
  */
 function hideDisclosablePasswordField(item) {
     $("#" + CSS.escape(item)).prop("type", "password");

--- a/js/common.js
+++ b/js/common.js
@@ -1546,6 +1546,35 @@ $(document.body).on('shown.bs.tab', 'a[data-bs-toggle="tab"]', (e) => {
 });
 
 /**
+ * Toggles a disclosable password field between its hidden and revealed states.
+ * The button's label changes between show/hide so it can be operated with the
+ * keyboard and announces the action it will perform next.
+ * @param {HTMLButtonElement} button The toggle button that was activated
+ * @param {string} item The ID of the field to reveal/hide
+ */
+function toggleDisclosablePasswordField(button, item) {
+    const field = document.getElementById(item);
+    if (field === null) {
+        return;
+    }
+
+    const reveal = field.type === "password";
+    field.type = reveal ? "text" : "password";
+
+    const label = reveal ? button.dataset.hideLabel : button.dataset.showLabel;
+    if (label !== undefined) {
+        button.setAttribute("aria-label", label);
+        button.setAttribute("title", label);
+    }
+
+    const icon = button.querySelector("i.disclose");
+    if (icon !== null) {
+        icon.classList.toggle("ti-eye", !reveal);
+        icon.classList.toggle("ti-eye-off", reveal);
+    }
+}
+
+/**
  * Converts a disclosable password field to a normal text field
  * @param {string} item The ID of the field to be shown
  */

--- a/js/common.js
+++ b/js/common.js
@@ -1577,6 +1577,7 @@ function toggleDisclosablePasswordField(button, item) {
 /**
  * Converts a disclosable password field to a normal text field
  * @param {string} item The ID of the field to be shown
+ * @deprecated Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
  */
 function showDisclosablePasswordField(item) {
     $("#" + CSS.escape(item)).prop("type", "text");
@@ -1585,6 +1586,7 @@ function showDisclosablePasswordField(item) {
 /**
  * Converts a normal text field to a password field
  * @param {string} item The ID of the field to be hidden
+ * @deprecated Use {@link toggleDisclosablePasswordField} instead. Kept for backward compatibility.
  */
 function hideDisclosablePasswordField(item) {
     $("#" + CSS.escape(item)).prop("type", "password");
@@ -1595,18 +1597,23 @@ function hideDisclosablePasswordField(item) {
  * @param {string} item The ID of the field to be copied
  */
 function copyDisclosablePasswordFieldToClipboard(item) {
-    const is_password_input = $("#" + CSS.escape(item)).prop("type") === "password";
-    if (is_password_input) {
-        showDisclosablePasswordField(item);
+    const field = document.getElementById(item);
+    if (field === null) {
+        return;
     }
-    $("#" + CSS.escape(item)).select();
+
+    const is_password_input = field.type === "password";
+    if (is_password_input) {
+        field.type = "text";
+    }
+    field.select();
     try {
         document.execCommand("copy");
     } catch {
-        alert("Copy to clipboard failed'");
+        alert("Copy to clipboard failed");
     }
     if (is_password_input) {
-        hideDisclosablePasswordField(item);
+        field.type = "password";
     }
 }
 

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -86,16 +86,18 @@
     {% set more_html %}
         {% if options.is_disclosable %}
             <button type="button" class="btn btn-outline-secondary"
-                 onmousedown="showDisclosablePasswordField('{{ options.id|e('js') }}')"
-                 onmouseup="hideDisclosablePasswordField('{{ options.id|e('js') }}')"
-                 onmouseout="hideDisclosablePasswordField('{{ options.id|e('js') }}')">
-                <i class="ti ti-eye disclose"></i>
+                 aria-label="{{ __('Show password') }}" title="{{ __('Show password') }}"
+                 data-show-label="{{ __('Show password') }}" data-hide-label="{{ __('Hide password') }}"
+                 onclick="toggleDisclosablePasswordField(this, '{{ options.id|e('js') }}')">
+                <i class="ti ti-eye disclose" aria-hidden="true"></i>
             </button>
         {% endif %}
 
         {% if options.is_copyable %}
-            <button type="button" class="btn btn-outline-secondary" onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id|e('js') }}')">
-                <i class="ti ti-clipboard-copy disclose"></i>
+            <button type="button" class="btn btn-outline-secondary"
+                 aria-label="{{ __('Click to copy to clipboard') }}" title="{{ __('Click to copy to clipboard') }}"
+                 onclick="copyDisclosablePasswordFieldToClipboard('{{ options.id|e('js') }}')">
+                <i class="ti ti-clipboard-copy disclose" aria-hidden="true"></i>
             </button>
         {% endif %}
     {% endset %}

--- a/templates/components/form/item_device.html.twig
+++ b/templates/components/form/item_device.html.twig
@@ -50,21 +50,6 @@
          <div class="d-flex flex-row flex-wrap flex-xl-nowrap">
             <div class="row flex-row align-items-start flex-grow-1">
                <div class="row flex-row">
-                  <script>
-                     function showField(item) {
-                        // BC - Remove in 11.0
-                        showDisclosablePasswordField(item);
-                     }
-                     function hideField(item) {
-                        // BC - Remove in 11.0
-                        hideDisclosablePasswordField(item);
-                     }
-                     function copyToClipboard(item) {
-                        // BC - Remove in 11.0
-                        copyDisclosablePasswordFieldToClipboard(item);
-                     }
-                  </script>
-
                   {% set field_options = field_options|merge(params) %}
 
                   <input type="hidden" name={{ get_static(item, 'itemtype_1') }} value={{ item.fields[get_static(item, 'itemtype_1')] }}>

--- a/tests/cypress/e2e/Setup/webhooks.cy.js
+++ b/tests/cypress/e2e/Setup/webhooks.cy.js
@@ -72,9 +72,9 @@ describe('Webhooks', () => {
         cy.findByRole('tab', { name: 'Security' }).click();
         cy.findByRole('tabpanel').within(() => {
             cy.findByLabelText(/^Secret/).should('have.attr', 'type', 'password');
-            cy.findByLabelText(/^Secret/).next().trigger('mousedown');
+            cy.findByLabelText(/^Secret/).next().click();
             cy.findByLabelText(/^Secret/).should('have.attr', 'type', 'text');
-            cy.findByLabelText(/^Secret/).next().trigger('mouseup');
+            cy.findByLabelText(/^Secret/).next().click();
             cy.findByLabelText(/^Secret/).should('have.attr', 'type', 'password');
             cy.findByLabelText(/^Secret/).next().next().click();
             cy.findByLabelText(/^Secret/).invoke('val').then((secretValue) => {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The password **disclose** button used `mousedown`/`mouseup` (unusable with a keyboard) and the disclose/copy buttons had no accessible name.

- Disclose is now a click toggle, operable with **Enter/Space**; its label switches between *Show password* / *Hide password* with an eye / eye-off icon.
- Copy button labelled *Click to copy to clipboard*.
- Icons set to `aria-hidden`.

Label-changing button rather than an `aria-pressed` toggle, which would announce a contradictory state (*"Hide password, pressed"*).

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.3

## Screenshot: 

<img width="837" height="427" alt="image" src="https://github.com/user-attachments/assets/b0660e01-59f2-4e57-a064-63cac15fb167" />



