### PR TITLE
Fix: keep saved search filter active after list refresh

### DIFF
--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -816,6 +816,10 @@ final class QueryBuilder implements SearchInputInterface
             && $usesession
         ) {
             foreach ($params as $key => $val) {
+                // 'reset' is one-shot, must not persist in session
+                if ($key === 'reset') {
+                    continue;
+                }
                 $_SESSION['glpisearch'][$itemtype][$key] = $val;
             }
         }

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -62,6 +62,12 @@ use TaskCategory;
 use Ticket;
 use User;
 
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+use function Safe\preg_match;
+use function Safe\preg_replace;
+use function Safe\strtotime;
+
 class SearchTest extends DbTestCase
 {
     private function doSearch($itemtype, $params, array $forcedisplay = [])
@@ -1532,7 +1538,10 @@ class SearchTest extends DbTestCase
             ])
         );
 
-        $search = \Search::manageParams('Ticket', ['reset' => 1], true, false);
+        // SavedSearch::load() sets this session flag before redirecting to the search page
+        $_SESSION['glpi_loaded_savedsearch'] = $bk_id;
+
+        $search = \Search::manageParams('Ticket', ['reset' => 1, 'savedsearches_id' => $bk_id], true, false);
         $this->assertEquals(
             [
                 'reset'        => 1,
@@ -1556,6 +1565,24 @@ class SearchTest extends DbTestCase
             ],
             $search
         );
+
+        // no stale 'reset' flag must remain in session after loading a saved search
+        $this->assertEquals($bk_id, $_SESSION['glpi_loaded_savedsearch']);
+        $this->assertArrayNotHasKey('reset', $_SESSION['glpisearch']['Ticket']);
+
+        // saved search criteria must survive a subsequent unrelated request (sort/pagination)
+        \Search::manageParams('Ticket', ['sort' => 6, 'order' => 'ASC'], true, false);
+        $this->assertEquals(
+            [
+                0 => [
+                    'field' => '5',
+                    'searchtype' => 'equals',
+                    'value' => $uid,
+                ],
+            ],
+            $_SESSION['glpisearch']['Ticket']['criteria']
+        );
+        $this->assertEquals($bk_id, $_SESSION['glpi_loaded_savedsearch']);
 
         // let's test for Computers
         $search = \Search::manageParams('Computer', ['reset' => 1], false, false);
@@ -1608,7 +1635,10 @@ class SearchTest extends DbTestCase
             ])
         );
 
-        $search = \Search::manageParams('Computer', ['reset' => 1], true, false);
+        // SavedSearch::load() sets this session flag before redirecting to the search page
+        $_SESSION['glpi_loaded_savedsearch'] = $bk_id;
+
+        $search = \Search::manageParams('Computer', ['reset' => 1, 'savedsearches_id' => $bk_id], true, false);
         $this->assertEquals(
             [
                 'reset'        => 1,
@@ -1633,6 +1663,24 @@ class SearchTest extends DbTestCase
             ],
             $search
         );
+
+        // no stale 'reset' flag must remain in session after loading a saved search
+        $this->assertEquals($bk_id, $_SESSION['glpi_loaded_savedsearch']);
+        $this->assertArrayNotHasKey('reset', $_SESSION['glpisearch']['Computer']);
+
+        // saved search criteria must survive a subsequent unrelated request (sort/pagination)
+        \Search::manageParams('Computer', ['sort' => 1, 'order' => 'ASC'], true, false);
+        $this->assertEquals(
+            [
+                0 => [
+                    'field' => 'view',
+                    'searchtype' => 'contains',
+                    'value' => 'test',
+                ],
+            ],
+            $_SESSION['glpisearch']['Computer']['criteria']
+        );
+        $this->assertEquals($bk_id, $_SESSION['glpi_loaded_savedsearch']);
     }
 
     public static function addSelectProvider()


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45194
- After loading a saved search, sorting a column or changing the page or page size could silently clear the active filter and fall back to showing all results, while the saved search name stayed displayed as active in the list header.
- The `reset` flag used to load a saved search was persisted into the search session instead of being consumed once, so a later unrelated request (sort, pagination) would wipe the whole search session.

## Screenshots (if appropriate):

