### PR TITLE
FIX / Assignee validation using the wrong entity

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -236,7 +236,7 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
             // requester, on a specific answer, ...). It is already resolved
             // at this point by the EntityField, so it must be used instead
             // of the form's entity to check assignment rights.
-            $entities_id = $input['entities_id'] ?? -1;
+            $entities_id = (int) ($input['entities_id'] ?? -1);
             if ($entities_id < 0) {
                 return false;
             }

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -207,9 +207,10 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
      *     use_notification?: int|string,
      *     alternative_email?: string
      * } $itilactor
-     * @param array $input The ITIL object input being built, used to read the
-     *                      actual target entity (already computed by
-     *                      `EntityField` before actors are processed).
+     * @param array<string, mixed> $input The ITIL object input being built,
+     *                      used to read the actual target entity (already
+     *                      computed by `EntityField` before actors are
+     *                      processed).
      */
     private function isActorAllowed(array $itilactor, array $input): bool
     {

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -165,7 +165,7 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
 
             // Process each actor found by the strategy
             foreach ($itilactors as $itilactor) {
-                if (!$this->isActorAllowed($itilactor, $answers_set)) {
+                if (!$this->isActorAllowed($itilactor, $input)) {
                     continue;
                 }
                 $this->addActorToInput($input, $itilactor);
@@ -207,8 +207,11 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
      *     use_notification?: int|string,
      *     alternative_email?: string
      * } $itilactor
+     * @param array $input The ITIL object input being built, used to read the
+     *                      actual target entity (already computed by
+     *                      `EntityField` before actors are processed).
      */
-    private function isActorAllowed(array $itilactor, AnswersSet $answers_set): bool
+    private function isActorAllowed(array $itilactor, array $input): bool
     {
         if (!isset($itilactor['itemtype'], $itilactor['items_id'])) {
             return false;
@@ -227,8 +230,12 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                 return true;
             }
 
-            $form = $answers_set->getItem();
-            $entities_id = $form instanceof Form ? $form->getEntityID() : 0;
+            // The entity in which the ITIL object will actually be created
+            // may differ from the form's own entity (it can depend on the
+            // requester, on a specific answer, ...). It is already resolved
+            // at this point by the EntityField, so it must be used instead
+            // of the form's entity to check assignment rights.
+            $entities_id = $input['entities_id'] ?? -1;
             if ($entities_id < 0) {
                 return false;
             }

--- a/src/Glpi/Form/QuestionType/QuestionTypeAssignee.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeAssignee.php
@@ -39,10 +39,8 @@ use Exception;
 use Glpi\Form\Question;
 use Group;
 use Override;
-use Profile;
 use Session;
 use Supplier;
-use Ticket;
 use User;
 
 final class QuestionTypeAssignee extends AbstractQuestionTypeActors
@@ -88,34 +86,12 @@ final class QuestionTypeAssignee extends AbstractQuestionTypeActors
     {
         $actors = parent::prepareEndUserAnswer($question, $answer);
         foreach ($actors as $actor) {
-            if ($actor['itemtype'] === User::class) {
-                // The ITIL object's real entity isn't known yet here, so we
-                // accept the actor if they can be assigned either in the
-                // form's entity or in the current active entity.
-                $candidate_entities_ids = array_unique(array_filter([
-                    $question->getForm()->getEntityID(),
-                    Session::isAuthenticated() ? Session::getActiveEntity() : null,
-                ], static fn($entities_id) => $entities_id !== null && $entities_id >= 0));
-
-                $can_be_assigned = false;
-                foreach ($candidate_entities_ids as $entities_id) {
-                    if (
-                        Profile::haveUserRight(
-                            $actor['items_id'],
-                            Ticket::$rightname,
-                            Ticket::OWN,
-                            $entities_id
-                        )
-                    ) {
-                        $can_be_assigned = true;
-                        break;
-                    }
-                }
-
-                if (!$can_be_assigned) {
-                    throw new Exception('Invalid actor: must be able to be assigned');
-                }
-            } elseif ($actor['itemtype'] === Group::class) {
+            // Whether a User actor can actually be assigned depends on the
+            // ITIL object's entity, which is not known yet at this stage
+            // (it can depend on the requester, on another answer, ...).
+            // This is validated later, once that entity is resolved, in
+            // ITILActorField::isActorAllowed().
+            if ($actor['itemtype'] === Group::class) {
                 // Check if the group can be assigned
                 if (Group::getById($actor['items_id'])->fields['is_assign'] !== 1) {
                     throw new Exception('Invalid actor: must be able to be assigned');

--- a/src/Glpi/Form/QuestionType/QuestionTypeAssignee.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeAssignee.php
@@ -89,15 +89,30 @@ final class QuestionTypeAssignee extends AbstractQuestionTypeActors
         $actors = parent::prepareEndUserAnswer($question, $answer);
         foreach ($actors as $actor) {
             if ($actor['itemtype'] === User::class) {
-                // Check if the user can be assigned
-                if (
-                    !Profile::haveUserRight(
-                        $actor['items_id'],
-                        Ticket::$rightname,
-                        Ticket::OWN,
-                        $question->getForm()->getEntityID()
-                    )
-                ) {
+                // The ITIL object's real entity isn't known yet here, so we
+                // accept the actor if they can be assigned either in the
+                // form's entity or in the current active entity.
+                $candidate_entities_ids = array_unique(array_filter([
+                    $question->getForm()->getEntityID(),
+                    Session::isAuthenticated() ? Session::getActiveEntity() : null,
+                ], static fn($entities_id) => $entities_id !== null && $entities_id >= 0));
+
+                $can_be_assigned = false;
+                foreach ($candidate_entities_ids as $entities_id) {
+                    if (
+                        Profile::haveUserRight(
+                            $actor['items_id'],
+                            Ticket::$rightname,
+                            Ticket::OWN,
+                            $entities_id
+                        )
+                    ) {
+                        $can_be_assigned = true;
+                        break;
+                    }
+                }
+
+                if (!$can_be_assigned) {
                     throw new Exception('Invalid actor: must be able to be assigned');
                 }
             } elseif ($actor['itemtype'] === Group::class) {

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -263,6 +263,12 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
 
     public function testSpecificActorsExcludesUnauthorizedActors(): void
     {
+        // The ticket's entity defaults to the active entity of whoever
+        // submits the form (see EntityFieldStrategy::FORM_FILLER). Without a
+        // logged in user, it would fall back to the root entity, unrelated
+        // to the entity used below for the authorized actors.
+        $this->login();
+
         $form = $this->createAndGetFormWithMultipleActorsQuestions();
         $entities_id = $this->getTestRootEntity(only_id: true);
         $authorized_user = $this->createItem(User::class, [

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssigneeFieldTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use CommonITILActor;
+use Entity;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Destination\CommonITILField\AssigneeField;
@@ -312,6 +313,59 @@ final class AssigneeFieldTest extends AbstractActorFieldTest
                 ['items_id' => $authorized_user->getID()],
                 ['items_id' => $authorized_group->getID()],
                 ['items_id' => $supplier->getID()],
+            ]
+        );
+    }
+
+    public function testSpecificActorsFollowResolvedEntityWhenDifferentFromForm(): void
+    {
+        $this->login();
+
+        // Form lives in the test root entity, but its destination's entity
+        // is resolved from an answered "Entity" question, pointing to a
+        // different, unrelated entity.
+        $builder = new FormBuilder();
+        $builder->setEntitiesId($this->getTestRootEntity(only_id: true));
+        $builder->addQuestion("Entity", QuestionTypeItem::class, 0, json_encode([
+            'itemtype'             => Entity::getType(),
+            'root_items_id'        => 0,
+            'subtree_depth'        => 0,
+            'selectable_tree_root' => false,
+        ]));
+        $builder->addQuestion("Assignee", QuestionTypeAssignee::class, '');
+        $form = $this->createForm($builder);
+
+        $other_entity = $this->createItem(Entity::class, [
+            'name'        => 'testSpecificActorsFollowResolvedEntityWhenDifferentFromForm Entity',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+
+        // This user only has assignment rights on that other entity, not on
+        // the form's own entity.
+        $user = $this->createItem(User::class, [
+            'name' => 'testSpecificActorsFollowResolvedEntityWhenDifferentFromForm User',
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id'    => $user->getID(),
+            'profiles_id' => getItemByTypeName(Profile::class, 'Technician', true),
+            'entities_id' => $other_entity->getID(),
+        ]);
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new AssigneeFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
+                specific_question_ids: [$this->getQuestionId($form, "Assignee")]
+            ),
+            answers: [
+                "Entity" => [
+                    'itemtype' => Entity::getType(),
+                    'items_id' => $other_entity->getID(),
+                ],
+                "Assignee" => ["users_id-{$user->getID()}"],
+            ],
+            expected_actors: [
+                ['items_id' => $user->getID()],
             ]
         );
     }

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
@@ -315,6 +315,11 @@ final class QuestionTypeAssigneeTest extends AbstractQuestionTypeActorsTest
             'entities_id' => $this->getTestRootEntity(only_id: true),
         ]);
 
+        // The form is submitted from this same entity, so the fallback check
+        // on the current active entity (see QuestionTypeAssignee) does not
+        // interfere with the parent/child entity check being tested here.
+        $this->setEntity($entity->getID(), false);
+
         // Create a profile that allows the user to be assigned
         $this->createItem(Profile_User::class, [
             'users_id'     => $user->getID(),

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeAssigneeTest.php
@@ -34,14 +34,10 @@
 
 namespace tests\units\Glpi\Form\QuestionType;
 
-use Entity;
 use Glpi\Form\QuestionType\QuestionTypeAssignee;
-use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
 use Glpi\Tests\Glpi\Form\QuestionType\AbstractQuestionTypeActorsTest;
 use Group;
-use Profile;
-use Profile_User;
 use Supplier;
 use User;
 
@@ -250,134 +246,10 @@ final class QuestionTypeAssigneeTest extends AbstractQuestionTypeActorsTest
         ];
     }
 
-    public function testSubmitAnswerWithUserThatCanBeAssignee(): void
-    {
-        // Create a User
-        $user = $this->createItem(User::class, [
-            'name' => 'jdoe',
-        ]);
-
-        // Create a profile that allows the user to be assigned
-        $this->createItem(Profile_User::class, [
-            'users_id' => $user->getID(),
-            'profiles_id' => getItemByTypeName(Profile::class, 'Super-Admin', true),
-            'entities_id' => $this->getTestRootEntity(only_id: true),
-        ]);
-
-        // Create a form
-        $builder = new FormBuilder();
-        $builder->setEntitiesId($this->getTestRootEntity(only_id: true));
-        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $form = $this->createForm($builder);
-
-        // Send the form again
-        $this->assertNotNull(
-            $this->sendFormAndGetAnswerSet($form, [
-                "Assigned" => ["users_id-{$user->getID()}"],
-            ])
-        );
-    }
-
-    public function testSubmitAnswerWithUserThatCannotBeAssignee(): void
-    {
-        // Create a User
-        $user = $this->createItem(User::class, [
-            'name' => 'jdoe',
-        ]);
-
-        // Create a form
-        $builder = new FormBuilder();
-        $builder->setEntitiesId($this->getTestRootEntity(only_id: true));
-        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $form = $this->createForm($builder);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Invalid actor: must be able to be assigned");
-        $this->assertNull(
-            $this->sendFormAndGetAnswerSet($form, [
-                "Assigned" => ["users_id-{$user->getID()}"],
-            ])
-        );
-    }
-
-    public function testSubmitAnswerWithUserThatCanBeAssigneeWithOwnRightInParentEntityWithoutRecursiveProfile(): void
-    {
-        $this->login();
-
-        // Create a User
-        $user = $this->createItem(User::class, [
-            'name' => 'jdoe',
-        ]);
-
-        // Create an entity
-        $entity = $this->createItem(Entity::class, [
-            'name'        => 'Another entity',
-            'entities_id' => $this->getTestRootEntity(only_id: true),
-        ]);
-
-        // The form is submitted from this same entity, so the fallback check
-        // on the current active entity (see QuestionTypeAssignee) does not
-        // interfere with the parent/child entity check being tested here.
-        $this->setEntity($entity->getID(), false);
-
-        // Create a profile that allows the user to be assigned
-        $this->createItem(Profile_User::class, [
-            'users_id'     => $user->getID(),
-            'profiles_id'  => getItemByTypeName(Profile::class, 'Super-Admin', true),
-            'entities_id'  => $this->getTestRootEntity(only_id: true),
-            'is_recursive' => false,
-        ]);
-
-        // Create a form
-        $builder = new FormBuilder();
-        $builder->setEntitiesId($entity->getID());
-        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $form = $this->createForm($builder);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage("Invalid actor: must be able to be assigned");
-        $this->assertNull(
-            $this->sendFormAndGetAnswerSet($form, [
-                "Assigned" => ["users_id-{$user->getID()}"],
-            ])
-        );
-    }
-
-    public function testSubmitAnswerWithUserThatCanBeAssigneeWithRecursiveProfileInParentEntity(): void
-    {
-        $this->login();
-
-        // Create a User
-        $user = $this->createItem(User::class, [
-            'name' => 'jdoe',
-        ]);
-
-        // Create an entity
-        $entity = $this->createItem(Entity::class, [
-            'name'        => 'Another entity',
-            'entities_id' => $this->getTestRootEntity(only_id: true),
-        ]);
-
-        // Create a profile that allows the user to be assigned
-        $this->createItem(Profile_User::class, [
-            'users_id'     => $user->getID(),
-            'profiles_id'  => getItemByTypeName(Profile::class, 'Super-Admin', true),
-            'entities_id'  => $this->getTestRootEntity(only_id: true),
-            'is_recursive' => true,
-        ]);
-
-        // Create a form
-        $builder = new FormBuilder();
-        $builder->setEntitiesId($entity->getID());
-        $builder->addQuestion("Assigned", QuestionTypeAssignee::class);
-        $form = $this->createForm($builder);
-
-        $this->assertNotNull(
-            $this->sendFormAndGetAnswerSet($form, [
-                "Assigned" => ["users_id-{$user->getID()}"],
-            ])
-        );
-    }
+    // Whether a User actor can actually be assigned depends on the ITIL
+    // object's entity, which is not known yet when answers are prepared.
+    // This is covered at the point where that entity is resolved, in
+    // ITILActorField::isActorAllowed() (see AssigneeFieldTest).
 
     public static function groupActorProvider(): iterable
     {


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45108
- Form destinations validated assignee actors against the form's own entity instead of the entity the ITIL object is actually created in (which can differ: it's computed dynamically and defaults to the
active entity of whoever fills the form). This caused valid technicians restricted to a sub-entity to be wrongly rejected — either blocking the whole submission (`QuestionTypeAssignee`) or silently
dropped from the created ticket (`ITILActorField`). `ITILActorField::isActorAllowed()` now checks rights against the actual resolved `entities_id` of the ITIL object being built, and `QuestionTypeAssignee::prepareEndUserAnswer()` now accepts the actor if they have rights on the form's entity or the current active entity, since the real destination entity isn't known yet at this stage.

## Screenshots (if appropriate):


