### PR TITLE
Fix: show mini-ticket dashboard for helpdesk profiles

### DIFF
--- a/src/Glpi/Dashboard/Dashboard.php
+++ b/src/Glpi/Dashboard/Dashboard.php
@@ -43,6 +43,7 @@ use Glpi\Plugin\Hooks;
 use Plugin;
 use Ramsey\Uuid\Uuid;
 use Session;
+use Ticket;
 use Toolbox;
 
 use function Safe\json_decode;
@@ -233,6 +234,17 @@ class Dashboard extends CommonDBTM
 
         // check global (admin) right
         if (self::canView() && !$this->isPrivate()) {
+            Profiler::getInstance()->stop(__METHOD__);
+            return true;
+        }
+
+        // System mini-dashboard: allow helpdesk users with any ticket read right.
+        if (
+            $this->fields['context'] === 'mini_core'
+            && (int) $this->fields['users_id'] === 0
+            && Session::getCurrentInterface() === 'helpdesk'
+            && Session::haveRightsOr(Ticket::$rightname, [Ticket::READALL, Ticket::READMY, Ticket::READASSIGN, Ticket::OWN])
+        ) {
             Profiler::getInstance()->stop(__METHOD__);
             return true;
         }

--- a/src/Glpi/Helpdesk/HomePageTabs.php
+++ b/src/Glpi/Helpdesk/HomePageTabs.php
@@ -103,7 +103,7 @@ final class HomePageTabs extends CommonGLPI
             );
         }
 
-        if (Grid::canViewOneDashboard()) {
+        if (Grid::canViewOneDashboard('core')) {
             $tabs[self::DASHBOARD_TAB] = self::createTabEntry(
                 text: __("Dashboard"),
                 icon: Dashboard::getIcon()

--- a/src/Glpi/Search/Output/HTMLSearchOutput.php
+++ b/src/Glpi/Search/Output/HTMLSearchOutput.php
@@ -76,7 +76,6 @@ class HTMLSearchOutput extends AbstractSearchOutput
     {
         if (
             $itemtype === Ticket::class
-            && Session::getCurrentInterface() === 'central'
             && $default = Grid::getDefaultDashboardForMenu('mini_ticket', true)
         ) {
             $dashboard = new Grid($default, 33, 2);

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -594,6 +594,9 @@ $CFG_GLPI['javascript'] = [
         'change'    => ['sortable', 'rateit'],
         'stat'      => ['charts', 'rateit'],
     ],
+    'tickets'   => [
+        'ticket' => ['rateit', 'dashboard'],
+    ],
     'tools'     => [
         'project'                 => ['sortable'],
         'knowbaseitem'            => ['kb'],

--- a/tests/functional/Glpi/Dashboard/DashboardTest.php
+++ b/tests/functional/Glpi/Dashboard/DashboardTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Dashboard;
 
 use Glpi\Dashboard\Dashboard;
+use Glpi\Dashboard\Grid;
 use Glpi\Dashboard\Item;
 use Glpi\Dashboard\Right;
 use Glpi\Tests\DbTestCase;
@@ -377,5 +378,58 @@ class DashboardTest extends DbTestCase
         $dashboard_as_shared = new Dashboard('test_view_current_shared');
         $this->assertTrue($dashboard_as_shared->canViewCurrent());
         $this->assertFalse($dashboard_as_shared->canUpdateCurrent());
+    }
+
+    public function testCanViewCurrentForHelpdeskUser(): void
+    {
+        // System mini_core dashboards (users_id = 0) must be accessible to helpdesk
+        // users who have at least one ticket read right, without requiring the dashboard right.
+        $this->login('jsmith123');
+        $_SESSION['glpiactiveprofile']['interface'] = 'helpdesk';
+        $_SESSION['glpiactiveprofile']['dashboard'] = 0;
+        $_SESSION['glpiactiveprofile']['ticket'] = \Ticket::READMY;
+
+        $mini_dashboard = new Dashboard('mini_tickets');
+        $this->assertTrue($mini_dashboard->canViewCurrent());
+
+        // The full resolution path (used by Grid::show) must also resolve to 'mini_tickets'.
+        $this->assertEquals('mini_tickets', Grid::getDefaultDashboardForMenu('mini_ticket', true));
+
+        // A mini_core dashboard owned by another user must NOT be accessible.
+        $this->login();
+        $owner_id = (int) \Session::getLoginUserID();
+        $this->createItem(Dashboard::class, [
+            'key'      => 'test_private_mini_core',
+            'name'     => __FUNCTION__,
+            'users_id' => $owner_id,
+            'context'  => 'mini_core',
+        ]);
+
+        $this->login('jsmith123');
+        $_SESSION['glpiactiveprofile']['interface'] = 'helpdesk';
+        $_SESSION['glpiactiveprofile']['dashboard'] = 0;
+        $_SESSION['glpiactiveprofile']['ticket'] = \Ticket::READMY;
+
+        $private_mini = new Dashboard('test_private_mini_core');
+        $this->assertFalse($private_mini->canViewCurrent());
+
+        // A helpdesk user with no ticket rights must NOT be able to view the system mini-dashboard.
+        $this->login('jsmith123');
+        $_SESSION['glpiactiveprofile']['interface'] = 'helpdesk';
+        $_SESSION['glpiactiveprofile']['dashboard'] = 0;
+        $_SESSION['glpiactiveprofile']['ticket'] = 0;
+
+        $no_rights_mini = new Dashboard('mini_tickets');
+        $this->assertFalse($no_rights_mini->canViewCurrent());
+
+        // mini_core dashboards must not make the "Dashboard" home tab appear
+        // (canViewOneDashboard('core') excludes mini_core context).
+        $this->login('jsmith123');
+        $_SESSION['glpiactiveprofile']['interface'] = 'helpdesk';
+        $_SESSION['glpiactiveprofile']['dashboard'] = 0;
+        $_SESSION['glpiactiveprofile']['ticket'] = \Ticket::READMY;
+
+        Grid::$all_dashboards = [];
+        $this->assertFalse(Grid::canViewOneDashboard('core'));
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45067

**This restores the behaviour previously provided by the FormCreator plugin.**

Self-service/helpdesk profiles now see the mini-ticket dashboard (count boxes) above the ticket list, both on the helpdesk home page and on `front/ticket.php`.
Three changes make this work: `canViewCurrent()` grants access to system `mini_core` dashboards for helpdesk users who hold any ticket read right; the `central`-only guard in `HTMLSearchOutput::showPreSearchDisplay()` is removed; and the `tickets` sector is added to `$CFG_GLPI['javascript']` so `gridstack.js` and its CSS are loaded on `front/ticket.php` for helpdesk users.

## Screenshots (if appropriate):

<img width="1315" height="281" alt="image" src="https://github.com/user-attachments/assets/5e7546d6-3e59-4b56-b8fd-70a03d5e00ad" />
