### PR TITLE
fix (User Clone) exclude user_dn_hash field when cloning a user

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -132,6 +132,8 @@ class User extends CommonDBTM implements TreeBrowseInterface
         unset($input['cookie_token']);
         unset($input['cookie_token_date']);
         unset($input['user_dn_hash']);
+        unset($input['user_dn']);
+        unset($input['sync_field']);
         return $input;
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -131,6 +131,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         unset($input['api_token_date']);
         unset($input['cookie_token']);
         unset($input['cookie_token_date']);
+        unset($input['user_dn_hash']);
         return $input;
     }
 

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -949,6 +949,34 @@ class UserTest extends DbTestCase
         }
     }
 
+    public function testCloneDoesNotCopyLdapFields(): void
+    {
+        $this->login();
+
+        $user = new User();
+        $uid = $user->add([
+            'name'       => 'ldap_user_to_clone',
+            'user_dn'    => 'uid=ldap_user_to_clone,ou=people,dc=example,dc=com',
+            'sync_field' => 'ldap_user_to_clone',
+        ]);
+        $this->assertGreaterThan(0, $uid);
+        $this->assertTrue($user->getFromDB($uid));
+
+        $this->assertNotEmpty($user->fields['user_dn']);
+        $this->assertNotEmpty($user->fields['user_dn_hash']);
+        $this->assertNotEmpty($user->fields['sync_field']);
+
+        $cloned_id = $user->clone();
+        $this->assertGreaterThan(0, (int) $cloned_id);
+
+        $cloned_user = new User();
+        $this->assertTrue($cloned_user->getFromDB($cloned_id));
+
+        $this->assertEmpty($cloned_user->fields['user_dn']);
+        $this->assertEmpty($cloned_user->fields['user_dn_hash']);
+        $this->assertEmpty($cloned_user->fields['sync_field']);
+    }
+
     public function testGetFromDBbyDn()
     {
         $user = new User();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45036
- When cloning a user, the `user_dn_hash` field was cloned. This field should not be transferred, because the cloned user should have a different DN. This causes a uniqueness error during an LDAP user import.

