### PR TITLE
Fix: separate validation and visibility conditions badges

### DIFF
--- a/js/modules/Forms/EditorController.js
+++ b/js/modules/Forms/EditorController.js
@@ -311,11 +311,16 @@ export class GlpiFormEditorController
 
         // Handle conditions count changes
         document.addEventListener('conditions_count_changed', (e) => {
+            const is_validation = $(e.detail.container).closest(
+                '[data-glpi-form-editor-validation-dropdown-container]'
+            ).length > 0;
+
             this.#updateConditionsCount(
                 $(e.detail.container).closest(
                     '[data-glpi-form-editor-block],[data-glpi-form-editor-section-details],[data-glpi-form-editor-container]'
                 ),
-                e.detail.conditions_count
+                e.detail.conditions_count,
+                is_validation ? 'validation' : 'visibility',
             );
         });
 
@@ -2984,8 +2989,8 @@ export class GlpiFormEditorController
             .addClass('d-flex');
     }
 
-    #updateConditionsCount(container, value) {
-        container.find('[data-glpi-editor-validation-conditions-count-badge], [data-glpi-editor-visibility-conditions-count-badge]')
+    #updateConditionsCount(container, value, type) {
+        container.find(`[data-glpi-editor-${CSS.escape(type)}-conditions-count-badge]`)
             .html(value);
     }
 

--- a/tests/e2e/specs/Form/validations.spec.ts
+++ b/tests/e2e/specs/Form/validations.spec.ts
@@ -308,3 +308,45 @@ test('Conditions count badge is updated when conditions are added or removed', a
     await form.doCloseValidationConditionEditor(1);
     await expect(form.getValidationConditionsCountBadge(1)).toHaveText('0');
 });
+
+test('Validation conditions count badge is not overwritten by visibility conditions count', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const form = new FormPage(page);
+
+    const form_id = await api.createItem('Glpi\\Form\\Form', {
+        name: `Test validation and visibility badges independence - ${randomUUID()}`,
+        entities_id: getWorkerEntityId(),
+    });
+    await form.goto(form_id);
+
+    await form.addQuestion('My first question');
+    await form.addQuestion('My second question');
+
+    // Configure two validation conditions on the second question
+    await form.doInitValidationConfiguration(1);
+    await form.doSetValidationStrategy('Valid if...');
+    await form.doFillValidationCondition(
+        0, null, 'Match regular expression', '/^I love GLPI$/'
+    );
+    await form.doAddValidationCondition();
+    await form.doFillValidationCondition(
+        1, 'Or', 'Match regular expression', '/^GLPI is great$/'
+    );
+    await form.doCloseValidationConditionEditor(1);
+    await expect(form.getValidationConditionsCountBadge(1)).toHaveText('2');
+
+    // Configure a single visibility condition on the same question
+    await form.doInitVisibilityConditionsDropdown(1);
+    await form.doSetVisibilityStrategy('Visible if...');
+    await form.doFillStringCondition(
+        0, 'And', 'My first question', 'Is equal to', 'GLPI'
+    );
+
+    // The validation badge must keep showing its own count and must not
+    // be overwritten by the visibility conditions count.
+    await expect(form.getValidationConditionsCountBadge(1)).toHaveText('2');
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45149

When a form question had both a validation condition and a visibility condition configured, adding or removing a condition on one of them incorrectly updated the conditions count badge of the other one as well.
Each badge is now updated independently, based on which editor (validation or visibility) actually triggered the change.

## Screenshots (if appropriate):
