### PR TITLE
Prevent calendar time computation failures with `'NULL'` values

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -295,6 +295,15 @@ class Calendar extends CommonDropdown
             return 0;
         }
 
+        // `$start` and/or `$end` may be the `'NULL'` SQL sentinel string (for
+        // instance, reopening a solved/closed ITIL object resets `solvedate` and
+        // `closedate` to `'NULL'`) or be empty. These are not parseable dates:
+        // return early instead of letting `Safe\strtotime()` (used below) throw an
+        // uncaught `DatetimeException`.
+        if (empty($start) || empty($end) || $start === 'NULL' || $end === 'NULL') {
+            return 0;
+        }
+
         if ($end < $start) {
             return 0;
         }

--- a/src/LevelAgreement.php
+++ b/src/LevelAgreement.php
@@ -716,6 +716,14 @@ TWIG, $twig_params);
      **/
     public function getActiveTimeBetween($start, $end)
     {
+        // Mirror Calendar::getActiveTimeBetween(): the `'NULL'` SQL sentinel string
+        // and empty bounds are not parseable dates and would make `Safe\strtotime()`
+        // throw an uncaught `DatetimeException` (e.g. on the "No calendar" branch
+        // below). Return early instead.
+        if (empty($start) || empty($end) || $start === 'NULL' || $end === 'NULL') {
+            return 0;
+        }
+
         if ($end < $start) {
             return 0;
         }

--- a/tests/functional/CalendarTest.php
+++ b/tests/functional/CalendarTest.php
@@ -138,6 +138,21 @@ class CalendarTest extends DbTestCase
                 'end'    => '2019-01-08 00:00:00',
                 'value'  => WEEK_TIMESTAMP,
                 'days'   => true,
+            ], [
+                // Regression for the ticket-reopen `DatetimeException`: when a date
+                // bound is the `'NULL'` SQL sentinel or empty, the method must return
+                // 0 instead of throwing through `Safe\strtotime()`.
+                'start'  => '2019-01-01 07:00:00',
+                'end'    => 'NULL',
+                'value'  => 0,
+            ], [
+                'start'  => 'NULL',
+                'end'    => '2019-01-01 09:00:00',
+                'value'  => 0,
+            ], [
+                'start'  => '2019-01-01 07:00:00',
+                'end'    => '',
+                'value'  => 0,
             ],
         ];
     }


### PR DESCRIPTION
# Harden `Calendar`/`LevelAgreement::getActiveTimeBetween()` against the `'NULL'` sentinel and empty dates

## Target branch
`11.0/bugfixes` (defense-in-depth follow-up to #21337).

## Context

Reopening a solved/closed ITIL object resets `solvedate`/`closedate` to the
literal `'NULL'` SQL sentinel string in `CommonITILObject::prepareInputForUpdate()`.
Because GLPI 11 wraps the PHP date functions with `thecodingmachine/safe`
(`use function Safe\strtotime;`), `Safe\strtotime('NULL')` **throws** an
`Safe\Exceptions\DatetimeException` ("An error occurred") where plain
`strtotime('NULL')` merely returned `false` in GLPI 10. The result is an
uncaught exception → HTTP 500 → the generic "An unexpected error occurred",
with the reopen silently failing.

The specific call sites were already fixed in **#21337** (shipped in **11.0.1**)
by guarding `computeSolveDelayStat()` / `computeCloseDelayStat()` with
`!== 'NULL'`, which closed **#21229** (and the duplicate **#21314**).

## Why this PR

The two-line call-site fix is correct, but the actual throw site —
`Calendar::getActiveTimeBetween()` — still validates nothing: its
`if ($end < $start)` early return is a *string* comparison that `'NULL'` slips
past (`'NULL' > '2026-…'` lexicographically), so it proceeds straight into
`Safe\strtotime()`. Any other current or future caller that reaches it with the
`'NULL'` sentinel (or an empty bound) hits the same uncaught crash.

This is the same kind of defensive hardening already accepted inside `Calendar`
in **#22306** (`Calendar::isHoliday()`, shipped in 11.0.5), which guarded
`empty($date)` — but that PR did not cover the `'NULL'` sentinel in
`getActiveTimeBetween()`.

## Change

Add an early return in `Calendar::getActiveTimeBetween()` and the mirroring
`LevelAgreement::getActiveTimeBetween()` (its "No calendar" branch calls
`strtotime()` directly) when a bound is empty or the `'NULL'` sentinel:

```php
if (empty($start) || empty($end) || $start === 'NULL' || $end === 'NULL') {
    return 0;
}
```

Returning `0` is consistent with the method's existing graceful early returns
(`!isset($this->fields['id'])`, `$end < $start`).

## Tests

Extends the existing `tests/functional/CalendarTest.php::activeProvider()` data
provider (consumed by `testGetActiveTimeBetween`) with three rows — `end = 'NULL'`,
`start = 'NULL'`, and `end = ''` — each expecting `0`. These rows **error via the
uncaught `DatetimeException` on the current code** and **pass with the guard**,
so they pin the regression at the throw site.

> Note: the `LevelAgreement` "No calendar" branch is guarded with the same
> pattern; happy to add a dedicated SLA/OLA test for it if preferred.

## Notes

- No behavior change for valid dates.
- No changelog entry / CLA required per `CONTRIBUTING.md`.

Refs #21229, #21314.
