### PR TITLE
A11Y : make form section titles meet text contrast

### DIFF
--- a/css/includes/components/_asset-form.scss
+++ b/css/includes/components/_asset-form.scss
@@ -39,6 +39,12 @@
         border-color: var(--glpi-form-header-border-color);
         padding: var(--tblr-card-cap-padding-y, 1rem) var(--tblr-card-cap-padding-x, 1.25rem);
 
+        // Tabler paints .card-subtitle with the secondary grey, dropping to ~4.3:1 on
+        // this tinted header. Use the palette text token so section titles keep >=4.5:1.
+        .card-subtitle {
+            color: var(--tblr-body-color);
+        }
+
         &:not(.main-header) {
             border-top: 1px solid var(--glpi-form-header-border-color);
         }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/309
- 
Form section headers rendered their title (.card-subtitle) with the secondary grey, sitting at ~4.3:1 (light) / ~4:1 (dark) on the tinted header background ; below the 4.5:1 needed for text. Titles now use the palette text token, reaching ~8.9:1 / ~16:1.

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#3.2

<img width="661" height="331" alt="image" src="https://github.com/user-attachments/assets/71c34230-964c-4b69-ba12-e740261a05ac" />

