### PR TITLE
A11Y : make profile picture modal keyboard-accessible and labelled

### DIFF
--- a/templates/components/form/modals_macros.html.twig
+++ b/templates/components/form/modals_macros.html.twig
@@ -57,11 +57,11 @@
       'modal_classes': ''
    }|merge(options) %}
 
-   <div class="modal fade {{ options.modal_classes }}" id="{{ options.id }}" tabindex="-1" role="dialog" aria-hidden="true">
+   <div class="modal fade {{ options.modal_classes }}" id="{{ options.id }}" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="{{ options.id }}_title" aria-hidden="true">
       <div class="modal-dialog" role="document">
          <div class="modal-content">
             <div class="modal-header">
-               <h5 class="modal-title">{{ modal_title }}</h5>
+               <h5 class="modal-title" id="{{ options.id }}_title">{{ modal_title }}</h5>
                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _x('button', 'Close') }}"></button>
             </div>
             <div class="modal-body overflow-auto">

--- a/templates/pages/admin/user/user_picture_field.html.twig
+++ b/templates/pages/admin/user/user_picture_field.html.twig
@@ -52,16 +52,22 @@
 {% endset %}
 
 {% set picture_field %}
-    <div
-        {% if can_update %}
-            class="cursor-pointer flex-shrink-1" title="{{ __('Change picture') }}" role="button" data-bs-toggle="modal" data-bs-target="#modal_picture_{{ rand_field }}"
-        {% endif %}>
+    {% set picture_avatars %}
         <div data-current-avatar data-testid="current-avatar-container">{{ avatar }}</div>
         <div data-default-avatar data-testid="default-avatar" class="d-none">{{ avatar_initials }}</div>
         <div class="avatar avatar-xl rounded d-none" data-preview-avatar data-testid="preview-avatar">
             <img src="" alt="{{ __('Preview') }}" class="img-fluid" />
         </div>
-    </div>
+    {% endset %}
+    {% if can_update %}
+        <button type="button" class="cursor-pointer flex-shrink-1 border-0 bg-transparent p-0"
+                title="{{ __('Change picture') }}" aria-label="{{ __('Change picture') }}"
+                data-bs-toggle="modal" data-bs-target="#modal_picture_{{ rand_field }}">
+            {{ picture_avatars }}
+        </button>
+    {% else %}
+        <div>{{ picture_avatars }}</div>
+    {% endif %}
     {% if can_update %}
         {% set modal_content %}
             <div class="text-center">


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/313
- 
The "change picture" trigger was a `<div role="button">` with no tabindex, so it couldn't be reached by keyboard, and modals exposed no accessible name. The trigger is now a native `<button>`, and the shared modal macro labels the dialog via aria-labelledby + aria-modal="true".

https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.3
https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#7.1

