### PR TITLE
[GraphQL] Prevent adding unused joins to query

### DIFF
--- a/src/Glpi/Api/HL/Doc/Schema.php
+++ b/src/Glpi/Api/HL/Doc/Schema.php
@@ -264,6 +264,7 @@ class Schema implements ArrayAccess
                 $new_join = $prop['x-join'] + [
                     'parent_type' => self::TYPE_OBJECT,
                     'x-full-schema' => $prop['x-full-schema'] ?? null,
+                    'x-skipped' => $prop['x-skipped'] ?? false,
                 ];
                 $joins[$prefix . $name] = $fn_add_parent_hint($new_join, $prefix);
                 $joins += self::getJoins($prop['properties'], $prefix . $name . '.', $new_join);
@@ -271,6 +272,7 @@ class Schema implements ArrayAccess
                 $new_join = $prop['items']['x-join'] + [
                     'parent_type' => self::TYPE_ARRAY,
                     'x-full-schema' => $prop['items']['x-full-schema'] ?? null,
+                    'x-skipped' => $prop['x-skipped'] ?? false,
                 ];
                 $joins[$prefix . $name] = $fn_add_parent_hint($new_join, $prefix);
                 if (array_key_exists('properties', $prop['items'])) {

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -336,7 +336,6 @@ class DefaultResolvers
         ];
 
         $schema = ResourceAccessor::applyFieldReadRestrictions($schema, true);
-        $search = new Search($schema, $request_params);
 
         if (!in_array('id', $field_selection, true)) {
             // Always select ID to uniquely identify records
@@ -345,6 +344,14 @@ class DefaultResolvers
 
         // remove all fields not in the schema (maybe they requested a field from the full schema which they cannot see) and write-only fields from selection
         $field_selection = array_filter($field_selection, static fn($field_name) => array_key_exists($field_name, $schema['properties']) && !($schema['properties'][$field_name]['writeOnly'] ?? false));
+
+        // mark properties as skipped in the schema that are not in the selection, but we keep them in the schema in case we need them later (like if they are used in RSQL)
+        foreach ($schema['properties'] as $field_name => &$field_schema) {
+            if (!in_array($field_name, $field_selection, true)) {
+                $field_schema['x-skipped'] = true;
+            }
+        }
+        unset($field_schema);
 
         // if any selected fields are mapped, ensure their source fields are also selected
         foreach ($field_selection as $field_name) {
@@ -355,6 +362,8 @@ class DefaultResolvers
                 }
             }
         }
+
+        $search = new Search($schema, $request_params);
 
         foreach ($field_selection as $field_name) {
             // skip mapped fields unless mapped from themselves
@@ -445,15 +454,24 @@ class DefaultResolvers
             }
             $parent_path = substr($property, 0, (int) strrpos($property, '.'));
             $join_name = $context->getJoinNameForProperty($parent_path);
+            $parent_property = str_replace($join_name . '.', '', $parent_path);
             if (array_key_exists($join_name, $joins)) {
                 $join_schema_name = $joins[$join_name]['x-full-schema'] ?? null;
+                $new_schema['properties'][$join_name]['x-skipped'] = false;
                 if ($join_schema_name !== null) {
                     $join_schema = $this->getSchemaForObjectName($join_schema_name);
                     if (($join_schema !== null)) {
-                        if (array_key_exists('items', $new_schema['properties'][$join_name])) {
-                            $new_schema['properties'][$join_name]['items']['properties'] = $join_schema['properties'];
-                        } else {
-                            $new_schema['properties'][$join_name]['properties'] = $join_schema['properties'];
+                        if (!($new_schema['properties'][$join_name]['x-expanded'] ?? false)) {
+                            $j_props = $join_schema['properties'];
+                            foreach ($j_props as $j_prop_name => &$j_prop_schema) {
+                                $j_prop_schema['x-skipped'] = $j_prop_name !== $parent_property;
+                            }
+                            if (array_key_exists('items', $new_schema['properties'][$join_name])) {
+                                $new_schema['properties'][$join_name]['items']['properties'] = $j_props;
+                            } else {
+                                $new_schema['properties'][$join_name]['properties'] = $j_props;
+                            }
+                            $new_schema['properties'][$join_name]['x-expanded'] = true;
                         }
                     }
                 }

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -388,6 +388,9 @@ final class Search
     public function addJoinsCriteria(array &$criteria): void
     {
         foreach ($this->context->getJoins() as $join_alias => $join_definition) {
+            if ($join_definition['x-skipped'] ?? false) {
+                continue;
+            }
             $join_clauses = $this->getJoins($join_alias, $join_definition);
             foreach ($join_clauses as $join_type => $join_tables) {
                 if (!isset($criteria[$join_type])) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

```graphql
query { Computer { id name } }
```

This GraphQL does not involve any joined properties, and the data was never used in the response, and yet all of them are added to the DB query. Normally, the DB could optimize away unused joins but the nature of these joins seem to make the DB unable to be certain they have no effect on the results.

As more joined properties get added to fill out the graph, linking individual schemas, this will become more of a performance hit. In fact, I hadn't noticed any issue until I had added a property for software installations which was missing a condition and therefore had no KEY to use so it was adding multiple seconds to the query time.