### PR TITLE
Fix - Qualify column references in buildParentCondition to prevent MySQL 1052

### DIFF
--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -1096,8 +1096,8 @@ class ITILFollowup extends CommonDBChild
         // We need to do some specific checks for tickets
         if ($itemtype == Ticket::class) {
             // Default condition
-            $condition = "(`itemtype` = '$itemtype' AND (0 = 1 ";
-            return $condition . Ticket::buildCanViewCondition("items_id") . ")) ";
+            $condition = "(`$itilfup_table`.`itemtype` = '$itemtype' AND (0 = 1 ";
+            return $condition . Ticket::buildCanViewCondition("items_id", $itilfup_table) . ")) ";
         } else {
             if (Session::haveRight($rightname, $itemtype::READMY)) {
                 // Subquery for affected/assigned/observer user

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5652,10 +5652,11 @@ JAVASCRIPT;
      * Build parent condition for search
      *
      * @param string $fieldID field used in the condition: tickets_id, items_id
+     * @param string $table   table name to qualify column references; prevents MySQL 1052 when JOINed tables share the same column name
      *
      * @return string
      */
-    public static function buildCanViewCondition($fieldID)
+    public static function buildCanViewCondition($fieldID, $table = '')
     {
 
         $condition = "";
@@ -5671,19 +5672,21 @@ JAVASCRIPT;
             $groups = '-1';
         }
 
+        $field_ref = $table ? "`$table`.`$fieldID`" : "`$fieldID`";
+
         if (Session::haveRight("ticket", Ticket::READMY)) {
             // Add tickets where the users is requester, observer or recipient
             // Subquery for requester/observer user
             $user_query = "SELECT `tickets_id`
             FROM `glpi_tickets_users`
             WHERE `users_id` = '$user' AND type IN ($requester, $obs)";
-            $condition .= "OR `$fieldID` IN ($user_query) ";
+            $condition .= "OR $field_ref IN ($user_query) ";
 
             // Subquery for recipient
             $recipient_query = "SELECT `id`
             FROM `glpi_tickets`
             WHERE `users_id_recipient` = '$user'";
-            $condition .= "OR `$fieldID` IN ($recipient_query) ";
+            $condition .= "OR $field_ref IN ($recipient_query) ";
         }
 
         if (Session::haveRight("ticket", Ticket::READGROUP)) {
@@ -5692,7 +5695,7 @@ JAVASCRIPT;
             $group_query = "SELECT `tickets_id`
             FROM `glpi_groups_tickets`
             WHERE `groups_id` IN ($groups) AND type IN ($requester, $obs)";
-            $condition .= "OR `$fieldID` IN ($group_query) ";
+            $condition .= "OR $field_ref IN ($group_query) ";
         }
 
         if (
@@ -5706,7 +5709,7 @@ JAVASCRIPT;
             $user_query = "SELECT `tickets_id`
             FROM `glpi_tickets_users`
             WHERE `users_id` = '$user' AND type = $assign";
-            $condition .= "OR `$fieldID` IN ($user_query) ";
+            $condition .= "OR $field_ref IN ($user_query) ";
         }
 
         if (Session::haveRight("ticket", Ticket::READASSIGN)) {
@@ -5715,14 +5718,14 @@ JAVASCRIPT;
             $group_query = "SELECT `tickets_id`
             FROM `glpi_groups_tickets`
             WHERE `groups_id` IN ($groups) AND type = $assign";
-            $condition .= "OR `$fieldID` IN ($group_query) ";
+            $condition .= "OR $field_ref IN ($group_query) ";
 
             if (Session::haveRight('ticket', Ticket::READNEWTICKET)) {
                 // Add new tickets
                 $tickets_query = "SELECT `id`
                FROM `glpi_tickets`
                WHERE `status` = '" . CommonITILObject::INCOMING . "'";
-                $condition .= "OR `$fieldID` IN ($tickets_query) ";
+                $condition .= "OR $field_ref IN ($tickets_query) ";
             }
         }
 
@@ -5738,7 +5741,7 @@ JAVASCRIPT;
             FROM `glpi_ticketvalidations`
             WHERE (`itemtype_target` = 'User' AND `items_id_target` = '$user')
                 OR (`itemtype_target` = 'Group' AND `items_id_target` IN (SELECT `glpi_groups_users`.`groups_id` FROM `glpi_groups_users` WHERE `glpi_groups_users`.`users_id` = '$user'))";
-            $condition .= "OR `$fieldID` IN ($validation_query) ";
+            $condition .= "OR $field_ref IN ($validation_query) ";
         }
 
         return $condition;

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5656,7 +5656,7 @@ JAVASCRIPT;
      *
      * @return string
      */
-    public static function buildCanViewCondition($fieldID, $table = '')
+    public static function buildCanViewCondition(string $fieldID, string $table = '')
     {
 
         $condition = "";

--- a/src/TicketTask.php
+++ b/src/TicketTask.php
@@ -96,6 +96,7 @@ class TicketTask extends CommonITILTask
      */
     public static function buildParentCondition()
     {
-        return "(0 = 1 " . Ticket::buildCanViewCondition("tickets_id") . ") ";
+        $tasktable = static::getTable();
+        return "(0 = 1 " . Ticket::buildCanViewCondition("tickets_id", $tasktable) . ") ";
     }
 }

--- a/tests/functional/ITILFollowupTest.php
+++ b/tests/functional/ITILFollowupTest.php
@@ -767,6 +767,7 @@ HTML,
         $this->assertStringContainsString("`$table`.`itemtype`", $condition);
         $this->assertStringNotContainsString('(`itemtype` = ', $condition);
         $this->assertStringNotContainsString('OR `items_id` IN', $condition);
+        $this->assertStringContainsString("OR `$table`.`items_id` IN", $condition);
     }
 
     /**

--- a/tests/functional/ITILFollowupTest.php
+++ b/tests/functional/ITILFollowupTest.php
@@ -743,6 +743,74 @@ HTML,
         return (int) iterator_to_array($results)[0]['number_of_followups'];
     }
 
+    /**
+     * Non-regression: buildParentCondition() must qualify column names to avoid MySQL 1052
+     * when the search engine JOINs polymorphic tables (plugin Fields, glpi_logs).
+     */
+    public function testBuildParentConditionReturnsQualifiedColumnsForSelfServiceUser(): void
+    {
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $this->login();
+        $selfservice_user = $this->createItem(User::class, [
+            'name'         => 'selfservice_' . $this->getUniqueString(),
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => $entity_id,
+        ], ['password', 'password2']);
+        $this->login($selfservice_user->fields['name']);
+
+        $condition = CoreITILFollowup::buildParentCondition(Ticket::class);
+        $table = CoreITILFollowup::getTable();
+
+        $this->assertStringContainsString("`$table`.`itemtype`", $condition);
+        $this->assertStringNotContainsString('(`itemtype` = ', $condition);
+        $this->assertStringNotContainsString('OR `items_id` IN', $condition);
+    }
+
+    /**
+     * Non-regression: buildParentCondition() output must be valid SQL when JOINed with
+     * a polymorphic table (glpi_logs reproduces the same 'itemtype' column ambiguity as
+     * plugin Fields tables). Without the fix: MySQL 1052 "Column 'itemtype' is ambiguous".
+     */
+    public function testBuildParentConditionDoesNotCauseAmbiguousColumnWhenJoined(): void
+    {
+        global $DB;
+
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $this->login();
+        $selfservice_user = $this->createItem(User::class, [
+            'name'         => 'selfservice_' . $this->getUniqueString(),
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => $entity_id,
+        ], ['password', 'password2']);
+        $this->login($selfservice_user->fields['name']);
+
+        $table     = CoreITILFollowup::getTable();
+        $condition = CoreITILFollowup::buildParentCondition(Ticket::class);
+
+        $threw = false;
+        try {
+            $DB->doQuery(
+                "SELECT `{$table}`.`id` FROM `{$table}`"
+                . " LEFT JOIN `glpi_logs` ON (`glpi_logs`.`items_id` = `{$table}`.`id`)"
+                . " WHERE {$condition}"
+                . " LIMIT 1"
+            );
+        } catch (\RuntimeException $e) {
+            if (str_contains($e->getMessage(), '1052')) {
+                $threw = true;
+            } else {
+                throw $e;
+            }
+        }
+        $this->assertFalse($threw, 'buildParentCondition() must not generate ambiguous column references');
+    }
+
     private function createFollowupInEntityForType(
         string $entity_name,
         string $itemtype

--- a/tests/functional/TicketTaskTest.php
+++ b/tests/functional/TicketTaskTest.php
@@ -38,6 +38,7 @@ use Glpi\Search\SearchEngine;
 use Glpi\Tests\CommonITILTaskTestCase;
 use Override;
 use TicketTask;
+use User;
 
 final class TicketTaskTest extends CommonITILTaskTestCase
 {
@@ -1035,5 +1036,30 @@ final class TicketTaskTest extends CommonITILTaskTestCase
                 'tickets_id' => $ticket->getID(),
             ])
         );
+    }
+
+    /**
+     * Non-regression: buildParentCondition() must qualify column names to avoid MySQL 1052
+     * when the search engine JOINs polymorphic tables that share the same column name.
+     */
+    public function testBuildParentConditionReturnsQualifiedColumns(): void
+    {
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $this->login();
+        $selfservice_user = $this->createItem(User::class, [
+            'name'         => 'selfservice_' . $this->getUniqueString(),
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => $entity_id,
+        ], ['password', 'password2']);
+        $this->login($selfservice_user->fields['name']);
+
+        $condition = TicketTask::buildParentCondition();
+        $table = TicketTask::getTable();
+
+        $this->assertStringContainsString("OR `$table`.`tickets_id` IN", $condition);
+        $this->assertStringNotContainsString('OR `tickets_id` IN', $condition);
     }
 }

--- a/tests/functional/WebhookTest.php
+++ b/tests/functional/WebhookTest.php
@@ -36,11 +36,12 @@ namespace tests\units;
 
 use Glpi\Api\HL\Controller\AbstractController;
 use Glpi\Search\CriteriaFilter;
-use Glpi\Search\SearchOption;
 use Glpi\Tests\DbTestCase;
+use ITILFollowup;
 use Psr\Log\LogLevel;
 use QueuedWebhook;
 use Ticket;
+use User;
 use Webhook;
 
 use function Safe\json_encode;
@@ -526,5 +527,70 @@ JSON;
         $matching_itemtype = \Computer::class;
         $no_mismatch = $webhook->getID() && $matching_itemtype !== $webhook->fields['itemtype'];
         $this->assertFalse($no_mismatch, 'Correct itemtype should not trigger the mismatch guard');
+    }
+
+    /**
+     * Non-regression: a Self-Service user adding a followup must not produce a webhook error
+     * popup (Webhook::raise() catches exceptions and converts them to session messages).
+     */
+    public function testWebhookDoesNotErrorOnFollowupAddBySelfServiceUser(): void
+    {
+        $entity_id = $this->getTestRootEntity(only_id: true);
+
+        $this->login();
+
+        $selfservice_user = $this->createItem(User::class, [
+            'name'         => 'selfservice_' . $this->getUniqueString(),
+            'password'     => 'testpassword',
+            'password2'    => 'testpassword',
+            '_profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+            '_entities_id' => $entity_id,
+        ], ['password', 'password2']);
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name'                => 'Test ticket',
+            'content'             => 'Test content',
+            'entities_id'         => $entity_id,
+            '_users_id_requester' => $selfservice_user->getID(),
+        ]);
+
+        $webhook = $this->createItem(Webhook::class, [
+            'name'                => 'Test webhook',
+            'entities_id'         => $entity_id,
+            'url'                 => 'http://localhost',
+            'itemtype'            => ITILFollowup::class,
+            'event'               => 'new',
+            'is_active'           => 1,
+            'use_default_payload' => 1,
+        ]);
+        $this->createItem(CriteriaFilter::class, [
+            'itemtype'        => Webhook::class,
+            'items_id'        => $webhook->getID(),
+            'search_itemtype' => ITILFollowup::class,
+            'search_criteria' => json_encode([[
+                'link'       => 'AND',
+                'field'      => 4, // is_private
+                'searchtype' => 'equals',
+                'value'      => '0',
+            ]]),
+        ], ['search_criteria']);
+
+        $this->login($selfservice_user->fields['name']);
+        $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
+
+        $followup    = new ITILFollowup();
+        $followup_id = $followup->add([
+            'items_id' => $ticket->getID(),
+            'itemtype' => Ticket::class,
+            'content'  => 'Test followup',
+        ]);
+
+        $this->assertGreaterThan(0, $followup_id);
+
+        $webhook_errors = array_filter(
+            $_SESSION['MESSAGE_AFTER_REDIRECT'][ERROR] ?? [],
+            static fn(string $msg) => stripos($msg, 'webhook') !== false
+        );
+        $this->assertEmpty($webhook_errors);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44879
- Here is a brief description of what this PR does

When a Self-Service user adds a followup on a ticket, a webhook error popup appears:
> "An error occurred raising 'New' webhook for item Followup (ID …)"

This happens when a webhook filter criterion references a polymorphic column (a plugin Fields custom field), causing the search engine to JOIN an extra table that also has `itemtype` and `items_id` columns.

The WHERE clause built by `buildParentCondition()` (for Self-Service users who lack READALL rights) used unqualified column names, which MySQL rejects with error 1052 "Column 'itemtype' in WHERE is ambiguous".

### Fix

- `ITILFollowup::buildParentCondition()` => qualify `itemtype` with the followup table name
- `Ticket::buildCanViewCondition()` => accept an optional `$table` parameter to qualify `items_id` / `tickets_id` references
- `TicketTask::buildParentCondition()` => same fix applied (same pattern, same risk)

### Tests

- `ITILFollowupTest` => unit test asserting the generated SQL contains qualified column names
- `ITILFollowupTest` => integration test executing the condition against the DB with a `glpi_logs` JOIN (reproduces the ambiguous column context)
- `WebhookTest` => end-to-end test verifying no webhook error appears in session when a Self-Service user creates a followup
