### PR TITLE
FIX / ALTCHA widget staying visible when the submit button is hidden

### DIFF
--- a/js/modules/Forms/RendererController.js
+++ b/js/modules/Forms/RendererController.js
@@ -499,6 +499,15 @@ export class GlpiFormRendererController
             this.#applyVisibilityToItem(submit_button, results.form_visibility);
         }
 
+        // Altcha widget must follow the same visibility as the submit button,
+        // as it has no purpose when the form cannot be submitted.
+        const altcha = container.querySelector(
+            '[data-glpi-form-renderer-altcha]'
+        );
+        if (altcha !== null) {
+            this.#applyVisibilityToItem(altcha, results.form_visibility);
+        }
+
         // Apply sections visibility
         for (const [id, must_be_visible] of Object.entries(
             results.sections_visibility

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -248,6 +248,7 @@
 
                                         {% set visibility_dropdown_field = include('pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig', {
                                                 'item'      : item,
+                                                'allow_unauthenticated_access': allow_unauthenticated_access,
                                             }, with_context = false) %}
 
                                         {{ fields.field(

--- a/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
+++ b/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
@@ -83,9 +83,11 @@
                         <i class="ti ti-circuit-changeover me-2"></i>
                         {{ __('Conditional visibility') }}
                     </h3>
+                    {% if allow_unauthenticated_access is defined and allow_unauthenticated_access %}
                     <p class="text-muted small mb-3">
                         {{ __('For anonymous forms, the ALTCHA anti-bot widget will follow this same visibility.') }}
                     </p>
+                    {% endif %}
 
                     {# Parent properties #}
                     {% set strategies = 'Glpi\\Form\\Condition\\VisibilityStrategy' %}

--- a/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
+++ b/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
@@ -83,6 +83,9 @@
                         <i class="ti ti-circuit-changeover me-2"></i>
                         {{ __('Conditional visibility') }}
                     </h3>
+                    <p class="text-muted small mb-3">
+                        {{ __('For anonymous forms, the ALTCHA anti-bot widget will follow this same visibility.') }}
+                    </p>
 
                     {# Parent properties #}
                     {% set strategies = 'Glpi\\Form\\Condition\\VisibilityStrategy' %}

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -196,7 +196,16 @@
             {# Form reference #}
             <input type="hidden" name="forms_id" value="{{ form.fields.id }}">
 
-            <div class="d-flex justify-content-end mb-3" data-glpi-form-renderer-actions>
+            <div
+                class="d-flex justify-content-end mb-3"
+                data-glpi-form-renderer-actions
+                {% if unauthenticated_user %}
+                    data-glpi-form-renderer-altcha
+                    {% if not visibility_engine_output.isFormVisible() %}
+                        data-glpi-form-renderer-hidden-by-condition
+                    {% endif %}
+                {% endif %}
+            >
                 {# Altcha #}
                 {% if unauthenticated_user %}
                     {{ include(

--- a/tests/js/modules/Forms/RendererController.test.js
+++ b/tests/js/modules/Forms/RendererController.test.js
@@ -1,0 +1,109 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { GlpiFormRendererController } from '/js/modules/Forms/RendererController.js';
+import { GlpiFormConditionEngine } from '/js/modules/Forms/Condition/Engine.js';
+import { jest } from '@jest/globals';
+
+const emptyVisibilityResults = (form_visibility) => ({
+    form_visibility: form_visibility,
+    sections_visibility: {},
+    questions_visibility: {},
+    comments_visibility: {},
+});
+
+const appendFixture = (withAltcha = true) => {
+    $('body').append(`
+        <form data-glpi-form-render-layout="single_page">
+            <input type="text" name="test_input" />
+            <button type="submit" data-glpi-form-renderer-action="submit"></button>
+            ${withAltcha ? '<div data-glpi-form-renderer-altcha></div>' : ''}
+        </form>
+    `);
+};
+
+// Trigger the recompute flow (debounced by 400ms) and wait for the mocked
+// async condition engine call to resolve.
+const triggerRecompute = async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick'] });
+    $('input[name="test_input"]').trigger('input');
+    jest.advanceTimersByTime(400);
+    await new Promise(process.nextTick);
+    jest.useRealTimers();
+};
+
+describe('GlpiFormRendererController', () => {
+    let compute_visibility_spy;
+
+    beforeEach(() => {
+        $('body').empty();
+        compute_visibility_spy = jest.spyOn(GlpiFormConditionEngine.prototype, 'computeVisiblity');
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    test('Altcha widget follows the submit button visibility', async () => {
+        appendFixture();
+        new GlpiFormRendererController('form', 1);
+
+        const submit_button = document.querySelector('[data-glpi-form-renderer-action="submit"]');
+        const altcha = document.querySelector('[data-glpi-form-renderer-altcha]');
+
+        compute_visibility_spy.mockResolvedValue(emptyVisibilityResults(false));
+        await triggerRecompute();
+
+        expect(submit_button.hasAttribute('data-glpi-form-renderer-hidden-by-condition')).toBeTrue();
+        expect(altcha.hasAttribute('data-glpi-form-renderer-hidden-by-condition')).toBeTrue();
+
+        compute_visibility_spy.mockResolvedValue(emptyVisibilityResults(true));
+        await triggerRecompute();
+
+        expect(submit_button.hasAttribute('data-glpi-form-renderer-hidden-by-condition')).toBeFalse();
+        expect(altcha.hasAttribute('data-glpi-form-renderer-hidden-by-condition')).toBeFalse();
+    });
+
+    test('Missing altcha widget is ignored without error', async () => {
+        appendFixture(false);
+        new GlpiFormRendererController('form', 1);
+
+        expect(document.querySelector('[data-glpi-form-renderer-altcha]')).toBeNull();
+
+        compute_visibility_spy.mockResolvedValue(emptyVisibilityResults(false));
+        await expect(triggerRecompute()).resolves.not.toThrow();
+
+        const submit_button = document.querySelector('[data-glpi-form-renderer-action="submit"]');
+        expect(submit_button.hasAttribute('data-glpi-form-renderer-hidden-by-condition')).toBeTrue();
+    });
+});


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45299
- On public (unauthenticated) forms, the ALTCHA widget was rendered unconditionally whenever `unauthenticated_user` was true, regardless of the submit button's own visibility state. If a form's submit button is configured to never display (e.g. `submit_button_visibility_strategy = visible_if` with no configured conditions, or a "hidden if" condition that becomes true), the ALTCHA checkbox remained visible even though there is nothing left to submit/protect. This ties the ALTCHA widget's visibility to the same visibility state as the submit button, both on initial render and dynamically when the condition engine recomputes visibility client-side.

- Added a short hint under "Conditional visibility"

## Screenshots : 

Before :
<img width="1314" height="446" alt="Capture d’écran du 2026-07-15 14-13-34" src="https://github.com/user-attachments/assets/7eb27098-bd0e-4c91-a1d0-43acd1e687f5" />

After :
<img width="1314" height="446" alt="Capture d’écran du 2026-07-15 14-14-35" src="https://github.com/user-attachments/assets/45143bc4-cc6b-4b0c-8ea3-a6c3bb60514a" />

Helper added :
<img width="749" height="248" alt="Capture d’écran du 2026-07-15 15-20-12" src="https://github.com/user-attachments/assets/262518c6-c930-41e0-b355-29e3ae420969" />






