### PR TITLE
`GHSA-fgmj-fm8m-jvvx` is not applicable in GLPI

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+    "GHSA-fgmj-fm8m-jvvx": "Not applicable in GLPI"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
                 "@vue/vue3-jest": "^29.2.6",
                 "axe-core": "^4.11.3",
                 "axios": "^1.16.1",
+                "better-npm-audit": "^3.11.0",
                 "clean-webpack-plugin": "^4.0.0",
                 "copy-webpack-plugin": "^14.0.0",
                 "css-loader": "^7.1.4",
@@ -7053,6 +7054,49 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "node_modules/better-npm-audit": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/better-npm-audit/-/better-npm-audit-3.11.0.tgz",
+            "integrity": "sha512-/Pt05DK6HQaRjWDc5McsCkJBZYfhgQGneKnxzPJExtRq38NttO1Hm30m0GVQeZogE94LVNBVrhWwVsoCo+at3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^8.0.0",
+                "dayjs": "^1.10.6",
+                "lodash.get": "^4.4.2",
+                "semver": "^7.6.3",
+                "table": "^6.7.1"
+            },
+            "bin": {
+                "better-npm-audit": "index.js"
+            },
+            "engines": {
+                "node": ">= 8.12"
+            }
+        },
+        "node_modules/better-npm-audit/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/better-npm-audit/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -13661,6 +13705,14 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "vue": "^3.5.35"
     },
     "scripts": {
+        "audit": "better-npm-audit audit",
         "build:pack": "webpack --config .webpack.config.js",
         "build:vue": "webpack --config .vue.webpack.config.js",
         "build:illustration-translations": "php bin/console tools:generate_illustration_translations --allow-superuser",
@@ -103,6 +104,7 @@
         "@vue/vue3-jest": "^29.2.6",
         "axe-core": "^4.11.3",
         "axios": "^1.16.1",
+        "better-npm-audit": "^3.11.0",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^14.0.0",
         "css-loader": "^7.1.4",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The audit indicates `GHSA-fgmj-fm8m-jvvx` must be fixed by an upgrade to `echarts@6.1.0`, but this vulnerability is not applicable in GLPI. Also upgrading will require to fix the rendering issues in the dashbard due to some changes int he library.

I propose to ignore this vulnerability. Since `npm` has no feature to list vulnerabilities to ignore during its audit, I propose to use the `better-npm-audit` library.

It produces this kind of report:
<img width="1621" height="465" alt="image" src="https://github.com/user-attachments/assets/1d9e4660-b277-4fe1-962a-e5f412416ca8" />
