### PR TITLE
A11Y : make form focus indicator meet contrast requirements

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -535,7 +535,7 @@ body .toast {
 .form-control:focus-visible,
 .form-select:focus-visible,
 .form-check-input:focus-visible {
-    outline: 2px solid var(--tblr-body-color);
+    outline: 2px solid color-mix(in srgb, var(--tblr-body-color), transparent 40%);
     outline-offset: 1px;
 }
 

--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -532,6 +532,13 @@ body .toast {
     );
 }
 
+.form-control:focus-visible,
+.form-select:focus-visible,
+.form-check-input:focus-visible {
+    outline: 2px solid var(--tblr-body-color);
+    outline-offset: 1px;
+}
+
 .tooltip {
     --tblr-tooltip-color: var(--tblr-body-bg); /* Text color */
     --tblr-tooltip-bg: var(--tblr-body-color); /* Background color */


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/318
- Here is a brief description of what this PR does : 

The form fields' focus indicator was `color-mix(--tblr-primary, white 50%)`, rendering at **1.1:1** against the field background ; keyboard focus was practically invisible. As several palettes use a pale primary, no primary-derived colour can reach 3:1 across all themes.

Adds a `:focus-visible` outline coloured with the theme text token (`--tblr-body-color`), which contrasts strongly on light and dark palettes alike: **~8:1** (light) / **~5.7:1** (dark), up from 1.1:1.

The decorative primary glow is kept.

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#10.7

## Screenshots : 


<img width="498" height="282" alt="Capture d’écran du 2026-06-19 10-39-11" src="https://github.com/user-attachments/assets/ed3c03af-d919-4ec2-8f1a-e9b611b4fc30" />
<img width="498" height="282" alt="Capture d’écran du 2026-06-19 10-39-19" src="https://github.com/user-attachments/assets/ed377135-7be5-4b3c-8516-bae77a93cea9" />
