### PR TITLE
Fix - Use translated category names in service catalog breadcrumb

### DIFF
--- a/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
+++ b/src/Glpi/Form/ServiceCatalog/Provider/CategoryProvider.php
@@ -104,14 +104,14 @@ final class CategoryProvider implements CompositeProviderInterface
         $categories = [];
         $current_category = [
             'id' => $category->getID(),
-            'name' => $category->fields['name'],
+            'name' => $category->getServiceCatalogItemTitle(),
         ];
 
         /** @var Category $ancestor */
         foreach ($category->getAncestors() as $ancestor) {
             $categories[] = [
                 'id' => $ancestor->getID(),
-                'name' => $ancestor->fields['name'],
+                'name' => $ancestor->getServiceCatalogItemTitle(),
             ];
         }
 

--- a/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
+++ b/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
@@ -494,7 +494,7 @@ class CategoryProviderTest extends DbTestCase
     public function testAncestorNamesAreTranslated(): void
     {
         $this->login();
-        
+
         $parent = $this->createItem(Category::class, ['name' => 'Parent category']);
         $child  = $this->createItem(Category::class, [
             'name'                => 'Child category',

--- a/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
+++ b/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
@@ -34,12 +34,14 @@
 
 namespace tests\units\Glpi\Form\ServiceCatalog\Provider;
 
+use DropdownTranslation;
 use Glpi\Form\AccessControl\FormAccessParameters;
 use Glpi\Form\Category;
 use Glpi\Form\ServiceCatalog\ItemRequest;
 use Glpi\Form\ServiceCatalog\Provider\CategoryProvider;
 use Glpi\Tests\DbTestCase;
 use Session;
+use User;
 
 class CategoryProviderTest extends DbTestCase
 {
@@ -484,5 +486,51 @@ class CategoryProviderTest extends DbTestCase
         $this->assertCount(2, $ancestors);
         $this->assertEquals($category2->getID(), $ancestors[0]['id']);
         $this->assertEquals($category2_1->getID(), $ancestors[1]['id']);
+    }
+
+    /**
+     * Non-regression test: ancestor names in breadcrumb must use the translated value.
+     */
+    public function testAncestorNamesAreTranslated(): void
+    {
+        $parent = $this->createItem(Category::class, ['name' => 'Parent category']);
+        $child  = $this->createItem(Category::class, [
+            'name'                => 'Child category',
+            'forms_categories_id' => $parent->getID(),
+        ]);
+
+        $this->createItem(DropdownTranslation::class, [
+            'items_id' => $parent->getID(),
+            'itemtype' => Category::class,
+            'language' => 'fr_FR',
+            'field'    => 'name',
+            'value'    => 'Catégorie parente',
+        ]);
+        $this->createItem(DropdownTranslation::class, [
+            'items_id' => $child->getID(),
+            'itemtype' => Category::class,
+            'language' => 'fr_FR',
+            'field'    => 'name',
+            'value'    => 'Catégorie enfant',
+        ]);
+
+        $this->createItem(User::class, [
+            'name'         => 'fr_FR',
+            'language'     => 'fr_FR',
+            '_entities_id' => $this->getTestRootEntity(only_id: true),
+            '_profiles_id' => 1,
+        ]);
+        $this->login('fr_FR');
+
+        $item_request = new ItemRequest(
+            access_parameters: new FormAccessParameters(),
+            category_id: $child->getID(),
+        );
+
+        $ancestors = $this->provider->getAncestors($item_request);
+
+        $this->assertCount(2, $ancestors);
+        $this->assertEquals('Catégorie parente', $ancestors[0]['name']);
+        $this->assertEquals('Catégorie enfant', $ancestors[1]['name']);
     }
 }

--- a/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
+++ b/tests/functional/Glpi/Form/ServiceCatalog/Provider/CategoryProviderTest.php
@@ -493,6 +493,8 @@ class CategoryProviderTest extends DbTestCase
      */
     public function testAncestorNamesAreTranslated(): void
     {
+        $this->login();
+        
         $parent = $this->createItem(Category::class, ['name' => 'Parent category']);
         $child  = $this->createItem(Category::class, [
             'name'                => 'Child category',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44884
- Here is a brief description of what this PR does

Service catalog breadcrumb was displaying the original category name instead of the translated one, even when a translation existed for the user's language.
### Root cause: 
`CategoryProvider::getAncestors()` was reading `fields['name']` directly, bypassing `DropdownTranslation`.

### Fix:
Replaced `fields['name']` with `getServiceCatalogItemTitle()`, which already calls `DropdownTranslation::getTranslatedValue()`.