### PR TITLE
Fix Home/End keys not scrolling the timeline in ITIL objects

### DIFF
--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -49,6 +49,11 @@
             transition: all 400ms ease;
         }
 
+        .itil-left-side:focus,
+        .itil-right-side:focus {
+            outline: none;
+        }
+
         .itil-left-side {
             height: 100%;
             border-top: 0 !important;

--- a/templates/components/itilobject/layout.html.twig
+++ b/templates/components/itilobject/layout.html.twig
@@ -66,14 +66,14 @@
     <div class="row d-flex flex-column itil-object">
         {% set is_timeline_reversed = user_pref('timeline_order') == constant('CommonITILObject::TIMELINE_ORDER_REVERSE') %}
         {% set fl_direction = (item.isNewItem() or is_timeline_reversed ? 'flex-column' : 'flex-column-reverse') %}
-        <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-lg-first pt-2 pe-2 pe-lg-4 d-flex {{ fl_direction }} border-top border-4 {{ not show_extra_fields ? "w-100" : "" }}">
+        <div class="itil-left-side col-12 {{ left_side_cls }} order-last order-lg-first pt-2 pe-2 pe-lg-4 d-flex {{ fl_direction }} border-top border-4 {{ not show_extra_fields ? "w-100" : "" }}" tabindex="-1">
             {% if item.isNewItem() %}
                 {{ include('components/itilobject/timeline/new_form.html.twig') }}
             {% else %}
                 {{ include('components/itilobject/timeline/timeline.html.twig') }}
             {% endif %}
         </div>
-        <div class="itil-right-side col-12 {{ right_side_cls }} mt-0 mt-lg-n1 card-footer p-0 rounded-0 {{ show_extra_fields ? '' : 'd-none' }}">
+        <div class="itil-right-side col-12 {{ right_side_cls }} mt-0 mt-lg-n1 card-footer p-0 rounded-0 {{ show_extra_fields ? '' : 'd-none' }}" tabindex="-1">
             {# Even without extra fields, this form is necessary for footer buttons #}
             {% if can_have_form and not item.isNewItem() %}
                 {{ include('components/itilobject/mainform_open.html.twig') }}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45038
- On large screens the ITIL object view uses a fixed-height layout where the timeline scrolls inside the `.itil-left-side`/`.itil-right-side` container (`overflow-y: auto`) rather than the page body. Because that container wasn't focusable, pressing "Home"/"End" (and "PageUp"/"PageDown") scrolled the document, which has nothing to scroll, so nothing happened.
- Fix: 
  - Add `tabindex="-1"` to` .itil-left-side`/`.itil-right-side`  so it can receive focus and respond to keyboard scroll keys (Home/End/PageUp/PageDown).
  - Hide the browser default focus outline on `.itil-left-side` / `.itil-right-side` (`outline: none` on `:focus`), since these are scroll regions rather than interactive controls, avoiding a distracting border on focus.


