### PR TITLE
Multiple Remember Me Tokens

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1460,12 +1460,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Auth.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$hash of static method Auth\\:\\:checkPassword\\(\\) expects string, string\\|false given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Auth.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#3 \\$options of function setcookie expects array\\{expires\\?\\: int, path\\?\\: string, domain\\?\\: string, secure\\?\\: bool, httponly\\?\\: bool, samesite\\?\\: \'Lax\'\\|\'lax\'\\|\'None\'\\|\'none\'\\|\'Strict\'\\|\'strict\'\\}, array\\{expires\\: \\(float\\|int\\), path\\: string, domain\\: string, secure\\: bool, httponly\\: true, samesite\\: string\\} given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The present file will list all changes made to the project; according to the
 - Improved client IP detection.
   If your GLPI instance is behind a reverse proxy, you should add its IP(s) the new `GLPI_TRUSTED_REVERSE_PROXIES` constant and modify the new `GLPI_REVERSE_PROXY_HEADERS` constant to include the headers your proxy uses to forward the client IP.
   Only the required HTTP headers should be listed for better security as any header not handled by the proxy could be spoofed by the client.
+- Remember me support for multiple devices at the same time.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
@@ -43,6 +44,9 @@ The present file will list all changes made to the project; according to the
 - `countDistinctElementsInTable` / `DbUtils::countDistinctElementsInTable()` method signatures changed.
 - `getAllDataFromTable` / `DbUtils::getAllDataFromTable()` method signatures changed.
 - Methods in `Dbutils` and the global counterparts in `src/autoload/dbutils-aliases.php` now have strict type declarations except for methods that have been deprecated.
+- `User::getAuthToken()` cannot be used for `cookie_token` anymore.
+- Remember me cookie token no longer stored in the `glpi_users` table. It is now stored in the `glpi_user_tokens` table.
+- `Auth::setRememberMeCookie()` signature changed. It no longer accepts an empty value to trigger the removal of the cookie.
 
 #### Deprecated
 - Usage of coma separated list of fields in `ORDER BY` clause.

--- a/install/migrations/update_11.0.x_to_12.0.0/sessions.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/sessions.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var Migration $migration
+ * @var DBmysql $DB
+ */
+
+if (!$DB->tableExists('glpi_user_tokens')) {
+    $DB->doQuery(<<<SQL
+        CREATE TABLE `glpi_user_tokens` (
+            `id` int unsigned NOT NULL AUTO_INCREMENT,
+            `users_id` int unsigned NOT NULL,
+            `type` varchar(64) NOT NULL,
+            `selector` char(16) NOT NULL,
+            `validator` varchar(255) NOT NULL,
+            `date_expiration` timestamp NOT NULL,
+            PRIMARY KEY (`id`),
+            UNIQUE KEY `selector` (`selector`),
+            KEY `users_id` (`users_id`),
+            KEY `type` (`type`),
+            KEY `date_expiration` (`date_expiration`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+SQL);
+}
+
+$migration->dropField('glpi_users', 'cookie_token');
+$migration->dropField('glpi_users', 'cookie_token_date');

--- a/install/migrations/update_11.0.x_to_12.0.0/sessions.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/sessions.php
@@ -37,17 +37,17 @@
  * @var DBmysql $DB
  */
 
-if (!$DB->tableExists('glpi_user_tokens')) {
+if (!$DB->tableExists('glpi_usertokens')) {
     $DB->doQuery(<<<SQL
-        CREATE TABLE `glpi_user_tokens` (
+        CREATE TABLE `glpi_usertokens` (
             `id` int unsigned NOT NULL AUTO_INCREMENT,
             `users_id` int unsigned NOT NULL,
             `type` varchar(64) NOT NULL,
-            `selector` char(16) NOT NULL,
-            `validator` varchar(255) NOT NULL,
+            `token_uid` char(16) NOT NULL,
+            `token_hash` varchar(255) NOT NULL,
             `date_expiration` timestamp NOT NULL,
             PRIMARY KEY (`id`),
-            UNIQUE KEY `selector` (`selector`),
+            UNIQUE KEY `token_uid` (`token_uid`),
             KEY `users_id` (`users_id`),
             KEY `type` (`type`),
             KEY `date_expiration` (`date_expiration`)

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8086,8 +8086,6 @@ CREATE TABLE `glpi_users` (
   `personal_token_date` timestamp NULL DEFAULT NULL,
   `api_token` varchar(255) DEFAULT NULL,
   `api_token_date` timestamp NULL DEFAULT NULL,
-  `cookie_token` varchar(255) DEFAULT NULL,
-  `cookie_token_date` timestamp NULL DEFAULT NULL,
   `display_count_on_home` int DEFAULT NULL,
   `notification_to_myself` tinyint DEFAULT NULL,
   `duedateok_color` varchar(255) DEFAULT NULL,
@@ -10529,6 +10527,21 @@ CREATE TABLE `glpi_sharetokens` (
   KEY `date_creation` (`date_creation`),
   KEY `date_mod` (`date_mod`),
   KEY `date_expiration` (`date_expiration`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
+
+DROP TABLE IF EXISTS `glpi_user_tokens`;
+CREATE TABLE `glpi_user_tokens` (
+    `id` int unsigned NOT NULL AUTO_INCREMENT,
+    `users_id` int unsigned NOT NULL,
+    `type` varchar(64) NOT NULL,
+    `selector` char(16) NOT NULL,
+    `validator` varchar(255) NOT NULL,
+    `date_expiration` timestamp NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `selector` (`selector`),
+    KEY `users_id` (`users_id`),
+    KEY `type` (`type`),
+    KEY `date_expiration` (`date_expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10529,16 +10529,16 @@ CREATE TABLE `glpi_sharetokens` (
   KEY `date_expiration` (`date_expiration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 
-DROP TABLE IF EXISTS `glpi_user_tokens`;
-CREATE TABLE `glpi_user_tokens` (
+DROP TABLE IF EXISTS `glpi_usertokens`;
+CREATE TABLE `glpi_usertokens` (
     `id` int unsigned NOT NULL AUTO_INCREMENT,
     `users_id` int unsigned NOT NULL,
     `type` varchar(64) NOT NULL,
-    `selector` char(16) NOT NULL,
-    `validator` varchar(255) NOT NULL,
+    `token_uid` char(16) NOT NULL,
+    `token_hash` varchar(255) NOT NULL,
     `date_expiration` timestamp NOT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `selector` (`selector`),
+    UNIQUE KEY `token_uid` (`token_uid`),
     KEY `users_id` (`users_id`),
     KEY `type` (`type`),
     KEY `date_expiration` (`date_expiration`)

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -675,20 +675,20 @@ class Auth extends CommonGLPI
                         $data = $_COOKIE[$cookie_name];
                     }
                     if (!empty($data) && str_contains($data, ':')) {
-                        [$selector, $validator] = explode(':', $data);
+                        [$token_uid, $token_hash] = explode(':', $data);
 
                         $it = $DB->request([
-                            'SELECT' => ['users_id', 'validator'],
-                            'FROM'   => 'glpi_user_tokens',
+                            'SELECT' => ['users_id', 'token_hash'],
+                            'FROM'   => 'glpi_usertokens',
                             'WHERE'  => [
                                 'type'     => 'rememberme',
-                                'selector' => $selector,
+                                'token_uid' => $token_uid,
                                 'date_expiration'   => ['>', date('Y-m-d H:i:s')],
                             ],
                             'LIMIT'  => 1,
                         ]);
-                        $known_validator = $it->current()['validator'] ?? null;
-                        if ($known_validator !== null && self::checkPassword($validator, $known_validator)) {
+                        $known_hash = $it->current()['token_hash'] ?? null;
+                        if ($known_hash !== null && self::checkPassword($token_hash, $known_hash)) {
                             $user = new User();
                             $user->getFromDB($it->current()['users_id']);
                             $this->user->fields['name'] = $user->fields['name'];
@@ -1167,8 +1167,8 @@ class Auth extends CommonGLPI
         if ($this->auth_succeded && $CFG_GLPI['login_remember_time'] > 0 && $remember_me) {
             self::setRememberMeCookie(
                 users_id: $this->user->getID(),
-                selector: bin2hex(random_bytes(8)),
-                validator: bin2hex(random_bytes(16)),
+                token_uid: bin2hex(random_bytes(8)),
+                token: bin2hex(random_bytes(16)),
             );
         }
 
@@ -1746,17 +1746,17 @@ class Auth extends CommonGLPI
      * Defines "rememberme" cookie.
      *
      * @param int $users_id The ID of the user for which the remember me cookie is being set.
-     * @param string $selector The value used in the query to the DB to fetch the remember me token.
-     * @param string $validator The non-hashed token value. A hashed version of this value is stored in the DB and compared to the hashed value of the cookie when validating the remember me token.
+     * @param string $token_uid The value used in the query to the DB to fetch the remember me token.
+     * @param string $token The non-hashed token value. A hashed version of this value is stored in the DB and compared to the hashed value of the cookie when validating the remember me token.
      *
      * @return void
      */
-    public static function setRememberMeCookie(int $users_id, string $selector, string $validator): void
+    private static function setRememberMeCookie(int $users_id, string $token_uid, string $token): void
     {
         global $CFG_GLPI, $DB;
 
-        if (empty($selector) || empty($validator)) {
-            throw new InvalidArgumentException('Selector and validator must not be empty.');
+        if (empty($token_uid) || empty($token)) {
+            throw new InvalidArgumentException('Token UID and hash must not be empty.');
         }
 
         $cookie_name     = session_name() . '_rememberme';
@@ -1765,19 +1765,19 @@ class Auth extends CommonGLPI
         $cookie_domain   = ini_get('session.cookie_domain');
         $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
-        $hashed_validator = password_hash($validator, PASSWORD_DEFAULT);
+        $token_hash = password_hash($token, PASSWORD_DEFAULT);
 
-        $DB->insert('glpi_user_tokens', [
+        $DB->insert('glpi_usertokens', [
             'type' => 'rememberme',
             'users_id' => $users_id,
-            'selector' => $selector,
-            'validator' => $hashed_validator,
+            'token_uid' => $token_uid,
+            'token_hash' => $token_hash,
             'date_expiration' => date('Y-m-d H:i:s', $cookie_lifetime),
         ]);
 
         setcookie(
             $cookie_name,
-            $selector . ':' . $validator,
+            $token_uid . ':' . $token,
             [
                 'expires'  => $cookie_lifetime,
                 'path'     => $cookie_path,
@@ -1788,6 +1788,6 @@ class Auth extends CommonGLPI
             ]
         );
 
-        $_COOKIE[$cookie_name] = $selector . ':' . $validator;
+        $_COOKIE[$cookie_name] = $token_uid . ':' . $token;
     }
 }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -43,8 +43,6 @@ use Glpi\Toolbox\IPUtilities;
 use Safe\Exceptions\LdapException;
 
 use function Safe\ini_get;
-use function Safe\json_decode;
-use function Safe\json_encode;
 use function Safe\ldap_bind;
 use function Safe\parse_url;
 use function Safe\preg_match;
@@ -541,7 +539,7 @@ class Auth extends CommonGLPI
      */
     public function getAlternateAuthSystemsUserLogin($authtype = 0)
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
 
         switch ($authtype) {
             case self::CAS:
@@ -674,18 +672,26 @@ class Auth extends CommonGLPI
                 if ($CFG_GLPI["login_remember_time"]) {
                     $data = null;
                     if (array_key_exists($cookie_name, $_COOKIE)) {
-                        $data = json_decode($_COOKIE[$cookie_name], true);
+                        $data = $_COOKIE[$cookie_name];
                     }
-                    if (is_array($data) && count($data) === 2) {
-                        [$cookie_id, $cookie_token] = $data;
+                    if (!empty($data) && str_contains($data, ':')) {
+                        [$selector, $validator] = explode(':', $data);
 
-                        $user = new User();
-                        $user->getFromDB($cookie_id);
-                        $hash = $user->getAuthToken('cookie_token');
-
-                        if (self::checkPassword($cookie_token, $hash)) {
+                        $it = $DB->request([
+                            'SELECT' => ['users_id', 'validator'],
+                            'FROM'   => 'glpi_user_tokens',
+                            'WHERE'  => [
+                                'type'     => 'rememberme',
+                                'selector' => $selector,
+                                'date_expiration'   => ['>', date('Y-m-d H:i:s')],
+                            ],
+                            'LIMIT'  => 1,
+                        ]);
+                        $known_validator = $it->current()['validator'] ?? null;
+                        if (self::checkPassword($validator, $known_validator)) {
+                            $user = new User();
+                            $user->getFromDB($it->current()['users_id']);
                             $this->user->fields['name'] = $user->fields['name'];
-                            // Use current time as session time may not be initialized yet or may be from previous session
                             $user->update(['id' => $user->getID(), 'last_login' => date("Y-m-d H:i:s")]);
                             return true;
                         } else {
@@ -696,8 +702,9 @@ class Auth extends CommonGLPI
                     $this->addToError(__("Auto login disabled"));
                 }
 
-                // Remove cookie to allow new login
-                self::setRememberMeCookie('');
+                // Remove cookie to allow new login by setting a blank cookie with a past expiration date
+                setcookie($cookie_name, '', ['expires' => time() - 3600, 'path' => '/']);
+                unset($_COOKIE[$cookie_name]);
                 break;
         }
         return false;
@@ -1158,17 +1165,11 @@ class Auth extends CommonGLPI
         }
 
         if ($this->auth_succeded && $CFG_GLPI['login_remember_time'] > 0 && $remember_me) {
-            $token = $this->user->getAuthToken('cookie_token', true);
-
-            if ($token) {
-                $data = json_encode([
-                    $this->user->fields['id'],
-                    $token,
-                ]);
-
-                //Send cookie to browser
-                self::setRememberMeCookie($data);
-            }
+            self::setRememberMeCookie(
+                users_id: $this->user->getID(),
+                selector: bin2hex(random_bytes(8)),
+                validator: bin2hex(random_bytes(16)),
+            );
         }
 
         if ($this->auth_succeded && !empty($this->user->fields['timezone']) && 'null' !== strtolower($this->user->fields['timezone'])) {
@@ -1744,28 +1745,39 @@ class Auth extends CommonGLPI
     /**
      * Defines "rememberme" cookie.
      *
-     * @param string $cookie_value
+     * @param int $users_id The ID of the user for which the remember me cookie is being set.
+     * @param string $selector The value used in the query to the DB to fetch the remember me token.
+     * @param string $validator The non-hashed token value. A hashed version of this value is stored in the DB and compared to the hashed value of the cookie when validating the remember me token.
      *
      * @return void
      */
-    public static function setRememberMeCookie(string $cookie_value): void
+    public static function setRememberMeCookie(int $users_id, string $selector, string $validator): void
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $DB;
+
+        if (empty($selector) || empty($validator)) {
+            throw new InvalidArgumentException('Selector and validator must not be empty.');
+        }
 
         $cookie_name     = session_name() . '_rememberme';
-        $cookie_lifetime = empty($cookie_value) ? time() - 3600 : time() + $CFG_GLPI['login_remember_time'];
+        $cookie_lifetime = time() + $CFG_GLPI['login_remember_time'];
         $cookie_path     = ini_get('session.cookie_path');
         $cookie_domain   = ini_get('session.cookie_domain');
         $cookie_secure   = filter_var(ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
         $cookie_samesite = ini_get('session.cookie_samesite');
+        $hashed_validator = password_hash($validator, PASSWORD_DEFAULT);
 
-        if (empty($cookie_value) && !isset($_COOKIE[$cookie_name])) {
-            return;
-        }
+        $DB->insert('glpi_user_tokens', [
+            'type' => 'rememberme',
+            'users_id' => $users_id,
+            'selector' => $selector,
+            'validator' => $hashed_validator,
+            'date_expiration' => date('Y-m-d H:i:s', $cookie_lifetime),
+        ]);
 
         setcookie(
             $cookie_name,
-            $cookie_value,
+            $selector . ':' . $validator,
             [
                 'expires'  => $cookie_lifetime,
                 'path'     => $cookie_path,
@@ -1776,10 +1788,6 @@ class Auth extends CommonGLPI
             ]
         );
 
-        if (empty($cookie_value)) {
-            unset($_COOKIE[$cookie_name]);
-        } else {
-            $_COOKIE[$cookie_name] = $cookie_value;
-        }
+        $_COOKIE[$cookie_name] = $selector . ':' . $validator;
     }
 }

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -688,7 +688,7 @@ class Auth extends CommonGLPI
                             'LIMIT'  => 1,
                         ]);
                         $known_validator = $it->current()['validator'] ?? null;
-                        if (self::checkPassword($validator, $known_validator)) {
+                        if ($known_validator !== null && self::checkPassword($validator, $known_validator)) {
                             $user = new User();
                             $user->getFromDB($it->current()['users_id']);
                             $this->user->fields['name'] = $user->fields['name'];

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1537,6 +1537,8 @@ TWIG, ['msg' => __('Last run list')]);
      **/
     public static function cronSession(self $task): int
     {
+        global $DB, $CFG_GLPI;
+
         // max time to keep the file session
         try {
             $maxlifetime = (int) ini_get('session.gc_maxlifetime');
@@ -1558,6 +1560,13 @@ TWIG, ['msg' => __('Last run list')]);
                 }
             }
         }
+
+        // Clean expired remember me tokens
+        $cookie_lifetime = time() + $CFG_GLPI['login_remember_time'];
+        $DB->delete('glpi_user_tokens', [
+            'type' => 'rememberme',
+            'date_expiration' => ['<', $cookie_lifetime],
+        ]);
 
         $task->setVolume($nb);
         if ($nb) {

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -1563,7 +1563,7 @@ TWIG, ['msg' => __('Last run list')]);
 
         // Clean expired remember me tokens
         $cookie_lifetime = time() + $CFG_GLPI['login_remember_time'];
-        $DB->delete('glpi_user_tokens', [
+        $DB->delete('glpi_usertokens', [
             'type' => 'rememberme',
             'date_expiration' => ['<', $cookie_lifetime],
         ]);

--- a/src/GLPIKey.php
+++ b/src/GLPIKey.php
@@ -75,7 +75,6 @@ class GLPIKey
         'glpi_snmpcredentials.auth_passphrase',
         'glpi_snmpcredentials.priv_passphrase',
         'glpi_users.api_token',
-        'glpi_users.cookie_token',
         'glpi_users.password_forget_token',
         'glpi_users.personal_token',
     ];

--- a/src/Session.php
+++ b/src/Session.php
@@ -50,6 +50,7 @@ use function Safe\ini_get;
 use function Safe\preg_match;
 use function Safe\scandir;
 use function Safe\session_id;
+use function Safe\session_name;
 use function Safe\session_regenerate_id;
 use function Safe\session_save_path;
 use function Safe\session_start;
@@ -2285,9 +2286,25 @@ class Session
     */
     public static function cleanOnLogout()
     {
-        Session::destroy();
-        //Remove cookie to allow new login
-        Auth::setRememberMeCookie('');
+        global $DB;
+
+        $users_id = self::getLoginUserID();
+        self::destroy();
+
+        // Remove remember me token and cookie
+        if (is_numeric($users_id)) {
+            $cookie_name = session_name() . '_rememberme';
+            [$selector] = explode(':', $_COOKIE[$cookie_name]);
+            if (!empty($selector)) {
+                $DB->delete('glpi_user_tokens', [
+                    'users_id' => $users_id,
+                    'selector' => $selector,
+                    'type' => 'rememberme',
+                ]);
+            }
+            setcookie($cookie_name, '', ['expires' => time() - 3600, 'path' => '/']);
+            unset($_COOKIE[$cookie_name]);
+        }
     }
 
     /**

--- a/src/Session.php
+++ b/src/Session.php
@@ -2294,11 +2294,11 @@ class Session
         // Remove remember me token and cookie
         $cookie_name = session_name() . '_rememberme';
         if (is_numeric($users_id) && isset($_COOKIE[$cookie_name])) {
-            [$selector] = explode(':', $_COOKIE[$cookie_name]);
-            if (!empty($selector)) {
-                $DB->delete('glpi_user_tokens', [
+            [$token_uid] = explode(':', $_COOKIE[$cookie_name]);
+            if (!empty($token_uid)) {
+                $DB->delete('glpi_usertokens', [
                     'users_id' => $users_id,
-                    'selector' => $selector,
+                    'token_uid' => $token_uid,
                     'type' => 'rememberme',
                 ]);
             }

--- a/src/Session.php
+++ b/src/Session.php
@@ -2292,8 +2292,8 @@ class Session
         self::destroy();
 
         // Remove remember me token and cookie
-        if (is_numeric($users_id)) {
-            $cookie_name = session_name() . '_rememberme';
+        $cookie_name = session_name() . '_rememberme';
+        if (is_numeric($users_id) && isset($_COOKIE[$cookie_name])) {
             [$selector] = explode(':', $_COOKIE[$cookie_name]);
             if (!empty($selector)) {
                 $DB->delete('glpi_user_tokens', [

--- a/src/User.php
+++ b/src/User.php
@@ -49,7 +49,6 @@ use Glpi\Security\TOTPManager;
 use LDAP\Connection;
 use LDAP\Result;
 use Sabre\VObject\Component\VCard;
-use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -99,7 +98,6 @@ class User extends CommonDBTM implements TreeBrowseInterface
         'password_history',
         'personal_token',
         'api_token',
-        'cookie_token',
         '2fa',
     ];
 
@@ -129,8 +127,6 @@ class User extends CommonDBTM implements TreeBrowseInterface
         unset($input['personal_token_date']);
         unset($input['api_token']);
         unset($input['api_token_date']);
-        unset($input['cookie_token']);
-        unset($input['cookie_token_date']);
         return $input;
     }
 
@@ -981,7 +977,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         }
 
         $glpi_key = new GLPIKey();
-        foreach (['api_token', 'cookie_token', 'password_forget_token', 'personal_token'] as $token_field) {
+        foreach (['api_token', 'password_forget_token', 'personal_token'] as $token_field) {
             if (
                 array_key_exists($token_field, $input)
                 && $input[$token_field] !== null
@@ -1235,7 +1231,6 @@ class User extends CommonDBTM implements TreeBrowseInterface
                 'api_token',
                 '_reset_api_token',
                 '_regenerate_api_token',
-                'cookie_token',
                 'password_forget_token',
                 'personal_token',
                 '_reset_personal_token',
@@ -1448,7 +1443,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
             );
         }
 
-        foreach (['api_token', 'cookie_token', 'password_forget_token', 'personal_token'] as $token_field) {
+        foreach (['api_token', 'password_forget_token', 'personal_token'] as $token_field) {
             if (
                 array_key_exists($token_field, $input)
                 && $input[$token_field] !== null
@@ -5881,7 +5876,7 @@ HTML;
      *
      * @param string $field Field storing the token
      *
-     * @return string
+     * @return string The encrypted token.
      */
     public static function getUniqueToken($field = 'personal_token')
     {
@@ -5943,44 +5938,21 @@ HTML;
      */
     public function getAuthToken($field = 'personal_token', $force_new = false)
     {
-        global $CFG_GLPI;
-
         if ($this->isNewItem()) {
             return false;
         }
 
-        // check date validity for cookie token
-        $outdated = false;
-        if ($field === 'cookie_token') {
-            if (empty($this->fields[$field . "_date"])) {
-                $outdated = true;
-            } else {
-                $date_create = new DateTime($this->fields[$field . "_date"]);
-                $date_expir = $date_create->add(new DateInterval('PT' . $CFG_GLPI["login_remember_time"] . 'S'));
-
-                if ($date_expir < new DateTime()) {
-                    $outdated = true;
-                }
-            }
-        }
-
         // token exists, is not oudated, and we may use it
-        if (!empty($this->fields[$field]) && !$force_new && !$outdated) {
+        if (!empty($this->fields[$field]) && !$force_new) {
             return (new GLPIKey())->decrypt($this->fields[$field]);
         }
 
         // else get a new token
         $token = self::getUniqueToken($field);
 
-        // for cookie token, we need to store it hashed
-        $hash = $token;
-        if ($field === 'cookie_token') {
-            $hash = Auth::getPasswordHash($token);
-        }
-
         // save this token in db
-        $this->update(['id'             => $this->getID(),
-            $field           => $hash,
+        $this->update(['id' => $this->getID(),
+            $field => $token,
             $field . "_date" => $_SESSION['glpi_currenttime'],
         ]);
 
@@ -6374,25 +6346,32 @@ HTML;
 
         // Disable users if their password has expire for too long.
         if (-1 !== $lock_delay) {
+            $lock_conditions = [
+                'is_deleted' => 0,
+                'is_active'  => 1,
+                'authtype'   => Auth::DB_GLPI,
+                new QueryExpression(
+                    QueryFunction::now() . ' > ' . QueryFunction::dateAdd(
+                        date: 'password_last_update',
+                        interval: $expiration_delay + $lock_delay,
+                        interval_unit: 'DAY'
+                    )
+                ),
+            ];
+
+            $DB->delete('glpi_user_tokens', [
+                'type' => 'rememberme',
+                'users_id' => new QuerySubQuery([
+                    'SELECT' => ['id'],
+                    'FROM'   => self::getTable(),
+                    'WHERE'  => $lock_conditions,
+                ]),
+            ]);
+
             $DB->update(
                 self::getTable(),
-                [
-                    'is_active'         => 0,
-                    'cookie_token'      => null,
-                    'cookie_token_date' => null,
-                ],
-                [
-                    'is_deleted' => 0,
-                    'is_active'  => 1,
-                    'authtype'   => Auth::DB_GLPI,
-                    new QueryExpression(
-                        QueryFunction::now() . ' > ' . QueryFunction::dateAdd(
-                            date: 'password_last_update',
-                            interval: $expiration_delay + $lock_delay,
-                            interval_unit: 'DAY'
-                        )
-                    ),
-                ]
+                ['is_active' => 0],
+                $lock_conditions
             );
         }
 

--- a/src/User.php
+++ b/src/User.php
@@ -6359,7 +6359,7 @@ HTML;
                 ),
             ];
 
-            $DB->delete('glpi_user_tokens', [
+            $DB->delete('glpi_usertokens', [
                 'type' => 'rememberme',
                 'users_id' => new QuerySubQuery([
                     'SELECT' => ['id'],

--- a/tests/functional/AuthTest.php
+++ b/tests/functional/AuthTest.php
@@ -312,21 +312,38 @@ class AuthTest extends DbTestCase
 
     public function testRememberMeLastLogin(): void
     {
-        $user = getItemByTypeName(User::class, 'post-only');
-        $token = $user->getAuthToken('cookie_token', true);
+        global $CFG_GLPI, $DB;
+
+        $CFG_GLPI['login_remember_time'] = 3600;
+
+        $cookie_name = session_name() . '_rememberme';
+        $user = getItemByTypeName(User::class, TU_USER);
         $this->assertnull($user->fields['last_login']);
 
-        $_COOKIE[session_name() . '_rememberme'] = json_encode([
-            $user->getID(),
-            $token,
-        ]);
-
-        //login using remember_me cookie just set
+        Auth::setRememberMeCookie(
+            users_id: $user->getID(),
+            selector: bin2hex(random_bytes(8)),
+            validator: bin2hex(random_bytes(16))
+        );
+        $first_cookie_value = $_COOKIE[$cookie_name];
         $this->assertTrue((new Auth())->login('', ''));
 
         //check if last_login is now set
         $this->assertTrue($user->getFromDB($user->getID()));
         $this->assertNotNull($user->fields['last_login']);
+
+        // Delete the cookie and then set another one to simulate a new login on another device
+        unset($_COOKIE[$cookie_name]);
+        Auth::setRememberMeCookie(
+            users_id: $user->getID(),
+            selector: bin2hex(random_bytes(8)),
+            validator: bin2hex(random_bytes(16))
+        );
+        $this->assertTrue((new Auth())->login('', ''));
+
+        // Restore the first cookie value to ensure it is still valid
+        $_COOKIE[$cookie_name] = $first_cookie_value;
+        $this->assertTrue((new Auth())->login('', ''));
     }
 
     /**

--- a/tests/functional/AuthTest.php
+++ b/tests/functional/AuthTest.php
@@ -320,11 +320,7 @@ class AuthTest extends DbTestCase
         $user = getItemByTypeName(User::class, TU_USER);
         $this->assertnull($user->fields['last_login']);
 
-        Auth::setRememberMeCookie(
-            users_id: $user->getID(),
-            selector: bin2hex(random_bytes(8)),
-            validator: bin2hex(random_bytes(16))
-        );
+        $this->callPrivateMethod(Auth::class, 'setRememberMeCookie', $user->getID(), bin2hex(random_bytes(8)), bin2hex(random_bytes(16)));
         $first_cookie_value = $_COOKIE[$cookie_name];
         $this->assertTrue((new Auth())->login('', ''));
 
@@ -334,11 +330,7 @@ class AuthTest extends DbTestCase
 
         // Delete the cookie and then set another one to simulate a new login on another device
         unset($_COOKIE[$cookie_name]);
-        Auth::setRememberMeCookie(
-            users_id: $user->getID(),
-            selector: bin2hex(random_bytes(8)),
-            validator: bin2hex(random_bytes(16))
-        );
+        $this->callPrivateMethod(Auth::class, 'setRememberMeCookie', $user->getID(), bin2hex(random_bytes(8)), bin2hex(random_bytes(16)));
         $this->assertTrue((new Auth())->login('', ''));
 
         // Restore the first cookie value to ensure it is still valid

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -369,6 +369,7 @@ class DBTest extends GLPITestCase
             'glpi_assets_assets', 'glpi_assets_assetmodels', 'glpi_assets_assettypes',
             'glpi_appliancerelations', 'glpi_dropdowns_dropdowns', 'glpi_oauth_access_tokens', 'glpi_oauth_auth_codes',
             'glpi_oauth_refresh_tokens', 'glpi_stencils', 'glpi_itemtranslations_itemtranslations', 'glpi_itils_validationsteps',
+            'glpi_user_tokens',
         ];
 
         //check if each table has a corresponding itemtype

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -369,7 +369,7 @@ class DBTest extends GLPITestCase
             'glpi_assets_assets', 'glpi_assets_assetmodels', 'glpi_assets_assettypes',
             'glpi_appliancerelations', 'glpi_dropdowns_dropdowns', 'glpi_oauth_access_tokens', 'glpi_oauth_auth_codes',
             'glpi_oauth_refresh_tokens', 'glpi_stencils', 'glpi_itemtranslations_itemtranslations', 'glpi_itils_validationsteps',
-            'glpi_user_tokens',
+            'glpi_usertokens',
         ];
 
         //check if each table has a corresponding itemtype

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -2510,7 +2510,7 @@ HTML;
                 $dd,
                 'filterDisplayWith',
                 new User(),
-                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'cookie_token', 'password_forget_token']
+                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'password_forget_token']
             )
         );
 
@@ -2522,7 +2522,7 @@ HTML;
                 $dd,
                 'filterDisplayWith',
                 new User(),
-                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'cookie_token', 'password_forget_token']
+                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'password_forget_token']
             )
         );
 
@@ -2534,7 +2534,7 @@ HTML;
                 $dd,
                 'filterDisplayWith',
                 new User(),
-                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'cookie_token', 'password_forget_token']
+                ['id', 'firstname', 'password', 'personal_token', 'api_token', 'password_forget_token']
             )
         );
     }

--- a/tests/functional/GLPIKeyTest.php
+++ b/tests/functional/GLPIKeyTest.php
@@ -448,7 +448,6 @@ class GLPIKeyTest extends DbTestCase
                 'glpi_snmpcredentials.auth_passphrase',
                 'glpi_snmpcredentials.priv_passphrase',
                 'glpi_users.api_token',
-                'glpi_users.cookie_token',
                 'glpi_users.password_forget_token',
                 'glpi_users.personal_token',
                 'glpi_plugin_myplugin_remote.key',

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -705,7 +705,6 @@ class UserTest extends DbTestCase
         $inputs = [
             'api_token'             => \bin2hex(\random_bytes(16)),
             '_reset_api_token'      => true,
-            'cookie_token'          => \bin2hex(\random_bytes(16)),
             'password_forget_token' => \bin2hex(\random_bytes(16)),
             'personal_token'        => \bin2hex(\random_bytes(16)),
             '_reset_personal_token' => true,
@@ -2142,7 +2141,6 @@ class UserTest extends DbTestCase
                 $this->assertArrayHasKey('password', $fields);
                 $this->assertArrayHasKey('personal_token', $fields);
                 $this->assertArrayHasKey('api_token', $fields);
-                $this->assertArrayHasKey('cookie_token', $fields);
                 $this->assertArrayHasKey('password_forget_token', $fields);
                 $this->assertArrayHasKey('password_forget_token_date', $fields);
 
@@ -2151,7 +2149,6 @@ class UserTest extends DbTestCase
                 $this->assertEquals(false, \array_key_exists('password', $fields));
                 $this->assertEquals(false, \array_key_exists('personal_token', $fields));
                 $this->assertEquals(false, \array_key_exists('api_token', $fields));
-                $this->assertEquals(false, \array_key_exists('cookie_token', $fields));
                 $this->assertEquals($disclose, \array_key_exists('password_forget_token', $fields));
                 $this->assertEquals($disclose, \array_key_exists('password_forget_token_date', $fields));
             }
@@ -2165,7 +2162,6 @@ class UserTest extends DbTestCase
             'name'                       => 'test',
             'password'                   => \bin2hex(\random_bytes(16)),
             'api_token'                  => \bin2hex(\random_bytes(16)),
-            'cookie_token'               => \bin2hex(\random_bytes(16)),
             'password_forget_token'      => \bin2hex(\random_bytes(16)),
             'personal_token'             => \bin2hex(\random_bytes(16)),
             'password_forget_token_date' => '2024-10-25 13:15:12',
@@ -2607,7 +2603,7 @@ class UserTest extends DbTestCase
 
         // Simulate Auth::login() update cycle (copies fields, calls update).
         $input = $user->fields;
-        unset($input['api_token'], $input['cookie_token'], $input['password_forget_token'], $input['personal_token']);
+        unset($input['api_token'], $input['password_forget_token'], $input['personal_token']);
         $user->update($input);
 
         // The profile must now be assigned in Profile_User.

--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -239,7 +239,7 @@ class GLPITestCase extends TestCase
     {
         $method = new ReflectionMethod($instance, $methodName);
 
-        return $method->invoke($instance, ...$args);
+        return $method->invoke(is_string($instance) ? null : $instance, ...$args);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update. (Maybe)

## Description

9 years ago, GLPI got a "Remember me" feature. Since then, it has only stored a single token at time for a user directly in the `glpi_users` table. When you log into a second device with the "Remember me" option selected, you would be silently logged out prematurely once the PHP session becomes idle too long and gets garbage collected. In fact, I am pretty sure this is why one of my coworkers when I was working IT was constantly annoyed about "random logouts". It is not unreasonable to expect some IT workers will want to log in to multiple devices such as their desk PC, and then a tablet or phone for when they are out addressing issues.

This also resolves one of the issues with the [proposed Session Tracker feature](https://github.com/glpi-project/glpi/pull/24000) where it was required to clear the remember me token when any session for a particular user was revoked. Now, only the relevant token can be removed. It also offers a way, with some more work, to track real login sessions rather than just PHP sessions.

The cookie now contains a `selector` and a `validator`. The selector is used like a unique ID to query the DB. The validator is checked against the known hash. I am not sure if there could be another use for this new table, but to start I made it a little flexible by adding a `type` column to differentiate between token types. We could possibly move the `api_token`, `password_forget_token` and `personal_token` to the new table taking care to ensure only one token per user is generated and handling the expiration, or lack thereof, as needed. This would remove the need to ensure these tokens are not disclosed with the rest of the User data.

https://paragonie.com/blog/2015/04/secure-authentication-php-with-long-term-persistence