### PR TITLE
A11Y : Fix aria-expanded on ticket answer toggle

### DIFF
--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -35,7 +35,7 @@
       {% set is_private = timeline_itemtype.item.fields['is_private'] ?? false %}
       {% set is_private_class = is_private ? "private-item" : "" %}
       <div class="timeline-item mb-1 ms-auto {{ is_private_class }} {{ timeline_itemtype.type }} collapse"
-        id="new-{{ timeline_itemtype.class }}-block" aria-expanded="false" data-bs-parent="#new-itilobject-form"
+        id="new-{{ timeline_itemtype.class }}-block" data-bs-parent="#new-itilobject-form"
         data-testid="new-{{ timeline_itemtype.class }}-block">
          <div class="row">
             <div class="col-auto todo-list-state"></div>

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -63,6 +63,8 @@
                      data-bs-target="#new-{{ default_action_data.class }}-block"
                      type="button"
                      aria-label="{{ default_action_data.label }}"
+                     aria-expanded="false"
+                     aria-controls="new-{{ default_action_data.class }}-block"
                   >
                      <i class="{{ default_action_data.icon }}" aria-hidden="true"></i>
                      <span>{{ default_action_data.label }}</span>
@@ -72,7 +74,7 @@
                      {% if timeline_btn_layout == constant('Config::TIMELINE_ACTION_BTN_SPLITTED') %}
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
                         {% if loop.index0 > 0 %}
-                              <button class="btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                              <button class="btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block" aria-expanded="false" aria-controls="new-{{ timeline_itemtype.class }}-block">
                                  <i class="{{ timeline_itemtype.icon }}" aria-hidden="true"></i>
                                  <span>{{ timeline_itemtype.short_label }}</span>
                               </button>
@@ -91,7 +93,7 @@
                               {% for action, timeline_itemtype in main_actions_itemtypes %}
                                  {% if loop.index0 > 0 %}
                                  <li aria-label="{{ timeline_itemtype.label }}"><a class="dropdown-item action-{{ action }} answer-action" href="#"
-                                    data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
+                                    data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block" aria-expanded="false" aria-controls="new-{{ timeline_itemtype.class }}-block">
                                     <i class="{{ timeline_itemtype.icon }}" aria-hidden="true"></i>
                                     <span>{{ timeline_itemtype.label }}</span>
                                  </a></li>


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/371
- Here is a brief description of what this PR does : 

The "Answer" button opened the inline form without exposing its state: aria-expanded was on the panel instead of the trigger, with no aria-controls. Both now sit on the button, so screen readers announce the expanded state and the region it controls.



