### PR TITLE
Fix annoying tickets scroll

### DIFF
--- a/css/includes/components/itilobject/_layout.scss
+++ b/css/includes/components/itilobject/_layout.scss
@@ -41,7 +41,7 @@
     }
 
     @include media-breakpoint-up(lg) {
-        height: calc(100vh - 187px);
+        height: calc(100vh - 197px);
 
         .itil-left-side,
         .itil-right-side {


### PR DESCRIPTION
There is an annoying scrollbar that does nothing useful, which happen because the itil layout container is 10px too big:

<img width="1734" height="858" alt="scroll" src="https://github.com/user-attachments/assets/3e7f5434-6cdc-45f7-9093-12be91c11262" />

This has been annoying me for many years so I finally decided to fix it.