### PR TITLE
A11Y : contrast compliance for form fields

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -86,6 +86,7 @@
     --glpi-form-header-danger-fg: var(--tblr-danger);
     --glpi-form-header-danger-bg: color-mix(in srgb, var(--glpi-form-header-danger-fg), var(--tblr-bg-surface) 90%);
     --glpi-form-header-danger-border-color: color-mix(in srgb, var(--glpi-form-header-danger-fg), var(--tblr-bg-surface) 75%);
+    --glpi-form-control-border-color: color-mix(in srgb, var(--tblr-body-color), transparent 40%);
     --glpi-topbar-height: 79px;
     --glpi-contextbar-height: 56px;
     --glpi-content-margin: 24px;
@@ -640,5 +641,18 @@ html {
 input.form-check-input[type="radio"]:disabled,
 input.form-check-input[type="checkbox"]:disabled {
     opacity: 0.9;
+}
+
+// Tabler's default control border (#e5e7eb) sits at ~1.2:1 on white, well below
+// the 3:1 needed to perceive the field boundary.
+.form-control,
+.form-select,
+.form-check-input {
+    border-color: var(--glpi-form-control-border-color);
+}
+
+// The checked state otherwise paints the border with the pale primary (~1.5:1 on white).
+.form-check-input:checked {
+    border-color: var(--glpi-form-control-border-color);
 }
 

--- a/css/includes/_palette_dark.scss
+++ b/css/includes/_palette_dark.scss
@@ -80,6 +80,7 @@
     }
 
     // missing border (TODO open a pr upstream ?)
+    // Uses the a11y-compliant control border so the boundary keeps >=3:1 on the dark surface.
     .form-check-input:not(:checked),
     .form-select,
     .form-file-text,
@@ -87,7 +88,7 @@
     .form-selectgroup-label,
     .form-selectgroup-check,
     .form-imagecheck-figure::before {
-        border-color: var(--tblr-border-color);
+        border-color: var(--glpi-form-control-border-color);
     }
 
     .card {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/304

Tabler's default field border (#e5e7eb) renders at ~1.2:1 on white, and the checked checkbox/radio fill (pale primary) at ~1.5:1 ; both below the 3:1 needed to perceive the control. The border now derives from the theme text token, reaching 3.3:1 on light and 6:1 on dark palettes.

Note : Dropdowns borders (as seen on screenshot) will be processed in the dedicated issue.

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#3.3

<img width="600" height="691" alt="image" src="https://github.com/user-attachments/assets/9e610e33-d0b7-40fc-941f-3bee8ae7c86e" />


