### PR TITLE
KB article UI tweaks

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -78,13 +78,21 @@
 }
 
 .kb-illustration-preview {
-    padding: 0.25rem;
     border: 1px solid transparent;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 
-    &[role="button"]:hover {
-        border-color: var(--tblr-border-color);
-        box-shadow: var(--tblr-box-shadow-input);
+    // Only add spacing in edit mode, where the preview becomes an interactive
+    // button (role="button") that can be hovered to pick an illustration.
+    // Offset the padding with a matching negative margin so surrounding
+    // content keeps its position when switching between view and edit mode.
+    &[role="button"] {
+        padding: 0.25rem;
+        margin: -0.25rem;
+
+        &:hover {
+            border-color: var(--tblr-border-color);
+            box-shadow: var(--tblr-box-shadow-input);
+        }
     }
 }
 
@@ -248,9 +256,21 @@
 
 // KB documents footer tabs navigation
 #kb-documents {
-    .nav-link:hover,
-    .nav-link:focus {
-        background-color: transparent !important;
+    // Draw a continuous light gray line under the whole tab row so it reads as
+    // a standard tab layout; the active/hover tab underline sits on top of it.
+    .nav-underline {
+        border-bottom: 1px solid var(--tblr-border-color);
+    }
+
+    .nav-link {
+        // Overlap the container line so the active/hover underline replaces it
+        // instead of stacking just above it.
+        margin-bottom: -1px;
+
+        &:hover,
+        &:focus {
+            background-color: transparent !important;
+        }
     }
 }
 

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -86,17 +86,17 @@
             ></button>
         </div>
 
-        <div class="d-flex align-items-center mb-3">
+        <div class="d-flex align-items-center mb-1 mt-1">
             {% if mode == 'add' or mode == 'edit' or mode == 'view' %}
                 {# Hide container in view mode when no illustration is set;
                    JS will reveal it when switching to edit mode. #}
                 <div
-                    class="me-3 flex-shrink-0{% if illustration is empty and mode == 'view' %} d-none{% endif %}"
+                    class="me-2 flex-shrink-0{% if illustration is empty and mode == 'view' %} d-none{% endif %}"
                     data-glpi-kb-illustration-container
                 >
                     {{ include('components/illustration/icon_picker.html.twig', {
                         'value': illustration,
-                        'size': 48,
+                        'size': 36,
                         'preview_css_classes': "kb-illustration-preview d-flex align-items-center justify-content-center rounded",
                         'preview_inner_css_classes': "",
                         'editable': false,
@@ -265,12 +265,10 @@
 
         {% endif %}
 
-        <hr class="mt-4 mb-4">
-
         {# Tiptap editor container #}
         <div
             id="kb-tiptap-editor"
-            class="rich_text_container article-container"
+            class="rich_text_container article-container mt-4"
             data-glpi-kb-content
             data-testid="content"
         >
@@ -279,7 +277,7 @@
 
         {# Documents and Related Items section #}
         {% if (mode == "view" or mode == "edit") and (documents|length > 0 or can_add_documents or related_items|length > 0 or can_link_items) %}
-            <div id="kb-documents" class="kb-documents-footer mt-5 pt-4 border-top">
+            <div id="kb-documents" class="kb-documents-footer mt-5">
                 {# Tab navigation #}
                 <ul class="nav nav-underline mb-3" role="tablist">
                     <li class="nav-item" role="presentation">


### PR DESCRIPTION
At the top of the article, I've removed the line separator, using a spacing only solution.
I've tweaked a bit the padding and margins to make sure the header informations feels connected to the article title.

Before:
<img width="1051" height="272" alt="image" src="https://github.com/user-attachments/assets/eb83a7ab-16cb-43a7-8e41-c04c105059c4" />

After:
<img width="1055" height="226" alt="image" src="https://github.com/user-attachments/assets/7d0b8a13-566c-4716-8824-0562356a31aa" />
* Remove the bottom separator and use the tabs themselves as the separator instead.

At the end of the article, we remove the lone line separator and use the tab themselves as the separator instead:

Before:
<img width="536" height="359" alt="image" src="https://github.com/user-attachments/assets/7efe2077-5768-4353-9da0-e2a52ba0752b" />

After:
<img width="521" height="332" alt="image" src="https://github.com/user-attachments/assets/e9d4d8f5-206d-4b6f-8c76-3eaf616bb5b6" />

