### PR TITLE
FIX / Clean custom object definition profiles JSON when a profile is purged

### DIFF
--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -629,11 +629,13 @@ abstract class AbstractDefinition extends CommonDBTM
         }
 
         unset($profiles[$profile_id]);
+        $encoded = json_encode($profiles);
         $DB->update(
             static::getTable(),
-            ['profiles' => json_encode($profiles)],
+            ['profiles' => $encoded],
             ['id' => $this->getID()]
         );
+        $this->fields['profiles'] = $encoded;
     }
 
     /**

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -612,6 +612,31 @@ abstract class AbstractDefinition extends CommonDBTM
     }
 
     /**
+     * Remove given profile from the `profiles` field.
+     * Uses a direct DB update to bypass validation, which may fail if other stale
+     * profile IDs are already present in the JSON.
+     *
+     * @param int $profile_id
+     * @return void
+     */
+    public function removeProfileFromField(int $profile_id): void
+    {
+        global $DB;
+
+        $profiles = $this->getDecodedProfilesField();
+        if (!array_key_exists($profile_id, $profiles)) {
+            return;
+        }
+
+        unset($profiles[$profile_id]);
+        $DB->update(
+            static::getTable(),
+            ['profiles' => json_encode($profiles)],
+            ['id' => $this->getID()]
+        );
+    }
+
+    /**
      * Remove given rights from `profiles` field.
      *
      * @param int[] $rights_to_remove

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -35,10 +35,10 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinitionManager;
-use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Dashboard\Grid;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QuerySubQuery;
+use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Event;
 use Glpi\Features\Clonable;
 use Glpi\Form\Form;

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Dashboard\Grid;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QuerySubQuery;
@@ -338,6 +339,14 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
         // PROFILES and UNIQUE_PROFILE in RuleMailcollector
         Rule::cleanForItemCriteria($this, 'PROFILES');
         Rule::cleanForItemCriteria($this, 'UNIQUE_PROFILE');
+
+        $profile_id = $this->getID();
+        foreach (AssetDefinitionManager::getInstance()->getDefinitions() as $definition) {
+            $definition->removeProfileFromField($profile_id);
+        }
+        foreach (DropdownDefinitionManager::getInstance()->getDefinitions() as $definition) {
+            $definition->removeProfileFromField($profile_id);
+        }
     }
 
     public function getCloneRelations(): array

--- a/tests/functional/Glpi/Asset/AssetDefinitionTest.php
+++ b/tests/functional/Glpi/Asset/AssetDefinitionTest.php
@@ -890,4 +890,31 @@ class AssetDefinitionTest extends DbTestCase
             )
         );
     }
+
+    public function testRemoveProfileFromField(): void
+    {
+        $technician_id  = getItemByTypeName(Profile::class, 'Technician', true);
+        $super_admin_id = getItemByTypeName(Profile::class, 'Super-Admin', true);
+
+        $definition = $this->initAssetDefinition(
+            profiles: [
+                $technician_id  => READ,
+                $super_admin_id => ALLSTANDARDRIGHT,
+            ]
+        );
+
+        // Removing a profile that exists removes it from the field
+        $definition->removeProfileFromField($technician_id);
+        $definition->getFromDB($definition->getID());
+        $profiles = $this->callPrivateMethod($definition, 'getDecodedProfilesField');
+        $this->assertArrayNotHasKey($technician_id, $profiles);
+        $this->assertArrayHasKey($super_admin_id, $profiles);
+
+        // Removing a profile that is not in the field is a no-op
+        $definition->removeProfileFromField($technician_id);
+        $definition->getFromDB($definition->getID());
+        $profiles = $this->callPrivateMethod($definition, 'getDecodedProfilesField');
+        $this->assertArrayNotHasKey($technician_id, $profiles);
+        $this->assertArrayHasKey($super_admin_id, $profiles);
+    }
 }

--- a/tests/functional/Glpi/Dropdown/DropdownDefinitionTest.php
+++ b/tests/functional/Glpi/Dropdown/DropdownDefinitionTest.php
@@ -840,4 +840,31 @@ class DropdownDefinitionTest extends DbTestCase
             $this->assertEquals($expected[$index]['examples'], $category->examples);
         }
     }
+
+    public function testRemoveProfileFromField(): void
+    {
+        $technician_id  = getItemByTypeName(Profile::class, 'Technician', true);
+        $super_admin_id = getItemByTypeName(Profile::class, 'Super-Admin', true);
+
+        $definition = $this->initDropdownDefinition(
+            profiles: [
+                $technician_id  => READ,
+                $super_admin_id => ALLSTANDARDRIGHT,
+            ]
+        );
+
+        // Removing a profile that exists removes it from the field
+        $definition->removeProfileFromField($technician_id);
+        $definition->getFromDB($definition->getID());
+        $profiles = $this->callPrivateMethod($definition, 'getDecodedProfilesField');
+        $this->assertArrayNotHasKey($technician_id, $profiles);
+        $this->assertArrayHasKey($super_admin_id, $profiles);
+
+        // Removing a profile that is not in the field is a no-op
+        $definition->removeProfileFromField($technician_id);
+        $definition->getFromDB($definition->getID());
+        $profiles = $this->callPrivateMethod($definition, 'getDecodedProfilesField');
+        $this->assertArrayNotHasKey($technician_id, $profiles);
+        $this->assertArrayHasKey($super_admin_id, $profiles);
+    }
 }

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -36,6 +36,7 @@ namespace tests\units;
 
 use Glpi\Asset\AssetDefinition;
 use Glpi\DBAL\QueryExpression;
+use Glpi\Dropdown\DropdownDefinition;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -428,6 +429,42 @@ class ProfileTest extends DbTestCase
                 ));
             }
         }
+    }
+
+    public function testCleanDefinitionsOnPurge(): void
+    {
+        $profile = $this->createItem(\Profile::class, ['name' => 'Profile to purge']);
+        $profile_id = $profile->getID();
+
+        $asset_definition = $this->initAssetDefinition(
+            profiles: [$profile_id => READ]
+        );
+        $dropdown_definition = $this->initDropdownDefinition(
+            profiles: [$profile_id => READ]
+        );
+
+        $this->assertArrayHasKey(
+            $profile_id,
+            $this->callPrivateMethod($asset_definition, 'getDecodedProfilesField')
+        );
+        $this->assertArrayHasKey(
+            $profile_id,
+            $this->callPrivateMethod($dropdown_definition, 'getDecodedProfilesField')
+        );
+
+        $this->deleteItem(\Profile::class, $profile_id);
+
+        $asset_definition->getFromDB($asset_definition->getID());
+        $dropdown_definition->getFromDB($dropdown_definition->getID());
+
+        $this->assertArrayNotHasKey(
+            $profile_id,
+            $this->callPrivateMethod($asset_definition, 'getDecodedProfilesField')
+        );
+        $this->assertArrayNotHasKey(
+            $profile_id,
+            $this->callPrivateMethod($dropdown_definition, 'getDecodedProfilesField')
+        );
     }
 
     public function testRightsForForm()

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -442,6 +442,17 @@ class ProfileTest extends DbTestCase
             profiles: [$profile_id => READ]
         );
 
+        // Also create an inactive definition to ensure it is cleaned up as well.
+        $inactive_asset_definition = $this->initAssetDefinition(
+            profiles: [$profile_id => READ]
+        );
+        $this->updateItem(
+            \Glpi\Asset\AssetDefinition::class,
+            $inactive_asset_definition->getID(),
+            ['is_active' => false]
+        );
+        $inactive_asset_definition->getFromDB($inactive_asset_definition->getID());
+
         $this->assertArrayHasKey(
             $profile_id,
             $this->callPrivateMethod($asset_definition, 'getDecodedProfilesField')
@@ -449,12 +460,17 @@ class ProfileTest extends DbTestCase
         $this->assertArrayHasKey(
             $profile_id,
             $this->callPrivateMethod($dropdown_definition, 'getDecodedProfilesField')
+        );
+        $this->assertArrayHasKey(
+            $profile_id,
+            $this->callPrivateMethod($inactive_asset_definition, 'getDecodedProfilesField')
         );
 
         $this->deleteItem(\Profile::class, $profile_id);
 
         $asset_definition->getFromDB($asset_definition->getID());
         $dropdown_definition->getFromDB($dropdown_definition->getID());
+        $inactive_asset_definition->getFromDB($inactive_asset_definition->getID());
 
         $this->assertArrayNotHasKey(
             $profile_id,
@@ -463,6 +479,10 @@ class ProfileTest extends DbTestCase
         $this->assertArrayNotHasKey(
             $profile_id,
             $this->callPrivateMethod($dropdown_definition, 'getDecodedProfilesField')
+        );
+        $this->assertArrayNotHasKey(
+            $profile_id,
+            $this->callPrivateMethod($inactive_asset_definition, 'getDecodedProfilesField')
         );
     }
 

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -447,7 +447,7 @@ class ProfileTest extends DbTestCase
             profiles: [$profile_id => READ]
         );
         $this->updateItem(
-            \Glpi\Asset\AssetDefinition::class,
+            AssetDefinition::class,
             $inactive_asset_definition->getID(),
             ['is_active' => false]
         );

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -36,7 +36,6 @@ namespace tests\units;
 
 use Glpi\Asset\AssetDefinition;
 use Glpi\DBAL\QueryExpression;
-use Glpi\Dropdown\DropdownDefinition;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44772
- When a profile is purged, `Profile::cleanDBonPurge()` correctly removes `ProfileRight` entries but did not clean the `profiles` JSON field stored in `glpi_assets_assetdefinitions` and `glpi_dropdowns_dropdowndefinitions`. This left orphaned profile IDs in those JSON fields. Any subsequent attempt to update rights for an affected definition would fail with "incorrect value : Profiles" because `validateProfileArray()` checks that all profile IDs in the JSON exist in `glpi_profiles`.

<img width="442" height="197" alt="Capture d’écran du 2026-06-19 16-17-29" src="https://github.com/user-attachments/assets/bc842373-c681-4a7d-b567-7227fcc2bc77" />

