### PR TITLE
A11Y : unify outline on non drodpown fields

### DIFF
--- a/css/includes/_base.scss
+++ b/css/includes/_base.scss
@@ -678,11 +678,20 @@ input.form-check-input[type="checkbox"]:disabled {
     opacity: 0.9;
 }
 
-// Tabler's default control border (#e5e7eb) sits at ~1.2:1 on white, well below
-// the 3:1 needed to perceive the field boundary.
+// Tabler's default control border (#e5e7eb) sits at ~1.2:1 on white, below the
+// 3:1 needed to perceive the field boundary. Composite field skins share the
+// same token so every boundary renders identically, matching the dark palette.
 .form-control,
 .form-select,
-.form-check-input {
+.form-check-input,
+.input-group-text,
+.form-file-text,
+.form-selectgroup-label,
+.form-selectgroup-check {
+    border-color: var(--glpi-form-control-border-color);
+}
+
+.form-imagecheck-figure::before {
     border-color: var(--glpi-form-control-border-color);
 }
 

--- a/css/includes/components/_buttons-group.scss
+++ b/css/includes/components/_buttons-group.scss
@@ -63,12 +63,21 @@ which broke styles of btn-group > .btn-check
     }
 }
 
-// Make border color of secondary outline buttons match input border
-.btn-group {
-    @each $color, $value in $theme-colors {
-        .btn-outline-secondary {
-            border: var(--tblr-border-width) solid var(--tblr-border-color);
-        }
+// Legacy field border for outline addon buttons (kept as-is for dropdown fields).
+.btn-group .btn-outline-secondary {
+    border: var(--tblr-border-width) solid var(--tblr-border-color);
+}
+
+// Date-picker field: the calendar addon reads as part of the field — a single
+// outer border matching the input, with no internal separator.
+.btn-group.flatpickr {
+    .btn-outline-secondary {
+        border-color: var(--glpi-form-control-border-color);
+        border-inline-start: 0;
+    }
+
+    > :has(~ .btn-outline-secondary) {
+        border-inline-end: 0;
     }
 }
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/412
- Here is a brief description of what this PR does : make outline on non dropdown fields around the whole field.

Visual checks where made on different tabs on config page, and asset forms.

## Screenshot : 

<img width="990" height="485" alt="Capture d’écran 2026-07-09 à 16 52 00" src="https://github.com/user-attachments/assets/341f4fef-2505-43bd-a257-ec0f043b422c" />

