### PR TITLE
Fix: include plugin itemtypes in helpdesk profile dropdown

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -3412,7 +3412,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
 
         if (isset($PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET])) {
             $plugin_types = [];
-            foreach (array_keys($PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET]) as $plugin) {
+            foreach ($PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET] as $plugin => $value) {
                 if (!Plugin::isPluginActive($plugin)) {
                     continue;
                 }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -44,6 +44,7 @@ use Glpi\Form\Form;
 use Glpi\Helpdesk\Tile\LinkableToTilesInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\Inventory\Conf;
+use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\ArrayNormalizer;
 
 /**
@@ -3398,7 +3399,7 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
      */
     public static function getHelpdeskItemtypes()
     {
-        global $CFG_GLPI;
+        global $CFG_GLPI, $PLUGIN_HOOKS;
 
         $values = [];
         foreach ($CFG_GLPI["ticket_types"] as $key => $itemtype) {
@@ -3408,6 +3409,18 @@ class Profile extends CommonDBTM implements LinkableToTilesInterface
                 unset($CFG_GLPI["ticket_types"][$key]);
             }
         }
+
+        if (isset($PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET])) {
+            $plugin_types = [];
+            foreach (array_keys($PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET]) as $plugin) {
+                if (!Plugin::isPluginActive($plugin)) {
+                    continue;
+                }
+                $plugin_types = Plugin::doOneHook($plugin, Hooks::AUTO_ASSIGN_TO_TICKET, $plugin_types) ?? $plugin_types;
+            }
+            $values += $plugin_types;
+        }
+
         return $values;
     }
 

--- a/tests/fixtures/plugins/tester/setup.php
+++ b/tests/fixtures/plugins/tester/setup.php
@@ -39,13 +39,15 @@ use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Form\ServiceCatalog\HomeSearchManager;
 use Glpi\Form\ServiceCatalog\ServiceCatalogManager;
 use Glpi\Helpdesk\Tile\TilesManager;
+use Glpi\Http\SessionManager;
+use Glpi\Plugin\Hooks;
 use GlpiPlugin\Tester\Form\ComputerDestination;
 use GlpiPlugin\Tester\Form\ComputerProvider;
 use GlpiPlugin\Tester\Form\CustomTile;
 use GlpiPlugin\Tester\Form\DayOfTheWeekPolicy;
-use GlpiPlugin\Tester\Form\QuestionTypeRange;
-use GlpiPlugin\Tester\Form\QuestionTypeColor;
 use GlpiPlugin\Tester\Form\ExternalIDField;
+use GlpiPlugin\Tester\Form\QuestionTypeColor;
+use GlpiPlugin\Tester\Form\QuestionTypeRange;
 use GlpiPlugin\Tester\Form\TesterCategory;
 use GlpiPlugin\Tester\MyPsr4Class;
 
@@ -59,8 +61,8 @@ function plugin_version_tester()
         'requirements'   => [
             'glpi' => [
                 'min' => '9.5.0',
-            ]
-        ]
+            ],
+        ],
     ];
 }
 
@@ -125,11 +127,18 @@ function plugin_init_tester(): void
     $service_catalog_manager->registerPluginProvider(new ComputerProvider());
 
     $PLUGIN_HOOKS['menu_toadd']['tester'] = ['management' => MyPsr4Class::class];
+    $PLUGIN_HOOKS[Hooks::ASSIGN_TO_TICKET]['tester'] = true;
+}
+
+function plugin_tester_AssignToTicket(array $types): array
+{
+    $types[ConsumableItem::class] = ConsumableItem::getTypeName();
+    return $types;
 }
 
 function plugin_tester_boot()
 {
-    \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/$#');
-    \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/StatelessURI$#');
-    \Glpi\Http\SessionManager::registerPluginStatelessPath('tester', '#^/post-only$#');
+    SessionManager::registerPluginStatelessPath('tester', '#^/$#');
+    SessionManager::registerPluginStatelessPath('tester', '#^/StatelessURI$#');
+    SessionManager::registerPluginStatelessPath('tester', '#^/post-only$#');
 }

--- a/tests/functional/ProfileTest.php
+++ b/tests/functional/ProfileTest.php
@@ -443,4 +443,13 @@ class ProfileTest extends DbTestCase
             }
         }
     }
+
+    public function testGetHelpdeskItemtypesIncludesPluginTypes(): void
+    {
+        $types = \Profile::getHelpdeskItemtypes();
+
+        $this->assertArrayHasKey(\ConsumableItem::class, $types);
+        $this->assertSame(\ConsumableItem::getTypeName(), $types[\ConsumableItem::class]);
+        $this->assertArrayHasKey(\Computer::class, $types);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes:
  - !44902
  - #21740

`Profile::getHelpdeskItemtypes()` did not call the `ASSIGN_TO_TICKET` / `AUTO_ASSIGN_TO_TICKET` plugin hooks, so plugin-registered itemtypes (e.g. `ConsumableItem` from the Consumables plugin) could never appear in the helpdesk profile dropdown and were therefore excluded by `getAssignableVisiblityCriteriaForHelpdesk()`, making plugin assets invisible in the self-service interface.
The fix mirrors the existing pattern from `CommonITILObject::getAllTypesForHelpdesk()`.

## Screenshots (if appropriate):
