### PR TITLE
Gracefully handle old cookie format

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -671,32 +671,37 @@ class Auth extends CommonGLPI
 
                 if ($CFG_GLPI["login_remember_time"]) {
                     $data = null;
-                    if (array_key_exists($cookie_name, $_COOKIE)) {
-                        $data = $_COOKIE[$cookie_name];
-                    }
-                    if (!empty($data) && str_contains($data, ':')) {
-                        [$token_uid, $token_hash] = explode(':', $data);
-
-                        $it = $DB->request([
-                            'SELECT' => ['users_id', 'token_hash'],
-                            'FROM'   => 'glpi_usertokens',
-                            'WHERE'  => [
-                                'type'     => 'rememberme',
-                                'token_uid' => $token_uid,
-                                'date_expiration'   => ['>', date('Y-m-d H:i:s')],
-                            ],
-                            'LIMIT'  => 1,
-                        ]);
-                        $known_hash = $it->current()['token_hash'] ?? null;
-                        if ($known_hash !== null && self::checkPassword($token_hash, $known_hash)) {
-                            $user = new User();
-                            $user->getFromDB($it->current()['users_id']);
-                            $this->user->fields['name'] = $user->fields['name'];
-                            $user->update(['id' => $user->getID(), 'last_login' => date("Y-m-d H:i:s")]);
-                            return true;
-                        } else {
-                            $this->addToError(__("Invalid cookie data"));
+                    try {
+                        if (array_key_exists($cookie_name, $_COOKIE)) {
+                            $data = $_COOKIE[$cookie_name];
                         }
+                        if (!empty($data) && str_contains($data, ':')) {
+                            [$token_uid, $token_hash] = explode(':', $data);
+
+                            $it = $DB->request([
+                                'SELECT' => ['users_id', 'token_hash'],
+                                'FROM' => 'glpi_usertokens',
+                                'WHERE' => [
+                                    'type' => 'rememberme',
+                                    'token_uid' => $token_uid,
+                                    'date_expiration' => ['>', date('Y-m-d H:i:s')],
+                                ],
+                                'LIMIT' => 1,
+                            ]);
+                            $known_hash = $it->current()['token_hash'] ?? null;
+                            if ($known_hash !== null && self::checkPassword($token_hash, $known_hash)) {
+                                $user = new User();
+                                $user->getFromDB($it->current()['users_id']);
+                                $this->user->fields['name'] = $user->fields['name'];
+                                $user->update(['id' => $user->getID(), 'last_login' => date("Y-m-d H:i:s")]);
+                                return true;
+                            } else {
+                                $this->addToError(__("Invalid cookie data"));
+                            }
+                        }
+                    } catch (Throwable) {
+                        // Probably an old cookie format, ignore it and remove the cookie
+                        $this->addToError(__("Invalid cookie data"));
                     }
                 } else {
                     $this->addToError(__("Auto login disabled"));


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A little annoyance as I switch between GLPI 11 and `main` during development, but this will be an issue with users in production following the update to GLPI 12. If a GLPI cookie is set with the old format, GLPI would fail to decode it and it would cause a PHP error which soft-locked them, preventing access even to the login page, until they cleared their cookies. Now any exception during the handling of the cookie will trigger an "Invalid cookie data" error, clear the cookie, and redirect the user to the login page again which should honestly be required anyways after an upgrade.