### PR TITLE
A11Y : make email preference fields keyboard-accessible and distinctly labelled

### DIFF
--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -893,12 +893,12 @@ abstract class CommonDBChild extends CommonDBConnexity
 
             // Beware : -1 is for the first element added ...
             $result = "&nbsp;<script type='text/javascript'>var $child_count_js_var=2; </script>";
-            $result .= "<span id='add" . $lower_name . "button' class='ti ti-plus cursor-pointer'"
-              . " title=\"" . __s('Add') . "\"" . "aria-label=\"" . $add_label . "\""
-                . "\" onClick=\"var row = $('#" . $div_id . "');
+            $result .= "<button type='button' id='add" . $lower_name . "button' class='ti ti-plus cursor-pointer border-0 bg-transparent p-0 text-reset'"
+              . " title=\"" . __s('Add') . "\" aria-label=\"" . $add_label . "\""
+                . " onClick=\"var row = $('#" . $div_id . "');
                              row.append('" . static::getJSCodeToAddForItemChild($field_name, $child_count_js_var) . "');
-                            $child_count_js_var++;\"
-               ><span class='sr-only'>" . __s('Add') . "</span></span>";
+                            $child_count_js_var++;\""
+               . "><span class='sr-only'>" . __s('Add') . "</span></button>";
         }
         if ($display) {
             echo $result;

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -46,6 +46,15 @@ class UserEmail extends CommonDBChild
     public static string $items_id        = 'users_id';
     public bool $dohistory              = true;
 
+    /**
+     * 1-based position of the email row being rendered, for distinct accessible names
+     * ("Email address 1", "Email address 2"...). Reset in showForUser(), the single
+     * entry point that renders the rows, before each render pass.
+     *
+     * @internal
+     */
+    private static int $display_index = 0;
+
 
     public static function getTypeName($nb = 0)
     {
@@ -175,16 +184,25 @@ class UserEmail extends CommonDBChild
     #[Override()]
     public static function getJSCodeToAddForItemChild($field_name, $child_count_js_var)
     {
+        // Number the added row by counting the email inputs already in the DOM at click
+        // time, so its label continues the server-rendered numbering. Assumes rows are
+        // only appended (no client-side removal); revisit if a remove control is added.
+        $position_expr = "'+(document.querySelectorAll('[name^=" . $field_name . "]').length + 1)+'";
+
         $html = "<div class='d-flex' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>"
-            . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . __s('Set as default email') . "'>"
+            . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . htmlescape(sprintf(__('Set as default email %s'), '__LABEL_POS__')) . "'>"
             . "&nbsp;"
-            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . __s('Email address') . "'>"
+            . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . htmlescape(sprintf(__('Email address %s'), '__LABEL_POS__')) . "'>"
             . "</div>";
 
-        return str_replace(
-            '__JS_PLACEHOLDER__',
-            "'+{$child_count_js_var}+'", // string closing, + operator, JS variable name, + operator, string reopening
-            jsescape($html)
+        // The label placeholders are replaced after jsescape() so the counting expression
+        // stays executable JS, mirroring the `'+var+'` id placeholder of the parent class.
+        return strtr(
+            jsescape($html),
+            [
+                '__JS_PLACEHOLDER__' => "'+{$child_count_js_var}+'",
+                '__LABEL_POS__'      => $position_expr,
+            ]
         );
     }
 
@@ -204,6 +222,7 @@ class UserEmail extends CommonDBChild
         } else {
             $value = htmlescape($this->fields['email']);
         }
+        $position = ++self::$display_index;
         $result = "";
         $field_name = htmlescape($field_name . "[$id]");
         $result .= "<div class='d-flex align-items-center' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>";
@@ -215,12 +234,12 @@ class UserEmail extends CommonDBChild
         if ($this->fields['is_default']) {
             $result .= " checked";
         }
-        $result .= " aria-label='" . __s('Set as default email') . "'>&nbsp;";
+        $result .= " aria-label='" . htmlescape(sprintf(__('Set as default email %s'), $position)) . "'>&nbsp;";
         if (!$canedit || $this->fields['is_dynamic']) {
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));
         } else {
-            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . __s('Email address') . "'>";
+            $result .= "<input type='text' class='form-control' name='$field_name' value='$value' aria-label='" . htmlescape(sprintf(__('Email address %s'), $position)) . "'>";
         }
         $result .= "</div>";
 
@@ -261,6 +280,7 @@ class UserEmail extends CommonDBChild
             }
         }
 
+        self::$display_index = 0; // restart the per-render numbering used for aria-labels
         parent::showChildsForItemForm($user, '_useremails', $canedit);
     }
 

--- a/src/UserEmail.php
+++ b/src/UserEmail.php
@@ -190,7 +190,7 @@ class UserEmail extends CommonDBChild
         $position_expr = "'+(document.querySelectorAll('[name^=" . $field_name . "]').length + 1)+'";
 
         $html = "<div class='d-flex' role='group' aria-label='" . _sn('Email', 'Emails', 1) . "'>"
-            . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . htmlescape(sprintf(__('Set as default email %s'), '__LABEL_POS__')) . "'>"
+            . "<input title='" . __s('Default email') . "' type='radio' name='_default_email' value='-__JS_PLACEHOLDER__' aria-label='" . htmlescape(sprintf(__('Set %s email as default'), '__LABEL_POS__')) . "'>"
             . "&nbsp;"
             . "<input type='text' class='form-control' " . "name='" . htmlescape($field_name) . "[-__JS_PLACEHOLDER__]'  aria-label='" . htmlescape(sprintf(__('Email address %s'), '__LABEL_POS__')) . "'>"
             . "</div>";
@@ -234,7 +234,7 @@ class UserEmail extends CommonDBChild
         if ($this->fields['is_default']) {
             $result .= " checked";
         }
-        $result .= " aria-label='" . htmlescape(sprintf(__('Set as default email %s'), $position)) . "'>&nbsp;";
+        $result .= " aria-label='" . htmlescape(sprintf(__('Set %s email as default'), $position)) . "'>&nbsp;";
         if (!$canedit || $this->fields['is_dynamic']) {
             $result .= "<input type='hidden' name='$field_name' value='$value'>";
             $result .= sprintf('%s <span class="b">(%s)</span>', $value, __s('D'));

--- a/tests/e2e/pages/UserPage.ts
+++ b/tests/e2e/pages/UserPage.ts
@@ -95,7 +95,7 @@ export class UserPage extends GlpiPage
 
     public getDefaultEmailRadios(): Locator
     {
-        return this.page.getByRole('radio', { name: /^Set as default email \d+$/ })
+        return this.page.getByRole('radio', { name: /^Set \d+ email as default$/ })
             .filter({ visible: true });
     }
 }

--- a/tests/e2e/pages/UserPage.ts
+++ b/tests/e2e/pages/UserPage.ts
@@ -82,4 +82,20 @@ export class UserPage extends GlpiPage
     {
         await this.page.getByLabel('Add a new Emails').click();
     }
+
+    /**
+     * Email fields each carry a distinct accessible name ("Email address 1",
+     * "Email address 2"...), so match them by prefix to keep positional access.
+     */
+    public getEmailFields(): Locator
+    {
+        return this.page.getByRole('textbox', { name: /^Email address \d+$/ })
+            .filter({ visible: true });
+    }
+
+    public getDefaultEmailRadios(): Locator
+    {
+        return this.page.getByRole('radio', { name: /^Set as default email \d+$/ })
+            .filter({ visible: true });
+    }
 }

--- a/tests/e2e/specs/Admin/user.spec.ts
+++ b/tests/e2e/specs/Admin/user.spec.ts
@@ -140,23 +140,23 @@ test('Can add emails and set one as default', async ({ page, profile, api }) => 
 
     // Add first email
     await user_page.gotoUserForm(user_id, 'User$main');
-    await user_page.getTextbox('Email address').fill(email1);
+    await user_page.getEmailFields().fill(email1);
     await user_page.save_button.click();
 
     // Email should be added
-    await expect(user_page.getTextbox('Email address').first()).toHaveValue(email1);
-    await expect(user_page.getRadio('Set as default email')).toBeChecked();
+    await expect(user_page.getEmailFields().first()).toHaveValue(email1);
+    await expect(user_page.getDefaultEmailRadios()).toBeChecked();
 
     // Add second email
     await user_page.doAddNewEmailField();
-    await user_page.getTextbox('Email address').nth(1).fill(email2);
+    await user_page.getEmailFields().nth(1).fill(email2);
     await user_page.save_button.click();
 
     // Both email should be visible
-    await expect(user_page.getTextbox('Email address').nth(0)).toHaveValue(email2);
-    await expect(user_page.getTextbox('Email address').nth(1)).toHaveValue(email1);
-    await expect(user_page.getRadio('Set as default email').nth(0)).not.toBeChecked();
-    await expect(user_page.getRadio('Set as default email').nth(1)).toBeChecked();
+    await expect(user_page.getEmailFields().nth(0)).toHaveValue(email2);
+    await expect(user_page.getEmailFields().nth(1)).toHaveValue(email1);
+    await expect(user_page.getDefaultEmailRadios().nth(0)).not.toBeChecked();
+    await expect(user_page.getDefaultEmailRadios().nth(1)).toBeChecked();
 });
 
 test('Can add and remove my substitutes', async ({ page, profile, api }) => {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/311

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.3
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#11.2

The email "+" add button was a `<span>` with an onclick: not focusable and not operable by keyboard. All email fields also shared the same accessible name ("Email address").

- The shared add-child button (`CommonDBChild`) is now a real `<button>`, so it works with the keyboard (this also covers the other "+" buttons built on it).
- Each email field and its default radio now get a distinct name ("Email address 1", "2"...).

Numbering is kept to the email fields (the scope of this issue) ; other consumers can be handled separately.

