### PR TITLE
Use a unique Request object for a same request

### DIFF
--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -41,7 +41,6 @@ use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Search\FilterableInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\parse_url;
 

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Debug\Profiler;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Search\FilterableInterface;
@@ -926,6 +927,9 @@ class CommonGLPI implements CommonGLPIInterface
      */
     public function showTabsContent($options = [])
     {
+        /** @var Kernel $kernel */
+        global $kernel;
+
         // for objects not in table like central
         if (isset($this->fields['id'])) {
             $ID = $this->fields['id'];
@@ -940,7 +944,7 @@ class CommonGLPI implements CommonGLPIInterface
         $cleaned_options = $options;
         unset($cleaned_options['id'], $cleaned_options['stock_image']);
 
-        $request        = Request::createFromGlobals();
+        $request        = $kernel->getMainRequest();
         $target         = $request->getBasePath() . $request->getPathInfo();
         $withtemplate   = "";
 
@@ -1039,6 +1043,9 @@ class CommonGLPI implements CommonGLPIInterface
      */
     public function showNavigationHeader($options = [])
     {
+        /** @var Kernel $kernel */
+        global $kernel;
+
         // for objects not in table like central
         if (isset($this->fields['id'])) {
             $ID = $this->fields['id'];
@@ -1050,7 +1057,7 @@ class CommonGLPI implements CommonGLPIInterface
             }
         }
 
-        $request        = Request::createFromGlobals();
+        $request        = $kernel->getMainRequest();
         $target         = $request->getBasePath() . $request->getPathInfo();
         $extraparamhtml = "";
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,6 +42,7 @@ use Glpi\Config\ProxyExclusions;
 use Glpi\Dashboard\Grid;
 use Glpi\Event;
 use Glpi\Helpdesk\HelpdeskTranslation;
+use Glpi\Kernel\Kernel;
 use Glpi\Mail\SMTP\OauthConfig;
 use Glpi\Plugin\Hooks;
 use Glpi\System\Diagnostic\SourceCodeIntegrityChecker;
@@ -49,7 +50,6 @@ use Glpi\System\RequirementsManager;
 use Glpi\Toolbox\ArrayNormalizer;
 use Glpi\UI\ThemeManager;
 use Safe\Exceptions\OpcacheException;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\chdir;
 use function Safe\exec;
@@ -1380,13 +1380,14 @@ class Config extends CommonDBTM
      */
     public static function loadLegacyConfiguration()
     {
-        global $CFG_GLPI, $DB;
+        /** @var Kernel $kernel */
+        global $CFG_GLPI, $DB, $kernel;
 
         // Compute URLs base path.
         $root_doc = '';
         if (isset($_SERVER['REQUEST_URI'])) {
             // $_SERVER['REQUEST_URI'] is set, meaning that GLPI is accessed from web server.
-            $root_doc = Request::createFromGlobals()->getBasePath();
+            $root_doc = $kernel->getMainRequest()->getBasePath();
         }
         $CFG_GLPI['root_doc'] = $root_doc;
         $CFG_GLPI['typedoc_icon_dir'] = $root_doc . '/pics/icones';

--- a/src/Glpi/Cache/CacheManager.php
+++ b/src/Glpi/Cache/CacheManager.php
@@ -592,19 +592,12 @@ PHP;
      */
     private function clearSymfonyCache(): void
     {
-        /** @var Kernel|null $kernel */
+        /** @var Kernel $kernel */
         global $kernel;
-
-        $localKernel = $kernel;
-
-        if (!$localKernel instanceof Kernel) {
-            // This must be usable in non-kernel contexts, env vars will get the proper Kernel env.
-            $localKernel = new Kernel();
-        }
 
         // Execute the `cache:clear` command provided by Symfony itself, not our own `cache:clear` command.
         // This command will clear the Symfony cache gracefully.
-        $app = new Application($localKernel);
+        $app = new Application($kernel);
         $app->setAutoExit(false);
         // Skip optional cache warmers (e.g. Twig templates, more than 400 to cache so cause memory exception - default 128M).
         // Templates are compiled lazily on first render.

--- a/src/Glpi/Console/CommandLoader.php
+++ b/src/Glpi/Console/CommandLoader.php
@@ -344,12 +344,8 @@ class CommandLoader implements CommandLoaderInterface
 
     private function findSymfonyCommands(): void
     {
-        /** @var Kernel|null $kernel */
+        /** @var Kernel $kernel */
         global $kernel;
-
-        if (!$kernel instanceof Kernel) {
-            return;
-        }
 
         if (!Environment::get()->shouldEnableExtraDevAndDebugTools()) {
             return;

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -54,6 +54,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
@@ -67,6 +68,8 @@ final class Kernel extends BaseKernel
     private LoggerInterface $logger;
 
     private bool $in_reboot = false;
+
+    private ?Request $main_request = null;
 
     public function __construct(?string $env = null)
     {
@@ -98,6 +101,34 @@ final class Kernel extends BaseKernel
     {
         // FIXME: Inject it as a DI parameter when corresponding services will be instanciated from the DI system.
         return GLPI_CACHE_DIR . '/' . GLPI_FILES_VERSION . '-' . Environment::get()->value;
+    }
+
+    /**
+     * Get the main request object.
+     *
+     * @FIXME   This method exist to prevent using `Request::createFromGlobals()` too late in the application process.
+     *          Indeed, an exception may be thrown when uploaded files have been moved already, since Symfony throws
+     *          a `FileNotFoundException` when the `$_FILES` state refers to an unexisting file in the temporary upload
+     *          dir.
+     *          The goal is to replace all usages of this method by a way to get the request object directly from
+     *          the dependency injection system.
+     *
+     * @return Request
+     */
+    public function getMainRequest(): Request
+    {
+        if ($this->main_request !== null) {
+            // Web context case.
+            //
+            // The `main_request` property is set in web context, when the `public/index.php` script
+            // call the `Kernel::handle($request)` method.
+            return $this->main_request;
+        }
+
+        // CLI and test suite contexts.
+        //
+        // Fallback to a request object created from globals each time, since some tests are mocking super globals.
+        return Request::createFromGlobals();
     }
 
     #[Override()]
@@ -176,6 +207,16 @@ final class Kernel extends BaseKernel
         parent::reboot($warmupDir);
 
         $this->in_reboot = false;
+    }
+
+    #[Override()]
+    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
+    {
+        if (HttpKernelInterface::MAIN_REQUEST === $type) {
+            $this->main_request = $request;
+        }
+
+        return parent::handle($request, $type, $catch);
     }
 
     #[Override()]

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -37,6 +37,7 @@ namespace Glpi\Kernel\Listener\PostBootListener;
 use Glpi\Debug\Profiler;
 use Glpi\Http\RequestRouterTrait;
 use Glpi\Http\SessionManager;
+use Glpi\Kernel\Kernel;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
@@ -76,7 +77,8 @@ class SessionStart implements EventSubscriberInterface
 
     public function onPostBoot(): void
     {
-        global $CFG_GLPI;
+        /** @var Kernel $kernel */
+        global $CFG_GLPI, $kernel;
 
         Profiler::getInstance()->start('SessionStart::execute', Profiler::CATEGORY_BOOT);
 
@@ -97,7 +99,7 @@ class SessionStart implements EventSubscriberInterface
         if ($this->php_sapi === 'cli') {
             $is_stateless = true;
         } else {
-            $request = Request::createFromGlobals();
+            $request = $kernel->getMainRequest();
             $is_stateless = $this->session_manager->isResourceStateless($request);
         }
 

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -44,7 +44,6 @@ use Glpi\Kernel\PostBootEvent;
 use Session;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\ini_get;
 use function Safe\ini_set;

--- a/src/Html.php
+++ b/src/Html.php
@@ -57,7 +57,6 @@ use Glpi\UI\ThemeManager;
 use Safe\DateTime;
 use Safe\Exceptions\FilesystemException;
 use ScssPhp\ScssPhp\Compiler;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\file_get_contents;
 use function Safe\filesize;

--- a/src/Html.php
+++ b/src/Html.php
@@ -47,6 +47,7 @@ use Glpi\Exception\RedirectException;
 use Glpi\Form\Form;
 use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\Inventory\Inventory;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\SecurityConfig;
 use Glpi\System\Log\LogViewer;
@@ -1277,8 +1278,9 @@ TWIG,
     {
         /**
          * @var bool $FOOTER_LOADED
+         * @var Kernel $kernel
          */
-        global $CFG_GLPI, $FOOTER_LOADED;
+        global $CFG_GLPI, $FOOTER_LOADED, $kernel;
 
         // If in modal : display popFooter
         if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -1342,7 +1344,7 @@ TWIG,
         Profiler::getInstance()->stopAll();
         if (
             $_SESSION['glpi_use_mode'] === Session::DEBUG_MODE
-            && !str_starts_with(Request::createFromGlobals()->getPathInfo(), '/install/')
+            && !str_starts_with($kernel->getMainRequest()->getPathInfo(), '/install/')
         ) {
             $tpl_vars['debug_info'] = DebugProfile::getCurrent()->getDebugInfo();
         }

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -36,9 +36,9 @@
 use Glpi\Asset\CustomFieldDefinition;
 use Glpi\Event;
 use Glpi\Features\Clonable;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\SearchOption;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\preg_match;
 
@@ -1847,6 +1847,9 @@ class MassiveAction
      **/
     public function itemDone($itemtype, $id, $result)
     {
+        /** @var Kernel $kernel */
+        global $kernel;
+
         $this->current_itemtype = (string) $itemtype;
 
         if (!isset($this->done[$itemtype])) {
@@ -1890,7 +1893,7 @@ class MassiveAction
         // Reload every X seconds to refresh the progress bar
         $refresh_delay = 5;
         if ((microtime(true) - $this->start_time) > $refresh_delay) {
-            $request = Request::createFromGlobals();
+            $request = $kernel->getMainRequest();
             Html::redirect($request->getBasePath() . $request->getPathInfo() . '?identifier=' . $this->identifier);
         }
     }

--- a/src/Session.php
+++ b/src/Session.php
@@ -39,6 +39,7 @@ use Glpi\Controller\InventoryController;
 use Glpi\Event;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\SessionExpiredException;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\SessionTracker;
 use Glpi\Session\SessionInfo;
@@ -400,7 +401,10 @@ class Session
      */
     public static function initNavigateListItems($itemtype, $title = "", $url = null)
     {
-        if (Request::createFromGlobals()->isXmlHttpRequest() && $url === null) {
+        /** @var Kernel $kernel */
+        global $kernel;
+
+        if ($kernel->getMainRequest()->isXmlHttpRequest() && $url === null) {
             return;
         }
 
@@ -985,12 +989,13 @@ class Session
      */
     public static function getPreferredLanguage(): string
     {
-        global $CFG_GLPI;
+        /** @var Kernel $kernel */
+        global $CFG_GLPI, $kernel;
 
         if (!empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
             // Use Symfony Request to parse Accept-Language header
             // Will normalizes language tags (pl-PL -> pl_PL)
-            $request = Request::createFromGlobals();
+            $request = $kernel->getMainRequest();
             $accepted_languages = $request->getLanguages();
 
             foreach ($accepted_languages as $language) {
@@ -1046,10 +1051,13 @@ class Session
      **/
     public static function isCron()
     {
+        /** @var Kernel $kernel */
+        global $kernel;
+
         return (self::isInventory() || isset($_SESSION["glpicronuserrunning"]))
             && (
                 isCommandLine()
-                || str_starts_with(Request::createFromGlobals()->getPathInfo(), '/front/cron.php')
+                || str_starts_with($kernel->getMainRequest()->getPathInfo(), '/front/cron.php')
             );
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -46,7 +46,6 @@ use Glpi\Session\SessionInfo;
 use Laminas\I18n\Translator\Translator;
 use Safe\Exceptions\InfoException;
 use Safe\Exceptions\SessionException;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\ini_get;
 use function Safe\preg_match;

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -36,13 +36,13 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\Output\Csv;
 use Glpi\Search\Output\HTMLSearchOutput;
 use Glpi\Search\Output\Pdf;
 use Glpi\Search\SearchEngine;
 use Glpi\Stat\StatData;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\mktime;
 use function Safe\strtotime;
@@ -438,6 +438,9 @@ class Stat extends CommonGLPI
      **/
     public static function showTable($itemtype, $type, $date1, $date2, $start, array $value, $value2 = '')
     {
+        /** @var Kernel $kernel */
+        global $kernel;
+
         $numrows = count($value);
         // Set display type for export if define
         $output_type = $_GET["display_type"] ?? Search::HTML_OUTPUT;
@@ -466,7 +469,7 @@ class Stat extends CommonGLPI
             $nbcols--;
         }
 
-        $request = Request::createFromGlobals();
+        $request = $kernel->getMainRequest();
 
         if ($is_html_output) {
             $html_output .= $output::showHeader($end_display - $start + 1, $nbcols);

--- a/src/User.php
+++ b/src/User.php
@@ -44,6 +44,7 @@ use Glpi\Exception\PasswordTooWeakException;
 use Glpi\Features\Clonable;
 use Glpi\Features\TreeBrowse;
 use Glpi\Features\TreeBrowseInterface;
+use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\TOTPManager;
 use LDAP\Connection;
@@ -3109,7 +3110,8 @@ HTML;
 
     public function pre_updateInDB()
     {
-        global $DB;
+        /** @var Kernel $kernel */
+        global $DB, $kernel;
 
         if (($key = array_search('name', $this->updates)) !== false) {
             /// Check if user does not exists
@@ -3154,7 +3156,7 @@ HTML;
         if (
             Session::getLoginUserID() === (int) $this->input['id']
             && !Session::haveRight("user", UPDATE)
-            && !str_starts_with(Request::createFromGlobals()->getPathInfo(), "/front/login.php")
+            && !str_starts_with($kernel->getMainRequest()->getPathInfo(), "/front/login.php")
             && isset($this->fields["authtype"])
         ) {
             // extauth ldap case

--- a/src/User.php
+++ b/src/User.php
@@ -51,7 +51,6 @@ use LDAP\Connection;
 use LDAP\Result;
 use Sabre\VObject\Component\VCard;
 use Safe\Exceptions\FilesystemException;
-use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\fclose;
 use function Safe\fopen;

--- a/src/autoload/misc-functions.php
+++ b/src/autoload/misc-functions.php
@@ -33,7 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
-use Symfony\Component\HttpFoundation\Request;
+use Glpi\Kernel\Kernel;
 use Twig\Runtime\EscaperRuntime;
 
 use function Safe\preg_match;
@@ -57,7 +57,10 @@ function isCommandLine(): bool
  */
 function isAPI()
 {
-    $path = Request::createFromGlobals()->getPathInfo();
+    /** @var Kernel $kernel */
+    global $kernel;
+
+    $path = $kernel->getMainRequest()->getPathInfo();
 
     return str_starts_with($path, '/api.php') || str_starts_with($path, '/apirest.php');
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Since we do not yet have all of our services compatible with the dependency injection system, we used `\Symfony\Component\HttpFoundation\Request::createFromGlobals()` to get an object reflecting the request in a few GLPI methods. This can result in an exception when uploaded files have already been moved. In order to prevent this, I propose to store the request object in the kernel and reuse it when it is required.

Error example:
```
 [2026-06-30 14:10:10] glpi.CRITICAL:   *** Uncaught PHP Exception Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException: "The file "/tmp/phpamfln3fj99qc2CwjnXp" does not exist" at File.php line 36
   ├   Backtrace :                                                            
   ├   ./vendor/symfony/http-foundation/File/File.php:36                      
   ├   ...ymfony/http-foundation/File/UploadedFile.php:75 Symfony\Component\HttpFoundation\File\File->__construct()
   ├   ./vendor/symfony/http-foundation/FileBag.php:75    Symfony\Component\HttpFoundation\File\UploadedFile->__construct()
   ├   ./vendor/symfony/http-foundation/FileBag.php:78    Symfony\Component\HttpFoundation\FileBag->convertFileInformation()
   ├   :                                                  Symfony\Component\HttpFoundation\FileBag->{closure:Symfony\Component\HttpFoundation\FileBag::convertFileInformation():78}()
   ├   ./vendor/symfony/http-foundation/FileBag.php:78    array_map()        
   ├   ./vendor/symfony/http-foundation/FileBag.php:46    Symfony\Component\HttpFoundation\FileBag->convertFileInformation()
   ├   ./vendor/symfony/http-foundation/FileBag.php:52    Symfony\Component\HttpFoundation\FileBag->set()
   ├   ./vendor/symfony/http-foundation/FileBag.php:37    Symfony\Component\HttpFoundation\FileBag->add()
   ├   ./vendor/symfony/http-foundation/FileBag.php:31    Symfony\Component\HttpFoundation\FileBag->replace()
   ├   ./vendor/symfony/http-foundation/Request.php:266   Symfony\Component\HttpFoundation\FileBag->__construct()
   ├   ./vendor/symfony/http-foundation/Request.php:244   Symfony\Component\HttpFoundation\Request->initialize()
   ├   ./vendor/symfony/http-foundation/Request.php:2119  Symfony\Component\HttpFoundation\Request->__construct()
   ├   ./vendor/symfony/http-foundation/Request.php:289   Symfony\Component\HttpFoundation\Request::createRequestFromFactory()
   ├   ./src/autoload/misc-functions.php:60               Symfony\Component\HttpFoundation\Request::createFromGlobals()
   ├   ./src/CommonGLPI.php:200                           isAPI()            
   ├   ./src/CommonDBTM.php:2960                          CommonGLPI::isUserReauthenticationNeeded()
   ├   ./src/Glpi/Api/API.php:1909                        CommonDBTM->can()  
   ├   ./src/Glpi/Api/APIRest.php:347                     Glpi\Api\API->createItems()
   ├   ./src/Glpi/Controller/ApiController.php:78         Glpi\Api\APIRest->call()
   ├   ./vendor/symfony/http-kernel/HttpKernel.php:101    Glpi\Controller\ApiController->{closure:Glpi\Controller\ApiController::__invoke():76}()
   ├   ...ymfony/http-foundation/StreamedResponse.php:125 Symfony\Component\HttpKernel\HttpKernel::{closure:Symfony\Component\HttpKernel\HttpKernel::handle():98}()
   ├   ./vendor/symfony/http-foundation/Response.php:403  Symfony\Component\HttpFoundation\StreamedResponse->sendContent()
   ├   ./src/Glpi/Kernel/Kernel.php:330                   Symfony\Component\HttpFoundation\Response->send()
   ├   ./public/index.php:73                              Glpi\Kernel\Kernel->sendResponse()
```