### PR TITLE
add rector directive to remove unused imports

### DIFF
--- a/front/locale.php
+++ b/front/locale.php
@@ -38,7 +38,6 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 use Glpi\Application\Environment;
 use Glpi\Error\ErrorHandler;
 use Laminas\I18n\Translator\TextDomain;
-use Laminas\I18n\Translator\Translator;
 
 use function Safe\fopen;
 use function Safe\json_encode;

--- a/rector.php
+++ b/rector.php
@@ -44,6 +44,7 @@ return RectorConfig::configure()
     ->withSets([
         GlpiSetList::GLPI_DEFAULT_SET,
     ])
+    ->withImportNames(importNames: false, importDocBlockNames: false, importShortClasses: false, removeUnusedImports: true)
     ->withPaths([
         __DIR__ . '/ajax',
         __DIR__ . '/dependency_injection',

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -36,7 +36,6 @@
 namespace Glpi\Api\HL\Controller;
 
 use CommonDBTM;
-use Document;
 use Entity;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\RoutePath;

--- a/src/Glpi/Api/HL/Controller/SetupController.php
+++ b/src/Glpi/Api/HL/Controller/SetupController.php
@@ -50,7 +50,6 @@ use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
 use Glpi\Api\HL\ResourceAccessor;
 use Glpi\Api\HL\Route;
 use Glpi\Api\HL\RouteVersion;
-use Glpi\Api\HL\Search;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;

--- a/src/Glpi/Controller/Form/Condition/EditorController.php
+++ b/src/Glpi/Controller/Form/Condition/EditorController.php
@@ -40,7 +40,6 @@ use Glpi\Form\Condition\EditorManager;
 use Glpi\Form\Condition\FormData;
 use Glpi\Form\Condition\QuestionData;
 use Glpi\Form\Condition\Type;
-use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use InvalidArgumentException;

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -54,7 +54,6 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
 use Glpi\Search\Input\QueryBuilder;
-use Glpi\Search\SearchOption;
 use Group;
 use Group_Ticket;
 use Profile_User;


### PR DESCRIPTION
Rector config to remove unused imports.


```php
use \Glpi\NotUsedAnyWhere; // this line is remove because `NotUsedAnyWhere` class is ... not used anywhere.
```

```php
->withImportNames(importNames: false, importDocBlockNames: false, importShortClasses: false, removeUnusedImports: true);
 ```
 
 `removeUnusedImports` does the job.
 Other options are usefull but not yet added to limit changes on codebase.
 
 Important file : rector.php
 Other file changes are made by rector.