### PR TITLE
fix(i18n): upgrade tinymce-i18n language files from v6 to v7

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -176,7 +176,7 @@ const filesToCopy = [
     },
     {
         package: 'tinymce-i18n',
-        from: 'langs6/*.js',
+        from: 'langs7/*.js',
     },
     // SCSS files
     {

--- a/src/Html.php
+++ b/src/Html.php
@@ -3514,7 +3514,7 @@ JS;
         global $CFG_GLPI, $DB;
 
         $language = $_SESSION['glpilanguage'];
-        if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs6/$language.js")) {
+        if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs7/$language.js")) {
             // Some GLPI language codes don't match tinymce-i18n file names.
             // Use a dedicated mapping to find the correct tinymce language file.
             $tinymce_lang_map = [
@@ -3522,14 +3522,14 @@ JS;
                 'fr_CA'  => 'fr_FR',
                 'fr_BE'  => 'fr_FR',
                 'he_IL'  => 'he_IL',
-                'hi_IN'  => 'hi',
                 'nb_NO'  => 'nb_NO',
                 'nn_NO'  => 'nb_NO',
                 'pt_BR'  => 'pt_BR',
+                'pt_PT'  => 'pt_PT',
                 'ro_RO'  => 'ro',
                 'uk_UA'  => 'uk',
-                'zh_CN'  => 'zh-Hans',
-                'zh_TW'  => 'zh-Hant',
+                'zh_CN'  => 'zh_CN',
+                'zh_TW'  => 'zh_TW',
                 'zh_HK'  => 'zh_HK',
                 'is_IS'  => 'is_IS',
             ];
@@ -3538,11 +3538,11 @@ JS;
             } else {
                 $language = $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2];
             }
-            if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs6/$language.js")) {
+            if (!file_exists(GLPI_ROOT . "/public/lib/tinymce-i18n/langs7/$language.js")) {
                 $language = "en_GB";
             }
         }
-        $language_url = $CFG_GLPI['root_doc'] . '/lib/tinymce-i18n/langs6/' . $language . '.js';
+        $language_url = $CFG_GLPI['root_doc'] . '/lib/tinymce-i18n/langs7/' . $language . '.js';
 
         // Apply all GLPI styles to editor content
         $theme = ThemeManager::getInstance()->getCurrentTheme();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Update webpack config to copy langs7/*.js instead of langs6/*.js
- Update Html.php language file path references from langs6 to langs7
- Update language code mappings for TinyMCE 7:
  - zh_CN: zh-Hans -> zh_CN
  - zh_TW: zh-Hant -> zh_TW
  - Remove hi_IN mapping (no longer needed)
  - Add pt_PT mapping

## Screenshots (if appropriate):


