### PR TITLE
Fix(Form): Reintroduced the ability to search by contact

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -5196,6 +5196,9 @@ HTML;
         if (in_array($itemtype, $CFG_GLPI['asset_types'])) {
             $item = getItemForItemtype($itemtype);
             if ($item) {
+                if ($item->isField('contact')) {
+                    $displaywith[] = 'contact';
+                }
                 if ($item->isField('serial')) {
                     $displaywith[] = 'serial';
                 }

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -3130,4 +3130,48 @@ HTML;
             'entity_restrict must not be a JS array (would cause N POST params per entity)'
         );
     }
+
+    public function testSearchByContactField(): void
+    {
+        $this->login();
+
+        $computer = new Computer();
+        $computer_with_contact_id = $computer->add([
+            'name'        => 'PC-ContactSearch-Found',
+            'contact'     => 'Jean Dupont',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $this->assertGreaterThan(0, $computer_with_contact_id);
+
+        $other_computer_id = $computer->add([
+            'name'        => 'PC-ContactSearch-Other',
+            'contact'     => 'Marie Martin',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $this->assertGreaterThan(0, $other_computer_id);
+
+        $displaywith = Dropdown::getDisplayWith(Computer::class);
+        $this->assertContains('contact', $displaywith);
+
+        $params = [
+            'itemtype'            => Computer::class,
+            'display_emptychoice' => false,
+            'entity_restrict'     => $this->getTestRootEntity(true),
+            'searchText'          => 'Jean',
+            'displaywith'         => $displaywith,
+        ];
+        $params['_idor_token'] = Session::getNewIDORToken(Computer::class, $params);
+
+        $result = Dropdown::getDropdownValue($params, false);
+
+        $ids = [];
+        foreach ($result['results'] as $group) {
+            foreach ($group['children'] ?? [$group] as $item) {
+                $ids[] = $item['id'];
+            }
+        }
+
+        $this->assertContains($computer_with_contact_id, $ids);
+        $this->assertNotContains($other_computer_id, $ids);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45097

With `formcreator`, it was possible to search for an item in a dropdown list using its associated requester (the **Contact** field), as the plugin added the `contact` field to the `displaywith` configuration.

This capability was lost during the development of GLPI's native forms.

This pull request restores that functionality by adding the `contact` field back to `displaywith`, allowing items to be searched by their associated requester once again.



## Screenshots (if appropriate):


