### PR TITLE
Fix: remove user authorization via massive action

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -390,7 +390,7 @@ TWIG, $avatar_params) . $username;
 
             $entries[] = [
                 'itemtype' => self::class,
-                'id' => $data['id'],
+                'id' => $data['linkid'],
                 'name' => $username,
                 'profile' => $data['pname'],
             ];
@@ -576,7 +576,7 @@ TWIG, $avatar_params) . $username;
 TWIG, $avatar_params) . $username;
             $entries[] = [
                 'itemtype' => self::class,
-                'id' => $data['id'],
+                'id' => $data['linkid'],
                 'name' => $username,
                 'entity' => $entity_names[$data['entity']],
             ];

--- a/tests/functional/Profile_UserTest.php
+++ b/tests/functional/Profile_UserTest.php
@@ -36,9 +36,13 @@ namespace tests\units;
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\Tests\DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Profile;
 use Profile_User;
 use User;
+
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
 
 /**
  * Tests for Profile_User class
@@ -474,5 +478,49 @@ class Profile_UserTest extends DbTestCase
         //Check that the default profile of the user has been set to 0
         $user->getFromDB($user->getId());
         $this->assertEquals(0, $user->fields['profiles_id']);
+    }
+
+    public static function massiveActionTargetsLinkIdProvider(): iterable
+    {
+        yield 'users tab of a profile' => ['show_method' => 'showForProfile', 'target' => 'profile'];
+        yield 'users tab of an entity' => ['show_method' => 'showForEntity', 'target' => 'entity'];
+    }
+
+    #[DataProvider('massiveActionTargetsLinkIdProvider')]
+    public function testMassiveActionTargetsLinkId(string $show_method, string $target): void
+    {
+        // Massive action must target the Profile_User link id, not the user id
+        $this->login();
+
+        $profile = getItemByTypeName(Profile::class, 'Self-Service');
+        $entity  = getItemByTypeName(\Entity::class, '_test_root_entity');
+
+        $user = $this->createItem(User::class, [
+            'name'         => $this->getUniqueString(),
+            '_profiles_id' => $profile->getId(),
+            '_entities_id' => $entity->getId(),
+        ]);
+
+        $links = (new Profile_User())->find([
+            'users_id'    => $user->getId(),
+            'profiles_id' => $profile->getId(),
+            'entities_id' => $entity->getId(),
+        ]);
+        $this->assertCount(1, $links);
+        $link_id = array_key_first($links);
+        $this->assertNotEquals($user->getId(), $link_id);
+
+        ob_start();
+        Profile_User::$show_method($target === 'profile' ? $profile : $entity);
+        $html = ob_get_clean();
+
+        $this->assertStringContainsString(
+            sprintf('name="item[Profile_User][%d]"', $link_id),
+            $html
+        );
+        $this->assertStringNotContainsString(
+            sprintf('name="item[Profile_User][%d]"', $user->getId()),
+            $html
+        );
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45174
- Deleting a user's authorization (Profile_User) from the "Users" tab of a Profile or an Entity failed with a generic "Authorization error", even though the same deletion worked fine from the user's own "Authorizations" tab.
- The massive action checkbox on those two tabs targeted the user id instead of the Profile_User link id, so the permission check and the delete operation ran against the wrong record.

## Screenshots (if appropriate):

<img width="407" height="531" alt="image" src="https://github.com/user-attachments/assets/93213f50-864f-46e9-a209-a978458f84f8" />
<img width="407" height="531" alt="image" src="https://github.com/user-attachments/assets/e713434a-4451-4fe1-8073-605ffd7b7e6e" />


