### PR TITLE
GraphQL RFC3339 DateTime Type

### DIFF
--- a/src/Glpi/Api/HL/GraphQL/Type/DateTimeType.php
+++ b/src/Glpi/Api/HL/GraphQL/Type/DateTimeType.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL\GraphQL\Type;
+
+use GraphQL\Type\Definition\StringType;
+
+use function Safe\strtotime;
+
+/**
+ * GraphQL type for RFC 3339 date-time strings.
+ */
+class DateTimeType extends StringType
+{
+    public string $name = 'RFC3339DateTime';
+
+    private static ?DateTimeType $instance = null;
+
+    public function serialize($value): string
+    {
+        $value = parent::serialize($value);
+        return date(DATE_RFC3339, strtotime($value));
+    }
+
+    public static function dateTime(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new DateTimeType();
+        }
+        return self::$instance;
+    }
+}

--- a/src/Glpi/Api/HL/GraphQL/Types.php
+++ b/src/Glpi/Api/HL/GraphQL/Types.php
@@ -35,12 +35,11 @@
 namespace Glpi\Api\HL\GraphQL;
 
 use Glpi\Api\HL\Doc as Doc;
+use Glpi\Api\HL\GraphQL\Type\DateTimeType;
 use Glpi\Api\HL\OpenAPIGenerator;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
-
-use function Safe\strtotime;
 
 class Types
 {
@@ -91,13 +90,14 @@ class Types
             Doc\Schema::TYPE_BOOLEAN => Type::boolean(),
             default => null,
         };
+        if (
+            $graphql_type === Type::string()
+            && isset($property['format'])
+            && $property['format'] === Doc\Schema::FORMAT_STRING_DATE_TIME
+        ) {
+            $graphql_type = DateTimeType::dateTime();
+        }
         if ($graphql_type !== null) {
-            if (($property['format'] ?? $property['type']) === Doc\Schema::FORMAT_STRING_DATE_TIME) {
-                return [
-                    'type' => $graphql_type,
-                    'resolve' => static fn($value) => isset($value[$name]) ? date(DATE_RFC3339, strtotime($value[$name])) : null,
-                ];
-            }
             return ['type' => $graphql_type];
         }
 

--- a/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/GraphQLControllerTest.php
@@ -464,4 +464,18 @@ class GraphQLControllerTest extends HLAPITestCase
                 });
         });
     }
+
+    public function testRFC3339DateTimeFormat(): void
+    {
+        $this->login();
+
+        $this->graphql->call('query { Ticket(limit: 1) { date } }', function ($call) {
+            $call->response
+                ->isOK()
+                ->data('Ticket', function ($tickets) {
+                    $ticket = $tickets[0];
+                    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/', $ticket['date']);
+                });
+        });
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Adds custom scalar type for DateTime strings to handle the conversion of datetime strings to the expected format instead of using a hard-coded field resolver. This may cause issues in the future because this field resolver was causing the fields to not be processed by the default/type resolver once fetched and added to the result.