### PR TITLE
Fix (link ticket to problem) missing entity check when linking tickets to a problem via massive action

### DIFF
--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -412,6 +412,7 @@ class MassiveActionTest extends DbTestCase
             $input['problems_id'] = $problem->add([
                 'name'    => "tmp",
                 'content' => "tmp",
+                'entities_id' => $item->getEntityID(),
             ]);
             $this->assertGreaterThan(0, $input['problems_id']);
 

--- a/phpunit/functional/MassiveActionTest.php
+++ b/phpunit/functional/MassiveActionTest.php
@@ -435,6 +435,73 @@ class MassiveActionTest extends DbTestCase
         $_SESSION['glpiactiveprofile'][Problem::$rightname] = $old_session;
     }
 
+    public static function linkToProblemEntityProvider(): array
+    {
+        return [
+            'same entity — accepted' => [
+                'ticket'              => getItemByTypeName('Ticket', '_ticket01'),
+                'problem_entity_name' => '_test_root_entity',
+                'problem_recursive'   => false,
+                'expected_ok'         => 1,
+                'expected_ko'         => 0,
+            ],
+            'cross-entity non-recursive — rejected' => [
+                // Ticket is in _test_child_1; problem is in _test_child_2 (sibling,
+                // not an ancestor) → incompatible even if is_recursive were set.
+                'ticket'              => getItemByTypeName('Ticket', '_ticket03'),
+                'problem_entity_name' => '_test_child_2',
+                'problem_recursive'   => false,
+                'expected_ok'         => 0,
+                'expected_ko'         => 1,
+            ],
+            'recursive parent problem on child-entity ticket — accepted' => [
+                // Problem is in the parent entity _test_root_entity with
+                // is_recursive = 1 → visible from child entity _test_child_1.
+                'ticket'              => getItemByTypeName('Ticket', '_ticket03'),
+                'problem_entity_name' => '_test_root_entity',
+                'problem_recursive'   => true,
+                'expected_ok'         => 1,
+                'expected_ko'         => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider linkToProblemEntityProvider
+     */
+    public function testProcessMassiveActionsForOneItemtype_linkToProblem_entityCheck(
+        Ticket $ticket,
+        string $problem_entity_name,
+        bool   $problem_recursive,
+        int    $expected_ok,
+        int    $expected_ko
+    ): void {
+        // Grant Problem update right
+        $old_right = $_SESSION['glpiactiveprofile'][Problem::$rightname] ?? 0;
+        $_SESSION['glpiactiveprofile'][Problem::$rightname] = UPDATE;
+
+        $problem    = new Problem();
+        $problem_id = $problem->add([
+            'name'         => 'entity check problem',
+            'content'      => 'entity check problem',
+            'entities_id'  => getItemByTypeName('Entity', $problem_entity_name, true),
+            'is_recursive' => (int) $problem_recursive,
+        ]);
+        $this->assertGreaterThan(0, $problem_id);
+
+        $this->processMassiveActionsForOneItemtype(
+            'link_to_problem',
+            $ticket,
+            [$ticket->fields['id']],
+            ['problems_id' => $problem_id],
+            $expected_ok,
+            $expected_ko,
+            Ticket::class
+        );
+
+        $_SESSION['glpiactiveprofile'][Problem::$rightname] = $old_right;
+    }
+
     protected function resolveTicketsProvider()
     {
         $ticket = new Ticket();

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2957,7 +2957,7 @@ JAVASCRIPT;
                     // A problem is compatible with a ticket when:
                     // - both are in the same entity, OR
                     // - the problem is in a parent entity and is recursive
-                    $ancestors      = getAncestorsOf('glpi_entities', $ticket_entity);
+                    $ancestors      = getAncestorsOf('glpi_entities', (string) $ticket_entity);
                     $is_compatible  = ($problem_entity === $ticket_entity)
                         || ($problem_recursive && in_array($problem_entity, $ancestors));
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2941,7 +2941,37 @@ JAVASCRIPT;
                 }
 
                 $em = new Problem_Ticket();
+                $problem_entity    = $problem->getEntityID();
+                $problem_recursive = (bool) $problem->fields['is_recursive'];
+
                 foreach ($ids as $id) {
+                    $ticket_to_check = new Ticket();
+                    if (!$ticket_to_check->getFromDB($id)) {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage($item->getErrorMessage(ERROR_ON_ACTION));
+                        continue;
+                    }
+
+                    $ticket_entity = $ticket_to_check->getEntityID();
+
+                    // A problem is compatible with a ticket when:
+                    // - both are in the same entity, OR
+                    // - the problem is in a parent entity and is recursive
+                    $ancestors      = getAncestorsOf('glpi_entities', $ticket_entity);
+                    $is_compatible  = ($problem_entity === $ticket_entity)
+                        || ($problem_recursive && in_array($problem_entity, $ancestors));
+
+                    if (!$is_compatible) {
+                        $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                        $ma->addMessage(
+                            sprintf(
+                                __('Ticket %d and the selected problem do not belong to compatible entities.'),
+                                $id
+                            )
+                        );
+                        continue;
+                    }
+
                     // Add new link
                     $res = $em->add([
                         'problems_id' => $input['problems_id'],

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2763,6 +2763,8 @@ class Ticket extends CommonITILObject
                 Problem::dropdown([
                     'name'      => 'problems_id',
                     'condition' => Problem::getOpenCriteria(),
+                    'entity'      => $_SESSION['glpiactive_entity'],
+                    'entity_sons' => $_SESSION['glpiactive_entity_recursive'],
                 ]);
                 echo '<br><br>';
                 echo Html::submit(_x('button', 'Link'), [


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45187
- When linking tickets to a problem via the "Link to a problem" massive action, no entity restriction was applied, allowing tickets from unrelated entities to be linked. The problem dropdown is now filtered by the active session entity, and each ticket is validated against the problem's entity before the link is created. This aligns the massive action behavior with the existing manual linking logic in Problem_Ticket.


## Screenshots (if appropriate):


