### PR TITLE
fix(i18n): add tinymce language code mapping for mismatched locale codes

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -3531,7 +3531,7 @@ JS;
                 'zh_CN'  => 'zh-Hans',
                 'zh_TW'  => 'zh-Hant',
                 'zh_HK'  => 'zh_HK',
-                'is_IS'  => 'is_IS'
+                'is_IS'  => 'is_IS',
             ];
             if (isset($tinymce_lang_map[$_SESSION['glpilanguage']])) {
                 $language = $tinymce_lang_map[$_SESSION['glpilanguage']];

--- a/src/Html.php
+++ b/src/Html.php
@@ -3515,7 +3515,29 @@ JS;
 
         $language = $_SESSION['glpilanguage'];
         if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs6/$language.js")) {
-            $language = $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2];
+            // Some GLPI language codes don't match tinymce-i18n file names.
+            // Use a dedicated mapping to find the correct tinymce language file.
+            $tinymce_lang_map = [
+                'fr_FR'  => 'fr_FR',
+                'fr_CA'  => 'fr_FR',
+                'fr_BE'  => 'fr_FR',
+                'he_IL'  => 'he_IL',
+                'hi_IN'  => 'hi',
+                'nb_NO'  => 'nb_NO',
+                'nn_NO'  => 'nb_NO',
+                'pt_BR'  => 'pt_BR',
+                'ro_RO'  => 'ro',
+                'uk_UA'  => 'uk',
+                'zh_CN'  => 'zh-Hans',
+                'zh_TW'  => 'zh-Hant',
+                'zh_HK'  => 'zh_HK',
+                'is_IS'  => 'is_IS'
+            ];
+            if (isset($tinymce_lang_map[$_SESSION['glpilanguage']])) {
+                $language = $tinymce_lang_map[$_SESSION['glpilanguage']];
+            } else {
+                $language = $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2];
+            }
             if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs6/$language.js")) {
                 $language = "en_GB";
             }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #24774
- Here is a brief description of what this PR does

Several GLPI locale codes (zh_CN, zh_TW, pt_BR, he_IL, nb_NO, nn_NO,
hi_IN, bn_BD, km_KH, is_IS, ro_RO, uk_UA) don't match the file names
used by tinymce-i18n. Add an explicit mapping to resolve the correct
tinymce language file before falling back to the generic locale lookup.

## Screenshots (if appropriate):

before
<img width="663" height="183" alt="Image" src="https://github.com/user-attachments/assets/cd4ad3a5-f1e9-40c8-9c6b-64e10fdd3d87" />

after
<img width="859" height="223" alt="Image" src="https://github.com/user-attachments/assets/e28f0105-2242-4932-a158-a0bc04d99558" />