### PR TITLE
fix(planning): show availability warning when creating an external event

### DIFF
--- a/front/planningexternalevent.form.php
+++ b/front/planningexternalevent.form.php
@@ -49,11 +49,13 @@ if (isset($_POST["add"])) {
     $extevent->check(-1, CREATE, $_POST);
 
     if ($newID = $extevent->add($_POST)) {
-        if ($_SESSION['glpibackcreated']) {
+        if (!Toolbox::isAjax() && $_SESSION['glpibackcreated']) {
             Html::redirect($extevent->getLinkURL());
         }
     }
-    Html::back();
+    if (!Toolbox::isAjax()) {
+        Html::back();
+    }
 } elseif (isset($_POST["delete"])) {
     $extevent->check($_POST["id"], DELETE);
     $extevent->delete($_POST);
@@ -82,7 +84,9 @@ if (isset($_POST["add"])) {
 } elseif (isset($_POST["update"])) {
     $extevent->check($_POST["id"], UPDATE);
     $extevent->update($_POST);
-    Html::back();
+    if (!Toolbox::isAjax()) {
+        Html::back();
+    }
 } else {
     $menus = ["helpdesk", "planning", "PlanningExternalEvent"];
     PlanningExternalEvent::displayFullPageForItem($_GET["id"], $menus);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When creating or editing a planning external event through the planning modal, the form is submitted via AJAX (Html::ajaxForm). Its target, front/planningexternalevent.form.php, ended the add/update handling with Html::back(), which issues a 302 redirect. The XHR transparently follows that redirect to a full page whose rendering pulls (and clears) the session messages. The "user is busy at the selected timeframe" warning added by Planning::checkAlreadyPlanned() was therefore consumed before the JS callback (displayAjaxMessageAfterRedirect) could display it.

As a result the warning only showed up when moving an event (drag & drop, which goes through Planning::updateEventTimes and returns without a redirect), not when creating one.

Skip the redirect for AJAX submissions so the messages stay in session and can be displayed by the modal callback.

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


