### PR TITLE
A11Y : fix issues due to 4.1.0 (Multiple Select2)

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -200,7 +200,7 @@ const filesToCopy = [
     },
     {
         package: 'select2',
-        from: 'src/scss/**/*.scss',
+        from: 'dist/css/select2.css',
         to: scssOutputPath,
     },
     {

--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -130,7 +130,7 @@
                     border: var(--tblr-border-width) solid var(--tblr-border-color);
                     border-radius: var(--tblr-border-radius-sm);
                     padding: 1px 3px 1px 20px; // keep room for the absolutely-positioned remove button (Select2 4.1.0)
-                    margin: 3px 3px 0 3px; // Select2 4.1.0 moved the left gutter to the choice margin (was on the container in 4.0.13)
+                    margin: 3px 3px 0; // Select2 4.1.0 moved the left gutter to the choice margin (was on the container in 4.0.13)
                     max-width: 100%;
                     white-space: normal;
 

--- a/css/includes/components/_select2.scss
+++ b/css/includes/components/_select2.scss
@@ -31,7 +31,7 @@
  * ---------------------------------------------------------------------
  */
 
-@import "~select2/src/scss/core";
+@import "~select2/select2";
 
 .select2-container {
     display: inline-block;
@@ -47,7 +47,8 @@
         box-shadow: var(--tblr-box-shadow-input);
         transition: $input-transition;
 
-        .select2-selection__rendered input[type="search"] {
+        .select2-selection__rendered input[type="search"],
+        .select2-selection__rendered textarea {
             color: var(--tblr-body-color);
         }
 
@@ -128,15 +129,15 @@
                     background-color: var(--tblr-active-bg);
                     border: var(--tblr-border-width) solid var(--tblr-border-color);
                     border-radius: var(--tblr-border-radius-sm);
-                    padding: 1px 3px;
-                    margin: 3px 3px 0 0;
+                    padding: 1px 3px 1px 20px; // keep room for the absolutely-positioned remove button (Select2 4.1.0)
+                    margin: 3px 3px 0 3px; // Select2 4.1.0 moved the left gutter to the choice margin (was on the container in 4.0.13)
                     max-width: 100%;
                     white-space: normal;
 
                     .select2-selection__choice__remove {
                         color: var(--tblr-dark);
                         font-weight: bold;
-                        margin: 0 0 0 3px;
+                        border-right-color: var(--tblr-border-color);
 
                         &:hover {
                             color: var(--tblr-black);

--- a/js/common.js
+++ b/js/common.js
@@ -1749,7 +1749,7 @@ function setupAjaxDropdown(config) {
     const field_id = CSS.escape(config.field_id);
 
     const select2_el = $('#' + field_id).select2({
-        containerCssClass: config.container_css_class,
+        selectionCssClass: config.container_css_class,
         width: config.width,
         multiple: config.multiple,
         placeholder: config.placeholder,

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "qtip2": "^3.0.3",
                 "rfs": "^10.0.0",
                 "rrule": "^2.8.1",
-                "select2": "^4.0.13",
+                "select2": "^4.1.0",
                 "spectrum-colorpicker2": "^2.0.10",
                 "spin.js": "^4.1.2",
                 "swagger-ui-dist": "^5.32.8",
@@ -12645,9 +12645,13 @@
             "dev": true
         },
         "node_modules/select2": {
-            "version": "4.0.13",
-            "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-            "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0.tgz",
+            "integrity": "sha512-i9KalWOP4/LRRGc8+rj2krNm0ZqP14cV+j1TRCEBSsOhCPkKH8rYZ2MCRXcgvqIqN+llqGci0hj9aVkCMvL0+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=24"
+            }
         },
         "node_modules/selfsigned": {
             "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "qtip2": "^3.0.3",
         "rfs": "^10.0.0",
         "rrule": "^2.8.1",
-        "select2": "^4.0.13",
+        "select2": "^4.1.0",
         "spectrum-colorpicker2": "^2.0.10",
         "spin.js": "^4.1.2",
         "swagger-ui-dist": "^5.32.8",

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -252,7 +252,7 @@
             tags: true,
             width: select2_width,
             tokenSeparators: [',', ' '],
-            containerCssClass: 'actor-field',
+            selectionCssClass: 'actor-field',
             templateSelection: (option) => genericTemplate(option, true),
             templateResult: (option) => genericTemplate(option, false),
             disabled: {{ canupdate ? 'false' : 'true' }},

--- a/tests/e2e/pages/FormPage.ts
+++ b/tests/e2e/pages/FormPage.ts
@@ -123,12 +123,29 @@ export class FormPage extends GlpiPage
 
     public async setItemTypeForItemQuestion(question: Locator, item_type: string): Promise<void>
     {
+        // Changing the itemtype triggers an asynchronous reload of the
+        // default-value dropdown, which replaces the current dropdown in the
+        // DOM. Grab it beforehand so we can wait for it to be detached and
+        // avoid interacting with the stale, previous-itemtype dropdown.
+        const previous_item_dropdown = await this
+            .getDropdownByLabel('Select an item', question)
+            .filter({visible : true})
+            .first()
+            .elementHandle();
+
         await this.doSetDropdownValue(
             this.getDropdownByLabel('Select an itemtype', question)
                 .filter({visible : true}),
             item_type,
             false
         );
+
+        if (previous_item_dropdown !== null) {
+            await this.page.waitForFunction(
+                (element) => !element.isConnected,
+                previous_item_dropdown
+            );
+        }
     }
 
     public async addComment(name: string): Promise<Locator>

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -141,12 +141,22 @@ export class GlpiPage
             .getByRole('listbox')
             .getByRole('option', {'name': value, exact: exact})
         ;
+        // Tree dropdowns (e.g. entities) prefix hierarchical options with "»",
+        // which Select2 4.1.0 exposes in the option accessible name.
+        const simple_dropdown_with_prefix = this.page
+            .getByRole('listbox')
+            .getByRole('option', {'name': `»${value}`, exact: exact})
+        ;
         const dropdown_with_groups = this.page
             .getByRole('listbox')
             .getByRole('listitem', {'name': value, exact: exact})
         ;
 
-        await simple_dropdown.or(dropdown_with_groups).click();
+        await simple_dropdown
+            .or(simple_dropdown_with_prefix)
+            .or(dropdown_with_groups)
+            .click()
+        ;
 
         if (check_value) {
             await expect(dropdown).toContainText(value);

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -157,11 +157,8 @@ export class GlpiPage
         dropdown: Locator,
         value: string,
     ): Promise<void> {
-        // We have no control on select2 selectors
-        // eslint-disable-next-line playwright/no-raw-locators
-        await dropdown.getByText(value)
-            .locator('..')
-            .locator('.select2-selection__choice__remove')
+        await dropdown.getByTitle(value)
+            .getByRole('button', {name: /remove item/i})
             .click()
         ;
     }

--- a/tests/e2e/specs/Dropdown/dropdown_a11y.spec.ts
+++ b/tests/e2e/specs/Dropdown/dropdown_a11y.spec.ts
@@ -1,3 +1,35 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 import { test, expect } from '../../fixtures/glpi_fixture';
 import { Profiles } from '../../utils/Profiles';
 import { getWorkerEntityId } from '../../utils/WorkerEntities';

--- a/tests/e2e/specs/Dropdown/dropdown_a11y.spec.ts
+++ b/tests/e2e/specs/Dropdown/dropdown_a11y.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '../../fixtures/glpi_fixture';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+import { UserPage } from '../../pages/UserPage';
+
+test('multi-select remove control is a labelled accessible button', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    const substitute_name = `substitute_${crypto.randomUUID().slice(0, 8)}`;
+    const substitute_id = await api.createItem('User', {
+        'name': substitute_name,
+        'password': 'testpassword',
+        'password2': 'testpassword',
+    });
+    await api.createItem('Profile_User', {
+        'users_id': substitute_id,
+        'profiles_id': Profiles.SuperAdmin,
+        'entities_id': getWorkerEntityId(),
+        'is_recursive': 1,
+    });
+
+    const user_page = new UserPage(page);
+    await user_page.gotoPreferences('ValidatorSubstitute$1');
+
+    const substitutes_dropdown = user_page.getDropdownByLabel('Approval substitutes');
+    await user_page.doSearchAndClickDropdownValue(substitutes_dropdown, substitute_name);
+
+    const remove_button = substitutes_dropdown
+        .getByTitle(substitute_name)
+        .getByRole('button', {name: /remove item/i});
+    await expect(remove_button).toBeVisible();
+
+    await remove_button.click();
+    await expect(substitutes_dropdown).not.toContainText(substitute_name);
+});


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.


## Description

- one fixe for https://github.com/glpi-project/roadmap/issues/310 that comes from : https://github.com/glpi-project/glpi/pull/24438, as 4.1.0 ships an improvment for a11y (close button is now a real button)

- Here is a brief description of what this PR does : 

Finishes the 4.1.0 bump from #24438. Kept because the chip's remove control is now a real `<button aria-label="Remove item">` (keyboard/screen-reader reachable) instead of a decorative `<span>`. The raw bump broke our overrides, so I adapted the SCSS to the new chip layout: `padding-left` to stop the `×` overlapping the text, `margin-left` restored so the first chip isn't glued to the left edge, styled the search field (now a `<textarea>`), and renamed the removed `containerCssClass` option to `selectionCssClass`.

It's one global rule, no per-screen special-casing. Checked live on Forms, ITIL, Assets and Config: renders as before, minus the overlap. New `dropdown_a11y.spec.ts` locks the accessible button (fails on 4.0.13, passes on 4.1.0).

## Screenshots :

<img width="189" height="109" alt="Capture d’écran 2026-07-10 à 13 19 14" src="https://github.com/user-attachments/assets/dd958b23-32a4-4769-b1fa-134ff9151566" />

<img width="613" height="253" alt="Capture d’écran 2026-07-10 à 13 19 36" src="https://github.com/user-attachments/assets/9f0cb24b-b24c-4825-ad5d-d8056af2c869" />


