### PR TITLE
fix(forms): Add predefined value support for selectable question types

### DIFF
--- a/css/includes/components/form/_form-editor.scss
+++ b/css/includes/components/form/_form-editor.scss
@@ -236,6 +236,18 @@
     }
 }
 
+// Reveal the "Copy UUID" option button only when its option row is hovered
+[data-glpi-form-editor-question][data-glpi-form-editor-active-question] {
+    [data-glpi-form-selectable-question-option] [data-glpi-form-editor-question-option-copy-uuid] {
+        opacity: 0;
+        transition: opacity 0.20s linear;
+    }
+
+    [data-glpi-form-selectable-question-option]:hover [data-glpi-form-editor-question-option-copy-uuid] {
+        opacity: 1;
+    }
+}
+
 [data-glpi-form-editor-comment] {
     &[data-glpi-form-editor-active-comment] {
         // Show secondary data on active comments

--- a/js/common.js
+++ b/js/common.js
@@ -1512,7 +1512,10 @@ $(() => {
     // General "copy to clipboard" handler.
     // TODO: refactorate existing code to use this unique handler.
     $(document).on('click', '[data-glpi-clipboard-text]', function() {
-        const text = $(this).data('glpi-clipboard-text');
+        // Read the attribute instead of `.data()`: the value may be updated
+        // dynamically (jQuery caches its data store on first read) and must not
+        // be type-casted (`.data()` would turn a numeric value into a Number).
+        const text = $(this).attr('data-glpi-clipboard-text');
         if (navigator.clipboard === undefined) {
             // The clipboard is not available in non secure environements.
             // See: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard

--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -130,15 +130,12 @@ export class GlpiFormQuestionTypeSelectable {
             const clone = template.content.cloneNode(true);
             const uuid = getUUID(); // Generate a new UUID to avoid duplicates
 
-            $(clone).find('input[type="text"]')
-                .val(value.value)
-                .attr('name', `options[${uuid}]`);
+            this.#setOptionUuid($(clone), uuid);
+            $(clone).find('input[type="text"]').val(value.value);
             $(clone).find(`input[type="${CSS.escape(this._inputType)}"]`)
-                .val(uuid)
                 .prop('checked', value.checked);
             $(clone).find('input[data-glpi-form-editor-question-option-order]')
-                .val(value.order)
-                .attr('name', `options_order[${uuid}]`);
+                .val(value.order);
 
             const insertedElement = $(clone).children().appendTo(this._container);
 
@@ -194,42 +191,24 @@ export class GlpiFormQuestionTypeSelectable {
             .find('button[data-glpi-form-editor-question-option-remove]')
             .on('click', (event) => this.#removeOption(event));
 
-        option
-            .find('[data-glpi-form-editor-question-option-copy-uuid]')
-            .on('click', (event) => this.#copyOptionUuidToClipboard(event));
+        // The "copy uuid" button is handled by the generic `data-glpi-clipboard-text`
+        // handler, no listener is needed here. Its value is kept in sync by
+        // `#setOptionUuid()`.
     }
 
     /**
-     * Copy the option's UUID to the clipboard and briefly confirm on the button.
+     * Assign an uuid to an option and update every input/attribute referencing it.
      *
-     * @param {JQuery.ClickEvent} event
+     * @param {JQuery<HTMLElement>} option
+     * @param {string} uuid
      */
-    #copyOptionUuidToClipboard(event) {
-        const button = $(event.currentTarget);
-        const option = button.closest('[data-glpi-form-selectable-question-option]');
-        const uuid = option.find(`input[type="${CSS.escape(this._inputType)}"]`).val();
-
-        // Write the uuid to the clipboard
-        navigator.clipboard.writeText(uuid);
-
-        // Swap the button to a "Copied" confirmation state, then restore it.
-        // Keep the original markup so repeated clicks don't lose it.
-        if (button.data('copy-reset-timeout')) {
-            clearTimeout(button.data('copy-reset-timeout'));
-        } else {
-            button.data('copy-original-html', button.html());
-        }
-
-        button
-            .addClass('text-success')
-            .html(`<i class="ti ti-check me-1"></i><span>${__("Copied")}</span>`);
-
-        button.data('copy-reset-timeout', setTimeout(() => {
-            button
-                .removeClass('text-success')
-                .html(button.data('copy-original-html'))
-                .removeData('copy-reset-timeout');
-        }, 2000));
+    #setOptionUuid(option, uuid) {
+        option.find(`input[type="${CSS.escape(this._inputType)}"]`).val(uuid);
+        option.find('input[type="text"]').attr('name', `options[${uuid}]`);
+        option.find('input[data-glpi-form-editor-question-option-order]')
+            .attr('name', `options_order[${uuid}]`);
+        option.find('[data-glpi-form-editor-question-option-copy-uuid]')
+            .attr('data-glpi-clipboard-text', uuid);
     }
 
     /**
@@ -274,10 +253,7 @@ export class GlpiFormQuestionTypeSelectable {
         }
 
         // Update the uuid with a new random value (random number like mt_rand)
-        const uuid = getUUID();
-        $(input).parent().next().find('input[type="radio"], input[type="checkbox"]').val(uuid);
-        $(input).parent().next().find('input[type="text"]').attr('name', `options[${uuid}]`);
-        $(input).parent().next().find('input[data-glpi-form-editor-question-option-order]').attr('name', `options_order[${uuid}]`);
+        this.#setOptionUuid($(input).parent().next(), getUUID());
         $(input).parent().next().find('input[data-glpi-form-editor-question-option-order]').val(this._container.children().length + 1);
 
         /**

--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -193,6 +193,43 @@ export class GlpiFormQuestionTypeSelectable {
         option
             .find('button[data-glpi-form-editor-question-option-remove]')
             .on('click', (event) => this.#removeOption(event));
+
+        option
+            .find('[data-glpi-form-editor-question-option-copy-uuid]')
+            .on('click', (event) => this.#copyOptionUuidToClipboard(event));
+    }
+
+    /**
+     * Copy the option's UUID to the clipboard and briefly confirm on the button.
+     *
+     * @param {JQuery.ClickEvent} event
+     */
+    #copyOptionUuidToClipboard(event) {
+        const button = $(event.currentTarget);
+        const option = button.closest('[data-glpi-form-selectable-question-option]');
+        const uuid = option.find(`input[type="${CSS.escape(this._inputType)}"]`).val();
+
+        // Write the uuid to the clipboard
+        navigator.clipboard.writeText(uuid);
+
+        // Swap the button to a "Copied" confirmation state, then restore it.
+        // Keep the original markup so repeated clicks don't lose it.
+        if (button.data('copy-reset-timeout')) {
+            clearTimeout(button.data('copy-reset-timeout'));
+        } else {
+            button.data('copy-original-html', button.html());
+        }
+
+        button
+            .addClass('text-success')
+            .html(`<i class="ti ti-check me-1"></i><span>${__("Copied")}</span>`);
+
+        button.data('copy-reset-timeout', setTimeout(() => {
+            button
+                .removeClass('text-success')
+                .html(button.data('copy-original-html'))
+                .removeData('copy-reset-timeout');
+        }, 2000));
     }
 
     /**
@@ -314,6 +351,7 @@ export class GlpiFormQuestionTypeSelectable {
         $(input).siblings('input[type="radio"], input[type="checkbox"]').prop('disabled', false);
         $(input).parent().removeAttr('data-glpi-form-editor-question-extra-details');
         $(input).siblings('button[data-glpi-form-editor-question-option-remove]').removeClass('d-none');
+        $(input).siblings('button[data-glpi-form-editor-question-option-copy-uuid]').removeClass('d-none');
     }
 
     /**

--- a/js/modules/Forms/QuestionSelectable.js
+++ b/js/modules/Forms/QuestionSelectable.js
@@ -203,7 +203,10 @@ export class GlpiFormQuestionTypeSelectable {
      * @param {string} uuid
      */
     #setOptionUuid(option, uuid) {
-        option.find(`input[type="${CSS.escape(this._inputType)}"]`).val(uuid);
+        // The option may still use the input type of the template it was cloned
+        // from (which is not updated when the question switches between single
+        // and multiple mode), so both types must be targeted here.
+        option.find('input[type="radio"], input[type="checkbox"]').val(uuid);
         option.find('input[type="text"]').attr('name', `options[${uuid}]`);
         option.find('input[data-glpi-form-editor-question-option-order]')
             .attr('name', `options_order[${uuid}]`);

--- a/src/Glpi/Form/Question.php
+++ b/src/Glpi/Form/Question.php
@@ -45,6 +45,7 @@ use Glpi\Form\Condition\ConditionableVisibilityInterface;
 use Glpi\Form\Condition\ConditionableVisibilityTrait;
 use Glpi\Form\Export\Context\DatabaseMapper;
 use Glpi\Form\Export\Serializer\DynamicExportData;
+use Glpi\Form\QuestionType\PredefinedValueValidationInterface;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\QuestionType\TranslationAwareQuestionType;
@@ -298,9 +299,19 @@ final class Question extends CommonDBChild implements BlockInterface, Conditiona
             $type = $this->getQuestionType();
             $value = $type->formatPredefinedValue($get[$uuid]);
 
-            if ($value !== null) {
-                $this->fields['default_value'] = $value;
+            if ($value === null) {
+                return;
             }
+
+            // Discard values that can not be applied to this specific question
+            if (
+                $type instanceof PredefinedValueValidationInterface
+                && !$type->isValidPredefinedValue($value, $this)
+            ) {
+                return;
+            }
+
+            $this->fields['default_value'] = $value;
         }
     }
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -412,6 +412,15 @@ TWIG;
                 >
                 <button
                     type="button"
+                    class="btn btn-sm btn-action px-1 text-nowrap {{ value ? '' : 'd-none' }}"
+                    data-glpi-form-editor-question-extra-details
+                    data-glpi-form-editor-question-option-copy-uuid
+                >
+                    <i class="ti ti-copy me-1"></i>
+                    <span>{{ translations.copy_uuid }}</span>
+                </button>
+                <button
+                    type="button"
                     class="btn btn-sm btn-icon btn-ghost-secondary {{ value ? '' : 'd-none' }}"
                     aria-label="{{ translations.remove_option }}"
                     data-glpi-form-editor-question-extra-details
@@ -465,6 +474,7 @@ TWIG;
                 'remove_option'     => __('Remove option'),
                 'selectable_option' => __('Selectable option'),
                 'enter_option'      => __('Enter an option'),
+                'copy_uuid'         => __('Copy UUID'),
             ],
         ]);
     }

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -150,6 +150,21 @@ TWIG;
     }
 
     #[Override]
+    public function formatPredefinedValue(string $value): ?string
+    {
+        $uuids = array_filter(
+            array_map('trim', explode(',', $value)),
+            fn($uuid) => $uuid !== ''
+        );
+
+        if ($uuids === []) {
+            return null;
+        }
+
+        return implode(',', $uuids);
+    }
+
+    #[Override]
     public function formatDefaultValueForDB(mixed $value): ?string
     {
         if (is_array($value)) {

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -51,7 +51,7 @@ use function Safe\json_decode;
 /**
  * Short answers are single line inputs used to answer simple questions.
  */
-abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType implements FormQuestionDataConverterInterface, TranslationAwareQuestionType, ConditionValueTransformerInterface
+abstract class AbstractQuestionTypeSelectable extends AbstractQuestionType implements FormQuestionDataConverterInterface, TranslationAwareQuestionType, ConditionValueTransformerInterface, PredefinedValueValidationInterface
 {
     public const TRANSLATION_KEY_OPTION = 'option';
 
@@ -162,6 +162,26 @@ TWIG;
         }
 
         return implode(',', $uuids);
+    }
+
+    #[Override]
+    public function isValidPredefinedValue(string $value, Question $question): bool
+    {
+        // A question that only accepts a single option can not decide which
+        // value to keep, the whole parameter is therefore rejected.
+        return $this->allowsMultipleDefaultValues($question)
+            || count(explode(',', $value)) === 1;
+    }
+
+    /**
+     * Check if the question allows several options to be selected by default
+     *
+     * @param ?Question $question
+     * @return bool
+     */
+    public function allowsMultipleDefaultValues(?Question $question): bool
+    {
+        return true;
     }
 
     #[Override]

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -415,6 +415,7 @@ TWIG;
                     class="btn btn-sm btn-action px-1 text-nowrap {{ value ? '' : 'd-none' }}"
                     data-glpi-form-editor-question-extra-details
                     data-glpi-form-editor-question-option-copy-uuid
+                    data-glpi-clipboard-text="{{ uuid }}"
                 >
                     <i class="ti ti-copy me-1"></i>
                     <span>{{ translations.copy_uuid }}</span>

--- a/src/Glpi/Form/QuestionType/PredefinedValueValidationInterface.php
+++ b/src/Glpi/Form/QuestionType/PredefinedValueValidationInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\QuestionType;
+
+use Glpi\Form\Question;
+
+/**
+ * Question types whose predefined values (set through GET parameters) depend on
+ * the question configuration must implement this interface.
+ *
+ * An invalid predefined value is discarded, leaving the default value that was
+ * configured in the form editor untouched.
+ */
+interface PredefinedValueValidationInterface
+{
+    /**
+     * Check whether a formatted predefined value can be applied to a question.
+     *
+     * @param string   $value    The value returned by `formatPredefinedValue()`
+     * @param Question $question The question the value would be applied to
+     */
+    public function isValidPredefinedValue(string $value, Question $question): bool;
+}

--- a/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeDropdown.php
@@ -104,6 +104,12 @@ final class QuestionTypeDropdown extends AbstractQuestionTypeSelectable implemen
     }
 
     #[Override]
+    public function allowsMultipleDefaultValues(?Question $question): bool
+    {
+        return $this->isMultipleDropdown($question);
+    }
+
+    #[Override]
     public function hideOptionsContainerWhenUnfocused(): bool
     {
         return true;

--- a/src/Glpi/Form/QuestionType/QuestionTypeRadio.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeRadio.php
@@ -63,6 +63,12 @@ final class QuestionTypeRadio extends AbstractQuestionTypeSelectable implements 
     }
 
     #[Override]
+    public function allowsMultipleDefaultValues(?Question $question): bool
+    {
+        return false;
+    }
+
+    #[Override]
     public function getConditionHandlers(
         ?JsonFieldInterface $question_config
     ): array {

--- a/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
@@ -169,8 +169,10 @@ for (const questionType of ['Radio', 'Checkbox', 'Dropdown']) {
         // Click the option's "Copy UUID" button
         await copyButton.click();
 
-        // Assert the button switches to its "Copied" confirmation state
-        await expect(question.getByRole('button', { name: 'Copied' })).toBeVisible();
+        // Assert the generic clipboard handler confirmed the copy
+        await expect(
+            page.getByRole('alert').filter({ hasText: 'Copied to clipboard' })
+        ).toBeVisible();
 
         // Assert the clipboard holds the option's (non-empty) uuid
         const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());

--- a/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/selectables.spec.ts
@@ -129,3 +129,52 @@ for (const questionType of ['Radio', 'Checkbox', 'Dropdown']) {
         await expect(savedOptions.nth(2)).toHaveValue('Option C');
     });
 }
+
+for (const questionType of ['Radio', 'Checkbox', 'Dropdown']) {
+    test(`Can copy an option's uuid to the clipboard for ${questionType} question`, async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+        const form = new FormPage(page);
+
+        // Create a form and navigate to its editor
+        const uuid = randomUUID();
+        const form_id = await api.createItem('Glpi\\Form\\Form', {
+            name: `Form - ${uuid}`,
+            entities_id: getWorkerEntityId(),
+        });
+        await form.goto(form_id);
+
+        const question = await form.addQuestion(`${questionType} question`);
+        await form.setQuestionType(question, questionType);
+
+        // Add an option to the question
+        const optionInput = question.getByRole('textbox', { name: 'Selectable option' }).first();
+        await question.getByRole('textbox', { name: 'Selectable option' }).last().fill('Option 1');
+
+        // The option's uuid is the last bracket key of its text input name
+        // (e.g. _questions[0][extra_data][options][<uuid>]), which is the value
+        // the button copies. This holds for every selectable type, unlike the
+        // default-value control (a hidden radio / a select2 for dropdowns).
+        const optionName = await optionInput.getAttribute('name');
+        const expectedUuid = optionName?.match(/\[([^\]]+)\]$/)?.[1];
+
+        const copyButton = question.getByRole('button', { name: 'Copy UUID' }).first();
+
+        // The button stays hidden until its option row is hovered
+        await page.mouse.move(0, 0);
+        await expect(copyButton).toHaveCSS('opacity', '0');
+        await optionInput.hover();
+        await expect(copyButton).toHaveCSS('opacity', '1');
+
+        // Click the option's "Copy UUID" button
+        await copyButton.click();
+
+        // Assert the button switches to its "Copied" confirmation state
+        await expect(question.getByRole('button', { name: 'Copied' })).toBeVisible();
+
+        // Assert the clipboard holds the option's (non-empty) uuid
+        const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+        expect(clipboardContent).not.toBe('');
+        expect(clipboardContent).toBe(expectedUuid);
+    });
+}

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
@@ -73,5 +74,29 @@ final class QuestionTypeCheckboxTest extends AbstractQuestionTypeSelectableTest
             "1) Shopping list: Bread, Milk, Cheese",
             strip_tags($ticket->fields['content']),
         );
+    }
+
+    public function testMultiplePredefinedValuesAreApplied(): void
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Shopping list",
+            type: QuestionTypeCheckbox::class,
+            default_value: 'bread',
+            extra_data: json_encode(new QuestionTypeSelectableExtraDataConfig([
+                'bread'  => 'Bread',
+                'milk'   => 'Milk',
+                'cheese' => 'Cheese',
+            ]))
+        );
+        $form = $this->createForm($builder);
+        $question = Question::getById($this->getQuestionId($form, "Shopping list"));
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'milk,cheese',
+        ]);
+
+        // A checkbox question holds several values, the parameter is valid
+        $this->assertEquals('milk,cheese', $question->fields['default_value']);
     }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeCheckboxTest.php
@@ -34,15 +34,20 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
-use Glpi\Tests\DbTestCase;
+use Glpi\Tests\Form\QuestionType\AbstractQuestionTypeSelectableTest;
 use Glpi\Tests\FormBuilder;
-use Glpi\Tests\FormTesterTrait;
+use Override;
 
-final class QuestionTypeCheckboxTest extends DbTestCase
+final class QuestionTypeCheckboxTest extends AbstractQuestionTypeSelectableTest
 {
-    use FormTesterTrait;
+    #[Override]
+    protected function getQuestionType(): AbstractQuestionTypeSelectable
+    {
+        return new QuestionTypeCheckbox();
+    }
 
     public function testCheckboxAnswerIsDisplayedInTicketDescription(): void
     {

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
@@ -154,8 +154,58 @@ final class QuestionTypeDropdownTest extends AbstractQuestionTypeSelectableTest
         $this->assertStringNotContainsString('DropdownValues', $html, 'Should use the standard template, not AJAX');
     }
 
-    private function createDropdownQuestion(int $option_count, bool $is_multiple): Question
+    public function testMultiplePredefinedValuesAreIgnoredOnSingleDropdown(): void
     {
+        $question = $this->createDropdownQuestion(
+            option_count: 3,
+            is_multiple: false,
+            default_value: 'option_1',
+        );
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'option_2,option_3',
+        ]);
+
+        // A single dropdown can only hold a single value: the ambiguous
+        // parameter must be discarded and the configured default preserved.
+        $this->assertEquals('option_1', $question->fields['default_value']);
+    }
+
+    public function testMultiplePredefinedValuesAreAppliedOnMultipleDropdown(): void
+    {
+        $question = $this->createDropdownQuestion(
+            option_count: 3,
+            is_multiple: true,
+            default_value: 'option_1',
+        );
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'option_2,option_3',
+        ]);
+
+        $this->assertEquals('option_2,option_3', $question->fields['default_value']);
+    }
+
+    public function testSinglePredefinedValueIsAppliedOnSingleDropdown(): void
+    {
+        $question = $this->createDropdownQuestion(
+            option_count: 3,
+            is_multiple: false,
+            default_value: 'option_1',
+        );
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'option_3',
+        ]);
+
+        $this->assertEquals('option_3', $question->fields['default_value']);
+    }
+
+    private function createDropdownQuestion(
+        int $option_count,
+        bool $is_multiple,
+        string $default_value = "",
+    ): Question {
         $options = [];
         for ($i = 1; $i <= $option_count; $i++) {
             $options["option_$i"] = "Option $i";
@@ -165,6 +215,7 @@ final class QuestionTypeDropdownTest extends AbstractQuestionTypeSelectableTest
         $builder->addQuestion(
             name: "Pick options",
             type: QuestionTypeDropdown::class,
+            default_value: $default_value,
             extra_data: json_encode(new QuestionTypeDropdownExtraDataConfig(
                 options: $options,
                 is_multiple_dropdown: $is_multiple,

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeDropdownTest.php
@@ -35,15 +35,20 @@
 namespace tests\units\Glpi\Form\QuestionType;
 
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeDropdown;
 use Glpi\Form\QuestionType\QuestionTypeDropdownExtraDataConfig;
-use Glpi\Tests\DbTestCase;
+use Glpi\Tests\Form\QuestionType\AbstractQuestionTypeSelectableTest;
 use Glpi\Tests\FormBuilder;
-use Glpi\Tests\FormTesterTrait;
+use Override;
 
-final class QuestionTypeDropdownTest extends DbTestCase
+final class QuestionTypeDropdownTest extends AbstractQuestionTypeSelectableTest
 {
-    use FormTesterTrait;
+    #[Override]
+    protected function getQuestionType(): AbstractQuestionTypeSelectable
+    {
+        return new QuestionTypeDropdown();
+    }
 
     public function testSingleValueDropdownAnswerIsDisplayedInTicketDescription(): void
     {

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeRadio;
 use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
@@ -71,5 +72,47 @@ final class QuestionTypeRadioTest extends AbstractQuestionTypeSelectableTest
             "1) Your favorite software: GLPI again",
             strip_tags($ticket->fields['content']),
         );
+    }
+
+    public function testSinglePredefinedValueIsApplied(): void
+    {
+        $question = $this->createRadioQuestion(default_value: 'glpi');
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'still_glpi',
+        ]);
+
+        $this->assertEquals('still_glpi', $question->fields['default_value']);
+    }
+
+    public function testMultiplePredefinedValuesAreIgnored(): void
+    {
+        $question = $this->createRadioQuestion(default_value: 'glpi');
+
+        $question->setDefaultValueFromParameters([
+            $question->fields['uuid'] => 'glpi_again,still_glpi',
+        ]);
+
+        // A radio question can only hold a single value: the ambiguous
+        // parameter must be discarded and the configured default preserved.
+        $this->assertEquals('glpi', $question->fields['default_value']);
+    }
+
+    private function createRadioQuestion(string $default_value): Question
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "Your favorite software",
+            type: QuestionTypeRadio::class,
+            default_value: $default_value,
+            extra_data: json_encode(new QuestionTypeSelectableExtraDataConfig([
+                'glpi'       => 'GLPI',
+                'glpi_again' => 'GLPI again',
+                'still_glpi' => 'Still GLPI',
+            ]))
+        );
+        $form = $this->createForm($builder);
+
+        return Question::getById($this->getQuestionId($form, "Your favorite software"));
     }
 }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeRadioTest.php
@@ -34,15 +34,20 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
 use Glpi\Form\QuestionType\QuestionTypeRadio;
 use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
-use Glpi\Tests\DbTestCase;
+use Glpi\Tests\Form\QuestionType\AbstractQuestionTypeSelectableTest;
 use Glpi\Tests\FormBuilder;
-use Glpi\Tests\FormTesterTrait;
+use Override;
 
-final class QuestionTypeRadioTest extends DbTestCase
+final class QuestionTypeRadioTest extends AbstractQuestionTypeSelectableTest
 {
-    use FormTesterTrait;
+    #[Override]
+    protected function getQuestionType(): AbstractQuestionTypeSelectable
+    {
+        return new QuestionTypeRadio();
+    }
 
     public function testRadioAnswerIsDisplayedInTicketDescription(): void
     {

--- a/tests/src/Form/QuestionType/AbstractQuestionTypeSelectableTest.php
+++ b/tests/src/Form/QuestionType/AbstractQuestionTypeSelectableTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests\Form\QuestionType;
+
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\FormTesterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+abstract class AbstractQuestionTypeSelectableTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    /**
+     * Get the selectable question type instance under test.
+     */
+    abstract protected function getQuestionType(): AbstractQuestionTypeSelectable;
+
+    public static function formatPredefinedValueProvider(): iterable
+    {
+        yield 'valid uuid' => [
+            'value'    => '12345678-1234-1234-1234-123456789012',
+            'expected' => '12345678-1234-1234-1234-123456789012',
+        ];
+
+        yield 'multiple valid uuids' => [
+            'value'    => '12345678-1234-1234-1234-123456789012,87654321-4321-4321-4321-210987654321',
+            'expected' => '12345678-1234-1234-1234-123456789012,87654321-4321-4321-4321-210987654321',
+        ];
+
+        yield 'empty uuid' => [
+            'value'    => '',
+            'expected' => null,
+        ];
+
+        yield 'mixed valid and invalid uuids' => [
+            'value'    => '12345678-1234-1234-1234-123456789012,, 87654321-4321-4321-4321-210987654321',
+            'expected' => '12345678-1234-1234-1234-123456789012,87654321-4321-4321-4321-210987654321',
+        ];
+    }
+
+    #[DataProvider('formatPredefinedValueProvider')]
+    public function testFormatPredefinedValue(string $value, ?string $expected): void
+    {
+        $this->assertSame($expected, $this->getQuestionType()->formatPredefinedValue($value));
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description

- It fixes !44844

Add predefined value support for selectable question types.
This fix allows users to enter a URL as the answer to a Radio, Checkbox, or Dropdown question.
Added a button to retrieve the UUID for each option

## Screenshots (if appropriate):
<img width="1171" height="496" alt="image" src="https://github.com/user-attachments/assets/92eb8364-e87e-4cc7-9133-c5e8e0c196a1" />


