### PR TITLE
Add firmware field to device components

### DIFF
--- a/src/Glpi/Inventory/Asset/Device.php
+++ b/src/Glpi/Inventory/Asset/Device.php
@@ -93,6 +93,11 @@ abstract class Device extends InventoryAsset
             $fk              = getForeignKeyFieldForTable($devicetable);
 
             $existing = $this->getExisting($itemdevicetable, $fk);
+            $supports_firmware = in_array(
+                Item_DeviceFirmware::class,
+                Item_Devices::getItemAffinities($itemdevice::class),
+                true
+            );
 
             foreach ($value as $val) {
                 if (!isset($val->designation) || $val->designation == '') {
@@ -109,11 +114,7 @@ abstract class Device extends InventoryAsset
                 $device_value = clone $val;
                 if (
                     property_exists($device_value, 'firmware')
-                    && in_array(
-                        Item_DeviceFirmware::class,
-                        Item_Devices::getItemAffinities($itemdevice::class),
-                        true
-                    )
+                    && $supports_firmware
                 ) {
                     unset($device_value->firmware);
                 }
@@ -203,7 +204,7 @@ abstract class Device extends InventoryAsset
                     $this->itemdeviceAdded($itemdevice, $val);
                 }
 
-                $this->itemdeviceHandled($itemdevice, $val, $device_input);
+                $this->itemdeviceHandled($itemdevice, $val, $device_input, $supports_firmware);
 
                 if (count($existing[$device_id] ?? []) == 0) {
                     unset($existing[$device_id]);
@@ -238,13 +239,19 @@ abstract class Device extends InventoryAsset
      * @param Item_Devices        $itemdevice
      * @param object              $val
      * @param array<string,mixed> $device_input
+     * @param bool                $supports_firmware
      *
      * @return void
      */
-    protected function itemdeviceHandled(Item_Devices $itemdevice, object $val, array $device_input): void
+    protected function itemdeviceHandled(
+        Item_Devices $itemdevice,
+        object $val,
+        array $device_input,
+        bool $supports_firmware
+    ): void
     {
         if (
-            !in_array(Item_DeviceFirmware::class, Item_Devices::getItemAffinities($itemdevice::class), true)
+            !$supports_firmware
             || !property_exists($val, 'firmware')
         ) {
             return;

--- a/src/Glpi/Inventory/Asset/Device.php
+++ b/src/Glpi/Inventory/Asset/Device.php
@@ -248,8 +248,7 @@ abstract class Device extends InventoryAsset
         object $val,
         array $device_input,
         bool $supports_firmware
-    ): void
-    {
+    ): void {
         if (
             !$supports_firmware
             || !property_exists($val, 'firmware')

--- a/src/Glpi/Inventory/Asset/Device.php
+++ b/src/Glpi/Inventory/Asset/Device.php
@@ -35,7 +35,9 @@
 
 namespace Glpi\Inventory\Asset;
 
+use DeviceFirmware;
 use Glpi\Inventory\Conf;
+use Item_DeviceFirmware;
 use Item_Devices;
 use stdClass;
 
@@ -104,8 +106,20 @@ abstract class Device extends InventoryAsset
                     $val->date = date('Y-m-d', strtotime($val->date));
                 }
 
+                $device_value = clone $val;
+                if (
+                    property_exists($device_value, 'firmware')
+                    && in_array(
+                        Item_DeviceFirmware::class,
+                        Item_Devices::getItemAffinities($itemdevice::class),
+                        true
+                    )
+                ) {
+                    unset($device_value->firmware);
+                }
+
                 //create device or get existing device ID
-                $device_input = $this->handleInput($val, $device);
+                $device_input = $this->handleInput($device_value, $device);
                 $device_criteria = $device->getImportCriteria();
                 foreach (array_keys($device_criteria) as $device_criterion) {
                     if (!isset($device_input[$device_criterion]) && \isForeignKeyField($device_criterion)) {
@@ -170,7 +184,7 @@ abstract class Device extends InventoryAsset
                             'itemtype'           => $this->item::class,
                             'items_id'           => $this->item->fields['id'],
                             'is_dynamic'         => 1,
-                        ] + $this->handleInput($val, $itemdevice);
+                        ] + $this->handleInput($device_value, $itemdevice);
                         $itemdevice->update($itemdevice_data, true);
                         unset($existing[$device_id][$key]);
                         break;
@@ -184,10 +198,12 @@ abstract class Device extends InventoryAsset
                         'itemtype' => $this->item::class,
                         'items_id' => $this->item->fields['id'],
                         'is_dynamic' => 1,
-                    ] + $this->handleInput($val, $itemdevice);
+                    ] + $this->handleInput($device_value, $itemdevice);
                     $itemdevice->add($itemdevice_data, [], !$this->item->isNewItem()); //log only if mainitem is not new
                     $this->itemdeviceAdded($itemdevice, $val);
                 }
+
+                $this->itemdeviceHandled($itemdevice, $val, $device_input);
 
                 if (count($existing[$device_id] ?? []) == 0) {
                     unset($existing[$device_id]);
@@ -214,6 +230,82 @@ abstract class Device extends InventoryAsset
     protected function itemdeviceAdded(Item_Devices $itemdevice, $val)
     {
         //to be overridden
+    }
+
+    /**
+     * Handle data that depends on the resulting component instance.
+     *
+     * @param Item_Devices        $itemdevice
+     * @param object              $val
+     * @param array<string,mixed> $device_input
+     *
+     * @return void
+     */
+    protected function itemdeviceHandled(Item_Devices $itemdevice, object $val, array $device_input): void
+    {
+        if (
+            !in_array(Item_DeviceFirmware::class, Item_Devices::getItemAffinities($itemdevice::class), true)
+            || !property_exists($val, 'firmware')
+        ) {
+            return;
+        }
+
+        $item_firmware = new Item_DeviceFirmware();
+        $existing_links = $item_firmware->find([
+            'itemtype'   => $itemdevice::class,
+            'items_id'   => $itemdevice->getID(),
+            'is_dynamic' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $version = trim((string) $val->firmware);
+        if ($version === '') {
+            foreach ($existing_links as $existing_link) {
+                $item_firmware->delete(
+                    ['id' => $existing_link['id']],
+                    true,
+                    !$this->item->isNewItem()
+                );
+            }
+            return;
+        }
+
+        $firmware = new DeviceFirmware();
+        $firmware_id = $firmware->import([
+            'designation'            => $device_input['designation'] ?? $itemdevice->getTypeName(1),
+            'devicefirmwaretypes_id' => 0,
+            'manufacturers_id'       => (int) ($device_input['manufacturers_id'] ?? 0),
+            'version'                => $version,
+            'entities_id'            => $itemdevice->getEntityID(),
+            'with_history'           => false,
+        ]);
+        if (!$firmware_id) {
+            return;
+        }
+
+        $existing_link = array_shift($existing_links);
+        if ($existing_link === null) {
+            $item_firmware->add([
+                'itemtype'           => $itemdevice::class,
+                'items_id'           => $itemdevice->getID(),
+                'devicefirmwares_id' => $firmware_id,
+                'is_dynamic'         => 1,
+            ], [], !$this->item->isNewItem());
+        } elseif ($existing_link['devicefirmwares_id'] != $firmware_id) {
+            $item_firmware->update([
+                'id'                 => $existing_link['id'],
+                'devicefirmwares_id' => $firmware_id,
+            ], true);
+        }
+
+        // Only one firmware value can be reported for a component by an inventory.
+        foreach ($existing_links as $extra_link) {
+            $item_firmware->delete(
+                ['id' => $extra_link['id']],
+                true,
+                !$this->item->isNewItem()
+            );
+        }
     }
 
     public function checkConf(Conf $conf): bool

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -1041,12 +1041,46 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             $peer = null;
         }
 
-        $iterator = $DB->request($criteria);
+        $links = iterator_to_array($DB->request($criteria), false);
+        $firmwares_by_item = [];
+        if ($firmware_column !== null && $links !== []) {
+            $item_firmware_table = Item_DeviceFirmware::getTable();
+            $firmware_table = DeviceFirmware::getTable();
+            $firmware_iterator = $DB->request([
+                'SELECT' => [
+                    "$item_firmware_table.items_id AS item_device_id",
+                    "$firmware_table.*",
+                ],
+                'FROM' => $item_firmware_table,
+                'INNER JOIN' => [
+                    $firmware_table => [
+                        'FKEY' => [
+                            $item_firmware_table => 'devicefirmwares_id',
+                            $firmware_table      => 'id',
+                        ],
+                    ],
+                ],
+                'WHERE' => [
+                    "$item_firmware_table.itemtype"   => static::class,
+                    "$item_firmware_table.items_id"   => array_column($links, 'id'),
+                    "$item_firmware_table.is_deleted" => 0,
+                ],
+            ]);
+            foreach ($firmware_iterator as $firmware_data) {
+                $item_device_id = $firmware_data['item_device_id'];
+                unset($firmware_data['item_device_id']);
+
+                $firmware = new DeviceFirmware();
+                $firmware->getFromResultSet($firmware_data);
+                $firmwares_by_item[$item_device_id][] = $firmware;
+            }
+        }
+
         // Will be loaded only if/when data is needed from the device model
         $device_type = static::getDeviceType();
         /** @var CommonDevice $device */
         $device = getItemForItemtype($device_type);
-        foreach ($iterator as $link) {
+        foreach ($links as $link) {
             Session::addToNavigateListItems(static::class, $link["id"]);
             $this->getFromDB($link['id']);
             $current_row  = $table_group->createRow();
@@ -1079,18 +1113,8 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             }
 
             if ($firmware_column !== null) {
-                $firmware_links = (new Item_DeviceFirmware())->find([
-                    'itemtype'   => static::class,
-                    'items_id'   => $link['id'],
-                    'is_deleted' => 0,
-                ]);
                 $firmware_versions = [];
-                $firmware = new DeviceFirmware();
-                foreach ($firmware_links as $firmware_link) {
-                    if (!$firmware->getFromDB($firmware_link['devicefirmwares_id'])) {
-                        continue;
-                    }
-
+                foreach ($firmwares_by_item[$link['id']] ?? [] as $firmware) {
                     $version = $firmware->fields['version'] ?: $firmware->getName();
                     if ($firmware->can($firmware->getID(), READ)) {
                         $firmware_versions[] = sprintf(

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -598,9 +598,10 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         /** @var CommonDBTM $item */
         if ($item->canView()) {
             $nb = 0;
-            if (self::getItemAffinities($item::class) !== []) {
+            $affinities = self::getItemAffinities($item::class);
+            if ($affinities !== []) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
-                    foreach (self::getItemAffinities($item::class) as $link_type) {
+                    foreach ($affinities as $link_type) {
                         $nb   += countElementsInTable(
                             $link_type::getTable(),
                             ['items_id'   => $item->getID(),

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -490,10 +490,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
     {
         global $CFG_GLPI;
 
-        if (!in_array($itemtype, $CFG_GLPI['itemdevices_types'], true)) {
-            // Itemtype does not support devices.
-            return [];
-        }
+        $supports_devices = in_array($itemtype, $CFG_GLPI['itemdevices_types'], true);
 
         $result = [];
 
@@ -503,7 +500,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
 
             if (
                 in_array($itemtype, $item_device_affinities, true)
-                || in_array('*', $item_device_affinities, true)
+                || ($supports_devices && in_array('*', $item_device_affinities, true))
             ) {
                 $result[] = $item_device_class;
             }
@@ -528,7 +525,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
 
         $conf_param = str_replace('_', '', strtolower(static::class)) . '_types';
         if (isset($CFG_GLPI[$conf_param]) && !in_array('*', $CFG_GLPI[$conf_param])) {
-            $itemtypes = array_intersect($itemtypes, $CFG_GLPI[$conf_param]);
+            $itemtypes = $CFG_GLPI[$conf_param];
         }
 
         return $itemtypes;
@@ -601,7 +598,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         /** @var CommonDBTM $item */
         if ($item->canView()) {
             $nb = 0;
-            if (in_array($item::class, self::getConcernedItems())) {
+            if (self::getItemAffinities($item::class) !== []) {
                 if ($_SESSION['glpishow_count_on_tabs']) {
                     foreach (self::getItemAffinities($item::class) as $link_type) {
                         $nb   += countElementsInTable(
@@ -970,6 +967,15 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             );
         }
 
+        $has_firmware = !$is_device && in_array(
+            Item_DeviceFirmware::class,
+            self::getItemAffinities(static::class),
+            true
+        );
+        $firmware_column = $has_firmware && $table_group instanceof HTMLTableGroup
+            ? $table_group->addHeader('firmware', _sn('Firmware', 'Firmware', 1), $common_column)
+            : null;
+
         $specificity_columns = [];
         $link_column         = $table_group->addHeader('spec_link', '', $specific_column);
         $spec_column         = $link_column;
@@ -1070,6 +1076,33 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                 } elseif ($peer instanceof CommonDevice) {
                     $peer->getHTMLTableCellForItem($current_row, $item, null, $options);
                 }
+            }
+
+            if ($firmware_column !== null) {
+                $firmware_links = (new Item_DeviceFirmware())->find([
+                    'itemtype'   => static::class,
+                    'items_id'   => $link['id'],
+                    'is_deleted' => 0,
+                ]);
+                $firmware_versions = [];
+                $firmware = new DeviceFirmware();
+                foreach ($firmware_links as $firmware_link) {
+                    if (!$firmware->getFromDB($firmware_link['devicefirmwares_id'])) {
+                        continue;
+                    }
+
+                    $version = $firmware->fields['version'] ?: $firmware->getName();
+                    if ($firmware->can($firmware->getID(), READ)) {
+                        $firmware_versions[] = sprintf(
+                            '<a href="%s">%s</a>',
+                            htmlescape($firmware->getLinkURL()),
+                            htmlescape($version)
+                        );
+                    } else {
+                        $firmware_versions[] = htmlescape($version);
+                    }
+                }
+                $current_row->addCell($firmware_column, implode('<br>', $firmware_versions));
             }
 
             if (Session::haveRight('device', UPDATE)) {
@@ -1487,8 +1520,21 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         $this->addStandardTab(Lock::class, $ong, $options);
         $this->addStandardTab(Log::class, $ong, $options);
         $this->addStandardTab(Contract_Item::class, $ong, $options);
+        if (self::getItemAffinities(static::class) !== []) {
+            $this->addStandardTab(self::class, $ong, $options);
+        }
 
         return $ong;
+    }
+
+    public function cleanDBonPurge()
+    {
+        $items_id = $this->getID();
+        if ($items_id > 0) {
+            self::cleanItemDeviceDBOnItemDelete(static::class, $items_id, false);
+        }
+
+        parent::cleanDBonPurge();
     }
 
     public function showForm($ID, array $options = [])

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -384,7 +384,17 @@ $CFG_GLPI['itemdeviceharddrive_types']    = [Computer::class, Peripheral::class,
 
 $CFG_GLPI['itemdevicebattery_types']      = [Computer::class, Peripheral::class, Phone::class, Printer::class];
 
-$CFG_GLPI['itemdevicefirmware_types']     = [Computer::class, Peripheral::class, Phone::class, NetworkEquipment::class, Printer::class];
+$CFG_GLPI['itemdevicefirmware_types']     = [
+    Computer::class,
+    Peripheral::class,
+    Phone::class,
+    NetworkEquipment::class,
+    Printer::class,
+    Item_DeviceHardDrive::class,
+    Item_DeviceNetworkCard::class,
+    Item_DevicePowerSupply::class,
+    Item_DeviceGraphicCard::class,
+];
 
 $CFG_GLPI['itemdevicesimcard_types']      = [Computer::class, Peripheral::class, Phone::class, NetworkEquipment::class, Printer::class];
 

--- a/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
@@ -147,6 +147,8 @@ class DeviceTest extends AbstractInventoryAsset
     {
         global $DB;
         $item_drv = new \Item_DeviceHardDrive();
+        $item_firmware = new \Item_DeviceFirmware();
+        $firmware = new \DeviceFirmware();
         $info_com = new \Infocom();
 
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -206,6 +208,24 @@ class DeviceTest extends AbstractInventoryAsset
         $drives = $item_drv->find(['itemtype' => \Computer::class, 'items_id' => $computers_id, 'is_dynamic' => 1]);
 
         $this->assertCount(2, $drives);
+        $firmware_by_serial = [];
+        foreach ($drives as $drive) {
+            $firmware_links = $item_firmware->find([
+                'itemtype'   => \Item_DeviceHardDrive::class,
+                'items_id'   => $drive['id'],
+                'is_dynamic' => 1,
+            ]);
+            $this->assertCount(1, $firmware_links);
+            $firmware_link = reset($firmware_links);
+            $this->assertTrue($firmware->getFromDB($firmware_link['devicefirmwares_id']));
+            $firmware_by_serial[$drive['serial']] = [
+                'relation_id' => $firmware_link['id'],
+                'version'     => $firmware->fields['version'],
+            ];
+        }
+        $this->assertSame('BXV77D0Q', $firmware_by_serial['S29NNXAH146764']['version']);
+        $this->assertSame('GHBOA900', $firmware_by_serial['131005TF0401Y11K4NNN']['version']);
+        $initial_firmware_links = $firmware_by_serial;
 
         $data_to_check = [];
 
@@ -227,14 +247,39 @@ class DeviceTest extends AbstractInventoryAsset
             $data_to_check[] = $input;
         }
 
-        //redo an inventory
-        $this->doInventory($xml_source, true);
+        //redo an inventory with an updated firmware
+        $updated_xml_source = str_replace(
+            '<FIRMWARE>BXV77D0Q</FIRMWARE>',
+            '<FIRMWARE>BXV77D0R</FIRMWARE>',
+            $xml_source
+        );
+        $this->doInventory($updated_xml_source, true);
 
         //drives present in the inventory source are still dynamic
         $drives = $item_drv->find(['itemtype' =>  \Computer::class, 'items_id' => $computers_id, 'is_dynamic' => 1]);
         $this->assertCount(2, $drives);
+        $firmware_by_serial = [];
+        foreach ($drives as $drive) {
+            $firmware_links = $item_firmware->find([
+                'itemtype'   => \Item_DeviceHardDrive::class,
+                'items_id'   => $drive['id'],
+                'is_dynamic' => 1,
+            ]);
+            $this->assertCount(1, $firmware_links);
+            $firmware_link = reset($firmware_links);
+            $this->assertTrue($firmware->getFromDB($firmware_link['devicefirmwares_id']));
+            $firmware_by_serial[$drive['serial']] = [
+                'relation_id' => $firmware_link['id'],
+                'version'     => $firmware->fields['version'],
+            ];
+        }
+        $this->assertSame('BXV77D0R', $firmware_by_serial['S29NNXAH146764']['version']);
+        $this->assertSame(
+            $initial_firmware_links['S29NNXAH146764']['relation_id'],
+            $firmware_by_serial['S29NNXAH146764']['relation_id']
+        );
 
-        //check item_device_memory is the same from first step
+        //check item_device_drive is the same from first step
         foreach ($data_to_check as $data_value) {
             $drives = $item_drv->find(['id' => $data_value['items_id'], "itemtype" => \Computer::class, 'is_dynamic' => 1]);
             $this->assertCount(1, $drives);

--- a/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
+++ b/tests/functional/Glpi/Inventory/Assets/DeviceTest.php
@@ -227,6 +227,21 @@ class DeviceTest extends AbstractInventoryAsset
         $this->assertSame('GHBOA900', $firmware_by_serial['131005TF0401Y11K4NNN']['version']);
         $initial_firmware_links = $firmware_by_serial;
 
+        $first_drive = reset($drives);
+        $static_firmware_id = $firmware->add([
+            'designation' => 'Manually managed firmware',
+            'version'     => 'STATIC-1.0',
+            'entities_id' => $computer->getEntityID(),
+        ]);
+        $this->assertGreaterThan(0, $static_firmware_id);
+        $static_firmware_link_id = $item_firmware->add([
+            'itemtype'           => \Item_DeviceHardDrive::class,
+            'items_id'           => $first_drive['id'],
+            'devicefirmwares_id' => $static_firmware_id,
+            'is_dynamic'         => 0,
+        ]);
+        $this->assertGreaterThan(0, $static_firmware_link_id);
+
         $data_to_check = [];
 
         $infocom_buy_date = '2020-10-21';
@@ -278,6 +293,10 @@ class DeviceTest extends AbstractInventoryAsset
             $initial_firmware_links['S29NNXAH146764']['relation_id'],
             $firmware_by_serial['S29NNXAH146764']['relation_id']
         );
+
+        $this->assertTrue($item_firmware->getFromDB($static_firmware_link_id));
+        $this->assertSame(0, $item_firmware->fields['is_dynamic']);
+        $this->assertSame($static_firmware_id, $item_firmware->fields['devicefirmwares_id']);
 
         //check item_device_drive is the same from first step
         foreach ($data_to_check as $data_value) {

--- a/tests/functional/Item_DevicesTest.php
+++ b/tests/functional/Item_DevicesTest.php
@@ -157,4 +157,59 @@ class Item_DevicesTest extends DbTestCase
             );
         }
     }
+
+    public static function firmwareDeviceProvider(): iterable
+    {
+        yield 'hard drive' => ['Item_DeviceHardDrive'];
+        yield 'network card' => ['Item_DeviceNetworkCard'];
+        yield 'power supply' => ['Item_DevicePowerSupply'];
+        yield 'graphic card' => ['Item_DeviceGraphicCard'];
+    }
+
+    #[DataProvider('firmwareDeviceProvider')]
+    public function testFirmwareAffinity(string $itemtype): void
+    {
+        $this->assertSame(
+            [\Item_DeviceFirmware::class],
+            Item_Devices::getItemAffinities($itemtype)
+        );
+        $this->assertContains($itemtype, \Item_DeviceFirmware::getConcernedItems());
+        $this->assertNotContains(
+            \Item_DeviceGeneric::class,
+            Item_Devices::getItemAffinities($itemtype)
+        );
+    }
+
+    public function testNestedFirmwareRelation(): void
+    {
+        $this->login();
+
+        $computer = $this->createItem(\Computer::class, [
+            'name'        => __FUNCTION__,
+            'entities_id' => 0,
+        ]);
+        $hard_drive = $this->createItem(\DeviceHardDrive::class, [
+            'designation' => 'Test drive',
+        ]);
+        $item_hard_drive = $this->createItem(\Item_DeviceHardDrive::class, [
+            'deviceharddrives_id' => $hard_drive->getID(),
+            'itemtype'            => \Computer::class,
+            'items_id'            => $computer->getID(),
+        ]);
+        $firmware = $this->createItem(\DeviceFirmware::class, [
+            'designation' => 'Test drive',
+            'version'     => '1.2.3',
+        ]);
+        $item_firmware = $this->createItem(\Item_DeviceFirmware::class, [
+            'devicefirmwares_id' => $firmware->getID(),
+            'itemtype'           => \Item_DeviceHardDrive::class,
+            'items_id'           => $item_hard_drive->getID(),
+        ]);
+        $item_firmware_id = $item_firmware->getID();
+
+        $this->assertArrayHasKey('Item_Devices$1', $item_hard_drive->defineAllTabs());
+        $this->assertTrue($item_hard_drive->delete(['id' => $item_hard_drive->getID()], true));
+
+        $this->assertFalse($item_firmware->getFromDB($item_firmware_id));
+    }
 }


### PR DESCRIPTION
## Description

This PR allows firmware versions to be associated with installed device components where tracking firmware is commonly useful:

- hard drives;
- network cards;
- power supplies;
- graphics cards.

Instead of adding a plain-text field to each item-device table, the change reuses the existing `DeviceFirmware` and `Item_DeviceFirmware` item types. The polymorphic `itemtype` and `items_id` fields of `Item_DeviceFirmware` can now refer to an installed component record such as `Item_DeviceHardDrive`.

This keeps firmware data normalized and makes the existing firmware metadata, including version, type, manufacturer, and release date, available for components. It also lets multiple installed components reuse the same firmware record while retaining their own relations to it.

Firmware tracking on individual parts is useful in existing hardware inventory systems. For example, Device42 exposes a Firmware Version for part records:
[Managing Spare Parts in Device42](https://docs.device42.com/infrastructure-management/parts-and-parts-slots/managing-spare-parts/)

The change:

- adds firmware support for the four installed component types listed above;
- displays the firmware version in the main components table and links it to the corresponding `DeviceFirmware` record when the user has permission to view it;
- exposes the standard components tab on supported installed component records so firmware relations can be managed manually;
- imports firmware reported by inventory and updates the existing dynamic relation when the version changes;
- leaves manually managed firmware relations untouched during inventory synchronization;
- removes nested firmware relations when an installed component is purged;
- adds functional coverage for affinities, nested relations, cleanup, inventory persistence, and inventory updates.

No database migration or template changes are required. The existing `Item_DeviceFirmware` table is already polymorphic, and component tables are rendered dynamically.


## AI usage

OpenAI Codex was used to assist with codebase exploration, implementation and test drafting, code review, and preparation of the pull request description. The resulting changes were reviewed by the contributor and validated by the project CI.