### PR TITLE
Fix notification bell from form and delegation

### DIFF
--- a/src/Glpi/Controller/Form/SubmitAnswerController.php
+++ b/src/Glpi/Controller/Form/SubmitAnswerController.php
@@ -134,9 +134,12 @@ final class SubmitAnswerController extends AbstractController
         $post = $request->request->all();
         $provider = new EndUserInputNameProvider();
 
+        $delegated_users_id = $request->request->getInt('delegation_users_id', 0) ?: null;
         $delegation = new DelegationData(
-            $request->request->getInt('delegation_users_id', 0) ?: null,
-            $request->request->getBoolean('delegation_use_notification', false) ?: null,
+            $delegated_users_id,
+            $delegated_users_id !== null
+                ? $request->request->getBoolean('delegation_use_notification', false)
+                : null,
             $request->request->getString('delegation_alternative_email', '') ?: null
         );
         $answers    = $provider->getAnswers($post);

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -142,10 +142,13 @@ enum ITILActorFieldStrategy: string
                 ],
             ];
         } else {
+            $current_user = new User();
+            $current_user->getFromDB($user_id);
             return [
                 [
                     'itemtype' => User::class,
-                    'items_id' => $user_id,
+                    'items_id' => (int) $user_id,
+                    'use_notification' => (int) $current_user->isUserNotificationEnable(),
                 ],
             ];
         }

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -188,6 +188,7 @@ final class RequesterFieldTest extends AbstractActorFieldTest
             [
                 'itemtype'          => User::class,
                 'items_id'          => $post_only_id,
+                'use_notification'  => 1,
             ],
             $actors[0]
         );

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -135,10 +135,31 @@ final class RequesterFieldTest extends AbstractActorFieldTest
             answers: [],
             expected_actors: [
                 [
-                    'items_id' => $auth->getUser()->getID(),
-                    'itemtype' => User::class,
-                    // Make sure notifications are enabled
+                    'items_id'         => $auth->getUser()->getID(),
+                    'itemtype'         => User::class,
                     'use_notification' => 1,
+                ],
+            ]
+        );
+
+        // User with notifications explicitly disabled: use_notification must be 0
+        $user_no_notif = $this->createItem(User::class, [
+            'name'                    => 'testRequesterFormFiller NoNotif',
+            'password'                => 'testRequesterFormFiller NoNotif',
+            'password2'               => 'testRequesterFormFiller NoNotif',
+            'is_notif_enable_default' => 0,
+        ], ['password', 'password2']);
+
+        $this->login($user_no_notif->fields['name'], $user_no_notif->fields['name']);
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: $form_filler_config,
+            answers: [],
+            expected_actors: [
+                [
+                    'items_id'         => $user_no_notif->getID(),
+                    'itemtype'         => User::class,
+                    'use_notification' => 0,
                 ],
             ]
         );


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44335


When a user submits a helpdesk form, the FORM_FILLER actor strategy resolves the requester through getActorsFromCurrentUser(). This method handles two cases:

- Delegation — the submitter selects another user from their delegation group ("Ticket is for [other member]")
- Self — the submitter selects themselves, or is not in any delegation group ("Ticket is for [myself]")

Two bugs were identified in this flow.

#### Bug 1  use_notification=false silently converted to null in the controller

`DelegationData::$use_notification` was built with:

`$request->request->getBoolean('delegation_use_notification', false) ?: null,`

The Elvis operator converts both "field absent" and "field = false" to null, making it impossible to distinguish between no delegation (field not submitted) and delegation with notifications explicitly disabled. When a real delegatee selected "He doesn't want" notifications, the value arrived as null instead of false.

Fix: extract `$delegated_users_id` first, then conditionally read `delegation_use_notification` only when a delegation is actually present, preserving false as a distinct value.

#### Bug 2  notification preference ignored when submitting for oneself

When the delegation UI shows "Ticket is for [myself]", the notification dropdown is intentionally not rendered (the user cannot express a preference). 
The form still submits `delegation_users_id = own_id`, which correctly bypasses the delegation branch. However, the else branch returned the actor without a `use_notification` field, causing `ITILActorField` to unconditionally default to 1 (notifications always enabled), ignoring the user's account-level preference (`isUserNotificationEnable()`).

The same applies when no delegation group is configured and the field is never shown.

Fix: load the current user in the else branch and explicitly set use_notification from isUserNotificationEnable().


## Screenshots (if appropriate):


