### PR TITLE
Adding database version in `system:status` CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The present file will list all changes made to the project; according to the
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
 - Password policy and 2FA settings moved from `Setup > General` to `Setup > Security`.
+- CLI command `system:status` now gives information about database version.
 
 ### Deprecated
 

--- a/src/Glpi/System/Status/StatusChecker.php
+++ b/src/Glpi/System/Status/StatusChecker.php
@@ -45,6 +45,7 @@ use Plugin;
 use RuntimeException;
 use Throwable;
 use Toolbox;
+use Update;
 
 use function Safe\fclose;
 
@@ -75,6 +76,12 @@ final class StatusChecker
      */
     public const STATUS_NO_DATA = 'NO_DATA';
 
+    /**
+     * The value is hidden.
+     * This is likely when value is sensitive and method is called with `$public_only = true`).
+     */
+    public const VALUE_REDACTED = 'REDACTED';
+
     private static array $cached_status = [];
 
     /**
@@ -86,6 +93,7 @@ final class StatusChecker
     public static function getServices(): array
     {
         return [
+            'glpi'            => [self::class, 'getGLPIStatus'],
             'db'              => [self::class, 'getDBStatus'],
             'cas'             => [self::class, 'getCASStatus'],
             'ldap'            => [self::class, 'getLDAPStatus'],
@@ -129,11 +137,7 @@ final class StatusChecker
     {
         $services = self::getServices();
         if ($service === 'all' || $service === null) {
-            $status = [
-                'glpi'   => [
-                    'status' => self::STATUS_OK,
-                ],
-            ];
+            $status = [];
             foreach (array_keys($services) as $name) {
                 $service_status = self::getServiceStatus($name, $public_only);
                 $status[$name] = $service_status;
@@ -152,6 +156,43 @@ final class StatusChecker
             return $service_check_method($public_only);
         }
         return [];
+    }
+
+    /**
+     * Get GLPI service's status
+     *
+     * @param bool $public_only True if only public status information should be given.
+     * @return array{status: string, database_version: array{defined: string, installed: string, uptodate: bool, status: string}}
+     */
+    public static function getGLPIStatus(bool $public_only = true): array
+    {
+        $cache_key = 'glpi.' . ($public_only ? 'public' : 'private');
+        if (!isset(self::$cached_status[$cache_key])) {
+            global $CFG_GLPI;
+
+            $status = [
+                'status' => self::STATUS_OK,
+                'database_version' => [
+                    'defined' => $public_only ? self::VALUE_REDACTED : GLPI_SCHEMA_VERSION,
+                    'installed' => $public_only ? self::VALUE_REDACTED : trim($CFG_GLPI['dbversion'] ?? ''),
+                    'uptodate' => $public_only ? false : Update::isDbUpToDate(),
+                ],
+            ];
+
+            // Compute database_version status from "uptodate" state
+            $status['database_version']['status'] = (
+                $public_only
+                ? self::STATUS_NO_DATA
+                : ($status['database_version']['uptodate'] ? self::STATUS_OK : self::STATUS_WARNING)
+            );
+
+            // Propagate database_version status to root status
+            $status['status'] = $status['database_version']['status'];
+
+            self::$cached_status[$cache_key] = $status;
+        }
+
+        return self::$cached_status[$cache_key];
     }
 
     /**

--- a/tests/functional/Glpi/System/StatusCheckerTest.php
+++ b/tests/functional/Glpi/System/StatusCheckerTest.php
@@ -55,6 +55,40 @@ class StatusCheckerTest extends GLPITestCase
         $this->assertIsArray($status);
     }
 
+    public function testDbVersions()
+    {
+        $statusPublic = StatusChecker::getServiceStatus(service: null, public_only: true);
+        $statusPrivate = StatusChecker::getServiceStatus(service: null, public_only: false);
+
+        foreach (['public' => $statusPublic, 'private' => $statusPrivate] as $visibility => $status) {
+            $this->assertIsArray($status['glpi']['database_version']);
+            $this->assertArrayHasKey('status', $status['glpi']['database_version']);
+
+            // Verify value types
+            $this->assertIsString($status['glpi']['database_version']['defined']);
+            $this->assertIsString($status['glpi']['database_version']['installed']);
+            $this->assertIsString($status['glpi']['database_version']['status']);
+
+            // Verify "uptodate" type according to visibility
+            $this->{$visibility == 'public' ? 'assertFalse' : 'assertIsBool'}($status['glpi']['database_version']['uptodate']);
+
+            // Verify versions
+            $this->assertEquals(
+                $visibility == 'public' ? StatusChecker::VALUE_REDACTED : GLPI_SCHEMA_VERSION,
+                $status['glpi']['database_version']['defined'],
+            );
+        }
+
+        $this->assertEquals(StatusChecker::VALUE_REDACTED, $statusPublic['glpi']['database_version']['installed']);
+
+        // Verify "status" represents "uptodate" value
+        $this->assertEquals(StatusChecker::STATUS_NO_DATA, $statusPublic['glpi']['database_version']['status']);
+        $this->assertEquals(
+            $statusPrivate['glpi']['database_version']['uptodate'] ? StatusChecker::STATUS_OK : StatusChecker::STATUS_WARNING,
+            $statusPrivate['glpi']['database_version']['status'],
+        );
+    }
+
     public function testDefaultStatus()
     {
         $status = StatusChecker::getServiceStatus(service: null);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my feature works.
- [ ] This change requires a documentation update.
- [x] No IA/GenIA/LLM were involved.

## Description

This PR implements https://github.com/glpi-project/roadmap/discussions/408 which adds database version information to console `system:status` command.

## Output:

```
$ bin/console system:status
{
    "glpi": {
        "status": "OK"
    },
    "db": {
        "status": "OK",
        "version": {
            "installed": "11.0.6@84160e91f70f353b33495a7928e5b1476d4b6d98",
            "defined": "11.0.8@7b129479687ebafebb6966eaa1d72cb683390613",
            "uptodate": false
        },
        "main": {
            "status": "OK"
        },
        "replicas": {
            "status": "NO_DATA",
            "servers": []
        }
    },
    …
}
```
