### PR TITLE
Improve playwright makefile command to automatically reinstall the db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,25 @@ e2e-db-update: ## Update e2e testing's database
 		--env=e2e_testing
 .PHONY: e2e-db-update
 
+e2e-db-check: ## Ensure the e2e database is up to date before running the tests
+	@if $(CONSOLE) database:is_up_to_date --env=e2e_testing >/dev/null 2>&1; then \
+		exit 0; \
+	fi; \
+	printf $(_ERROR) "playwright" "The e2e database is out of date or not yet installed."; \
+	if [ -t 0 ]; then \
+		read -p "Reinstall it now? [y/N] " answer; \
+		if [ "$$answer" = "y" ] || [ "$$answer" = "Y" ]; then \
+			$(MAKE) --no-print-directory e2e-db-install; \
+		else \
+			printf $(_ERROR) "playwright" "Aborted. Run \"make e2e-db-install\" to reinstall it."; \
+			exit 1; \
+		fi; \
+	else \
+		printf $(_ERROR) "playwright" "Run \"make e2e-db-install\" to reinstall it."; \
+		exit 1; \
+	fi
+.PHONY: e2e-db-check
+
 ## —— Dependencies —————————————————————————————————————————————————————————————
 composer: ## Run a composer command, example: make composer c='require mypackage/package'
 	@$(eval c ?=)
@@ -284,7 +303,7 @@ cypress-open: ## Open cypress UI
 	$(PHP) node_modules/.bin/cypress open --e2e --browser electron --project tests $(c)
 .PHONY: cypress-open
 
-playwright: ## Run playwright tests
+playwright: e2e-db-check ## Run playwright tests
 	@$(eval c ?=)
 	$(CONSOLE) config:set url_base $(E2E_BASE_URL) --env=e2e_testing
 	$(PLAYWRIGHT) test $(c)
@@ -296,7 +315,7 @@ playwright-report: ## View playwright reports
 	$(PLAYWRIGHT) show-report tests/e2e/results --host=0.0.0.0 $(c)
 .PHONY: playwright-report
 
-playwright-ui: ## Open playwright's UI mode
+playwright-ui: e2e-db-check ## Open playwright's UI mode
 	@$(eval c ?=)
 	$(PLAYWRIGHT) test --ui-host=0.0.0.0 --ui-port=9323 $(c)
 .PHONY: playwright-ui

--- a/src/Glpi/Console/Database/IsUpToDateCommand.php
+++ b/src/Glpi/Console/Database/IsUpToDateCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Database;
+
+use Glpi\Console\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Update;
+
+final class IsUpToDateCommand extends AbstractCommand
+{
+    protected $requires_db_up_to_date = false;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('database:is_up_to_date');
+        $this->setAliases(['db:is_up_to_date']);
+        $this->setDescription(__('Check if the database schema version matches the installed GLPI version.'));
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ): int {
+        if (!Update::isDbUpToDate()) {
+            $output->writeln(
+                '<error>' . __('The database is not up to date.') . '</error>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+            return Command::FAILURE;
+        }
+
+        $output->writeln(__('The database is up to date.'));
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
The `make playwright` command will now detect an outdated e2e database and offer to update it for you:

<img width="663" height="64" alt="image" src="https://github.com/user-attachments/assets/bf92b701-38f5-4122-afc7-4ccec97455c4" />

This way, you no longer have to worry about running `make e2e-db-install` each time the database is out of sync (which is super common if you switch branches very often).

Example with a confirmation:

<img width="1215" height="726" alt="image" src="https://github.com/user-attachments/assets/6fab4008-615b-40b9-ac69-155fbe342066" />

It does not impact the CI and scripts.