### PR TITLE
Fix (TicketTask) empty task duration dropdown no longer overrides the planned end date

### DIFF
--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -434,12 +434,15 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      */
     private function handleTaskDuration(array &$input, int $timestart, int $timeend): void
     {
-        // If 'actiontime' is set and different from the current 'actiontime'
-        if (isset($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
+        // If a real duration (> 0) is set and different from the current 'actiontime'
+        //it takes precedence and the end date is recomputed from it An empty duration 0,
+        //e.g. the "-----" choice of the duration dropdown, must not override an explicitly entered end date,
+        //otherwise end would collapse onto begin
+        if (!empty($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
             // Compute the end date based on 'actiontime'
             $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);
         } else {
-            // If 'actiontime' is not set, compute it based on the start and end times
+            // Otherwise, compute the duration based on the start and end times
             $input["actiontime"] = $timeend - $timestart;
         }
     }

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -434,10 +434,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      */
     private function handleTaskDuration(array &$input, int $timestart, int $timeend): void
     {
-        // If a real duration (> 0) is set and different from the current 'actiontime'
-        //it takes precedence and the end date is recomputed from it An empty duration 0,
-        //e.g. the "-----" choice of the duration dropdown, must not override an explicitly entered end date,
-        //otherwise end would collapse onto begin
+        // A non-zero 'actiontime' recomputes 'end'.
+        // A zero value (empty dropdown choice) must not override an explicitly entered end date.
         if (!empty($input['actiontime']) && $this->fields['actiontime'] != $input['actiontime']) {
             // Compute the end date based on 'actiontime'
             $input["end"] = date("Y-m-d H:i:s", $timestart + $input['actiontime']);

--- a/tests/functional/TicketTaskTest.php
+++ b/tests/functional/TicketTaskTest.php
@@ -838,6 +838,62 @@ final class TicketTaskTest extends CommonITILTaskTestCase
         );
     }
 
+    /**
+     * An empty duration (selecting ‘----’ from the duration drop-down menu sends the value ‘0’)
+     * must not replace an end date that has been entered.
+     * Otherwise, the "end" will coincide with the "start"
+     * and the error : "the start date is later than the end date" will be generated incorrectly
+     *
+     * @return void
+     */
+    public function testEmptyActiontimeDoesNotOverrideEndDate()
+    {
+        $this->login();
+        $ticketId = $this->getNewTicket();
+        $uid = getItemByTypeName('User', TU_USER, true);
+
+        $date_begin = new \DateTime(); // ==> now
+        $date_begin_string = $date_begin->format('Y-m-d H:i:s');
+
+        $date_end = clone $date_begin;
+        $date_end->add(new \DateInterval('PT1H')); // ==> +1 hour
+        $date_end_string = $date_end->format('Y-m-d H:i:s');
+
+        // Create a task with a duration that is not one of the duration dropdown steps (12 min)
+        // Such a value makes the dropdown fall back to its empty choice, which submits "0"
+        $task = new TicketTask();
+        $task_id = $task->add([
+            'state'              => \Planning::TODO,
+            'tickets_id'         => $ticketId,
+            'tasktemplates_id'   => '0',
+            'taskcategories_id'  => '0',
+            'content'            => "Task with non-standard duration",
+            'users_id_tech'      => $uid,
+            'actiontime'         => 720,
+        ]);
+        $this->assertGreaterThan(0, $task_id);
+        $this->assertEquals(720, $task->fields['actiontime']);
+
+        // Schedule the task with an explicit end date while the duration dropdown submits "0".
+        $this->assertTrue(
+            $task->update([
+                'id'                 => $task_id,
+                'tickets_id'         => $ticketId,
+                'users_id_tech'      => $uid,
+                'actiontime'         => '0',
+                'plan'               => [
+                    'begin'        => $date_begin_string,
+                    'end'          => $date_end_string,
+                ],
+            ])
+        );
+
+        // The explicitly entered end date must be preserved and the duration recomputed from it.
+        $this->assertEquals($date_begin_string, $task->fields['begin']);
+        $this->assertEquals($date_end_string, $task->fields['end']);
+        $this->assertEquals(3600, $task->fields['actiontime']);
+    }
+
     public function testParentMetaSearchOptions()
     {
         $this->login();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45088
- Here is a ~~brief~~ description of what this PR does

The task form contains two duration fields that are submitted at the same time during saving:

The duration drop-down list: `actiontime` field
The schedule 
Upon saving, `handleTaskDuration` determines which one takes precedence. Its rule was:

If the duration from the drop-down list differs from the one saved, then it takes precedence, and it recalculates the end date as start date + duration.

The duration drop-down list only offers fixed increments (1 to 9 minutes, then in 5-minute increments, then in hours, etc.). If the task has a duration that does not match any of these increments (for example, 12 minutes), the list cannot display it → it defaults to the empty option “-----,” which sends the value 0.

Upon saving:

list duration (0)  ≠  saved duration (e.g., 720 s)   → the list “wins”
therefore  end = start + 0 = start
therefore  start = end  →  validation fails  →  ERROR

Now: we only allow the “duration” list to override the end date if an actual duration (> 0) has been selected.



## Screenshots (if appropriate):


<img width="503" height="323" alt="Capture d’écran du 2026-07-08 14-32-11" src="https://github.com/user-attachments/assets/16df3b91-873c-4052-9d26-e332903cf91c" />
<img width="274" height="98" alt="Capture d’écran du 2026-07-08 14-33-36" src="https://github.com/user-attachments/assets/ae464399-f3b7-4201-ab5a-fc16faae0041" />



