### PR TITLE
A11Y : date picker usable and labelled with keyboard

### DIFF
--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -363,7 +363,10 @@
                             if (!picker.altInput.hasAttribute('aria-label') && !picker.altInput.hasAttribute('aria-labelledby')) {
                                 picker.altInput.setAttribute('aria-label', '{{ a11y_name|e('js') }}');
                             }
-                            picker.altInput.setAttribute('placeholder', '{{ format_hint|e('js') }}');
+                            // keep a caller-provided placeholder; only fall back to the format hint
+                            if (!picker.altInput.getAttribute('placeholder')) {
+                                picker.altInput.setAttribute('placeholder', '{{ format_hint|e('js') }}');
+                            }
                             picker.altInput.setAttribute('aria-haspopup', 'dialog');
                             picker.altInput.setAttribute('aria-expanded', 'false');
                             picker.calendarContainer.id = picker.input.id + '_calendar';

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -249,6 +249,7 @@
         'disabled': false,
         'maybeempty': false,
         'addCalendarButton': true,
+        'field_label': '',
     }|merge(options) %}
 
     {% set editable = not options.readonly and not options.disabled %}
@@ -323,6 +324,16 @@
             {# No time and no date, doesn't make sense so fallback to full format #}
             {% set date_format = 'Y-m-d H:i:S' %}
         {% endif %}
+
+        {# flatpickr hides the real input and builds an unlabelled altInput; expose the field label and a human-readable format hint on it #}
+        {% set a11y_name = options.field_label is not empty ? options.field_label : __('Enter or select a date') %}
+        {% if options.enableTime and not options.noCalendar %}
+            {% set format_hint = call('Toolbox::getDateFormat', ['php']) ~ ' HH:MM:SS' %}
+        {% elseif options.enableTime and options.noCalendar %}
+            {% set format_hint = 'HH:MM:SS' %}
+        {% else %}
+            {% set format_hint = call('Toolbox::getDateFormat', ['php']) %}
+        {% endif %}
         <script>
             $(function() {
                 $("#{{ options.id|e('css')|e('js') }}").flatpickr({
@@ -347,10 +358,32 @@
                                     picker.altInput.setAttribute(attribute.name, attribute.value);
                                 }
                             }
+
+                            // keep a caller provided label, fall back to the field label
+                            if (!picker.altInput.hasAttribute('aria-label') && !picker.altInput.hasAttribute('aria-labelledby')) {
+                                picker.altInput.setAttribute('aria-label', '{{ a11y_name|e('js') }}');
+                            }
+                            picker.altInput.setAttribute('placeholder', '{{ format_hint|e('js') }}');
+                            picker.altInput.setAttribute('aria-haspopup', 'dialog');
+                            picker.altInput.setAttribute('aria-expanded', 'false');
+                            picker.calendarContainer.id = picker.input.id + '_calendar';
+                            picker.altInput.setAttribute('aria-controls', picker.calendarContainer.id);
+                            // flatpickr does not close on Escape while the altInput is focused
+                            picker.altInput.addEventListener('keydown', (event) => {
+                                if (event.key === 'Escape' && picker.isOpen) {
+                                    event.stopPropagation();
+                                    picker.close();
+                                    picker.altInput.focus();
+                                }
+                            });
                         }
+                    },
+                    onOpen(dates, currentdatestring, picker) {
+                        picker.altInput.setAttribute('aria-expanded', 'true');
                     },
                     onClose(dates, currentdatestring, picker) {
                         picker.setDate(picker.altInput.value, true, picker.config.altFormat)
+                        picker.altInput.setAttribute('aria-expanded', 'false');
                     },
                     plugins: [
                         CustomFlatpickrButtons()

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -285,7 +285,7 @@
 {% macro dateField(name, value, label = '', options = {}) %}
    {% set field %}
         {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-        {{ _inputs.date(name, value, options) }}
+        {{ _inputs.date(name, value, options|merge({'field_label': label})) }}
    {% endset %}
 
    {{ _self.field(name, field, label, options) }}
@@ -295,7 +295,7 @@
 {% macro datetimeField(name, value, label = '', options = {}) %}
    {% set field %}
         {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
-        {{ _inputs.datetime(name, value, options) }}
+        {{ _inputs.datetime(name, value, options|merge({'field_label': label})) }}
    {% endset %}
 
    {{ _self.field(name, field, label, options) }}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/319


Here is a brief description of what this PR does :  flatpickr's visible input had no accessible name, no format hint, no popup semantics, and Escape didn't close the calendar.

- accessible name from the field label (RGAA 11.1)
- format shown as placeholder (RGAA 11.10)
- aria-haspopup + aria-expanded on open/close (RGAA 7.1)
- Escape closes, keeps focus (RGAA 7.3)

Typing the date is now the labelled keyboard path.

Follow-up: the calendar grid stays mouse-only (flatpickr); making it a keyboard ARIA grid is a separate change.

Note: placeholder tokens (YYYY-MM-DD) get mispronounced by some screen readers (Orca says "millimetre" for MM); kept for sighted users, spoken hint left to #322.

Refs https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.1




