### PR TITLE
Add GraphQL Test Helper

### DIFF
--- a/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AdministrationControllerTest.php
@@ -45,14 +45,12 @@ class AdministrationControllerTest extends HLAPITestCase
     public function testSearchUsers()
     {
         $this->api->call(new Request('GET', '/Administration/User'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isUnauthorizedError();
         });
 
         $this->login();
         $this->api->call(new Request('GET', '/Administration/User'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -71,7 +69,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Administration/User');
         $request->setParameter('filter', 'username==' . TU_USER);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -86,7 +83,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Administration/User');
         $request->setParameter('filter', 'emails.email=like=*glpi.com');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -123,7 +119,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Administration/User');
         $request->setParameter('filter', 'emails.email==' . TU_USER . '@glpi.com');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -186,7 +181,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login('glpi', 'glpi');
         $this->api->call(new Request('GET', "/Administration/$type/$id"), function ($call) use ($id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($id) {
@@ -200,7 +194,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Administration/User/username/' . TU_USER), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -213,7 +206,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -225,7 +217,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Administration/User/me');
         $request->setParameter('filter', 'username==' . TU_USER . '_other');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -234,7 +225,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Administration/User/me/email'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -268,7 +258,6 @@ class AdministrationControllerTest extends HLAPITestCase
         ])->current()['id'];
 
         $this->api->call(new Request('GET', "/Administration/User/me/email/$email_id"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -279,14 +268,12 @@ class AdministrationControllerTest extends HLAPITestCase
 
         // Try getting an email that doesn't exist
         $this->api->call(new Request('GET', "/Administration/User/me/email/999999999"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
         // Log in as another user and try to get the email of the first user (should fail)
         $this->login('tech', 'tech');
         $this->api->call(new Request('GET', "/Administration/User/me/email/$email_id"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -308,7 +295,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Administration/User/me/picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -318,7 +304,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -327,7 +312,6 @@ class AdministrationControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('GET', '/Administration/User/me/picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -342,7 +326,6 @@ class AdministrationControllerTest extends HLAPITestCase
 
         $tu_id = getItemByTypeName('User', TU_USER, true);
         $this->api->call(new Request('GET', '/Administration/User/' . $tu_id . '/Picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -352,7 +335,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
         $this->api->call(new Request('GET', '/Administration/User/' . $tu_id . '/Picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -366,7 +348,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Administration/User/username/' . TU_USER . '/Picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -376,7 +357,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->addCustomUserPicture($_SESSION['glpiID'], GLPI_ROOT . '/tests/fixtures/uploads/foo.png');
 
         $this->api->call(new Request('GET', '/Administration/User/username/' . TU_USER . '/Picture'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->content(function ($content) {
@@ -444,7 +424,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request->setParameter('filter', 'username=in=(testuser1,testuser2,testuser3)');
         $request->setParameter('sort', 'firstname,username');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -456,7 +435,6 @@ class AdministrationControllerTest extends HLAPITestCase
         });
         $request->setParameter('sort', 'firstname:desc,username');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -510,7 +488,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->login();
         foreach ($used_endpoints as $endpoint) {
             $this->api->call(new Request('GET', $endpoint), function ($call) use ($expected_used) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->jsonContent(function ($content) use ($expected_used) {
@@ -523,7 +500,6 @@ class AdministrationControllerTest extends HLAPITestCase
         }
         foreach ($managed_endpoints as $endpoint) {
             $this->api->call(new Request('GET', $endpoint), function ($call) use ($expected_managed) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->jsonContent(function ($content) use ($expected_managed) {
@@ -540,7 +516,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login(api_options: ['scope' => 'api']);
         $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -548,7 +523,6 @@ class AdministrationControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Administration/User/Me/Emails/Default'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -557,14 +531,10 @@ class AdministrationControllerTest extends HLAPITestCase
         });
         $this->login(api_options: ['scope' => 'user']);
         $this->api->call(new Request('GET', '/Administration/User/Me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
         $this->api->call(new Request('GET', '/Administration/User/Me/Emails/Default'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
     }
 
@@ -572,7 +542,6 @@ class AdministrationControllerTest extends HLAPITestCase
     {
         $this->login(api_options: ['scope' => 'api']);
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -580,7 +549,6 @@ class AdministrationControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -590,7 +558,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->login(api_options: ['scope' => 'email']);
         // Access to email scope doesn't allow broad access to current user info
         $this->api->call(new Request('GET', '/Administration/User/me'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -598,9 +565,7 @@ class AdministrationControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Administration/User/me/Emails/Default'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
     }
 
@@ -620,7 +585,6 @@ class AdministrationControllerTest extends HLAPITestCase
 
         $tu_id = getItemByTypeName('User', TU_USER, true);
         $this->api->call(new Request('GET', '/Administration/User/' . $tu_id . '/Preference'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -634,7 +598,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Administration/User/' . TU_USER . '/Preference'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -648,7 +611,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Administration/User/me/Preference'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -666,7 +628,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request->setParameter('palette', 'teclib');
         $request->setParameter('language', 'fr_FR');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -685,7 +646,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request->setParameter('palette', 'teclib');
         $request->setParameter('language', 'fr_FR');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -704,7 +664,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $request->setParameter('palette', 'teclib');
         $request->setParameter('language', 'fr_FR');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -721,7 +680,6 @@ class AdministrationControllerTest extends HLAPITestCase
 
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
         $this->api->call(new Request('GET', '/Administration/EventLog'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -740,7 +698,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $_SESSION['glpiactiveprofile']['system_logs'] = 0;
 
         $this->api->call(new Request('GET', '/Administration/EventLog'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
     }
@@ -758,7 +715,6 @@ class AdministrationControllerTest extends HLAPITestCase
         $this->loginWeb();
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
         $this->api->call(new Request('GET', '/Administration/EventLog/' . $eventlog_id), function ($call) use ($eventlog_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($eventlog_id) {
@@ -769,7 +725,6 @@ class AdministrationControllerTest extends HLAPITestCase
 
         $_SESSION['glpiactiveprofile']['system_logs'] = 0;
         $this->api->call(new Request('GET', '/Administration/EventLog/' . $eventlog_id), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
     }

--- a/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/AssetControllerTest.php
@@ -44,7 +44,6 @@ use Glpi\Features\AssignableItemInterface;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use Group_Item;
-use HLAPICallAsserter;
 use Item_RemoteManagement;
 use OperatingSystem;
 use OperatingSystemArchitecture;
@@ -68,7 +67,6 @@ class AssetControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Assets'), function ($call) use ($types) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($types) {
@@ -120,7 +118,6 @@ class AssetControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Assets/' . $schema);
         $request->setParameter('filter', $filters);
         $this->api->call($request, function ($call) use ($expected) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($expected) {
@@ -148,7 +145,6 @@ class AssetControllerTest extends HLAPITestCase
             ],
         ];
         $this->api->call(new Request('GET', '/Assets'), function ($call) use ($dataset) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($dataset) {
@@ -183,7 +179,6 @@ class AssetControllerTest extends HLAPITestCase
         $this->login();
         $request = new Request('GET', '/Assets/' . $schema . '/' . $id);
         $this->api->call($request, function ($call) use ($schema, $expected) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($expected) {
@@ -240,7 +235,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // get rack items (should be empty)
         $this->api->call(new Request('GET', '/Assets/Rack/' . $rack_id . '/Item'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -255,7 +249,6 @@ class AssetControllerTest extends HLAPITestCase
         $request->setParameter('position', 1);
         $rackitem_location = null;
         $this->api->call($request, function ($call) use (&$rackitem_location) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$rackitem_location) {
@@ -266,7 +259,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // get rack items (should contain the computer)
         $this->api->call(new Request('GET', '/Assets/Rack/' . $rack_id . '/Item'), function ($call) use ($computer_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($computer_id) {
@@ -280,14 +272,11 @@ class AssetControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $rackitem_location);
         $request->setParameter('position', 2);
         $this->api->call($request, function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         // get specific rack item and validate the update
         $this->api->call(new Request('GET', $rackitem_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -297,14 +286,11 @@ class AssetControllerTest extends HLAPITestCase
 
         // Delete computer from rack
         $this->api->call(new Request('DELETE', $rackitem_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         // get rack items (should be empty)
         $this->api->call(new Request('GET', '/Assets/Rack/' . $rack_id . '/Item'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -321,7 +307,6 @@ class AssetControllerTest extends HLAPITestCase
         $request->setParameter('filter', ['name=ilike=*_test*']);
         $request->setParameter('limit', 10000);
         $this->api->call($request, function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -354,7 +339,6 @@ class AssetControllerTest extends HLAPITestCase
         $request->setParameter('name', '1.0');
         $new_item_location = null;
         $this->api->call($request, function ($call) use ($software_id, &$new_item_location) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use ($software_id, &$new_item_location) {
@@ -366,7 +350,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Get and verify
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -379,7 +362,6 @@ class AssetControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_item_location);
         $request->setParameter('name', '1.1');
         $this->api->call($request, function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -389,16 +371,12 @@ class AssetControllerTest extends HLAPITestCase
 
         // Delete
         $this->api->call(new Request('DELETE', $new_item_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         // Verify item does not exist anymore
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isNotFoundError();
+            $call->response->isNotFoundError();
         });
     }
 
@@ -427,7 +405,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Get and verify
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($state_id) {
@@ -440,7 +417,6 @@ class AssetControllerTest extends HLAPITestCase
             'Accept-Language' => 'fr_FR',
         ]);
         $this->api->call($request, function ($call) use ($state_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($state_id) {
@@ -467,7 +443,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Get and verify
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($state_id) {
@@ -478,7 +453,6 @@ class AssetControllerTest extends HLAPITestCase
         // Change language and verify the default name is returned instead of null
         $_SESSION['glpilanguage'] = 'fr_FR';
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computer_id), function ($call) use ($state_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($state_id) {
@@ -498,9 +472,7 @@ class AssetControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computers_id . '/Infocom'), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isNotFoundError();
+            $call->response->isNotFoundError();
         });
 
         $this->createItem('Infocom', [
@@ -510,7 +482,6 @@ class AssetControllerTest extends HLAPITestCase
         ]);
 
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computers_id . '/Infocom'), function ($call) use ($computers_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($computers_id) {
@@ -531,7 +502,6 @@ class AssetControllerTest extends HLAPITestCase
         $request->setParameter('name', 'Test');
         $new_location = null;
         $this->api->call($request, function ($call) use (&$new_location) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_location) {
@@ -541,7 +511,6 @@ class AssetControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('GET', $new_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -556,7 +525,6 @@ class AssetControllerTest extends HLAPITestCase
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
 
         $this->api->call(new Request('GET', '/Assets'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -572,7 +540,6 @@ class AssetControllerTest extends HLAPITestCase
                         $new_location = null;
                         $new_items_id = null;
                         $this->api->call($create_request, function ($call) use (&$new_location, &$new_items_id) {
-                            /** @var HLAPICallAsserter $call */
                             $call->response
                                 ->isOK()
                                 ->headers(function ($headers) use (&$new_location) {
@@ -641,7 +608,6 @@ class AssetControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Assets/Computer/' . $computers_id), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -710,7 +676,6 @@ class AssetControllerTest extends HLAPITestCase
 
         $new_location = null;
         $this->api->call($request, function ($call) use (&$new_location) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_location) {
@@ -721,7 +686,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Search
         $this->api->call(new Request('GET', "/Assets/Computer/{$computer_id}/SoftwareInstallation"), function ($call) use ($softwareversion_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($softwareversion_id) {
@@ -730,7 +694,6 @@ class AssetControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', "/Assets/Computer/{$other_computer_id}/SoftwareInstallation"), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -740,7 +703,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Get
         $this->api->call(new Request('GET', $new_location), function ($call) use ($softwareversion_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($softwareversion_id) {
@@ -753,7 +715,6 @@ class AssetControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_location);
         $request->setParameter('date_install', '2026-02-10');
         $this->api->call($request, function ($call) use ($softwareversion_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($softwareversion_id) {
@@ -764,13 +725,10 @@ class AssetControllerTest extends HLAPITestCase
 
         // Delete
         $this->api->call(new Request('DELETE', $new_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', $new_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -826,7 +784,6 @@ class AssetControllerTest extends HLAPITestCase
         $new_location = null;
         $this->login();
         $this->api->call($request, function ($call) use (&$new_location, $computer_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_location, $computer_id) {
@@ -837,7 +794,6 @@ class AssetControllerTest extends HLAPITestCase
 
         // Get and verify
         $this->api->call(new Request('GET', $new_location), function ($call) use ($appliance_id) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($appliance_id) {
@@ -847,16 +803,12 @@ class AssetControllerTest extends HLAPITestCase
 
         // Delete
         $this->api->call(new Request('DELETE', $new_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         // Verify item does not exist anymore
         $this->api->call(new Request('GET', $new_location), function ($call) {
-            /** @var HLAPICallAsserter $call */
-            $call->response
-                ->isNotFoundError();
+            $call->response->isNotFoundError();
         });
     }
 

--- a/tests/functional/Glpi/Api/HL/Controller/ComponentControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ComponentControllerTest.php
@@ -49,7 +49,6 @@ class ComponentControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Components'), function ($call) use ($types) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($types) {
@@ -106,7 +105,6 @@ class ComponentControllerTest extends HLAPITestCase
         $request->setParameter('entities_id', getItemByTypeName('Entity', '_test_root_entity', true));
         $new_item_location = null;
         $this->api->call($request, function ($call) use ($type, &$new_item_location) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use ($type, &$new_item_location) {
@@ -118,7 +116,6 @@ class ComponentControllerTest extends HLAPITestCase
         $items_location = $new_item_location . '/Items';
         // By default, there is no component of this type. Response should be an empty array
         $this->api->call(new Request('GET', $items_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -146,7 +143,6 @@ class ComponentControllerTest extends HLAPITestCase
 
         // There should now be one component of this type
         $this->api->call(new Request('GET', $items_location), function ($call) use ($type) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($type) {

--- a/tests/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/CoreControllerTest.php
@@ -64,7 +64,6 @@ class CoreControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('OPTIONS', '/Session'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) {
@@ -74,7 +73,6 @@ class CoreControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('OPTIONS', '/Administration/User'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) {
@@ -88,7 +86,6 @@ class CoreControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('HEAD', '/Session'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) {
@@ -110,9 +107,7 @@ class CoreControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call($request, function ($call) use ($schema_name) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->matchesSchema($schema_name);
+            $call->response->matchesSchema($schema_name);
         });
     }
 
@@ -195,9 +190,7 @@ class CoreControllerTest extends HLAPITestCase
         $_SESSION['glpiactiveprofile'][Transfer::$rightname] = 0;
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isAccessDenied();
+            $call->response->isAccessDenied();
         });
 
         $_SESSION['glpiactiveprofile'][Transfer::$rightname] = READ;
@@ -208,7 +201,6 @@ class CoreControllerTest extends HLAPITestCase
             'GLPI-Entity-Recursive' => 'true',
         ], json_encode($transfer_records));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(200, $status))
                 ->content(fn($content) => $this->assertEmpty($content));
@@ -269,7 +261,6 @@ class CoreControllerTest extends HLAPITestCase
 
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(400, $status))
                 ->jsonContent(function ($content) {
@@ -285,7 +276,6 @@ class CoreControllerTest extends HLAPITestCase
 
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(200, $status))
                 ->jsonContent(function ($content) {
@@ -329,7 +319,6 @@ class CoreControllerTest extends HLAPITestCase
             'Authorization' => 'Basic ' . base64_encode($client_data['identifier'] . ':' . (new \GLPIKey())->decrypt($client_data['secret'])),
         ], json_encode($auth_data));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(200, $status))
                 ->jsonContent(function ($content) {
@@ -370,7 +359,6 @@ class CoreControllerTest extends HLAPITestCase
 
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(400, $status))
                 ->jsonContent(function ($content) {
@@ -387,7 +375,6 @@ class CoreControllerTest extends HLAPITestCase
 
         $request = new Request('POST', '/Token', ['Content-Type' => 'application/json'], json_encode($auth_data));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->status(fn($status) => $this->assertEquals(200, $status))
                 ->jsonContent(function ($content) {
@@ -402,7 +389,6 @@ class CoreControllerTest extends HLAPITestCase
     {
         $this->login(api_options: ['scope' => 'api']);
         $this->api->call(new Request('GET', '/Status'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -411,7 +397,6 @@ class CoreControllerTest extends HLAPITestCase
         });
         $this->login(api_options: ['scope' => 'status']);
         $this->api->call(new Request('GET', '/Status'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK();
         });
@@ -421,7 +406,6 @@ class CoreControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Session/EntityTree'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/CustomAssetControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/CustomAssetControllerTest.php
@@ -39,7 +39,6 @@ use Glpi\Api\HL\Controller\CustomAssetController;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
-use HLAPICallAsserter;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class CustomAssetControllerTest extends HLAPITestCase
@@ -57,7 +56,6 @@ class CustomAssetControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Assets/Custom'), function ($call) use ($types) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($types) {
@@ -89,7 +87,6 @@ class CustomAssetControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Assets/Custom/' . $schema);
         $request->setParameter('filter', $filters);
         $this->api->call($request, function ($call) use ($expected) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($expected) {
@@ -133,7 +130,6 @@ class CustomAssetControllerTest extends HLAPITestCase
         $type_1 = getItemByTypeName('Glpi\\CustomAsset\\Test01AssetType', 'Test01Type01', true);
 
         $this->api->call(new Request('GET', '/Assets/Custom/Test01/' . $asset_1), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -146,11 +142,9 @@ class CustomAssetControllerTest extends HLAPITestCase
         $request->setParameter('model', $model_1);
         $request->setParameter('type', $type_1);
         $this->api->call($request, function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isOK();
         });
         $this->api->call(new Request('GET', '/Assets/Custom/Test01/' . $asset_1), function ($call) use ($model_1, $type_1) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($model_1, $type_1) {
@@ -165,7 +159,6 @@ class CustomAssetControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Assets/Custom/Test01Model'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -174,7 +167,6 @@ class CustomAssetControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Assets/Custom/Test02Model'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -184,7 +176,6 @@ class CustomAssetControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('GET', '/Assets/Custom/Test01Type'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -193,7 +184,6 @@ class CustomAssetControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Assets/Custom/Test02Type'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/DropdownControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/DropdownControllerTest.php
@@ -54,7 +54,6 @@ class DropdownControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Dropdowns'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -102,7 +101,6 @@ class DropdownControllerTest extends HLAPITestCase
             ],
         ];
         $this->api->call(new Request('GET', '/Dropdowns'), function ($call) use ($dataset) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($dataset) {
@@ -118,7 +116,6 @@ class DropdownControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Dropdowns'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -147,7 +144,6 @@ class DropdownControllerTest extends HLAPITestCase
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
 
         $this->api->call(new Request('GET', '/Dropdowns'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -169,7 +165,6 @@ class DropdownControllerTest extends HLAPITestCase
                         $new_location = null;
                         $new_items_id = null;
                         $this->api->call($create_request, function ($call) use (&$new_location, &$new_items_id) {
-                            /** @var \HLAPICallAsserter $call */
                             $call->response
                                 ->isOK()
                                 ->headers(function ($headers) use (&$new_location) {
@@ -220,7 +215,6 @@ class DropdownControllerTest extends HLAPITestCase
         $this->api->call(new Request('GET', '/Dropdowns/Location', [
             'GLPI-Entity' => getItemByTypeName('Entity', '_test_child_1', true),
         ]), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -251,7 +245,6 @@ class DropdownControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Dropdowns/State/' . $state->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK()
                 ->jsonContent(function ($content) {
                     $this->assertTrue($content['visibilities']['computer']);
@@ -269,12 +262,10 @@ class DropdownControllerTest extends HLAPITestCase
             'printer' => false,
         ]);
         $this->api->call($update_request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', '/Dropdowns/State/' . $state->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK()
                 ->jsonContent(function ($content) {
                     $this->assertFalse($content['visibilities']['computer']);

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -47,14 +47,12 @@ class GraphQLControllerTest extends HLAPITestCase
     {
         $this->login();
 
-        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name } } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { __schema { types { name } } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertGreaterThan(150, $content['data']['__schema']['types']);
-                    $types = $content['data']['__schema']['types'];
+                ->data('__schema', function ($schema) {
+                    $types = $schema['types'];
+                    $this->assertGreaterThan(150, $types);
                     $some_expected = ['Computer', 'Ticket', 'User', 'PrinterModel', 'FirmwareType'];
                     $found = [];
                     foreach ($types as $type) {
@@ -69,14 +67,11 @@ class GraphQLControllerTest extends HLAPITestCase
                 });
         });
 
-        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name description } } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { __schema { types { name description } } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $types = $content['data']['__schema']['types'];
-                    foreach ($types as $type) {
+                ->data('__schema', function ($schema) {
+                    foreach ($schema['types'] as $type) {
                         $this->assertArrayHasKey('name', $type);
                         $this->assertArrayHasKey('description', $type);
                         $this->assertArrayNotHasKey('fields', $type);
@@ -84,14 +79,11 @@ class GraphQLControllerTest extends HLAPITestCase
                 });
         });
 
-        $request = new Request('POST', '/GraphQL', [], 'query { __schema { types { name fields { type { name } } } } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { __schema { types { name fields { type { name } } } } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $types = $content['data']['__schema']['types'];
-                    foreach ($types as $type) {
+                ->data('__schema', function ($schema) {
+                    foreach ($schema['types'] as $type) {
                         $this->assertArrayHasKey('name', $type);
                         $this->assertArrayNotHasKey('description', $type);
                         $this->assertArrayHasKey('fields', $type);
@@ -104,16 +96,13 @@ class GraphQLControllerTest extends HLAPITestCase
     {
         $this->login();
 
-        $request = new Request('POST', '/GraphQL', [], 'query { Computer(id: 1) { id name } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Computer(id: 1) { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertCount(1, $content['data']['Computer']);
-                    $this->assertEquals(1, $content['data']['Computer'][0]['id']);
-                    $this->assertEquals('_test_pc01', $content['data']['Computer'][0]['name']);
+                ->data('Computer', function ($computers) {
+                    $this->assertCount(1, $computers);
+                    $this->assertEquals(1, $computers[0]['id']);
+                    $this->assertEquals('_test_pc01', $computers[0]['name']);
                 });
         });
     }
@@ -122,14 +111,11 @@ class GraphQLControllerTest extends HLAPITestCase
     {
         $this->login();
 
-        $request = new Request('POST', '/GraphQL', [], 'query { Computer { id name } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Computer { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertGreaterThan(2, count($content['data']['Computer']));
+                ->data('Computer', function ($computers) {
+                    $this->assertGreaterThan(2, count($computers));
                 });
         });
     }
@@ -138,14 +124,11 @@ class GraphQLControllerTest extends HLAPITestCase
     {
         $this->login();
 
-        $request = new Request('POST', '/GraphQL', [], 'query { Computer(filter: "name=like=\'*_test_pc*\'") { id name } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Computer(filter: "name=like=\'*_test_pc*\'") { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertCount(9, $content['data']['Computer']);
+                ->data('Computer', function ($computers) {
+                    $this->assertCount(9, $computers);
                 });
         });
     }
@@ -167,18 +150,15 @@ class GraphQLControllerTest extends HLAPITestCase
         ]));
 
         // product_number is not available this way via the REST API, but should be available here as the partial schema gets replaced by the full schema
-        $request = new Request('POST', '/GraphQL', [], 'query { CartridgeItem { id name printer_models { name product_number } } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { CartridgeItem { id name printer_models { name product_number } } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertArrayHasKey('id', $content['data']['CartridgeItem'][0]);
-                    $this->assertArrayHasKey('name', $content['data']['CartridgeItem'][0]);
-                    $this->assertGreaterThan(0, count($content['data']['CartridgeItem'][0]['printer_models']));
-                    $this->assertArrayHasKey('name', $content['data']['CartridgeItem'][0]['printer_models'][0]);
-                    $this->assertArrayHasKey('product_number', $content['data']['CartridgeItem'][0]['printer_models'][0]);
+                ->data('CartridgeItem', function ($items) {
+                    $this->assertArrayHasKey('id', $items[0]);
+                    $this->assertArrayHasKey('name', $items[0]);
+                    $this->assertGreaterThan(0, count($items[0]['printer_models']));
+                    $this->assertArrayHasKey('name', $items[0]['printer_models'][0]);
+                    $this->assertArrayHasKey('product_number', $items[0]['printer_models'][0]);
                 });
         });
     }
@@ -204,34 +184,18 @@ class GraphQLControllerTest extends HLAPITestCase
         ]));
 
         $this->login();
-        $request = new Request('POST', '/GraphQL', [], <<<GRAPHQL
-            query {
-                Computer(id: $computers_id) {
-                    id
-                    name
-                    status {
-                        name
-                        visibilities {
-                            computer monitor
-                        }
-                    }
-                }
-            }
-GRAPHQL);
 
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call("query { Computer(id: $computers_id) { id name status { name visibilities { computer monitor } } } }", function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertCount(1, $content['data']['Computer']);
-                    $this->assertArrayHasKey('id', $content['data']['Computer'][0]);
-                    $this->assertArrayHasKey('name', $content['data']['Computer'][0]);
-                    $this->assertArrayHasKey('status', $content['data']['Computer'][0]);
-                    $this->assertArrayHasKey('name', $content['data']['Computer'][0]['status']);
-                    $this->assertTrue($content['data']['Computer'][0]['status']['visibilities']['computer']);
-                    $this->assertFalse($content['data']['Computer'][0]['status']['visibilities']['monitor']);
+                ->data('Computer', function ($computers) {
+                    $this->assertCount(1, $computers);
+                    $this->assertArrayHasKey('id', $computers[0]);
+                    $this->assertArrayHasKey('name', $computers[0]);
+                    $this->assertArrayHasKey('status', $computers[0]);
+                    $this->assertArrayHasKey('name', $computers[0]['status']);
+                    $this->assertTrue($computers[0]['status']['visibilities']['computer']);
+                    $this->assertFalse($computers[0]['status']['visibilities']['monitor']);
                 });
         });
     }
@@ -248,38 +212,31 @@ GRAPHQL);
         $tickets_id = $DB->insertId();
 
         $this->loginWeb();
-        $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
+        $this->graphql->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
 
         $_SESSION['glpi_use_mode'] = 2;
 
         // Can see no tickets
         $_SESSION['glpiactiveprofile']['ticket'] = 0;
-        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertEmpty($content['data']['Ticket']);
-                });
+        $this->graphql->call('query { Ticket { id name } }', function ($call) {
+            $call->response->isCompletelyError();
         });
 
         // Can only see my own tickets
         $_SESSION['glpiactiveprofile']['ticket'] = READ;
 
-        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }'), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Ticket { id name } }', function ($call) use ($tickets_id) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) use ($tickets_id) {
-                    $this->assertNotContains($tickets_id, array_column($content['data']['Ticket'], 'id'));
+                ->data('Ticket', function ($tickets) use ($tickets_id) {
+                    $this->assertNotContains($tickets_id, array_column($tickets, 'id'));
                 });
         });
-        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket(id: ' . $tickets_id . ') { id name } }'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Ticket(id: ' . $tickets_id . ') { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertEmpty($content['data']['Ticket']);
+                ->data('Ticket', function ($tickets) {
+                    $this->assertEmpty($tickets);
                 });
         });
     }
@@ -300,18 +257,17 @@ GRAPHQL);
         ]));
 
         $this->loginWeb();
-        $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
+        $this->graphql->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
 
         $_SESSION['glpi_use_mode'] = 2;
 
         // Can see no entities
         $_SESSION['glpiactiveprofile']['entity'] = 0;
-        $this->api->call(new Request('POST', '/GraphQL', [], 'query { Ticket { id name entity { id name comment } } }'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Ticket { id name entity { id name comment } } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    foreach ($content['data']['Ticket'] as $ticket) {
+                ->data('Ticket', function ($tickets) {
+                    foreach ($tickets as $ticket) {
                         // The name is part of the partial schema, so it is always visible
                         $this->assertNotNull($ticket['entity']['name']);
                         // The comment comes from the full schema which the user has no right to see
@@ -326,7 +282,6 @@ GRAPHQL);
         $this->login(api_options: ['scope' => 'api']);
         $request = new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isAccessDenied()
                 ->jsonContent(function ($content) {
@@ -334,11 +289,8 @@ GRAPHQL);
                 });
         });
         $this->login(api_options: ['scope' => 'graphql']);
-        $request = new Request('POST', '/GraphQL', [], 'query { Ticket { id name } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+        $this->graphql->call('query { Ticket { id name } }', function ($call) {
+            $call->response->isOK();
         });
     }
 
@@ -349,7 +301,6 @@ GRAPHQL);
         $query = 'query { Computer(id: 1) { id name } }';
         $request = new Request('POST', '/GraphQL', ['Content-Type' => 'application/graphql'], $query);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -369,7 +320,6 @@ GRAPHQL);
         $body = json_encode(['query' => $query]);
         $request = new Request('POST', '/GraphQL', ['Content-Type' => 'application/json'], $body);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -388,7 +338,6 @@ GRAPHQL);
         $query = 'query { Computer(id: 1) { id name } }';
         $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -444,7 +393,6 @@ GRAPHQL);
                     'X-Debug-Mode' => '1', // Debug mode allows seeing more information in errors
                 ], $query);
                 $this->api->call($request, function ($call) use ($schema_name, &$schemas_errors) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($schema_name, &$schemas_errors) {
@@ -477,16 +425,12 @@ GRAPHQL);
     {
         $this->login();
 
-        $query = 'query { Project(filter: "name==_project01;entity.level==2") { id name } }';
-        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Project(filter: "name==_project01;entity.level==2") { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertCount(1, $content['data']['Project']);
-                    $this->assertEquals('_project01', $content['data']['Project'][0]['name']);
+                ->data('Project', function ($projects) {
+                    $this->assertCount(1, $projects);
+                    $this->assertEquals('_project01', $projects[0]['name']);
                 });
         });
 
@@ -503,27 +447,20 @@ GRAPHQL);
             'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
         ]);
 
-        $query = 'query { Project(filter: "name==_project01;tasks.parent_task.name==test") { id name } }';
-        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Project(filter: "name==_project01;tasks.parent_task.name==test") { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertEmpty($content['data']['Project']);
+                ->data('Project', function ($projects) {
+                    $this->assertCount(0, $projects);
                 });
         });
 
-        $query = 'query { Project(filter: "name==_project01;tasks.parent_task.name==ParentTask") { id name } }';
-        $request = new Request('POST', '/GraphQL', ['Content-Type' => 'text/plain'], $query);
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Project(filter: "name==_project01;tasks.parent_task.name==ParentTask") { id name } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertCount(1, $content['data']);
-                    $this->assertCount(1, $content['data']['Project']);
-                    $this->assertEquals('_project01', $content['data']['Project'][0]['name']);
+                ->data('Project', function ($projects) {
+                    $this->assertCount(1, $projects);
+                    $this->assertEquals('_project01', $projects[0]['name']);
                 });
         });
     }

--- a/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
@@ -78,7 +78,6 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('entity', getItemByTypeName('Entity', '_test_root_entity', true));
             $itil_base_path = null;
             $this->api->call($request, function ($call) use ($itil_type, &$itil_base_path) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use ($itil_type, &$itil_base_path) {
@@ -106,7 +105,6 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('entity', getItemByTypeName('Entity', '_test_root_entity', true));
             $itil_base_path = null;
             $this->api->call($request, function ($call) use ($itil_type, &$itil_base_path) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use ($itil_type, &$itil_base_path) {
@@ -134,7 +132,6 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('entity', getItemByTypeName('Entity', '_test_root_entity', true));
             $itil_base_path = null;
             $this->api->call($request, function ($call) use ($itil_type, &$itil_base_path) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use ($itil_type, &$itil_base_path) {
@@ -150,7 +147,6 @@ class ITILControllerTest extends HLAPITestCase
                     $request = new Request('POST', $itil_base_path . '/Timeline/' . $subtype);
                     $request->setParameter('content', 'test' . $i);
                     $this->api->call($request, function ($call) {
-                        /** @var \HLAPICallAsserter $call */
                         $call->response->isOK();
                     });
                 }
@@ -158,7 +154,6 @@ class ITILControllerTest extends HLAPITestCase
 
             // Get timeline
             $this->api->call(new Request('GET', $itil_base_path . '/Timeline'), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->jsonContent(function ($content) {
@@ -205,7 +200,6 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('entity', getItemByTypeName('Entity', '_test_root_entity', true));
             $itil_base_path = null;
             $this->api->call($request, function ($call) use ($itil_type, &$itil_base_path) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use ($itil_type, &$itil_base_path) {
@@ -222,7 +216,6 @@ class ITILControllerTest extends HLAPITestCase
                     $request = new Request('POST', $itil_base_path . '/Timeline/' . $subtype);
                     $request->setParameter('content', 'test' . $i);
                     $this->api->call($request, function ($call) {
-                        /** @var \HLAPICallAsserter $call */
                         $call->response->isOK();
                     });
                 }
@@ -231,7 +224,6 @@ class ITILControllerTest extends HLAPITestCase
             // Get the specific subtype
             foreach ($subtypes as $subtype) {
                 $this->api->call(new Request('GET', $itil_base_path . '/Timeline/' . $subtype), function ($call) use ($subtype) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($subtype) {
@@ -340,12 +332,10 @@ class ITILControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'Change');
         $request->setParameter('items_id', $tickets_id + 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
         // verify the parent was not changed
         $this->api->call(new Request('GET', "/Assistance/Ticket/$tickets_id/Timeline/Followup/$fup_id"), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) use ($tickets_id) {
                 $this->assertEquals($tickets_id, $content['items_id']);
@@ -357,12 +347,10 @@ class ITILControllerTest extends HLAPITestCase
         $request = new Request('PATCH', "/Assistance/Ticket/$tickets_id/Timeline/Task/$task_id");
         $request->setParameter('tickets_id', $tickets_id + 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
         // verify the parent was not changed
         $this->api->call(new Request('GET', "/Assistance/Ticket/$tickets_id/Timeline/Task/$task_id"), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) use ($tickets_id) {
                 $this->assertEquals($tickets_id, $content['tickets_id']);
@@ -374,12 +362,10 @@ class ITILControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'Change');
         $request->setParameter('items_id', $tickets_id + 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
         // verify the parent was not changed
         $this->api->call(new Request('GET', "/Assistance/Ticket/$tickets_id/Timeline/Solution/$solution_id"), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) use ($tickets_id) {
                 $this->assertEquals($tickets_id, $content['items_id']);
@@ -391,12 +377,10 @@ class ITILControllerTest extends HLAPITestCase
         $request = new Request('PATCH', "/Assistance/Ticket/$tickets_id/Timeline/Validation/$validation_id");
         $request->setParameter('tickets_id', $tickets_id + 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
         // verify the parent was not changed
         $this->api->call(new Request('GET', "/Assistance/Ticket/$tickets_id/Timeline/Validation/$validation_id"), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) use ($tickets_id) {
                 $this->assertEquals($tickets_id, $content['tickets_id']);
@@ -408,12 +392,10 @@ class ITILControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'Change');
         $request->setParameter('items_id', $tickets_id + 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
         // verify the parent was not changed
         $this->api->call(new Request('GET', "/Assistance/Ticket/$tickets_id/Timeline/Document/$document_item_id"), function ($call) use ($tickets_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) use ($tickets_id) {
                 $this->assertEquals($tickets_id, $content['items_id']);
@@ -529,7 +511,6 @@ class ITILControllerTest extends HLAPITestCase
             if ($itil_type !== Ticket::class) {
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = CommonITILObject::READMY;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -545,7 +526,6 @@ class ITILControllerTest extends HLAPITestCase
             } else {
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = CommonITILObject::READMY;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -558,7 +538,6 @@ class ITILControllerTest extends HLAPITestCase
 
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = Ticket::READGROUP;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -569,7 +548,6 @@ class ITILControllerTest extends HLAPITestCase
 
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = Ticket::OWN;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -581,7 +559,6 @@ class ITILControllerTest extends HLAPITestCase
 
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = Ticket::READASSIGN;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -594,7 +571,6 @@ class ITILControllerTest extends HLAPITestCase
 
                 $_SESSION['glpiactiveprofile'][$itil_type::$rightname] = Ticket::READNEWTICKET;
                 $this->api->call($request, function ($call) use ($func_name) {
-                    /** @var \HLAPICallAsserter $call */
                     $call->response
                         ->isOK()
                         ->jsonContent(function ($content) use ($func_name) {
@@ -637,7 +613,6 @@ class ITILControllerTest extends HLAPITestCase
         $request->setParameter('id', $members[0]['id']);
         $request->setParameter('role', $members[0]['role']);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
@@ -648,7 +623,6 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('id', $member['id']);
             $request->setParameter('role', $member['role']);
             $this->api->call($request, function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response->isOK();
             });
         }
@@ -656,13 +630,10 @@ class ITILControllerTest extends HLAPITestCase
         // Get all members
         $_SESSION['glpiactiveprofile'][Ticket::$rightname] = 0;
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember"), function ($call) use ($members) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isAccessDenied();
+            $call->response->isAccessDenied();
         });
         $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $original_ticket_rights;
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember"), function ($call) use ($members) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($members) {
@@ -677,21 +648,17 @@ class ITILControllerTest extends HLAPITestCase
         // Get by role
         $_SESSION['glpiactiveprofile'][Ticket::$rightname] = 0;
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/requester"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/observer"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/assigned"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
         $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $original_ticket_rights;
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/requester"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -700,7 +667,6 @@ class ITILControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/observer"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -709,7 +675,6 @@ class ITILControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember/assigned"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -725,7 +690,6 @@ class ITILControllerTest extends HLAPITestCase
         $request->setParameter('id', $members[0]['id']);
         $request->setParameter('role', $members[0]['role']);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
@@ -736,14 +700,12 @@ class ITILControllerTest extends HLAPITestCase
             $request->setParameter('id', $member['id']);
             $request->setParameter('role', $member['role']);
             $this->api->call($request, function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response->isOK();
             });
         }
 
         // Verify removal
         $this->api->call(new Request('GET', "/Assistance/Ticket/{$ticket->getID()}/TeamMember"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/InventoryControllerTest.php
@@ -38,7 +38,6 @@ use Agent;
 use AgentType;
 use Computer;
 use Glpi\Http\Request;
-use Glpi\Tests\HLAPICallAsserter;
 use Glpi\Tests\HLAPITestCase;
 use Lockedfield;
 use SNMPCredential;
@@ -75,7 +74,6 @@ class InventoryControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Inventory/Agent'), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) {
                 $found_agent = false;
@@ -92,7 +90,6 @@ class InventoryControllerTest extends HLAPITestCase
         $update_request = new Request('PATCH', "/Inventory/Agent/{$agents_id}");
         $update_request->setParameter('threads_network_discovery', 6);
         $this->api->call($update_request, function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) {
                 $this->assertEquals(6, $content['threads_network_discovery']);
@@ -100,7 +97,6 @@ class InventoryControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('GET', "/Inventory/Agent/{$agents_id}"), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isOK();
             $call->response->jsonContent(function ($content) {
                 $this->assertEquals(6, $content['threads_network_discovery']);
@@ -108,12 +104,10 @@ class InventoryControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('DELETE', "/Inventory/Agent/{$agents_id}"), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', "/Inventory/Agent/{$agents_id}"), function ($call) {
-            /** @var HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }

--- a/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
@@ -93,7 +93,6 @@ class KnowbaseControllerTest extends HLAPITestCase
 
         $last_revision_id = null;
         $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $kbi->getID() . '/Revision'), function ($call) use (&$last_revision_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use (&$last_revision_id) {
@@ -103,7 +102,6 @@ class KnowbaseControllerTest extends HLAPITestCase
         });
         // Get last revision
         $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $kbi->getID() . '/Revision/' . $last_revision_id), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -130,7 +128,6 @@ class KnowbaseControllerTest extends HLAPITestCase
 
         $last_revision_id = null;
         $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $kbi->getID() . '/fr_FR/Revision'), function ($call) use (&$last_revision_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use (&$last_revision_id) {
@@ -140,7 +137,6 @@ class KnowbaseControllerTest extends HLAPITestCase
         });
         // Get last revision
         $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $kbi->getID() . '/fr_FR/Revision/' . $last_revision_id), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/ManagementControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ManagementControllerTest.php
@@ -87,7 +87,6 @@ class ManagementControllerTest extends HLAPITestCase
             $new_location = null;
             $new_items_id = null;
             $this->api->call($create_request, function ($call) use (&$new_location, &$new_items_id) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use (&$new_location) {

--- a/tests/functional/Glpi/Api/HL/Controller/ProjectControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ProjectControllerTest.php
@@ -62,7 +62,6 @@ class ProjectControllerTest extends HLAPITestCase
 
         $projects_id = null;
         $this->api->call($request, function ($call) use (&$projects_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) {
@@ -79,7 +78,6 @@ class ProjectControllerTest extends HLAPITestCase
         $request->setParameter('content', 'test');
         $new_item_location = null;
         $this->api->call($request, function ($call) use (&$new_item_location) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_item_location) {
@@ -90,7 +88,6 @@ class ProjectControllerTest extends HLAPITestCase
 
         // Get
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -102,13 +99,11 @@ class ProjectControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_item_location);
         $request->setParameter('content', 'test2');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         // Verify Update
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -118,13 +113,11 @@ class ProjectControllerTest extends HLAPITestCase
 
         // Delete (Trash)
         $this->api->call(new Request('DELETE', $new_item_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         // Get (Trash)
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
@@ -132,13 +125,11 @@ class ProjectControllerTest extends HLAPITestCase
         $request = new Request('DELETE', $new_item_location);
         $request->setParameter('force', 1);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         // Verify not found
         $this->api->call(new Request('GET', $new_item_location), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -163,13 +154,11 @@ class ProjectControllerTest extends HLAPITestCase
         $_SESSION['glpiactiveprofile'][Project::$rightname] = 0;
 
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
         $_SESSION['glpiactiveprofile'][Project::$rightname] = Project::READMY;
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
@@ -178,7 +167,6 @@ class ProjectControllerTest extends HLAPITestCase
             'users_id' => $_SESSION['glpiID'] + 1, // Created by another user
         ]));
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
@@ -188,7 +176,6 @@ class ProjectControllerTest extends HLAPITestCase
             'items_id'   => $_SESSION['glpiID'],
         ]);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
@@ -198,7 +185,6 @@ class ProjectControllerTest extends HLAPITestCase
         ], ['id' => $project->getID()]));
         $project->getFromDB($project->getID());
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -214,7 +200,6 @@ class ProjectControllerTest extends HLAPITestCase
             'entities_id' => getItemByTypeName(Entity::class, '_test_root_entity', true),
         ]);
         $this->api->call(new Request('GET', '/Project/' . $project->getID() . '/Task'), function ($call) use ($project_task) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(static fn($c) => count($c) === 1 && $c[0]['id'] === $project_task->getID());
@@ -222,13 +207,11 @@ class ProjectControllerTest extends HLAPITestCase
 
         $_SESSION['glpiactiveprofile'][Project::$rightname] = 0;
         $this->api->call(new Request('GET', '/Project/' . $project->getID() . '/Task'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(static fn($c) => empty($c));
         });
         $this->api->call(new Request('GET', '/Project/Task/' . $project_task->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -272,7 +255,6 @@ class ProjectControllerTest extends HLAPITestCase
         $teammember_endpoint = "/Project/{$project->getID()}/TeamMember";
 
         $this->api->call(new Request('GET', $teammember_endpoint), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -285,14 +267,11 @@ class ProjectControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'User');
         $request->setParameter('items_id', $user_id);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         $teammember_id = null;
         $this->api->call(new Request('GET', $teammember_endpoint), function ($call) use ($user_id, &$teammember_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($user_id, &$teammember_id) {
@@ -307,13 +286,10 @@ class ProjectControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'User');
         $request->setParameter('items_id', $user_id);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', $teammember_endpoint), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -346,14 +322,11 @@ class ProjectControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'User');
         $request->setParameter('items_id', $user_id);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         $teammember_id = null;
         $this->api->call(new Request('GET', $teammember_endpoint), function ($call) use ($user_id, &$teammember_id) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($user_id, &$teammember_id) {
@@ -368,13 +341,10 @@ class ProjectControllerTest extends HLAPITestCase
         $request->setParameter('itemtype', 'User');
         $request->setParameter('items_id', $user_id);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', $teammember_endpoint), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/ReportControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ReportControllerTest.php
@@ -44,7 +44,6 @@ class ReportControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Assistance/Stat'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->matchesSchema('StatReport[]')
@@ -85,7 +84,6 @@ class ReportControllerTest extends HLAPITestCase
         $itil_types = ['Ticket', 'Change', 'Problem'];
         foreach ($itil_types as $itil_type) {
             $this->api->call(new Request('GET', "/Assistance/Stat/$itil_type/Global"), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->matchesSchema('GlobalStats');
@@ -99,7 +97,6 @@ class ReportControllerTest extends HLAPITestCase
         $itil_types = ['Ticket', 'Change', 'Problem'];
         foreach ($itil_types as $itil_type) {
             $this->api->call(new Request('GET', "/Assistance/Stat/$itil_type/Characteristics"), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->status(fn($status) => $status === 400)
                     ->jsonContent(fn($content) => $this->assertEquals([
@@ -117,7 +114,6 @@ class ReportControllerTest extends HLAPITestCase
             $request = new Request('GET', "/Assistance/Stat/$itil_type/Characteristics");
             $request->setParameter('field', 'user');
             $this->api->call($request, function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->matchesSchema('ITILStats[]');
@@ -131,7 +127,6 @@ class ReportControllerTest extends HLAPITestCase
         $itil_types = ['Ticket', 'Change', 'Problem'];
         foreach ($itil_types as $itil_type) {
             $this->api->call(new Request('GET', "/Assistance/Stat/$itil_type/Asset"), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->matchesSchema('AssetStats[]');
@@ -145,7 +140,6 @@ class ReportControllerTest extends HLAPITestCase
         $itil_types = ['Ticket', 'Change', 'Problem'];
         foreach ($itil_types as $itil_type) {
             $this->api->call(new Request('GET', "/Assistance/Stat/$itil_type/AssetCharacteristics"), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->status(fn($status) => $status === 400)
                     ->jsonContent(fn($content) => $this->assertEquals([
@@ -163,7 +157,6 @@ class ReportControllerTest extends HLAPITestCase
             $request = new Request('GET', "/Assistance/Stat/$itil_type/AssetCharacteristics");
             $request->setParameter('field', 'user');
             $this->api->call($request, function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->matchesSchema('AssetCharacteristicsStats[]');

--- a/tests/functional/Glpi/Api/HL/Controller/RuleControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/RuleControllerTest.php
@@ -60,7 +60,6 @@ class RuleControllerTest extends HLAPITestCase
 
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
         $this->api->call(new Request('GET', '/Rule/Collection'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -80,7 +79,6 @@ class RuleControllerTest extends HLAPITestCase
         $_SESSION['glpiactiveprofile']['rule_ticket'] = $rule_ticket_right;
 
         $this->api->call(new Request('GET', '/Rule/Collection'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -102,7 +100,6 @@ class RuleControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', '/Rule/Collection'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -164,7 +161,6 @@ class RuleControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', "/Rule/Collection/{$type}/CriteriaCondition"), function ($call) use ($conditions) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($conditions) {
@@ -222,7 +218,6 @@ class RuleControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', "/Rule/Collection/{$type}/CriteriaCriteria"), function ($call) use ($criteria) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($criteria) {
@@ -274,7 +269,6 @@ class RuleControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', "/Rule/Collection/{$type}/ActionType"), function ($call) use ($action_types) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($action_types) {
@@ -329,7 +323,6 @@ class RuleControllerTest extends HLAPITestCase
         $this->login();
 
         $this->api->call(new Request('GET', "/Rule/Collection/{$type}/ActionField"), function ($call) use ($fields) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($fields) {
@@ -361,7 +354,6 @@ class RuleControllerTest extends HLAPITestCase
 
             // Create
             $this->api->call($request, function ($call) use ($collection, &$new_url) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use ($collection, &$new_url) {
@@ -372,7 +364,6 @@ class RuleControllerTest extends HLAPITestCase
 
             // Get
             $this->api->call(new Request('GET', $new_url), function ($call) use ($collection) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->jsonContent(function ($content) use ($collection) {
@@ -384,7 +375,6 @@ class RuleControllerTest extends HLAPITestCase
             $request = new Request('PATCH', $new_url);
             $request->setParameter('name', "testCRUDRules{$collection}2");
             $this->api->call($request, function ($call) use ($collection) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->jsonContent(function ($content) use ($collection) {
@@ -394,15 +384,12 @@ class RuleControllerTest extends HLAPITestCase
 
             // Delete
             $this->api->call(new Request('DELETE', $new_url), function ($call) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response->isOK();
             });
 
             // Verify delete
             $this->api->call(new Request('GET', $new_url), function ($call) {
-                /** @var \HLAPICallAsserter $call */
-                $call->response
-                    ->isNotFoundError();
+                $call->response->isNotFoundError();
             });
         }
     }
@@ -425,7 +412,6 @@ class RuleControllerTest extends HLAPITestCase
         $request->setParameter('pattern', 'testCRUDRuleCriteria');
         $new_url = null;
         $this->api->call($request, function ($call) use ($rules_id, &$new_url) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use ($rules_id, &$new_url) {
@@ -436,7 +422,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // List
         $this->api->call(new Request('GET', "/Rule/Collection/Ticket/Rule/{$rules_id}/Criteria"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -447,7 +432,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Get
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -461,7 +445,6 @@ class RuleControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_url);
         $request->setParameter('pattern', 'testCRUDRuleCriteria2');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -473,15 +456,12 @@ class RuleControllerTest extends HLAPITestCase
 
         // Delete
         $this->api->call(new Request('DELETE', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         // Verify delete
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isNotFoundError();
+            $call->response->isNotFoundError();
         });
     }
 
@@ -503,7 +483,6 @@ class RuleControllerTest extends HLAPITestCase
         $request->setParameter('value', 'testCRUDRuleAction');
         $new_url = null;
         $this->api->call($request, function ($call) use ($rules_id, &$new_url) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use ($rules_id, &$new_url) {
@@ -514,7 +493,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // List
         $this->api->call(new Request('GET', "/Rule/Collection/Ticket/Rule/{$rules_id}/Action"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -525,7 +503,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Get
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -539,7 +516,6 @@ class RuleControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_url);
         $request->setParameter('value', 'testCRUDRuleAction2');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -551,15 +527,12 @@ class RuleControllerTest extends HLAPITestCase
 
         // Delete
         $this->api->call(new Request('DELETE', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         // Verify delete
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isNotFoundError();
+            $call->response->isNotFoundError();
         });
     }
 
@@ -574,7 +547,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Create
         $this->api->call($request, function ($call) use (&$new_url) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_url) {
@@ -584,7 +556,6 @@ class RuleControllerTest extends HLAPITestCase
         });
         // Get and check ranking
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -605,7 +576,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Create
         $this->api->call($request, function ($call) use (&$new_url) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_url) {
@@ -616,7 +586,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Get and check ranking
         $this->api->call(new Request('GET', $new_url), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -636,7 +605,6 @@ class RuleControllerTest extends HLAPITestCase
 
         // Create
         $this->api->call($request, function ($call) use (&$new_url) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->headers(function ($headers) use (&$new_url) {
@@ -649,7 +617,6 @@ class RuleControllerTest extends HLAPITestCase
         $request = new Request('PATCH', $new_url);
         $request->setParameter('ranking', 0);
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {

--- a/tests/functional/Glpi/Api/HL/Controller/SetupControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/SetupControllerTest.php
@@ -55,7 +55,6 @@ class SetupControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Setup'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -108,7 +107,6 @@ class SetupControllerTest extends HLAPITestCase
             ],
         ];
         $this->api->call(new Request('GET', '/Setup'), function ($call) use ($dataset) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($dataset) {
@@ -143,7 +141,6 @@ class SetupControllerTest extends HLAPITestCase
 
 
         $this->api->call(new Request('GET', '/Setup'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -270,7 +267,6 @@ class SetupControllerTest extends HLAPITestCase
             $new_items_id = null;
             $this->login();
             $this->api->call($create_request, function ($call) use (&$new_location, &$new_items_id) {
-                /** @var \HLAPICallAsserter $call */
                 $call->response
                     ->isOK()
                     ->headers(function ($headers) use (&$new_location) {
@@ -330,7 +326,6 @@ class SetupControllerTest extends HLAPITestCase
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
         // Can get a config value
         $this->api->call(new Request('GET', '/Setup/Config/core/priority_1'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -343,13 +338,11 @@ class SetupControllerTest extends HLAPITestCase
         // Get an undisclosable config value
         Config::setConfigurationValues('core', ['smtp_passwd' => 'test']);
         $this->api->call(new Request('GET', '/Setup/Config/core/smtp_passwd'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
         // Not existing config value
         $this->api->call(new Request('GET', '/Setup/Config/core/notrealconfig'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
@@ -357,7 +350,6 @@ class SetupControllerTest extends HLAPITestCase
         $request = new Request('PATCH', '/Setup/Config/core/priority_1');
         $request->setParameter('value', '#ffffff');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -367,7 +359,6 @@ class SetupControllerTest extends HLAPITestCase
                 });
         });
         $this->api->call(new Request('GET', '/Setup/Config/core/priority_1'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -381,56 +372,40 @@ class SetupControllerTest extends HLAPITestCase
         $request = new Request('PATCH', '/Setup/Config/core/smtp_passwd');
         $request->setParameter('value', 'newtest');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->status(static fn($status) => $status === 204);
+            $call->response->status(static fn($status) => $status === 204);
         });
 
         // Can delete a config value
         $this->api->call(new Request('DELETE', '/Setup/Config/core/priority_1'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->status(static fn($status) => $status === 204);
+            $call->response->status(static fn($status) => $status === 204);
         });
         $this->api->call(new Request('GET', '/Setup/Config/core/priority_1'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
         // Can delete an undisclosable config value
         $this->api->call(new Request('DELETE', '/Setup/Config/core/smtp_passwd'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->status(static fn($status) => $status === 204);
+            $call->response->status(static fn($status) => $status === 204);
         });
 
         // Can get a config value using GraphQL
-        $request = new Request('POST', '/GraphQL', [], 'query { Config(filter: "context==core;name==priority_2") { context, name, value } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Config(filter: "context==core;name==priority_2") { context, name, value } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertArrayHasKey('data', $content);
-                    $this->assertArrayHasKey('Config', $content['data']);
-                    $this->assertCount(1, $content['data']['Config']);
-                    $config = $content['data']['Config'][0];
-                    $this->assertEquals('core', $config['context']);
-                    $this->assertEquals('priority_2', $config['name']);
-                    $this->assertEquals('#ffe0e0', $config['value']);
+                ->data('Config', function ($config) {
+                    $this->assertCount(1, $config);
+                    $this->assertEquals('core', $config[0]['context']);
+                    $this->assertEquals('priority_2', $config[0]['name']);
+                    $this->assertEquals('#ffe0e0', $config[0]['value']);
                 });
         });
 
         // Cannot get an undisclosable config value using GraphQL
-        $request = new Request('POST', '/GraphQL', [], 'query { Config(filter: "context==core;name==smtp_passwd") { context, name, value } }');
-        $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->call('query { Config(filter: "context==core;name==smtp_passwd") { context, name, value } }', function ($call) {
             $call->response
                 ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertArrayHasKey('data', $content);
-                    $this->assertArrayHasKey('Config', $content['data']);
-                    $this->assertEmpty($content['data']['Config']);
+                ->data('Config', function ($config) {
+                    $this->assertEmpty($config);
                 });
         });
 
@@ -438,7 +413,6 @@ class SetupControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Setup/Config');
         $request->setParameter('filter', 'name==priority_2');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -454,7 +428,6 @@ class SetupControllerTest extends HLAPITestCase
         $request = new Request('GET', '/Setup/Config');
         $request->setParameter('filter', 'name==smtp_passwd');
         $this->api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -469,26 +442,19 @@ class SetupControllerTest extends HLAPITestCase
 
         $v2_api = $this->api->withVersion('2.0.0');
         $v2_api->call(new Request('GET', '/Setup/Config/core/test'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
         $v2_api->call(new Request('PATCH', '/Setup/Config/core/test'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
         $v2_api->call(new Request('DELETE', '/Setup/Config/core/test'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
 
-        $request = new Request('POST', '/GraphQL', [], 'query { Config(filter: "context==core;name==test") { context, name, value } }');
-        $v2_api->call($request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
+        $this->graphql->withVersion('2.0.0')->call('query { Config(filter: "context==core;name==test") { context, name, value } }', function ($call) {
             $call->response
-                ->isOK()
-                ->jsonContent(function ($content) {
-                    $this->assertArrayHasKey('errors', $content);
-                });
+                ->isCompletelyError()
+                ->hasErrorWithMessage('Cannot query field "Config" on type "Query".');
         });
     }
 
@@ -517,7 +483,6 @@ class SetupControllerTest extends HLAPITestCase
         $queued_webhook = $this->createQueuedWebhook();
 
         $this->api->call(new Request('GET', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) use ($queued_webhook) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($queued_webhook) {
@@ -528,12 +493,10 @@ class SetupControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('DELETE', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) use ($queued_webhook) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($queued_webhook) {
@@ -544,12 +507,10 @@ class SetupControllerTest extends HLAPITestCase
         $force_delete_request = new Request('DELETE', '/Setup/QueuedWebhook/' . $queued_webhook->getID());
         $force_delete_request->setParameter('force', true);
         $this->api->call($force_delete_request, function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isOK();
         });
 
         $this->api->call(new Request('GET', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -568,7 +529,6 @@ class SetupControllerTest extends HLAPITestCase
 
         $this->login();
         $this->api->call(new Request('GET', '/Setup/NotImportedEmail'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -588,7 +548,6 @@ class SetupControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('GET', "/Setup/NotImportedEmail/{$not_imported_id}"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($email) {
@@ -600,12 +559,9 @@ class SetupControllerTest extends HLAPITestCase
         });
 
         $this->api->call(new Request('DELETE', "/Setup/NotImportedEmail/{$not_imported_id}"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
-            $call->response
-                ->isOK();
+            $call->response->isOK();
         });
         $this->api->call(new Request('GET', "/Setup/NotImportedEmail/{$not_imported_id}"), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isNotFoundError();
         });
     }
@@ -619,14 +575,12 @@ class SetupControllerTest extends HLAPITestCase
         $_SESSION['glpiactiveprofile'][QueuedWebhook::$rightname] = ALLSTANDARDRIGHT & ~READ;
 
         $this->api->call(new Request('GET', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
 
         $_SESSION['glpiactiveprofile'][QueuedWebhook::$rightname] = ALLSTANDARDRIGHT & ~UPDATE;
 
         $this->api->call(new Request('DELETE', '/Setup/QueuedWebhook/' . $queued_webhook->getID()), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response->isAccessDenied();
         });
     }

--- a/tests/functional/Glpi/Api/HL/Controller/ToolControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ToolControllerTest.php
@@ -44,7 +44,6 @@ class ToolControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Tools'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -74,7 +73,6 @@ class ToolControllerTest extends HLAPITestCase
             ],
         ];
         $this->api->call(new Request('GET', '/Tools'), function ($call) use ($dataset) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) use ($dataset) {
@@ -99,7 +97,6 @@ class ToolControllerTest extends HLAPITestCase
     {
         $this->login();
         $this->api->call(new Request('GET', '/Tools'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -123,7 +120,6 @@ class ToolControllerTest extends HLAPITestCase
         $this->api->getRouter()->registerAuthMiddleware(new InternalAuthMiddleware());
 
         $this->api->call(new Request('GET', '/Tools'), function ($call) {
-            /** @var \HLAPICallAsserter $call */
             $call->response
                 ->isOK()
                 ->jsonContent(function ($content) {
@@ -140,7 +136,6 @@ class ToolControllerTest extends HLAPITestCase
                         $new_location = null;
                         $new_items_id = null;
                         $this->api->call($create_request, function ($call) use (&$new_location, &$new_items_id) {
-                            /** @var \HLAPICallAsserter $call */
                             $call->response
                                 ->isOK()
                                 ->headers(function ($headers) use (&$new_location) {

--- a/tests/src/HLAPITestCase.php
+++ b/tests/src/HLAPITestCase.php
@@ -53,6 +53,7 @@ use Session;
 
 /**
  * @property HLAPIHelper $api
+ * @property GraphQLHelper $graphql
  */
 class HLAPITestCase extends DbTestCase
 {
@@ -155,6 +156,8 @@ class HLAPITestCase extends DbTestCase
     {
         if ($name === 'api') {
             return new HLAPIHelper(Router::getInstance(), $this);
+        } elseif ($name === 'graphql') {
+            return new GraphQLHelper(Router::getInstance(), $this);
         }
     }
 }
@@ -1206,5 +1209,224 @@ final class HLAPIRouteAsserter
     public function get(): RoutePath
     {
         return $this->routePath;
+    }
+}
+
+// @codingStandardsIgnoreStart
+final class GraphQLHelper
+{
+    private Router $router;
+    private HLAPITestCase $test;
+    private string $api_version;
+
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * @param Router $router
+     * @param HLAPITestCase $test
+     * @param string|null $api_version The API version to use. Cannot be specified or overridden by the request URL. Defaults to the current API version.
+     */
+    public function __construct(Router $router, HLAPITestCase $test, ?string $api_version = null)
+    {
+        $this->router = $router;
+        $this->test = $test;
+        $this->api_version = $api_version ?? $router::API_VERSION;
+    }
+
+    public function withVersion(string $api_version): self
+    {
+        return new self($this->router, $this->test, $api_version);
+    }
+
+    public function getRouter(): Router
+    {
+        return $this->router;
+    }
+
+    /**
+     * @param string $query The GraphQL query string to send in the request body.
+     * @param callable(GraphQLCallAsserter): void $fn
+     * @return self
+     */
+    public function call(string $query, callable $fn, bool $auto_auth_header = true): self
+    {
+        $request = new Request('POST', '/GraphQL', [], $query);
+        if ($auto_auth_header && $this->test->getCurrentBearerToken() !== null) {
+            $request = $request->withHeader('Authorization', 'Bearer ' . $this->test->getCurrentBearerToken());
+        }
+        $request = $request->withHeader('GLPI-API-Version', $this->api_version);
+        $response = $this->router->handleRequest($request);
+        if ($response instanceof StreamedResponseWrapper) {
+            $symfony_response = $response->getSymfonyResponse();
+            ob_start();
+            $symfony_response->sendContent();
+            $content = ob_get_clean();
+            $response = new Response($symfony_response->getStatusCode(), $symfony_response->headers->all(), $content);
+        }
+        $fn(new GraphQLCallAsserter($this->test, $this->router, $response));
+        return $this;
+    }
+}
+
+// @codingStandardsIgnoreStart
+/**
+ * @property GraphQLResponseAsserter $response
+ */
+final class GraphQLCallAsserter
+{
+    // @codingStandardsIgnoreEnd
+    public function __construct(
+        public HLAPITestCase $test,
+        private Router $router,
+        private Response $response
+    ) {}
+
+    public function __get(string $name)
+    {
+        return match ($name) {
+            'response' => new GraphQLResponseAsserter($this, $this->response, $this->router->getOriginalRequest()->getHeaderLine('GLPI-API-Version') ?: $this->router::API_VERSION),
+            default => null,
+        };
+    }
+}
+
+// @codingStandardsIgnoreStart
+final class GraphQLResponseAsserter
+{
+    private array $decoded_content;
+
+    // @codingStandardsIgnoreEnd
+    public function __construct(
+        private GraphQLCallAsserter $call_asserter,
+        private Response $response,
+        private string $api_version,
+    ) {
+        $this->decoded_content = json_decode((string) $this->response->getBody(), true);
+    }
+
+    public function status(callable $fn): self
+    {
+        $fn($this->response->getStatusCode());
+        return $this;
+    }
+
+    public function headers(callable $fn): self
+    {
+        $headers = $this->response->getHeaders();
+        $headers = array_map(static function ($header) {
+            if (is_array($header) && count($header) === 1) {
+                return $header[0];
+            }
+            return $header;
+        }, $headers);
+        $fn($headers);
+        return $this;
+    }
+
+    /**
+     * @param string $field
+     * @param callable $fn
+     * @phpstan-param callable(array): void $fn
+     * @return $this
+     */
+    public function data(string $field, callable $fn): self
+    {
+        $this->call_asserter->test->assertArrayHasKey($field, $this->decoded_content['data'], 'GraphQL response does not contain field "' . $field . '"');
+        $fn($this->decoded_content['data'][$field]);
+        return $this;
+    }
+
+    /**
+     * @param callable $fn
+     * @phpstan-param callable(array): void $fn
+     * @return $this
+     */
+    public function extensions(callable $fn): self
+    {
+        $this->call_asserter->test->assertArrayHasKey('extensions', $this->decoded_content, 'GraphQL response does not contain "extensions" property');
+        $fn($this->decoded_content['extensions']);
+        return $this;
+    }
+
+    /**
+     * @param callable $fn
+     * @phpstan-param callable(array<int, array{message: string, locations: array<int, array{line: int, column: int}>, path: string[]}>): void $fn
+     * @return $this
+     */
+    public function errors(callable $fn): self
+    {
+        $fn($this->decoded_content['errors']);
+        return $this;
+    }
+
+    /**
+     * Asserts that the GraphQL response has a 200 status code and does not contain any errors.
+     * @return $this
+     */
+    public function isOK(): self
+    {
+        $this->call_asserter->test->assertEquals(200, $this->response->getStatusCode());
+        $this->call_asserter->test->assertArrayNotHasKey('errors', $this->decoded_content);
+        return $this;
+    }
+
+    /**
+     * Asserts that the GraphQL response has a 200 status code and contains errors, and does not contain any data.
+     * @return $this
+     */
+    public function isCompletelyError(): self
+    {
+        // Even a GraphQL error will return a 200 status. If some other code is returned, a more severe error occured which needs fixed in the code.
+        $this->call_asserter->test->assertEquals(200, $this->response->getStatusCode());
+        $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content);
+        // Even if every part of the query fails, GraphQL will still return a data property. It may or may not contain properties for each requested field, but they should be null.
+        $has_data = false;
+        if (isset($this->decoded_content['data']) && is_array($this->decoded_content['data'])) {
+            foreach ($this->decoded_content['data'] as $value) {
+                if ($value !== null) {
+                    $has_data = true;
+                    break;
+                }
+            }
+        }
+        $this->call_asserter->test->assertFalse($has_data, 'GraphQL response contains data when it should not');
+        return $this;
+    }
+
+    /**
+     * Asserts that the GraphQL response has a 200 status code and contains errors, and contains data.
+     * @return $this
+     */
+    public function isPartialError(): self
+    {
+        // Even a GraphQL error will return a 200 status. If some other code is returned, a more severe error occured which needs fixed in the code.
+        $this->call_asserter->test->assertEquals(200, $this->response->getStatusCode());
+        $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content);
+        // Verify data is returned when there is a partial error
+        $has_data = false;
+        if (isset($this->decoded_content['data']) && is_array($this->decoded_content['data'])) {
+            foreach ($this->decoded_content['data'] as $value) {
+                if ($value !== null) {
+                    $has_data = true;
+                    break;
+                }
+            }
+        }
+        $this->call_asserter->test->assertTrue($has_data, 'GraphQL response does not contain data when it should');
+        return $this;
+    }
+
+    public function hasErrorWithMessage(string $message): self
+    {
+        $this->call_asserter->test->assertArrayHasKey('errors', $this->decoded_content, 'GraphQL response does not contain errors');
+        $found = false;
+        foreach ($this->decoded_content['errors'] as $error) {
+            if (isset($error['message']) && $error['message'] === $message) {
+                $found = true;
+                break;
+            }
+        }
+        $this->call_asserter->test->assertTrue($found, 'GraphQL response does not contain an error with message "' . $message . '"');
+        return $this;
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Only affects test code.

The GraphQL side of the API has been somewhat neglected in the tests in that there aren't many tests. These tests have previously used the HLAPI test helper which focused more on the REST side which doesn't really match the expectations of a GraphQL API. For example, GraphQL queries that have errors are expected to return a 200 status and there is a concept of partial failures.

This PR adds a separate helper for GraphQL.
I also removed the PHPDoc for "HLAPICallAsserter" variables as they were not valid, and were preventing the automatic type detection from working.