### PR TITLE
Add dedicated Enclosure profile rights

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -13196,18 +13196,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Item_Disk.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Enclosure.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method getLink\\(\\) on CommonDBTM\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Item_Enclosure.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call static method dropdown\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'staticMethod.nonObject',
 	'count' => 1,

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -8343,6 +8343,38 @@ style="color: #8b8c8f; font-weight: bold; text-decoration: underline;"&gt;
                 'name' => 'datacenter',
                 'rights' => READ,
             ], [
+                'profiles_id' => self::PROFILE_SELF_SERVICE,
+                'name' => 'enclosure',
+                'rights' => self::RIGHT_NONE,
+            ], [
+                'profiles_id' => self::PROFILE_OBSERVER,
+                'name' => 'enclosure',
+                'rights' => READ,
+            ], [
+                'profiles_id' => self::PROFILE_ADMIN,
+                'name' => 'enclosure',
+                'rights' => ALLSTANDARDRIGHT,
+            ], [
+                'profiles_id' => self::PROFILE_SUPER_ADMIN,
+                'name' => 'enclosure',
+                'rights' => ALLSTANDARDRIGHT,
+            ], [
+                'profiles_id' => self::PROFILE_HOTLINER,
+                'name' => 'enclosure',
+                'rights' => self::RIGHT_NONE,
+            ], [
+                'profiles_id' => self::PROFILE_TECHNICIAN,
+                'name' => 'enclosure',
+                'rights' => ALLSTANDARDRIGHT,
+            ], [
+                'profiles_id' => self::PROFILE_SUPERVISOR,
+                'name' => 'enclosure',
+                'rights' => ALLSTANDARDRIGHT,
+            ], [
+                'profiles_id' => self::PROFILE_READ_ONLY,
+                'name' => 'enclosure',
+                'rights' => READ,
+            ], [
                 'profiles_id' => self::PROFILE_SUPER_ADMIN,
                 'name' => 'rule_asset',
                 'rights' => READ | UPDATE | CREATE | PURGE | RuleAsset::PARENT,

--- a/install/migrations/update_11.0.x_to_12.0.0/enclosure_right.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/enclosure_right.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ */
+
+$datacenter_rights = $DB->request([
+    'SELECT' => ['profiles_id', 'rights'],
+    'FROM'   => 'glpi_profilerights',
+    'WHERE'  => ['name' => 'datacenter'],
+]);
+
+$existing_enclosure_rights = $DB->request([
+    'SELECT' => ['profiles_id'],
+    'FROM'   => 'glpi_profilerights',
+    'WHERE'  => ['name' => 'enclosure'],
+]);
+$profiles_with_enclosure_right = array_fill_keys(
+    array_column(iterator_to_array($existing_enclosure_rights), 'profiles_id'),
+    true,
+);
+
+foreach ($datacenter_rights as $datacenter_right) {
+    if (isset($profiles_with_enclosure_right[$datacenter_right['profiles_id']])) {
+        continue;
+    }
+
+    $DB->insert('glpi_profilerights', [
+        'profiles_id' => $datacenter_right['profiles_id'],
+        'name'        => 'enclosure',
+        'rights'      => $datacenter_right['rights'],
+    ]);
+}

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -56,7 +56,7 @@ class Enclosure extends CommonDBTM implements AssignableItemInterface, DCBreadcr
 
     // From CommonDBTM
     public bool $dohistory                   = true;
-    public static string $rightname                   = 'datacenter';
+    public static string $rightname                   = 'enclosure';
 
     public function getCloneRelations(): array
     {

--- a/src/Enclosure.php
+++ b/src/Enclosure.php
@@ -56,7 +56,7 @@ class Enclosure extends CommonDBTM implements AssignableItemInterface, DCBreadcr
 
     // From CommonDBTM
     public bool $dohistory                   = true;
-    public static string $rightname                   = 'enclosure';
+    public static string $rightname          = 'enclosure';
 
     public function getCloneRelations(): array
     {

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -41,7 +41,8 @@ class Item_Enclosure extends CommonDBRelation
     public static ?string $items_id_1 = 'enclosures_id';
     public static ?string $itemtype_2 = 'itemtype';
     public static ?string $items_id_2 = 'items_id';
-    public static int $checkItem_1_Rights = self::DONT_CHECK_ITEM_RIGHTS;
+    public static int $checkItem_1_Rights = self::HAVE_SAME_RIGHT_ON_ITEM;
+    public static bool $checkAlwaysBothItems = true;
     public static bool $mustBeAttached_1 = false; // FIXME It make no sense for an enclosure item to not be attached to an Enclosure.
     public static bool $mustBeAttached_2 = false; // FIXME It make no sense for an enclosure item to not be attached to an Item.
 
@@ -117,7 +118,18 @@ class Item_Enclosure extends CommonDBRelation
         $entries = [];
         foreach ($items as $row) {
             $item = getItemForItemtype($row['itemtype']);
-            $item->getFromDB($row['items_id']);
+            if (
+                !$item instanceof CommonDBTM
+                || !$item->getFromDB($row['items_id'])
+                || !$item->can($row['items_id'], READ)
+            ) {
+                $entries[] = [
+                    'item'     => __('Possibly no access'),
+                    'position' => $row['position'],
+                    'skip_ma'  => true,
+                ];
+                continue;
+            }
             $entries[] = [
                 'itemtype' => static::class,
                 'id'       => $row['id'],

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -124,7 +124,7 @@ class Item_Enclosure extends CommonDBRelation
                 || !$item->can($row['items_id'], READ)
             ) {
                 $entries[] = [
-                    'item'     => __('Possibly no access'),
+                    'item'     => __('You are not allowed to view this item''),
                     'position' => $row['position'],
                     'skip_ma'  => true,
                 ];

--- a/src/Item_Enclosure.php
+++ b/src/Item_Enclosure.php
@@ -124,7 +124,7 @@ class Item_Enclosure extends CommonDBRelation
                 || !$item->can($row['items_id'], READ)
             ) {
                 $entries[] = [
-                    'item'     => __('You are not allowed to view this item''),
+                    'item'     => __('You are not allowed to view this item'),
                     'position' => $row['position'],
                     'skip_ma'  => true,
                 ];

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -991,6 +991,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                                 $fn_get_rights(Consumable::class, 'central'),
                                 $fn_get_rights(Phone::class, 'central'),
                                 $fn_get_rights(Peripheral::class, 'central'),
+                                $fn_get_rights(Enclosure::class, 'central'),
                                 $fn_get_rights(NetworkName::class, 'central', [
                                     'label' => __('Internet'),
                                 ]),
@@ -1968,6 +1969,20 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
             'joinparams'         => [
                 'jointype'           => 'child',
                 'condition'          => ['NEWTABLE.name' => Datacenter::$rightname],
+            ],
+        ];
+
+        $tab[] = [
+            'id'                 => '178',
+            'table'              => 'glpi_profilerights',
+            'field'              => 'rights',
+            'name'               => Enclosure::getTypeName(Session::getPluralNumber()),
+            'datatype'           => 'right',
+            'rightclass'         => Enclosure::class,
+            'rightname'          => Enclosure::$rightname,
+            'joinparams'         => [
+                'jointype'           => 'child',
+                'condition'          => ['NEWTABLE.name' => Enclosure::$rightname],
             ],
         ];
 

--- a/tests/functional/Item_EnclosureTest.php
+++ b/tests/functional/Item_EnclosureTest.php
@@ -55,7 +55,7 @@ class Item_EnclosureTest extends DbTestCase
         $this->assertTrue(Item_Enclosure::showItems($enclosure));
         $html = ob_get_clean();
 
-        $this->assertStringContainsString('Possibly no access', $html);
+        $this->assertStringContainsString('You are not allowed to view this item', $html);
         $this->assertStringNotContainsString($computer->fields['name'], $html);
 
         $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
@@ -65,7 +65,7 @@ class Item_EnclosureTest extends DbTestCase
         $html = ob_get_clean();
 
         $this->assertStringContainsString($computer->fields['name'], $html);
-        $this->assertStringNotContainsString('Possibly no access', $html);
+        $this->assertStringNotContainsString('You are not allowed to view this item', $html);
     }
 
     public function testUpdatingRelationRequiresRightsOnBothItems(): void

--- a/tests/functional/Item_EnclosureTest.php
+++ b/tests/functional/Item_EnclosureTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Computer;
+use Enclosure;
+use Glpi\Tests\DbTestCase;
+use Item_Enclosure;
+
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+
+class Item_EnclosureTest extends DbTestCase
+{
+    public function testContainedItemVisibility(): void
+    {
+        [$enclosure, $computer] = $this->createEnclosureWithComputer(__FUNCTION__);
+
+        $_SESSION['glpiactiveprofile'][Enclosure::$rightname] = READ;
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = 0;
+
+        ob_start();
+        $this->assertTrue(Item_Enclosure::showItems($enclosure));
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString('Possibly no access', $html);
+        $this->assertStringNotContainsString($computer->fields['name'], $html);
+
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = READ;
+
+        ob_start();
+        $this->assertTrue(Item_Enclosure::showItems($enclosure));
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString($computer->fields['name'], $html);
+        $this->assertStringNotContainsString('Possibly no access', $html);
+    }
+
+    public function testUpdatingRelationRequiresRightsOnBothItems(): void
+    {
+        [$enclosure, $computer, $relation] = $this->createEnclosureWithComputer(__FUNCTION__);
+
+        $_SESSION['glpiactiveprofile'][Enclosure::$rightname] = UPDATE;
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = UPDATE;
+        $this->assertTrue($relation->canUpdateItem());
+
+        $_SESSION['glpiactiveprofile'][Enclosure::$rightname] = 0;
+        $this->assertFalse($relation->canUpdateItem());
+
+        $_SESSION['glpiactiveprofile'][Enclosure::$rightname] = UPDATE;
+        $_SESSION['glpiactiveprofile'][Computer::$rightname] = 0;
+        $this->assertFalse($relation->canUpdateItem());
+    }
+
+    /**
+     * @return array{Enclosure, Computer, Item_Enclosure}
+     */
+    private function createEnclosureWithComputer(string $test_name): array
+    {
+        $this->login();
+        $this->setEntity('_test_root_entity', false);
+        $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $enclosure = $this->createItem(Enclosure::class, [
+            'name'        => 'Test enclosure ' . $test_name,
+            'entities_id' => $entities_id,
+        ]);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Test enclosed computer ' . $test_name,
+            'entities_id' => $entities_id,
+        ]);
+        $relation = $this->createItem(Item_Enclosure::class, [
+            'enclosures_id' => $enclosure->getID(),
+            'itemtype'      => Computer::class,
+            'items_id'      => $computer->getID(),
+            'position'      => 1,
+        ]);
+
+        return [$enclosure, $computer, $relation];
+    }
+}

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -470,7 +470,10 @@ class ProfileTest extends DbTestCase
         $enclosure_rights = iterator_to_array($DB->request([
             'SELECT' => ['profiles_id', 'rights'],
             'FROM'   => \ProfileRight::getTable(),
-            'WHERE'  => ['name' => \Enclosure::$rightname],
+            'WHERE'  => [
+                'name'        => \Enclosure::$rightname,
+                'profiles_id' => range(1, 8),
+            ],
             'ORDER'  => 'profiles_id',
         ]));
         $this->assertSame([

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -453,6 +453,19 @@ class ProfileTest extends DbTestCase
         $this->assertArrayHasKey(\Computer::class, $types);
     }
 
+    public function testEnclosureHasDedicatedProfileRight(): void
+    {
+        $this->assertSame('enclosure', \Enclosure::$rightname);
+
+        $asset_rights = \Profile::getRightsForForm('central', 'assets', 'general');
+        $enclosure_rights = array_filter(
+            $asset_rights,
+            static fn(array $right): bool => $right['field'] === \Enclosure::$rightname,
+        );
+
+        $this->assertCount(1, $enclosure_rights);
+    }
+
     public function testExcludedSearchOptionsPrepareInput(): void
     {
         $this->login();

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -455,6 +455,8 @@ class ProfileTest extends DbTestCase
 
     public function testEnclosureHasDedicatedProfileRight(): void
     {
+        global $DB;
+
         $this->assertSame('enclosure', \Enclosure::$rightname);
 
         $asset_rights = \Profile::getRightsForForm('central', 'assets', 'general');
@@ -464,6 +466,23 @@ class ProfileTest extends DbTestCase
         );
 
         $this->assertCount(1, $enclosure_rights);
+
+        $enclosure_rights = iterator_to_array($DB->request([
+            'SELECT' => ['profiles_id', 'rights'],
+            'FROM'   => \ProfileRight::getTable(),
+            'WHERE'  => ['name' => \Enclosure::$rightname],
+            'ORDER'  => 'profiles_id',
+        ]));
+        $this->assertSame([
+            1 => 0,
+            2 => READ,
+            3 => ALLSTANDARDRIGHT,
+            4 => ALLSTANDARDRIGHT,
+            5 => 0,
+            6 => ALLSTANDARDRIGHT,
+            7 => ALLSTANDARDRIGHT,
+            8 => READ,
+        ], array_column($enclosure_rights, 'rights', 'profiles_id'));
     }
 
     public function testExcludedSearchOptionsPrepareInput(): void


### PR DESCRIPTION
## Summary

This contribution adds dedicated profile rights for Enclosures.

Enclosures currently reuse the generic `datacenter` right, preventing administrators from managing access to Enclosures independently from other datacenter-related objects.

Enclosures can represent blade chassis, storage bays, or network equipment chassis containing individually managed assets, potentially with different entity and profile visibility.

## Changes

- Add a dedicated `enclosure` profile right.
- Expose Enclosure permissions in the Assets section of profile settings.
- Migrate existing profiles by copying their current `datacenter` rights to the new `enclosure` right.
- Require update permission on both the Enclosure and the contained asset when modifying their relation.
- Replace inaccessible contained assets with `Possibly no access`, without exposing their names, IDs, links, or massive-action controls.
- Add functional tests for the profile right, contained-item visibility, and relation permissions.

## Backward compatibility

During the 11.0.x to 12.0.0 migration, the new `enclosure` right inherits the existing `datacenter` right for each profile.

Existing `enclosure` rights are preserved if the migration is executed again.

## Context

Related issue: #24401

The issue was closed because this is considered an enhancement rather than a bug. The suggested UserEcho website was unavailable, so this draft PR is intended to present and discuss a concrete implementation.

## Testing

- PHP syntax checks: passed
- PHP-CS-Fixer: passed
- PHPStan on changed source, migration, and new test: passed
- Parallel lint on changed files: passed
- Functional tests were added but could not be executed locally because no GLPI testing database is configured. They are expected to run in CI.

## AI usage

AI tools were used to assist with codebase exploration, implementation drafting, and test drafting. The resulting changes were reviewed by the contributor.