### PR TITLE
A11Y : descriptive page titles and proper <h1> on item pages

### DIFF
--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -44,7 +44,13 @@ global $CFG_GLPI;
 $rr = new Reservation();
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()));
+    Html::helpHeader(
+        sprintf(
+            '%s - %s',
+            Reservation::getTypeName(Session::getPluralNumber()),
+            __('Simplified interface')
+        )
+    );
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/front/reservation.form.php
+++ b/front/reservation.form.php
@@ -44,7 +44,7 @@ global $CFG_GLPI;
 $rr = new Reservation();
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'));
+    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -40,7 +40,7 @@ if (!isset($_GET["reservationitems_id"])) {
 }
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'));
+    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()));
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/front/reservation.php
+++ b/front/reservation.php
@@ -40,7 +40,13 @@ if (!isset($_GET["reservationitems_id"])) {
 }
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()));
+    Html::helpHeader(
+        sprintf(
+            '%s - %s',
+            Reservation::getTypeName(Session::getPluralNumber()),
+            __('Simplified interface')
+        )
+    );
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/front/reservationitem.php
+++ b/front/reservationitem.php
@@ -38,7 +38,14 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()), 'reservation');
+    Html::helpHeader(
+        sprintf(
+            '%s - %s',
+            Reservation::getTypeName(Session::getPluralNumber()),
+            __('Simplified interface')
+        ),
+        'reservation'
+    );
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/front/reservationitem.php
+++ b/front/reservationitem.php
@@ -38,7 +38,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 Session::checkRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM]);
 
 if (Session::getCurrentInterface() == "helpdesk") {
-    Html::helpHeader(__('Simplified interface'), 'reservation');
+    Html::helpHeader(Reservation::getTypeName(Session::getPluralNumber()), 'reservation');
 } else {
     Html::header(Reservation::getTypeName(Session::getPluralNumber()), '', "tools", "reservationitem");
 }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1171,7 +1171,8 @@ class CommonGLPI implements CommonGLPIInterface
             echo "</div>";
 
             if (static::$showTitleInNavigationHeader && $this instanceof CommonDBTM) {
-                echo "<h3 class='navigationheader-title strong d-flex align-items-center order-2'>";
+                // RGAA 9.1 : titre de page ITIL en <h1> ; fs-3 conserve la taille (la classe n'a pas de font-size propre)
+                echo "<h1 class='navigationheader-title strong fs-3 d-flex align-items-center order-2'>";
                 if (method_exists($this, 'getStatusIcon') && $this->isField('status')) {
                     echo "<span class='me-1'>" . $this->getStatusIcon($this->fields['status']) . '</span>';
                 }
@@ -1188,12 +1189,13 @@ class CommonGLPI implements CommonGLPIInterface
                     echo __s('Deleted');
                     echo "</span>";
                 }
-                echo "</h3>";
+                echo "</h1>";
             } else {
                 echo TemplateRenderer::getInstance()->render('components/form/header_content.html.twig', [
                     'item'          => $this,
                     'params'        => $options,
                     'in_navheader'  => true,
+                    'level'         => 1,
                     'header_toolbar' => $this->getFormHeaderToolbar(),
                 ]);
             }

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -1171,7 +1171,7 @@ class CommonGLPI implements CommonGLPIInterface
             echo "</div>";
 
             if (static::$showTitleInNavigationHeader && $this instanceof CommonDBTM) {
-                // RGAA 9.1 : titre de page ITIL en <h1> ; fs-3 conserve la taille (la classe n'a pas de font-size propre)
+                // Page title as <h1> for heading hierarchy; fs-3 keeps the size (the class has no font-size of its own)
                 echo "<h1 class='navigationheader-title strong fs-3 d-flex align-items-center order-2'>";
                 if (method_exists($this, 'getStatusIcon') && $this->isField('status')) {
                     echo "<span class='me-1'>" . $this->getStatusIcon($this->fields['status']) . '</span>';

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -68,7 +68,8 @@
 {% endif %}
    <div id="mainformtable">
       {% if include_header_content %}
-         {{ include('components/form/header_content.html.twig') }}
+         {# RGAA 9.1 : item neuf = pas de navheader, ce titre est le h1 ; sinon il est subordonné au h1 du navheader #}
+         {{ include('components/form/header_content.html.twig', { level: item.isNewItem() ? 1 : 2 }) }}
       {% endif %}
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params ?? []}) }}

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -68,7 +68,7 @@
 {% endif %}
    <div id="mainformtable">
       {% if include_header_content %}
-         {# RGAA 9.1 : item neuf = pas de navheader, ce titre est le h1 ; sinon il est subordonné au h1 du navheader #}
+         {# New item has no navigation header, so this title is the page h1; otherwise it sits below the navheader h1 #}
          {{ include('components/form/header_content.html.twig', {level: item.isNewItem() ? 1 : 2}) }}
       {% endif %}
 

--- a/templates/components/form/header.html.twig
+++ b/templates/components/form/header.html.twig
@@ -69,7 +69,7 @@
    <div id="mainformtable">
       {% if include_header_content %}
          {# RGAA 9.1 : item neuf = pas de navheader, ce titre est le h1 ; sinon il est subordonné au h1 du navheader #}
-         {{ include('components/form/header_content.html.twig', { level: item.isNewItem() ? 1 : 2 }) }}
+         {{ include('components/form/header_content.html.twig', {level: item.isNewItem() ? 1 : 2}) }}
       {% endif %}
 
       {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::PRE_ITEM_FORM'), {'item': item, 'options': params ?? []}) }}

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -39,7 +39,7 @@
 {% set in_navheader = in_navheader|default(false) %}
 {% set header_toolbar = header_toolbar|default([]) %}
 {% set entity_name = entity_name|default('') %}
-{# RGAA 9.1 : le niveau du titre dépend du contexte d'appel (navheader vs corps, neuf vs existant) #}
+{# Heading level depends on the calling context (navheader vs body, new vs existing item) #}
 {% set level = level|default(3) %}
 {% set level = level in [1, 2, 3, 4, 5, 6] ? level : 3 %}
 

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -39,6 +39,9 @@
 {% set in_navheader = in_navheader|default(false) %}
 {% set header_toolbar = header_toolbar|default([]) %}
 {% set entity_name = entity_name|default('') %}
+{# RGAA 9.1 : le niveau du titre dépend du contexte d'appel (navheader vs corps, neuf vs existant) #}
+{% set level = level|default(3) %}
+{% set level = level in [1, 2, 3, 4, 5, 6] ? level : 3 %}
 
 {% if entity_id is not defined %}
     {% if item.getType() == 'Entity' %}
@@ -78,7 +81,7 @@
              name="template_name" id="textfield_template_name{{ rand }}"
              value="{{ template_name }}" />
    {% endif %}
-   <h3 class="card-title d-flex align-items-center ps-0 {{ in_navheader ? "ps-sm-5" : "ps-sm-4" }}">
+   <h{{ level }} class="card-title d-flex align-items-center ps-0 {{ in_navheader ? "ps-sm-5" : "ps-sm-4" }}">
       {% if item.showFriendlyNameBadgeInForm() %}
          {% set icon = item.getIcon() %}
          {% if not in_navheader and icon|length > 0 %}
@@ -124,7 +127,7 @@
             {% endfor %}
          </div>
       {% endif %}
-   </h3>
+   </h{{ level }}>
 
    {% set single_actions_ms_auto = true %}
    {% if item.isEntityAssign() and is_multi_entities_mode() and item is not instanceof('Entity') %}

--- a/templates/layout/page_without_tabs.html.twig
+++ b/templates/layout/page_without_tabs.html.twig
@@ -33,12 +33,12 @@
 {% extends "layout/page_skeleton.html.twig" %}
 
 {% block content %}
+    {% set title_content %}{% block content_title %}{% endblock content_title %}{% endset %}
     <div class="page-header mt-0">
         <div class="container container-{{ container_size ?? "xl" }}">
-            <h1 class="page title mb-0">
-                {% block content_title %}
-                {% endblock content_title %}
-            </h1>
+            {% if title_content|trim is not empty %}
+                <h1 class="page-title mb-0">{{ title_content }}</h1>
+            {% endif %}
         </div>
     </div>
     <div class="page-body mt-3">

--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -35,6 +35,8 @@
 {% set title = __('Inventory') %}
 {% set menu = ["admin", "glpi\\inventory\\inventory"] %}
 
+{% block content_title %}{{ __('Inventory') }}{% endblock %}
+
 {% block content_body %}
 <div class="container-fluid">
     <div class="search_page">

--- a/tests/cypress/e2e/Tools/dcroom.cy.js
+++ b/tests/cypress/e2e/Tools/dcroom.cy.js
@@ -77,8 +77,7 @@ describe('DC Room', () => {
             cy.findByRole('dialog')
                 .should('have.attr', 'data-cy-shown', 'true')
                 .within(() => {
-                    //TODO the heading here should not be level 3
-                    cy.findByRole('heading', {level: 3}).should('contain.text', 'New item - Rack');
+                    cy.findByRole('heading', {level: 1}).should('contain.text', 'New item - Rack');
                     cy.findByRole('button', {name: 'Close'}).click();
                     cy.should('not.exist');
                 });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/375
- Here is a brief description of what this PR does : 

[8.6](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#8.6) (audit Access42 P04, P05): the reservation screens in the simplified interface showed a generic "Simplified interface" title; they now use the reservation type name, like the central interface.

[9.1](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/#9.1) (audit P07, P09): item pages had no `<h1>` (the title was an `<h3>`). The navigation-header title is promoted to `<h1>`, inline for ITIL objects and via a new `level` parameter on the shared
header template for other items, keeping the visual size; the body form card drops to `<h2>` so each page keeps a single `<h1>`. `page_without_tabs` no longer emits an empty `<h1>`, and the
inventory upload result gets a title.

Some audited sub-headings (P05, P07, P09) and the new-ticket `<h1>` are left as coming follow-ups.

