### PR TITLE
Fix(kanban): project tasks not displayed when no kanban state is saved

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1821,7 +1821,7 @@ TWIG, $twig_params);
             ];
         }
         $criteria = [];
-        if (!empty($column_ids) && !$get_default) {
+        if (!empty($column_ids)) {
             $criteria = [
                 'projectstates_id'   => $column_ids,
             ];

--- a/src/Project.php
+++ b/src/Project.php
@@ -1821,7 +1821,7 @@ TWIG, $twig_params);
             ];
         }
         $criteria = [];
-        if (!empty($column_ids)) {
+        if (!empty($column_ids) && !$get_default) {
             $criteria = [
                 'projectstates_id'   => $column_ids,
             ];
@@ -1926,7 +1926,7 @@ TWIG, $twig_params);
         }
 
         foreach (array_keys($columns) as $column_id) {
-            if ($column_id !== 0 && !in_array($column_id, $column_ids)) {
+            if ($column_id !== 0 && !$get_default && !in_array($column_id, $column_ids)) {
                 unset($columns[$column_id]);
             }
         }

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -802,6 +802,15 @@ PLAINTEXT;
 
         $this->assertArrayHasKey($state->getID(), $columns);
         $this->assertCount(1, $columns[$state->getID()]['items']);
+
+        // Normal filtering ($get_default = false): only the requested column is returned.
+        $columns_filtered = \Project::getKanbanColumns($project->getID(), 'projectstates_id', [$state->getID()], false);
+        $this->assertArrayHasKey($state->getID(), $columns_filtered);
+        $this->assertCount(1, $columns_filtered[$state->getID()]['items']);
+
+        // Requesting only column 0 must exclude the task's state column.
+        $columns_no_status = \Project::getKanbanColumns($project->getID(), 'projectstates_id', [0], false);
+        $this->assertArrayNotHasKey($state->getID(), $columns_no_status);
     }
 
     public function testNotepadDisplayWithUpdateRights()

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -775,6 +775,35 @@ PLAINTEXT;
         $this->assertStringContainsString('toggle-all-notes', $html);
     }
 
+    public function testGetKanbanColumnsReturnsTasksWhenNoStateIsSaved(): void
+    {
+        $this->login();
+
+        $state = $this->createItem(\ProjectState::class, [
+            'name'        => 'In progress',
+            'color'       => '#ff0000',
+            'is_finished' => 0,
+        ]);
+
+        $project = $this->createItem(\Project::class, [
+            'name'       => 'Kanban Test Project',
+            'entities_id' => 0,
+        ]);
+
+        $this->createItem(\ProjectTask::class, [
+            'name'                   => 'Task 1',
+            'projects_id'            => $project->getID(),
+            'projectstates_id'       => $state->getID(),
+            'projecttasktemplates_id' => 0,
+        ]);
+
+        // Simulate first load with no saved state: $column_ids = [], $get_default = true
+        $columns = \Project::getKanbanColumns($project->getID(), 'projectstates_id', [], true);
+
+        $this->assertArrayHasKey($state->getID(), $columns);
+        $this->assertCount(1, $columns[$state->getID()]['items']);
+    }
+
     public function testNotepadDisplayWithUpdateRights()
     {
         $this->login();

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -779,7 +779,7 @@ PLAINTEXT;
     {
         $this->login();
 
-        $state = $this->createItem(\ProjectState::class, [
+        $state = $this->createItem(ProjectState::class, [
             'name'        => 'In progress',
             'color'       => '#ff0000',
             'is_finished' => 0,
@@ -790,7 +790,7 @@ PLAINTEXT;
             'entities_id' => 0,
         ]);
 
-        $this->createItem(\ProjectTask::class, [
+        $this->createItem(ProjectTask::class, [
             'name'                   => 'Task 1',
             'projects_id'            => $project->getID(),
             'projectstates_id'       => $state->getID(),


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44808
- When opening the kanban tab of a specific project for the first time (ni saved state in `glpi_items_kanbans`) tasks with a non-zero `projectstates_id` were not displayed. Only the "No status" column appeared with a counter of zero.
It was because `getKanbanColumns()` used `$column_ids`  to filter the returned columns, even when `$get_default = true`. With no saved state, `$column_ids = []` caused the cleanup loop to wipe every non-zero column. This broken state was then persisted, making the issue reappear on subsequent loads.


<img width="1588" height="457" alt="Capture d’écran du 2026-06-26 15-56-26" src="https://github.com/user-attachments/assets/8ccd4a45-e5fd-4020-8f7e-6bed323cd094" />
<img width="1588" height="457" alt="Capture d’écran du 2026-06-26 15-56-34" src="https://github.com/user-attachments/assets/ccc9c7a0-a34c-4694-ab1c-944d90caff87" />



