### PR TITLE
fix(i18n): fix i18n translation issues in planning and reservations modules

### DIFF
--- a/js/planning.js
+++ b/js/planning.js
@@ -135,7 +135,7 @@ var GLPIPlanning  = {
                 },
                 resourceWeek: {
                     type: 'resourceTimeline',
-                    buttonText: 'Timeline Week',
+                    buttonText: __('Timeline Week'),
                     duration: { weeks: 1 },
                     //hiddenDays: [6, 0],
                     groupByDateAndResource: true,

--- a/js/planning.js
+++ b/js/planning.js
@@ -36,7 +36,6 @@
 /* global FullCalendar, FullCalendarLocales, FullCalendarInteraction */
 /* global glpi_ajax_dialog, glpi_html_dialog */
 /* global _ */
-/* global getFlatPickerLocale */
 
 var GLPIPlanning  = {
     calendar:      null,
@@ -87,7 +86,7 @@ var GLPIPlanning  = {
         var all_days = [0, 1, 2, 3, 4, 5, 6];
         var enabled_days = CFG_GLPI.planning_work_days;
         var hidden_days = all_days.filter(day => !enabled_days.some(n => n == day));
-        var loadedLocales = Object.keys(FullCalendarLocales);
+        var loadedLocales = typeof FullCalendarLocales !== 'undefined' ? Object.keys(FullCalendarLocales) : [];
         const list_full_year_range = options.full_view ? 5 : 1; // +/- number of years to display in list full view
 
         this.calendar = new FullCalendar.Calendar(document.getElementById(GLPIPlanning.dom_id), {

--- a/js/planning.js
+++ b/js/planning.js
@@ -101,6 +101,7 @@ var GLPIPlanning  = {
             maxTime:     CFG_GLPI.planning_end,
             schedulerLicenseKey: "GPL-My-Project-Is-Open-Source",
             resourceAreaWidth: '15%',
+            resourceLabelText: __('Resources'),
             editable: true, // we can drag / resize items
             droppable: false, // we cant drop external items by default
             nowIndicator: true,
@@ -967,6 +968,7 @@ var GLPIPlanning  = {
     initFCDatePicker: function(currentDate) {
         $('#planning_datepicker').flatpickr({
             defaultDate: currentDate,
+            locale: getFlatPickerLocale(CFG_GLPI.flatpickr_lang || 'en', CFG_GLPI.flatpickr_region || ''),
             onChange: function(selected_date) {
             // convert to UTC to avoid timezone issues
                 var date = new Date(

--- a/js/planning.js
+++ b/js/planning.js
@@ -36,6 +36,7 @@
 /* global FullCalendar, FullCalendarLocales, FullCalendarInteraction */
 /* global glpi_ajax_dialog, glpi_html_dialog */
 /* global _ */
+/* global getFlatPickerLocale */
 
 var GLPIPlanning  = {
     calendar:      null,

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -93,6 +93,7 @@ var Reservations = function() {
                 return _newheight;
             },
             resourceAreaWidth: '15%',
+            resourceLabelText: __('Resources'),
             plugins: ['dayGrid', 'interaction', 'list', 'timeGrid', 'resourceTimeline'],
             header: {
                 left:   'prev,next,today',

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -269,7 +269,7 @@ var Reservations = function() {
         my.calendar.render();
 
         // load language
-        var loadedLocales = Object.keys(FullCalendarLocales);
+        var loadedLocales = typeof FullCalendarLocales !== 'undefined' ? Object.keys(FullCalendarLocales) : [];
         if (loadedLocales.length === 1) {
             my.calendar.setOption('locale', loadedLocales[0]);
         }

--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -334,6 +334,11 @@ class FrontEndAssetsExtension extends AbstractExtension
             $cfg_glpi += Config::getSafeConfig(true);
         }
 
+        // Add flatpickr locale for i18n
+        $locale = \Locale::parseLocale($_SESSION['glpilanguage'] ?? 'en_GB');
+        $cfg_glpi['flatpickr_lang'] = $locale['language'] ?? 'en';
+        $cfg_glpi['flatpickr_region'] = $locale['region'] ?? '';
+
         $plugins_path = \array_combine(
             Plugin::getPlugins(),
             \array_map(fn(string $plugin_key) => "/plugins/{$plugin_key}", Plugin::getPlugins())

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -582,16 +582,30 @@ class Reservation extends CommonDBChild
 
         $js = "
             $(function() {
-                var reservation = new Reservations();
-                reservation.init({
-                    id: $ID,
-                    is_all: " . ($ID === 0 ? "true" : "false") . ",
-                    rand: $rand,
-                    can_reserve: " . ($can_reserve ? "true" : "false") . ",
-                    now: '" . jsescape($_SESSION["glpi_currenttime"]) . "',
-                    defaultDate: '" . jsescape($default_date) . "',
-                });
-                reservation.displayPlanning();
+                var reservationInitialized = false;
+                function initReservation() {
+                    if (reservationInitialized) {
+                        return;
+                    }
+                    reservationInitialized = true;
+                    clearInterval(retryTimer);
+                    var reservation = new Reservations();
+                    reservation.init({
+                        id: $ID,
+                        is_all: " . ($ID === 0 ? "true" : "false") . ",
+                        rand: $rand,
+                        can_reserve: " . ($can_reserve ? "true" : "false") . ",
+                        now: '" . jsescape($_SESSION["glpi_currenttime"]) . "',
+                        defaultDate: '" . jsescape($default_date) . "',
+                    });
+                    reservation.displayPlanning();
+                }
+                // Wait until all pending AJAX requests (including i18n locale loading) are done
+                var retryTimer = setInterval(function() {
+                    if (typeof $ === 'undefined' || $.active === 0) {
+                        initReservation();
+                    }
+                }, 100);
           });
         ";
         echo Html::scriptBlock($js);

--- a/tools/patches/npm/gettext.js+2.0.3.patch
+++ b/tools/patches/npm/gettext.js+2.0.3.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/gettext.js/lib/gettext.js b/node_modules/gettext.js/lib/gettext.js
+index 1234567..abcdefg 100644
+--- a/node_modules/gettext.js/lib/gettext.js
++++ b/node_modules/gettext.js/lib/gettext.js
+@@ -218,7 +218,12 @@
+         // because it's not possible to define both a singular and a plural form of the same msgid,
+         // we need to check that the stored form is the same as the expected one.
+         // if not, we'll just ignore the translation and consider it as not translated.
+         if (msgid_plural) {
++          // If the translation is stored as a string (e.g. languages with nplurals=1),
++          // wrap it in an array so plural form lookup works correctly.
++          if (exist && "string" === typeof _dictionary[domain][locale][key]) {
++            _dictionary[domain][locale][key] = [_dictionary[domain][locale][key]];
++          }
+           exist = exist && "string" !== typeof _dictionary[domain][locale][key];
+         } else {
+           exist = exist && "string" === typeof _dictionary[domain][locale][key];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- The 'Timeline Week' button text in the resource week view was hardcoded and not translatable. Wrapping it with __() enables proper i18n support.
- Add translatable resourceLabelText for planning and reservations resource area label so it follows user locale
- Add flatpickr locale configuration derived from session language to ensure date picker displays in correct language
- Add 'Resources' translation entry to all locale files
- Inject flatpickr_lang and flatpickr_region into CFG_GLPI for client-side locale resolution"
- fix(reservations): wait for i18n translations before calendar init
  
  The reservations page creates the FullCalendar synchronously inside
  $(function(){}) while i18n translations are loaded via async AJAX.
  By the time the calendar is created, the AJAX may not have completed,
  causing __('Resources') and __('Timeline Week') to display in English
  instead of the user's language.

  Fix by polling $.active (jQuery's pending AJAX counter) until all
  requests—including the locale loading—are done before initializing
  the calendar. This works for all languages including English.
- fix(i18n): patch gettext.js to handle plural forms as strings
  
  gettext.js requires plural form values to be arrays, but locales with
  nplurals=1 (e.g. zh_CN) may store them as plain strings in the JSON
  from front/locale.php. This causes _n() calls like
  _n('Calendar', 'Calendars', 1) to fall back to English.

  Patch dcnpgettext to auto-wrap string values into single-element
  arrays when a plural lookup is performed, so the existing array
  access logic works correctly.

## Screenshots (if appropriate):

<img width="1359" height="660" src="https://github.com/user-attachments/assets/7a69eacb-581a-4ae6-8f39-4aabfb2043a9" />

<img width="618" height="308" src="https://github.com/user-attachments/assets/8ff1c971-90f5-4b70-a53b-ef4a44200da2" />
