### PR TITLE
Fix (FormCreator migration) - Map 'Group from object' actor types to their GLPI 11 equivalents

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -355,8 +355,8 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                 7 => ITILActorFieldStrategy::SPECIFIC_VALUES, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_SUPPLIER
                 8 => ITILActorFieldStrategy::SPECIFIC_ANSWERS, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_QUESTION_SUPPLIER
                 9 => ITILActorFieldStrategy::SPECIFIC_ANSWERS, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_QUESTION_ACTORS
-                // 10 => Group from an object // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
-                // 11 => Tech group from an object // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                10 => ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                11 => ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
                 // 12 => Form author supervisor // PluginFormcreatorTarget_Actor::ACTOR_TYPE_SUPERVISOR
             ];
 
@@ -381,7 +381,11 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                         }
                     }
 
-                    if ($strategy === ITILActorFieldStrategy::SPECIFIC_ANSWERS) {
+                    if (
+                        $strategy === ITILActorFieldStrategy::SPECIFIC_ANSWERS
+                        || $strategy === ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER
+                        || $strategy === ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER
+                    ) {
                         foreach ($ids as $id) {
                             $mapped_item = $migration->getMappedItemTarget(
                                 'PluginFormcreatorQuestion',

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -771,6 +771,8 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 3, // Assignee
                     'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],
@@ -785,6 +787,8 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 3, // Assignee
                     'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -774,7 +774,9 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new AssigneeField())->getDefaultConfig($form),
+            'field_config' => new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+            ),
         ];
 
         yield 'Tech group from an object' => [
@@ -786,7 +788,45 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new AssigneeField())->getDefaultConfig($form),
+            'field_config' => new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+            ),
+        ];
+
+        yield 'Group from an object with question' => [
+            'field_key'     => AssigneeField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 3, // Assignee
+                    'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
+        ];
+
+        yield 'Tech group from an object with question' => [
+            'field_key'     => AssigneeField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 3, // Assignee
+                    'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
         ];
 
         yield 'Form author\'s supervisor' => [

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
@@ -659,7 +659,9 @@ final class ObserverFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new ObserverField())->getDefaultConfig($form),
+            'field_config' => new ObserverFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+            ),
         ];
 
         yield 'Tech group from an object' => [
@@ -671,7 +673,45 @@ final class ObserverFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new ObserverField())->getDefaultConfig($form),
+            'field_config' => new ObserverFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+            ),
+        ];
+
+        yield 'Group from an object with question' => [
+            'field_key'     => ObserverField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 2, // Observer
+                    'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new ObserverFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
+        ];
+
+        yield 'Tech group from an object with question' => [
+            'field_key'     => ObserverField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 2, // Observer
+                    'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new ObserverFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
         ];
 
         yield 'Form author\'s supervisor' => [

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/ObserverFieldTest.php
@@ -656,6 +656,8 @@ final class ObserverFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 2, // Observer
                     'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],
@@ -670,6 +672,8 @@ final class ObserverFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 2, // Observer
                     'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -742,6 +742,8 @@ final class RequesterFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 1, // Requester
                     'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],
@@ -756,6 +758,8 @@ final class RequesterFieldTest extends AbstractActorFieldTest
                 [
                     'actor_role'  => 1, // Requester
                     'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    // actor_value = 0 represents an incomplete/degenerate FormCreator config where no question is linked;
+                    // valid configurations of types 10 and 11 always reference a real question ID.
                     'actor_value' => 0,
                 ],
             ],

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -745,7 +745,9 @@ final class RequesterFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new RequesterField())->getDefaultConfig($form),
+            'field_config' => new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+            ),
         ];
 
         yield 'Tech group from an object' => [
@@ -757,7 +759,45 @@ final class RequesterFieldTest extends AbstractActorFieldTest
                     'actor_value' => 0,
                 ],
             ],
-            'field_config' => fn($migration, $form) => (new RequesterField())->getDefaultConfig($form),
+            'field_config' => new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+            ),
+        ];
+
+        yield 'Group from an object with question' => [
+            'field_key'     => RequesterField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 1, // Requester
+                    'actor_type'  => 10, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
+        ];
+
+        yield 'Tech group from an object with question' => [
+            'field_key'     => RequesterField::getKey(),
+            'fields_to_set' => [
+                [
+                    'actor_role'  => 1, // Requester
+                    'actor_type'  => 11, // PluginFormcreatorTarget_Actor::ACTOR_TYPE_TECH_GROUP_FROM_OBJECT
+                    'actor_value' => 74, // Computer question
+                ],
+            ],
+            'field_config' => fn($migration, $form) => new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER],
+                specific_question_ids: [
+                    $migration->getMappedItemTarget('PluginFormcreatorQuestion', 74)['items_id']
+                    ?? throw new \Exception("Question not found"),
+                ]
+            ),
         ];
 
         yield 'Form author\'s supervisor' => [


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44803
- Here is a brief description of what this PR does

When migrating FormCreator to GLPI 11 native Forms, actors configured with type "Group from an object" (type 10) or "Tech group from an object" (type 11) were silently dropped.

These two actor types store a reference to a form question whose answered object provides a group (via `groups_id` or `groups_id_tech`). The equivalent strategies already exist in GLPI 11 as `GROUP_FROM_OBJECT_ANSWER` and `TECH_GROUP_FROM_OBJECT_ANSWER`, but they were never wired up in the migration strategy map.

### Changes

- Map actor type 10 => `ITILActorFieldStrategy::GROUP_FROM_OBJECT_ANSWER`
- Map actor type 11 => `ITILActorFieldStrategy::TECH_GROUP_FROM_OBJECT_ANSWER`
- Extend the question ID mapping to handle these two new strategies (same logic already used for `SPECIFIC_ANSWERS`)
- Update existing migration tests to reflect the corrected behavior
- Add new migration tests covering the case where a valid question ID is referenced (the actual bug scenario reported by users)


## Screenshots (if appropriate):

### Bug

**Formcreator config :** 

<img width="337" height="98" alt="image" src="https://github.com/user-attachments/assets/647bf21b-25c9-4bc4-bd03-9bb98b8af76c" />


**Result in Forms after migration :** 

<img width="360" height="436" alt="image" src="https://github.com/user-attachments/assets/99ee6917-097c-4409-a2f6-6ed59f3e6d92" />

