### PR TITLE
Fix: resolve Monaco worker URLs under subfolder installs

### DIFF
--- a/.webpack.config.js
+++ b/.webpack.config.js
@@ -121,7 +121,7 @@ const config = {
         new MiniCssExtractPlugin(), // Extract styles into CSS files
         new MonacoWebpackPlugin({
             'languages': ['html', 'javascript', 'typescript', 'json', 'markdown', 'twig', 'css', 'scss', 'shell'],
-            'publicPath': '/lib/'
+            // No hardcoded publicPath: see runtime override in lib/bundles/monaco.js
         }),
         new RtlCssPlugin('[name].rtl.css'), // Generate RTL CSS files
     ],

--- a/lib/bundles/monaco.js
+++ b/lib/bundles/monaco.js
@@ -32,4 +32,9 @@
  */
 
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.main';
+
+/* global __webpack_public_path__ */
+// eslint-disable-next-line no-global-assign
+__webpack_public_path__ = `${CFG_GLPI.root_doc}/lib/`;
+
 window.monaco = monaco;

--- a/tests/functional/Glpi/Application/View/Extension/FrontEndAssetsExtensionTest.php
+++ b/tests/functional/Glpi/Application/View/Extension/FrontEndAssetsExtensionTest.php
@@ -326,4 +326,34 @@ class FrontEndAssetsExtensionTest extends GLPITestCase
         $ext = new FrontEndAssetsExtension(vfsStream::url('glpi'));
         $this->assertEquals($expected, $ext->cssPath($path, $options));
     }
+
+    public function testPathsAreProperlyPrefixedWhenInstalledInSubfolder(): void
+    {
+        global $CFG_GLPI;
+
+        vfsStream::setup(
+            'glpi',
+            null,
+            [
+                'public' => [
+                    'js' => [
+                        'scripts_1.js' => '/* Source JS file */',
+                    ],
+                    'css' => [
+                        'styles_1.css' => '/* Source CSS file */',
+                    ],
+                ],
+            ]
+        );
+
+        // GLPI installed in a subfolder
+        $CFG_GLPI['root_doc'] = '/subfolder';
+        $_SESSION['glpi_use_mode'] = \Session::NORMAL_MODE;
+
+        $ext = new FrontEndAssetsExtension(vfsStream::url('glpi'));
+
+        $this->assertStringStartsWith('/subfolder/', $ext->assetPath('pics/foo.png'));
+        $this->assertStringStartsWith('/subfolder/js/scripts_1.js', $ext->jsPath('js/scripts_1.js'));
+        $this->assertStringStartsWith('/subfolder/css/styles_1.css', $ext->cssPath('css/styles_1.css'));
+    }
 }

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -35,11 +35,20 @@
 namespace tests\units;
 
 use Glpi\Tests\DbTestCase;
+use function Safe\preg_replace;
 use Glpi\Toolbox\FrontEnd;
 use GlpiPlugin\Tester\MyPsr4Class;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LogLevel;
+
+use function Safe\file_put_contents;
+use function Safe\mktime;
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+use function Safe\realpath;
+use function Safe\touch;
+use function Safe\unlink;
 
 class HtmlTest extends DbTestCase
 {
@@ -384,6 +393,21 @@ class HtmlTest extends DbTestCase
         $this->assertStringContainsString(GLPI_YEAR, $message);
     }
 
+    public function testGetPrefixedUrl(): void
+    {
+        global $CFG_GLPI;
+
+        // GLPI installed at domain root
+        $CFG_GLPI['root_doc'] = '';
+        $this->assertSame('/css/styles.css', \Html::getPrefixedUrl('css/styles.css'));
+        $this->assertSame('/css/styles.css', \Html::getPrefixedUrl('/css/styles.css'));
+
+        // GLPI installed in a subfolder
+        $CFG_GLPI['root_doc'] = '/subfolder';
+        $this->assertSame('/subfolder/css/styles.css', \Html::getPrefixedUrl('css/styles.css'));
+        $this->assertSame('/subfolder/css/styles.css', \Html::getPrefixedUrl('/css/styles.css'));
+    }
+
     public function testCss()
     {
         global $CFG_GLPI;
@@ -403,7 +427,7 @@ class HtmlTest extends DbTestCase
 
         //create test files
         foreach ($fake_files as $fake_file) {
-            $this->assertTrue(touch(GLPI_TMP_DIR . '/' . $fake_file));
+            touch(GLPI_TMP_DIR . '/' . $fake_file);
         }
 
         //expect minified file

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -35,7 +35,6 @@
 namespace tests\units;
 
 use Glpi\Tests\DbTestCase;
-use function Safe\preg_replace;
 use Glpi\Toolbox\FrontEnd;
 use GlpiPlugin\Tester\MyPsr4Class;
 use org\bovigo\vfs\vfsStream;
@@ -46,6 +45,7 @@ use function Safe\file_put_contents;
 use function Safe\mktime;
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
+use function Safe\preg_replace;
 use function Safe\realpath;
 use function Safe\touch;
 use function Safe\unlink;
@@ -1031,7 +1031,7 @@ SCSS,
         $compiled_scss = @\Html::compileScss(['file' => '/plugins/tester/css/styles.scss']);
 
         // Strip comments to ease comparison.
-        $compiled_scss = \preg_replace('~/\*.*\*/~s', '', $compiled_scss);
+        $compiled_scss = preg_replace('~/\*.*\*/~s', '', $compiled_scss);
 
         $this->assertEquals(
             <<<CSS

--- a/tests/js/webpack-config.test.js
+++ b/tests/js/webpack-config.test.js
@@ -1,0 +1,73 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+const fs = require('fs');
+const path = require('path');
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+
+// publicPath must be relative, or overridden at runtime via CFG_GLPI.root_doc (see js/src/vue/app.js)
+const bundles = [
+    {
+        name: 'main lib bundle',
+        getPublicPath: () => require('../../.webpack.config.js').output.publicPath,
+        entryFile: null,
+    },
+    {
+        name: 'Monaco editor bundle',
+        getPublicPath: () => {
+            const config = require('../../.webpack.config.js');
+            const plugin = config.plugins.find((p) => p instanceof MonacoWebpackPlugin);
+            return plugin.options.publicPath;
+        },
+        entryFile: 'lib/bundles/monaco.js',
+    },
+    {
+        name: 'Vue bundle',
+        getPublicPath: () => require('../../.vue.webpack.config.js').output.publicPath,
+        entryFile: 'js/src/vue/app.js',
+    },
+];
+
+describe('Webpack publicPath configuration', () => {
+    test.each(bundles)('$name has a safe publicPath under a subfolder install', ({ getPublicPath, entryFile }) => {
+        const public_path = getPublicPath();
+
+        if (!public_path) {
+            // relative/empty: safe by default
+            return;
+        }
+
+        const entry_source = fs.readFileSync(path.resolve(__dirname, '../..', entryFile), 'utf8');
+        expect(entry_source).toMatch(/__webpack_public_path__\s*=/);
+    });
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45227
- The Monaco code editor (used in webhook payload/header editors and the custom UI macro editor) failed to load its worker assets when GLPI is installed under a subfolder, because its webpack bundle had a hardcoded absolute publicPath.
- Removed the hardcoded publicPath and added the same runtime override already used by the Vue bundle, so asset URLs follow CFG_GLPI.root_doc at runtime.
- Added a generalized webpack config test covering all three bundles (main lib, Monaco, Vue) and two PHPUnit tests covering URL prefixing under a subfolder install, to catch this class of bug even though dev/CI always run GLPI at the domain root.

## Screenshots (if appropriate):


