### PR TITLE
Fix(Core): update preselection setting labels to match actual behavio

### DIFF
--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -962,11 +962,11 @@ EOD,
                 ],
                 'set_default_tech' => [
                     'type' => Doc\Schema::TYPE_BOOLEAN,
-                    'description' => 'Pre-select me as a technician when creating a ticket',
+                    'description' => 'Pre-select me as a technician for new ITIL items',
                 ],
                 'set_default_requester' => [
                     'type' => Doc\Schema::TYPE_BOOLEAN,
-                    'description' => 'Pre-select me as a requester when creating a ticket',
+                    'description' => 'Pre-select me as a requester for new ITIL items',
                 ],
                 'set_followup_tech' => [
                     'type' => Doc\Schema::TYPE_BOOLEAN,

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -295,15 +295,17 @@
       ) }}
    {% endif %}
 
+   {% set itil_default_field_options = field_options|merge({helper: __('Applies to Tickets, Changes, and Problems')}) %}
+
    {% if has_profile_right('ticket', constant('Ticket::OWN')) %}
-      {{ fields.dropdownYesNo('set_default_tech', config['set_default_tech'], __('Pre-select me as a technician when creating a ticket'), field_options) }}
+      {{ fields.dropdownYesNo('set_default_tech', config['set_default_tech'], __('Pre-select me as a technician for new ITIL items'), itil_default_field_options) }}
    {% else %}
-      {{ fields.htmlField('', __('No')|e, __('Pre-select me as a technician when creating a ticket'), field_options) }}
+      {{ fields.htmlField('', __('No')|e, __('Pre-select me as a technician for new ITIL items'), itil_default_field_options) }}
    {% endif %}
    {% if has_profile_right('ticket', constant('CREATE')) %}
-      {{ fields.dropdownYesNo('set_default_requester', config['set_default_requester'], __('Pre-select me as a requester when creating a ticket'), field_options) }}
+      {{ fields.dropdownYesNo('set_default_requester', config['set_default_requester'], __('Pre-select me as a requester for new ITIL items'), itil_default_field_options) }}
    {% else %}
-      {{ fields.htmlField('', __('No')|e, __('Pre-select me as a requester when creating a ticket'), field_options) }}
+      {{ fields.htmlField('', __('No')|e, __('Pre-select me as a requester for new ITIL items'), itil_default_field_options) }}
    {% endif %}
    {% if has_profile_right('ticket', constant('Ticket::OWN')) %}
       {{ fields.dropdownYesNo('set_followup_tech', config['set_followup_tech'], __('Add me as a technician when adding a ticket follow-up'), field_options) }}


### PR DESCRIPTION


## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45221

`set_default_tech` and `set_default_requester` were previously described as applying only to Tickets. However, these settings are now used across all ITIL objects, including Tickets, Changes, and Problems.

This pull request updates the descriptions to accurately reflect their actual scope. A helper has also been introduced for both the user preferences and the general configuration.

## Screenshots (if appropriate):


