### PR TITLE
Add dots menu to KB aside

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -824,6 +824,31 @@
         list-style: none;
     }
 
+    // Article line: title link truncates, kebab menu sits at the end.
+    .article {
+        .article-line > a {
+            // Required so `text-truncate` shrinks below its content in the flex row.
+            min-width: 0;
+        }
+
+        // Kebab menu: revealed on hover/focus (or while its dropdown is open) to
+        // keep the tree uncluttered while staying keyboard reachable.
+        .dropdown {
+            opacity: 0;
+
+            [data-glpi-kb-dots] {
+                font-size: 1.25rem;
+                line-height: 1;
+            }
+        }
+
+        &:hover .dropdown,
+        &:focus-within .dropdown,
+        .dropdown:has([aria-expanded="true"]) {
+            opacity: 1;
+        }
+    }
+
     // Collapsed category: hide children and rotate chevron
     .node[data-glpi-kb-aside-category-collapsed] {
         > ul {
@@ -878,7 +903,9 @@
         padding: 0;
         margin: 0;
 
-        ul {
+        // Exclude the kebab menu's own <ul class="dropdown-menu"> so the tree
+        // connectors and list spacing never bleed into the actions dropdown.
+        ul:not(.dropdown-menu) {
             list-style: none;
             padding: 0 0 0 1.5rem;
             margin: 0;

--- a/css/includes/components/_utils.scss
+++ b/css/includes/components/_utils.scss
@@ -69,6 +69,10 @@
     display: flex;
 }
 
+.fs-08x {
+    font-size: 0.8em !important;
+}
+
 .fs-2x {
     font-size: 2em !important;
 }

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -40,6 +40,7 @@ import { GlpiKnowbaseServiceCatalogPanelController } from "/js/modules/Knowbase/
 import {
     EditorActionType,
     extractParamsFromDataset,
+    syncToggleCheckboxes,
     toggleFavorite,
     toggleField,
     deleteArticle,
@@ -539,10 +540,12 @@ export class GlpiKnowbaseArticleController
     async #toggleFavorite(id, toggle)
     {
         const value = toggle.checked;
+        // Reflect the change on every menu for this article, aside included.
+        syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, value);
         try {
             await toggleFavorite(id, value);
         } catch (e) {
-            toggle.checked = !value;
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, !value);
             throw e;
         }
     }
@@ -555,10 +558,12 @@ export class GlpiKnowbaseArticleController
     async #toggleValue(id, field, toggle)
     {
         const value = toggle.checked;
+        // Reflect the change on every menu for this article, aside included.
+        syncToggleCheckboxes(id, EditorActionType.TOGGLE_VALUE, value, field);
         try {
             await toggleField(id, field, value);
         } catch (e) {
-            toggle.checked = !value;
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_VALUE, !value, field);
             throw e;
         }
     }

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -37,14 +37,13 @@ import { DocumentLinkController } from "/js/modules/Knowbase/DocumentLinkControl
 import { LinkItemFormController } from "/js/modules/Knowbase/LinkItemFormController.js";
 import { GlpiKnowbaseArticleSidePanelController } from "/js/modules/Knowbase/ArticleSidePanelController.js";
 import { GlpiKnowbaseServiceCatalogPanelController } from "/js/modules/Knowbase/ServiceCatalogPanelController.js";
-
-const EditorActionType = Object.freeze({
-    LOAD_SIDE_PANEL: 'LOAD_SIDE_PANEL',
-    TOGGLE_VALUE:    'TOGGLE_VALUE',
-    TOGGLE_FAVORITE: 'TOGGLE_FAVORITE',
-    DELETE_ARTICLE:  'DELETE_ARTICLE',
-    OPEN_MODAL:      'OPEN_MODAL',
-});
+import {
+    EditorActionType,
+    extractParamsFromDataset,
+    toggleFavorite,
+    toggleField,
+    deleteArticle,
+} from "/js/modules/Knowbase/EditorActions.js";
 
 export class GlpiKnowbaseArticleController
 {
@@ -438,7 +437,7 @@ export class GlpiKnowbaseArticleController
         const target = event.target;
 
         const type = element.dataset.glpiKbAction;
-        const params = this.#extractParamsFromDataset(element.dataset);
+        const params = extractParamsFromDataset(element.dataset);
 
         switch (type) {
             case EditorActionType.LOAD_SIDE_PANEL:
@@ -476,22 +475,6 @@ export class GlpiKnowbaseArticleController
                 this.#openModal(params.id, params.key, params.title, params.icon ?? null);
                 break;
         }
-    }
-
-    /** @param {DOMStringMap} dataset */
-    #extractParamsFromDataset(dataset)
-    {
-        const params = {};
-        const prefix = 'glpiKbActionParam';
-
-        for (const [key, value] of Object.entries(dataset)) {
-            if (key.startsWith(prefix)) {
-                const param_name = key.slice(prefix.length).toLowerCase();
-                params[param_name] = value;
-            }
-        }
-
-        return params;
     }
 
     /**
@@ -557,7 +540,7 @@ export class GlpiKnowbaseArticleController
     {
         const value = toggle.checked;
         try {
-            await post(`Knowbase/${id}/ToggleFavorite`, { value: value });
+            await toggleFavorite(id, value);
         } catch (e) {
             toggle.checked = !value;
             throw e;
@@ -573,10 +556,7 @@ export class GlpiKnowbaseArticleController
     {
         const value = toggle.checked;
         try {
-            await post(`Knowbase/${id}/ToggleField`, {
-                field: field,
-                value: value,
-            });
+            await toggleField(id, field, value);
         } catch (e) {
             toggle.checked = !value;
             throw e;
@@ -597,7 +577,7 @@ export class GlpiKnowbaseArticleController
             return;
         }
 
-        const response = await post(`Knowbase/KnowbaseItem/${id}/Delete`, {});
+        const response = await deleteArticle(id);
         const body = await response.json();
         window.location.href = body.redirect;
     }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -30,9 +30,17 @@
  * ---------------------------------------------------------------------
  */
 
-/* global _ */
+/* global _, glpi_confirm_danger, glpi_toast_error */
 
 import { get } from "/js/modules/Ajax.js";
+import {
+    EditorActionType,
+    extractParamsFromDataset,
+    syncToggleCheckboxes,
+    toggleFavorite,
+    toggleField,
+    deleteArticle,
+} from "/js/modules/Knowbase/EditorActions.js";
 
 export class GlpiKnowbaseAsideController
 {
@@ -55,6 +63,14 @@ export class GlpiKnowbaseAsideController
     #favorites_originally_hidden = false;
 
     /**
+     * In-flight/resolved dots menu content, keyed by article id. The tree
+     * renders only the dots trigger; the menu items are fetched on demand
+     * (prefetched on hover) so we never build every article's actions up-front.
+     * @type {Map<number, Promise<string>>}
+     */
+    #actions_cache = new Map();
+
+    /**
      * @param {HTMLElement} aside
      */
     constructor(aside)
@@ -62,6 +78,7 @@ export class GlpiKnowbaseAsideController
         this.#aside = aside;
         this.#initCategoryToggle();
         this.#initSearch();
+        this.#initActions();
     }
 
     #initCategoryToggle()
@@ -309,5 +326,315 @@ export class GlpiKnowbaseAsideController
         }
 
         return has_visible;
+    }
+
+    /**
+     * Wire up the per-article kebab menu actions (add to favorites, add to FAQ,
+     * delete). Clicks are delegated so entries added later (e.g. a cloned
+     * favorite) work without re-binding.
+     */
+    #initActions()
+    {
+        this.#aside.addEventListener('click', (e) => {
+            const button = e.target.closest('[data-glpi-kb-action]');
+            if (!button || !this.#aside.contains(button)) {
+                return;
+            }
+
+            e.preventDefault();
+            try {
+                this.#executeAction(e, button);
+            } catch (error) {
+                glpi_toast_error(__("An unexpected error occurred."));
+                throw error;
+            }
+        });
+
+        // Prefetch the menu content as soon as the row is hovered or focused, so
+        // it is ready by the time the user opens the kebab (no visible latency).
+        const prefetch = (e) => {
+            const line = e.target.closest('.article[data-glpi-kb-article-id]');
+            if (line && this.#aside.contains(line)) {
+                this.#populateMenus(parseInt(line.dataset.glpiKbArticleId));
+            }
+        };
+        this.#aside.addEventListener('mouseover', prefetch);
+        this.#aside.addEventListener('focusin', prefetch);
+
+        // Fallback for opens that outran the prefetch (touch, instant clicks,
+        // keyboard): make sure the content is loaded when the menu opens.
+        this.#aside.addEventListener('show.bs.dropdown', (e) => {
+            const line = e.target.closest('.article[data-glpi-kb-article-id]');
+            if (line) {
+                this.#populateMenus(parseInt(line.dataset.glpiKbArticleId));
+            }
+        });
+    }
+
+    /**
+     * Fetch (once) and inject the kebab menu items for an article into every
+     * not-yet-populated menu bearing that id (tree + favorites).
+     *
+     * @param {number} id
+     */
+    async #populateMenus(id)
+    {
+        if (!Number.isInteger(id)) {
+            return;
+        }
+
+        const selector = `[data-glpi-kb-article-id="${id}"] `
+            + `[data-glpi-kb-actions-menu]:not([data-glpi-kb-actions-loaded])`;
+        if (this.#aside.querySelector(selector) === null) {
+            return; // Nothing left to populate for this id.
+        }
+
+        let html;
+        try {
+            html = await this.#loadActions(id);
+        } catch {
+            // Drop the cached rejection so a later hover/open can retry.
+            this.#actions_cache.delete(id);
+            return;
+        }
+
+        for (const menu of this.#aside.querySelectorAll(selector)) {
+            menu.innerHTML = html;
+            menu.setAttribute('data-glpi-kb-actions-loaded', '');
+        }
+    }
+
+    /**
+     * @param {number} id
+     * @returns {Promise<string>} rendered menu items HTML
+     */
+    #loadActions(id)
+    {
+        if (!this.#actions_cache.has(id)) {
+            this.#actions_cache.set(
+                id,
+                get(`Knowbase/${id}/AsideActions`).then((response) => response.text()),
+            );
+        }
+        return this.#actions_cache.get(id);
+    }
+
+    /**
+     * @param {Event} e
+     * @param {HTMLElement} button
+     */
+    #executeAction(e, button)
+    {
+        const type = button.dataset.glpiKbAction;
+        const params = extractParamsFromDataset(button.dataset);
+        const id = parseInt(params.id);
+
+        switch (type) {
+            case EditorActionType.TOGGLE_FAVORITE: {
+                // Keep the dropdown open when toggling.
+                e.stopPropagation();
+                const toggle = button.querySelector('input[type="checkbox"]');
+                if (!toggle) {
+                    break;
+                }
+                if (e.target !== toggle) {
+                    toggle.checked = !toggle.checked;
+                }
+                this.#onToggleFavorite(id, toggle.checked);
+                break;
+            }
+            case EditorActionType.TOGGLE_VALUE: {
+                // Keep the dropdown open when toggling.
+                e.stopPropagation();
+                const toggle = button.querySelector('input[type="checkbox"]');
+                if (!toggle) {
+                    break;
+                }
+                if (e.target !== toggle) {
+                    toggle.checked = !toggle.checked;
+                }
+                this.#onToggleField(id, params.field, toggle.checked);
+                break;
+            }
+            case EditorActionType.DELETE_ARTICLE:
+                this.#onDelete(id);
+                break;
+        }
+    }
+
+    /**
+     * @param {number} id
+     * @param {boolean} value
+     */
+    async #onToggleFavorite(id, value)
+    {
+        this.#updateFavoritesSection(id, value);
+        // Sync every menu for this article, page-wide (aside + article header).
+        syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, value);
+        try {
+            await toggleFavorite(id, value);
+        } catch (error) {
+            // Revert the optimistic UI changes.
+            this.#updateFavoritesSection(id, !value);
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, !value);
+            throw error;
+        }
+    }
+
+    /**
+     * @param {number} id
+     * @param {string} field
+     * @param {boolean} value
+     */
+    async #onToggleField(id, field, value)
+    {
+        // Sync every menu for this article, page-wide (aside + article header).
+        syncToggleCheckboxes(id, EditorActionType.TOGGLE_VALUE, value, field);
+        try {
+            await toggleField(id, field, value);
+        } catch (error) {
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_VALUE, !value, field);
+            throw error;
+        }
+    }
+
+    /**
+     * @param {number} id
+     */
+    async #onDelete(id)
+    {
+        const confirmed = await glpi_confirm_danger({
+            title: __('Delete article'),
+            message: __('Are you sure you want to delete this article?'),
+            confirm_label: __('Delete'),
+        });
+        if (!confirmed) {
+            return;
+        }
+
+        const response = await deleteArticle(id);
+        const body = await response.json();
+
+        // Deleting the article currently being viewed: leave the page.
+        const current = this.#aside.querySelector('[data-glpi-kb-article-current]');
+        if (current && parseInt(current.dataset.glpiKbArticleId) === id) {
+            window.location.href = body.redirect;
+            return;
+        }
+
+        // Otherwise remove every entry for this article (tree + favorites) in
+        // place. Categories are left as-is: the server renders empty categories
+        // too, so a now-empty category should stay visible (as it would on reload).
+        for (const entry of this.#aside.querySelectorAll(`[data-glpi-kb-article-id="${id}"]`)) {
+            entry.remove();
+        }
+
+        const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
+        if (favorites) {
+            this.#refreshFavoritesVisibility(favorites);
+        }
+    }
+
+    /**
+     * Add or remove the article from the favorites section to mirror its new
+     * favorite state, then refresh the section visibility.
+     *
+     * @param {number} id
+     * @param {boolean} is_favorited
+     */
+    #updateFavoritesSection(id, is_favorited)
+    {
+        const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
+        if (!favorites) {
+            return;
+        }
+        const list = favorites.querySelector('ul');
+        if (!list) {
+            return;
+        }
+
+        // The current article has a dedicated entry that is only toggled between
+        // "pending" (hidden) and "active" (shown) states, never added/removed.
+        const current = favorites.querySelector('[data-glpi-kb-favorite-current]');
+        if (current && parseInt(current.dataset.glpiKbArticleId) === id) {
+            current.setAttribute('data-glpi-kb-favorite-current', is_favorited ? 'active' : 'pending');
+            this.#refreshFavoritesVisibility(favorites);
+            return;
+        }
+
+        if (is_favorited) {
+            const already_listed = list.querySelector(`:scope > [data-glpi-kb-article-id="${id}"]`);
+            if (!already_listed) {
+                const source = this.#aside.querySelector(
+                    `[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${id}"]`
+                );
+                if (source) {
+                    const clone = source.cloneNode(true);
+                    clone.classList.add('mb-2');
+                    clone.removeAttribute('data-glpi-kb-search-hidden');
+                    // The source row's dots menu is still open (the user just
+                    // clicked a toggle inside it); close it in the clone.
+                    this.#resetClonedDropdown(clone);
+                    list.appendChild(clone);
+                }
+            }
+        } else {
+            for (const entry of list.querySelectorAll(`:scope > [data-glpi-kb-article-id="${id}"]`)) {
+                if (!entry.hasAttribute('data-glpi-kb-favorite-current')) {
+                    entry.remove();
+                }
+            }
+        }
+
+        this.#refreshFavoritesVisibility(favorites);
+    }
+
+    /**
+     * Reset a cloned article row's dots menu to a closed state. The source row
+     * is cloned while its dropdown is still open (the user just clicked a toggle
+     * inside it), and the clone is not a Bootstrap-managed instance — so without
+     * this it would render a second, orphaned open menu that never closes.
+     *
+     * @param {HTMLElement} clone
+     */
+    #resetClonedDropdown(clone)
+    {
+        for (const shown of clone.querySelectorAll('.show')) {
+            shown.classList.remove('show');
+        }
+        const trigger = clone.querySelector('[data-bs-toggle="dropdown"]');
+        if (trigger) {
+            trigger.setAttribute('aria-expanded', 'false');
+        }
+        const menu = clone.querySelector('.dropdown-menu');
+        if (menu) {
+            // Drop any inline positioning Popper may have applied while open.
+            menu.removeAttribute('style');
+        }
+    }
+
+    /**
+     * Show or hide the favorites section (and matching header border) depending
+     * on whether it still holds any visible entry.
+     *
+     * @param {HTMLElement} favorites_el
+     */
+    #refreshFavoritesVisibility(favorites_el)
+    {
+        const header = this.#aside.querySelector('[data-glpi-kb-aside-header]');
+        const has_visible = favorites_el.querySelector(
+            '[data-glpi-kb-article-id]:not([data-glpi-kb-favorite-current="pending"])'
+        ) !== null;
+
+        if (has_visible) {
+            favorites_el.removeAttribute('data-glpi-kb-aside-favorites-hidden');
+            header?.removeAttribute('data-glpi-kb-aside-header-no-border');
+        } else {
+            favorites_el.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
+            header?.setAttribute('data-glpi-kb-aside-header-no-border', '');
+        }
+
+        // Keep the "restore after search" baseline in sync with the live state.
+        this.#favorites_originally_hidden = !has_visible;
     }
 }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -383,7 +383,7 @@ export class GlpiKnowbaseAsideController
             return;
         }
 
-        const selector = `[data-glpi-kb-article-id="${id}"] `
+        const selector = `[data-glpi-kb-article-id="${CSS.escape(id)}"] `
             + `[data-glpi-kb-actions-menu]:not([data-glpi-kb-actions-loaded])`;
         if (this.#aside.querySelector(selector) === null) {
             return; // Nothing left to populate for this id.

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -525,7 +525,7 @@ export class GlpiKnowbaseAsideController
         // Otherwise remove every entry for this article (tree + favorites) in
         // place. Categories are left as-is: the server renders empty categories
         // too, so a now-empty category should stay visible (as it would on reload).
-        for (const entry of this.#aside.querySelectorAll(`[data-glpi-kb-article-id="${id}"]`)) {
+        for (const entry of this.#aside.querySelectorAll(`[data-glpi-kb-article-id="${CSS.escape(id)}"]`)) {
             entry.remove();
         }
 
@@ -563,10 +563,10 @@ export class GlpiKnowbaseAsideController
         }
 
         if (is_favorited) {
-            const already_listed = list.querySelector(`:scope > [data-glpi-kb-article-id="${id}"]`);
+            const already_listed = list.querySelector(`:scope > [data-glpi-kb-article-id="${CSS.escape(id)}"]`);
             if (!already_listed) {
                 const source = this.#aside.querySelector(
-                    `[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${id}"]`
+                    `[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${CSS.escape(id)}"]`
                 );
                 if (source) {
                     const clone = source.cloneNode(true);
@@ -579,7 +579,7 @@ export class GlpiKnowbaseAsideController
                 }
             }
         } else {
-            for (const entry of list.querySelectorAll(`:scope > [data-glpi-kb-article-id="${id}"]`)) {
+            for (const entry of list.querySelectorAll(`:scope > [data-glpi-kb-article-id="${CSS.escape(id)}"]`)) {
                 if (!entry.hasAttribute('data-glpi-kb-favorite-current')) {
                     entry.remove();
                 }

--- a/js/modules/Knowbase/EditorActions.js
+++ b/js/modules/Knowbase/EditorActions.js
@@ -117,9 +117,9 @@ export function deleteArticle(id)
  */
 export function syncToggleCheckboxes(id, type, checked, field = null)
 {
-    let selector = `[data-glpi-kb-action="${type}"][data-glpi-kb-action-param-id="${id}"]`;
+    let selector = `[data-glpi-kb-action="${CSS.escape(type)}"][data-glpi-kb-action-param-id="${CSS.escape(id)}"]`;
     if (field !== null) {
-        selector += `[data-glpi-kb-action-param-field="${field}"]`;
+        selector += `[data-glpi-kb-action-param-field="${CSS.escape(field)}"]`;
     }
 
     for (const button of document.querySelectorAll(selector)) {

--- a/js/modules/Knowbase/EditorActions.js
+++ b/js/modules/Knowbase/EditorActions.js
@@ -1,0 +1,103 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { post } from "/js/modules/Ajax.js";
+
+/**
+ * Mirror of the PHP Glpi\Knowbase\EditorActionType enum. Shared between the
+ * article editor kebab menu and the knowledge base aside tree.
+ */
+export const EditorActionType = Object.freeze({
+    LOAD_SIDE_PANEL: 'LOAD_SIDE_PANEL',
+    TOGGLE_VALUE:    'TOGGLE_VALUE',
+    TOGGLE_FAVORITE: 'TOGGLE_FAVORITE',
+    DELETE_ARTICLE:  'DELETE_ARTICLE',
+    OPEN_MODAL:      'OPEN_MODAL',
+});
+
+/**
+ * Extract `data-glpi-kb-action-param-*` values from a dataset into a plain
+ * object keyed by the (lower-cased) param name.
+ *
+ * @param {DOMStringMap} dataset
+ * @returns {Object<string, string>}
+ */
+export function extractParamsFromDataset(dataset)
+{
+    const params = {};
+    const prefix = 'glpiKbActionParam';
+
+    for (const [key, value] of Object.entries(dataset)) {
+        if (key.startsWith(prefix)) {
+            const param_name = key.slice(prefix.length).toLowerCase();
+            params[param_name] = value;
+        }
+    }
+
+    return params;
+}
+
+/**
+ * Add or remove an article from the current user's favorites.
+ *
+ * @param {number} id
+ * @param {boolean} value
+ * @returns {Promise<Response>}
+ */
+export function toggleFavorite(id, value)
+{
+    return post(`Knowbase/${id}/ToggleFavorite`, { value: value });
+}
+
+/**
+ * Toggle a boolean field (e.g. `is_faq`) on an article.
+ *
+ * @param {number} id
+ * @param {string} field
+ * @param {boolean} value
+ * @returns {Promise<Response>}
+ */
+export function toggleField(id, field, value)
+{
+    return post(`Knowbase/${id}/ToggleField`, { field: field, value: value });
+}
+
+/**
+ * Delete an article.
+ *
+ * @param {number} id
+ * @returns {Promise<Response>}
+ */
+export function deleteArticle(id)
+{
+    return post(`Knowbase/KnowbaseItem/${id}/Delete`, {});
+}

--- a/js/modules/Knowbase/EditorActions.js
+++ b/js/modules/Knowbase/EditorActions.js
@@ -101,3 +101,31 @@ export function deleteArticle(id)
 {
     return post(`Knowbase/KnowbaseItem/${id}/Delete`, {});
 }
+
+/**
+ * Keep every rendered menu checkbox for a given article/action in sync across
+ * the whole page (article editor header + aside tree + aside favorites). The
+ * same article is shown in several places, each with its own dots menu.
+ *
+ * Lazy aside menus that are not loaded yet simply have no checkbox to update;
+ * they fetch fresh state when opened.
+ *
+ * @param {number|string} id
+ * @param {string} type EditorActionType.TOGGLE_FAVORITE or TOGGLE_VALUE
+ * @param {boolean} checked
+ * @param {string|null} field field name for TOGGLE_VALUE (e.g. 'is_faq')
+ */
+export function syncToggleCheckboxes(id, type, checked, field = null)
+{
+    let selector = `[data-glpi-kb-action="${type}"][data-glpi-kb-action-param-id="${id}"]`;
+    if (field !== null) {
+        selector += `[data-glpi-kb-action-param-field="${field}"]`;
+    }
+
+    for (const button of document.querySelectorAll(selector)) {
+        const toggle = button.querySelector('input[type="checkbox"]');
+        if (toggle) {
+            toggle.checked = checked;
+        }
+    }
+}

--- a/src/Glpi/Controller/Knowbase/AsideActionsController.php
+++ b/src/Glpi/Controller/Knowbase/AsideActionsController.php
@@ -64,7 +64,7 @@ final class AsideActionsController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        if (!$item->canViewItem()) {
+        if (!$item->can($id, READ)) {
             throw new AccessDeniedHttpException();
         }
 

--- a/src/Glpi/Controller/Knowbase/AsideActionsController.php
+++ b/src/Glpi/Controller/Knowbase/AsideActionsController.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Returns the rendered kebab menu items (add to favorites, add to FAQ, delete)
+ * for a single knowledge base article. Used by the aside tree, which renders
+ * only the kebab trigger and lazy-loads the menu content on hover/open so it
+ * never has to load every tree article up-front just to gate the actions.
+ */
+final class AsideActionsController extends AbstractController
+{
+    #[Route(
+        "/Knowbase/{id}/AsideActions",
+        name: "knowbase_aside_actions",
+        requirements: [
+            'id' => '\d+',
+        ],
+        methods: 'GET',
+    )]
+    public function __invoke(int $id): Response
+    {
+        $item = new KnowbaseItem();
+        if (!$item->getFromDB($id)) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$item->canViewItem()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return $this->render('pages/tools/kb/aside_actions.html.twig', [
+            'actions' => $item->getAsideActions(),
+        ]);
+    }
+}

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2870,6 +2870,14 @@ TWIG, $twig_params);
             return null;
         }
 
+        // Whether to render the per-article dots menu trigger. This is a cheap
+        // session-level check: the menu content itself (and its per-article
+        // permission gating) is lazy-loaded on demand, so we never load every
+        // tree article here just to know if any action is available.
+        $show_actions = KnowbaseItem_Favorite::canCreate()
+            || self::canUpdate()
+            || self::canPurge();
+
         return TemplateRenderer::getInstance()->render(
             'pages/tools/kb/aside.html.twig',
             [
@@ -2877,6 +2885,7 @@ TWIG, $twig_params);
                 'favorites'           => $favorites,
                 'current_is_favorite' => $current_is_favorite,
                 'has_other_favorites' => $has_other_favorites,
+                'show_actions'        => $show_actions,
             ]
         );
     }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1260,6 +1260,28 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             );
         }
 
+        // Include base actions that are available for articles in the aside
+        $management = $this->getAsideActions();
+        if ($management !== []) {
+            if ($actions !== []) {
+                $actions[] = new EditorActionSeparator();
+            }
+            array_push($actions, ...$management);
+        }
+
+        return $actions;
+    }
+
+    /**
+     * Build the actions that will be available on the aside dots menu for
+     * the loaded article.
+     *
+     * @return array<EditorAction|EditorActionSeparator>
+     */
+    public function getAsideActions(): array
+    {
+        $actions = [];
+
         // Toggle actions
         $toggles = [];
         if (KnowbaseItem_Favorite::canCreate()) {
@@ -1285,15 +1307,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 ],
             );
         }
-        if ($toggles !== []) {
-            if ($actions !== []) {
-                $actions[] = new EditorActionSeparator();
-            }
-            array_push($actions, ...$toggles);
-        }
+        array_push($actions, ...$toggles);
 
         if ($this->can($this->fields['id'], PURGE)) {
-            $actions[] = new EditorActionSeparator();
+            if ($toggles !== []) {
+                $actions[] = new EditorActionSeparator();
+            }
             $actions[] = new EditorAction(
                 label: __("Delete article"),
                 icon: "ti ti-trash",

--- a/templates/pages/tools/kb/_actions_menu.html.twig
+++ b/templates/pages/tools/kb/_actions_menu.html.twig
@@ -1,0 +1,99 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# Renders the <li> items of a dots menu from a list of EditorAction /
+ # EditorActionSeparator value objects. Extracted so it can be rendered both
+ # inline (article editor) and standalone (lazy-loaded aside menu content). #}
+{% macro render_actions_items(actions) %}
+    {% set add_separator = false %}
+    {% for action in actions %}
+        {% if action is instanceof('\\Glpi\\Knowbase\\EditorActionSeparator') %}
+            {# Will add an extra border on the next iteration #}
+            {% set add_separator = true %}
+        {% else %}
+            <li class="{{ add_separator ? 'border-top' : '' }}">
+                <button
+                    type="button"
+                    class="dropdown-item {{ action.is_danger ? "text-danger" : "" }}"
+                    aria-label="{{ action.label }}"
+                    data-glpi-kb-action="{{ action.type.value }}"
+                    {% for key, param in action.params %}
+                        data-glpi-kb-action-param-{{ key }}="{{ param }}"
+                    {% endfor %}
+                >
+                    <i class="{{ action.icon }}"></i>
+                    <span>{{ action.label }}</span>
+
+                    {% if action.counter is not null %}
+                        <span
+                            class="badge glpi-badge ms-auto"
+                            data-testid="{{ action.params.key }}-counter"
+                            data-glpi-kb-action-counter="{{ action.params.key }}"
+                        >{{ action.counter }}</span>
+                    {% endif %}
+
+                    {% if action.type == constant('Glpi\\Knowbase\\EditorActionType::TOGGLE_VALUE') or action.type == constant('Glpi\\Knowbase\\EditorActionType::TOGGLE_FAVORITE') %}
+                        <span class="form-check form-switch ms-auto mb-0">
+                            <input
+                                type="checkbox"
+                                class="form-check-input ms-0"
+                                {{ action.params.checked ? 'checked' : '' }}
+                            >
+                        </span>
+                    {% endif %}
+                </button>
+            </li>
+            {% set add_separator = false %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{# Renders a "vertical dots" menu with its items rendered inline. Used by
+ # the KB article editor header, where the actions are already available. #}
+{% macro render_actions_menu(actions) %}
+    {% import _self as self %}
+    <div class="dropdown cursor-pointer d-flex align-items-center">
+        {% if actions|length > 0 %}
+            <i
+                class="ti ti-dots-vertical"
+                data-glpi-kb-dots
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+                role="button"
+                title="{{ __('More actions') }}"
+            ></i>
+            <ul class="dropdown-menu" data-bs-popper="none">
+                {{ self.render_actions_items(actions) }}
+            </ul>
+        {% endif %}
+    </div>
+{% endmacro %}

--- a/templates/pages/tools/kb/_actions_menu.html.twig
+++ b/templates/pages/tools/kb/_actions_menu.html.twig
@@ -83,14 +83,17 @@
     {% import _self as self %}
     <div class="dropdown cursor-pointer d-flex align-items-center">
         {% if actions|length > 0 %}
-            <i
-                class="ti ti-dots-vertical"
+            <button
+                type="button"
+                class="border-0 bg-transparent p-0 text-reset lh-1"
                 data-glpi-kb-dots
                 data-bs-toggle="dropdown"
                 aria-expanded="false"
-                role="button"
+                aria-label="{{ __('More actions') }}"
                 title="{{ __('More actions') }}"
-            ></i>
+            >
+                <i class="ti ti-dots-vertical" aria-hidden="true"></i>
+            </button>
             <ul class="dropdown-menu" data-bs-popper="none">
                 {{ self.render_actions_items(actions) }}
             </ul>
@@ -104,14 +107,17 @@
  # fetched items. #}
 {% macro render_actions_menu_lazy() %}
     <div class="dropdown cursor-pointer d-flex align-items-center">
-        <i
-            class="ti ti-dots-vertical"
+        <button
+            type="button"
+            class="border-0 bg-transparent p-0 text-reset lh-1"
             data-glpi-kb-dots
             data-bs-toggle="dropdown"
             aria-expanded="false"
-            role="button"
+            aria-label="{{ __('More actions') }}"
             title="{{ __('More actions') }}"
-        ></i>
+        >
+            <i class="fs-08x ti ti-dots-vertical " aria-hidden="true"></i>
+        </button>
         <ul class="dropdown-menu" data-bs-popper="none" data-glpi-kb-actions-menu>
             <li data-glpi-kb-actions-loading>
                 <span class="dropdown-item-text text-muted d-flex align-items-center">

--- a/templates/pages/tools/kb/_actions_menu.html.twig
+++ b/templates/pages/tools/kb/_actions_menu.html.twig
@@ -97,3 +97,28 @@
         {% endif %}
     </div>
 {% endmacro %}
+
+{# Renders a dots menu whose items are lazy-loaded (on hover/open) by the aside
+ # controller, so the tree never has to build every article's actions up-front.
+ # The menu starts with a loading placeholder that gets replaced with the
+ # fetched items. #}
+{% macro render_actions_menu_lazy() %}
+    <div class="dropdown cursor-pointer d-flex align-items-center">
+        <i
+            class="ti ti-dots-vertical"
+            data-glpi-kb-dots
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+            role="button"
+            title="{{ __('More actions') }}"
+        ></i>
+        <ul class="dropdown-menu" data-bs-popper="none" data-glpi-kb-actions-menu>
+            <li data-glpi-kb-actions-loading>
+                <span class="dropdown-item-text text-muted d-flex align-items-center">
+                    <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                    {{ __('Loading...') }}
+                </span>
+            </li>
+        </ul>
+    </div>
+{% endmacro %}

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -41,6 +41,7 @@
         data-glpi-kb-default-language="{{ default_language }}"
         data-glpi-kb-existing-translations="{{ existing_translations|json_encode }}"
     {% endif %}
+    data-testid="kb-article"
 >
     <article
         class="col-12 ms-0 px-4 py-3 kb-article"

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -30,6 +30,8 @@
  # ---------------------------------------------------------------------
  #}
 
+{% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
+
 <div
     class="d-flex mx-n2 my-n2 pe-none"
     data-glpi-knowbase-article
@@ -140,61 +142,7 @@
                 {% endif %}
 
                 {# Actions dropdown #}
-                <div class="dropdown cursor-pointer d-flex align-items-center">
-                    {% if actions|length > 0 %}
-                        <i
-                            class="ti ti-dots-vertical"
-                            data-glpi-kb-dots
-                            data-bs-toggle="dropdown"
-                            aria-expanded="false"
-                            role="button"
-                            title="{{ __('More actions') }}"
-                        ></i>
-                        <ul class="dropdown-menu" data-bs-popper="none">
-                            {% set add_separator = false %}
-                            {% for action in actions %}
-                                {% if action is instanceof('\\Glpi\\Knowbase\\EditorActionSeparator') %}
-                                    {# Will add an extra border on the next iteration #}
-                                    {% set add_separator = true %}
-                                {% else %}
-                                    <li class="{{ add_separator ? 'border-top' : '' }}">
-                                        <button
-                                            type="button"
-                                            class="dropdown-item {{ action.is_danger ? "text-danger" : "" }}"
-                                            aria-label="{{ action.label }}"
-                                            data-glpi-kb-action="{{ action.type.value }}"
-                                            {% for key, param in action.params %}
-                                                data-glpi-kb-action-param-{{ key }}="{{ param }}"
-                                            {% endfor %}
-                                        >
-                                            <i class="{{ action.icon }}"></i>
-                                            <span>{{ action.label }}</span>
-
-                                            {% if action.counter is not null %}
-                                                <span
-                                                    class="badge glpi-badge ms-auto"
-                                                    data-testid="{{ action.params.key }}-counter"
-                                                    data-glpi-kb-action-counter="{{ action.params.key }}"
-                                                >{{ action.counter }}</span>
-                                            {% endif %}
-
-                                            {% if action.type == constant('Glpi\\Knowbase\\EditorActionType::TOGGLE_VALUE') or action.type == constant('Glpi\\Knowbase\\EditorActionType::TOGGLE_FAVORITE') %}
-                                                <span class="form-check form-switch ms-auto mb-0">
-                                                    <input
-                                                        type="checkbox"
-                                                        class="form-check-input ms-0"
-                                                        {{ action.params.checked ? 'checked' : '' }}
-                                                    >
-                                                </span>
-                                            {% endif %}
-                                        </button>
-                                    </li>
-                                    {% set add_separator = false %}
-                                {% endif %}
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                </div>
+                {{ actions_menu.render_actions_menu(actions) }}
             </div>
         </div>
 

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -30,7 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{% macro render_category(category) %}
+{% macro render_category(category, show_actions = false) %}
     {% import _self as macros %}
     <li class="node" data-glpi-kb-aside-category role="group" aria-label="{{ category.title }}">
         <button
@@ -47,12 +47,13 @@
             <span class="ms-2 fw-bold text-truncate d-block">{{ category.title }}</span>
         </button>
         <ul>
-            {{ macros.render_node(category) }}
+            {{ macros.render_node(category, show_actions) }}
         </ul>
     </li>
 {% endmacro %}
 
-{% macro render_article(article, add_margin = false, favorite_state = null) %}
+{% macro render_article(article, add_margin = false, favorite_state = null, show_actions = false) %}
+    {% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
     <li
         data-glpi-kb-article-id="{{ article.id }}"
         {% if favorite_state is not null %}
@@ -64,22 +65,27 @@
         {% endif %}
         class="article {{ add_margin ? 'mb-2' : '' }}"
     >
-        <a class="text-dark text-hover-link text-truncate d-block" href="{{ article.link }}">
-            {% if article.illustration %}
-                {{ render_illustration(article.illustration, 20) }}
+        <div class="article-line d-flex align-items-center">
+            <a class="text-dark text-hover-link text-truncate flex-grow-1" href="{{ article.link }}">
+                {% if article.illustration %}
+                    {{ render_illustration(article.illustration, 20) }}
+                {% endif %}
+                <span data-glpi-kb-article-title>{{ article.title }}</span>
+            </a>
+            {% if show_actions %}
+                {{ actions_menu.render_actions_menu_lazy() }}
             {% endif %}
-            <span data-glpi-kb-article-title>{{ article.title }}</span>
-        </a>
+        </div>
     </li>
 {% endmacro %}
 
-{% macro render_node(node) %}
+{% macro render_node(node, show_actions = false) %}
     {% import _self as macros %}
     {% for article in node.articles %}
-        {{ macros.render_article(article) }}
+        {{ macros.render_article(article, false, null, show_actions) }}
     {% endfor %}
     {% for category in node.categories %}
-        {{ macros.render_category(category) }}
+        {{ macros.render_category(category, show_actions) }}
     {% endfor %}
 {% endmacro %}
 
@@ -127,9 +133,10 @@
                         article,
                         true,
                         current_is_favorite ? 'active' : 'pending',
+                        show_actions,
                     ) }}
                 {% else %}
-                    {{ macros.render_article(article, true) }}
+                    {{ macros.render_article(article, true, null, show_actions) }}
                 {% endif %}
             {% endfor %}
         </ul>
@@ -144,12 +151,12 @@
                 illustration: "",
                 articles: tree.articles,
                 categories: [],
-            }) }}
+            }, show_actions) }}
         {% endif %}
 
         {# Render each categories #}
         {% for category in tree.categories %}
-            {{ macros.render_category(category) }}
+            {{ macros.render_category(category, show_actions) }}
         {% endfor %}
     </ul>
     <p class="text-muted" data-glpi-kb-aside-no-results hidden>

--- a/templates/pages/tools/kb/aside_actions.html.twig
+++ b/templates/pages/tools/kb/aside_actions.html.twig
@@ -1,0 +1,35 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{# Lazy-loaded kebab menu items for a single KB aside article. #}
+{% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
+{{ actions_menu.render_actions_items(actions) }}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -116,6 +116,18 @@ export class KnowbaseItemPage extends GlpiPage
         );
     }
 
+    /**
+     * The article header's dots menu trigger. Scoped to the article content so
+     * it is not confused with the per-row "More actions" menus that the aside
+     * tree renders on every article.
+     */
+    public get articleActionsMenu(): Locator
+    {
+        return this.page
+            .getByTestId('kb-article')
+            .getByRole('button', { name: 'More actions' });
+    }
+
     public async doToggleFaqStatus(): Promise<void>
     {
         const faq_toggle = this.getButton('Add to FAQ');
@@ -146,6 +158,87 @@ export class KnowbaseItemPage extends GlpiPage
         return this.favoritesSection.getByRole('link', { name: title });
     }
 
+    public get aside(): Locator
+    {
+        return this.page.getByRole('main').getByRole('complementary');
+    }
+
+    public getAsideTreeArticleRow(id: number): Locator
+    {
+        return this.aside.locator(`[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${id}"]`);
+    }
+
+    /**
+     * The dots menu trigger button of an article in the aside tree.
+     */
+    public getAsideArticleMenuTrigger(id: number): Locator
+    {
+        return this.getAsideTreeArticleRow(id).getByRole('button', { name: 'More actions' });
+    }
+
+    /**
+     * Open the (lazy-loaded) dots menu of an article in the aside tree.
+     */
+    public async doOpenAsideArticleMenu(id: number): Promise<void>
+    {
+        const row = this.getAsideTreeArticleRow(id);
+        await row.hover();
+        await this.getAsideArticleMenuTrigger(id).click();
+        // The aside menu content is lazy-loaded; wait until it is rendered.
+        await expect(row.getByRole('button', { name: 'Add to favorites' })).toBeVisible();
+    }
+
+    /**
+     * An action button inside an aside tree article's dots menu.
+     */
+    public getAsideArticleAction(id: number, name: string): Locator
+    {
+        return this.getAsideTreeArticleRow(id).getByRole('button', { name });
+    }
+
+    public async doToggleAsideFavorite(id: number): Promise<void>
+    {
+        const response_promise = this.page.waitForResponse(
+            response => response.url().includes('/ToggleFavorite')
+        );
+        await this.getAsideArticleAction(id, 'Add to favorites').click();
+        await response_promise;
+    }
+
+    public async doToggleAsideFaq(id: number): Promise<void>
+    {
+        const response_promise = this.page.waitForResponse(
+            response => response.url().includes('/ToggleField')
+        );
+        await this.getAsideArticleAction(id, 'Add to FAQ').click();
+        await response_promise;
+    }
+
+    public async doDeleteAsideArticle(id: number): Promise<void>
+    {
+        await this.getAsideArticleAction(id, 'Delete article').click();
+
+        const confirm_button = this.page.getByRole('button', { name: 'Delete', exact: true });
+        await expect(confirm_button).toBeVisible();
+
+        const response_promise = this.page.waitForResponse(
+            response => response.url().includes('/Delete')
+        );
+        await confirm_button.click();
+        await response_promise;
+    }
+
+    /**
+     * "Add to favorites" toggles currently visible in the aside, i.e. inside an
+     * open dots menu. Used to assert that only a single menu is open at a time.
+     */
+    public get openAsideFavoriteToggles(): Locator
+    {
+        return this.aside
+            .getByRole('button', { name: 'Add to favorites' })
+            .filter({ visible: true });
+    }
+
     public get childEntitiesCheckbox(): Locator
     {
         return this.page.getByRole('checkbox', { name: 'Child entities' });
@@ -161,7 +254,7 @@ export class KnowbaseItemPage extends GlpiPage
 
     public async doOpenCommentsPanel(): Promise<void>
     {
-        await this.page.getByTitle('More actions').click();
+        await this.articleActionsMenu.click();
         await this.getButton('Comments').click();
     }
 
@@ -241,7 +334,7 @@ export class KnowbaseItemPage extends GlpiPage
 
     public async doEnableSchedulePanel(): Promise<void>
     {
-        await this.page.getByTitle('More actions').click();
+        await this.articleActionsMenu.click();
         await this.getButton('Schedule visibility').click();
         await expect(this.page.getByTestId('schedule-panel')).toBeVisible();
     }
@@ -260,7 +353,7 @@ export class KnowbaseItemPage extends GlpiPage
 
     public async doOpenVisibilityModal(): Promise<void>
     {
-        await this.page.getByTitle('More actions').click();
+        await this.articleActionsMenu.click();
         await this.getButton('Permissions and sharing').click();
     }
 
@@ -281,7 +374,7 @@ export class KnowbaseItemPage extends GlpiPage
 
     public async doOpenHistoryPanel(): Promise<void>
     {
-        await this.page.getByTitle('More actions').click();
+        await this.articleActionsMenu.click();
         await this.getButton('History').click();
     }
 
@@ -357,7 +450,7 @@ export class KnowbaseItemPage extends GlpiPage
 
     public async doOpenSharingTab(): Promise<Locator>
     {
-        await this.page.getByTitle('More actions').click();
+        await this.articleActionsMenu.click();
         await this.getButton('Permissions and sharing').click();
 
         const modal = this.page.getByRole('dialog');

--- a/tests/e2e/specs/Knowbase/delete.spec.ts
+++ b/tests/e2e/specs/Knowbase/delete.spec.ts
@@ -46,7 +46,7 @@ test('Can delete an article', async ({ page, profile, api }) => {
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
 
     // Delete article
     const delete_button = kb.getButton('Delete article');

--- a/tests/e2e/specs/Knowbase/faq.spec.ts
+++ b/tests/e2e/specs/Knowbase/faq.spec.ts
@@ -47,7 +47,7 @@ test('Can toggle FAQ from false to true', async ({ page, profile, api }) => {
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
 
     // Toggle value
     const faq_toggle = kb.getButton('Add to FAQ');
@@ -57,7 +57,7 @@ test('Can toggle FAQ from false to true', async ({ page, profile, api }) => {
 
     // Validate value was saved
     await page.reload();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     const faq_toggle_after_reload = kb.getButton('Add to FAQ');
     await expect(faq_toggle_after_reload.getByRole('checkbox')).toBeChecked();
 });
@@ -74,7 +74,7 @@ test('Can toggle FAQ from true to false', async ({ page, profile, api }) => {
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
 
     // Toggle value
     const faq_toggle = kb.getButton('Add to FAQ');
@@ -84,7 +84,7 @@ test('Can toggle FAQ from true to false', async ({ page, profile, api }) => {
 
     // Validate value was saved
     await page.reload();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     const faq_toggle_after_reload = kb.getButton('Add to FAQ');
     await expect(faq_toggle_after_reload.getByRole('checkbox')).not.toBeChecked();
 });

--- a/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from "../../fixtures/glpi_fixture";
+import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
+import { Profiles } from "../../utils/Profiles";
+import { getUniqueName } from "../../utils/Random";
+
+test('Can add and remove a favorite from the aside dots menu', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside viewed`),
+        answer: "My answer",
+    });
+    const target_name = getUniqueName(`Aside favorite`);
+    const target_id = await api.knowbase.createArticle({
+        name: target_name,
+        answer: "My answer",
+    });
+
+    await kb.goto(viewed_id);
+    await expect(kb.getFavoriteArticle(target_name)).toBeHidden();
+
+    // Add to favorites from the tree row's dots menu.
+    await kb.doOpenAsideArticleMenu(target_id);
+    const favorite_checkbox = kb.getAsideArticleAction(target_id, 'Add to favorites').getByRole('checkbox');
+    await expect(favorite_checkbox).not.toBeChecked();
+
+    await kb.doToggleAsideFavorite(target_id);
+
+    // It now appears in the favorites section and the toggle reflects the state.
+    await expect(favorite_checkbox).toBeChecked();
+    await expect(kb.getFavoriteArticle(target_name)).toBeVisible();
+
+    // Only the tree row's menu stays open: the freshly cloned favorites row
+    // must not render a second, orphaned open menu.
+    await expect(kb.openAsideFavoriteToggles).toHaveCount(1);
+
+    // Remove it again from the same menu.
+    await kb.doToggleAsideFavorite(target_id);
+    await expect(favorite_checkbox).not.toBeChecked();
+    await expect(kb.getFavoriteArticle(target_name)).toBeHidden();
+});
+
+test('Can toggle FAQ status from the aside dots menu', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside viewed`),
+        answer: "My answer",
+    });
+    const target_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside FAQ`),
+        answer: "My answer",
+    });
+
+    // Go to article and open aside menu for another article
+    await kb.goto(viewed_id);
+    await kb.doOpenAsideArticleMenu(target_id);
+
+    // It should be unchecked by default
+    const faq_checkbox = kb.getAsideArticleAction(target_id, 'Add to FAQ').getByRole('checkbox');
+    await expect(faq_checkbox).not.toBeChecked();
+
+    // We toggle the value
+    await kb.doToggleAsideFaq(target_id);
+    await expect(faq_checkbox).toBeChecked();
+
+    // Make sure the change is persisted by reloading the page to refresh the data
+    await page.reload();
+    await kb.doOpenAsideArticleMenu(target_id);
+    await expect(kb.getAsideArticleAction(target_id, 'Add to FAQ').getByRole('checkbox')).toBeChecked();
+});
+
+test('Aside dots menu is reachable and operable with the keyboard', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside viewed`),
+        answer: "My answer",
+    });
+    const target_name = getUniqueName(`Aside favorite`);
+    const target_id = await api.knowbase.createArticle({
+        name: target_name,
+        answer: "My answer",
+    });
+
+    await kb.goto(viewed_id);
+
+    // Tabbing off the article link reaches the dots trigger...
+    await kb.getAsideTreeArticleRow(target_id).getByRole('link', { name: target_name }).focus();
+    await page.keyboard.press('Tab');
+    await expect(kb.getAsideArticleMenuTrigger(target_id)).toBeFocused();
+
+    // ...and pressing Enter opens its menu.
+    await page.keyboard.press('Enter');
+    await expect(kb.getAsideArticleAction(target_id, 'Add to favorites')).toBeVisible();
+});
+
+test('Can delete an article from the aside dots menu without leaving the page', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside viewed`),
+        answer: "My answer",
+    });
+    const target_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside delete`),
+        answer: "My answer",
+    });
+
+    await kb.goto(viewed_id);
+    await expect(kb.getAsideTreeArticleRow(target_id)).toBeVisible();
+
+    await kb.doOpenAsideArticleMenu(target_id);
+    await kb.doDeleteAsideArticle(target_id);
+
+    // The row is removed from the tree in place, and we stay on the article we
+    // were viewing (no redirect, since it is not the deleted one).
+    await expect(kb.getAsideTreeArticleRow(target_id)).toHaveCount(0);
+    await expect(page).toHaveURL(new RegExp(`knowbaseitem\\.form\\.php\\?id=${viewed_id}(\\D|$)`));
+});

--- a/tests/e2e/specs/Knowbase/kb-favorites.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-favorites.spec.ts
@@ -48,7 +48,7 @@ test('Can toggle favorites from false to true', async ({ page, profile, api }) =
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
 
     const favorite_toggle = kb.getButton('Add to favorites');
     await expect(favorite_toggle.getByRole('checkbox')).not.toBeChecked();
@@ -59,7 +59,7 @@ test('Can toggle favorites from false to true', async ({ page, profile, api }) =
     await expect(kb.getFavoriteArticle(name)).toBeVisible();
 
     await page.reload();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     const favorite_toggle_after_reload = kb.getButton('Add to favorites');
     await expect(favorite_toggle_after_reload.getByRole('checkbox')).toBeChecked();
     await expect(kb.getFavoriteArticle(name)).toBeVisible();
@@ -77,11 +77,11 @@ test('Can toggle favorites from true to false', async ({ page, profile, api }) =
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.doToggleFavoriteStatus();
 
     await page.reload();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
 
     const favorite_toggle = kb.getButton('Add to favorites');
     await expect(favorite_toggle.getByRole('checkbox')).toBeChecked();
@@ -92,7 +92,7 @@ test('Can toggle favorites from true to false', async ({ page, profile, api }) =
     await expect(kb.getFavoriteArticle(name)).toBeHidden();
 
     await page.reload();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     const favorite_toggle_after_reload = kb.getButton('Add to favorites');
     await expect(favorite_toggle_after_reload.getByRole('checkbox')).not.toBeChecked();
     await expect(kb.getFavoriteArticle(name)).toBeHidden();

--- a/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
+++ b/tests/e2e/specs/Knowbase/responsive_offcanvas.spec.ts
@@ -62,7 +62,7 @@ test('Side panel displays as offcanvas on small screens', async ({
     await expect(page.getByText('Responsive test answer')).toBeVisible();
 
     // Open comments panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Comments').click();
 
     // On small screens, an offcanvas should be disabled
@@ -112,7 +112,7 @@ test('Side panel displays normally on large screens', async ({
     await expect(page.getByText('Responsive test answer')).toBeVisible();
 
     // Open comments panel and verify it uses the side panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Comments').click();
 
     // On default sized screens, a side panel should be disabled

--- a/tests/e2e/specs/Knowbase/revisions.spec.ts
+++ b/tests/e2e/specs/Knowbase/revisions.spec.ts
@@ -54,7 +54,7 @@ test('Can view revision history and restore a previous version', async ({ page, 
 
     // Toggle history panel
     await expect(kb.getHeading('History')).not.toBeAttached();
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await expect(page.getByTestId('history-counter')).toHaveText("3");
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
@@ -84,7 +84,7 @@ test('Can view revision history and restore a previous version', async ({ page, 
     await expect(page.getByText('Original content')).toBeVisible();
 
     // Counter should be updated (new revision created from previous current version)
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await expect(page.getByTestId('history-counter')).toHaveText("4");
 });
 
@@ -112,7 +112,7 @@ test('Associated item changes appear in history', async ({ page, profile, api })
 
     // Go to article and open history panel
     await kb.goto(kb_id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -139,7 +139,7 @@ test('Permission changes appear in history', async ({ page, profile, api }) => {
     });
 
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -172,7 +172,7 @@ test('Document attachment changes appear in history', async ({ page, profile, ap
 
     // Go to article and open history panel
     await kb.goto(kb_id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -196,7 +196,7 @@ test('Name changes appear in history', async ({ page, profile, api }) => {
 
     // Go to article and open history panel
     await kb.goto(id);
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -222,7 +222,7 @@ test('Can compare a revision with the current version', async ({ page, profile, 
     await expect(page.getByText('Updated paragraph')).toBeVisible();
 
     // Open history panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -269,7 +269,7 @@ test('Switching between revisions does not corrupt the diff', async ({ page, pro
     await kb.goto(id);
 
     // Open history panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 
@@ -318,7 +318,7 @@ test('Clicking current version deactivates comparison', async ({ page, profile, 
     await expect(page.getByText('Updated content')).toBeVisible();
 
     // Open history panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('History').click();
     await expect(kb.getHeading('History')).toBeVisible();
 

--- a/tests/e2e/specs/Knowbase/service_catalog.spec.ts
+++ b/tests/e2e/specs/Knowbase/service_catalog.spec.ts
@@ -55,7 +55,7 @@ test('Can configure service catalog settings', async ({ page, profile, api }) =>
     await kb.goto(kb_id);
 
     // Open service catalog panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Service catalog').click();
 
     // Confirm default state
@@ -79,7 +79,7 @@ test('Can configure service catalog settings', async ({ page, profile, api }) =>
     await page.reload();
 
     // Validate values
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Service catalog').click();
 
     await expect(kb.getCheckbox('Show in service catalog')).toBeChecked();
@@ -102,7 +102,7 @@ test('Can disable service catalog settings', async ({ page, profile, api }) => {
     await kb.goto(kb_id);
 
     // Open service catalog panel
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Service catalog').click();
     await expect(kb.getHeading('Service catalog')).toBeVisible();
 
@@ -126,7 +126,7 @@ test('Can disable service catalog settings', async ({ page, profile, api }) => {
     await page.reload();
 
     // Service catalog is now disabled
-    await page.getByTitle('More actions').click();
+    await kb.articleActionsMenu.click();
     await kb.getButton('Service catalog').click();
 
     await expect(kb.getCheckbox('Show in service catalog')).not.toBeChecked();

--- a/tests/functional/Glpi/Controller/Knowbase/AsideActionsControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/AsideActionsControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\Knowbase;
+
+use Glpi\Controller\Knowbase\AsideActionsController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+
+class AsideActionsControllerTest extends DbTestCase
+{
+    private function callController(int $id): string
+    {
+        $controller = new AsideActionsController();
+        return $controller->__invoke($id)->getContent();
+    }
+
+    public function testReturnsAllActionsForManagedArticle(): void
+    {
+        // Grant UPDATE + PURGE so all three actions are rendered (favorites is
+        // available to the super-admin via CREATE).
+        $this->login();
+        $_SESSION['glpiactiveprofile'][KnowbaseItem::$rightname] |= UPDATE | PURGE;
+
+        // Article must live in an active entity for the delete (PURGE) gate.
+        $id = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Managed article',
+            'answer'       => '<p>Content</p>',
+            'entities_id'  => $this->getTestRootEntity(only_id: true),
+            'is_recursive' => 1,
+        ])->getID();
+
+        $html = $this->callController($id);
+
+        $this->assertStringContainsString('data-glpi-kb-action="TOGGLE_FAVORITE"', $html);
+        $this->assertStringContainsString('data-glpi-kb-action="TOGGLE_VALUE"', $html);
+        $this->assertStringContainsString('data-glpi-kb-action="DELETE_ARTICLE"', $html);
+        $this->assertStringContainsString('data-glpi-kb-action-param-field="is_faq"', $html);
+    }
+
+    public function testNonExistentArticleReturnsNotFound(): void
+    {
+        $this->login();
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->callController(99999);
+    }
+
+    public function testUnviewableArticleReturnsAccessDenied(): void
+    {
+        // Article created by the super-admin with no shared visibility.
+        $this->login();
+        $id = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Private article',
+            'answer'       => '<p>Secret</p>',
+            'entities_id'  => $this->getTestRootEntity(only_id: true),
+            'is_recursive' => 1,
+        ])->getID();
+
+        // A regular user without visibility access cannot view it.
+        $this->login('normal', 'normal');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->callController($id);
+    }
+}


### PR DESCRIPTION
For each item in the KB aside, a dots menu is available with some administration options:

<img width="530" height="212" alt="image" src="https://github.com/user-attachments/assets/16cc7800-c4c5-45f7-a9b5-a56367ea83be" />

UX wise, the dots appear when hovering the item in the tree to avoid polluting the UI with too much information (similarly to what others competing products are doing).

Regarding accessibility, it fully works with keyboard controls so no issues here hopefully.

On the technical side, I've chosent to not include the dropdown in the DOM as it is repeated on every row and could cause performances issues for huge tree.
Instead, it is lazy loaded when the user hover on an item in the tree.

I've tried to split the work by commit to isolate the needed refactors from the actual code change. Might help to review per commit.