### PR TITLE
Get parent search options in Certificate.php and SoftwareLicense.php

### DIFF
--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -103,22 +103,7 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
 
     public function rawSearchOptions()
     {
-
-        $tab = [];
-
-        $tab[] = [
-            'id'                 => 'common',
-            'name'               => __('Characteristics'),
-        ];
-
-        $tab[] = [
-            'id'                 => '1',
-            'table'              => $this->getTable(),
-            'field'              => 'name',
-            'name'               => __('Name'),
-            'datatype'           => 'itemlink',
-            'massiveaction'      => false, // implicit key==1
-        ];
+        $tab = parent::rawSearchOptions();
 
         $tab[] = [
             'id'                 => '2',
@@ -366,14 +351,6 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
         ];
 
         $tab[] = [
-            'id'                 => '86',
-            'table'              => $this->getTable(),
-            'field'              => 'is_recursive',
-            'name'               => __('Child entities'),
-            'datatype'           => 'bool',
-        ];
-
-        $tab[] = [
             'id'                 => '121',
             'table'              => $this->getTable(),
             'field'              => 'date_creation',
@@ -382,8 +359,6 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
             'massiveaction'      => false,
         ];
 
-        // add objectlock search options
-        $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
         $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
         return $tab;

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -291,13 +291,11 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
 
     public function rawSearchOptions()
     {
-        $tab = [];
-
-        // Only use for History (not by search Engine)
-        $tab[] = [
-            'id'                 => 'common',
-            'name'               => __('Characteristics'),
-        ];
+        // Filter out entries that we need to override (to add forcegroupby)
+        $tab = array_values(array_filter(
+            parent::rawSearchOptions(),
+            fn($opt) => !in_array($opt['id'] ?? null, ['1', '2', '13'])
+        ));
 
         $tab[] = [
             'id'                 => '1',
@@ -416,23 +414,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         ];
 
         $tab[] = [
-            'id'                 => '16',
-            'table'              => static::getTable(),
-            'field'              => 'comment',
-            'name'               => _n('Comment', 'Comments', Session::getPluralNumber()),
-            'datatype'           => 'text',
-        ];
-
-        $tab[] = [
-            'id'                 => '121',
-            'table'              => $this->getTable(),
-            'field'              => 'date_creation',
-            'name'               => __('Creation date'),
-            'datatype'           => 'datetime',
-            'massiveaction'      => false,
-        ];
-
-        $tab[] = [
             'id'                 => '24',
             'table'              => User::getTable(),
             'field'              => 'name',
@@ -513,22 +494,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         ];
 
         $tab[] = [
-            'id'                 => '80',
-            'table'              => Entity::getTable(),
-            'field'              => 'completename',
-            'name'               => Entity::getTypeName(1),
-            'datatype'           => 'dropdown',
-        ];
-
-        $tab[] = [
-            'id'                 => '86',
-            'table'              => static::getTable(),
-            'field'              => 'is_recursive',
-            'name'               => __('Child entities'),
-            'datatype'           => 'bool',
-        ];
-
-        $tab[] = [
             'id'                 => '162',
             'table'              => static::getTable(),
             'field'              => 'otherserial',
@@ -569,8 +534,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
             'nosort'             => true,
         ];
 
-        // add objectlock search options
-        $tab = array_merge($tab, ObjectLock::rawSearchOptionsToAdd(get_class($this)));
         $tab = array_merge($tab, Notepad::rawSearchOptionsToAdd());
 
         return $tab;

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -291,31 +291,7 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
 
     public function rawSearchOptions()
     {
-        // Filter out entries that we need to override (to add forcegroupby)
-        $tab = array_values(array_filter(
-            parent::rawSearchOptions(),
-            fn($opt) => !in_array($opt['id'] ?? null, ['1', '2', '13'])
-        ));
-
-        $tab[] = [
-            'id'                 => '1',
-            'table'              => static::getTable(),
-            'field'              => 'name',
-            'name'               => __('Name'),
-            'datatype'           => 'itemlink',
-            'massiveaction'      => false,
-            'forcegroupby'       => true,
-        ];
-
-        $tab[] = [
-            'id'                 => '2',
-            'table'              => static::getTable(),
-            'field'              => 'id',
-            'name'               => __('ID'),
-            'massiveaction'      => false,
-            'datatype'           => 'number',
-            'forcegroupby'       => true,
-        ];
+        $tab = parent::rawSearchOptions();
 
         $tab = array_merge($tab, Location::rawSearchOptionsToAdd());
 
@@ -401,16 +377,6 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
             'field'              => 'allow_overquota',
             'name'               => __('Allow Over-Quota'),
             'datatype'           => 'bool',
-        ];
-
-        $tab[] = [
-            'id'                 => '13',
-            'table'              => static::getTable(),
-            'field'              => 'completename',
-            'name'               => __('Father'),
-            'datatype'           => 'itemlink',
-            'forcegroupby'       => true,
-            'joinparams'        => ['condition' => [new QueryExpression('true')]], // Add virtual condition to relink table
         ];
 
         $tab[] = [

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -6919,6 +6919,58 @@ class SearchTest extends DbTestCase
         $this->assertContains($computer_high->getID(), $ids_found, 'Computer with 67% free space should match ">= 67"');
         $this->assertNotContains($computer_low->getID(), $ids_found, 'Computer with 10% free space must NOT match ">= 67"');
     }
+
+    public function testCertificateRawSearchOptionsInheritance(): void
+    {
+        $item = new \Certificate();
+        $so = $item->rawSearchOptions();
+        $ids = array_column($so, 'id');
+
+        // No duplicate numeric IDs — would indicate parent options being re-added manually
+        $numeric_ids = array_values(array_filter($ids, 'is_numeric'));
+        $this->assertCount(count($numeric_ids), array_unique($numeric_ids), 'Certificate::rawSearchOptions() contains duplicate numeric IDs');
+
+        // id=1 (Name) is inherited from CommonDBTM
+        $this->assertContains(1, $ids);
+        $this->assertContains(86, $ids);
+    }
+
+    public function testSoftwareLicenseRawSearchOptionsInheritance(): void
+    {
+        $item = new \SoftwareLicense();
+        $so = $item->rawSearchOptions();
+        $ids = array_column($so, 'id');
+
+        // No duplicate numeric IDs — would indicate parent options being re-added manually
+        $numeric_ids = array_values(array_filter($ids, 'is_numeric'));
+        $this->assertCount(count($numeric_ids), array_unique($numeric_ids), 'SoftwareLicense::rawSearchOptions() contains duplicate numeric IDs');
+
+        // id=1 keeps the license-specific forcegroupby override
+        $name_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '1'));
+        $this->assertNotFalse($name_opt);
+        $this->assertSame('name', $name_opt['field']);
+        $this->assertTrue($name_opt['forcegroupby'] ?? false, 'id=1 must keep forcegroupby=true from the SoftwareLicense override');
+
+        // id=2 keeps the license-specific forcegroupby override
+        $id_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '2'));
+        $this->assertNotFalse($id_opt);
+        $this->assertSame('id', $id_opt['field']);
+        $this->assertTrue($id_opt['forcegroupby'] ?? false, 'id=2 must keep forcegroupby=true from the SoftwareLicense override');
+
+        // id=13 keeps its license-specific forcegroupby override
+        $father_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '13'));
+        $this->assertNotFalse($father_opt);
+        $this->assertSame('completename', $father_opt['field']);
+        $this->assertTrue($father_opt['forcegroupby'] ?? false, 'id=13 must keep forcegroupby=true from the SoftwareLicense override');
+
+        // assert that inherited options are present
+        $this->assertContains('14', $ids);
+        $this->assertContains('19', $ids);
+        $this->assertContains('16', $ids);
+        $this->assertContains('121', $ids);
+        $this->assertContains('80', $ids);
+        $this->assertContains('86', $ids);
+    }
 }
 
 // @codingStandardsIgnoreStart

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -6930,7 +6930,7 @@ class SearchTest extends DbTestCase
         $numeric_ids = array_values(array_filter($ids, 'is_numeric'));
         $this->assertCount(count($numeric_ids), array_unique($numeric_ids), 'Certificate::rawSearchOptions() contains duplicate numeric IDs');
 
-        // id=1 (Name) is inherited from CommonDBTM
+        // assert that inherited options are present
         $this->assertContains(1, $ids);
         $this->assertContains(86, $ids);
     }
@@ -6945,25 +6945,10 @@ class SearchTest extends DbTestCase
         $numeric_ids = array_values(array_filter($ids, 'is_numeric'));
         $this->assertCount(count($numeric_ids), array_unique($numeric_ids), 'SoftwareLicense::rawSearchOptions() contains duplicate numeric IDs');
 
-        // id=1 keeps the license-specific forcegroupby override
-        $name_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '1'));
-        $this->assertNotFalse($name_opt);
-        $this->assertSame('name', $name_opt['field']);
-        $this->assertTrue($name_opt['forcegroupby'] ?? false, 'id=1 must keep forcegroupby=true from the SoftwareLicense override');
-
-        // id=2 keeps the license-specific forcegroupby override
-        $id_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '2'));
-        $this->assertNotFalse($id_opt);
-        $this->assertSame('id', $id_opt['field']);
-        $this->assertTrue($id_opt['forcegroupby'] ?? false, 'id=2 must keep forcegroupby=true from the SoftwareLicense override');
-
-        // id=13 keeps its license-specific forcegroupby override
-        $father_opt = current(array_filter($so, fn($opt) => ($opt['id'] ?? null) === '13'));
-        $this->assertNotFalse($father_opt);
-        $this->assertSame('completename', $father_opt['field']);
-        $this->assertTrue($father_opt['forcegroupby'] ?? false, 'id=13 must keep forcegroupby=true from the SoftwareLicense override');
-
         // assert that inherited options are present
+        $this->assertContains('1', $ids);
+        $this->assertContains('2', $ids);
+        $this->assertContains('13', $ids);
         $this->assertContains('14', $ids);
         $this->assertContains('19', $ids);
         $this->assertContains('16', $ids);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Call `parent::rawSearchOptions()` in `Certificate.php` and `SoftwareLicense.php` and remove the duplicated search options to make the behavior of these two classes consistent with comparable classes ( Computer, Monitor, Phone, Printer).