### PR TITLE
Feat/sql optimization

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -11732,12 +11732,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Output/Tcpdf.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Argument of an invalid type array\\<string\\>\\|null supplied for foreach, only iterables are supported\\.$#',
-	'identifier' => 'foreach.nonIterable',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Provider/SQLProvider.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Argument of an invalid type list\\<array\\<int\\>\\|int\\|string\\|null\\>\\|null supplied for foreach, only iterables are supported\\.$#',
 	'identifier' => 'foreach.nonIterable',
 	'count' => 1,

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -114,6 +114,7 @@ use User;
 use ValidatorSubstitute;
 
 use function Safe\preg_match;
+use function Safe\preg_match_all;
 use function Safe\preg_replace;
 use function Safe\preg_split;
 use function Safe\strtotime;
@@ -4426,6 +4427,293 @@ final class SQLProvider implements SearchProviderInterface
         return $orderby_criteria;
     }
 
+    /**
+     * IDs of forcegroupby (1:N) fields used as a WHERE filter: their join must stay in the
+     * minimal FROM (the WHERE references it), unlike display-only 1:N joins which are deferred.
+     *
+     * @param array<int|string, mixed> $criteria
+     * @param array<int|string, mixed> $searchopt
+     * @return list<int>
+     */
+    private static function collectFilterForcegroupbyIds(array $criteria, array $searchopt): array
+    {
+        $ids = [];
+        foreach ($criteria as $criterion) {
+            if (isset($criterion['criteria']) && is_array($criterion['criteria'])) {
+                $ids = array_merge($ids, self::collectFilterForcegroupbyIds($criterion['criteria'], $searchopt));
+                continue;
+            }
+            if (
+                isset($criterion['field'])
+                && !in_array($criterion['field'], ['all', 'view'], true)
+                && !($criterion['meta'] ?? false)
+                && isset($criterion['value'])
+                && (string) $criterion['value'] !== ''
+                && !empty($searchopt[$criterion['field']]['forcegroupby'])
+            ) {
+                $ids[] = $criterion['field'];
+            }
+        }
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Minimal FROM for the inner/COUNT queries: base table + default join + the 1:1
+     * $data['tocompute'] joins, deferring display-only 1:N (forcegroupby) joins — except those in
+     * $keep_forcegroupby_ids (filtered in WHERE, so still referenced). Aliases are deterministic
+     * ({@see computeComplexJoinID()}) so they match the $WHERE fragment. Only valid without meta
+     * criterion / all_search (their WHERE may reference joins absent from $data['tocompute']).
+     *
+     * @param array<int|string, mixed> $data
+     * @param array<int|string, mixed> $searchopt
+     * @param array<int, string>       $blacklist_tables
+     * @param list<int>                $keep_forcegroupby_ids Forcegroupby field IDs filtered in WHERE.
+     * @return array{query: string, params: array<int, mixed>}
+     */
+    private static function buildMinimalFrom(
+        array $data,
+        string $itemtable,
+        array $searchopt,
+        array $blacklist_tables,
+        array $keep_forcegroupby_ids
+    ): array {
+        $already_link_tables = [$itemtable];
+
+        $query  = self::buildFrom($itemtable) . ' ';
+        $default_ljoin = Search::addDefaultJoin($data['itemtype'], $itemtable, $already_link_tables);
+        $query .= $default_ljoin->getQuery() . ' ';
+        $params = $default_ljoin->getParams();
+
+        foreach ($data['tocompute'] as $val) {
+            if (
+                !isset($searchopt[$val]['table'])
+                || in_array($searchopt[$val]['table'], $blacklist_tables, true)
+            ) {
+                continue;
+            }
+            // Defer display-only 1:N joins, but keep those filtered in WHERE.
+            if (!empty($searchopt[$val]['forcegroupby']) && !in_array($val, $keep_forcegroupby_ids, true)) {
+                continue;
+            }
+            $ljoin = Search::addLeftJoin(
+                $data['itemtype'],
+                $itemtable,
+                $already_link_tables,
+                $searchopt[$val]['table'],
+                $searchopt[$val]['linkfield'],
+                false,
+                '',
+                $searchopt[$val]['joinparams'] ?? [],
+                $searchopt[$val]['field'] ?? '',
+                ($searchopt[$val]['use_join_subquery'] ?? false)
+            );
+            $query  .= $ljoin->getQuery() . ' ';
+            $params  = array_merge($params, $ljoin->getParams());
+        }
+
+        return ['query' => $query, 'params' => $params];
+    }
+
+    /**
+     * Inner-subquery ORDER BY: plain main-table columns only (guaranteed by canUseDeferredJoin),
+     * with a trailing `id` for stable pagination.
+     *
+     * @param array<int|string, mixed> $sort_fields
+     * @param array<int|string, mixed> $searchopt
+     */
+    private static function buildInnerOrderBy(string $itemtable, array $sort_fields, array $searchopt): string
+    {
+        global $DB;
+
+        $criteria = [];
+        foreach ($sort_fields as $sort_field) {
+            $ID = $sort_field['searchopt_id'];
+            if (!isset($searchopt[$ID]['field'])) {
+                continue;
+            }
+            $order      = (($sort_field['order'] ?? 'ASC') === 'ASC') ? 'ASC' : 'DESC';
+            $criteria[] = $DB::quoteName("{$itemtable}.{$searchopt[$ID]['field']}") . ' ' . $order;
+        }
+        $criteria[] = $DB::quoteName("{$itemtable}.id") . ' ASC';
+
+        return ' ORDER BY ' . implode(', ', $criteria);
+    }
+
+    /**
+     * Inner subquery resolving the page of main-table IDs alone (no display 1:N joins), grouped
+     * by id with ORDER BY + LIMIT. getParams() order: minimal-FROM, then WHERE.
+     *
+     * @param array{query: string, params: array<int, mixed>} $minimal_from
+     * @param array<int, mixed>                                $WHERE_VALUES
+     */
+    private static function buildDeferredInnerQuery(
+        string $itemtable,
+        array $minimal_from,
+        string $WHERE,
+        array $WHERE_VALUES,
+        string $inner_order,
+        string $LIMIT
+    ): Select {
+        $query = 'SELECT `' . $itemtable . '`.`id`'
+            . $minimal_from['query']
+            . $WHERE
+            . ' GROUP BY `' . $itemtable . '`.`id`'
+            . $inner_order
+            . $LIMIT;
+
+        return (new Select())
+            ->setQuery($query)
+            ->setParams(array_merge($minimal_from['params'], $WHERE_VALUES));
+    }
+
+    /**
+     * COUNT(DISTINCT id) query giving the total row count for an active (SQL-limited) search.
+     *
+     * @param array{query: string, params: array<int, mixed>} $minimal_from
+     * @param array<int, mixed>                                $WHERE_VALUES
+     */
+    private static function buildActiveCountQuery(
+        string $itemtable,
+        array $minimal_from,
+        string $WHERE,
+        array $WHERE_VALUES
+    ): Select {
+        $query = 'SELECT COUNT(DISTINCT `' . $itemtable . '`.`id`)'
+            . $minimal_from['query']
+            . $WHERE;
+
+        return (new Select())
+            ->setQuery($query)
+            ->setParams(array_merge($minimal_from['params'], $WHERE_VALUES));
+    }
+
+    /**
+     * Whether deferred-join pagination is safe: grouped, limited, ordered, non-union search with
+     * no meta/`view`/`all` criterion, no HAVING, and every sort field a plain main-table column
+     * (so the page can be resolved and ordered from the main table alone). HAVING / 1:N-aggregate
+     * sorts are excluded on purpose — the aggregate must be computed over the whole relation
+     * anyway, so deferral buys little. Otherwise the normal query is emitted.
+     *
+     * @param array<int|string, mixed> $data
+     * @param array<int|string, mixed> $sort_fields
+     * @param array<int|string, mixed> $searchopt
+     */
+    private static function canUseDeferredJoin(
+        array $data,
+        string $itemtable,
+        string $GROUPBY,
+        string $LIMIT,
+        string $ORDER,
+        string $HAVING,
+        array $sort_fields,
+        array $searchopt
+    ): bool {
+        global $CFG_GLPI;
+
+        if (isset($CFG_GLPI['union_search_type'][$data['itemtype']])) {
+            return false;
+        }
+        if ($GROUPBY === '' || $LIMIT === '' || $ORDER === '' || $HAVING !== '') {
+            return false;
+        }
+        if (!empty($data['search']['all_search'])) {
+            return false;
+        }
+        if (count($data['search']['metacriteria'] ?? []) > 0) {
+            return false;
+        }
+        if (self::hasMetaCriteria($data['search']['criteria'] ?? [])) {
+            return false;
+        }
+        // `view`/`all` filters over every displayed column (incl. deferred 1:N joins).
+        if (self::criteriaReferenceAllColumns($data['search']['criteria'] ?? [])) {
+            return false;
+        }
+
+        foreach ($sort_fields as $sort_field) {
+            $ID = $sort_field['searchopt_id'];
+            if (!isset($searchopt[$ID]['table']) || !isset($searchopt[$ID]['field'])) {
+                return false;
+            }
+            $opt = $searchopt[$ID];
+            // Only plain main-table columns are orderable in the inner subquery.
+            if (
+                $opt['table'] !== $itemtable
+                || !empty($opt['joinparams'])
+                || !empty($opt['forcegroupby'])
+                || !empty($opt['nosort'])
+                || isset($opt['computation'])
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether the criteria tree contains any meta criterion (recursively).
+     *
+     * @param array<int|string, mixed> $criteria
+     */
+    private static function hasMetaCriteria(array $criteria): bool
+    {
+        foreach ($criteria as $criterion) {
+            if (isset($criterion['criteria']) && is_array($criterion['criteria'])) {
+                if (self::hasMetaCriteria($criterion['criteria'])) {
+                    return true;
+                }
+            } elseif ($criterion['meta'] ?? false) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the criteria tree has a `view`/`all` criterion with a non-empty value: it expands
+     * the WHERE over every displayed column (incl. deferred 1:N joins), so we cannot optimise.
+     *
+     * @param array<int|string, mixed> $criteria
+     */
+    private static function criteriaReferenceAllColumns(array $criteria): bool
+    {
+        foreach ($criteria as $criterion) {
+            if (isset($criterion['criteria']) && is_array($criterion['criteria'])) {
+                if (self::criteriaReferenceAllColumns($criterion['criteria'])) {
+                    return true;
+                }
+            } elseif (
+                isset($criterion['field'])
+                && in_array($criterion['field'], ['all', 'view'], true)
+                && isset($criterion['value'])
+                && (string) $criterion['value'] !== ''
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether every `alias`.`column` table reference in the WHERE clause has its alias present in
+     * the given (minimal) FROM clause. Guards against a WHERE that pulls in a deferred 1:N join
+     * via the itemtype visibility/default restriction. Errs on the safe side: a subquery-local
+     * alias (rare in WHERE) yields false → the optimisation is skipped, never a broken query.
+     */
+    private static function minimalFromCoversWhere(string $minimal_from, string $where): bool
+    {
+        if (!preg_match_all('/`([a-z0-9_]+)`\s*\.\s*`/i', $where, $matches)) {
+            return true;
+        }
+        foreach (array_unique($matches[1]) as $alias) {
+            if (!str_contains($minimal_from, '`' . $alias . '`')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     #[Override]
     public static function constructSQL(array &$data)
     {
@@ -4439,6 +4727,10 @@ final class SQLProvider implements SearchProviderInterface
         $data['sql']['count']  = [];
         $data['sql']['search'] = '';
         $data['sql']['raw']    = [];
+        // Set to true when a SQL LIMIT is applied to an *active* search (see the deferred-join
+        // optimisation below): pagination then happens in the database and the total row count
+        // is obtained from the dedicated COUNT queries rather than from numrows().
+        $data['sql']['has_sql_limit'] = false;
 
         $searchopt        = SearchOption::getOptionsForItemtype($data['itemtype']);
 
@@ -4470,6 +4762,11 @@ final class SQLProvider implements SearchProviderInterface
         // Set reference table
         $FROM = self::buildFrom($itemtable);
 
+        // LEFT JOIN part kept in its own buffers (in lockstep with $FROM), so the deferred-join
+        // outer query can reuse the display joins without substring extraction.
+        $FROM_JOINS = '';
+        $FROM_JOINS_VALUES = [];
+
         // Init already linked tables array in order not to link a table several times
         // Put reference table
         $already_link_tables = [$itemtable];
@@ -4479,6 +4776,8 @@ final class SQLProvider implements SearchProviderInterface
         $COMMONLEFTJOIN = $default_ljoin->getQuery() . ' ';
         $FROM          .= $COMMONLEFTJOIN;
         $FROM_VALUES = $default_ljoin->getParams();
+        $FROM_JOINS        .= $COMMONLEFTJOIN;
+        $FROM_JOINS_VALUES  = $default_ljoin->getParams();
 
         // Add all table for toview items
         foreach ($data['tocompute'] as $val) {
@@ -4497,6 +4796,8 @@ final class SQLProvider implements SearchProviderInterface
                 );
                 $FROM .= $ljoin->getQuery() . ' ';
                 $FROM_VALUES = array_merge($FROM_VALUES, $ljoin->getParams());
+                $FROM_JOINS .= $ljoin->getQuery() . ' ';
+                $FROM_JOINS_VALUES = array_merge($FROM_JOINS_VALUES, $ljoin->getParams());
             }
         }
 
@@ -4521,6 +4822,8 @@ final class SQLProvider implements SearchProviderInterface
                         );
                         $FROM .= $ljoin->getQuery() . ' ';
                         $FROM_VALUES = array_merge($FROM_VALUES, $ljoin->getParams());
+                        $FROM_JOINS .= $ljoin->getQuery() . ' ';
+                        $FROM_JOINS_VALUES = array_merge($FROM_JOINS_VALUES, $ljoin->getParams());
                     }
                 }
             }
@@ -4629,6 +4932,8 @@ final class SQLProvider implements SearchProviderInterface
             foreach ($adds['FROM'] as $add_from) {
                 $FROM .= $add_from->getQuery() . ' ';
                 $FROM_VALUES = array_merge($FROM_VALUES, $add_from->getParams());
+                $FROM_JOINS .= $add_from->getQuery() . ' ';
+                $FROM_JOINS_VALUES = array_merge($FROM_JOINS_VALUES, $add_from->getParams());
             }
             $data['meta_toview'] = $adds['meta_toview'];
         }
@@ -5012,6 +5317,47 @@ final class SQLProvider implements SearchProviderInterface
                 $WHERE_VALUES = array_merge($WHERE_VALUES, $system_criteria_sql->getParams());
             }
 
+            // Active-search pagination: apply a SQL LIMIT (+ a dedicated COUNT query) so paging
+            // happens in the DB instead of fetching everything. Relies on the minimal FROM
+            // covering the WHERE, which holds only without meta/all_search/`view`/`all`/HAVING;
+            // otherwise keep the legacy fetch-all behaviour.
+            $supports_sql_limit = empty($data['search']['all_search'])
+                && $HAVING === ''
+                && count($data['search']['metacriteria'] ?? []) === 0
+                && !self::hasMetaCriteria($data['search']['criteria'] ?? [])
+                && !self::criteriaReferenceAllColumns($data['search']['criteria'] ?? []);
+
+            $need_active_count = false;
+            if (
+                $supports_sql_limit
+                && empty($LIMIT)
+                && !$data['search']['export_all']
+                && (($data['search']['as_map'] ?? 0) != 1)
+            ) {
+                $LIMIT = " LIMIT " . (int) $data['search']['start'] . ", " . (int) $data['search']['list_limit'];
+                $data['sql']['has_sql_limit'] = true;
+                $need_active_count = true;
+            }
+
+            $can_defer = self::canUseDeferredJoin($data, $itemtable, $GROUPBY, $LIMIT, $ORDER, $HAVING, $sort_fields, $searchopt);
+
+            // Minimal FROM shared by the active COUNT query and the deferred inner subquery.
+            $minimal_from = null;
+            if ($can_defer || $need_active_count) {
+                $keep_forcegroupby_ids = self::collectFilterForcegroupbyIds($data['search']['criteria'], $searchopt);
+                $minimal_from = self::buildMinimalFrom($data, $itemtable, $searchopt, $blacklist_tables, $keep_forcegroupby_ids);
+                // The WHERE may reference a 1:N join via the itemtype visibility/default
+                // restriction (not just user criteria, e.g. KnowbaseItem). If the minimal FROM
+                // does not cover every alias the WHERE uses, fall back to the full query.
+                if (!self::minimalFromCoversWhere($minimal_from['query'], $WHERE)) {
+                    $can_defer         = false;
+                    $need_active_count = false;
+                    $minimal_from      = null;
+                    $LIMIT             = '';
+                    $data['sql']['has_sql_limit'] = false;
+                }
+            }
+
             $data['sql']['raw'] = [
                 'SELECT' => $SELECT,
                 'FROM' => $FROM,
@@ -5021,19 +5367,53 @@ final class SQLProvider implements SearchProviderInterface
                 'ORDER' => $ORDER,
                 'LIMIT' => $LIMIT,
             ];
-            $QUERY_VALUES = array_merge(
-                $SELECT_VALUES,
-                $FROM_VALUES,
-                $WHERE_VALUES,
-                $HAVING_VALUES
-            );
-            $QUERY = $SELECT
-                . $FROM
-                . $WHERE
-                . $GROUPBY
-                . $HAVING
-                . $ORDER
-                . $LIMIT;
+
+            if ($need_active_count && $minimal_from !== null) {
+                $data['sql']['count'][] = self::buildActiveCountQuery(
+                    $itemtable,
+                    $minimal_from,
+                    $WHERE,
+                    $WHERE_VALUES
+                );
+            }
+
+            if ($can_defer && $minimal_from !== null) {
+                // Two-phase: inner subquery picks the page of ids (no display 1:N joins), outer
+                // query attaches the display joins to just those ids.
+                $inner = self::buildDeferredInnerQuery(
+                    $itemtable,
+                    $minimal_from,
+                    $WHERE,
+                    $WHERE_VALUES,
+                    self::buildInnerOrderBy($itemtable, $sort_fields, $searchopt),
+                    $LIMIT
+                );
+
+                $QUERY = $SELECT
+                    . " FROM `" . $itemtable . "`"
+                    . " INNER JOIN (" . $inner->getQuery() . ") AS `deferred_page`"
+                    . " ON `" . $itemtable . "`.`id` = `deferred_page`.`id` "
+                    . $FROM_JOINS
+                    . $GROUPBY
+                    . $ORDER;
+                // Param order matches the `?` order: outer SELECT, inner subquery (its WHERE
+                // included), then outer display joins — inner WHERE BEFORE the joins here.
+                $QUERY_VALUES = array_merge($SELECT_VALUES, $inner->getParams(), $FROM_JOINS_VALUES);
+            } else {
+                $QUERY_VALUES = array_merge(
+                    $SELECT_VALUES,
+                    $FROM_VALUES,
+                    $WHERE_VALUES,
+                    $HAVING_VALUES
+                );
+                $QUERY = $SELECT
+                    . $FROM
+                    . $WHERE
+                    . $GROUPBY
+                    . $HAVING
+                    . $ORDER
+                    . $LIMIT;
+            }
         }
         $data['sql']['search'] = (new Select())
             ->setQuery($QUERY)
@@ -5457,27 +5837,24 @@ final class SQLProvider implements SearchProviderInterface
             }
 
             $data['data']['totalcount'] = 0;
-            // if real search or complete export : get numrows from request
-            if (
-                !$data['search']['no_search']
-                || $data['search']['export_all']
-            ) {
-                $data['data']['totalcount'] = $DBread->numrows($result);
-            } else {
-                if (
-                    !isset($data['sql']['count'])
-                    || (count($data['sql']['count']) == 0)
-                ) {
-                    $data['data']['totalcount'] = $DBread->numrows($result);
-                } else {
-                    foreach ($data['sql']['count'] as $sqlcount) {
-                        $stmt = $DBread->prepare($sqlcount->getQuery());
-                        $DBread->executeStatement($stmt, $sqlcount->getParams());
-                        if ($sqlcount_result = $stmt->get_result()) {
-                            $data['data']['totalcount'] += $DBread->result($sqlcount_result, 0, 0);
-                        }
+            // With a SQL LIMIT (no_search, or active search via has_sql_limit) the result is only
+            // the current page, so the total comes from the COUNT queries; otherwise numrows().
+            $use_count_queries = (
+                ($data['search']['no_search'] || ($data['sql']['has_sql_limit'] ?? false))
+                && !$data['search']['export_all']
+                && isset($data['sql']['count'])
+                && count($data['sql']['count']) > 0
+            );
+            if ($use_count_queries) {
+                foreach ($data['sql']['count'] as $sqlcount) {
+                    $stmt = $DBread->prepare($sqlcount->getQuery());
+                    $DBread->executeStatement($stmt, $sqlcount->getParams());
+                    if ($sqlcount_result = $stmt->get_result()) {
+                        $data['data']['totalcount'] += $DBread->result($sqlcount_result, 0, 0);
                     }
                 }
+            } else {
+                $data['data']['totalcount'] = $DBread->numrows($result);
             }
 
             if ($onlycount) {
@@ -5608,8 +5985,8 @@ final class SQLProvider implements SearchProviderInterface
 
             // Get rows
 
-            // if real search seek to begin of items to display (because of complete search)
-            if (!$data['search']['no_search']) {
+            // Seek to the page start, unless a SQL LIMIT already positioned the result there.
+            if (!$data['search']['no_search'] && !($data['sql']['has_sql_limit'] ?? false)) {
                 $DBread->dataSeek($result, $data['search']['start']);
             }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5881,7 +5881,9 @@ final class SQLProvider implements SearchProviderInterface
                     self::constructSQL($data);
                     $stmt = $DBread->prepare($data['sql']['search']->getQuery());
                     $DBread->executeStatement($stmt, $data['sql']['search']->getParams());
-                    $result = $stmt->get_result();
+                    if ($rebuilt_result = $stmt->get_result()) {
+                        $result = $rebuilt_result;
+                    }
                 }
             }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4451,18 +4451,17 @@ final class SQLProvider implements SearchProviderInterface
                 && (string) $criterion['value'] !== ''
                 && !empty($searchopt[$criterion['field']]['forcegroupby'])
             ) {
-                $ids[] = $criterion['field'];
+                $ids[] = (int) $criterion['field'];
             }
         }
         return array_values(array_unique($ids));
     }
 
     /**
-     * Minimal FROM for the inner/COUNT queries: base table + default join + the 1:1
-     * $data['tocompute'] joins, deferring display-only 1:N (forcegroupby) joins — except those in
-     * $keep_forcegroupby_ids (filtered in WHERE, so still referenced). Aliases are deterministic
-     * ({@see computeComplexJoinID()}) so they match the $WHERE fragment. Only valid without meta
-     * criterion / all_search (their WHERE may reference joins absent from $data['tocompute']).
+     * Minimal FROM for the inner/COUNT queries: base + default join + 1:1 joins, deferring
+     * display-only 1:N (forcegroupby) joins except those in $keep_forcegroupby_ids (WHERE-filtered).
+     * Uses its own $already_link_tables so a kept filter join re-emits any `beforejoin` parent a
+     * deferred join would otherwise have supplied. Not valid with meta criterion / all_search.
      *
      * @param array<int|string, mixed> $data
      * @param array<int|string, mixed> $searchopt
@@ -4491,8 +4490,8 @@ final class SQLProvider implements SearchProviderInterface
             ) {
                 continue;
             }
-            // Defer display-only 1:N joins, but keep those filtered in WHERE.
-            if (!empty($searchopt[$val]['forcegroupby']) && !in_array($val, $keep_forcegroupby_ids, true)) {
+            // Defer display-only 1:N joins; keep WHERE-filtered ones ((int) $val: mixed id types).
+            if (!empty($searchopt[$val]['forcegroupby']) && !in_array((int) $val, $keep_forcegroupby_ids, true)) {
                 continue;
             }
             $ljoin = Search::addLeftJoin(
@@ -4515,8 +4514,9 @@ final class SQLProvider implements SearchProviderInterface
     }
 
     /**
-     * Inner-subquery ORDER BY: plain main-table columns only (guaranteed by canUseDeferredJoin),
-     * with a trailing `id` for stable pagination.
+     * Inner-subquery ORDER BY: bare main-table column per sort field + trailing `id` for stable
+     * paging. The outer ORDER BY can't be reused (it uses the `ITEM_x` SELECT aliases, absent
+     * here); canUseDeferredJoin() guarantees each sort field is a plain column, so this is valid.
      *
      * @param array<int|string, mixed> $sort_fields
      * @param array<int|string, mixed> $searchopt
@@ -4643,6 +4643,16 @@ final class SQLProvider implements SearchProviderInterface
                 || !empty($opt['forcegroupby'])
                 || !empty($opt['nosort'])
                 || isset($opt['computation'])
+            ) {
+                return false;
+            }
+            // Skip if the sort has a computed ORDER expression (date_delay, IP, plugin, …): the
+            // inner subquery can only order by the bare column. getOrderByCriteria() returns the
+            // `ITEM_x` alias only for plain columns, so anything else disqualifies deferral.
+            $order_exprs = self::getOrderByCriteria($data['itemtype'], [$sort_field]);
+            if (
+                count($order_exprs) !== 1
+                || !str_starts_with($order_exprs[0]->getValue(), '`ITEM_' . $data['itemtype'] . '_' . $ID . '`')
             ) {
                 return false;
             }
@@ -5865,6 +5875,14 @@ final class SQLProvider implements SearchProviderInterface
 
             if ($data['search']['start'] > $data['data']['totalcount']) {
                 $data['search']['start'] = 0;
+                // A SQL LIMIT already fetched the (empty) out-of-range page; rebuild with the
+                // clamped start and re-run so the first page is returned, as before optimization.
+                if ($data['sql']['has_sql_limit'] ?? false) {
+                    self::constructSQL($data);
+                    $stmt = $DBread->prepare($data['sql']['search']->getQuery());
+                    $DBread->executeStatement($stmt, $data['sql']['search']->getParams());
+                    $result = $stmt->get_result();
+                }
             }
 
             // Search case
@@ -6003,6 +6021,10 @@ final class SQLProvider implements SearchProviderInterface
             Profiler::getInstance()->pause('SQLProvider::constructData - giveItem');
             while (($i < $data['data']['totalcount']) && ($i <= $data['data']['end'])) {
                 $row = $DBread->fetchAssoc($result);
+                if ($row === null || $row === false) {
+                    // Defensive: fewer rows than totalcount expects; don't parse a null row.
+                    break;
+                }
 
                 $newrow        = [];
                 $newrow['raw'] = $row;

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -7422,6 +7422,130 @@ class SearchTest extends DbTestCase
         $this->assertStringNotContainsString('deferred_page', $data['sql']['search']->getQuery());
         $this->assertFalse($data['sql']['has_sql_limit']);
     }
+
+    /**
+     * Sorting on a computed-ORDER column must not be deferred. Contract "End date" (option 20,
+     * a `date_delay` whose `field` is the non-existent column `end_date`) previously reached the
+     * deferred inner subquery, which emitted `ORDER BY glpi_contracts.end_date` and crashed with
+     * "Unknown column". The optimisation must now be skipped for such fields: the regular query
+     * (ordering by DATE_ADD()) is emitted and returns correctly ordered rows.
+     */
+    public function testDeferredJoinSkippedForComputedOrderColumn()
+    {
+        $this->login();
+        $entity = (int) $_SESSION['glpiactive_entity'];
+
+        $token    = 'deferredorder_' . mt_rand();
+        $contract = new \Contract();
+        // Same begin_date, different duration => distinct computed end dates.
+        $c_short = (int) $contract->add([
+            'name'        => $token . ' short',
+            'entities_id' => $entity,
+            'begin_date'  => '2020-01-01',
+            'duration'    => 12, // ends 2021-01-01
+        ]);
+        $c_long = (int) $contract->add([
+            'name'        => $token . ' long',
+            'entities_id' => $entity,
+            'begin_date'  => '2020-01-01',
+            'duration'    => 24, // ends 2022-01-01
+        ]);
+        $this->assertGreaterThan(0, $c_short);
+        $this->assertGreaterThan(0, $c_long);
+
+        // Displaying option 29 (Associated supplier, a forcegroupby 1:N column) forces GROUP BY
+        // and thus the deferred-join optimisation; the criterion on the main-table name isolates
+        // our contracts.
+        $base = [
+            'reset'    => 'reset',
+            'sort'     => [20], // End date (date_delay, main table)
+            'criteria' => [
+                ['field' => 1, 'searchtype' => 'contains', 'value' => $token],
+            ],
+        ];
+        $get_ids = static fn(array $d): array => array_values(
+            array_map('intval', array_column(array_column($d['data']['rows'], 'raw'), 'id'))
+        );
+
+        $asc = \Search::getDatas(\Contract::class, $base + ['order' => ['ASC'], 'start' => 0, 'list_limit' => 30], [29]);
+        $query = $asc['sql']['search']->getQuery();
+        // Computed-ORDER field => deferral skipped, regular query with the DATE_ADD expression.
+        $this->assertStringNotContainsString('deferred_page', $query);
+        $this->assertStringContainsStringIgnoringCase('DATE_ADD', $query);
+        $this->assertSame(2, $asc['data']['totalcount']);
+        $this->assertSame([$c_short, $c_long], $get_ids($asc));
+
+        $desc = \Search::getDatas(\Contract::class, $base + ['order' => ['DESC'], 'start' => 0, 'list_limit' => 30], [29]);
+        $this->assertSame([$c_long, $c_short], $get_ids($desc));
+    }
+
+    /**
+     * Filtering on a forcegroupby (1:N) field puts a condition on its joined table in the WHERE,
+     * so that join must be kept in the minimal FROM (its searchopt id is collected). A former
+     * int-vs-string strict comparison never matched, so the join was deferred out and
+     * minimalFromCoversWhere() silently disabled the optimisation. It must stay active.
+     */
+    public function testDeferredJoinKeepsForcegroupbyFilterJoin()
+    {
+        $this->login();
+
+        // Computer option 49 = "Group in charge" (forcegroupby, no usehaving) => WHERE condition.
+        $data = \Search::prepareDatasForSearch(Computer::class, [
+            'reset'    => 'reset',
+            'sort'     => [2], // id (plain main-table column)
+            'order'    => ['ASC'],
+            'criteria' => [
+                ['field' => 49, 'searchtype' => 'contains', 'value' => 'whatever'],
+            ],
+        ]);
+        \Search::constructSQL($data);
+        $query = $data['sql']['search']->getQuery();
+
+        $this->assertStringContainsString(
+            'deferred_page',
+            $query,
+            'filtering a forcegroupby field must not disable the deferred-join optimisation'
+        );
+        // The filtered group join must be present (inside the inner subquery / minimal FROM).
+        $this->assertStringContainsString('glpi_groups', $query);
+        $this->assertSame(
+            substr_count($query, '?'),
+            count($data['sql']['search']->getParams()),
+            'placeholder/param count mismatch: ' . $query
+        );
+    }
+
+    /**
+     * Requesting a page past the last one under an active SQL LIMIT (stale bookmark / edited URL
+     * / API) must not error: it falls back to the first page, matching the pre-optimization
+     * behaviour where the full result was fetched and the start clamped.
+     */
+    public function testActiveSearchOutOfRangeStart()
+    {
+        $this->login();
+        $entity = (int) $_SESSION['glpiactive_entity'];
+
+        $token    = 'oorstart_' . mt_rand();
+        $computer = new Computer();
+        $id = (int) $computer->add(['name' => $token, 'entities_id' => $entity]);
+        $this->assertGreaterThan(0, $id);
+
+        $data = \Search::getDatas(Computer::class, [
+            'reset'      => 'reset',
+            'sort'       => [2],
+            'order'      => ['ASC'],
+            'start'      => 50, // far past the single match
+            'list_limit' => 20,
+            'criteria'   => [
+                ['field' => 1, 'searchtype' => 'contains', 'value' => $token],
+            ],
+        ]);
+
+        $this->assertTrue($data['sql']['has_sql_limit']);
+        $this->assertSame(1, $data['data']['totalcount']);
+        $ids = array_values(array_map('intval', array_column(array_column($data['data']['rows'], 'raw'), 'id')));
+        $this->assertSame([$id], $ids);
+    }
 }
 
 // @codingStandardsIgnoreStart

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -7299,6 +7299,129 @@ class SearchTest extends DbTestCase
         $this->assertArrayHasKey('data', $result);
         $this->assertEquals(0, $result['data']['totalcount'], 'Should find no computer for a non-existing asset URL');
     }
+
+    /**
+     * The deferred-join pagination optimisation must produce, for a grouped search (here a
+     * Computer search displaying the 1:N "Group in charge" column, option 49), the exact same
+     * total count and the same ordered page of ids as a non-paginated reference run.
+     */
+    public function testDeferredJoinPaginationConsistency()
+    {
+        $this->login();
+        $entity = (int) $_SESSION['glpiactive_entity'];
+
+        $token    = 'deferredjoin_' . mt_rand();
+        $computer = new Computer();
+        $created  = [];
+        for ($i = 0; $i < 5; $i++) {
+            $id = $computer->add([
+                'name'        => sprintf('%s %02d', $token, $i),
+                'entities_id' => $entity,
+            ]);
+            $this->assertGreaterThan(0, $id);
+            $created[] = (int) $id;
+        }
+        sort($created);
+
+        // option 49 ("Group in charge") is forcegroupby, so forcing its display triggers the
+        // GROUP BY and therefore the deferred-join optimisation; criterion on the main-table
+        // name (option 1) isolates our 5 computers.
+        $base = [
+            'reset'    => 'reset',
+            'sort'     => [2], // id (plain main-table column)
+            'order'    => ['ASC'],
+            'criteria' => [
+                ['field' => 1, 'searchtype' => 'contains', 'value' => $token],
+            ],
+        ];
+        $get_ids = static fn(array $d): array => array_values(
+            array_map('intval', array_column(array_column($d['data']['rows'], 'raw'), 'id'))
+        );
+
+        // Reference: one large page.
+        $ref = \Search::getDatas(Computer::class, $base + ['start' => 0, 'list_limit' => 1000], [49]);
+        $query = $ref['sql']['search']->getQuery();
+        $this->assertStringContainsString('deferred_page', $query, 'deferred-join optimisation should be active');
+        $this->assertSame(
+            substr_count($query, '?'),
+            count($ref['sql']['search']->getParams()),
+            'placeholder/param count mismatch: ' . $query
+        );
+        $this->assertSame(5, $ref['data']['totalcount']);
+        $this->assertSame($created, $get_ids($ref));
+
+        // Paginated: 2 + 2 + 1 must equal the reference slices, with a stable total count.
+        $page1 = \Search::getDatas(Computer::class, $base + ['start' => 0, 'list_limit' => 2], [49]);
+        $page2 = \Search::getDatas(Computer::class, $base + ['start' => 2, 'list_limit' => 2], [49]);
+        $page3 = \Search::getDatas(Computer::class, $base + ['start' => 4, 'list_limit' => 2], [49]);
+
+        foreach ([$page1, $page2, $page3] as $page) {
+            $this->assertSame(5, $page['data']['totalcount']);
+        }
+        $this->assertSame(array_slice($created, 0, 2), $get_ids($page1));
+        $this->assertSame(array_slice($created, 2, 2), $get_ids($page2));
+        $this->assertSame(array_slice($created, 4, 1), $get_ids($page3));
+    }
+
+    /**
+     * A criterion on a forcegroupby (1:N) field produces a HAVING clause: the deferred-join
+     * inner subquery must then expose the aggregated SELECT aliases referenced by HAVING and
+     * keep a consistent placeholder/parameter count, and the whole thing must execute.
+     */
+    public function testDeferredJoinSkippedForHavingAndAggregateSort()
+    {
+        $this->login();
+
+        // Filtering on a HAVING (usehaving) field — Ticket option 188 "Next escalation level":
+        // the aggregate must be computed over the whole relation, so deferral is skipped.
+        $having = \Search::prepareDatasForSearch(Ticket::class, [
+            'reset'    => 'reset',
+            'sort'     => [2],
+            'order'    => ['ASC'],
+            'criteria' => [['field' => 188, 'searchtype' => 'contains', 'value' => '2020']],
+        ]);
+        \Search::constructSQL($having);
+        $this->assertStringNotContainsString('deferred_page', $having['sql']['search']->getQuery());
+
+        // Sorting on a 1:N aggregate — Software option 72 "Number of installations": same reason,
+        // deferral is skipped and the regular query is emitted.
+        $agg = \Search::prepareDatasForSearch(\Software::class, [
+            'reset'    => 'reset',
+            'sort'     => [72],
+            'order'    => ['DESC'],
+            'criteria' => [['field' => 'view', 'searchtype' => 'contains', 'value' => '']],
+        ]);
+        \Search::constructSQL($agg);
+        $this->assertStringNotContainsString('deferred_page', $agg['sql']['search']->getQuery());
+    }
+
+    /**
+     * The optimisation must be skipped for union itemtypes and for full exports, falling back
+     * to the regular (non deferred) query.
+     */
+    public function testDeferredJoinSkippedForUnionAndExport()
+    {
+        $this->login();
+
+        // Union itemtype: never deferred.
+        $union = \Search::getDatas(\AllAssets::class, [
+            'reset'      => 'reset',
+            'start'      => 0,
+            'list_limit' => 10,
+            'criteria'   => [['field' => 'view', 'searchtype' => 'contains', 'value' => '']],
+        ]);
+        $this->assertStringNotContainsString('deferred_page', $union['sql']['search']->getQuery());
+
+        // Full export: LIMIT is cleared, so no SQL pagination / deferral.
+        $data = \Search::prepareDatasForSearch(Computer::class, [
+            'reset'    => 'reset',
+            'criteria' => [['field' => 1, 'searchtype' => 'contains', 'value' => '']],
+        ]);
+        $data['search']['export_all'] = true;
+        \Search::constructSQL($data);
+        $this->assertStringNotContainsString('deferred_page', $data['sql']['search']->getQuery());
+        $this->assertFalse($data['sql']['has_sql_limit']);
+    }
 }
 
 // @codingStandardsIgnoreStart


### PR DESCRIPTION
PR is done above #23156 to avoid the need for @trasher to rebase its works later.
I sent it in draft, we can merge after prepared statement, or include directly in the parent PR if you prefer.
I may send later an 11.0/bugfixes version as it impact our cloud production right now.

The change allows detecting when a deferred join is possible for generated SQL queries by the search engine.

**Before**: 
   ```sql
   SELECT ... FROM item LEFT JOIN <1:N> ... GROUP BY id ORDER BY x LIMIT 0,30
   ```
   -> joins / groups / sorts the WHOLE table, then keeps 30 rows.

**After**:  
   ```sql
   SELECT ... FROM item
   INNER JOIN (SELECT id FROM item ORDER BY x LIMIT 0,30) AS page
      ON page.id = item.id
   LEFT JOIN <1:N> ... GROUP BY id ORDER BY x
   ```
   -> sorts / limits on the bare table, then joins only those 30 id.

This allows to compute the order without the joins, and gains massive performance when only fields from the primary table are involved for the `ORDER BY` part. The most data and joins present, the most the gain is significant.

Some examples on my instance:
- Softwares (460k rows), order by name, from 15s to 1.5s
- Computers with a lot of joins (2.5k rows), order by name, from 15s to 2s
- Tickets with a few joins (28k rows), order by title from 2s to 1s

`ORDER BY maintable.name` are the default usage in a lot of search page for GLPI.

I tried to have the “intelligence” in helper functions and keep the existing functions being lightly modified.
Note, I had a version taking into account HAVING, but gains were not that important for a more complex change.