### PR TITLE
A11Y : calendar link on reservation page

### DIFF
--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -637,8 +637,9 @@ TWIG, $twig_params);
                     $entry['entity'] = $entity_cache[$row["entities_id"]];
                 }
                 $cal_href = htmlescape(Reservation::getSearchURL() . "?reservationitems_id=" . $row['id']);
-                $entry['calendar'] = "<a href='$cal_href'>";
-                $entry['calendar'] .= "<i class='" . htmlescape(Reservation::getIcon()) . " fa-2x cursor-pointer' title=\"" . __s("Reserve this item") . "\"></i>";
+                $entry['calendar'] = "<a href='$cal_href' title=\"" . __s("Reserve this item") . "\">";
+                $entry['calendar'] .= "<i class='" . htmlescape(Reservation::getIcon()) . " fa-2x cursor-pointer' aria-hidden='true'></i>";
+                $entry['calendar'] .= "</a>";
 
                 $ok = true;
                 $entries[] = $entry;

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -637,8 +637,9 @@ TWIG, $twig_params);
                     $entry['entity'] = $entity_cache[$row["entities_id"]];
                 }
                 $cal_href = htmlescape(Reservation::getSearchURL() . "?reservationitems_id=" . $row['id']);
-                $entry['calendar'] = "<a href='$cal_href' title=\"" . __s("Reserve this item") . "\">";
+                $entry['calendar'] = "<a href='$cal_href'>";
                 $entry['calendar'] .= "<i class='" . htmlescape(Reservation::getIcon()) . " fa-2x cursor-pointer' aria-hidden='true'></i>";
+                $entry['calendar'] .= "<span class='visually-hidden'>" . __s("Reserve this item") . "</span>";
                 $entry['calendar'] .= "</a>";
 
                 $ok = true;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/373
- Here is a brief description of what this PR does : The per-row "Booking calendar" link was announced as an empty link: the `title` sat on the `<i>` icon instead of the `<a>`. Moved it to the link, marked the icon `aria-hidden`, and closed the missing `</a>`.



