### PR TITLE
Improve helpdesk tiles rights

### DIFF
--- a/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/ExternalPageTile.php
@@ -44,6 +44,8 @@ use Override;
 
 final class ExternalPageTile extends CommonDBTM implements TileInterface, ProvideTranslationsInterface
 {
+    use TileRightTrait;
+
     public static $rightname = 'config';
 
     public const TRANSLATION_KEY_TITLE = 'title';
@@ -59,18 +61,6 @@ final class ExternalPageTile extends CommonDBTM implements TileInterface, Provid
     public function getLabel(): string
     {
         return __("External page");
-    }
-
-    #[Override]
-    public static function canCreate(): bool
-    {
-        return self::canUpdate();
-    }
-
-    #[Override]
-    public static function canPurge(): bool
-    {
-        return self::canUpdate();
     }
 
     #[Override]

--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -45,6 +45,8 @@ use Ticket;
 
 final class FormTile extends CommonDBChild implements TileInterface
 {
+    use TileRightTrait;
+
     public static $rightname = 'config';
     public static $itemtype = Form::class;
     public static $items_id = 'forms_forms_id';
@@ -61,18 +63,6 @@ final class FormTile extends CommonDBChild implements TileInterface
     public function getLabel(): string
     {
         return Form::getTypeName(1);
-    }
-
-    #[Override]
-    public static function canCreate(): bool
-    {
-        return self::canUpdate();
-    }
-
-    #[Override]
-    public static function canPurge(): bool
-    {
-        return self::canUpdate();
     }
 
     #[Override]

--- a/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
+++ b/src/Glpi/Helpdesk/Tile/GlpiPageTile.php
@@ -51,6 +51,8 @@ use Toolbox;
 
 final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTranslationsInterface
 {
+    use TileRightTrait;
+
     public static $rightname = 'config';
 
     public const PAGE_SERVICE_CATALOG = 'service_catalog';
@@ -72,18 +74,6 @@ final class GlpiPageTile extends CommonDBTM implements TileInterface, ProvideTra
     public function getLabel(): string
     {
         return __("GLPI page");
-    }
-
-    #[Override]
-    public static function canCreate(): bool
-    {
-        return self::canUpdate();
-    }
-
-    #[Override]
-    public static function canPurge(): bool
-    {
-        return self::canUpdate();
     }
 
     public static function getPossiblesPages(): array

--- a/src/Glpi/Helpdesk/Tile/TileRightTrait.php
+++ b/src/Glpi/Helpdesk/Tile/TileRightTrait.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Helpdesk\Tile;
+
+use CommonDBTM;
+use Entity;
+use Profile;
+
+/**
+ * Right management for items implementing {@link TileInterface}.
+ *
+ * Tiles do not have their own dedicated right: they can be viewed, created,
+ * updated, deleted or purged by anyone that is allowed to *update* the item
+ * they are attached to (see {@link LinkableToTilesInterface}).
+ */
+trait TileRightTrait
+{
+    public static function canView(): bool
+    {
+        return self::canViewTiles();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canManageTiles();
+    }
+
+    public static function canUpdate(): bool
+    {
+        return self::canManageTiles();
+    }
+
+    public static function canDelete(): bool
+    {
+        return self::canManageTiles();
+    }
+
+    public static function canPurge(): bool
+    {
+        return self::canManageTiles();
+    }
+
+    public function canViewItem(): bool
+    {
+        return $this->hasRightOnLinkedItem(READ);
+    }
+
+    public function canCreateItem(): bool
+    {
+        $holder = $this->getHolderFromInput();
+        if ($holder === null) {
+            return false;
+        }
+
+        return $holder->can($holder->getID(), UPDATE);
+    }
+
+    public function canUpdateItem(): bool
+    {
+        return $this->hasRightOnLinkedItem(UPDATE);
+    }
+
+    public function canDeleteItem(): bool
+    {
+        return $this->hasRightOnLinkedItem(UPDATE);
+    }
+
+    public function canPurgeItem(): bool
+    {
+        return $this->hasRightOnLinkedItem(UPDATE);
+    }
+
+    public function post_addItem()
+    {
+        parent::post_addItem();
+
+        // Attach the tile to the holder captured from the creation input. This
+        // makes the holder both the value validated by canCreateItem() and the
+        // value that is actually persisted, so it can not be spoofed.
+        $holder = $this->getHolderFromInput();
+        if ($holder === null) {
+            return;
+        }
+
+        $item_tile = new Item_Tile();
+        $item_tile->add([
+            'itemtype_item' => $holder::class,
+            'items_id_item' => $holder->getID(),
+            'itemtype_tile' => static::class,
+            'items_id_tile' => $this->getID(),
+            'rank'          => $this->getNextTileRank($holder),
+        ]);
+    }
+
+    /**
+     * Itemtypes that are allowed to hold tiles.
+     *
+     * @return array<class-string<CommonDBTM&LinkableToTilesInterface>>
+     */
+    private static function getTileHolderItemtypes(): array
+    {
+        return [
+            Entity::class,
+            Profile::class,
+        ];
+    }
+
+    /**
+     * Whether the current user can view at least one item that can hold tiles.
+     *
+     * Used as a coarse check for the global "view" right.
+     */
+    private static function canViewTiles(): bool
+    {
+        foreach (self::getTileHolderItemtypes() as $itemtype) {
+            if ($itemtype::canView()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the current user can update at least one item that can hold
+     * tiles.
+     *
+     * Used as a coarse check for the global rights and for actions that are not
+     * yet tied to a specific tile (e.g. creation).
+     */
+    private static function canManageTiles(): bool
+    {
+        foreach (self::getTileHolderItemtypes() as $itemtype) {
+            if ($itemtype::canUpdate()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Whether the current user has the given right on the item this tile is
+     * attached to. Viewing a tile follows the item's view right, while altering
+     * it (create/update/delete/purge) follows the item's update right.
+     */
+    private function hasRightOnLinkedItem(int $right): bool
+    {
+        $item_tile = new Item_Tile();
+        $found = $item_tile->getFromDBByCrit([
+            'itemtype_tile' => static::class,
+            'items_id_tile' => $this->getID(),
+        ]);
+        if (!$found) {
+            return false;
+        }
+
+        $holder = $this->resolveHolder(
+            $item_tile->fields['itemtype_item'],
+            (int) $item_tile->fields['items_id_item'],
+        );
+
+        return $holder !== null && $holder->can($holder->getID(), $right);
+    }
+
+    /**
+     * The tile holder described by the creation input, or null when none is
+     * provided or it is invalid.
+     *
+     * @return (CommonDBTM&LinkableToTilesInterface)|null
+     */
+    private function getHolderFromInput(): ?CommonDBTM
+    {
+        $itemtype = $this->input['_itemtype_item'] ?? null;
+        $items_id = $this->input['_items_id_item'] ?? null;
+        if ($itemtype === null || $items_id === null) {
+            return null;
+        }
+
+        return $this->resolveHolder((string) $itemtype, (int) $items_id);
+    }
+
+    /**
+     * Load the given tile holder, or return null when it is invalid.
+     *
+     * @return (CommonDBTM&LinkableToTilesInterface)|null
+     */
+    private function resolveHolder(string $itemtype, int $items_id): ?CommonDBTM
+    {
+        $holder = getItemForItemtype($itemtype);
+        if (
+            !$holder instanceof CommonDBTM
+            || !$holder instanceof LinkableToTilesInterface
+            || !$holder->getFromDB($items_id)
+        ) {
+            return null;
+        }
+
+        return $holder;
+    }
+
+    /**
+     * Next available rank for a tile attached to the given holder.
+     */
+    private function getNextTileRank(CommonDBTM&LinkableToTilesInterface $holder): int
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $result = $DB->request([
+            'SELECT' => ['MAX' => 'rank AS max_rank'],
+            'FROM'   => Item_Tile::getTable(),
+            'WHERE'  => [
+                'itemtype_item' => $holder::class,
+                'items_id_item' => $holder->getID(),
+            ],
+        ])->current();
+
+        return ($result['max_rank'] ?? 0) + 1;
+    }
+}

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -231,25 +231,29 @@ final class TilesManager
             throw new InvalidArgumentException();
         }
 
+        // The holder is passed through the tile input: the tile links itself to
+        // it (see TileRightTrait::post_addItem()), so the created link always
+        // matches the holder the rights were checked against.
         $tile = new $tile_class();
-        $id = $tile->add($params);
-        if (!$id) {
+        $tile_id = $tile->add($params + [
+            '_itemtype_item' => $item::class,
+            '_items_id_item' => $item->getID(),
+        ]);
+        if (!$tile_id) {
             throw new RuntimeException("Failed to create tile");
         }
 
         $item_tile = new Item_Tile();
-        $id = $item_tile->add([
-            'items_id_item' => $item->getID(),
-            'itemtype_item' => $item::class,
-            'items_id_tile' => $id,
-            'itemtype_tile' => $tile_class,
-            'rank'          => $this->getMaxUsedRankForItem($item) + 1,
-        ]);
-        if (!$id) {
+        if (
+            !$item_tile->getFromDBByCrit([
+                'itemtype_tile' => $tile_class,
+                'items_id_tile' => $tile_id,
+            ])
+        ) {
             throw new RuntimeException("Failed to link tile to item");
         }
 
-        return $id;
+        return $item_tile->getID();
     }
 
     public function getItemTileForTile(TileInterface $tile): Item_Tile

--- a/templates/pages/admin/helpdesk_home_translation.html.twig
+++ b/templates/pages/admin/helpdesk_home_translation.html.twig
@@ -89,30 +89,34 @@
 {% for handlers in item.listTranslationsHandlers() %}
     {% set group_entries = [] %}
     {% for handler in handlers %}
-        {% set item_translation = helpdesk_translation.getForItemKeyAndLanguage(
-            handler.getItem(),
-            handler.getKey(),
-            helpdesk_translation.fields['language']
-        ) %}
-        {% if handler.getValue() is not empty or (item_translation is not null and item_translation.getTranslation() is not empty) %}
-            {% set default_value = handler.getValue() %}
-            {% if handler.getValue() is empty %}
-                {% set default_value = '<span class="text-muted fst-italic">' ~ __('No default value') ~ '</span>' %}
-            {% else %}
-                {% set default_value = handler.isRichText() ? '<div class="rich_text_container rich_text_container_translation">' ~ default_value|safe_html ~ '</div>' : default_value|e %}
+        {% set handler_item = handler.getItem() %}
+        {# Only expose translations for items the current user is allowed to see #}
+        {% if handler_item.can(handler_item.getID(), constant('READ')) %}
+            {% set item_translation = helpdesk_translation.getForItemKeyAndLanguage(
+                handler.getItem(),
+                handler.getKey(),
+                helpdesk_translation.fields['language']
+            ) %}
+            {% if handler.getValue() is not empty or (item_translation is not null and item_translation.getTranslation() is not empty) %}
+                {% set default_value = handler.getValue() %}
+                {% if handler.getValue() is empty %}
+                    {% set default_value = '<span class="text-muted fst-italic">' ~ __('No default value') ~ '</span>' %}
+                {% else %}
+                    {% set default_value = handler.isRichText() ? '<div class="rich_text_container rich_text_container_translation">' ~ default_value|safe_html ~ '</div>' : default_value|e %}
+                {% endif %}
+                {% set group_entries = group_entries|merge([{
+                    'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',
+                    'default': default_value,
+                    'translation': _self.getTranslationInput(
+                        handler,
+                        item_translation,
+                        helpdesk_translation.getCldrLanguage().getPluralKey(1)
+                    ),
+                    'type_aria_label': __('Translation name'),
+                    'default_aria_label': __('Default value'),
+                    'translation_aria_label': __('Translated value')
+                }]) %}
             {% endif %}
-            {% set group_entries = group_entries|merge([{
-                'type': '<span class="fw-medium">' ~ handler.getName() ~ '</span>',
-                'default': default_value,
-                'translation': _self.getTranslationInput(
-                    handler,
-                    item_translation,
-                    helpdesk_translation.getCldrLanguage().getPluralKey(1)
-                ),
-                'type_aria_label': __('Translation name'),
-                'default_aria_label': __('Default value'),
-                'translation_aria_label': __('Translated value')
-            }]) %}
         {% endif %}
     {% endfor %}
 

--- a/tests/cypress/e2e/self-service/helpdesk_translation.cy.js
+++ b/tests/cypress/e2e/self-service/helpdesk_translation.cy.js
@@ -100,14 +100,9 @@ describe('Edit helpdesk translations', () => {
             'title': tile_title,
             'description': tile_description,
             'page': 'faq',
-        }).as('tileId').then((tile_id) => {
-            cy.createWithAPI('Glpi\\Helpdesk\\Tile\\Item_Tile', {
-                'itemtype_item': 'Entity',
-                'items_id_item': 1,
-                'itemtype_tile': 'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
-                'items_id_tile': tile_id,
-            });
-        });
+            '_itemtype_item': 'Entity',
+            '_items_id_item': 1,
+        }).as('tileId');
 
         // Navigate to the helpdesk translations tab in general configuration
         cy.visit('/front/config.form.php');

--- a/tests/e2e/utils/Api.ts
+++ b/tests/e2e/utils/Api.ts
@@ -131,27 +131,13 @@ export class Api
         id: number,
         tiles: Tile[]
     ): Promise<void> {
-        // Create a few tiles
-        const created_tiles = [];
         for (const tile of tiles) {
-            created_tiles.push(
-                this.createItem('Glpi\\Helpdesk\\Tile\\GlpiPageTile', tile)
-            );
+            await this.createItem('Glpi\\Helpdesk\\Tile\\GlpiPageTile', {
+                ...tile,
+                '_itemtype_item': itemtype,
+                '_items_id_item': id,
+            });
         }
-        const tile_ids = await Promise.all(created_tiles);
-
-        const linked_tiles = [];
-        let i = 0;
-        for (const tile_id of tile_ids) {
-            linked_tiles.push(this.createItem('Glpi\\Helpdesk\\Tile\\Item_Tile', {
-                'itemtype_item': itemtype,
-                'items_id_item': id,
-                'itemtype_tile': 'Glpi\\Helpdesk\\Tile\\GlpiPageTile',
-                'items_id_tile': tile_id,
-                'rank': i++,
-            }));
-        }
-        await Promise.all(linked_tiles);
     }
 
     private async doCreateItem(itemtype: string, fields: object): Promise<number>

--- a/tests/functional/Glpi/Helpdesk/Tile/ExternalPageTileTest.php
+++ b/tests/functional/Glpi/Helpdesk/Tile/ExternalPageTileTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Helpdesk\Tile;
+
+use Glpi\Helpdesk\Tile\ExternalPageTile;
+use Glpi\Tests\AbstractTileRightsTest;
+
+final class ExternalPageTileTest extends AbstractTileRightsTest
+{
+    protected function getTileClass(): string
+    {
+        return ExternalPageTile::class;
+    }
+
+    protected function getTileInput(): array
+    {
+        return [
+            'title'        => 'GLPI project',
+            'description'  => 'Link to GLPI project website',
+            'illustration' => 'request-service',
+            'url'          => 'https://glpi-project.org',
+        ];
+    }
+}

--- a/tests/functional/Glpi/Helpdesk/Tile/FormTileTest.php
+++ b/tests/functional/Glpi/Helpdesk/Tile/FormTileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Helpdesk\Tile;
+
+use Glpi\Helpdesk\Tile\FormTile;
+use Glpi\Tests\AbstractTileRightsTest;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+
+final class FormTileTest extends AbstractTileRightsTest
+{
+    use FormTesterTrait;
+
+    protected function getTileClass(): string
+    {
+        return FormTile::class;
+    }
+
+    protected function getTileInput(): array
+    {
+        $form = $this->createForm(new FormBuilder('Tile form'));
+
+        return [
+            'forms_forms_id' => $form->getID(),
+        ];
+    }
+}

--- a/tests/functional/Glpi/Helpdesk/Tile/GlpiPageTileTest.php
+++ b/tests/functional/Glpi/Helpdesk/Tile/GlpiPageTileTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Helpdesk\Tile;
+
+use Glpi\Helpdesk\Tile\GlpiPageTile;
+use Glpi\Tests\AbstractTileRightsTest;
+
+final class GlpiPageTileTest extends AbstractTileRightsTest
+{
+    protected function getTileClass(): string
+    {
+        return GlpiPageTile::class;
+    }
+
+    protected function getTileInput(): array
+    {
+        return [
+            'title'        => 'FAQ',
+            'description'  => 'Link to the FAQ',
+            'illustration' => 'browse-kb',
+            'page'         => GlpiPageTile::PAGE_FAQ,
+        ];
+    }
+}

--- a/tests/src/AbstractTileRightsTest.php
+++ b/tests/src/AbstractTileRightsTest.php
@@ -1,0 +1,239 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tests;
+
+use CommonDBTM;
+use Glpi\Helpdesk\Tile\Item_Tile;
+use Glpi\Helpdesk\Tile\TileInterface;
+use Glpi\Helpdesk\Tile\TilesManager;
+use Profile;
+use ProfileRight;
+use User;
+
+abstract class AbstractTileRightsTest extends DbTestCase
+{
+    /**
+     * @return class-string<CommonDBTM&TileInterface>
+     */
+    abstract protected function getTileClass(): string;
+
+    /**
+     * A valid creation input for the tested tile type.
+     *
+     * @return array<string, mixed>
+     */
+    abstract protected function getTileInput(): array;
+
+    /**
+     * A user that can view and update the item a tile is attached to must be
+     * able to view / update / delete / purge / create that tile.
+     */
+    public function testTileIsManageableByUserAbleToUpdateLinkedItem(): void
+    {
+        // Arrange: a helpdesk profile that will hold the tile, and a tile linked
+        // to it.
+        $this->login();
+        $linked_profile = $this->createHelpdeskProfile('Tile holder profile');
+        [$tile_class, $tile_id] = $this->createTile($linked_profile);
+
+        // Arrange: a user that can read and update profiles (thus the linked
+        // profile) but does NOT have the "config" right.
+        $this->createCentralUser('user_that_can_edit_profiles', [
+            'profile' => READ | UPDATE,
+        ]);
+
+        // Act: log in as this user
+        $this->login('user_that_can_edit_profiles');
+
+        // Assert: the user is indeed able to update the linked profile...
+        $this->assertTrue(
+            $linked_profile->can($linked_profile->getID(), UPDATE),
+            'Precondition failed: the user should be able to update the linked profile',
+        );
+
+        // ...and therefore must be able to manage the tile.
+        $this->assertTrue((new $tile_class())->can($tile_id, READ));
+        $this->assertTrue((new $tile_class())->can($tile_id, UPDATE));
+        $this->assertTrue((new $tile_class())->can($tile_id, DELETE));
+        $this->assertTrue((new $tile_class())->can($tile_id, PURGE));
+
+        // ...and be able to create tiles for this item
+        $create_input = [
+            '_itemtype_item' => Profile::class,
+            '_items_id_item' => $linked_profile->getID(),
+        ];
+        $this->assertTrue((new $tile_class())->can(-1, CREATE, $create_input));
+    }
+
+    /**
+     * A user that can NOT update the item a tile is attached to must not be able
+     * to manage that tile.
+     */
+    public function testTileIsNotManageableByUserUnableToUpdateLinkedItem(): void
+    {
+        // Arrange: a helpdesk profile that will hold the tile, and a tile linked
+        // to it.
+        $this->login();
+        $linked_profile = $this->createHelpdeskProfile('Tile holder profile');
+        [$tile_class, $tile_id] = $this->createTile($linked_profile);
+
+        // Arrange: a user that holds the "config" right but can NOT update
+        // profiles (thus can not update the linked profile).
+        $this->createCentralUser('user_that_cant_edit_profiles', [
+            'profile' => 0,
+        ]);
+
+        // Act: log in as this user
+        $this->login('user_that_cant_edit_profiles');
+
+        // Assert: the user can NOT update the linked profile...
+        $this->assertFalse(
+            $linked_profile->can($linked_profile->getID(), UPDATE),
+            'Precondition failed: the user should not be able to update the linked profile',
+        );
+
+        // ...and therefore must NOT be able to manage the tile.
+        $this->assertFalse((new $tile_class())->can($tile_id, READ));
+        $this->assertFalse((new $tile_class())->can($tile_id, UPDATE));
+        $this->assertFalse((new $tile_class())->can($tile_id, DELETE));
+        $this->assertFalse((new $tile_class())->can($tile_id, PURGE));
+
+        // ...and not be able to create tiles for this item
+        $create_input = [
+            '_itemtype_item' => Profile::class,
+            '_items_id_item' => $linked_profile->getID(),
+        ];
+        $this->assertFalse((new $tile_class())->can(-1, CREATE, $create_input));
+    }
+
+    /**
+     * The item validated by the create right check is the one that is
+     * actually persisted: it is read from the same input, so it can not be
+     * spoofed to pass the check while linking to another item.
+     */
+    public function testTileCreationLinksToTheHolderFromInput(): void
+    {
+        // Arrange
+        $this->login();
+        $linked_profile = $this->createHelpdeskProfile('Tile holder profile');
+
+        // Act: create a tile, providing the holder through the input.
+        $tile_class = $this->getTileClass();
+        $input = $this->getTileInput() + [
+            '_itemtype_item' => Profile::class,
+            '_items_id_item' => $linked_profile->getID(),
+        ];
+        $tile = new $tile_class();
+        $tile_id = $tile->add($input);
+        $this->assertIsInt($tile_id);
+        $this->assertGreaterThan(0, $tile_id);
+
+        // Assert: the tile has been linked to the holder from the input.
+        $item_tile = new Item_Tile();
+        $this->assertTrue($item_tile->getFromDBByCrit([
+            'itemtype_tile' => $tile_class,
+            'items_id_tile' => $tile_id,
+        ]));
+        $this->assertEquals(Profile::class, $item_tile->fields['itemtype_item']);
+        $this->assertEquals(
+            $linked_profile->getID(),
+            $item_tile->fields['items_id_item']
+        );
+    }
+
+    private function createHelpdeskProfile(string $name): Profile
+    {
+        return $this->createItem(Profile::class, [
+            'name'      => $name,
+            'interface' => 'helpdesk',
+        ]);
+    }
+
+    /**
+     * Create the tested tile, linked to the given profile.
+     *
+     * @return array{0: class-string<CommonDBTM&TileInterface>, 1: int}
+     */
+    private function createTile(Profile $linked_profile): array
+    {
+        $tile_class = $this->getTileClass();
+
+        $manager = TilesManager::getInstance();
+        $item_tile_id = $manager->addTile(
+            $linked_profile,
+            $tile_class,
+            $this->getTileInput()
+        );
+
+        $item_tile = Item_Tile::getById($item_tile_id);
+        $tile_id = $item_tile->fields['items_id_tile'];
+
+        return [$tile_class, $tile_id];
+    }
+
+    /**
+     * Create a central user tied to a brand new profile with the given rights.
+     *
+     * @param array<string, int> $rights Map of right name => right value.
+     */
+    private function createCentralUser(string $login, array $rights): void
+    {
+        $profile = $this->createItem(Profile::class, [
+            'name'      => $login . '_profile',
+            'interface' => 'central',
+        ]);
+
+        foreach ($rights as $right_name => $right_value) {
+            $profile_right = new ProfileRight();
+            $this->assertTrue($profile_right->getFromDBByCrit([
+                'profiles_id' => $profile->getID(),
+                'name'        => $right_name,
+            ]));
+            $this->updateItem(ProfileRight::class, $profile_right->getID(), [
+                'rights' => $right_value,
+            ]);
+        }
+
+        $this->createItem(User::class, [
+            'name'          => $login,
+            'password'      => 'password',
+            'password2'     => 'password',
+            'profiles_id'   => $profile->getID(),
+            '_profiles_id'  => $profile->getID(),
+            '_entities_id'  => 0,
+            '_is_recursive' => true,
+        ], ['password', 'password2']);
+    }
+}


### PR DESCRIPTION
## Description

Right checks for the helpdesk tiles configuration were a bit too harsh as they would check if the user is an admin (=able to update the config).

Since tiles are always attached to another object (a profile or an entity), it makes sense to check if we can update this target item instead (e.g. if you can update an entity, you should be able to edit the tiles linked to this entity).

These changes implement this new item based checks.

## References

Internal support ticket: !45132.