### PR TITLE
[HLAPI] Improve join helper functions

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -9188,12 +9188,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getDropdownTypeSchema\\(\\) return type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Api/HL/Controller/AbstractController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Api\\\\HL\\\\Controller\\\\AbstractController\\:\\:getErrorResponseBody\\(\\) has parameter \\$detail with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/src/Glpi/Api/HL/Controller/AbstractController.php
+++ b/src/Glpi/Api/HL/Controller/AbstractController.php
@@ -35,6 +35,8 @@
 
 namespace Glpi\Api\HL\Controller;
 
+use CommonDBChild;
+use CommonDBRelation;
 use CommonDBTM;
 use Document;
 use Entity;
@@ -46,6 +48,7 @@ use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
 use Glpi\Plugin\Hooks;
+use LogicException;
 use Plugin;
 use RuntimeException;
 use Session;
@@ -140,14 +143,24 @@ abstract class AbstractController
     }
 
     /**
+     * Utility function to generate a property schema for a dropdown type (foreign key) field.
+     *
      * @param class-string<CommonDBTM> $class The class this schema represents. Used in the SQL join.
      * @param string|null $field The SQL field to use as a reference in the SQL join.
-     * @param string $name_field The field that contains the name
+     * @param string|null $name_field The field that contains the name
      * @param string|null $full_schema The name of the schema that represents the full object
-     * @return array The schema
+     * @param bool $graphql_only Whether this schema is only used for GraphQL
+     * @param array<string, mixed>|null $params Additional parameters for the property
+     * @return array<string, mixed> The schema
      */
-    public static function getDropdownTypeSchema(string $class, ?string $field = null, string $name_field = 'name', ?string $full_schema = null): array
-    {
+    public static function getDropdownTypeSchema(
+        string $class,
+        ?string $field = null,
+        ?string $name_field = 'name',
+        ?string $full_schema = null,
+        bool $graphql_only = false,
+        ?array $params = null
+    ): array {
         if ($field === null) {
             $field = $class::getForeignKeyField();
         }
@@ -165,17 +178,133 @@ abstract class AbstractController
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                 ],
-                $name_field => [
-                    'type' => Doc\Schema::TYPE_STRING,
-                    'readOnly' => true,
-                ],
             ],
         ];
+
+        if ($name_field !== null) {
+            $schema['properties'][$name_field] = [
+                'type' => Doc\Schema::TYPE_STRING,
+                'readOnly' => true,
+            ];
+        }
+
         if ($full_schema !== null) {
             $schema['x-full-schema'] = $full_schema;
         }
         if ($class === Entity::class) {
             $schema['properties']['id']['readOnly'] = true;
+        }
+        if ($graphql_only) {
+            $schema['x-graphql-only'] = true;
+        }
+        if ($params !== null) {
+            if (isset($params['additional_properties'])) {
+                $schema['properties'] = array_merge($schema['properties'], $params['additional_properties']);
+                unset($params['additional_properties']);
+            }
+            $schema = array_merge($schema, $params);
+        }
+        return $schema;
+    }
+
+    /**
+     * Utility function to generate a property schema for an array of children of a given class/schema.
+     *
+     * @param class-string<CommonDBTM> $parent_class The class of the parent object
+     * @param class-string<CommonDBTM> $class The class this schema represents
+     * @param string|null $name_field The field that contains the name
+     * @param string|null $full_schema The name of the schema that represents the full object
+     * @param bool $graphql_only Whether this schema is only used for GraphQL
+     * @param array<string, mixed>|null $params Additional parameters for the property
+     * @return array<string, mixed> The schema
+     */
+    protected static function getChildrenTypeSchema(
+        string $parent_class,
+        string $class,
+        ?string $name_field = 'name',
+        ?string $full_schema = null,
+        bool $graphql_only = false,
+        ?array $params = null
+    ): array {
+        $join_params = [
+            'table' => $class::getTable(), // The table to join
+            'fkey' => 'id', // The field in the main table to use as a reference
+            'primary-property' => 'id',
+        ];
+
+        if (is_subclass_of($class, CommonDBChild::class)) {
+            $join_params['field'] = $class::$items_id;
+            if ($class::$itemtype === 'itemtype') {
+                $join_params['condition'] = [
+                    'itemtype' => $parent_class::getType(),
+                ];
+            }
+        } elseif (is_subclass_of($class, CommonDBRelation::class)) {
+            // There are two sides to these relations, so we need to determine which side is the parent and which is the child
+            // For example Item_OperatingSystem (represented as OSInstallation schema) has a side for the OS and a side for the Item.
+            $itemtype_1 = $class::$itemtype_1;
+            $itemtype_2 = $class::$itemtype_2;
+
+            // If one of the itemtypes matches the parent class, we can determine which side is the child. Otherwise, it is the side with the generic "itemtype" field.
+            // If both side have generic "itemtype*" fields, we cannot determine which side to use.
+
+            if ($itemtype_1 === $parent_class::getType()) {
+                $join_params['field'] = $class::$items_id_1;
+            } elseif ($itemtype_2 === $parent_class::getType()) {
+                $join_params['field'] = $class::$items_id_2;
+            } elseif ($itemtype_1 === 'itemtype') {
+                $join_params['field'] = $class::$items_id_1;
+                $join_params['condition'] = [
+                    $class::$itemtype_1 => $parent_class::getType(),
+                ];
+            } elseif ($itemtype_2 === 'itemtype') {
+                $join_params['field'] = $class::$items_id_2;
+                $join_params['condition'] = [
+                    $class::$itemtype_2 => $parent_class::getType(),
+                ];
+            } else {
+                throw new LogicException("Cannot determine which side of the relation to use for {$class} and {$parent_class}");
+            }
+        }
+
+        $schema = [
+            'type' => Doc\Schema::TYPE_ARRAY,
+            'items' => [
+                'type' => Doc\Schema::TYPE_OBJECT,
+                'x-itemtype' => $class,
+                'x-join' => $join_params,
+                'properties' => [
+                    'id' => [
+                        'type' => Doc\Schema::TYPE_INTEGER,
+                        'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                        'readOnly' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        if (!$graphql_only && $name_field !== null) {
+            $schema['items']['properties'][$name_field] = [
+                'type' => Doc\Schema::TYPE_STRING,
+                'readOnly' => true,
+            ];
+        } else {
+            $schema['x-graphql-only'] = true;
+        }
+
+        if ($params !== null) {
+            if (isset($params['additional_properties'])) {
+                $schema['items']['properties'] = array_merge($schema['items']['properties'], $params['additional_properties']);
+                unset($params['additional_properties']);
+            }
+            $schema = array_merge($schema, $params);
+        }
+
+        if ($full_schema !== null) {
+            $schema['items']['x-full-schema'] = $full_schema;
+        }
+        if ($class === Entity::class) {
+            $schema['items']['properties']['id']['readOnly'] = true;
         }
         return $schema;
     }

--- a/src/Glpi/Api/HL/Controller/AdministrationController.php
+++ b/src/Glpi/Api/HL/Controller/AdministrationController.php
@@ -129,39 +129,18 @@ final class AdministrationController extends AbstractController
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'Mobile phone number',
                     ],
-                    'emails' => [
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'description' => 'Email addresses',
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'EmailAddress',
-                            'x-join' => [
-                                'table' => 'glpi_useremails',
-                                'fkey' => 'id',
-                                'field' => 'users_id',
-                                'primary-property' => 'id', // Help the search engine understand the 'id' property is this object's primary key since the fkey and field params are reversed for this join.
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'description' => 'ID',
-                                ],
-                                'email' => [
-                                    'type' => Doc\Schema::TYPE_STRING,
-                                    'description' => 'Email address',
-                                ],
-                                'is_default' => [
-                                    'type' => Doc\Schema::TYPE_BOOLEAN,
-                                    'description' => 'Is default',
-                                ],
-                                'is_dynamic' => [
-                                    'type' => Doc\Schema::TYPE_BOOLEAN,
-                                    'description' => 'Is dynamic',
-                                ],
+                    'emails' => self::getChildrenTypeSchema(
+                        parent_class: User::class,
+                        class: UserEmail::class,
+                        name_field: 'email',
+                        full_schema: 'EmailAddress',
+                        params: [
+                            'additional_properties' => [
+                                'is_default' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'description' => 'Is default'],
+                                'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'description' => 'Is dynamic'],
                             ],
                         ],
-                    ],
+                    ),
                     'comment' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'Comment',
@@ -207,7 +186,11 @@ final class AdministrationController extends AbstractController
                         'readOnly' => true,
                         'x-field' => 'password_last_update',
                     ],
-                    'location' => self::getDropdownTypeSchema(class: 'Location', full_schema: 'Location') + ['x-version-introduced' => '2.1.0'],
+                    'location' => self::getDropdownTypeSchema(
+                        class: 'Location',
+                        full_schema: 'Location',
+                        params: ['x-version-introduced' => '2.1.0']
+                    ),
                     'authtype' => [
                         'x-version-introduced' => '2.1.0',
                         'type' => Doc\Schema::TYPE_NUMBER,
@@ -226,14 +209,22 @@ EOD,
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                     ],
-                    'default_profile' => self::getDropdownTypeSchema(class: Profile::class, full_schema: 'Profile') + [
-                        'x-version-introduced' => '2.1.0',
-                        'description' => 'Default profile',
-                    ],
-                    'default_entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity') + [
-                        'x-version-introduced' => '2.1.0',
-                        'description' => 'Default entity',
-                    ],
+                    'default_profile' => self::getDropdownTypeSchema(
+                        class: Profile::class,
+                        full_schema: 'Profile',
+                        params: [
+                            'x-version-introduced' => '2.1.0',
+                            'description' => 'Default profile',
+                        ],
+                    ),
+                    'default_entity' => self::getDropdownTypeSchema(
+                        class: Entity::class,
+                        full_schema: 'Entity',
+                        params: [
+                            'x-version-introduced' => '2.1.0',
+                            'description' => 'Default entity',
+                        ],
+                    ),
                     'date_creation' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
@@ -250,8 +241,8 @@ EOD,
                         'readOnly' => true,
                         'x-version-introduced' => '2.2.0',
                     ],
-                    'title' => self::getDropdownTypeSchema(class: UserTitle::class, full_schema: 'UserTitle') + ['x-version-introduced' => '2.2.0'],
-                    'category' => self::getDropdownTypeSchema(class: UserCategory::class, full_schema: 'UserCategory') + ['x-version-introduced' => '2.2.0'],
+                    'title' => self::getDropdownTypeSchema(class: UserTitle::class, full_schema: 'UserTitle', params: ['x-version-introduced' => '2.2.0']),
+                    'category' => self::getDropdownTypeSchema(class: UserCategory::class, full_schema: 'UserCategory', params: ['x-version-introduced' => '2.2.0']),
                     'registration_number' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'x-version-introduced' => '2.2.0',
@@ -309,28 +300,7 @@ EOD,
                         'description' => 'Complete name',
                         'readOnly' => true,
                     ],
-                    'parent' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-itemtype' => Group::class,
-                        'x-full-schema' => 'Group',
-                        'x-join' => [
-                            'table' => 'glpi_groups',
-                            'fkey' => 'groups_id',
-                            'field' => 'id',
-                        ],
-                        'description' => 'Parent group',
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'description' => 'ID',
-                            ],
-                            'name' => [
-                                'type' => Doc\Schema::TYPE_STRING,
-                                'description' => 'Name',
-                            ],
-                        ],
-                    ],
+                    'parent' => self::getDropdownTypeSchema(class: Group::class, full_schema: 'Group'),
                     'level' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'description' => 'Level',
@@ -454,28 +424,7 @@ EOD,
                         'description' => 'Complete name',
                         'readOnly' => true,
                     ],
-                    'parent' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-itemtype' => Entity::class,
-                        'x-full-schema' => 'Entity',
-                        'x-join' => [
-                            'table' => 'glpi_entities',
-                            'fkey' => 'entities_id',
-                            'field' => 'id',
-                        ],
-                        'description' => 'Parent entity',
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'description' => 'ID',
-                            ],
-                            'name' => [
-                                'type' => Doc\Schema::TYPE_STRING,
-                                'description' => 'Name',
-                            ],
-                        ],
-                    ],
+                    'parent' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
                     'level' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'description' => 'Level',
@@ -609,7 +558,7 @@ EOD,
                         'maxLength' => 255,
                         'description' => 'Tag of the entity populated by an inventory tool.',
                     ],
-                    'authldap' => self::getDropdownTypeSchema(class: 'AuthLDAP', full_schema: 'LDAPDirectory') + ['x-version-introduced' => '2.3.0'],
+                    'authldap' => self::getDropdownTypeSchema(class: 'AuthLDAP', full_schema: 'LDAPDirectory', params: ['x-version-introduced' => '2.3.0']),
                     'mail_domain' => [
                         'x-version-introduced' => '2.3.0',
                         'type' => Doc\Schema::TYPE_STRING,

--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -875,7 +875,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                     'readOnly' => true,
                 ],
-                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential') + ['x-version-introduced' => '2.3.0'],
+                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential', params: ['x-version-introduced' => '2.3.0']),
             ],
         ];
 
@@ -976,7 +976,7 @@ final class AssetController extends AbstractController
                 ],
                 'autoupdatesystem' => $autoupdatesystem_property,
                 'brand' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'x-version-introduced' => '2.3.0'],
-                'power_supply' => self::getDropdownTypeSchema(class: PhonePowerSupply::class, field: 'phonepowersupplies_id', full_schema: 'PhonePowerSupply') + ['x-version-introduced' => '2.3.0'],
+                'power_supply' => self::getDropdownTypeSchema(class: PhonePowerSupply::class, field: 'phonepowersupplies_id', full_schema: 'PhonePowerSupply', params: ['x-version-introduced' => '2.3.0']),
                 'number_line' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'x-version-introduced' => '2.3.0'],
                 'have_headset' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'have_hp' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
@@ -1080,7 +1080,7 @@ final class AssetController extends AbstractController
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                     'readOnly' => true,
                 ],
-                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential') + ['x-version-introduced' => '2.3.0'],
+                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential', params: ['x-version-introduced' => '2.3.0']),
             ],
         ];
 
@@ -1239,7 +1239,7 @@ final class AssetController extends AbstractController
                 'autoupdatesystem' => $autoupdatesystem_property,
                 'is_dynamic' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'sysdescr' => ['type' => Doc\Schema::TYPE_STRING, 'x-version-introduced' => '2.3.0'],
-                'agent' => self::getDropdownTypeSchema(class: Agent::class, full_schema: 'Agent') + ['x-version-introduced' => '2.3.0'],
+                'agent' => self::getDropdownTypeSchema(class: Agent::class, full_schema: 'Agent', params: ['x-version-introduced' => '2.3.0']),
                 'itemtype' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'x-version-introduced' => '2.3.0',
@@ -1248,7 +1248,7 @@ final class AssetController extends AbstractController
                 'accepted' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'x-version-introduced' => '2.3.0'],
                 'is_hub' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'x-field' => 'hub', 'x-version-introduced' => '2.3.0'],
                 'ip' => ['type' => Doc\Schema::TYPE_STRING, 'x-version-introduced' => '2.3.0'],
-                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential') + ['x-version-introduced' => '2.3.0'],
+                'snmp_credential' => self::getDropdownTypeSchema(class: SNMPCredential::class, full_schema: 'SNMPCredential', params: ['x-version-introduced' => '2.3.0']),
                 'last_inventory_update' => [
                     'x-version-introduced' => '2.3.0',
                     'type' => Doc\Schema::TYPE_STRING,
@@ -1290,7 +1290,7 @@ final class AssetController extends AbstractController
                 'type' => self::getDropdownTypeSchema(class: ApplianceType::class, full_schema: 'ApplianceType'),
                 'group' => $fn_get_group_property(Appliance::class),
                 'group_tech' => $fn_get_group_tech_property(Appliance::class),
-                'environment' => self::getDropdownTypeSchema(class: ApplianceEnvironment::class, full_schema: 'ApplianceEnvironment') + ['x-version-introduced' => '2.3.0'],
+                'environment' => self::getDropdownTypeSchema(class: ApplianceEnvironment::class, full_schema: 'ApplianceEnvironment', params: ['x-version-introduced' => '2.3.0']),
                 'external_id' => ['type' => Doc\Schema::TYPE_STRING, 'x-field' => 'externalidentifier', 'x-version-introduced' => '2.3.0'],
                 'is_helpdesk_visible' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => true, 'x-version-introduced' => '2.3.0'],
             ],
@@ -1382,23 +1382,13 @@ final class AssetController extends AbstractController
                         ],
                     ],
                 ],
-                'cartridges' => [
-                    'type' => Doc\Schema::TYPE_ARRAY,
-                    'description' => 'List of cartridges',
-                    'items' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'Cartridge',
-                        'x-join' => [
-                            'table' => Cartridge::getTable(),
-                            'fkey' => 'id',
-                            'field' => CartridgeItem::getForeignKeyField(),
-                        ],
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'readOnly' => true,
-                            ],
+                'cartridges' => self::getChildrenTypeSchema(
+                    parent_class: CartridgeItem::class,
+                    class: Cartridge::class,
+                    name_field: null,
+                    full_schema: 'Cartridge',
+                    params: [
+                        'additional_properties' => [
                             'pages' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
                             'date_in' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                             'date_use' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -1407,7 +1397,7 @@ final class AssetController extends AbstractController
                             'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                         ],
                     ],
-                ],
+                ),
             ],
         ];
 
@@ -1465,23 +1455,13 @@ final class AssetController extends AbstractController
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
                 'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User'),
-                'consumables' => [
-                    'type' => Doc\Schema::TYPE_ARRAY,
-                    'description' => 'List of consumables',
-                    'items' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'Consumable',
-                        'x-join' => [
-                            'table' => Consumable::getTable(),
-                            'fkey' => 'id',
-                            'field' => ConsumableItem::getForeignKeyField(),
-                        ],
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'readOnly' => true,
-                            ],
+                'consumables' => self::getChildrenTypeSchema(
+                    parent_class: ConsumableItem::class,
+                    class: Consumable::class,
+                    name_field: null,
+                    full_schema: 'Consumable',
+                    params: [
+                        'additional_properties' => [
                             'date_in' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                             'date_out' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                             'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
@@ -1490,7 +1470,7 @@ final class AssetController extends AbstractController
                             'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                         ],
                     ],
-                ],
+                ),
             ],
         ];
 
@@ -1772,29 +1752,18 @@ final class AssetController extends AbstractController
                     'x-field' => 'mesured_power', // Took liberty to fix typo in DB without having to mess with the DB itself or other code
                 ],
                 'max_weight' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT32],
-                'items' => [
-                    'type' => Doc\Schema::TYPE_ARRAY,
-                    'description' => 'List of items in the rack',
-                    'items' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'RackItem',
-                        'x-join' => [
-                            'table' => Item_Rack::getTable(),
-                            'fkey' => 'id',
-                            'field' => Rack::getForeignKeyField(),
-                            'primary-property' => 'id',
-                        ],
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'readOnly' => true,
-                            ],
+                'items' => self::getChildrenTypeSchema(
+                    parent_class: Rack::class,
+                    class: Item_Rack::class,
+                    name_field: null,
+                    full_schema: 'RackItem',
+                    params: [
+                        'additional_properties' => [
                             'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                             'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                         ],
                     ],
-                ],
+                ),
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
             ],
@@ -2204,8 +2173,8 @@ final class AssetController extends AbstractController
                 'sockets_id_endpoint_b' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
                 'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
-                'cable_strand' => self::getDropdownTypeSchema(class: CableStrand::class, full_schema: 'CableStrand') + ['x-version-introduced' => '2.3.0'],
-                'type' => self::getDropdownTypeSchema(class: CableType::class, full_schema: 'CableType') + ['x-version-introduced' => '2.3.0'],
+                'cable_strand' => self::getDropdownTypeSchema(class: CableStrand::class, full_schema: 'CableStrand', params: ['x-version-introduced' => '2.3.0']),
+                'type' => self::getDropdownTypeSchema(class: CableType::class, full_schema: 'CableType', params: ['x-version-introduced' => '2.3.0']),
                 'is_template' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3.0'],
                 'template_name' => ['type' => Doc\Schema::TYPE_STRING, 'x-version-introduced' => '2.3.0'],
                 'color' => [

--- a/src/Glpi/Api/HL/Controller/DashboardController.php
+++ b/src/Glpi/Api/HL/Controller/DashboardController.php
@@ -107,46 +107,22 @@ final class DashboardController extends AbstractController
                         'enum' => $known_contexts,
                     ],
                     'user' => self::getDropdownTypeSchema(class: \User::class, full_schema: 'User'),
-                    'filters' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'DashboardFilter',
-                            'x-join' => [
-                                'table' => Dashboard\Filter::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'dashboards_dashboards_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
-                    'items' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'DashboardItem',
-                            'x-join' => [
-                                'table' => Dashboard\Item::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'dashboards_dashboards_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
+                    'filters' => self::getChildrenTypeSchema(
+                        parent_class: Dashboard\Dashboard::class,
+                        class: Dashboard\Filter::class,
+                        name_field: null,
+                        full_schema: 'DashboardFilter',
+                        graphql_only: true,
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
+                    'items' => self::getChildrenTypeSchema(
+                        parent_class: Dashboard\Dashboard::class,
+                        class: Dashboard\Item::class,
+                        name_field: null,
+                        full_schema: 'DashboardItem',
+                        graphql_only: true,
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                 ],
             ],
             'DashboardFilter' => [

--- a/src/Glpi/Api/HL/Controller/ITILController.php
+++ b/src/Glpi/Api/HL/Controller/ITILController.php
@@ -188,8 +188,8 @@ final class ITILController extends AbstractController
                     'format' => Doc\Schema::FORMAT_STRING_HTML,
                     'x-supports-mentions' => true,
                 ],
-                'user_recipient' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_recipient', full_schema: 'User') + ['x-version-introduced' => '2.1.0'],
-                'user_editor' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_lastupdater', full_schema: 'User') + ['x-version-introduced' => '2.1.0'],
+                'user_recipient' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_recipient', full_schema: 'User', params: ['x-version-introduced' => '2.1.0']),
+                'user_editor' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_lastupdater', full_schema: 'User', params: ['x-version-introduced' => '2.1.0']),
                 'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'category' => self::getDropdownTypeSchema(class: ITILCategory::class, full_schema: 'ITILCategory'),
                 'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location'),
@@ -445,12 +445,12 @@ final class ITILController extends AbstractController
                     'description' => 'Total take into account duration in seconds',
                     'x-field' => 'takeintoaccount_delay_stat',
                 ];
-                $schemas[$itil_type]['properties']['sla_ttr'] = self::getDropdownTypeSchema(class: SLA::class, field: 'slas_id_ttr', full_schema: 'SLA') + ['x-version-introduced' => '2.1.0'];
-                $schemas[$itil_type]['properties']['sla_tto'] = self::getDropdownTypeSchema(class: SLA::class, field: 'slas_id_tto', full_schema: 'SLA') + ['x-version-introduced' => '2.1.0'];
-                $schemas[$itil_type]['properties']['ola_ttr'] = self::getDropdownTypeSchema(class: OLA::class, field: 'olas_id_ttr', full_schema: 'OLA') + ['x-version-introduced' => '2.1.0'];
-                $schemas[$itil_type]['properties']['ola_tto'] = self::getDropdownTypeSchema(class: OLA::class, field: 'olas_id_tto', full_schema: 'OLA') + ['x-version-introduced' => '2.1.0'];
-                $schemas[$itil_type]['properties']['sla_level_ttr'] = self::getDropdownTypeSchema(class: SlaLevel::class, field: 'slalevels_id_ttr', full_schema: 'SLALevel') + ['x-version-introduced' => '2.1.0'];
-                $schemas[$itil_type]['properties']['ola_level_ttr'] = self::getDropdownTypeSchema(class: OlaLevel::class, field: 'olalevels_id_ttr', full_schema: 'OLALevel') + ['x-version-introduced' => '2.1.0'];
+                $schemas[$itil_type]['properties']['sla_ttr'] = self::getDropdownTypeSchema(class: SLA::class, field: 'slas_id_ttr', full_schema: 'SLA', params: ['x-version-introduced' => '2.1.0']);
+                $schemas[$itil_type]['properties']['sla_tto'] = self::getDropdownTypeSchema(class: SLA::class, field: 'slas_id_tto', full_schema: 'SLA', params: ['x-version-introduced' => '2.1.0']);
+                $schemas[$itil_type]['properties']['ola_ttr'] = self::getDropdownTypeSchema(class: OLA::class, field: 'olas_id_ttr', full_schema: 'OLA', params: ['x-version-introduced' => '2.1.0']);
+                $schemas[$itil_type]['properties']['ola_tto'] = self::getDropdownTypeSchema(class: OLA::class, field: 'olas_id_tto', full_schema: 'OLA', params: ['x-version-introduced' => '2.1.0']);
+                $schemas[$itil_type]['properties']['sla_level_ttr'] = self::getDropdownTypeSchema(class: SlaLevel::class, field: 'slalevels_id_ttr', full_schema: 'SLALevel', params: ['x-version-introduced' => '2.1.0']);
+                $schemas[$itil_type]['properties']['ola_level_ttr'] = self::getDropdownTypeSchema(class: OlaLevel::class, field: 'olalevels_id_ttr', full_schema: 'OLALevel', params: ['x-version-introduced' => '2.1.0']);
                 $schemas[$itil_type]['properties']['sla_waiting_duration'] = [
                     'x-version-introduced' => '2.1.0',
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -558,27 +558,13 @@ final class ITILController extends AbstractController
                 Change::class => ChangeCost::class,
                 Problem::class => ProblemCost::class,
             };
-            $schemas[$itil_type]['properties']['costs'] = [
-                'x-version-introduced' => '2.3.0',
-                'type' => Doc\Schema::TYPE_ARRAY,
-                'items' => [
-                    'type' => Doc\Schema::TYPE_OBJECT,
-                    'x-full-schema' => $cost_type,
-                    'x-join' => [
-                        'table' => $cost_type::getTable(),
-                        'fkey' => 'id',
-                        'field' => $itil_type::getForeignKeyField(),
-                        'primary-property' => 'id',
-                    ],
-                    'properties' => [
-                        'id' => [
-                            'type' => Doc\Schema::TYPE_INTEGER,
-                            'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                            'readOnly' => true,
-                        ],
-                    ],
-                ],
-            ];
+            $schemas[$itil_type]['properties']['costs'] = self::getChildrenTypeSchema(
+                parent_class: $itil_type,
+                class: $cost_type,
+                name_field: null,
+                full_schema: $cost_type,
+                params: ['x-version-introduced' => '2.3.0']
+            );
         }
 
         $timeline_position_enum = [
@@ -636,8 +622,8 @@ final class ITILController extends AbstractController
                 'is_private' => ['type' => Doc\Schema::TYPE_BOOLEAN],
                 'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
                 'user_editor' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_editor', full_schema: 'User'),
-                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User') + ['x-version-introduced' => '2.1.0'],
-                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group') + ['x-version-introduced' => '2.1.0'],
+                'user_tech' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_tech', full_schema: 'User', params: ['x-version-introduced' => '2.1.0']),
+                'group_tech' => self::getDropdownTypeSchema(class: Group::class, field: 'groups_id_tech', full_schema: 'Group', params: ['x-version-introduced' => '2.1.0']),
                 'date' => [
                     'x-version-introduced' => '2.1.0',
                     'type' => Doc\Schema::TYPE_STRING,
@@ -793,7 +779,7 @@ final class ITILController extends AbstractController
                 ],
                 'itemtype' => ['type' => Doc\Schema::TYPE_STRING],
                 'items_id' => ['type' => Doc\Schema::TYPE_INTEGER, 'format' => Doc\Schema::FORMAT_INTEGER_INT64],
-                'type' => self::getDropdownTypeSchema(class: SolutionType::class, full_schema: 'SolutionType') + ['x-version-introduced' => '2.2.0'],
+                'type' => self::getDropdownTypeSchema(class: SolutionType::class, full_schema: 'SolutionType', params: ['x-version-introduced' => '2.2.0']),
                 'content' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_HTML,
@@ -801,7 +787,7 @@ final class ITILController extends AbstractController
                 ],
                 'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
                 'user_editor' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_editor', full_schema: 'User'),
-                'approver' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_approval', full_schema: 'User') + ['x-version-introduced' => '2.1.0'],
+                'approver' => self::getDropdownTypeSchema(class: User::class, field: 'users_id_approval', full_schema: 'User', params: ['x-version-introduced' => '2.1.0']),
                 'status' => [
                     'x-version-introduced' => '2.1.0',
                     'type' => Doc\Schema::TYPE_INTEGER,
@@ -819,25 +805,12 @@ final class ITILController extends AbstractController
                         - 4: Refused
                         EOT,
                 ],
-                'approval_followup' => [
-                    'x-version-introduced' => '2.1.0',
-                    'type' => Doc\Schema::TYPE_OBJECT,
-                    'x-full-schema' => 'Followup',
-                    'x-field' => ITILFollowup::getForeignKeyField(),
-                    'x-itemtype' => ITILFollowup::class,
-                    'x-join' => [
-                        'table' => ITILFollowup::getTable(),
-                        'fkey' => ITILFollowup::getForeignKeyField(),
-                        'field' => 'id',
-                    ],
-                    'properties' => [
-                        'id' => [
-                            'type' => Doc\Schema::TYPE_INTEGER,
-                            'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                            'readOnly' => true,
-                        ],
-                    ],
-                ],
+                'approval_followup' => self::getDropdownTypeSchema(
+                    class: ITILFollowup::class,
+                    name_field: null,
+                    full_schema: 'Followup',
+                    params: ['x-version-introduced' => '2.1.0']
+                ),
                 'date_creation' => [
                     'x-version-introduced' => '2.1.0',
                     'type' => Doc\Schema::TYPE_STRING,

--- a/src/Glpi/Api/HL/Controller/InventoryController.php
+++ b/src/Glpi/Api/HL/Controller/InventoryController.php
@@ -66,10 +66,10 @@ final class InventoryController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'type' => self::getDropdownTypeSchema(class: AgentType::class, full_schema: 'AgentType') + ['readOnly' => true],
+                    'type' => self::getDropdownTypeSchema(class: AgentType::class, full_schema: 'AgentType', params: ['readOnly' => true]),
                     'deviceid' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
                     'name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
-                    'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity') + ['readOnly' => true],
+                    'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity', params: ['readOnly' => true]),
                     'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'readOnly' => true],
                     'last_contact' => [
                         'type' => Doc\Schema::TYPE_STRING,

--- a/src/Glpi/Api/HL/Controller/KnowbaseController.php
+++ b/src/Glpi/Api/HL/Controller/KnowbaseController.php
@@ -192,31 +192,19 @@ class KnowbaseController extends AbstractController
                             ],
                         ],
                     ],
-                    'translations' => [
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'KBArticleTranslation',
-                            'x-join' => [
-                                'table' => KnowbaseItemTranslation::getTable(),
-                                'fkey' => 'id',
-                                'field' => KnowbaseItem::getForeignKeyField(),
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
+                    'translations' => self::getChildrenTypeSchema(
+                        parent_class: KnowbaseItem::class,
+                        class: KnowbaseItemTranslation::class,
+                        full_schema: 'KBArticleTranslation',
+                        params: [
+                            'additional_properties' => [
                                 'language' => [
                                     'type' => Doc\Schema::TYPE_STRING,
                                     'description' => 'Language code (POSIX compliant format e.g. en_US or fr_FR)',
                                 ],
-                                'name' => ['type' => Doc\Schema::TYPE_STRING],
                             ],
                         ],
-                    ],
+                    ),
                 ],
             ],
             'KBCategory' => [
@@ -261,24 +249,12 @@ class KnowbaseController extends AbstractController
                         'description' => 'Language code (POSIX compliant format e.g. en_US or fr_FR)',
                     ],
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                    'parent' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'KBArticleComment',
-                        'x-field' => 'parent_comment_id',
-                        'x-itemtype' => KnowbaseItem_Comment::class,
-                        'x-join' => [
-                            'table' => KnowbaseItem_Comment::getTable(),
-                            'fkey' => 'parent_comment_id',
-                            'field' => 'id',
-                        ],
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'readOnly' => true,
-                            ],
-                        ],
-                    ],
+                    'parent' => self::getDropdownTypeSchema(
+                        class: KnowbaseItem_Comment::class,
+                        field: 'parent_comment_id',
+                        name_field: null,
+                        full_schema: 'KBArticleComment'
+                    ),
                     'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 ],

--- a/src/Glpi/Api/HL/Controller/ManagementController.php
+++ b/src/Glpi/Api/HL/Controller/ManagementController.php
@@ -374,34 +374,20 @@ final class ManagementController extends AbstractController
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'type' => self::getDropdownTypeSchema(class: ContractType::class, full_schema: 'ContractType'),
                     'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                    'costs' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'ContractCost',
-                            'x-join' => [
-                                'table' => ContractCost::getTable(),
-                                'fkey' => 'id',
-                                'field' => Contract::getForeignKeyField(),
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
+                    'costs' => self::getChildrenTypeSchema(
+                        parent_class: Contract::class,
+                        class: ContractCost::class,
+                        name_field: null,
+                        full_schema: 'ContractCost',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                     'number' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
                         'x-version-introduced' => '2.3.0',
                         'x-field' => 'num',
                     ],
-                    'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location') + ['x-version-introduced' => '2.3.0'],
+                    'location' => self::getDropdownTypeSchema(class: Location::class, full_schema: 'Location', params: ['x-version-introduced' => '2.3.0']),
                     'date_begin' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'format' => Doc\Schema::FORMAT_STRING_DATE,
@@ -551,9 +537,11 @@ EOT,
                     'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN],
-                    'instance' => self::getDropdownTypeSchema(class: DatabaseInstance::class, full_schema: 'DatabaseInstance') + [
-                        'x-version-introduced' => '2.2',
-                    ],
+                    'instance' => self::getDropdownTypeSchema(
+                        class: DatabaseInstance::class,
+                        full_schema: 'DatabaseInstance',
+                        params: ['x-version-introduced' => '2.2'],
+                    ),
                 ],
             ],
             'DatabaseInstance' => [
@@ -593,27 +581,11 @@ EOT,
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'date_lastboot' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'date_lastbackup' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
-                    'database' => [
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'Database',
-                            'x-join' => [
-                                'table' => Database::getTable(), // The table with the desired data
-                                'fkey' => 'id',
-                                'field' => DatabaseInstance::getForeignKeyField(),
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
-                                'name' => ['type' => Doc\Schema::TYPE_STRING],
-                            ],
-                        ],
-                    ],
+                    'database' => self::getChildrenTypeSchema(
+                        parent_class: DatabaseInstance::class,
+                        class: Database::class,
+                        full_schema: 'Database',
+                    ),
                 ],
             ],
             'DataCenter' => [
@@ -666,9 +638,13 @@ EOT,
                     ],
                     'mime' => ['type' => Doc\Schema::TYPE_STRING],
                     'sha1sum' => ['type' => Doc\Schema::TYPE_STRING],
-                    'category' => self::getDropdownTypeSchema(class: DocumentCategory::class, full_schema: 'DocumentCategory') + ['x-version-introduced' => '2.3.0'],
+                    'category' => self::getDropdownTypeSchema(
+                        class: DocumentCategory::class,
+                        full_schema: 'DocumentCategory',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                     'link' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'x-version-introduced' => '2.3.0'],
-                    'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User') + ['x-version-introduced' => '2.3.0'],
+                    'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User', params: ['x-version-introduced' => '2.3.0']),
                     'checksum_sha1' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 40,
@@ -820,7 +796,11 @@ EOT,
                         'type' => Doc\Schema::TYPE_STRING,
                         'maxLength' => 255,
                     ],
-                    'operator' => self::getDropdownTypeSchema(class: LineOperator::class, full_schema: 'LineOperator') + ['x-version-introduced' => '2.3.0'],
+                    'operator' => self::getDropdownTypeSchema(
+                        class: LineOperator::class,
+                        full_schema: 'LineOperator',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                 ],
             ],
             'Supplier' => [
@@ -868,7 +848,7 @@ EOT,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                     'readOnly' => true,
                 ],
-                'document' => self::getDropdownTypeSchema(class: Document::class, full_schema: 'Document') + ['x-version-introduced' => '2.3.0'],
+                'document' => self::getDropdownTypeSchema(class: Document::class, full_schema: 'Document', params: ['x-version-introduced' => '2.3.0']),
                 'filepath' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'x-mapped-from' => 'documents_id',

--- a/src/Glpi/Api/HL/Controller/NotificationController.php
+++ b/src/Glpi/Api/HL/Controller/NotificationController.php
@@ -112,26 +112,13 @@ class NotificationController extends AbstractController
                         'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                         'readOnly' => true,
                     ],
-                    'recipients' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'NotificationRecipient',
-                            'x-join' => [
-                                'table' => NotificationTarget::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'notifications_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
+                    'recipients' => self::getChildrenTypeSchema(
+                        parent_class: Notification::class,
+                        class: NotificationTarget::class,
+                        name_field: null,
+                        full_schema: 'NotificationRecipient',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                 ],
             ],
             'NotificationRecipient' => [
@@ -242,26 +229,13 @@ EOT,
                         'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,
                         'readOnly' => true,
                     ],
-                    'translations' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'NotificationTemplateTranslation',
-                            'x-join' => [
-                                'table' => NotificationTemplateTranslation::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'notificationtemplates_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
+                    'translations' => self::getChildrenTypeSchema(
+                        parent_class: NotificationTemplate::class,
+                        class: NotificationTemplateTranslation::class,
+                        name_field: null,
+                        full_schema: 'NotificationTemplateTranslation',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
                 ],
             ],
             'NotificationTemplateTranslation' => [

--- a/src/Glpi/Api/HL/Controller/ProjectController.php
+++ b/src/Glpi/Api/HL/Controller/ProjectController.php
@@ -147,59 +147,33 @@ final class ProjectController extends AbstractController
                             EOT,
                     ],
                     'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity'),
-                    'tasks' => [
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'ProjectTask',
-                            'x-join' => [
-                                'table' => 'glpi_projecttasks',
-                                'fkey' => 'id',
-                                'field' => 'projects_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
-                                'name' => ['type' => Doc\Schema::TYPE_STRING],
+                    'tasks' => self::getChildrenTypeSchema(
+                        parent_class: Project::class,
+                        class: ProjectTask::class,
+                        full_schema: 'ProjectTask',
+                        params: [
+                            'additional_properties' => [
                                 'comment' => ['type' => Doc\Schema::TYPE_STRING],
-                                'content' => ['type' => Doc\Schema::TYPE_STRING],
+                                'content' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_HTML],
                             ],
-                        ],
-                    ],
-                    'costs' => [
-                        'x-version-introduced' => '2.3.0',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'ProjectCost',
-                            'x-join' => [
-                                'table' => ProjectCost::getTable(),
-                                'fkey' => 'id',
-                                'field' => Project::getForeignKeyField(),
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
-                            ],
-                        ],
-                    ],
-                    'status' => self::getDropdownTypeSchema(class: ProjectState::class, full_schema: 'ProjectState') + ['x-version-introduced' => '2.3'],
+                        ]
+                    ),
+                    'costs' => self::getChildrenTypeSchema(
+                        parent_class: Project::class,
+                        class: ProjectCost::class,
+                        name_field: null,
+                        full_schema: 'ProjectCost',
+                        params: ['x-version-introduced' => '2.3.0']
+                    ),
+                    'status' => self::getDropdownTypeSchema(class: ProjectState::class, full_schema: 'ProjectState', params: ['x-version-introduced' => '2.3']),
                     'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'x-version-introduced' => '2.3'],
-                    'parent' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project') + ['x-version-introduced' => '2.3'],
-                    'type' => self::getDropdownTypeSchema(class: ProjectType::class, full_schema: 'ProjectType') + ['x-version-introduced' => '2.3'],
+                    'parent' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project', params: ['x-version-introduced' => '2.3']),
+                    'type' => self::getDropdownTypeSchema(class: ProjectType::class, full_schema: 'ProjectType', params: ['x-version-introduced' => '2.3']),
                     'date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
                     'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
-                    'user' => self::getDropdownTypeSchema(class: 'User', full_schema: 'User') + ['x-version-introduced' => '2.3'],
-                    'group' => self::getDropdownTypeSchema(class: 'Group', full_schema: 'Group') + ['x-version-introduced' => '2.3'],
+                    'user' => self::getDropdownTypeSchema(class: 'User', full_schema: 'User', params: ['x-version-introduced' => '2.3']),
+                    'group' => self::getDropdownTypeSchema(class: 'Group', full_schema: 'Group', params: ['x-version-introduced' => '2.3']),
                     'plan_start_date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
                     'plan_end_date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
                     'real_start_date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
@@ -302,24 +276,14 @@ final class ProjectController extends AbstractController
                             ],
                         ],
                     ],
-                    'team' => [
-                        'x-version-introduced' => '2.3',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'ProjectTeamMember',
-                            'x-join' => [
-                                'table' => ProjectTeam::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'projects_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
+                    'team' => self::getChildrenTypeSchema(
+                        parent_class: Project::class,
+                        class: ProjectTeam::class,
+                        name_field: null,
+                        full_schema: 'ProjectTeamMember',
+                        params: [
+                            'x-version-introduced' => '2.3',
+                            'additional_properties' => [
                                 'itemtype' => [
                                     'type' => Doc\Schema::TYPE_STRING,
                                     'enum' => [User::class, Group::class, Supplier::class, Contact::class],
@@ -331,8 +295,8 @@ final class ProjectController extends AbstractController
                                     'readOnly' => true,
                                 ],
                             ],
-                        ],
-                    ],
+                        ]
+                    ),
                 ],
             ],
             'ProjectTask' => [
@@ -416,8 +380,8 @@ final class ProjectController extends AbstractController
                     'content' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_HTML],
                     'project' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project'),
                     'parent_task' => self::getDropdownTypeSchema(class: ProjectTask::class, full_schema: 'ProjectTask'),
-                    'status' => self::getDropdownTypeSchema(class: ProjectState::class, full_schema: 'ProjectState') + ['x-version-introduced' => '2.3'],
-                    'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity') + ['x-version-introduced' => '2.3'],
+                    'status' => self::getDropdownTypeSchema(class: ProjectState::class, full_schema: 'ProjectState', params: ['x-version-introduced' => '2.3']),
+                    'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity', params: ['x-version-introduced' => '2.3']),
                     'is_recursive' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'x-version-introduced' => '2.3'],
                     'is_deleted' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3'],
                     'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'x-version-introduced' => '2.3'],
@@ -446,8 +410,8 @@ final class ProjectController extends AbstractController
                         'x-field' => 'auto_projectstates',
                         'description' => 'If true, the status of the task will be automatically updated based on the percent done and the global configuration for project task states',
                     ],
-                    'type' => self::getDropdownTypeSchema(class: ProjectTaskType::class, full_schema: 'ProjectTaskType') + ['x-version-introduced' => '2.3'],
-                    'user' => self::getDropdownTypeSchema(class: 'User', full_schema: 'User') + ['x-version-introduced' => '2.3'],
+                    'type' => self::getDropdownTypeSchema(class: ProjectTaskType::class, full_schema: 'ProjectTaskType', params: ['x-version-introduced' => '2.3']),
+                    'user' => self::getDropdownTypeSchema(class: 'User', full_schema: 'User', params: ['x-version-introduced' => '2.3']),
                     'percent_done' => [
                         'type' => Doc\Schema::TYPE_INTEGER,
                         'x-version-introduced' => '2.3',
@@ -456,24 +420,14 @@ final class ProjectController extends AbstractController
                     ],
                     'auto_percent_done' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3'],
                     'is_milestone' => ['type' => Doc\Schema::TYPE_BOOLEAN, 'default' => false, 'x-version-introduced' => '2.3'],
-                    'team' => [
-                        'x-version-introduced' => '2.3',
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'ProjectTaskTeamMember',
-                            'x-join' => [
-                                'table' => ProjectTaskTeam::getTable(),
-                                'fkey' => 'id',
-                                'field' => 'projecttasks_id',
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
+                    'team' => self::getChildrenTypeSchema(
+                        parent_class: ProjectTask::class,
+                        class: ProjectTaskTeam::class,
+                        name_field: null,
+                        full_schema: 'ProjectTaskTeamMember',
+                        params: [
+                            'x-version-introduced' => '2.3',
+                            'additional_properties' => [
                                 'itemtype' => [
                                     'type' => Doc\Schema::TYPE_STRING,
                                     'enum' => [User::class, Group::class, Supplier::class, Contact::class],
@@ -485,8 +439,8 @@ final class ProjectController extends AbstractController
                                     'readOnly' => true,
                                 ],
                             ],
-                        ],
-                    ],
+                        ]
+                    ),
                 ],
             ],
             'ProjectCost' => [
@@ -565,7 +519,7 @@ final class ProjectController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'project' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project') + ['required' => true],
+                    'project' => self::getDropdownTypeSchema(class: Project::class, full_schema: 'Project', params: ['required' => true]),
                     'itemtype' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'enum' => [User::class, Group::class, Supplier::class, Contact::class],
@@ -588,7 +542,7 @@ final class ProjectController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'task' => self::getDropdownTypeSchema(class: ProjectTask::class, full_schema: 'ProjectTask') + ['required' => true],
+                    'task' => self::getDropdownTypeSchema(class: ProjectTask::class, full_schema: 'ProjectTask', params: ['required' => true]),
                     'itemtype' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'enum' => [User::class, Group::class, Supplier::class, Contact::class],

--- a/src/Glpi/Api/HL/Controller/ReportController.php
+++ b/src/Glpi/Api/HL/Controller/ReportController.php
@@ -257,9 +257,9 @@ class ReportController extends AbstractController
                             'name' => [
                                 'type' => Doc\Schema::TYPE_STRING,
                             ],
-                            'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity') + [
+                            'entity' => self::getDropdownTypeSchema(class: Entity::class, full_schema: 'Entity', params: [
                                 'description' => 'The entity the item belongs to',
-                            ],
+                            ]),
                             'is_deleted' => [
                                 'type' => Doc\Schema::TYPE_BOOLEAN,
                                 'description' => 'Whether the item is deleted or not',

--- a/src/Glpi/Api/HL/Controller/RuleController.php
+++ b/src/Glpi/Api/HL/Controller/RuleController.php
@@ -99,7 +99,7 @@ final class RuleController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['writeOnly' => true],
+                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule', params: ['writeOnly' => true]),
                     'criteria' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'The criteria to use. See /Rule/Collection/{collection}/CriteriaCriteria for a complete list of criteria.',
@@ -184,7 +184,7 @@ final class RuleController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule') + ['writeOnly' => true],
+                    'rule' => self::getDropdownTypeSchema(class: Rule::class, full_schema: 'Rule', params: ['writeOnly' => true]),
                     'action_type' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'The action to perform. See /Rule/Collection/{collection}/ActionType for a complete list of actions.',
@@ -242,36 +242,24 @@ final class RuleController extends AbstractController
                     'type' => Doc\Schema::TYPE_INTEGER,
                     'format' => Doc\Schema::FORMAT_INTEGER_INT32,
                 ],
-                'criteria' => [
-                    'type' => Doc\Schema::TYPE_ARRAY,
-                    'readOnly' => true,
-                    'items' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'RuleCriteria',
-                        'x-join' => [
-                            'table' => 'glpi_rulecriterias',
-                            'fkey' => 'id',
-                            'field' => 'rules_id',
-                            'primary-property' => 'id',
-                        ],
-                        'properties' => array_filter($schemas['RuleCriteria']['properties'], static fn($k) => $k !== 'rule', ARRAY_FILTER_USE_KEY),
-                    ],
-                ],
-                'actions' => [
-                    'type' => Doc\Schema::TYPE_ARRAY,
-                    'readOnly' => true,
-                    'items' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-full-schema' => 'RuleAction',
-                        'x-join' => [
-                            'table' => 'glpi_ruleactions',
-                            'fkey' => 'id',
-                            'field' => 'rules_id',
-                            'primary-property' => 'id',
-                        ],
-                        'properties' => array_filter($schemas['RuleAction']['properties'], static fn($k) => $k !== 'rule', ARRAY_FILTER_USE_KEY),
-                    ],
-                ],
+                'criteria' => self::getChildrenTypeSchema(
+                    parent_class: Rule::class,
+                    class: RuleCriteria::class,
+                    name_field: null,
+                    full_schema: 'RuleCriteria',
+                    params: [
+                        'additional_properties' => array_filter($schemas['RuleCriteria']['properties'], static fn($k) => $k !== 'rule', ARRAY_FILTER_USE_KEY),
+                    ]
+                ),
+                'actions' => self::getChildrenTypeSchema(
+                    parent_class: Rule::class,
+                    class: RuleAction::class,
+                    name_field: null,
+                    full_schema: 'RuleAction',
+                    params: [
+                        'additional_properties' => array_filter($schemas['RuleAction']['properties'], static fn($k) => $k !== 'rule', ARRAY_FILTER_USE_KEY),
+                    ]
+                ),
                 'date_creation' => [
                     'type' => Doc\Schema::TYPE_STRING,
                     'format' => Doc\Schema::FORMAT_STRING_DATE_TIME,

--- a/src/Glpi/Api/HL/Controller/SetupController.php
+++ b/src/Glpi/Api/HL/Controller/SetupController.php
@@ -457,9 +457,11 @@ EOT,
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'automatic_action' => self::getDropdownTypeSchema(class: CronTask::class, full_schema: 'AutomaticAction') + [
-                        'readOnly' => true,
-                    ],
+                    'automatic_action' => self::getDropdownTypeSchema(
+                        class: CronTask::class,
+                        full_schema: 'AutomaticAction',
+                        params: ['readOnly' => true]
+                    ),
                     'previous' => [
                         'type' => Doc\Schema::TYPE_OBJECT,
                         'description' => 'The previous log entry for the same automatic action execution, if any. Typically points to the start log entry.',
@@ -841,9 +843,7 @@ EOT,
                         'description' => 'The number of times this webhook has been tried to be sent.',
                         'readOnly' => true,
                     ],
-                    'webhook' => self::getDropdownTypeSchema(class: Webhook::class, full_schema: 'Webhook') + [
-                        'readOnly' => true,
-                    ],
+                    'webhook' => self::getDropdownTypeSchema(class: Webhook::class, full_schema: 'Webhook', params: ['readOnly' => true]),
                     'url' => [
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'The resolved URL the webhook will be sent to.',
@@ -908,7 +908,11 @@ EOT,
                     ],
                     'from' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
                     'to' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
-                    'mail_collector' => self::getDropdownTypeSchema(class: MailCollector::class, full_schema: 'EmailCollector') + ['readOnly' => true],
+                    'mail_collector' => self::getDropdownTypeSchema(
+                        class: MailCollector::class,
+                        full_schema: 'EmailCollector',
+                        params: ['readOnly' => true]
+                    ),
                     'date' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME, 'readOnly' => true],
                     'subject' => ['type' => Doc\Schema::TYPE_STRING, 'readOnly' => true],
                     'messageid' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255, 'readOnly' => true],
@@ -928,7 +932,7 @@ EOT,
 EOT,
                         'readOnly' => true,
                     ],
-                    'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User') + ['readOnly' => true],
+                    'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User', params: ['readOnly' => true]),
                 ],
             ],
             'OAuthClient' => [
@@ -1013,28 +1017,17 @@ EOT,
                         'type' => Doc\Schema::TYPE_STRING,
                         'description' => 'JSON encoded object of translations for the asset type label where the keys are the language and the values are objects with properties for "one", "many" and "other".',
                     ],
-                    'custom_fields' => [
-                        'type' => Doc\Schema::TYPE_ARRAY,
-                        'items' => [
-                            'type' => Doc\Schema::TYPE_OBJECT,
-                            'x-full-schema' => 'AssetDefinitionCustomField',
-                            'x-join' => [
-                                'table' => CustomFieldDefinition::getTable(),
-                                'fkey' => 'id',
-                                'field' => AssetDefinition::getForeignKeyField(),
-                                'primary-property' => 'id',
-                            ],
-                            'properties' => [
-                                'id' => [
-                                    'type' => Doc\Schema::TYPE_INTEGER,
-                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                    'readOnly' => true,
-                                ],
+                    'custom_fields' => self::getChildrenTypeSchema(
+                        parent_class: AssetDefinition::class,
+                        class: CustomFieldDefinition::class,
+                        name_field: 'label',
+                        full_schema: 'AssetDefinitionCustomField',
+                        params: [
+                            'additional_properties' => [
                                 'system_name' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
-                                'label' => ['type' => Doc\Schema::TYPE_STRING, 'maxLength' => 255],
                             ],
-                        ],
-                    ],
+                        ]
+                    ),
                     'date_creation' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                     'date_mod' => ['type' => Doc\Schema::TYPE_STRING, 'format' => Doc\Schema::FORMAT_STRING_DATE_TIME],
                 ],

--- a/src/Glpi/Api/HL/Controller/ToolController.php
+++ b/src/Glpi/Api/HL/Controller/ToolController.php
@@ -192,32 +192,24 @@ final class ToolController extends AbstractController
                         'format' => Doc\Schema::FORMAT_INTEGER_INT64,
                         'readOnly' => true,
                     ],
-                    'reservable_item' => [
-                        'type' => Doc\Schema::TYPE_OBJECT,
-                        'x-field' => 'reservationitems_id',
-                        'x-itemtype' => ReservationItem::class,
-                        'x-join' => [
-                            'table' => ReservationItem::getTable(),
-                            'fkey' => 'reservationitems_id',
-                            'field' => 'id',
-                        ],
-                        'properties' => [
-                            'id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'readOnly' => true,
-                            ],
-                            'itemtype' => [
-                                'type' => Doc\Schema::TYPE_STRING,
-                                'description' => 'The itemtype of the reservable item',
-                            ],
-                            'items_id' => [
-                                'type' => Doc\Schema::TYPE_INTEGER,
-                                'format' => Doc\Schema::FORMAT_INTEGER_INT64,
-                                'description' => 'The ID of the reservable item',
+                    'reservable_item' => self::getDropdownTypeSchema(
+                        class: ReservationItem::class,
+                        name_field: null,
+                        full_schema: 'ReservableItem',
+                        params: [
+                            'additional_properties' => [
+                                'itemtype' => [
+                                    'type' => Doc\Schema::TYPE_STRING,
+                                    'description' => 'The itemtype of the reservable item',
+                                ],
+                                'items_id' => [
+                                    'type' => Doc\Schema::TYPE_INTEGER,
+                                    'format' => Doc\Schema::FORMAT_INTEGER_INT64,
+                                    'description' => 'The ID of the reservable item',
+                                ],
                             ],
                         ],
-                    ],
+                    ),
                     'comment' => ['type' => Doc\Schema::TYPE_STRING],
                     'user' => self::getDropdownTypeSchema(class: User::class, full_schema: 'User'),
                     'group' => [

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -38,6 +38,7 @@ use CommonDBTM;
 use DBConnection;
 use Glpi\Api\HL\APIException;
 use Glpi\Api\HL\OpenAPIGenerator;
+use Glpi\Api\HL\ResourceAccessor;
 use Glpi\Api\HL\RightConditionNotMetException;
 use Glpi\Api\HL\RSQL\RSQLException;
 use Glpi\Api\HL\Search;
@@ -334,6 +335,7 @@ class DefaultResolvers
             'WHERE' => [],
         ];
 
+        $schema = ResourceAccessor::applyFieldReadRestrictions($schema, true);
         $search = new Search($schema, $request_params);
 
         if (!in_array('id', $field_selection, true)) {

--- a/src/Glpi/Api/HL/ResourceAccessor.php
+++ b/src/Glpi/Api/HL/ResourceAccessor.php
@@ -252,6 +252,27 @@ final class ResourceAccessor
     }
 
     /**
+     * Filter the schema properties based on the read restrictions.
+     * @param array<string, mixed> $schema The schema
+     * @param bool $is_graphql_mode Whether the schema is being used in GraphQL mode. If false, the x-graphql-only properties are filtered out.
+     * @return array<string, mixed> The filtered schema
+     */
+    public static function applyFieldReadRestrictions(array $schema, bool $is_graphql_mode = false): array
+    {
+        $filtered_schema = $schema;
+
+        if (!$is_graphql_mode) {
+            foreach ($filtered_schema['properties'] as $key => $prop) {
+                if ($prop['x-graphql-only'] ?? false) {
+                    unset($filtered_schema['properties'][$key]);
+                }
+            }
+        }
+
+        return $filtered_schema;
+    }
+
+    /**
      * Update an item of the given schema using the given request parameters.
      * @param array $schema The schema
      * @param array $request_attrs The request attributes
@@ -263,6 +284,7 @@ final class ResourceAccessor
      */
     public static function updateBySchema(array $schema, array $request_attrs, array $request_params, string $field = 'id'): Response
     {
+        $schema = self::applyFieldReadRestrictions($schema);
         $items_id = $field === 'id' ? $request_attrs['id'] : self::getIDForOtherUniqueFieldBySchema($schema, $field, $request_attrs[$field]);
         // Ignore entity updates. This needs to be done through the Transfer process
         // TODO This should probably be handled in a more generic way (support other fields that can be used during creation but not updates)
@@ -307,6 +329,7 @@ final class ResourceAccessor
      */
     public static function createBySchema(array $schema, array $request_params, array $get_route, array $extra_get_route_params = []): Response
     {
+        $schema = self::applyFieldReadRestrictions($schema);
         if (!isset($request_params['entity']) && isset($_SESSION['glpiactive_entity'])) {
             $request_params['entity'] = $_SESSION['glpiactive_entity'];
         }
@@ -348,6 +371,7 @@ final class ResourceAccessor
      */
     public static function searchBySchema(array $schema, array $request_params): Response
     {
+        $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property
         if (($itemtype !== null) && !$itemtype::canView()) {
@@ -406,6 +430,7 @@ final class ResourceAccessor
      */
     public static function getOneBySchema(array $schema, array $request_attrs, array $request_params, string $field = 'id'): Response
     {
+        $schema = self::applyFieldReadRestrictions($schema);
         $itemtype = self::getItemtypeFromSchema($schema);
         // No item-level checks done here. They are handled when generating the SQL using the x-rights-condtions schema property
         if (($itemtype !== null) && !$itemtype::canView()) {

--- a/tests/fixtures/hlapi/snapshots/2.0.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.0.0/components.json
@@ -1174,7 +1174,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Cartridge",
+                        "x-itemtype": "Cartridge",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -1205,7 +1205,8 @@
                                 "type": "string",
                                 "format": "date-time"
                             }
-                        }
+                        },
+                        "x-full-schema": "Cartridge"
                     }
                 }
             }
@@ -2666,7 +2667,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Consumable",
+                        "x-itemtype": "Consumable",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -2696,7 +2697,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "Consumable"
                     }
                 }
             }
@@ -5688,18 +5690,18 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Entity",
-                    "x-full-schema": "Entity",
                     "properties": {
                         "id": {
                             "type": "integer",
                             "format": "int64",
-                            "description": "ID"
+                            "readOnly": true
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Entity"
                 },
                 "level": {
                     "type": "integer",
@@ -7117,18 +7119,17 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Group",
-                    "x-full-schema": "Group",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "description": "ID"
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Group"
                 },
                 "level": {
                     "type": "integer",
@@ -11422,7 +11423,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTask",
+                        "x-itemtype": "ProjectTask",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -11430,15 +11431,18 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             },
                             "comment": {
                                 "type": "string"
                             },
                             "content": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "html"
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTask"
                     }
                 }
             }
@@ -11734,7 +11738,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RackItem",
+                        "x-itemtype": "Item_Rack",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -11748,7 +11752,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "RackItem"
                     }
                 },
                 "date_creation": {
@@ -12178,10 +12183,9 @@
                 },
                 "criteria": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleCriteria",
+                        "x-itemtype": "RuleCriteria",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -12200,15 +12204,15 @@
                                 "type": "string",
                                 "description": "The value/pattern to match against. If the condition relates to regular expressions, this value needs to be a valid regular expression including the delimiters."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleCriteria"
                     }
                 },
                 "actions": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleAction",
+                        "x-itemtype": "RuleAction",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -12227,7 +12231,8 @@
                                 "type": "string",
                                 "description": "The value to set. If the field relates to regular expressions, this can include a # followed by 0 through 9 to indicate a captured value from the criteria regular expression."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleAction"
                     }
                 },
                 "date_creation": {
@@ -14926,16 +14931,16 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "EmailAddress",
+                        "x-itemtype": "UserEmail",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
-                                "description": "ID"
+                                "readOnly": true
                             },
                             "email": {
                                 "type": "string",
-                                "description": "Email address"
+                                "readOnly": true
                             },
                             "is_default": {
                                 "type": "boolean",
@@ -14945,7 +14950,8 @@
                                 "type": "boolean",
                                 "description": "Is dynamic"
                             }
-                        }
+                        },
+                        "x-full-schema": "EmailAddress"
                     }
                 },
                 "comment": {

--- a/tests/fixtures/hlapi/snapshots/2.1.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.1.0/components.json
@@ -1174,7 +1174,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Cartridge",
+                        "x-itemtype": "Cartridge",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -1205,7 +1205,8 @@
                                 "type": "string",
                                 "format": "date-time"
                             }
-                        }
+                        },
+                        "x-full-schema": "Cartridge"
                     }
                 }
             }
@@ -2831,7 +2832,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Consumable",
+                        "x-itemtype": "Consumable",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -2861,7 +2862,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "Consumable"
                     }
                 }
             }
@@ -5864,18 +5866,18 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Entity",
-                    "x-full-schema": "Entity",
                     "properties": {
                         "id": {
                             "type": "integer",
                             "format": "int64",
-                            "description": "ID"
+                            "readOnly": true
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Entity"
                 },
                 "level": {
                     "type": "integer",
@@ -7316,18 +7318,17 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Group",
-                    "x-full-schema": "Group",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "description": "ID"
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Group"
                 },
                 "level": {
                     "type": "integer",
@@ -11924,7 +11925,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTask",
+                        "x-itemtype": "ProjectTask",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -11932,15 +11933,18 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             },
                             "comment": {
                                 "type": "string"
                             },
                             "content": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "html"
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTask"
                     }
                 }
             }
@@ -12295,7 +12299,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RackItem",
+                        "x-itemtype": "Item_Rack",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -12309,7 +12313,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "RackItem"
                     }
                 },
                 "date_creation": {
@@ -12810,8 +12815,7 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "itemtype": {
                             "type": "string",
@@ -12822,7 +12826,8 @@
                             "format": "int64",
                             "description": "The ID of the reservable item"
                         }
-                    }
+                    },
+                    "x-full-schema": "ReservableItem"
                 },
                 "comment": {
                     "type": "string"
@@ -12921,10 +12926,9 @@
                 },
                 "criteria": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleCriteria",
+                        "x-itemtype": "RuleCriteria",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -12943,15 +12947,15 @@
                                 "type": "string",
                                 "description": "The value/pattern to match against. If the condition relates to regular expressions, this value needs to be a valid regular expression including the delimiters."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleCriteria"
                     }
                 },
                 "actions": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleAction",
+                        "x-itemtype": "RuleAction",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -12970,7 +12974,8 @@
                                 "type": "string",
                                 "description": "The value to set. If the field relates to regular expressions, this can include a # followed by 0 through 9 to indicate a captured value from the criteria regular expression."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleAction"
                     }
                 },
                 "date_creation": {
@@ -14623,15 +14628,14 @@
                 },
                 "approval_followup": {
                     "type": "object",
-                    "x-full-schema": "Followup",
                     "x-itemtype": "ITILFollowup",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "Followup"
                 },
                 "date_creation": {
                     "type": "string",
@@ -16249,16 +16253,16 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "EmailAddress",
+                        "x-itemtype": "UserEmail",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
-                                "description": "ID"
+                                "readOnly": true
                             },
                             "email": {
                                 "type": "string",
-                                "description": "Email address"
+                                "readOnly": true
                             },
                             "is_default": {
                                 "type": "boolean",
@@ -16268,7 +16272,8 @@
                                 "type": "boolean",
                                 "description": "Is dynamic"
                             }
-                        }
+                        },
+                        "x-full-schema": "EmailAddress"
                     }
                 },
                 "comment": {

--- a/tests/fixtures/hlapi/snapshots/2.2.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.2.0/components.json
@@ -1380,7 +1380,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Cartridge",
+                        "x-itemtype": "Cartridge",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -1411,7 +1411,8 @@
                                 "type": "string",
                                 "format": "date-time"
                             }
-                        }
+                        },
+                        "x-full-schema": "Cartridge"
                     }
                 }
             }
@@ -3332,7 +3333,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Consumable",
+                        "x-itemtype": "Consumable",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -3362,7 +3363,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "Consumable"
                     }
                 }
             }
@@ -6165,7 +6167,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Database",
+                        "x-itemtype": "Database",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -6173,9 +6175,11 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "Database"
                     }
                 }
             }
@@ -7040,18 +7044,18 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Entity",
-                    "x-full-schema": "Entity",
                     "properties": {
                         "id": {
                             "type": "integer",
                             "format": "int64",
-                            "description": "ID"
+                            "readOnly": true
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Entity"
                 },
                 "level": {
                     "type": "integer",
@@ -8605,18 +8609,17 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Group",
-                    "x-full-schema": "Group",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "description": "ID"
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Group"
                 },
                 "level": {
                     "type": "integer",
@@ -9600,21 +9603,23 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "KBArticleTranslation",
+                        "x-itemtype": "KnowbaseItemTranslation",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             },
+                            "name": {
+                                "type": "string",
+                                "readOnly": true
+                            },
                             "language": {
                                 "type": "string",
                                 "description": "Language code (POSIX compliant format e.g. en_US or fr_FR)"
-                            },
-                            "name": {
-                                "type": "string"
                             }
-                        }
+                        },
+                        "x-full-schema": "KBArticleTranslation"
                     }
                 }
             }
@@ -9666,15 +9671,14 @@
                 },
                 "parent": {
                     "type": "object",
-                    "x-full-schema": "KBArticleComment",
                     "x-itemtype": "KnowbaseItem_Comment",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "KBArticleComment"
                 },
                 "date_creation": {
                     "type": "string",
@@ -15141,7 +15145,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTask",
+                        "x-itemtype": "ProjectTask",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -15149,15 +15153,18 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             },
                             "comment": {
                                 "type": "string"
                             },
                             "content": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "html"
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTask"
                     }
                 }
             }
@@ -15512,7 +15519,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RackItem",
+                        "x-itemtype": "Item_Rack",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -15526,7 +15533,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "RackItem"
                     }
                 },
                 "date_creation": {
@@ -16027,8 +16035,7 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "itemtype": {
                             "type": "string",
@@ -16039,7 +16046,8 @@
                             "format": "int64",
                             "description": "The ID of the reservable item"
                         }
-                    }
+                    },
+                    "x-full-schema": "ReservableItem"
                 },
                 "comment": {
                     "type": "string"
@@ -16138,10 +16146,9 @@
                 },
                 "criteria": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleCriteria",
+                        "x-itemtype": "RuleCriteria",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -16160,15 +16167,15 @@
                                 "type": "string",
                                 "description": "The value/pattern to match against. If the condition relates to regular expressions, this value needs to be a valid regular expression including the delimiters."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleCriteria"
                     }
                 },
                 "actions": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleAction",
+                        "x-itemtype": "RuleAction",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -16187,7 +16194,8 @@
                                 "type": "string",
                                 "description": "The value to set. If the field relates to regular expressions, this can include a # followed by 0 through 9 to indicate a captured value from the criteria regular expression."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleAction"
                     }
                 },
                 "date_creation": {
@@ -19453,15 +19461,14 @@
                 },
                 "approval_followup": {
                     "type": "object",
-                    "x-full-schema": "Followup",
                     "x-itemtype": "ITILFollowup",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "Followup"
                 },
                 "date_creation": {
                     "type": "string",
@@ -21536,16 +21543,16 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "EmailAddress",
+                        "x-itemtype": "UserEmail",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
-                                "description": "ID"
+                                "readOnly": true
                             },
                             "email": {
                                 "type": "string",
-                                "description": "Email address"
+                                "readOnly": true
                             },
                             "is_default": {
                                 "type": "boolean",
@@ -21555,7 +21562,8 @@
                                 "type": "boolean",
                                 "description": "Is dynamic"
                             }
-                        }
+                        },
+                        "x-full-schema": "EmailAddress"
                     }
                 },
                 "comment": {

--- a/tests/fixtures/hlapi/snapshots/2.3.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/components.json
@@ -2209,7 +2209,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Cartridge",
+                        "x-itemtype": "Cartridge",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -2240,7 +2240,8 @@
                                 "type": "string",
                                 "format": "date-time"
                             }
-                        }
+                        },
+                        "x-full-schema": "Cartridge"
                     }
                 }
             }
@@ -3038,14 +3039,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ChangeCost",
+                        "x-itemtype": "ChangeCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ChangeCost"
                     }
                 }
             },
@@ -4584,7 +4586,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Consumable",
+                        "x-itemtype": "Consumable",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -4614,7 +4616,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "Consumable"
                     }
                 }
             }
@@ -4806,14 +4809,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ContractCost",
+                        "x-itemtype": "ContractCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ContractCost"
                     }
                 },
                 "number": {
@@ -7237,26 +7241,30 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "DashboardFilter",
+                        "x-itemtype": "Glpi\\Dashboard\\Filter",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "DashboardFilter"
                     }
                 },
                 "items": {
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "DashboardItem",
+                        "x-itemtype": "Glpi\\Dashboard\\Item",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "DashboardItem"
                     }
                 }
             }
@@ -7754,7 +7762,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Database",
+                        "x-itemtype": "Database",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -7762,9 +7770,11 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "Database"
                     }
                 }
             }
@@ -9232,18 +9242,18 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Entity",
-                    "x-full-schema": "Entity",
                     "properties": {
                         "id": {
                             "type": "integer",
                             "format": "int64",
-                            "description": "ID"
+                            "readOnly": true
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Entity"
                 },
                 "level": {
                     "type": "integer",
@@ -11085,18 +11095,17 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Group",
-                    "x-full-schema": "Group",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "description": "ID"
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Group"
                 },
                 "level": {
                     "type": "integer",
@@ -12355,21 +12364,23 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "KBArticleTranslation",
+                        "x-itemtype": "KnowbaseItemTranslation",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             },
+                            "name": {
+                                "type": "string",
+                                "readOnly": true
+                            },
                             "language": {
                                 "type": "string",
                                 "description": "Language code (POSIX compliant format e.g. en_US or fr_FR)"
-                            },
-                            "name": {
-                                "type": "string"
                             }
-                        }
+                        },
+                        "x-full-schema": "KBArticleTranslation"
                     }
                 }
             }
@@ -12421,15 +12432,14 @@
                 },
                 "parent": {
                     "type": "object",
-                    "x-full-schema": "KBArticleComment",
                     "x-itemtype": "KnowbaseItem_Comment",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "KBArticleComment"
                 },
                 "date_creation": {
                     "type": "string",
@@ -15762,13 +15772,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "NotificationRecipient",
+                        "x-itemtype": "NotificationTarget",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "NotificationRecipient"
                     }
                 }
             }
@@ -15854,13 +15866,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "NotificationTemplateTranslation",
+                        "x-itemtype": "NotificationTemplateTranslation",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "NotificationTemplateTranslation"
                     }
                 }
             }
@@ -19127,14 +19141,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProblemCost",
+                        "x-itemtype": "ProblemCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProblemCost"
                     }
                 }
             },
@@ -19852,7 +19867,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTask",
+                        "x-itemtype": "ProjectTask",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -19860,29 +19875,33 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             },
                             "comment": {
                                 "type": "string"
                             },
                             "content": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "html"
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTask"
                     }
                 },
                 "costs": {
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectCost",
+                        "x-itemtype": "ProjectCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectCost"
                     }
                 },
                 "status": {
@@ -20057,7 +20076,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTeamMember",
+                        "x-itemtype": "ProjectTeam",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -20079,7 +20098,8 @@
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTeamMember"
                     }
                 }
             }
@@ -20368,7 +20388,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTaskTeamMember",
+                        "x-itemtype": "ProjectTaskTeam",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -20390,7 +20410,8 @@
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTaskTeamMember"
                     }
                 }
             }
@@ -21082,7 +21103,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RackItem",
+                        "x-itemtype": "Item_Rack",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -21096,7 +21117,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "RackItem"
                     }
                 },
                 "date_creation": {
@@ -21636,8 +21658,7 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "itemtype": {
                             "type": "string",
@@ -21648,7 +21669,8 @@
                             "format": "int64",
                             "description": "The ID of the reservable item"
                         }
-                    }
+                    },
+                    "x-full-schema": "ReservableItem"
                 },
                 "comment": {
                     "type": "string"
@@ -21747,10 +21769,9 @@
                 },
                 "criteria": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleCriteria",
+                        "x-itemtype": "RuleCriteria",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -21769,15 +21790,15 @@
                                 "type": "string",
                                 "description": "The value/pattern to match against. If the condition relates to regular expressions, this value needs to be a valid regular expression including the delimiters."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleCriteria"
                     }
                 },
                 "actions": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleAction",
+                        "x-itemtype": "RuleAction",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -21796,7 +21817,8 @@
                                 "type": "string",
                                 "description": "The value to set. If the field relates to regular expressions, this can include a # followed by 0 through 9 to indicate a captured value from the criteria regular expression."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleAction"
                     }
                 },
                 "date_creation": {
@@ -25180,15 +25202,14 @@
                 },
                 "approval_followup": {
                     "type": "object",
-                    "x-full-schema": "Followup",
                     "x-itemtype": "ITILFollowup",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "Followup"
                 },
                 "date_creation": {
                     "type": "string",
@@ -26644,14 +26665,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "TicketCost",
+                        "x-itemtype": "TicketCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "TicketCost"
                     }
                 }
             },
@@ -27489,16 +27511,16 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "EmailAddress",
+                        "x-itemtype": "UserEmail",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
-                                "description": "ID"
+                                "readOnly": true
                             },
                             "email": {
                                 "type": "string",
-                                "description": "Email address"
+                                "readOnly": true
                             },
                             "is_default": {
                                 "type": "boolean",
@@ -27508,7 +27530,8 @@
                                 "type": "boolean",
                                 "description": "Is dynamic"
                             }
-                        }
+                        },
+                        "x-full-schema": "EmailAddress"
                     }
                 },
                 "comment": {

--- a/tests/fixtures/hlapi/snapshots/2.4.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/components.json
@@ -801,22 +801,23 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "AssetDefinitionCustomField",
+                        "x-itemtype": "Glpi\\Asset\\CustomFieldDefinition",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             },
+                            "label": {
+                                "type": "string",
+                                "readOnly": true
+                            },
                             "system_name": {
                                 "type": "string",
                                 "maxLength": 255
-                            },
-                            "label": {
-                                "type": "string",
-                                "maxLength": 255
                             }
-                        }
+                        },
+                        "x-full-schema": "AssetDefinitionCustomField"
                     }
                 },
                 "date_creation": {
@@ -2351,7 +2352,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Cartridge",
+                        "x-itemtype": "Cartridge",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -2382,7 +2383,8 @@
                                 "type": "string",
                                 "format": "date-time"
                             }
-                        }
+                        },
+                        "x-full-schema": "Cartridge"
                     }
                 }
             }
@@ -3180,14 +3182,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ChangeCost",
+                        "x-itemtype": "ChangeCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ChangeCost"
                     }
                 }
             },
@@ -4726,7 +4729,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Consumable",
+                        "x-itemtype": "Consumable",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -4756,7 +4759,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "Consumable"
                     }
                 }
             }
@@ -4948,14 +4952,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ContractCost",
+                        "x-itemtype": "ContractCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ContractCost"
                     }
                 },
                 "number": {
@@ -7379,26 +7384,30 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "DashboardFilter",
+                        "x-itemtype": "Glpi\\Dashboard\\Filter",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "DashboardFilter"
                     }
                 },
                 "items": {
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "DashboardItem",
+                        "x-itemtype": "Glpi\\Dashboard\\Item",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "DashboardItem"
                     }
                 }
             }
@@ -7896,7 +7905,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "Database",
+                        "x-itemtype": "Database",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -7904,9 +7913,11 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "Database"
                     }
                 }
             }
@@ -9389,18 +9400,18 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Entity",
-                    "x-full-schema": "Entity",
                     "properties": {
                         "id": {
                             "type": "integer",
                             "format": "int64",
-                            "description": "ID"
+                            "readOnly": true
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Entity"
                 },
                 "level": {
                     "type": "integer",
@@ -11361,18 +11372,17 @@
                 "parent": {
                     "type": "object",
                     "x-itemtype": "Group",
-                    "x-full-schema": "Group",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "description": "ID"
+                            "format": "int64"
                         },
                         "name": {
                             "type": "string",
-                            "description": "Name"
+                            "readOnly": true
                         }
-                    }
+                    },
+                    "x-full-schema": "Group"
                 },
                 "level": {
                     "type": "integer",
@@ -12631,21 +12641,23 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "KBArticleTranslation",
+                        "x-itemtype": "KnowbaseItemTranslation",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             },
+                            "name": {
+                                "type": "string",
+                                "readOnly": true
+                            },
                             "language": {
                                 "type": "string",
                                 "description": "Language code (POSIX compliant format e.g. en_US or fr_FR)"
-                            },
-                            "name": {
-                                "type": "string"
                             }
-                        }
+                        },
+                        "x-full-schema": "KBArticleTranslation"
                     }
                 }
             }
@@ -12697,15 +12709,14 @@
                 },
                 "parent": {
                     "type": "object",
-                    "x-full-schema": "KBArticleComment",
                     "x-itemtype": "KnowbaseItem_Comment",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "KBArticleComment"
                 },
                 "date_creation": {
                     "type": "string",
@@ -16071,13 +16082,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "NotificationRecipient",
+                        "x-itemtype": "NotificationTarget",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "NotificationRecipient"
                     }
                 }
             }
@@ -16163,13 +16176,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "NotificationTemplateTranslation",
+                        "x-itemtype": "NotificationTemplateTranslation",
                         "properties": {
                             "id": {
                                 "type": "integer",
+                                "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "NotificationTemplateTranslation"
                     }
                 }
             }
@@ -19436,14 +19451,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProblemCost",
+                        "x-itemtype": "ProblemCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProblemCost"
                     }
                 }
             },
@@ -20161,7 +20177,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTask",
+                        "x-itemtype": "ProjectTask",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -20169,29 +20185,33 @@
                                 "readOnly": true
                             },
                             "name": {
-                                "type": "string"
+                                "type": "string",
+                                "readOnly": true
                             },
                             "comment": {
                                 "type": "string"
                             },
                             "content": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "html"
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTask"
                     }
                 },
                 "costs": {
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectCost",
+                        "x-itemtype": "ProjectCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectCost"
                     }
                 },
                 "status": {
@@ -20366,7 +20386,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTeamMember",
+                        "x-itemtype": "ProjectTeam",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -20388,7 +20408,8 @@
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTeamMember"
                     }
                 }
             }
@@ -20677,7 +20698,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "ProjectTaskTeamMember",
+                        "x-itemtype": "ProjectTaskTeam",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -20699,7 +20720,8 @@
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "ProjectTaskTeamMember"
                     }
                 }
             }
@@ -21391,7 +21413,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RackItem",
+                        "x-itemtype": "Item_Rack",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -21405,7 +21427,8 @@
                                 "type": "integer",
                                 "format": "int64"
                             }
-                        }
+                        },
+                        "x-full-schema": "RackItem"
                     }
                 },
                 "date_creation": {
@@ -22005,8 +22028,7 @@
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         },
                         "itemtype": {
                             "type": "string",
@@ -22017,7 +22039,8 @@
                             "format": "int64",
                             "description": "The ID of the reservable item"
                         }
-                    }
+                    },
+                    "x-full-schema": "ReservableItem"
                 },
                 "comment": {
                     "type": "string"
@@ -22116,10 +22139,9 @@
                 },
                 "criteria": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleCriteria",
+                        "x-itemtype": "RuleCriteria",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -22138,15 +22160,15 @@
                                 "type": "string",
                                 "description": "The value/pattern to match against. If the condition relates to regular expressions, this value needs to be a valid regular expression including the delimiters."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleCriteria"
                     }
                 },
                 "actions": {
                     "type": "array",
-                    "readOnly": true,
                     "items": {
                         "type": "object",
-                        "x-full-schema": "RuleAction",
+                        "x-itemtype": "RuleAction",
                         "properties": {
                             "id": {
                                 "type": "integer",
@@ -22165,7 +22187,8 @@
                                 "type": "string",
                                 "description": "The value to set. If the field relates to regular expressions, this can include a # followed by 0 through 9 to indicate a captured value from the criteria regular expression."
                             }
-                        }
+                        },
+                        "x-full-schema": "RuleAction"
                     }
                 },
                 "date_creation": {
@@ -25592,15 +25615,14 @@
                 },
                 "approval_followup": {
                     "type": "object",
-                    "x-full-schema": "Followup",
                     "x-itemtype": "ITILFollowup",
                     "properties": {
                         "id": {
                             "type": "integer",
-                            "format": "int64",
-                            "readOnly": true
+                            "format": "int64"
                         }
-                    }
+                    },
+                    "x-full-schema": "Followup"
                 },
                 "date_creation": {
                     "type": "string",
@@ -27056,14 +27078,15 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "TicketCost",
+                        "x-itemtype": "TicketCost",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
                                 "readOnly": true
                             }
-                        }
+                        },
+                        "x-full-schema": "TicketCost"
                     }
                 }
             },
@@ -27901,16 +27924,16 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "x-full-schema": "EmailAddress",
+                        "x-itemtype": "UserEmail",
                         "properties": {
                             "id": {
                                 "type": "integer",
                                 "format": "int64",
-                                "description": "ID"
+                                "readOnly": true
                             },
                             "email": {
                                 "type": "string",
-                                "description": "Email address"
+                                "readOnly": true
                             },
                             "is_default": {
                                 "type": "boolean",
@@ -27920,7 +27943,8 @@
                                 "type": "boolean",
                                 "description": "Is dynamic"
                             }
-                        }
+                        },
+                        "x-full-schema": "EmailAddress"
                     }
                 },
                 "comment": {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The HLAPI is currently at 358 schemas, with many having one or more links with other schemas. By relying on utility functions which use the relationships already known to GLPI from CommonDBConnexity classes (assuming GLPI itself uses the correct parent classes for things, which it doesn't for some things) to add joined properties it helps enforce consistency and reduce complexity.

Adds concept of "GraphQL-only" properties which are essentially just restricted to joins to help link the various individual schemas in the graph without polluting the REST API where such things would have their own endpoints.