### PR TITLE
Use dedicated objects for languages

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -8414,12 +8414,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Helpdesk/DefaultDataManager.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$lang of method Glpi\\\\Helpdesk\\\\DefaultDataManager\\:\\:applyTranslation\\(\\) expects string, int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Helpdesk/DefaultDataManager.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method listTranslationsHandlers\\(\\) on Entity\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -16004,12 +15998,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Plugin.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$language of static method Glpi\\\\Dashboard\\\\Grid\\:\\:getAllDashboardCardsCacheKey\\(\\) expects string\\|null, int\\|string given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Plugin.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$name of static method Plugin\\:\\:messageMissingRequirement\\(\\) expects string, int\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,
@@ -18782,7 +18770,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Webhook.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$string of function strtolower expects string, array\\<int\\|string, array\\<int\\<0, max\\>\\|string, list\\<string\\>\\|string\\>\\|int\\|string\\>\\|class\\-string\\|string given\\.$#',
+	'message' => '#^Parameter \\#1 \\$string of function strtolower expects string, array\\<int\\|string, array\\<int\\|string, list\\<string\\>\\|string\\>\\|int\\|string\\>\\|string given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 2,
 	'path' => __DIR__ . '/src/autoload/CFG_GLPI.php',

--- a/front/locale.php
+++ b/front/locale.php
@@ -37,6 +37,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\Application\Environment;
 use Glpi\Error\ErrorHandler;
+use Glpi\Locale\LanguageRegistry;
 use Laminas\I18n\Translator\TextDomain;
 
 use function Safe\fopen;
@@ -44,7 +45,7 @@ use function Safe\json_encode;
 use function Safe\preg_match;
 use function Safe\preg_replace;
 
-global $CFG_GLPI, $TRANSLATE;
+global $TRANSLATE;
 
 header("Content-Type: application/json; charset=UTF-8");
 
@@ -58,11 +59,11 @@ if ($is_cacheable) {
 }
 
 $requested_language = $_GET['lang'];
-if (!isset($CFG_GLPI['languages'][$requested_language])) {
+if (!LanguageRegistry::has($requested_language)) {
     // Fallback to default language if requested one is not available
     $requested_language = Session::getPreferredLanguage();
 }
-$requested_language_file = $CFG_GLPI['languages'][$requested_language][1];
+$requested_language_file = LanguageRegistry::get($requested_language)->mo_file;
 
 // Default response to send if locales cannot be loaded.
 // Prevent JS error for plugins that does not provide any translation files

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -47,6 +47,7 @@ use Glpi\Features\AssignableItem;
 use Glpi\Features\CacheableListInterface;
 use Glpi\Features\Clonable;
 use Glpi\Features\DCBreadcrumbInterface;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\RichText\UserMention;
@@ -4961,8 +4962,9 @@ class CommonDBTM extends CommonGLPI
                         break;
 
                     case "language":
-                        if (isset($CFG_GLPI['languages'][$value ?? ''])) {
-                            return htmlescape($CFG_GLPI['languages'][$value][0]);
+                        $language = LanguageRegistry::tryGet($value ?? '');
+                        if ($language !== null) {
+                            return htmlescape($language->native_name);
                         }
                         return __s('Default value');
                 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -43,6 +43,7 @@ use Glpi\Dashboard\Grid;
 use Glpi\Event;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\Kernel\Kernel;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Mail\SMTP\OauthConfig;
 use Glpi\Plugin\Hooks;
 use Glpi\System\Diagnostic\SourceCodeIntegrityChecker;
@@ -955,35 +956,32 @@ class Config extends CommonDBTM
      **/
     public static function getLanguage($lang)
     {
-        global $CFG_GLPI;
-
         // Alternative language code: en-EN --> en_EN
         $altLang = str_replace("-", "_", $lang);
 
-        // Search in order : ID or extjs dico or tinymce dico / native lang / english name
-        //                   / extjs dico / tinymce dico
-        // ID  or extjs dico or tinymce dico
-        foreach ($CFG_GLPI["languages"] as $ID => $language) {
+        // Search in order : ID or jquery dico or js dico / native lang / english name
+        // ID or jquery dico or js dico
+        foreach (LanguageRegistry::all() as $ID => $language) {
             if (
                 (strcasecmp($lang, $ID) == 0)
                 || (strcasecmp($altLang, $ID) == 0)
-                || (strcasecmp($lang, $language[2]) == 0)
-                || (strcasecmp($lang, $language[3]) == 0)
+                || (strcasecmp($lang, $language->jquery_code) == 0)
+                || (strcasecmp($lang, $language->js_code) == 0)
             ) {
                 return $ID;
             }
         }
 
         // native lang
-        foreach ($CFG_GLPI["languages"] as $ID => $language) {
-            if (strcasecmp($lang, $language[0]) == 0) {
+        foreach (LanguageRegistry::all() as $ID => $language) {
+            if (strcasecmp($lang, $language->native_name) == 0) {
                 return $ID;
             }
         }
 
         // english lang name
-        foreach ($CFG_GLPI["languages"] as $ID => $language) {
-            if (strcasecmp($lang, $language[4]) == 0) {
+        foreach (LanguageRegistry::all() as $ID => $language) {
+            if (strcasecmp($lang, $language->english_name) == 0) {
                 return $ID;
             }
         }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -41,6 +41,7 @@ use Glpi\DBAL\QueryFunction;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Features\AssignableItem;
 use Glpi\Form\Category;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\SocketModel;
@@ -1572,12 +1573,10 @@ HTML;
      */
     public static function getLanguages()
     {
-        global $CFG_GLPI;
-
         $languages = [];
-        foreach ($CFG_GLPI["languages"] as $key => $val) {
-            if (isset($val[1]) && is_file(GLPI_ROOT . "/locales/" . $val[1])) {
-                $languages[$key] = $val[0];
+        foreach (LanguageRegistry::all() as $key => $language) {
+            if (is_file(GLPI_ROOT . "/locales/" . $language->mo_file)) {
+                $languages[$key] = $language->native_name;
             }
         }
 
@@ -1594,8 +1593,8 @@ HTML;
      **/
     public static function getLanguageName($value)
     {
-        global $CFG_GLPI;
-        return $CFG_GLPI["languages"][$value][0] ?? $value;
+        $language = LanguageRegistry::tryGet($value);
+        return $language !== null ? $language->native_name : $value;
     }
 
 

--- a/src/Glpi/Api/HL/Controller/CoreController.php
+++ b/src/Glpi/Api/HL/Controller/CoreController.php
@@ -49,6 +49,7 @@ use Glpi\Error\ErrorHandler;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\OAuth\Server;
 use Glpi\System\Status\StatusChecker;
 use Glpi\Toolbox\MarkdownRenderer;
@@ -920,7 +921,7 @@ HTML;
     )]
     public function getLocales(Request $request): Response
     {
-        global $TRANSLATE, $CFG_GLPI;
+        global $TRANSLATE;
 
         $messages = $TRANSLATE->getAllMessages($_GET['domain']);
         if (!($messages instanceof TextDomain)) {
@@ -939,7 +940,7 @@ HTML;
         $po_file = GLPI_ROOT . '/locales/' . preg_replace(
             '/\.mo$/',
             '.po',
-            $CFG_GLPI['languages'][$_SESSION['glpilanguage']][1]
+            LanguageRegistry::get($_SESSION['glpilanguage'])->mo_file
         );
         $po_file_handle = fopen(
             $po_file,

--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -39,6 +39,7 @@ use Config;
 use DBmysql;
 use Entity;
 use Glpi\Application\ImportMapGenerator;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Toolbox\FrontEnd;
 use Glpi\UI\Theme;
 use Glpi\UI\ThemeManager;
@@ -268,8 +269,6 @@ class FrontEndAssetsExtension extends AbstractExtension
      */
     public function localesJs(): string
     {
-        global $CFG_GLPI;
-
         if (!isset($_SESSION['glpilanguage'])) {
             return '';
         }
@@ -288,7 +287,7 @@ class FrontEndAssetsExtension extends AbstractExtension
 
             $.fn.select2.defaults.set(
                 'language',
-                '" . \jsescape($CFG_GLPI['languages'][$_SESSION['glpilanguage']][2]) . "',
+                '" . \jsescape(LanguageRegistry::get($_SESSION['glpilanguage'])->jquery_code) . "',
             );
         ";
 

--- a/src/Glpi/Application/View/Extension/I18nExtension.php
+++ b/src/Glpi/Application/View/Extension/I18nExtension.php
@@ -36,6 +36,7 @@
 namespace Glpi\Application\View\Extension;
 
 use CommonDBTM;
+use Dropdown;
 use Glpi\Form\FormTranslation;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\ItemTranslation\Context\ProvideTranslationsInterface;
@@ -57,6 +58,7 @@ class I18nExtension extends AbstractExtension
             new TwigFunction('_x', '_x'),
             new TwigFunction('_nx', '_nx'),
             new TwigFunction('get_current_locale', [$this, 'getCurrentLocale']),
+            new TwigFunction('get_language_name', [Dropdown::class, 'getLanguageName']),
             new TwigFunction('get_plural_number', [Session::class, 'getPluralNumber']),
             new TwigFunction('translate_form_item_key', $this->translateFormItemKey(...)),
             new TwigFunction('translate_helpdesk_item_key', $this->translateHelpdeskItemKey(...)),

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -41,6 +41,7 @@ use Glpi\Asset\CustomFieldType\RawType;
 use Glpi\Asset\CustomFieldType\TypeInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\Locale\LanguageRegistry;
 use InvalidArgumentException;
 use RuntimeException;
 use Session;
@@ -378,8 +379,6 @@ final class CustomFieldDefinition extends CommonDBChild
      */
     protected function validateTranslationsArray(mixed $translations): bool
     {
-        global $CFG_GLPI;
-
         if (!is_array($translations)) {
             return false;
         }
@@ -388,7 +387,7 @@ final class CustomFieldDefinition extends CommonDBChild
 
         // Array keys must be valid language codes
         foreach (array_keys($translations) as $language) {
-            if (!array_key_exists($language, $CFG_GLPI['languages'])) {
+            if (!LanguageRegistry::has($language)) {
                 $is_valid = false;
                 break;
             }

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -42,6 +42,7 @@ use Glpi\Console\Command\GlpiCommandInterface;
 use Glpi\Console\Exception\EarlyExitException;
 use Glpi\Error\ErrorDisplayHandler\ConsoleErrorDisplayHandler;
 use Glpi\Kernel\Kernel;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\System\Requirement\RequirementInterface;
 use Glpi\System\RequirementsManager;
 use Glpi\Toolbox\Filesystem;
@@ -220,8 +221,6 @@ class Application extends BaseApplication
     protected function configureIO(InputInterface $input, OutputInterface $output): void
     {
 
-        global $CFG_GLPI;
-
         $this->output = $output;
         ConsoleErrorDisplayHandler::setOutput($output);
 
@@ -229,7 +228,7 @@ class Application extends BaseApplication
 
         // Trigger error on invalid lang. This is not done before as error handler would not be set.
         $lang = $input->getParameterOption('--lang', null, true);
-        if (null !== $lang && !array_key_exists($lang, $CFG_GLPI['languages'])) {
+        if (null !== $lang && !LanguageRegistry::has($lang)) {
             throw new RuntimeException(
                 sprintf(__('Invalid "--lang" option value "%s".'), $lang)
             );

--- a/src/Glpi/Controller/IndexController.php
+++ b/src/Glpi/Controller/IndexController.php
@@ -38,6 +38,7 @@ use Auth;
 use CronTask;
 use Dropdown;
 use Glpi\Http\Firewall;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Html;
@@ -98,7 +99,7 @@ final class IndexController extends AbstractController
                 'errors'    => $errors,
                 'title'     => __('Access denied'),
                 'login_url' => $CFG_GLPI["root_doc"] . '/front/logout.php?noAUTO=1&redirect=' . \rawurlencode($redirect),
-                'lang'      => $CFG_GLPI["languages"][$_SESSION['glpilanguage']][3],
+                'lang'      => LanguageRegistry::get($_SESSION['glpilanguage'])->getPageLang(),
             ]);
         }
 
@@ -113,7 +114,7 @@ final class IndexController extends AbstractController
         return $this->render('pages/login.html.twig', [
             'rand'                => $rand,
             'card_bg_width'       => true,
-            'lang'                => $CFG_GLPI["languages"][$_SESSION['glpilanguage']][3],
+            'lang'                => LanguageRegistry::get($_SESSION['glpilanguage'])->getPageLang(),
             'title'               => __('Authentication'),
             'noAuto'              => $_GET["noAUTO"] ?? 0,
             'redirect'            => $redirect,

--- a/src/Glpi/Controller/MaintenanceController.php
+++ b/src/Glpi/Controller/MaintenanceController.php
@@ -37,6 +37,7 @@ declare(strict_types=1);
 namespace Glpi\Controller;
 
 use Glpi\Http\Firewall;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -48,12 +49,10 @@ class MaintenanceController extends AbstractController
     #[SecurityStrategy(Firewall::STRATEGY_NO_CHECK)]
     public function __invoke(): Response
     {
-        global $CFG_GLPI;
-
         return $this->render(
             'maintenance.html.twig',
             [
-                'lang'      => $CFG_GLPI["languages"][$_SESSION['glpilanguage']][3],
+                'lang'      => LanguageRegistry::get($_SESSION['glpilanguage'])->getPageLang(),
             ]
         );
     }

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -42,6 +42,7 @@ use Gettext\Languages\CldrData as Language_CldrData;
 use Gettext\Languages\Language;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\CustomFieldDefinition;
+use Glpi\Locale\LanguageRegistry;
 use LogicException;
 use Profile;
 use ProfileRight;
@@ -330,8 +331,6 @@ abstract class AbstractDefinition extends CommonDBTM
      */
     protected function showTranslationForm(): void
     {
-        global $CFG_GLPI;
-
         $asset_name_translations = $this->getDecodedTranslationsField();
 
         $translations = [];
@@ -360,7 +359,10 @@ abstract class AbstractDefinition extends CommonDBTM
 
         usort(
             $translations,
-            static fn(array $a, array $b) => strnatcasecmp($CFG_GLPI['languages'][$a['language']][0], $CFG_GLPI['languages'][$b['language']][0])
+            static fn(array $a, array $b) => strnatcasecmp(
+                LanguageRegistry::get($a['language'])->native_name,
+                LanguageRegistry::get($b['language'])->native_name
+            )
         );
 
         $rand = mt_rand();
@@ -912,8 +914,6 @@ TWIG, ['name' => $name, 'value' => $value]);
      */
     protected function validateTranslationsArray(mixed $translations): bool
     {
-        global $CFG_GLPI;
-
         if (!is_array($translations)) {
             return false;
         }
@@ -921,7 +921,7 @@ TWIG, ['name' => $name, 'value' => $value]);
         $is_valid = true;
 
         foreach ($translations as $language => $values) {
-            if (!in_array($language, array_keys($CFG_GLPI['languages']), true)) {
+            if (!LanguageRegistry::has($language)) {
                 $is_valid = false;
                 break;
             }
@@ -953,10 +953,8 @@ TWIG, ['name' => $name, 'value' => $value]);
      */
     public static function getPluralFormsForLanguage(string $language): array
     {
-        global $CFG_GLPI;
-
         // check language exists in GLPI configuration
-        if (!array_key_exists($language, $CFG_GLPI['languages'])) {
+        if (!LanguageRegistry::has($language)) {
             return [];
         }
 

--- a/src/Glpi/Helpdesk/DefaultDataManager.php
+++ b/src/Glpi/Helpdesk/DefaultDataManager.php
@@ -62,6 +62,7 @@ use Glpi\Helpdesk\Tile\GlpiPageTile;
 use Glpi\Helpdesk\Tile\TilesManager;
 use Glpi\ItemTranslation\Context\TranslationHandler;
 use Glpi\ItemTranslation\ItemTranslation;
+use Glpi\Locale\LanguageRegistry;
 use ITILCategory;
 use Location;
 use RuntimeException;
@@ -217,7 +218,7 @@ final class DefaultDataManager
     /** @param Form[] $forms */
     private function addFormsTranslations(array $forms): void
     {
-        global $CFG_GLPI, $DB, $TRANSLATE;
+        global $DB, $TRANSLATE;
 
         // List all values that need to be translated
         /** @var TranslationHandler[] $values_to_translate */
@@ -244,7 +245,7 @@ final class DefaultDataManager
         ]);
         $add_translation_stmt = $DB->prepare($add_translation_query);
 
-        foreach (array_keys($CFG_GLPI['languages']) as $lang) {
+        foreach (array_keys(LanguageRegistry::all()) as $lang) {
             foreach ($values_to_translate as $value_to_translate) {
                 // Translate value
                 $translated_value = $this->applyTranslation(

--- a/src/Glpi/Locale/Language.php
+++ b/src/Glpi/Locale/Language.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Locale/Language.php
+++ b/src/Glpi/Locale/Language.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Locale;
+
+use function Safe\preg_match;
+
+/**
+ * Immutable description of a GLPI language.
+ *
+ * Every piece of information GLPI needs about a language is exposed as a typed,
+ * named property to no longer rely on `$CFG_GLPI['languages']` array.
+ *
+ * Most languages only need a `$code` and a `$nativeName`: the MO file name, the
+ * jQuery/i18n code and the JS/page-lang code are derived from the code with
+ * defaults, and only the exceptions have to be provided explicitly.
+ */
+final class Language
+{
+    /**
+     * MO file name (e.g. `fr_FR.mo`). Defaults to `{code}.mo`.
+     */
+    public readonly string $mo_file;
+
+    /**
+     * jQuery / select2 / fullcalendar i18n code (e.g. `fr`, `en-GB`, `pt-BR`).
+     * Defaults to the region-less part of the code.
+     */
+    public readonly string $jquery_code;
+
+    /**
+     * JS code, also used as the HTML page `lang` attribute (e.g. `fr`, `en`).
+     * Defaults to the region-less part of the code.
+     */
+    public readonly string $js_code;
+
+    /**
+     * @param string      $code         Regionalized language code, e.g. `fr_FR` (the array key).
+     * @param string      $native_name  Language name written in its own language.
+     * @param string|null $mo_file      MO file name; defaults to `{code}.mo`.
+     * @param string|null $jquery_code  jQuery/i18n code; defaults to the region-less code.
+     * @param string|null $js_code      JS/page-lang code; defaults to the region-less code.
+     * @param string      $english_name Language name written in english.
+     * @param int         $plural_number Gettext plural rule number.
+     */
+    public function __construct(
+        public readonly string $code,
+        public readonly string $native_name,
+        ?string $mo_file = null,
+        ?string $jquery_code = null,
+        ?string $js_code = null,
+        public readonly string $english_name = '',
+        public readonly int $plural_number = 2,
+    ) {
+        $regionless = self::regionlessCode($code);
+
+        $this->mo_file     = $mo_file ?? ($code . '.mo');
+        $this->jquery_code = $jquery_code ?? $regionless;
+        $this->js_code     = $js_code ?? $regionless;
+    }
+
+    /**
+     * Region-less part of the code (`fr_FR` -> `fr`).
+     */
+    public function getRegionlessCode(): string
+    {
+        return self::regionlessCode($this->code);
+    }
+
+    /**
+     * Code to use as the HTML page `lang` attribute and in front-end JS.
+     */
+    public function getPageLang(): string
+    {
+        return $this->js_code;
+    }
+
+    /**
+     * Whether the language is written right-to-left.
+     */
+    public function isRTL(): bool
+    {
+        if (function_exists('locale_is_right_to_left')) {
+            return locale_is_right_to_left($this->code);
+        }
+
+        return (bool) preg_match(
+            '/^(?:ar|he|fa|ur|ps|sd|ug|ckb|yi|dv|ku_arab|ku-arab)(?:[_-].*)?$/i',
+            $this->code
+        );
+    }
+
+    private static function regionlessCode(string $code): string
+    {
+        return explode('_', $code)[0];
+    }
+}

--- a/src/Glpi/Locale/Language.php
+++ b/src/Glpi/Locale/Language.php
@@ -34,8 +34,6 @@
 
 namespace Glpi\Locale;
 
-use function Safe\preg_match;
-
 /**
  * Immutable description of a GLPI language.
  *
@@ -111,14 +109,7 @@ final class Language
      */
     public function isRTL(): bool
     {
-        if (function_exists('locale_is_right_to_left')) {
-            return locale_is_right_to_left($this->code);
-        }
-
-        return (bool) preg_match(
-            '/^(?:ar|he|fa|ur|ps|sd|ug|ckb|yi|dv|ku_arab|ku-arab)(?:[_-].*)?$/i',
-            $this->code
-        );
+        return locale_is_right_to_left($this->code);
     }
 
     private static function regionlessCode(string $code): string

--- a/src/Glpi/Locale/LanguageRegistry.php
+++ b/src/Glpi/Locale/LanguageRegistry.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/src/Glpi/Locale/LanguageRegistry.php
+++ b/src/Glpi/Locale/LanguageRegistry.php
@@ -1,0 +1,299 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Locale;
+
+/**
+ * Canonical catalog of the languages supported by GLPI.
+ *
+ * This registry is the single source of truth for language data. The legacy
+ * `$CFG_GLPI['languages']` and `$CFG_GLPI['main_languages']` arrays are derived
+ * from it (see {@see self::toLegacyArray()} and {@see self::getMainLanguages()})
+ * for backward compatibility.
+ */
+final class LanguageRegistry
+{
+    /**
+     * @var array<string, Language>|null Memoized catalog, code => Language.
+     */
+    private static ?array $languages = null;
+
+    /**
+     * All supported languages, indexed by their regionalized code.
+     *
+     * @return array<string, Language>
+     */
+    public static function all(): array
+    {
+        if (self::$languages === null) {
+            $languages = [];
+            foreach (self::definitions() as $language) {
+                $languages[$language->code] = $language;
+            }
+            self::$languages = $languages;
+        }
+
+        return self::$languages;
+    }
+
+    /**
+     * Whether the given code matches a supported language.
+     */
+    public static function has(string $code): bool
+    {
+        return array_key_exists($code, self::all());
+    }
+
+    /**
+     * Get the language matching the given code.
+     *
+     * When the code is unknown, a default {@see Language} instance
+     * is returned, so callers can always rely on a valid page lang,
+     * plural number, etc.
+     */
+    public static function get(string $code): Language
+    {
+        return self::all()[$code] ?? new Language(
+            code: $code,
+            native_name: $code,
+            mo_file: 'en_GB.mo',
+        );
+    }
+
+    /**
+     * Get the language matching the given code, or `null` if it is unknown.
+     */
+    public static function tryGet(string $code): ?Language
+    {
+        return self::all()[$code] ?? null;
+    }
+
+    /**
+     * Mapping of region-less language codes to their main regionalized locale
+     * (e.g. `fr` => `fr_FR`).
+     *
+     * @return array<string, string>
+     */
+    public static function getMainLanguages(): array
+    {
+        return [
+            // 'ar' => 'ar_SA', // not sure about the default region for arabic language
+            'az' => 'az_AZ',
+            'bg' => 'bg_BG',
+            'bn' => 'bn_BD',
+            'id' => 'id_ID',
+            'ms' => 'ms_MY',
+            'ca' => 'ca_ES',
+            'cs' => 'cs_CZ',
+            'de' => 'de_DE',
+            'da' => 'da_DK',
+            'et' => 'et_EE',
+            'en' => 'en_GB',
+            'es' => 'es_ES',
+            'eu' => 'eu_ES',
+            'fr' => 'fr_FR',
+            'gl' => 'gl_ES',
+            'el' => 'el_GR',
+            'he' => 'he_IL',
+            'hi' => 'hi_IN',
+            'hr' => 'hr_HR',
+            'hu' => 'hu_HU',
+            'it' => 'it_IT',
+            'km' => 'km_KH',
+            'lv' => 'lv_LV',
+            'lt' => 'lt_LT',
+            'mn' => 'mn_MN',
+            'nl' => 'nl_NL',
+            'nb' => 'nb_NO',
+            'nn' => 'nn_NO',
+            'fa' => 'fa_IR',
+            'pl' => 'pl_PL',
+            'pt' => 'pt_BR',
+            'ro' => 'ro_RO',
+            'ru' => 'ru_RU',
+            'sk' => 'sk_SK',
+            'sl' => 'sl_SI',
+            'sq' => 'sq_AL',
+            'sr' => 'sr_RS',
+            'fi' => 'fi_FI',
+            'sv' => 'sv_SE',
+            'vi' => 'vi_VN',
+            'th' => 'th_TH',
+            'tr' => 'tr_TR',
+            'uk' => 'uk_UA',
+            'ja' => 'ja_JP',
+            'zh' => 'zh_CN',
+            'ko' => 'ko_KR',
+            'be' => 'be_BY',
+            'is' => 'is_IS',
+        ];
+    }
+
+    /**
+     * Resolve a region-less code to its main regionalized locale
+     * (e.g. `fr` => `fr_FR`), or `null` if there is no mapping.
+     */
+    public static function getMainLanguage(string $short_code): ?string
+    {
+        return self::getMainLanguages()[$short_code] ?? null;
+    }
+
+    /**
+     * Resolve an arbitrary language code to a supported one, being tolerant to
+     * the region: a direct match is preferred, then a fallback through the
+     * region-less to main-locale mapping (e.g. `pl` => `pl_PL`).
+     *
+     * @return string|null The supported code, or `null` if none matches.
+     */
+    public static function resolve(string $code): ?string
+    {
+        if (self::has($code)) {
+            return $code;
+        }
+
+        $main = self::getMainLanguage($code);
+        if ($main !== null && self::has($main)) {
+            return $main;
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the legacy positional `$CFG_GLPI['languages']` array from the
+     * catalog, for backward compatibility.
+     *
+     * Columns: [0] native name, [1] MO file, [2] jQuery code, [3] JS/page code,
+     * [4] english name, [5] plural number.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string, 4: string, 5: int}>
+     */
+    public static function toLegacyArray(): array
+    {
+        $legacy = [];
+        foreach (self::all() as $code => $language) {
+            $legacy[$code] = [
+                $language->native_name,
+                $language->mo_file,
+                $language->jquery_code,
+                $language->js_code,
+                $language->english_name,
+                $language->plural_number,
+            ];
+        }
+
+        return $legacy;
+    }
+
+    /**
+     * Canonical language definitions.
+     *
+     * Order is preserved for backward compatibility with the legacy array.
+     *
+     * @return list<Language>
+     */
+    private static function definitions(): array
+    {
+        return [
+            new Language('ar_SA', 'العربية السعودية', js_code: 'ar_SA', english_name: 'arabic', plural_number: 103),
+            new Language('ar_IQ', 'العربية العراق', english_name: 'irak arabic', plural_number: 103),
+            new Language('ar_SY', 'العربية سوريا', english_name: 'syria arabic', plural_number: 103),
+            new Language('az_AZ', 'Azərbaycan dili', english_name: 'azerbaijani'),
+            new Language('bg_BG', 'Български', english_name: 'bulgarian'),
+            new Language('bn_BD', 'বাংলা (বাংলাদেশ)', js_code: 'bn_BD', english_name: 'bengali'),
+            new Language('id_ID', 'Bahasa Indonesia', english_name: 'indonesian'),
+            new Language('ms_MY', 'Bahasa Melayu', english_name: 'malay'),
+            new Language('ca_ES', 'Català', english_name: 'catalan'), // ca_CA
+            new Language('cs_CZ', 'Čeština', english_name: 'czech', plural_number: 10),
+            new Language('de_DE', 'Deutsch', english_name: 'german'),
+            new Language('da_DK', 'Dansk', english_name: 'danish'), // dk_DK
+            new Language('et_EE', 'Eesti', english_name: 'estonian'), // ee_ET
+            new Language('en_GB', 'English', jquery_code: 'en-GB', js_code: 'en', english_name: 'english'),
+            new Language('en_US', 'English (US)', jquery_code: 'en-GB', js_code: 'en', english_name: 'english'),
+            new Language('es_AR', 'Español (Argentina)', english_name: 'spanish'),
+            new Language('es_EC', 'Español (Ecuador)', english_name: 'spanish'),
+            new Language('es_CO', 'Español (Colombia)', english_name: 'spanish'),
+            new Language('es_ES', 'Español (España)', english_name: 'spanish'),
+            new Language('es_419', 'Español (América Latina)', english_name: 'spanish'),
+            new Language('es_MX', 'Español (Mexico)', english_name: 'spanish'),
+            new Language('es_VE', 'Español (Venezuela)', english_name: 'spanish'),
+            new Language('eu_ES', 'Euskara', english_name: 'basque'),
+            new Language('fr_FR', 'Français', english_name: 'french'),
+            new Language('fr_CA', 'Français (Canada)', english_name: 'french'),
+            new Language('fr_BE', 'Français (Belgique)', english_name: 'french'),
+            new Language('gl_ES', 'Galego', english_name: 'galician'),
+            new Language('el_GR', 'Ελληνικά', english_name: 'greek'), // el_EL
+            new Language('he_IL', 'עברית', english_name: 'hebrew'), // he_HE
+            new Language('hi_IN', 'हिन्दी', js_code: 'hi_IN', english_name: 'hindi'),
+            new Language('hr_HR', 'Hrvatski', english_name: 'croatian'),
+            new Language('hu_HU', 'Magyar', english_name: 'hungarian'),
+            new Language('it_IT', 'Italiano', english_name: 'italian'),
+            new Language('km_KH', 'ខ្មែរ (កម្ពុជា)', js_code: 'km_KH', english_name: 'cambodgian khmer', plural_number: 0),
+            new Language('kn', 'ಕನ್ನಡ', jquery_code: 'en-GB', js_code: 'en', english_name: 'kannada'),
+            new Language('lv_LV', 'Latviešu', english_name: 'latvian'),
+            new Language('lt_LT', 'Lietuvių', english_name: 'lithuanian'),
+            new Language('mn_MN', 'Монгол хэл', english_name: 'mongolian'),
+            new Language('nl_NL', 'Nederlands', english_name: 'dutch'),
+            new Language('nl_BE', 'Flemish', english_name: 'flemish'),
+            new Language('nb_NO', 'Norsk (Bokmål)', jquery_code: 'no', english_name: 'norwegian'),
+            new Language('nn_NO', 'Norsk (Nynorsk)', jquery_code: 'no', english_name: 'norwegian'),
+            new Language('fa_IR', 'فارسی', english_name: 'persian'),
+            new Language('pl_PL', 'Polski', english_name: 'polish'),
+            new Language('pt_PT', 'Português', english_name: 'portuguese'),
+            new Language('pt_BR', 'Português do Brasil', jquery_code: 'pt-BR', english_name: 'brazilian portuguese'),
+            new Language('ro_RO', 'Română', js_code: 'en', english_name: 'romanian'),
+            new Language('ru_RU', 'Русский', english_name: 'russian'),
+            new Language('sk_SK', 'Slovenčina', english_name: 'slovak', plural_number: 10),
+            new Language('sl_SI', 'Slovenščina', english_name: 'slovenian slovene'),
+            new Language('sq_AL', 'Shqip', english_name: 'albanian'),
+            new Language('sr_RS', 'Srpski', english_name: 'serbian'),
+            new Language('fi_FI', 'Suomi', english_name: 'finish'),
+            new Language('sv_SE', 'Svenska', english_name: 'swedish'),
+            new Language('vi_VN', 'Tiếng Việt', english_name: 'vietnamese'),
+            new Language('th_TH', 'ภาษาไทย', english_name: 'thai'),
+            new Language('tr_TR', 'Türkçe', english_name: 'turkish'),
+            new Language('uk_UA', 'Українська', js_code: 'en', english_name: 'ukrainian'), // ua_UA
+            new Language('ja_JP', '日本語', english_name: 'japanese'),
+            new Language('zh_CN', '简体中文', jquery_code: 'zh-CN', english_name: 'chinese'),
+            new Language('zh_TW', '繁體中文', jquery_code: 'zh-TW', english_name: 'chinese'),
+            new Language('ko_KR', '한국/韓國', english_name: 'korean', plural_number: 1),
+            new Language('zh_HK', '香港', jquery_code: 'zh-HK', english_name: 'chinese'),
+            new Language('be_BY', 'Belarussian', english_name: 'belarussian', plural_number: 3),
+            new Language('is_IS', 'íslenska', js_code: 'en', english_name: 'icelandic'),
+            new Language('eo', 'Esperanto', js_code: 'en', english_name: 'esperanto'),
+            new Language('es_CL', 'Español chileno', english_name: 'spanish chilean'),
+        ];
+    }
+}

--- a/src/Glpi/Marketplace/Api/Plugins.php
+++ b/src/Glpi/Marketplace/Api/Plugins.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Marketplace\Api;
 
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Toolbox\HttpClient;
 use GLPINetwork;
 use Session;
@@ -368,11 +369,9 @@ class Plugins
      */
     public function getTopTags(): array
     {
-        global $CFG_GLPI;
-
         $response  = $this->request('tags/top', [
             'headers' => [
-                'X-Lang' => $CFG_GLPI['languages'][$_SESSION['glpilanguage']][2],
+                'X-Lang' => LanguageRegistry::get($_SESSION['glpilanguage'])->jquery_code,
             ],
         ]);
 

--- a/src/Glpi/Marketplace/Api/Plugins.php
+++ b/src/Glpi/Marketplace/Api/Plugins.php
@@ -371,7 +371,7 @@ class Plugins
     {
         $response  = $this->request('tags/top', [
             'headers' => [
-                'X-Lang' => LanguageRegistry::get($_SESSION['glpilanguage'])->jquery_code,
+                'X-Lang' => LanguageRegistry::get($_SESSION['glpilanguage'])->getRegionlessCode(),
             ],
         ]);
 

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -39,6 +39,7 @@ use CommonGLPI;
 use Config;
 use Document;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Marketplace\Api\Plugins as PluginsApi;
 use GLPINetwork;
 use Html;
@@ -923,9 +924,7 @@ JS;
      */
     public static function getLocalizedDescription(array $plugin = [], string $version = 'short_description'): string
     {
-        global $CFG_GLPI;
-
-        $userlang = $CFG_GLPI['languages'][$_SESSION['glpilanguage']][3] ?? "en";
+        $userlang = LanguageRegistry::get($_SESSION['glpilanguage'] ?? 'en')->getPageLang();
 
         if (!isset($plugin['descriptions'])) {
             return "";

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -70,6 +70,7 @@ use Glpi\Features\AssignableItemInterface;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\AnswersSet_FormDestinationItem;
 use Glpi\Form\Form;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\RichText\RichText;
 use Glpi\Search\Input\QueryBuilder;
@@ -7735,8 +7736,11 @@ final class SQLProvider implements SearchProviderInterface
                     return \htmlescape($out);
 
                 case "language":
-                    if (isset($data[$ID][0]['name'], $CFG_GLPI['languages'][$data[$ID][0]['name']])) {
-                        return $CFG_GLPI['languages'][$data[$ID][0]['name']][0];
+                    $language = isset($data[$ID][0]['name'])
+                        ? LanguageRegistry::tryGet($data[$ID][0]['name'])
+                        : null;
+                    if ($language !== null) {
+                        return $language->native_name;
                     }
                     return __('Default value');
                 case 'progressbar':

--- a/src/Html.php
+++ b/src/Html.php
@@ -48,6 +48,7 @@ use Glpi\Form\Form;
 use Glpi\Form\ServiceCatalog\ServiceCatalog;
 use Glpi\Inventory\Inventory;
 use Glpi\Kernel\Kernel;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\SecurityConfig;
 use Glpi\System\Log\LogViewer;
@@ -650,7 +651,7 @@ TWIG,
         $lang = $_SESSION['glpilanguage'] ?? Session::getPreferredLanguage();
 
         $tpl_vars = [
-            'lang'               => $CFG_GLPI["languages"][$lang][3],
+            'lang'               => LanguageRegistry::get($lang)->getPageLang(),
             'title'              => $title,
             'theme'              => $theme,
             'is_anonymous_page'  => false,
@@ -1200,7 +1201,7 @@ TWIG,
         /**
          * @var bool $HEADER_LOADED
          */
-        global $CFG_GLPI, $HEADER_LOADED, $DB;
+        global $HEADER_LOADED, $DB;
 
         // If in modal : display popHeader
         if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal']) {
@@ -1314,7 +1315,7 @@ TWIG,
             // select2
             $filename = sprintf(
                 'lib/select2/js/i18n/%s.js',
-                $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2]
+                LanguageRegistry::get($_SESSION['glpilanguage'])->jquery_code
             );
             if (file_exists(GLPI_ROOT . '/public/' . $filename)) {
                 $tpl_vars['js_files'][] = ['path' => $filename];
@@ -3133,8 +3134,9 @@ JS;
         $language_RFC5646    = str_replace('_', '-', $_SESSION['glpilanguage']);      // convert to RFC5646 format (fr_FR -> fr-FR)
         $language_regionless = preg_replace('/_.*$/', '', $_SESSION['glpilanguage']); // fallback to regionless locale (fr_FR -> fr)
         $expected_languages  = [$language_RFC5646, $language_regionless];
-        if (array_key_exists($language_regionless, $CFG_GLPI['main_languages'])) {
-            $expected_languages[] = str_replace('_', '-', $CFG_GLPI['main_languages'][$language_regionless]); // fallback to main language (fr_CA -> fr_FR)
+        $main_language       = LanguageRegistry::getMainLanguage($language_regionless);
+        if ($main_language !== null) {
+            $expected_languages[] = str_replace('_', '-', $main_language); // fallback to main language (fr_CA -> fr_FR)
         }
         $language_opts = '';
         foreach ($expected_languages as $language) {
@@ -5485,7 +5487,7 @@ JS);
      */
     public static function requireJs($name)
     {
-        global $CFG_GLPI, $PLUGIN_HOOKS;
+        global $PLUGIN_HOOKS;
 
         if (isset($_SESSION['glpi_js_toload'][$name])) {
             //already in stack
@@ -5509,13 +5511,14 @@ JS);
                 $_SESSION['glpi_js_toload'][$name][] = 'js/flatpickr_buttons_plugin.js';
                 if (isset($_SESSION['glpilanguage'])) {
                     $filename = "lib/flatpickr/l10n/"
-                    . strtolower($CFG_GLPI["languages"][$_SESSION['glpilanguage']][3]) . ".js";
+                    . strtolower(LanguageRegistry::get($_SESSION['glpilanguage'])->js_code) . ".js";
                     if (file_exists(GLPI_ROOT . '/public/' . $filename)) {
                         $_SESSION['glpi_js_toload'][$name][] = $filename;
                         break;
                     }
                 }
                 break;
+
             case 'fileupload':
                 $_SESSION['glpi_js_toload'][$name][] = 'lib/jquery-file-upload.js';
                 $_SESSION['glpi_js_toload'][$name][] = 'js/fileupload.js';
@@ -5608,7 +5611,7 @@ JS);
         if (isset($_SESSION['glpilanguage'])) {
             // select2
             $filename = "lib/select2/js/i18n/"
-                     . $CFG_GLPI["languages"][$_SESSION['glpilanguage']][2] . ".js";
+                     . LanguageRegistry::get($_SESSION['glpilanguage'])->jquery_code . ".js";
             if (file_exists(GLPI_ROOT . '/public/' . $filename)) {
                 echo Html::script($filename);
             }

--- a/src/NotificationTemplateTranslation.php
+++ b/src/NotificationTemplateTranslation.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\RichText\RichText;
 
 /**
@@ -77,10 +78,8 @@ class NotificationTemplateTranslation extends CommonDBChild
     #[Override]
     protected function computeFriendlyName()
     {
-        global $CFG_GLPI;
-
         if ($this->fields['language'] !== '') {
-            return $CFG_GLPI['languages'][$this->fields['language']][0];
+            return LanguageRegistry::get($this->fields['language'])->native_name;
         }
         return __('Default translation');
     }
@@ -132,7 +131,7 @@ class NotificationTemplateTranslation extends CommonDBChild
      */
     public function showSummary(NotificationTemplate $template, $options = [])
     {
-        global $CFG_GLPI, $DB;
+        global $DB;
 
         $nID     = $template->getID();
         $canedit = Config::canUpdate();
@@ -159,7 +158,7 @@ TWIG, $twig_params);
         ) {
             if ($this->getFromDB($data['id'])) {
                 $href = self::getFormURL() . "?id=" . $data['id'] . "&notificationtemplates_id=" . $nID;
-                $lang = $data['language'] !== '' ? $CFG_GLPI['languages'][$data['language']][0] : __('Default translation');
+                $lang = $data['language'] !== '' ? LanguageRegistry::get($data['language'])->native_name : __('Default translation');
 
                 $entries[] = [
                     'itemtype' => self::class,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -44,6 +44,7 @@ use Glpi\Debug\Profiler;
 use Glpi\Event;
 use Glpi\Exception\RedirectException;
 use Glpi\Exception\SessionExpiredException;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Marketplace\Controller as MarketplaceController;
 use Glpi\Marketplace\View as MarketplaceView;
 use Glpi\Plugin\Hooks;
@@ -579,17 +580,18 @@ class Plugin extends CommonDBTM
                 continue;
             }
             $locales_dir = "$base_dir/$plugin_key/locales/";
+            $trytoload_lang = LanguageRegistry::tryGet($trytoload);
+            $default_lang = !empty($CFG_GLPI["language"]) ? LanguageRegistry::tryGet($CFG_GLPI["language"]) : null;
             if (
-                array_key_exists($trytoload, $CFG_GLPI["languages"])
-                && file_exists($locales_dir . $CFG_GLPI["languages"][$trytoload][1])
+                $trytoload_lang !== null
+                && file_exists($locales_dir . $trytoload_lang->mo_file)
             ) {
-                $mofile = $locales_dir . $CFG_GLPI["languages"][$trytoload][1];
+                $mofile = $locales_dir . $trytoload_lang->mo_file;
             } elseif (
-                !empty($CFG_GLPI["language"])
-                && array_key_exists($CFG_GLPI["language"], $CFG_GLPI["languages"])
-                && file_exists($locales_dir . $CFG_GLPI["languages"][$CFG_GLPI["language"]][1])
+                $default_lang !== null
+                && file_exists($locales_dir . $default_lang->mo_file)
             ) {
-                $mofile = $locales_dir . $CFG_GLPI["languages"][$CFG_GLPI["language"]][1];
+                $mofile = $locales_dir . $default_lang->mo_file;
             } elseif (file_exists($locales_dir . "en_GB.mo")) {
                 $mofile = $locales_dir . "en_GB.mo";
             }
@@ -3278,7 +3280,7 @@ class Plugin extends CommonDBTM
      */
     private function resetHookableCacheEntries(string $plugin_key): bool
     {
-        global $CFG_GLPI, $GLPI_CACHE;
+        global $GLPI_CACHE;
 
         $to_clear = [
             // Plugin lowercase/case-sensitive class names mapping.
@@ -3289,7 +3291,7 @@ class Plugin extends CommonDBTM
             'all_possible_rights',
         ];
 
-        foreach (array_keys($CFG_GLPI['languages']) as $language) {
+        foreach (array_keys(LanguageRegistry::all()) as $language) {
             // Hookable using `$CFG_GLPI['device_types']`, `$CFG_GLPI['asset_types']`,
             // and `Hooks::DASHBOARD_FILTERS`.
             $to_clear[] = Grid::getAllDashboardCardsCacheKey($language);

--- a/src/Session.php
+++ b/src/Session.php
@@ -40,6 +40,7 @@ use Glpi\Event;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\SessionExpiredException;
 use Glpi\Kernel\Kernel;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\SessionTracker;
 use Glpi\Session\SessionInfo;
@@ -853,16 +854,17 @@ class Session
             $trytoload = $CFG_GLPI["language"];
         }
 
-        if (isset($CFG_GLPI["languages"][$trytoload])) {
-            $newfile = "/" . $CFG_GLPI["languages"][$trytoload][1];
+        $language = LanguageRegistry::tryGet($trytoload);
+        if ($language !== null) {
+            $newfile = "/" . $language->mo_file;
         }
 
         if (empty($newfile) || !is_file(GLPI_I18N_DIR . $newfile)) {
             $newfile = "/en_GB.mo";
         }
 
-        if (isset($CFG_GLPI["languages"][$trytoload][5])) {
-            $_SESSION['glpipluralnumber'] = $CFG_GLPI["languages"][$trytoload][5];
+        if ($language !== null) {
+            $_SESSION['glpipluralnumber'] = $language->plural_number;
         }
 
         $_SESSION['glpiisrtl'] = self::isRTL($trytoload);
@@ -946,7 +948,7 @@ class Session
      */
     public static function loadAllCoreLocales(): void
     {
-        global $CFG_GLPI, $TRANSLATE;
+        global $TRANSLATE;
 
         $core_folders = is_dir(GLPI_LOCAL_I18N_DIR) ? scandir(GLPI_LOCAL_I18N_DIR) : [];
         $core_folders = array_filter($core_folders, static function ($dir) {
@@ -964,8 +966,8 @@ class Session
         $core_folders = [GLPI_I18N_DIR, ...$core_folders];
 
         foreach ($core_folders as $core_folder) {
-            foreach ($CFG_GLPI['languages'] as $lang => $data) {
-                $mofile = "$core_folder/" . $data['1'];
+            foreach (LanguageRegistry::all() as $lang => $language) {
+                $mofile = "$core_folder/" . $language->mo_file;
                 $phpfile = str_replace('.mo', '.php', $mofile);
 
                 // Load local PHP file if it exists
@@ -998,17 +1000,11 @@ class Session
             $accepted_languages = $request->getLanguages();
 
             foreach ($accepted_languages as $language) {
-                // Direct match with locale key (e.g., 'pl_PL')
-                if (array_key_exists($language, $CFG_GLPI['languages'])) {
-                    return $language;
-                }
-
-                // Fallback using main_languages mapping (e.g., 'pl' -> 'pl_PL')
-                if (isset($CFG_GLPI['main_languages'][$language])) {
-                    $main_lang = $CFG_GLPI['main_languages'][$language];
-                    if (array_key_exists($main_lang, $CFG_GLPI['languages'])) {
-                        return $main_lang;
-                    }
+                // Region-tolerant resolution: direct match (e.g. 'pl_PL'),
+                // then fallback through the main languages mapping ('pl' -> 'pl_PL').
+                $resolved = LanguageRegistry::resolve($language);
+                if ($resolved !== null) {
+                    return $resolved;
                 }
             }
         }
@@ -2490,11 +2486,7 @@ class Session
      */
     public static function isRTL($locale): bool
     {
-        if (function_exists('locale_is_right_to_left')) {
-            return locale_is_right_to_left($locale);
-        }
-
-        return (bool) preg_match('/^(?:ar|he|fa|ur|ps|sd|ug|ckb|yi|dv|ku_arab|ku-arab)(?:[_-].*)?$/i', $locale);
+        return LanguageRegistry::get($locale)->isRTL();
     }
 
     public static function getLoginSessionUID(): ?string

--- a/src/User.php
+++ b/src/User.php
@@ -45,6 +45,7 @@ use Glpi\Features\Clonable;
 use Glpi\Features\TreeBrowse;
 use Glpi\Features\TreeBrowseInterface;
 use Glpi\Kernel\Kernel;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Plugin\Hooks;
 use Glpi\Security\SessionTracker;
 use Glpi\Security\TOTPManager;
@@ -312,7 +313,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
         }
 
         // Fallback for invalid language
-        if (!isset($CFG_GLPI['languages'][$this->fields["language"]])) {
+        if (!LanguageRegistry::has($this->fields["language"])) {
             $this->fields["language"] = $CFG_GLPI["language"];
         }
     }

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -35,6 +35,7 @@
 
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Config\ProxyExclusions;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Marketplace\Controller;
 use Glpi\Socket;
 use Glpi\SocketModel;
@@ -46,138 +47,22 @@ $CFG_GLPI = [];
 // set the default app_name
 $CFG_GLPI['app_name'] = 'GLPI';
 
-// Languages dictionnary:
-// 0 => regionalized lang code
-// 1 => translated (native) name
-// 2 => MO file Name
-// 3 => jquery lang code
-// 4 => other JS codes. Tinymce has a specific mapping in Html::initEditorSystem().
+// Languages data.
+// The `languages` and `main_languages` arrays are derived from the canonical
+// Glpi\Locale\LanguageRegistry catalog and kept here for backward compatibility
+// (plugins, ...). GLPI core code should rely on Glpi\Locale\LanguageRegistry
+// instead (and the `get_language_name()` Twig function in templates).
+//
+// Each `languages` entry is a positional array:
+// 0 => translated (native) name
+// 1 => MO file Name
+// 2 => jquery lang code
+// 3 => other JS codes. Tinymce has a specific mapping in Html::initEditorSystem().
 //      ⚠️ Also used for page lang! ⚠️
-// 5 => english name
-// 6 => number for plural
-$CFG_GLPI['languages'] = [
-    //Code       Name in native lang          LANG FILE      jquery  js    english name            standard plural number
-    'ar_SA'  => ['العربية السعودية',          'ar_SA.mo',    'ar',    'ar_SA', 'arabic',            103],
-    'ar_IQ'  => ['العربية العراق',            'ar_IQ.mo',    'ar',    'ar', 'irak arabic',          103],
-    'ar_SY'  => ['العربية سوريا',             'ar_SY.mo',    'ar',    'ar', 'syria arabic',         103],
-    'az_AZ'  => ['Azərbaycan dili',           'az_AZ.mo',    'az',    'az', 'azerbaijani',          2],
-    'bg_BG'  => ['Български',                 'bg_BG.mo',    'bg',    'bg', 'bulgarian',            2],
-    'bn_BD'  => ['বাংলা (বাংলাদেশ)',          'bn_BD.mo',    'bn',    'bn_BD', 'bengali',           2],
-    'id_ID'  => ['Bahasa Indonesia',          'id_ID.mo',    'id',    'id', 'indonesian',           2],
-    'ms_MY'  => ['Bahasa Melayu',             'ms_MY.mo',    'ms',    'ms', 'malay',                2],
-    'ca_ES'  => ['Català',                    'ca_ES.mo',    'ca',    'ca', 'catalan',              2], // ca_CA
-    'cs_CZ'  => ['Čeština',                   'cs_CZ.mo',    'cs',    'cs', 'czech',                10],
-    'de_DE'  => ['Deutsch',                   'de_DE.mo',    'de',    'de', 'german',               2],
-    'da_DK'  => ['Dansk',                     'da_DK.mo',    'da',    'da', 'danish',               2], // dk_DK
-    'et_EE'  => ['Eesti',                     'et_EE.mo',    'et',    'et', 'estonian',             2], // ee_ET
-    'en_GB'  => ['English',                   'en_GB.mo',    'en-GB', 'en', 'english',              2],
-    'en_US'  => ['English (US)',              'en_US.mo',    'en-GB', 'en', 'english',              2],
-    'es_AR'  => ['Español (Argentina)',       'es_AR.mo',    'es',    'es', 'spanish',              2],
-    'es_EC'  => ['Español (Ecuador)',         'es_EC.mo',    'es',    'es', 'spanish',              2],
-    'es_CO'  => ['Español (Colombia)',        'es_CO.mo',    'es',    'es', 'spanish',              2],
-    'es_ES'  => ['Español (España)',          'es_ES.mo',    'es',    'es', 'spanish',              2],
-    'es_419' => ['Español (América Latina)',  'es_419.mo',   'es',    'es', 'spanish',              2],
-    'es_MX'  => ['Español (Mexico)',          'es_MX.mo',    'es',    'es', 'spanish',              2],
-    'es_VE'  => ['Español (Venezuela)',       'es_VE.mo',    'es',    'es', 'spanish',              2],
-    'eu_ES'  => ['Euskara',                   'eu_ES.mo',    'eu',    'eu', 'basque',               2],
-    'fr_FR'  => ['Français',                  'fr_FR.mo',    'fr',    'fr', 'french',               2],
-    'fr_CA'  => ['Français (Canada)',         'fr_CA.mo',    'fr',    'fr', 'french',               2],
-    'fr_BE'  => ['Français (Belgique)',       'fr_BE.mo',    'fr',    'fr', 'french',               2],
-    'gl_ES'  => ['Galego',                    'gl_ES.mo',    'gl',    'gl', 'galician',             2],
-    'el_GR'  => ['Ελληνικά',                  'el_GR.mo',    'el',    'el', 'greek',                2], // el_EL
-    'he_IL'  => ['עברית',                     'he_IL.mo',    'he',    'he', 'hebrew',               2], // he_HE
-    'hi_IN'  => ['हिन्दी',                     'hi_IN.mo',    'hi',    'hi_IN', 'hindi',             2],
-    'hr_HR'  => ['Hrvatski',                  'hr_HR.mo',    'hr',    'hr', 'croatian',             2],
-    'hu_HU'  => ['Magyar',                    'hu_HU.mo',    'hu',    'hu', 'hungarian',            2],
-    'it_IT'  => ['Italiano',                  'it_IT.mo',    'it',    'it', 'italian',              2],
-    'km_KH'  => ['ខ្មែរ (កម្ពុជា)',              'km_KH.mo',    'km',    'km_KH', 'cambodgian khmer',  0],
-    'kn'     => ['ಕನ್ನಡ',                      'kn.mo',       'en-GB', 'en', 'kannada',              2],
-    'lv_LV'  => ['Latviešu',                  'lv_LV.mo',    'lv',    'lv', 'latvian',              2],
-    'lt_LT'  => ['Lietuvių',                  'lt_LT.mo',    'lt',    'lt', 'lithuanian',           2],
-    'mn_MN'  => ['Монгол хэл',                'mn_MN.mo',    'mn',    'mn', 'mongolian',            2],
-    'nl_NL'  => ['Nederlands',                'nl_NL.mo',    'nl',    'nl', 'dutch',                2],
-    'nl_BE'  => ['Flemish',                   'nl_BE.mo',    'nl',    'nl', 'flemish',              2],
-    'nb_NO'  => ['Norsk (Bokmål)',            'nb_NO.mo',    'no',    'nb', 'norwegian',            2],
-    'nn_NO'  => ['Norsk (Nynorsk)',           'nn_NO.mo',    'no',    'nn', 'norwegian',            2],
-    'fa_IR'  => ['فارسی',                     'fa_IR.mo',    'fa',    'fa', 'persian',              2],
-    'pl_PL'  => ['Polski',                    'pl_PL.mo',    'pl',    'pl', 'polish',               2],
-    'pt_PT'  => ['Português',                 'pt_PT.mo',    'pt',    'pt', 'portuguese',           2],
-    'pt_BR'  => ['Português do Brasil',       'pt_BR.mo',    'pt-BR', 'pt', 'brazilian portuguese', 2],
-    'ro_RO'  => ['Română',                    'ro_RO.mo',    'ro',    'en', 'romanian',             2],
-    'ru_RU'  => ['Русский',                   'ru_RU.mo',    'ru',    'ru', 'russian',              2],
-    'sk_SK'  => ['Slovenčina',                'sk_SK.mo',    'sk',    'sk', 'slovak',               10],
-    'sl_SI'  => ['Slovenščina',               'sl_SI.mo',    'sl',    'sl', 'slovenian slovene',    2],
-    'sq_AL'  => ['Shqip',                     'sq_AL.mo',    'sq',    'sq', 'albanian',             2],
-    'sr_RS'  => ['Srpski',                    'sr_RS.mo',    'sr',    'sr', 'serbian',              2],
-    'fi_FI'  => ['Suomi',                     'fi_FI.mo',    'fi',    'fi', 'finish',               2],
-    'sv_SE'  => ['Svenska',                   'sv_SE.mo',    'sv',    'sv', 'swedish',              2],
-    'vi_VN'  => ['Tiếng Việt',                'vi_VN.mo',    'vi',    'vi', 'vietnamese',           2],
-    'th_TH'  => ['ภาษาไทย',                   'th_TH.mo',    'th',    'th', 'thai',                 2],
-    'tr_TR'  => ['Türkçe',                    'tr_TR.mo',    'tr',    'tr', 'turkish',              2],
-    'uk_UA'  => ['Українська',                'uk_UA.mo',    'uk',    'en', 'ukrainian',            2], // ua_UA
-    'ja_JP'  => ['日本語',                    'ja_JP.mo',    'ja',    'ja', 'japanese',             2],
-    'zh_CN'  => ['简体中文',                  'zh_CN.mo',    'zh-CN', 'zh', 'chinese',              2],
-    'zh_TW'  => ['繁體中文',                  'zh_TW.mo',    'zh-TW', 'zh', 'chinese',              2],
-    'ko_KR'  => ['한국/韓國',                 'ko_KR.mo',    'ko',    'ko', 'korean',               1],
-    'zh_HK'  => ['香港',                      'zh_HK.mo',    'zh-HK', 'zh', 'chinese',              2],
-    'be_BY'  => ['Belarussian',               'be_BY.mo',    'be',    'be', 'belarussian',          3],
-    'is_IS'  => ['íslenska',                  'is_IS.mo',    'is',    'en', 'icelandic',            2],
-    'eo'     => ['Esperanto',                 'eo.mo',       'eo',    'en', 'esperanto',            2],
-    'es_CL'  => ['Español chileno',           'es_CL.mo',    'es',    'es', 'spanish chilean',      2],
-];
-
-// Mapping of short language codes to their main locale
-$CFG_GLPI['main_languages'] = [
-    // 'ar' => 'ar_SA', // not sure about the default region for arabic language
-    'az' => 'az_AZ',
-    'bg' => 'bg_BG',
-    'bn' => 'bn_BD',
-    'id' => 'id_ID',
-    'ms' => 'ms_MY',
-    'ca' => 'ca_ES',
-    'cs' => 'cs_CZ',
-    'de' => 'de_DE',
-    'da' => 'da_DK',
-    'et' => 'et_EE',
-    'en' => 'en_GB',
-    'es' => 'es_ES',
-    'eu' => 'eu_ES',
-    'fr' => 'fr_FR',
-    'gl' => 'gl_ES',
-    'el' => 'el_GR',
-    'he' => 'he_IL',
-    'hi' => 'hi_IN',
-    'hr' => 'hr_HR',
-    'hu' => 'hu_HU',
-    'it' => 'it_IT',
-    'km' => 'km_KH',
-    'lv' => 'lv_LV',
-    'lt' => 'lt_LT',
-    'mn' => 'mn_MN',
-    'nl' => 'nl_NL',
-    'nb' => 'nb_NO',
-    'nn' => 'nn_NO',
-    'fa' => 'fa_IR',
-    'pl' => 'pl_PL',
-    'pt' => 'pt_BR',
-    'ro' => 'ro_RO',
-    'ru' => 'ru_RU',
-    'sk' => 'sk_SK',
-    'sl' => 'sl_SI',
-    'sq' => 'sq_AL',
-    'sr' => 'sr_RS',
-    'fi' => 'fi_FI',
-    'sv' => 'sv_SE',
-    'vi' => 'vi_VN',
-    'th' => 'th_TH',
-    'tr' => 'tr_TR',
-    'uk' => 'uk_UA',
-    'ja' => 'ja_JP',
-    'zh' => 'zh_CN',
-    'ko' => 'ko_KR',
-    'be' => 'be_BY',
-    'is' => 'is_IS',
-];
+// 4 => english name
+// 5 => number for plural
+$CFG_GLPI['languages']      = LanguageRegistry::toLegacyArray();
+$CFG_GLPI['main_languages'] = LanguageRegistry::getMainLanguages();
 
 // Init to store glpi itemtype / tables link
 $CFG_GLPI['glpitables'] = [];

--- a/templates/pages/admin/customobjects/translations.html.twig
+++ b/templates/pages/admin/customobjects/translations.html.twig
@@ -90,7 +90,7 @@
                 {% for trans_data in translations %}
                     <tr data-field="{{ trans_data['id'] }}" data-language="{{ trans_data['language'] }}" data-translation="{{ trans_data['translation']|json_encode }}">
                         <td>{{ trans_data['name'] }}</td>
-                        <td lang="{{ trans_data['language'] }}">{{ config('languages')[trans_data['language']][0] }}</td>
+                        <td lang="{{ trans_data['language'] }}">{{ get_language_name(trans_data['language']) }}</td>
                         <td lang="{{ trans_data['language'] }}">
                             {% include "pages/admin/customobjects/plurals.html.twig" with {
                                 'plurals': trans_data['translation'],

--- a/tests/functional/Glpi/Locale/LanguageRegistryTest.php
+++ b/tests/functional/Glpi/Locale/LanguageRegistryTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/tests/functional/Glpi/Locale/LanguageRegistryTest.php
+++ b/tests/functional/Glpi/Locale/LanguageRegistryTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Locale;
+
+use Glpi\Locale\Language;
+use Glpi\Locale\LanguageRegistry;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class LanguageRegistryTest extends GLPITestCase
+{
+    public function testAllReturnsLanguageObjectsKeyedByCode(): void
+    {
+        $all = LanguageRegistry::all();
+
+        $this->assertNotEmpty($all);
+        foreach ($all as $code => $language) {
+            $this->assertInstanceOf(Language::class, $language);
+            $this->assertSame($code, $language->code);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function hasProvider(): iterable
+    {
+        yield 'known regionalized'   => ['fr_FR', true];
+        yield 'known no-region'      => ['eo', true];
+        yield 'short code is no key' => ['fr', false];
+        yield 'unknown'              => ['xx_XX', false];
+    }
+
+    #[DataProvider('hasProvider')]
+    public function testHas(string $code, bool $expected): void
+    {
+        $this->assertSame($expected, LanguageRegistry::has($code));
+    }
+
+    public function testGetKnownLanguage(): void
+    {
+        $language = LanguageRegistry::get('fr_FR');
+        $this->assertSame('fr_FR', $language->code);
+        $this->assertSame('Français', $language->native_name);
+        $this->assertSame('fr', $language->getPageLang());
+    }
+
+    public function testGetUnknownLanguageReturnsAcceptableDefaultAndNeverNull(): void
+    {
+        $language = LanguageRegistry::get('xx_YY');
+
+        // Never null: callers can always rely on a valid lang
+        $this->assertInstanceOf(Language::class, $language);
+        $this->assertSame('xx_YY', $language->code);
+        // The page lang falls back to the region-less part of the requested code.
+        $this->assertSame('xx', $language->getPageLang());
+        $this->assertSame('en_GB.mo', $language->mo_file);
+        $this->assertSame(2, $language->plural_number);
+    }
+
+    public function testTryGet(): void
+    {
+        $this->assertInstanceOf(Language::class, LanguageRegistry::tryGet('fr_FR'));
+        $this->assertNull(LanguageRegistry::tryGet('xx_YY'));
+    }
+
+    public function testGetMainLanguage(): void
+    {
+        $this->assertSame('fr_FR', LanguageRegistry::getMainLanguage('fr'));
+        $this->assertSame('zh_CN', LanguageRegistry::getMainLanguage('zh'));
+        $this->assertNull(LanguageRegistry::getMainLanguage('xx'));
+        // A full locale is not a short-code key.
+        $this->assertNull(LanguageRegistry::getMainLanguage('fr_FR'));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function resolveProvider(): iterable
+    {
+        yield 'direct match'                   => ['fr_FR', 'fr_FR'];
+        yield 'short code fallback'            => ['fr', 'fr_FR'];
+        yield 'short code fallback (polish)'   => ['pl', 'pl_PL'];
+        yield 'english short code'             => ['en', 'en_GB'];
+        yield 'supported region variant'       => ['fr_CA', 'fr_CA'];
+        yield 'unsupported region, no mapping' => ['es_PE', null];
+        yield 'unknown'                        => ['xx', null];
+    }
+
+    #[DataProvider('resolveProvider')]
+    public function testResolve(string $code, ?string $expected): void
+    {
+        $this->assertSame($expected, LanguageRegistry::resolve($code));
+    }
+
+    public function testToLegacyArrayReproducesTheHistoricalPositionalArray(): void
+    {
+        // `$CFG_GLPI['languages']` array must remain identical to the historical positional definition, so
+        // for backward compatibility.
+        $this->assertSame($this->historicalLegacyArray(), LanguageRegistry::toLegacyArray());
+    }
+
+    public function testToLegacyArrayEntriesAreWellFormed(): void
+    {
+        foreach (LanguageRegistry::toLegacyArray() as $code => $row) {
+            $this->assertCount(6, $row, "Language $code must have 6 columns");
+            $this->assertIsString($row[0], "native name of $code");
+            $this->assertIsString($row[1], "MO file of $code");
+            $this->assertIsString($row[2], "jQuery code of $code");
+            $this->assertIsString($row[3], "JS code of $code");
+            $this->assertIsString($row[4], "english name of $code");
+            $this->assertIsInt($row[5], "plural number of $code");
+        }
+    }
+
+    /**
+     * Snapshot of the positional `$CFG_GLPI['languages']` array as it was
+     * defined before the introduction of {@see LanguageRegistry}.
+     *
+     * Columns: [0] native name, [1] MO file, [2] jQuery code, [3] JS code,
+     * [4] english name, [5] plural number.
+     *
+     * @return array<string, array{0: string, 1: string, 2: string, 3: string, 4: string, 5: int}>
+     */
+    private function historicalLegacyArray(): array
+    {
+        return [
+            'ar_SA'   => ['العربية السعودية', 'ar_SA.mo', 'ar', 'ar_SA', 'arabic', 103],
+            'ar_IQ'   => ['العربية العراق', 'ar_IQ.mo', 'ar', 'ar', 'irak arabic', 103],
+            'ar_SY'   => ['العربية سوريا', 'ar_SY.mo', 'ar', 'ar', 'syria arabic', 103],
+            'az_AZ'   => ['Azərbaycan dili', 'az_AZ.mo', 'az', 'az', 'azerbaijani', 2],
+            'bg_BG'   => ['Български', 'bg_BG.mo', 'bg', 'bg', 'bulgarian', 2],
+            'bn_BD'   => ['বাংলা (বাংলাদেশ)', 'bn_BD.mo', 'bn', 'bn_BD', 'bengali', 2],
+            'id_ID'   => ['Bahasa Indonesia', 'id_ID.mo', 'id', 'id', 'indonesian', 2],
+            'ms_MY'   => ['Bahasa Melayu', 'ms_MY.mo', 'ms', 'ms', 'malay', 2],
+            'ca_ES'   => ['Català', 'ca_ES.mo', 'ca', 'ca', 'catalan', 2],
+            'cs_CZ'   => ['Čeština', 'cs_CZ.mo', 'cs', 'cs', 'czech', 10],
+            'de_DE'   => ['Deutsch', 'de_DE.mo', 'de', 'de', 'german', 2],
+            'da_DK'   => ['Dansk', 'da_DK.mo', 'da', 'da', 'danish', 2],
+            'et_EE'   => ['Eesti', 'et_EE.mo', 'et', 'et', 'estonian', 2],
+            'en_GB'   => ['English', 'en_GB.mo', 'en-GB', 'en', 'english', 2],
+            'en_US'   => ['English (US)', 'en_US.mo', 'en-GB', 'en', 'english', 2],
+            'es_AR'   => ['Español (Argentina)', 'es_AR.mo', 'es', 'es', 'spanish', 2],
+            'es_EC'   => ['Español (Ecuador)', 'es_EC.mo', 'es', 'es', 'spanish', 2],
+            'es_CO'   => ['Español (Colombia)', 'es_CO.mo', 'es', 'es', 'spanish', 2],
+            'es_ES'   => ['Español (España)', 'es_ES.mo', 'es', 'es', 'spanish', 2],
+            'es_419'  => ['Español (América Latina)', 'es_419.mo', 'es', 'es', 'spanish', 2],
+            'es_MX'   => ['Español (Mexico)', 'es_MX.mo', 'es', 'es', 'spanish', 2],
+            'es_VE'   => ['Español (Venezuela)', 'es_VE.mo', 'es', 'es', 'spanish', 2],
+            'eu_ES'   => ['Euskara', 'eu_ES.mo', 'eu', 'eu', 'basque', 2],
+            'fr_FR'   => ['Français', 'fr_FR.mo', 'fr', 'fr', 'french', 2],
+            'fr_CA'   => ['Français (Canada)', 'fr_CA.mo', 'fr', 'fr', 'french', 2],
+            'fr_BE'   => ['Français (Belgique)', 'fr_BE.mo', 'fr', 'fr', 'french', 2],
+            'gl_ES'   => ['Galego', 'gl_ES.mo', 'gl', 'gl', 'galician', 2],
+            'el_GR'   => ['Ελληνικά', 'el_GR.mo', 'el', 'el', 'greek', 2],
+            'he_IL'   => ['עברית', 'he_IL.mo', 'he', 'he', 'hebrew', 2],
+            'hi_IN'   => ['हिन्दी', 'hi_IN.mo', 'hi', 'hi_IN', 'hindi', 2],
+            'hr_HR'   => ['Hrvatski', 'hr_HR.mo', 'hr', 'hr', 'croatian', 2],
+            'hu_HU'   => ['Magyar', 'hu_HU.mo', 'hu', 'hu', 'hungarian', 2],
+            'it_IT'   => ['Italiano', 'it_IT.mo', 'it', 'it', 'italian', 2],
+            'km_KH'   => ['ខ្មែរ (កម្ពុជា)', 'km_KH.mo', 'km', 'km_KH', 'cambodgian khmer', 0],
+            'kn'      => ['ಕನ್ನಡ', 'kn.mo', 'en-GB', 'en', 'kannada', 2],
+            'lv_LV'   => ['Latviešu', 'lv_LV.mo', 'lv', 'lv', 'latvian', 2],
+            'lt_LT'   => ['Lietuvių', 'lt_LT.mo', 'lt', 'lt', 'lithuanian', 2],
+            'mn_MN'   => ['Монгол хэл', 'mn_MN.mo', 'mn', 'mn', 'mongolian', 2],
+            'nl_NL'   => ['Nederlands', 'nl_NL.mo', 'nl', 'nl', 'dutch', 2],
+            'nl_BE'   => ['Flemish', 'nl_BE.mo', 'nl', 'nl', 'flemish', 2],
+            'nb_NO'   => ['Norsk (Bokmål)', 'nb_NO.mo', 'no', 'nb', 'norwegian', 2],
+            'nn_NO'   => ['Norsk (Nynorsk)', 'nn_NO.mo', 'no', 'nn', 'norwegian', 2],
+            'fa_IR'   => ['فارسی', 'fa_IR.mo', 'fa', 'fa', 'persian', 2],
+            'pl_PL'   => ['Polski', 'pl_PL.mo', 'pl', 'pl', 'polish', 2],
+            'pt_PT'   => ['Português', 'pt_PT.mo', 'pt', 'pt', 'portuguese', 2],
+            'pt_BR'   => ['Português do Brasil', 'pt_BR.mo', 'pt-BR', 'pt', 'brazilian portuguese', 2],
+            'ro_RO'   => ['Română', 'ro_RO.mo', 'ro', 'en', 'romanian', 2],
+            'ru_RU'   => ['Русский', 'ru_RU.mo', 'ru', 'ru', 'russian', 2],
+            'sk_SK'   => ['Slovenčina', 'sk_SK.mo', 'sk', 'sk', 'slovak', 10],
+            'sl_SI'   => ['Slovenščina', 'sl_SI.mo', 'sl', 'sl', 'slovenian slovene', 2],
+            'sq_AL'   => ['Shqip', 'sq_AL.mo', 'sq', 'sq', 'albanian', 2],
+            'sr_RS'   => ['Srpski', 'sr_RS.mo', 'sr', 'sr', 'serbian', 2],
+            'fi_FI'   => ['Suomi', 'fi_FI.mo', 'fi', 'fi', 'finish', 2],
+            'sv_SE'   => ['Svenska', 'sv_SE.mo', 'sv', 'sv', 'swedish', 2],
+            'vi_VN'   => ['Tiếng Việt', 'vi_VN.mo', 'vi', 'vi', 'vietnamese', 2],
+            'th_TH'   => ['ภาษาไทย', 'th_TH.mo', 'th', 'th', 'thai', 2],
+            'tr_TR'   => ['Türkçe', 'tr_TR.mo', 'tr', 'tr', 'turkish', 2],
+            'uk_UA'   => ['Українська', 'uk_UA.mo', 'uk', 'en', 'ukrainian', 2],
+            'ja_JP'   => ['日本語', 'ja_JP.mo', 'ja', 'ja', 'japanese', 2],
+            'zh_CN'   => ['简体中文', 'zh_CN.mo', 'zh-CN', 'zh', 'chinese', 2],
+            'zh_TW'   => ['繁體中文', 'zh_TW.mo', 'zh-TW', 'zh', 'chinese', 2],
+            'ko_KR'   => ['한국/韓國', 'ko_KR.mo', 'ko', 'ko', 'korean', 1],
+            'zh_HK'   => ['香港', 'zh_HK.mo', 'zh-HK', 'zh', 'chinese', 2],
+            'be_BY'   => ['Belarussian', 'be_BY.mo', 'be', 'be', 'belarussian', 3],
+            'is_IS'   => ['íslenska', 'is_IS.mo', 'is', 'en', 'icelandic', 2],
+            'eo'      => ['Esperanto', 'eo.mo', 'eo', 'en', 'esperanto', 2],
+            'es_CL'   => ['Español chileno', 'es_CL.mo', 'es', 'es', 'spanish chilean', 2],
+        ];
+    }
+}

--- a/tests/functional/Glpi/Locale/LanguageTest.php
+++ b/tests/functional/Glpi/Locale/LanguageTest.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------

--- a/tests/functional/Glpi/Locale/LanguageTest.php
+++ b/tests/functional/Glpi/Locale/LanguageTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Locale;
+
+use Glpi\Locale\Language;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class LanguageTest extends GLPITestCase
+{
+    public function testDefaultsAreDerivedFromCode(): void
+    {
+        $language = new Language(code: 'fr_FR', native_name: 'Français');
+
+        $this->assertSame('fr_FR', $language->code);
+        $this->assertSame('Français', $language->native_name);
+        // MO file, jQuery code and JS code default from the code.
+        $this->assertSame('fr_FR.mo', $language->mo_file);
+        $this->assertSame('fr', $language->jquery_code);
+        $this->assertSame('fr', $language->js_code);
+        // English name and plural number have acceptable defaults.
+        $this->assertSame('', $language->english_name);
+        $this->assertSame(2, $language->plural_number);
+    }
+
+    public function testExplicitValuesOverrideDefaults(): void
+    {
+        $language = new Language(
+            code: 'en_GB',
+            native_name: 'English',
+            mo_file: 'custom.mo',
+            jquery_code: 'en-GB',
+            js_code: 'en',
+            english_name: 'english',
+            plural_number: 3,
+        );
+
+        $this->assertSame('custom.mo', $language->mo_file);
+        $this->assertSame('en-GB', $language->jquery_code);
+        $this->assertSame('en', $language->js_code);
+        $this->assertSame('english', $language->english_name);
+        $this->assertSame(3, $language->plural_number);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function regionlessProvider(): iterable
+    {
+        yield 'regionalized'    => ['fr_FR', 'fr'];
+        yield 'numeric region'  => ['es_419', 'es'];
+        yield 'no region'       => ['eo', 'eo'];
+    }
+
+    #[DataProvider('regionlessProvider')]
+    public function testGetRegionlessCode(string $code, string $expected): void
+    {
+        $language = new Language(code: $code, native_name: 'whatever');
+        $this->assertSame($expected, $language->getRegionlessCode());
+        // The JS/jQuery codes default to the region-less code.
+        $this->assertSame($expected, $language->js_code);
+        $this->assertSame($expected, $language->jquery_code);
+    }
+
+    public function testGetPageLangReturnsJsCode(): void
+    {
+        $language = new Language(code: 'zh_CN', native_name: '简体中文', js_code: 'zh');
+        $this->assertSame('zh', $language->getPageLang());
+        $this->assertSame($language->js_code, $language->getPageLang());
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function rtlProvider(): iterable
+    {
+        yield 'arabic'  => ['ar_SA', true];
+        yield 'hebrew'  => ['he_IL', true];
+        yield 'persian' => ['fa_IR', true];
+        yield 'french'  => ['fr_FR', false];
+        yield 'english' => ['en_GB', false];
+    }
+
+    #[DataProvider('rtlProvider')]
+    public function testIsRTL(string $code, bool $expected): void
+    {
+        $language = new Language(code: $code, native_name: 'whatever');
+        $this->assertSame($expected, $language->isRTL());
+    }
+}


### PR DESCRIPTION
Replace opaque positional access to `$CFG_GLPI['languages'][$code][0..5]`
with a typed value object and registry.
Legacy array is kept for backward compatibility.