### PR TITLE
Fix importForm returning wrong form, causing flaky tests

### DIFF
--- a/templates/pages/admin/form/import/step4_execute.html.twig
+++ b/templates/pages/admin/form/import/step4_execute.html.twig
@@ -43,7 +43,7 @@
         <div class="card-header py-3 px-4">
             <h3 class="card-title">{{ __("Import results") }}</h3>
         </div>
-        <table class="table table-card mb-0">
+        <table class="table table-card mb-0" data-testid="import-results">
             <thead>
                 <tr>
                     <th class="w-70 px-4">{{ "Glpi\\Form\\Form"|itemtype_name }}</th>

--- a/tests/e2e/utils/FormImporter.ts
+++ b/tests/e2e/utils/FormImporter.ts
@@ -78,7 +78,7 @@ export class FormImporter
 
         const dom = new JSDOM(body);
         const link = dom.window.document.querySelector(
-            'a[href^="/front/form/form.form.php?id="]'
+            '[data-testid="import-results"] a[href^="/front/form/form.form.php?id="]'
         ) as HTMLAnchorElement;
 
         if (link === null) {


### PR DESCRIPTION
Fix random failures seen in:
* https://github.com/glpi-project/glpi/actions/runs/28517074899/job/84531368881
* https://github.com/glpi-project/glpi/actions/runs/28519179640/job/84538554170

The cause is the form import module, which looks for links in the form results page to get the imported form id.
The link selector was not precise enough and would return forms found in leftover session messages from previous requests (e.g. "Item successfully updated: ...) instead of picking the form link in the import result.