### PR TITLE
(dashboard) naming filter group tech

### DIFF
--- a/src/Glpi/Dashboard/Filters/GroupTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupTechFilter.php
@@ -41,7 +41,7 @@ class GroupTechFilter extends AbstractGroupFilter
 {
     public static function getName(): string
     {
-        return __("Technician group");
+        return __("Technician group") . (" / ") . __("Assigned group");
     }
 
     public static function getId(): string

--- a/src/Glpi/Dashboard/Filters/GroupTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupTechFilter.php
@@ -36,12 +36,13 @@
 namespace Glpi\Dashboard\Filters;
 
 use Group_Item;
+use Session;
 
 class GroupTechFilter extends AbstractGroupFilter
 {
     public static function getName(): string
     {
-        return __("Technician group") . (" / ") . __("Assigned group");
+        return __("Technician group") . (" / ") . _n('Assigned group', 'Assigned groups', Session::getPluralNumber());
     }
 
     public static function getId(): string

--- a/src/Glpi/Dashboard/Filters/GroupTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupTechFilter.php
@@ -42,7 +42,11 @@ class GroupTechFilter extends AbstractGroupFilter
 {
     public static function getName(): string
     {
-        return __("Technician group") . (" / ") . _n('Assigned group', 'Assigned groups', Session::getPluralNumber());
+        return sprintf(
+            __('%1$s / %2$s'),
+            __('Technician group'),
+            _n('Assigned group', 'Assigned groups', 1)
+        );
     }
 
     public static function getId(): string

--- a/src/Glpi/Dashboard/Filters/GroupTechFilter.php
+++ b/src/Glpi/Dashboard/Filters/GroupTechFilter.php
@@ -36,7 +36,6 @@
 namespace Glpi\Dashboard\Filters;
 
 use Group_Item;
-use Session;
 
 class GroupTechFilter extends AbstractGroupFilter
 {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44705
- Dashboard : Rename filtrer "group technician" to "group technician / group assigned"

## Screenshots (if appropriate):
<img width="315" height="87" alt="image" src="https://github.com/user-attachments/assets/ce17306b-ff05-4f33-a337-24e28e9f97a9" />

