### PR TITLE
A11Y : make form help tooltips keyboard accessible

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1303,7 +1303,7 @@ document.addEventListener("keydown", (event) => {
         return;
     }
     const active = document.activeElement;
-    if (active === null) {
+    if (active === null || typeof bootstrap === "undefined") {
         return;
     }
     const instance = bootstrap.Tooltip.getInstance(active);

--- a/js/common.js
+++ b/js/common.js
@@ -1297,6 +1297,21 @@ function initTooltips(container) {
     );
 }
 
+// Tooltip ARIA pattern: dismiss the focused element's tooltip on Escape.
+document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape") {
+        return;
+    }
+    const active = document.activeElement;
+    if (active === null) {
+        return;
+    }
+    const instance = bootstrap.Tooltip.getInstance(active);
+    if (instance !== null) {
+        instance.hide();
+    }
+});
+
 /**
  * Returns CSRF token that can be used for AJAX requests.
  *

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -523,8 +523,10 @@
         {# Indeed, otherwise, due to the usage of `data-bs-html="true"`, any code snippet would be interpreted. #}
         {% set helper_safe_text = options.helper|escape|nl2br %}
         {% set helper %}
-        <span class="form-help"
+        <span class="form-help" tabindex="0"
+              aria-label="{{ options.helper }}"
               data-bs-toggle="tooltip"
+              data-bs-trigger="hover focus"
               data-bs-placement="top"
               data-bs-html="true"
               data-bs-title="{{ helper_safe_text|raw }}">

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -46,8 +46,9 @@
             {% endif %}
             {{ label }}
             {% if helper is not empty %}
-               <span class="form-help" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true"
-                     data-bs-title="{{ helper }}">?</span>
+               <span class="form-help" tabindex="0" aria-label="{{ helper }}"
+                     data-bs-toggle="tooltip" data-bs-trigger="hover focus" data-bs-placement="top"
+                     data-bs-html="true" data-bs-title="{{ helper }}">?</span>
             {% endif %}
          </h4>
       </div>
@@ -68,8 +69,9 @@
             {% endif %}
              <span class="ms-2">{{ label }}</span>
             {% if helper is not empty %}
-               <span class="form-help" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true"
-                     data-bs-title="{{ helper }}">?</span>
+               <span class="form-help" tabindex="0" aria-label="{{ helper }}"
+                     data-bs-toggle="tooltip" data-bs-trigger="hover focus" data-bs-placement="top"
+                     data-bs-html="true" data-bs-title="{{ helper }}">?</span>
             {% endif %}
          </h4>
       </div>

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -188,7 +188,8 @@
                         <div class="hr-text">
                             <i class="ti ti-list"></i>
                             <span>{{ __('Supported tasks') }} </span>
-                            <span class="form-help" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true"
+                            <span class="form-help" tabindex="0" aria-label="{{ __('When reported by GLPI agent via native inventory') }}"
+                                  data-bs-toggle="tooltip" data-bs-trigger="hover focus" data-bs-placement="top" data-bs-html="true"
                                   data-bs-title="{{ __('When reported by GLPI agent via native inventory') }}">?</span>
                         </div>
 

--- a/tests/e2e/pages/AssetDefinitionPage.ts
+++ b/tests/e2e/pages/AssetDefinitionPage.ts
@@ -44,7 +44,7 @@ export class AssetDefinitionPage extends GlpiPage
     public constructor(page: Page)
     {
         super(page);
-        this.system_name_input = page.getByLabel("System name");
+        this.system_name_input = page.getByRole("textbox", { name: "System name" });
         this.active_dropdown = this.getDropdownByLabel('Active');
         this.add_button = this.getButton('Add');
         this.save_button = this.getButton('Save');


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/320
- Here is a brief description of what this PR does : 

Make the `form-help` triggers focusable and show the tooltip on **focus** too (`data-bs-trigger="hover focus"`, scoped ; the global default is unchanged).
- Expose the help text as the accessible name (`aria-label`).
- Dismiss the focused tooltip on **Escape** without moving focus, per the [WAI-ARIA Tooltip pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/).

Kept as `<span>` (not `<button>`): the per-field helper is rendered inside a `<label>`, where a nested button would be an interactive-in-label issue.

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.1

## Screenshots (if appropriate):
<img width="518" height="390" alt="image" src="https://github.com/user-attachments/assets/a23690bc-c24e-4c6b-8b35-260418a0a2f0" />


