### PR TITLE
Fix(RichText): Handle img paste as items

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -260,21 +260,21 @@ const setRichTextEditorContent = function(editor_id, content) {
 if (typeof tinyMCE != 'undefined') {
     tinyMCE.PluginManager.add('glpi_upload_doc', (editor) => {
         let last_paste_content = null;
-        let last_paste_image_file = null;
+        let last_paste_image_files = [];
         const rtf_img_types = {
             'pngblip': 'image/png',
             'jpegblip': 'image/jpeg',
         };
+        const supported_img_types = Object.values(rtf_img_types);
         editor.on('paste', (e) => {
             last_paste_content = e.clipboardData;
-            // Keep the first image file from clipboard items so PastePreProcess can
-            // use the binary data if present.
-            last_paste_image_file = null;
+            // Collect all image files from clipboard items so PastePreProcess can
+            // use the binary data instead of any URL the pasted HTML may contain.
+            last_paste_image_files = [];
             if (last_paste_content && last_paste_content.items) {
                 for (const item of last_paste_content.items) {
-                    if (item.kind === 'file' && Object.values(rtf_img_types).includes(item.type)) {
-                        last_paste_image_file = item.getAsFile();
-                        break;
+                    if (item.kind === 'file' && supported_img_types.includes(item.type)) {
+                        last_paste_image_files.push(item.getAsFile());
                     }
                 }
             }
@@ -314,14 +314,12 @@ if (typeof tinyMCE != 'undefined') {
                     const rtf_content = base64_img_contents.shift();
                     src = `data:${rtf_content['type']};base64,${rtf_content['content']}`;
                     image.attr('src', src);
-                }
-                // If the clipboard carries binary image data, prefer it over whatever
-                // src the pasted HTML contains by converting it to a blob URL — the
-                // upload flow below then handles it identically to a directly pasted image.
-                if (last_paste_image_file !== null) {
-                    src = URL.createObjectURL(last_paste_image_file);
+                } else if (last_paste_image_files.length > 0) {
+                    // If the clipboard carries binary image data, prefer it over whatever
+                    // src the pasted HTML contains by converting it to a blob URL — the
+                    // upload flow below then handles it identically to a directly pasted image.
+                    src = URL.createObjectURL(last_paste_image_files.shift());
                     image.attr('src', src);
-                    last_paste_image_file = null;
                 }
                 if (src.match(new RegExp('^(data|blob):')) !== null) {
                     const upload_id = Math.random().toString();

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -260,12 +260,24 @@ const setRichTextEditorContent = function(editor_id, content) {
 if (typeof tinyMCE != 'undefined') {
     tinyMCE.PluginManager.add('glpi_upload_doc', (editor) => {
         let last_paste_content = null;
+        let last_paste_image_file = null;
         const rtf_img_types = {
             'pngblip': 'image/png',
             'jpegblip': 'image/jpeg',
         };
         editor.on('paste', (e) => {
             last_paste_content = e.clipboardData;
+            // Keep the first image file from clipboard items so PastePreProcess can
+            // use the binary data if present.
+            last_paste_image_file = null;
+            if (last_paste_content && last_paste_content.items) {
+                for (const item of last_paste_content.items) {
+                    if (/^image\//.test(item.type) && item.kind === 'file') {
+                        last_paste_image_file = item.getAsFile();
+                        break;
+                    }
+                }
+            }
         });
         editor.on('PastePreProcess', (event) => {
             const base64_img_contents = [];
@@ -302,6 +314,14 @@ if (typeof tinyMCE != 'undefined') {
                     const rtf_content = base64_img_contents.shift();
                     src = `data:${rtf_content['type']};base64,${rtf_content['content']}`;
                     image.attr('src', src);
+                }
+                // If the clipboard carries binary image data, prefer it over whatever
+                // src the pasted HTML contains by converting it to a blob URL — the
+                // upload flow below then handles it identically to a directly pasted image.
+                if (last_paste_image_file !== null) {
+                    src = URL.createObjectURL(last_paste_image_file);
+                    image.attr('src', src);
+                    last_paste_image_file = null;
                 }
                 if (src.match(new RegExp('^(data|blob):')) !== null) {
                     const upload_id = Math.random().toString();

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -272,7 +272,7 @@ if (typeof tinyMCE != 'undefined') {
             last_paste_image_file = null;
             if (last_paste_content && last_paste_content.items) {
                 for (const item of last_paste_content.items) {
-                    if (/^image\//.test(item.type) && item.kind === 'file') {
+                    if (item.kind === 'file' && Object.values(rtf_img_types).includes(item.type)) {
                         last_paste_image_file = item.getAsFile();
                         break;
                     }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -273,7 +273,7 @@ if (typeof tinyMCE != 'undefined') {
             last_paste_image_files = [];
             if (last_paste_content && last_paste_content.items) {
                 for (const item of last_paste_content.items) {
-                    if (item.kind === 'file' && supported_img_types.includes(item.type)) {
+                    if (item.kind === 'file' && isImage(item)) {
                         last_paste_image_files.push(item.getAsFile());
                     }
                 }

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -265,7 +265,6 @@ if (typeof tinyMCE != 'undefined') {
             'pngblip': 'image/png',
             'jpegblip': 'image/jpeg',
         };
-        const supported_img_types = Object.values(rtf_img_types);
         editor.on('paste', (e) => {
             last_paste_content = e.clipboardData;
             // Collect all image files from clipboard items so PastePreProcess can


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Pasted images from Google Chat (and potentially other applications) are provided as `items` within the clipboard object.

<img width="995" height="1002" alt="image" src="https://github.com/user-attachments/assets/5127074c-47e5-469c-8196-e921e0371a98" />

<img width="886" height="1033" alt="image" src="https://github.com/user-attachments/assets/ae0e213e-e21b-4c92-b066-5e613b84606f" />


Enhanced `fileupload.js` to properly handle `e.clipboardData.items` and support image uploads from clipboard content.



## Screenshots (if appropriate):


Before : 

<img width="839" height="234" alt="image" src="https://github.com/user-attachments/assets/dd80661f-3378-47f6-85b6-168d76382247" />

<img width="423" height="174" alt="image" src="https://github.com/user-attachments/assets/cc04d0cd-2c3c-4c4d-9338-a5fd742e3946" />


After

<img width="815" height="540" alt="image" src="https://github.com/user-attachments/assets/5e0c05c0-1197-4b35-a7ba-f38d2f519eb2" />

<img width="645" height="266" alt="image" src="https://github.com/user-attachments/assets/9694b520-829f-46be-b091-c951a09c0b06" />

