### PR TITLE
Update current KB article name in the sidebar when updated

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -528,6 +528,28 @@ export class GlpiKnowbaseArticleController
     }
 
     /**
+     * Update the article title displayed in the knowledge base aside tree.
+     * The same article can appear both in the favorites section and in the
+     * category tree, so every matching entry is updated.
+     *
+     * @param {string} title
+     */
+    #updateAsideTitle(title)
+    {
+        if (this.#item_id === null) {
+            return;
+        }
+
+        const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
+        const entries = aside.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-title]`
+        );
+        for (const entry of entries) {
+            entry.textContent = title;
+        }
+    }
+
+    /**
      * @param {number} id
      * @param {HTMLInputElement} toggle
      */
@@ -1099,6 +1121,7 @@ export class GlpiKnowbaseArticleController
             this.#original_content = this.#editor.getHTML();
             if (new_title !== null) {
                 this.#original_title = new_title;
+                this.#updateAsideTitle(new_title);
             }
             this.#editor.setEditable(false);
             this.#disableTitleEditing();
@@ -1490,6 +1513,7 @@ export class GlpiKnowbaseArticleController
             if (new_title !== null) {
                 this.#original_title = new_title;
                 this.#base_title = this.#original_title;
+                this.#updateAsideTitle(new_title);
             }
 
             glpi_toast_info(__("Article saved successfully"));

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -68,7 +68,7 @@
             {% if article.illustration %}
                 {{ render_illustration(article.illustration, 20) }}
             {% endif %}
-            {{ article.title }}
+            <span data-glpi-kb-article-title>{{ article.title }}</span>
         </a>
     </li>
 {% endmacro %}

--- a/tests/e2e/specs/Knowbase/Editor/core.spec.ts
+++ b/tests/e2e/specs/Knowbase/Editor/core.spec.ts
@@ -32,8 +32,10 @@
 
 import { expect, test } from "../../../fixtures/glpi_fixture";
 import { KnowbaseItemPage } from "../../../pages/KnowbaseItemPage";
+import { KnowbaseApi } from '../../../utils/KnowbaseApi';
 import { Profiles } from "../../../utils/Profiles";
 import { getWorkerEntityId } from "../../../utils/WorkerEntities";
+import { getUniqueName } from "../../../utils/Random";
 
 test.describe('Knowledge Base Editor - Core', () => {
     test('Can enter edit mode', async ({ page, profile, api }) => {
@@ -172,5 +174,79 @@ test.describe('Knowledge Base Editor - Core', () => {
         await kb.editor.cancel();
         await expect(kb.subject).toHaveText('Title Before Cancel');
         await expect(kb.subject).toHaveAttribute('contenteditable', 'false');
+    });
+
+    test('Renaming an article updates its name in the aside tree', async ({
+        page,
+        profile,
+        api,
+    }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const category_name = getUniqueName(`E2E Category`);
+        const original_name = getUniqueName(`Original article`);
+        const renamed_name  = getUniqueName(`Renamed article`);
+
+        const category_id = await api.createItem('KnowbaseItemCategory', {
+            name: category_name,
+            entities_id: getWorkerEntityId(),
+        });
+        const article_id = await api.createItem('KnowbaseItem', {
+            name: original_name,
+            answer: '<p>Some content</p>',
+            entities_id: getWorkerEntityId(),
+            _categories: [category_id],
+        });
+
+        await kb.goto(article_id);
+
+        // The aside tree shows the original name.
+        await expect(kb.getAsideCategoryArticle(category_name, original_name)).toBeVisible();
+
+        // Rename the article inline.
+        await kb.editor.enterEditMode();
+        await kb.subject.click();
+        await page.keyboard.press('Control+a');
+        await page.keyboard.type(renamed_name);
+        await kb.editor.save();
+
+        await expect(kb.subject).toHaveText(renamed_name);
+
+        // The aside tree reflects the new name without a page reload.
+        await expect(kb.getAsideCategoryArticle(category_name, renamed_name)).toBeVisible();
+        await expect(kb.getAsideCategoryArticle(category_name, original_name)).toBeHidden();
+    });
+
+    test('Renaming a favorited article updates its name in the favorites section', async ({
+        page,
+        profile,
+        api,
+    }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+        const kb_api = new KnowbaseApi(api);
+
+        const original_name = getUniqueName(`Original favorite`);
+        const renamed_name  = getUniqueName(`Renamed favorite`);
+
+        const article_id = await kb_api.createArticle({ name: original_name });
+        await kb_api.addFavorite(article_id);
+
+        await kb.goto(article_id);
+
+        // The favorites section shows the original name.
+        await expect(kb.getFavoriteArticle(original_name)).toBeVisible();
+
+        // Rename the article inline.
+        await kb.editor.enterEditMode();
+        await kb.subject.click();
+        await page.keyboard.press('Control+a');
+        await page.keyboard.type(renamed_name);
+        await kb.editor.save();
+
+        // The favorites entry reflects the new name without a page reload.
+        await expect(kb.getFavoriteArticle(renamed_name)).toBeVisible();
+        await expect(kb.getFavoriteArticle(original_name)).toBeHidden();
     });
 });


### PR DESCRIPTION
The name of an article is displayed at the top of the page but it may also appear in the KB sidebar.
When the user update it, we now make sure to update any references in the sidebar too.