### PR TITLE
fix cross-ITIL-object tabs (add unlink action)

### DIFF
--- a/src/Change_Problem.php
+++ b/src/Change_Problem.php
@@ -187,6 +187,14 @@ class Change_Problem extends CommonITILObject_CommonITILObject
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
+                'specific_actions' => [
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
+                ],
+                'extraparams'      => [
+                    'source_itemtype'       => Problem::class,
+                    'source_items_id'       => $problem->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id'],
+                ],
             ],
         ]);
     }
@@ -279,6 +287,14 @@ class Change_Problem extends CommonITILObject_CommonITILObject
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
+                'specific_actions' => [
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
+                ],
+                'extraparams'      => [
+                    'source_itemtype'       => Change::class,
+                    'source_items_id'       => $change->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id'],
+                ],
             ],
         ]);
     }

--- a/src/Change_Ticket.php
+++ b/src/Change_Ticket.php
@@ -266,8 +266,8 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
                     'displaywith' => ['id'],
                 ],
                 'create_link' => false,
-                'form_label' => __('Add a change'),
-                'button_label' => __('Create a change from this ticket'),
+                'form_label' => __('Add a ticket'),
+                'button_label' => __('Create a ticket from this change'),
             ]);
         }
 
@@ -292,11 +292,16 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
                 'specific_actions' => [
-                    'purge' => _sx('button', 'Delete permanently'),
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
                     self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'solveticket' => __s('Solve tickets'),
                     self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_task' => __s('Add a new task'),
                 ],
-                'extraparams'      => ['changes_id' => $change->getID()],
+                'extraparams'      => [
+                    'source_itemtype'       => Change::class,
+                    'source_items_id'       => $change->getID(),
+                    'changes_id'            => $change->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id', 'changes_id'],
+                ],
             ],
         ]);
     }
@@ -394,6 +399,14 @@ class Change_Ticket extends CommonITILObject_CommonITILObject
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
+                'specific_actions' => [
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
+                ],
+                'extraparams'      => [
+                    'source_itemtype'       => Ticket::class,
+                    'source_items_id'       => $ticket->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id'],
+                ],
             ],
         ]);
     }

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -137,6 +137,62 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
     public static function processMassiveActionsForOneItemtype(MassiveAction $ma, CommonDBTM $item, array $ids)
     {
         switch ($ma->getAction()) {
+            case 'unlink':
+                $input = $ma->getInput();
+                $source_itemtype = $input['source_itemtype'] ?? '';
+                $source_items_id = (int) ($input['source_items_id'] ?? 0);
+
+                if (!is_string($source_itemtype) || !is_a($source_itemtype, CommonITILObject::class, true)) {
+                    foreach ($ids as $id) {
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                    }
+                    return;
+                }
+
+                $link_class = self::getLinkClass($source_itemtype, $item::class);
+
+                if ($link_class === null || $source_items_id <= 0) {
+                    foreach ($ids as $id) {
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                    }
+                    return;
+                }
+
+                $link = getItemForItemtype($link_class);
+                if ($link === false) {
+                    foreach ($ids as $id) {
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                    }
+                    return;
+                }
+
+                $source_fk = $source_itemtype::getForeignKeyField();
+                $target_fk = $item::getForeignKeyField();
+
+                foreach ($ids as $id) {
+                    $criteria = [
+                        $source_fk => $source_items_id,
+                        $target_fk => $id,
+                    ];
+                    if ($link->getFromDBByCrit($criteria)) {
+                        if ($link->can($link->getID(), DELETE)) {
+                            if ($link->delete(['id' => $link->getID()])) {
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_OK);
+                            } else {
+                                $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                                $ma->addMessage($link->getErrorMessage(ERROR_ON_ACTION));
+                            }
+                        } else {
+                            $ma->itemDone($item::class, $id, MassiveAction::ACTION_NORIGHT);
+                            $ma->addMessage($link->getErrorMessage(ERROR_RIGHT));
+                        }
+                    } else {
+                        $ma->itemDone($item::class, $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage($link->getErrorMessage(ERROR_NOT_FOUND));
+                    }
+                }
+                return;
+
             case 'add':
                 $input = $ma->getInput();
 

--- a/src/Problem_Ticket.php
+++ b/src/Problem_Ticket.php
@@ -252,11 +252,16 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
                 'specific_actions' => [
-                    'purge' => _sx('button', 'Delete permanently'),
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
                     self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'solveticket' => __s('Solve tickets'),
                     self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_task' => __s('Add a new task'),
                 ],
-                'extraparams'      => ['problems_id' => $problem->getID()],
+                'extraparams'      => [
+                    'source_itemtype'       => Problem::class,
+                    'source_items_id'       => $problem->getID(),
+                    'problems_id'           => $problem->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id', 'problems_id'],
+                ],
             ],
         ]);
     }
@@ -329,6 +334,14 @@ class Problem_Ticket extends CommonITILObject_CommonITILObject
             'massiveactionparams' => [
                 'num_displayed' => count($entries),
                 'container'     => 'mass' . static::class . $rand,
+                'specific_actions' => [
+                    self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlink' => _sx('button', 'Unlink'),
+                ],
+                'extraparams'      => [
+                    'source_itemtype'       => Ticket::class,
+                    'source_items_id'       => $ticket->getID(),
+                    'massive_action_fields' => ['source_itemtype', 'source_items_id'],
+                ],
             ],
         ]);
     }

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use Change;
+use Change_Problem;
 use Change_Ticket;
 use CommonDBTM;
 use Contract;
@@ -1720,5 +1721,82 @@ class MassiveActionTest extends DbTestCase
                 'content'    => 'task from change massive action',
             ])
         );
+    }
+
+    public static function unlinkProvider(): array
+    {
+        return [
+            'Problem - Ticket' => [Problem::class, Ticket::class,  Problem_Ticket::class],
+            'Ticket - Problem' => [Ticket::class,  Problem::class, Problem_Ticket::class],
+            'Change - Ticket'  => [Change::class,  Ticket::class,  Change_Ticket::class],
+            'Ticket - Change'  => [Ticket::class,  Change::class,  Change_Ticket::class],
+            'Change - Problem' => [Change::class,  Problem::class, Change_Problem::class],
+            'Problem - Change' => [Problem::class, Change::class,  Change_Problem::class],
+        ];
+    }
+
+    #[DataProvider('unlinkProvider')]
+    public function testUnlinkMassiveAction(string $source_itemtype, string $target_itemtype, string $link_class): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $source = $this->createItem($source_itemtype, ['name' => 'source', 'content' => 'content']);
+        $target = $this->createItem($target_itemtype, ['name' => 'target', 'content' => 'content']);
+        $this->createItem($link_class, [
+            $source_itemtype::getForeignKeyField() => $source->getID(),
+            $target_itemtype::getForeignKeyField() => $target->getID(),
+        ]);
+
+        $this->processMassiveActionsForOneItemtype(
+            'unlink',
+            $target,
+            [$target->getID()],
+            ['source_itemtype' => $source_itemtype, 'source_items_id' => $source->getID()],
+            1,
+            0,
+            $link_class
+        );
+
+        $this->assertSame(0, countElementsInTable($link_class::getTable(), [
+            $source_itemtype::getForeignKeyField() => $source->getID(),
+            $target_itemtype::getForeignKeyField() => $target->getID(),
+        ]));
+        $this->assertSame(1, countElementsInTable($source_itemtype::getTable(), ['id' => $source->getID(), 'is_deleted' => 0]));
+        $this->assertSame(1, countElementsInTable($target_itemtype::getTable(), ['id' => $target->getID(), 'is_deleted' => 0]));
+    }
+
+    #[DataProvider('unlinkProvider')]
+    public function testUnlinkMassiveActionNoRight(string $source_itemtype, string $target_itemtype, string $link_class): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $source = $this->createItem($source_itemtype, ['name' => 'source', 'content' => 'content']);
+        $target = $this->createItem($target_itemtype, ['name' => 'target', 'content' => 'content']);
+        $this->createItem($link_class, [
+            $source_itemtype::getForeignKeyField() => $source->getID(),
+            $target_itemtype::getForeignKeyField() => $target->getID(),
+        ]);
+
+        // canDeleteItem() on the link allows deletion if EITHER linked item can be
+        // updated. Strip UPDATE from both sides so the rights check fails
+        // and the action returns ACTION_NORIGHT.
+        $_SESSION['glpiactiveprofile'][$source_itemtype::$rightname] = 0;
+        $_SESSION['glpiactiveprofile'][$target_itemtype::$rightname] = 0;
+
+        $this->processMassiveActionsForOneItemtype(
+            'unlink',
+            $target,
+            [$target->getID()],
+            ['source_itemtype' => $source_itemtype, 'source_items_id' => $source->getID()],
+            0,
+            1,
+            $link_class
+        );
+
+        // Link must still exist, nothing was deleted.
+        $this->assertSame(1, countElementsInTable($link_class::getTable(), [
+            $source_itemtype::getForeignKeyField() => $source->getID(),
+            $target_itemtype::getForeignKeyField() => $target->getID(),
+        ]));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

!44662

In GLPI 11, the cross-ITIL-object tabs (Ticket / Problem, Ticket / Change, Problem / Change) register datatable entries with the itemtype of the _linked_ object (e.g. `Ticket`).
As a result, the default massive action "Delete permanently" was hitting the linked objects themselves instead of just removing the relation row.

This PR introduces a generic `unlink` action in `CommonITILObject_CommonITILObject` that receives the context item's type and ID, looks up the relation record, and deletes only that.
The action is wired up consistently across all six tab directions so that every cross-ITIL tab now shows "Unlink" instead of "Delete permanently".
