### PR TITLE
Persist KB tree fold state

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
@@ -40,6 +40,6 @@
 $migration->addField(
     'glpi_users',
     'folded_knowbaseitems',
-    'text',
+    'json',
     ['after' => 'itil_layout']
 );

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
@@ -40,6 +40,6 @@
 $migration->addField(
     'glpi_users',
     'folded_knowbaseitems',
-    'json',
+    'json DEFAULT NULL',
     ['after' => 'itil_layout']
 );

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitemcategory_folds.php
@@ -32,39 +32,14 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Knowbase\Aside;
+/**
+ * @var Migration $migration
+ */
 
-final class Tree implements Node
-{
-    /** @var Article[] */
-    protected array $articles = [];
-
-    /** @var Category[] */
-    protected array $categories = [];
-
-    public function __construct(
-        public readonly bool $uncategorized_collapsed = false,
-    ) {}
-
-    public function addArticle(Article $article): void
-    {
-        $this->articles[] = $article;
-    }
-
-    public function addCategory(Category $category): void
-    {
-        $this->categories[] = $category;
-    }
-
-    /** @return Article[] */
-    public function getArticles(): array
-    {
-        return $this->articles;
-    }
-
-    /** @return Category[] */
-    public function getCategories(): array
-    {
-        return $this->categories;
-    }
-}
+// Per-user list of KB aside categories the user has collapsed.
+$migration->addField(
+    'glpi_users',
+    'folded_knowbaseitems',
+    'text',
+    ['after' => 'itil_layout']
+);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8112,7 +8112,7 @@ CREATE TABLE `glpi_users` (
   `savedsearches_pinned` text,
   `timeline_order` char(20) DEFAULT NULL,
   `itil_layout` text,
-  `folded_knowbaseitems` text,
+  `folded_knowbaseitems` json,
   `richtext_layout` char(20) DEFAULT NULL,
   `set_default_requester` tinyint DEFAULT NULL,
   `lock_autolock_mode` tinyint DEFAULT NULL,

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8112,6 +8112,7 @@ CREATE TABLE `glpi_users` (
   `savedsearches_pinned` text,
   `timeline_order` char(20) DEFAULT NULL,
   `itil_layout` text,
+  `folded_knowbaseitems` text,
   `richtext_layout` char(20) DEFAULT NULL,
   `set_default_requester` tinyint DEFAULT NULL,
   `lock_autolock_mode` tinyint DEFAULT NULL,

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -99,13 +99,16 @@ export class GlpiKnowbaseAsideController
 
             // Toggle collasped state
             const is_collapsed = node.hasAttribute('data-glpi-kb-aside-category-collapsed');
-            if (is_collapsed) {
-                node.removeAttribute('data-glpi-kb-aside-category-collapsed');
-                toggle.setAttribute('aria-expanded', 'true');
-            } else {
+            const new_collapsed_state = !is_collapsed;
+            if (new_collapsed_state) {
                 node.setAttribute('data-glpi-kb-aside-category-collapsed', '');
                 toggle.setAttribute('aria-expanded', 'false');
+            } else {
+                node.removeAttribute('data-glpi-kb-aside-category-collapsed');
+                toggle.setAttribute('aria-expanded', 'true');
             }
+
+            this.#persistCategoryFold(node.dataset.glpiKbAsideCategory, new_collapsed_state);
         });
     }
 
@@ -219,6 +222,21 @@ export class GlpiKnowbaseAsideController
         }
 
         window.location.href = data.url;
+    }
+
+    /**
+     * @param {string|undefined} id
+     * @param {boolean} collapsed
+     */
+    #persistCategoryFold(id, collapsed)
+    {
+        if (!id) {
+            return;
+        }
+
+        // Persist to server. We don't care about the response as the UI was
+        // already updated.
+        post(`Knowbase/Aside/Category/${encodeURIComponent(id)}/Fold`, { collapsed });
     }
 
     #initSearch()

--- a/src/Glpi/Controller/Knowbase/AsideCategoryFoldController.php
+++ b/src/Glpi/Controller/Knowbase/AsideCategoryFoldController.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use KnowbaseItemCategory;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Persists whether a knowledge base aside category is collapsed (folded) for the
+ * current user.
+ */
+final class AsideCategoryFoldController extends AbstractController
+{
+    #[Route(
+        "/Knowbase/Aside/Category/{id}/Fold",
+        name: "knowbase_aside_category_fold",
+        requirements: [
+            'id' => '\d+',
+        ],
+        methods: 'POST',
+    )]
+    #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
+    public function __invoke(int $id, Request $request): Response
+    {
+        $collapsed = $request->getPayload()->get('collapsed');
+        if ($collapsed === null) {
+            throw new BadRequestHttpException();
+        }
+
+        if (!Session::isAuthenticated()) {
+            // Nothing to be done as the user don't exist in the database, we
+            // can't persist any data.
+            return new Response();
+        }
+
+        KnowbaseItemCategory::setCategoryFoldedForCurrentUser(
+            category_id: $id,
+            folded: (bool) $collapsed
+        );
+
+        return new Response(); // OK
+    }
+}

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -39,11 +39,18 @@ use KnowbaseItemCategory;
 
 final class Builder
 {
+    /** @var int[] */
+    private array $folded_category_ids = [];
+
     public function __construct(private readonly int $current_id = 0) {}
 
     public function buildTree(): Tree
     {
-        $tree = new Tree();
+        $this->folded_category_ids = KnowbaseItemCategory::getFoldedCategoryIdsForCurrentUser();
+
+        $tree = new Tree(
+            uncategorized_collapsed: in_array(0, $this->folded_category_ids, true),
+        );
         $this->populateNode($tree, 0);
         return $tree;
     }
@@ -76,6 +83,7 @@ final class Builder
                 id: (int) $cat_data['id'],
                 title: $cat_data['name'] ?? '',
                 illustration: $cat_data['illustration'] ?? '',
+                collapsed: in_array((int) $cat_data['id'], $this->folded_category_ids, true),
             );
             $this->populateNode($category, (int) $cat_data['id']);
             $node->addCategory($category);

--- a/src/Glpi/Knowbase/Aside/Category.php
+++ b/src/Glpi/Knowbase/Aside/Category.php
@@ -43,9 +43,10 @@ final class Category implements Node
     protected array $categories = [];
 
     public function __construct(
+        public readonly int $id,
         public readonly string $title,
         public readonly string $illustration,
-        public readonly int $id,
+        public readonly bool $collapsed = false,
     ) {}
 
     public function addArticle(Article $article): void

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2928,7 +2928,7 @@ TWIG, $twig_params);
         return TemplateRenderer::getInstance()->render(
             'pages/tools/kb/aside.html.twig',
             [
-                'tree'                => (new Builder($current_id))->buildTree(),
+                'tree'                => $tree,
                 'favorites'           => $favorites,
                 'current_is_favorite' => $current_is_favorite,
                 'has_other_favorites' => $has_other_favorites,

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -130,4 +130,51 @@ class KnowbaseItemCategory extends CommonTreeDropdown
             ]
         );
     }
+
+    /**
+     * Ids of the KB aside categories the current user has collapsed.
+     * @return int[]
+     */
+    public static function getFoldedCategoryIdsForCurrentUser(): array
+    {
+        $user_id = Session::getLoginUserID();
+        if ($user_id === false) {
+            return [];
+        }
+
+        $user = new User();
+        if (!$user->getFromDB($user_id)) {
+            return [];
+        }
+
+        $ids = importArrayFromDB($user->fields['folded_knowbaseitems'] ?? null);
+
+        return array_values(array_map('intval', is_array($ids) ? $ids : []));
+    }
+
+    /**
+     * Persist whether a category is collapsed for the current user.
+     */
+    public static function setCategoryFoldedForCurrentUser(
+        int $category_id,
+        bool $folded
+    ): void {
+        $user_id = Session::getLoginUserID();
+        if ($user_id === false) {
+            return;
+        }
+
+        $ids = array_values(array_filter(
+            self::getFoldedCategoryIdsForCurrentUser(),
+            static fn(int $id): bool => $id !== $category_id,
+        ));
+        if ($folded) {
+            $ids[] = $category_id;
+        }
+
+        (new User())->update([
+            'id'                   => $user_id,
+            'folded_knowbaseitems' => exportArrayToDB($ids),
+        ]);
+    }
 }

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -35,6 +35,9 @@
 
 use Glpi\UI\IllustrationManager;
 
+use function Safe\json_decode;
+use function Safe\json_encode;
+
 /// Class KnowbaseItemCategory
 class KnowbaseItemCategory extends CommonTreeDropdown
 {
@@ -147,9 +150,9 @@ class KnowbaseItemCategory extends CommonTreeDropdown
             return [];
         }
 
-        $ids = importArrayFromDB($user->fields['folded_knowbaseitems'] ?? null);
+        $ids = json_decode($user->fields['folded_knowbaseitems'] ?? '[]', true);
 
-        return array_values(array_map('intval', is_array($ids) ? $ids : []));
+        return array_values(is_array($ids) ? $ids : []);
     }
 
     /**
@@ -174,7 +177,7 @@ class KnowbaseItemCategory extends CommonTreeDropdown
 
         (new User())->update([
             'id'                   => $user_id,
-            'folded_knowbaseitems' => exportArrayToDB($ids),
+            'folded_knowbaseitems' => json_encode($ids),
         ]);
     }
 }

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -32,14 +32,20 @@
 
 {% macro render_category(category, can_create = false, show_actions = false) %}
     {% import _self as macros %}
-    <li class="node" data-glpi-kb-aside-category role="group" aria-label="{{ category.title }}">
+    <li
+        class="node"
+        data-glpi-kb-aside-category="{{ category.id }}"
+        {{ category.collapsed ? 'data-glpi-kb-aside-category-collapsed' : '' }}
+        role="group"
+        aria-label="{{ category.title }}"
+    >
         <div class="d-flex align-items-center mb-2" data-glpi-kb-aside-category-header>
             <button
                 type="button"
                 class="d-flex align-items-center p-0 flex-grow-1 text-start border-0 bg-transparent"
                 data-glpi-kb-aside-category-toggle
                 aria-label="{{ category.title }}"
-                aria-expanded="true"
+                aria-expanded="{{ category.collapsed ? 'false' : 'true' }}"
             >
                 <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
                 {% if category.illustration %}
@@ -165,6 +171,7 @@
                 id: 0,
                 title: __("Uncategorized"),
                 illustration: "",
+                collapsed: tree.uncategorized_collapsed,
                 articles: tree.articles,
                 categories: [],
             }, can_create, show_actions) }}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -417,6 +417,36 @@ export class KnowbaseItemPage extends GlpiPage
         await this.getAsideCategoryToggle(title).click();
     }
 
+    /**
+     * Toggle a category and wait for its fold state to be persisted server-side.
+     * Persistence is a fire-and-forget POST, so callers that reload right after
+     * toggling must wait for it, otherwise the reload can abort the in-flight
+     * request and the server renders stale state.
+     */
+    public async doToggleAsideCategoryAndWaitForPersist(title: string): Promise<void>
+    {
+        await Promise.all([
+            this.page.waitForResponse(
+                (response) =>
+                    /\/Knowbase\/Aside\/Category\/\d+\/Fold$/.test(response.url())
+                    && response.request().method() === 'POST'
+                    && response.ok()
+            ),
+            this.doToggleAsideCategory(title),
+        ]);
+    }
+
+    /**
+     * Wait until the aside controller has finished initializing. It signals
+     * readiness by removing the `pe-none` class from the search input once all
+     * listeners (search, category toggle, actions) are attached, so interacting
+     * before this can silently no-op.
+     */
+    public async waitForAsideReady(): Promise<void>
+    {
+        await expect(this.asideSearchInput).not.toHaveClass(/pe-none/);
+    }
+
     public get asideSearchInput(): Locator
     {
         return this.page.getByLabel('Search articles');

--- a/tests/e2e/specs/Knowbase/kb-aside-category-fold.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-category-fold.spec.ts
@@ -75,3 +75,47 @@ test('Can fold and unfold a category in the KB aside', async ({ page, profile, a
     await expect(category_toggle).toHaveAttribute('aria-expanded', 'true');
     await expect(article_link).toBeVisible();
 });
+
+test('Category fold state is remembered across reloads', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    // Arrange: create some articles and categories so we have something to fold.
+    const unique = randomUUID().slice(0, 8);
+    const category_name = `E2E Category ${unique}`;
+    const article_name = `E2E Article ${unique}`;
+
+    const category_id = await api.createItem('KnowbaseItemCategory', {
+        name: category_name,
+        entities_id: getWorkerEntityId(),
+    });
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: article_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _categories: [category_id],
+    });
+
+    await kb.goto(article_id);
+    await kb.waitForAsideReady();
+
+    const category_toggle = kb.getAsideCategoryToggle(category_name);
+    const article_link = kb.getAsideCategoryArticle(category_name, article_name);
+
+    // Fold the category, then reload: the folded state must be restored.
+    await kb.doToggleAsideCategoryAndWaitForPersist(category_name);
+    await expect(article_link).toBeHidden();
+
+    await page.reload();
+    await expect(category_toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(article_link).toBeHidden();
+
+    // Unfold and reload again: the expanded state must likewise be restored.
+    await kb.waitForAsideReady();
+    await kb.doToggleAsideCategoryAndWaitForPersist(category_name);
+    await expect(article_link).toBeVisible();
+
+    await page.reload();
+    await expect(category_toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(article_link).toBeVisible();
+});


### PR DESCRIPTION
Persist the KB tree fold state so it isn't lost when reloading the page.

CI error is unrelated.