### PR TITLE
Fix: restrict AD nested group cache to batch sync only

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -466,6 +466,7 @@ class AuthLDAP extends CommonDBTM
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     return;
                 }
+                User::enableLdapGroupBatchMode();
                 $mode         = (int) ($input['mode'] ?? self::ACTION_IMPORT);
                 $authldaps_id = (int) ($input['authldaps_id'] ?? 0);
                 foreach ($ids as $id) {

--- a/src/Glpi/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Glpi/Console/Ldap/SynchronizeUsersCommand.php
@@ -382,6 +382,7 @@ class SynchronizeUsersCommand extends AbstractCommand
                 $users_progress_bar = new ProgressBar($output, count($users));
                 $users_progress_bar->start();
 
+                User::enableLdapGroupBatchMode();
                 foreach ($users as $user) {
                     $users_progress_bar->advance(1);
 

--- a/src/User.php
+++ b/src/User.php
@@ -105,6 +105,13 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
     private ?array $entities = null;
 
+    private static bool $ldap_group_batch_mode = false;
+
+    public static function enableLdapGroupBatchMode(): void
+    {
+        self::$ldap_group_batch_mode = true;
+    }
+
     public function getCloneRelations(): array
     {
         return [
@@ -2229,9 +2236,10 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
-        // Use cached lookup when MATCHING_RULE_IN_CHAIN is set (AD nested groups).
+        // Only use M-queries-per-group cache in batch mode; FPM spawns a new process per login so the cache never reuses.
         if (
-            str_contains($ldap_method["group_member_field"], AuthLDAP::MATCHING_RULE_IN_CHAIN_OID)
+            self::$ldap_group_batch_mode
+            && str_contains($ldap_method["group_member_field"], AuthLDAP::MATCHING_RULE_IN_CHAIN_OID)
             && !empty($ldap_method["group_field"])
         ) {
             return $this->getFromLDAPGroupDiscretCached(

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2682,9 +2682,15 @@ class UserTest extends DbTestCase
         $this->assertStringStartsWith(__FUNCTION__ . '_2', $tree[0]['title']);
     }
 
+    public function testLdapGroupBatchModeDefaultsFalse(): void
+    {
+        $prop = (new \ReflectionClass(User::class))->getProperty('ldap_group_batch_mode');
+        $this->assertFalse($prop->getValue(null));
+    }
+
     /**
-     * Verify that getFromLDAPGroupDiscret() routes to the cached path when the
-     * LDAP_MATCHING_RULE_IN_CHAIN OID is present in group_member_field.
+     * Verify that getFromLDAPGroupDiscret() routes to the cached path only when
+     * batch mode is enabled and the LDAP_MATCHING_RULE_IN_CHAIN OID is present.
      *
      * The cached path queries GLPI groups from DB (no LDAP call when DB is empty)
      * and returns true, while the standard path returns false when
@@ -2727,7 +2733,10 @@ class UserTest extends DbTestCase
         );
         $this->assertFalse($result);
 
-        // CHAIN OID present + group_field set → cached path → true.
+        // Batch mode required: cached path is only active during batch sync.
+        User::enableLdapGroupBatchMode();
+
+        // CHAIN OID present + batch mode + group_field set → cached path → true.
         // No groups with ldap_group_dn exist in DB, so no ldap_search is fired.
         $result = $this->callPrivateMethod(
             $user,
@@ -2776,6 +2785,7 @@ class UserTest extends DbTestCase
 
         $userdn = 'uid=cachetest,dc=example,dc=com';
 
+        User::enableLdapGroupBatchMode();
         $user1 = new User();
 
         // First call — DB has no groups with ldap_group_dn, cache is primed as empty.


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45085

PR #24043 introduced `getFromLDAPGroupDiscretCached()` to reduce LDAP queries from N (one per user) to M (one per group) during bulk AD sync when `group_member_field` contains the `MATCHING_RULE_IN_CHAIN` OID.
The static cache that makes this trade-off worthwhile only persists within a single PHP process.
For web logins handled by PHP-FPM, each request spawns a fresh process, so the cache is always empty and M slow `MATCHING_RULE_IN_CHAIN` queries hit every login instead of the previous single query.
The fix gates the cached path behind a `$ldap_group_batch_mode` flag that must be explicitly enabled by callers that process multiple users in the same process (CLI sync command, massive actions).


## Screenshots (if appropriate):


