### PR TITLE
Add explicit comparison operators for numeric search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The present file will list all changes made to the project; according to the
 ## [12.0.0] unreleased
 
 ### Added
+- `morethan` and `lessthan` search operators for numeric fields (number, integer, decimal, count, mio).
 - Sessions tab for OAuth Clients to display non-expired sessions associated with the client and allow revoking them.
 - Improved client IP detection.
   If your GLPI instance is behind a reverse proxy, you should add its IP(s) the new `GLPI_TRUSTED_REVERSE_PROXIES` constant and modify the new `GLPI_REVERSE_PROXY_HEADERS` constant to include the headers your proxy uses to forward the client IP.

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -1600,7 +1600,8 @@ abstract class API
      *        Each criterion object must provide :
      *           - link: (optional for 1st element) logical operator in [AND, OR, AND NOT, AND NOT].
      *           - field: id of searchoptions.
-     *           - searchtype: type of search in [contains, equals, notequals, lessthan, morethan, under, notunder].
+     *           - searchtype: type of search in [contains, equals, notequals, lessthan, morethan,
+     *                         lessthanorequal, morethanorequal, under, notunder].
      *           - value : value to search.
      *    - 'metacriteria' (optional): array of metacriterion object to filter search.
      *                                  Optional.
@@ -1610,7 +1611,8 @@ abstract class API
      *            - link: logical operator in [AND, OR, AND NOT, AND NOT]. Mandatory
      *            - itemtype: second itemtype to link.
      *            - field: id of searchoptions.
-     *            - searchtype: type of search in [contains, equals, notequals, lessthan, morethan, under, notunder].
+     *            - searchtype: type of search in [contains, equals, notequals, lessthan, morethan,
+     *                          lessthanorequal, morethanorequal, under, notunder].
      *            - value : value to search.
      *    - 'sort' :  id of searchoption to sort by (default 1). Optional.
      *    - 'order' : ASC - Ascending sort / DESC Descending sort (default ASC). Optional.

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -338,6 +338,7 @@ final class QueryBuilder implements SearchInputInterface
                     }
 
                     // Standard datatype usage
+                    $skip_value_to_select = false;
                     if (isset($searchopt['datatype'])) {
                         switch ($searchopt['datatype']) {
                             case "date":
@@ -345,13 +346,25 @@ final class QueryBuilder implements SearchInputInterface
                             case "datetime":
                                 $options2['relative_dates'] = true;
                                 break;
+
+                            case "count":
+                            case "mio":
+                            case "number":
+                            case "integer":
+                            case "decimal":
+                                if (in_array($request['searchtype'], ['morethan', 'lessthan'], true)) {
+                                    $skip_value_to_select = true;
+                                }
+                                break;
                         }
                     }
 
-                    $out = $item->getValueToSelect($searchopt, $inputname, $request['value'], $options2);
-                    if (strlen($out)) {
-                        echo $out;
-                        $display = true;
+                    if (!$skip_value_to_select) {
+                        $out = $item->getValueToSelect($searchopt, $inputname, $request['value'], $options2);
+                        if (strlen($out)) {
+                            echo $out;
+                            $display = true;
+                        }
                     }
 
                     //Could display be handled by a plugin ?

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -287,6 +287,8 @@ final class QueryBuilder implements SearchInputInterface
             case "notequals":
             case "morethan":
             case "lessthan":
+            case "morethanorequal":
+            case "lessthanorequal":
             case "under":
             case "notunder":
                 if (isset($searchopt['field'])) {
@@ -352,7 +354,13 @@ final class QueryBuilder implements SearchInputInterface
                             case "number":
                             case "integer":
                             case "decimal":
-                                if (in_array($request['searchtype'], ['morethan', 'lessthan'], true)) {
+                                if (
+                                    in_array(
+                                        $request['searchtype'],
+                                        ['morethan', 'lessthan', 'morethanorequal', 'lessthanorequal'],
+                                        true
+                                    )
+                                ) {
                                     $skip_value_to_select = true;
                                 }
                                 break;

--- a/src/Glpi/Search/Output/Spreadsheet.php
+++ b/src/Glpi/Search/Output/Spreadsheet.php
@@ -311,6 +311,14 @@ abstract class Spreadsheet extends ExportSearchOutput
                                 $titlecontain = sprintf(__('%1$s > %2$s'), $titlecontain, $valuename);
                                 break;
 
+                            case "lessthanorequal":
+                                $titlecontain = sprintf(__('%1$s <= %2$s'), $titlecontain, $valuename);
+                                break;
+
+                            case "morethanorequal":
+                                $titlecontain = sprintf(__('%1$s >= %2$s'), $titlecontain, $valuename);
+                                break;
+
                             case "contains":
                                 $titlecontain = sprintf(
                                     __('%1$s = %2$s'),
@@ -447,6 +455,22 @@ abstract class Spreadsheet extends ExportSearchOutput
                         case "morethan":
                             $titlecontain2 = sprintf(
                                 __('%1$s > %2$s'),
+                                $titlecontain2,
+                                $metacriteria['value']
+                            );
+                            break;
+
+                        case "lessthanorequal":
+                            $titlecontain2 = sprintf(
+                                __('%1$s <= %2$s'),
+                                $titlecontain2,
+                                $metacriteria['value']
+                            );
+                            break;
+
+                        case "morethanorequal":
+                            $titlecontain2 = sprintf(
+                                __('%1$s >= %2$s'),
                                 $titlecontain2,
                                 $metacriteria['value']
                             );

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2055,6 +2055,30 @@ final class SQLProvider implements SearchProviderInterface
                         ];
                     }
 
+                    if (in_array($searchtype, ['morethan', 'lessthan'], true) && is_numeric($val)) {
+                        if ($nott) {
+                            $operator = $searchtype === 'morethan' ? '<=' : '>=';
+                        } else {
+                            $operator = $searchtype === 'morethan' ? '>' : '<';
+                        }
+                        $numeric_val = floatval($val);
+                        $values = $tocompute instanceof QueryExpression ? $tocompute->getParams() : [];
+                        if ($searchopt[$ID]["datatype"] === 'progressbar') {
+                            return [
+                                new QueryExpression(
+                                    sprintf("%s %s %s", $tocompute, $operator, $numeric_val),
+                                    values: $values
+                                ),
+                            ];
+                        }
+                        return [
+                            new QueryExpression(
+                                sprintf("%s %s ?", $tocompute, $operator),
+                                values: array_merge($values, [$numeric_val])
+                            ),
+                        ];
+                    }
+
                     $values = $tocompute instanceof QueryExpression ? $tocompute->getParams() : [];
                     if (is_numeric($val) && !$decimal_contains) {
                         $numeric_val = floatval($val);
@@ -4201,6 +4225,17 @@ final class SQLProvider implements SearchProviderInterface
                         $regs[1] .= $regs[2];
                         return [
                             $NAME => [$regs[1], floatval($regs[3] . $regs[4])],
+                        ];
+                    }
+
+                    if (in_array($searchtype, ['morethan', 'lessthan'], true) && is_numeric($val)) {
+                        if ($NOT) {
+                            $operator = $searchtype === 'morethan' ? '<=' : '>=';
+                        } else {
+                            $operator = $searchtype === 'morethan' ? '>' : '<';
+                        }
+                        return [
+                            $NAME => [$operator, floatval($val)],
                         ];
                     }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -2055,12 +2055,14 @@ final class SQLProvider implements SearchProviderInterface
                         ];
                     }
 
-                    if (in_array($searchtype, ['morethan', 'lessthan'], true) && is_numeric($val)) {
-                        if ($nott) {
-                            $operator = $searchtype === 'morethan' ? '<=' : '>=';
-                        } else {
-                            $operator = $searchtype === 'morethan' ? '>' : '<';
-                        }
+                    $numeric_operators = [
+                        'morethan'       => $nott ? '<=' : '>',
+                        'lessthan'       => $nott ? '>=' : '<',
+                        'morethanorequal' => $nott ? '<' : '>=',
+                        'lessthanorequal' => $nott ? '>' : '<=',
+                    ];
+                    if (isset($numeric_operators[$searchtype]) && is_numeric($val)) {
+                        $operator = $numeric_operators[$searchtype];
                         $numeric_val = floatval($val);
                         $values = $tocompute instanceof QueryExpression ? $tocompute->getParams() : [];
                         if ($searchopt[$ID]["datatype"] === 'progressbar') {
@@ -4228,12 +4230,14 @@ final class SQLProvider implements SearchProviderInterface
                         ];
                     }
 
-                    if (in_array($searchtype, ['morethan', 'lessthan'], true) && is_numeric($val)) {
-                        if ($NOT) {
-                            $operator = $searchtype === 'morethan' ? '<=' : '>=';
-                        } else {
-                            $operator = $searchtype === 'morethan' ? '>' : '<';
-                        }
+                    $numeric_operators = [
+                        'morethan'       => $NOT ? '<=' : '>',
+                        'lessthan'       => $NOT ? '>=' : '<',
+                        'morethanorequal' => $NOT ? '<' : '>=',
+                        'lessthanorequal' => $NOT ? '>' : '<=',
+                    ];
+                    if (isset($numeric_operators[$searchtype]) && is_numeric($val)) {
+                        $operator = $numeric_operators[$searchtype];
                         return [
                             $NAME => [$operator, floatval($val)],
                         ];

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -574,6 +574,8 @@ final class SearchOption implements ArrayAccess
                             'notcontains' => __('not contains'),
                             'equals'      => __('is'),
                             'notequals'   => __('is not'),
+                            'morethan'    => __('greater than'),
+                            'lessthan'    => __('less than'),
                             'empty'       => __('is empty'),
                             'searchopt'   => $searchopt[$field_num],
                         ];

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -570,14 +570,16 @@ final class SearchOption implements ArrayAccess
                     case "integer":
                     case 'decimal':
                         $opt = [
-                            'contains'    => __('contains'),
-                            'notcontains' => __('not contains'),
-                            'equals'      => __('is'),
-                            'notequals'   => __('is not'),
-                            'morethan'    => __('greater than'),
-                            'lessthan'    => __('less than'),
-                            'empty'       => __('is empty'),
-                            'searchopt'   => $searchopt[$field_num],
+                            'contains'        => __('contains'),
+                            'notcontains'     => __('not contains'),
+                            'equals'          => __('is'),
+                            'notequals'       => __('is not'),
+                            'morethan'        => __('greater than'),
+                            'lessthan'        => __('less than'),
+                            'morethanorequal' => __('greater than or equal to'),
+                            'lessthanorequal' => __('less than or equal to'),
+                            'empty'           => __('is empty'),
+                            'searchopt'       => $searchopt[$field_num],
                         ];
                         // No is / isnot if no limits defined
                         if (

--- a/tests/deprecated-searchoptions/Computer_Item.json
+++ b/tests/deprecated-searchoptions/Computer_Item.json
@@ -14,6 +14,8 @@
             "notcontains",
             "morethan",
             "lessthan",
+            "morethanorequal",
+            "lessthanorequal",
             "empty"
         ],
         "uid": "Computer_Item.id"

--- a/tests/deprecated-searchoptions/Computer_Item.json
+++ b/tests/deprecated-searchoptions/Computer_Item.json
@@ -12,6 +12,8 @@
         "available_searchtypes": [
             "contains",
             "notcontains",
+            "morethan",
+            "lessthan",
             "empty"
         ],
         "uid": "Computer_Item.id"

--- a/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
@@ -14,6 +14,8 @@
             "notcontains",
             "morethan",
             "lessthan",
+            "morethanorequal",
+            "lessthanorequal",
             "empty"
         ],
         "uid": "Computer_SoftwareLicense.id"

--- a/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareLicense.json
@@ -12,6 +12,8 @@
         "available_searchtypes": [
             "contains",
             "notcontains",
+            "morethan",
+            "lessthan",
             "empty"
         ],
         "uid": "Computer_SoftwareLicense.id"

--- a/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
@@ -12,6 +12,8 @@
         "available_searchtypes": [
             "contains",
             "notcontains",
+            "morethan",
+            "lessthan",
             "empty"
         ],
         "uid": "Computer_SoftwareVersion.id"

--- a/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
+++ b/tests/deprecated-searchoptions/Computer_SoftwareVersion.json
@@ -14,6 +14,8 @@
             "notcontains",
             "morethan",
             "lessthan",
+            "morethanorequal",
+            "lessthanorequal",
             "empty"
         ],
         "uid": "Computer_SoftwareVersion.id"

--- a/tests/deprecated-searchoptions/TicketFollowup.json
+++ b/tests/deprecated-searchoptions/TicketFollowup.json
@@ -82,6 +82,8 @@
         "available_searchtypes": [
             "contains",
             "notcontains",
+            "morethan",
+            "lessthan",
             "empty"
         ],
         "uid": "TicketFollowup.id"

--- a/tests/deprecated-searchoptions/TicketFollowup.json
+++ b/tests/deprecated-searchoptions/TicketFollowup.json
@@ -84,6 +84,8 @@
             "notcontains",
             "morethan",
             "lessthan",
+            "morethanorequal",
+            "lessthanorequal",
             "empty"
         ],
         "uid": "TicketFollowup.id"

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -306,4 +306,16 @@ class SearchOptionTest extends DbTestCase
             );
         }
     }
+
+    public function testGetActionsForNumericDatatypeIncludesComparisonOperators(): void
+    {
+        $this->login();
+
+        $actions = SearchOption::getActionsFor(\Computer::class, 2);
+
+        $this->assertArrayHasKey('morethan', $actions);
+        $this->assertArrayHasKey('lessthan', $actions);
+        $this->assertSame(__('greater than'), $actions['morethan']);
+        $this->assertSame(__('less than'), $actions['lessthan']);
+    }
 }

--- a/tests/functional/Glpi/Search/SearchOptionTest.php
+++ b/tests/functional/Glpi/Search/SearchOptionTest.php
@@ -315,7 +315,11 @@ class SearchOptionTest extends DbTestCase
 
         $this->assertArrayHasKey('morethan', $actions);
         $this->assertArrayHasKey('lessthan', $actions);
+        $this->assertArrayHasKey('morethanorequal', $actions);
+        $this->assertArrayHasKey('lessthanorequal', $actions);
         $this->assertSame(__('greater than'), $actions['morethan']);
         $this->assertSame(__('less than'), $actions['lessthan']);
+        $this->assertSame(__('greater than or equal to'), $actions['morethanorequal']);
+        $this->assertSame(__('less than or equal to'), $actions['lessthanorequal']);
     }
 }

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -7297,6 +7297,36 @@ class SearchTest extends DbTestCase
         $this->assertContains($low_id, $ids_found);
         $this->assertNotContains($high_id, $ids_found);
 
+        // morethanorequal + low_id must include the boundary value
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND',
+                'field'      => 2,
+                'searchtype' => 'morethanorequal',
+                'value'      => $low_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertContains($high_id, $ids_found);
+
+        // lessthanorequal + high_id must include the boundary value
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND',
+                'field'      => 2,
+                'searchtype' => 'lessthanorequal',
+                'value'      => $high_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertContains($high_id, $ids_found);
+
         // NOT morethan must invert to <=
         $data = $this->doSearch(Computer::class, [
             'is_deleted' => 0,
@@ -7311,6 +7341,36 @@ class SearchTest extends DbTestCase
         $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
         $this->assertContains($low_id, $ids_found);
         $this->assertNotContains($high_id, $ids_found);
+
+        // NOT morethanorequal must invert to <
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND NOT',
+                'field'      => 2,
+                'searchtype' => 'morethanorequal',
+                'value'      => $low_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertNotContains($low_id, $ids_found);
+        $this->assertNotContains($high_id, $ids_found);
+
+        // NOT lessthanorequal must invert to >
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND NOT',
+                'field'      => 2,
+                'searchtype' => 'lessthanorequal',
+                'value'      => $low_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertNotContains($low_id, $ids_found);
+        $this->assertContains($high_id, $ids_found);
 
         // Regression: contains + >0 syntax must still work
         $data = $this->doSearch(Computer::class, [

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -7239,6 +7239,95 @@ class SearchTest extends DbTestCase
         $this->assertNotContains($computer_low->getID(), $ids_found, 'Computer with 10% free space must NOT match ">= 67"');
     }
 
+    public function testNumericMorethanLessthanSearch(): void
+    {
+        $this->login();
+
+        $unique    = uniqid('numsearch-', true);
+        $entity_id = $this->getTestRootEntity(true);
+
+        $computer_low = $this->createItem(Computer::class, [
+            'name'        => $unique . '-low',
+            'entities_id' => $entity_id,
+        ]);
+        $computer_high = $this->createItem(Computer::class, [
+            'name'        => $unique . '-high',
+            'entities_id' => $entity_id,
+        ]);
+
+        $low_id  = $computer_low->getID();
+        $high_id = $computer_high->getID();
+        $this->assertLessThan($high_id, $low_id);
+
+        $base_criteria = [
+            [
+                'field'      => 1, // name
+                'searchtype' => 'contains',
+                'value'      => $unique,
+            ],
+        ];
+
+        // morethan + 0 must not be treated as an equality search
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND',
+                'field'      => 2, // ID
+                'searchtype' => 'morethan',
+                'value'      => 0,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertContains($high_id, $ids_found);
+
+        // lessthan + high_id must exclude the highest matching ID
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND',
+                'field'      => 2,
+                'searchtype' => 'lessthan',
+                'value'      => $high_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertNotContains($high_id, $ids_found);
+
+        // NOT morethan must invert to <=
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND NOT',
+                'field'      => 2,
+                'searchtype' => 'morethan',
+                'value'      => $low_id,
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertNotContains($high_id, $ids_found);
+
+        // Regression: contains + >0 syntax must still work
+        $data = $this->doSearch(Computer::class, [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'criteria'   => array_merge($base_criteria, [[
+                'link'       => 'AND',
+                'field'      => 2,
+                'searchtype' => 'contains',
+                'value'      => '>0',
+            ]]),
+        ]);
+        $ids_found = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertContains($low_id, $ids_found);
+        $this->assertContains($high_id, $ids_found);
+    }
+
     public function testCertificateRawSearchOptionsInheritance(): void
     {
         $item = new \Certificate();


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that cover the new behavior.

## Description

Related to #19309.

GLPI already supports numeric comparisons by entering an operator in a contains criterion, for example <=25. This PR keeps that syntax working and makes the capability easier to discover by adding explicit greater than and less than actions for numeric search fields.

The change:

- exposes the two actions for number, integer, decimal, count, and mio datatypes;
- renders a numeric text input for these actions instead of a predefined value selector;
- applies the comparison consistently in WHERE and HAVING criteria, including negated criteria;
- adds functional coverage for the actions, comparisons, negation, and the existing contains syntax.

## Testing

- PHP syntax checks pass for all changed PHP files.
- Functional tests were added. The full PHPUnit suite could not be run locally because dependencies are not installed in this checkout and the Docker daemon is unavailable; CI is expected to run it.

## AI assistance disclosure

Cursor was used to assist with the initial implementation. OpenAI Codex was used for code review, rebasing onto the latest main branch, and correcting an inverted functional-test expectation. The final changes were reviewed by the contributor.