### PR TITLE
Fix password initialization form in case forgot password is disabled

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -5478,6 +5478,7 @@ HTML;
     {
         TemplateRenderer::getInstance()->display('forgotpassword.html.twig', [
             'title'    => __('Password Initialization'),
+            'type'     => 'init',
             'token'    => $token,
             'token_ok' => User::getUserByForgottenPasswordToken($token) !== null,
         ]);
@@ -5505,6 +5506,7 @@ HTML;
     {
         TemplateRenderer::getInstance()->display('forgotpassword.html.twig', [
             'title' => __('Password initialization'),
+            'type'  => 'init',
         ]);
     }
 

--- a/templates/forgotpassword.html.twig
+++ b/templates/forgotpassword.html.twig
@@ -30,10 +30,10 @@
  # ---------------------------------------------------------------------
  #}
 
-{% set target = path('front/lostpassword.php') %}
+{% set type = type|default('forget') %}
+{% set target = type == 'forget' ? path('front/lostpassword.php') : path('front/initpassword.php') %}
 {% set title = title|default(__('Forgotten password?')) %}
 {% set card_md_width = true %}
-{% set type = 'forget' %}
 
 {% extends 'layout/page_card_notlogged.html.twig' %}
 

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -100,7 +100,7 @@
 
             {% set save_button = '<i class="ti ti-device-floppy"></i><span>' ~ __('Save new password') ~ '<span>' %}
 
-        {% elseif type == 'forget' %}
+        {% elseif type == 'forget' or type == 'init' %}
             <p class="text-muted mb-4">
                 {{ __('Please enter your email address. An email will be sent to you and you will be able to choose a new password.') }}
             </p>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Password initialization does not work in case Forgot password notification is disabled.
This PR fixes this case and corrects redirect to front/initpassword.php form.