### PR TITLE
Fix: allow clearing single actor selection in forms

### DIFF
--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeActors.php
@@ -36,6 +36,7 @@
 namespace Glpi\Form\QuestionType;
 
 use CommonDBTM;
+use Dropdown;
 use Exception;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
@@ -384,6 +385,7 @@ abstract class AbstractQuestionTypeActors extends AbstractQuestionType implement
                 'mb'              : '',
                 'right_for_users' : right_for_users,
                 'group_conditions': group_conditions,
+                'placeholder'     : placeholder,
             }
         ]) %}
 
@@ -416,6 +418,8 @@ TWIG;
             'aria_label'         => $question->fields['name'],
             'right_for_users'    => $this->getRightForUsers(),
             'group_conditions'   => $this->getGroupConditions(),
+            // Non-empty placeholder enables the select2 clear button in Html::jsAjaxDropdown()
+            'placeholder'        => $is_multiple_actors ? '' : Dropdown::EMPTY_VALUE,
         ]);
     }
 

--- a/templates/pages/admin/form/question_type/actors_admin.html.twig
+++ b/templates/pages/admin/form/question_type/actors_admin.html.twig
@@ -45,6 +45,7 @@
         'right_for_users' : right_for_users,
         'group_conditions': group_conditions,
         'aria_label'      : __('Select an actor...'),
+        'placeholder'     : __('Select an actor...'),
         'specific_tags'   : is_multiple_actors ? {
             'disabled': 'disabled'
         } : {}

--- a/tests/cypress/e2e/form/question_types/actors.cy.js
+++ b/tests/cypress/e2e/form/question_types/actors.cy.js
@@ -80,7 +80,7 @@ describe('Actor form question type', () => {
         cy.reload();
 
         // Check the default value
-        cy.getDropdownByLabelText('Select an actor...').should('have.text', 'e2e_tests');
+        cy.getDropdownByLabelText('Select an actor...').should('have.text', '×e2e_tests');
     });
 
     it('should be able to define multiple actors as default value', () => {
@@ -119,7 +119,7 @@ describe('Actor form question type', () => {
         cy.reload();
 
         // Check the default value
-        cy.getDropdownByLabelText('Select an actor...').should('have.text', 'e2e_tests');
+        cy.getDropdownByLabelText('Select an actor...').should('have.text', '×e2e_tests');
 
         // Focus on the question
         cy.findByRole('option', { name: 'Test actor question' })

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -165,6 +165,13 @@ export class GlpiPage
         ;
     }
 
+    public async assertDropdownIsClearable(dropdown: Locator): Promise<void>
+    {
+        // We have no control on select2 selectors
+        // eslint-disable-next-line playwright/no-raw-locators
+        await expect(dropdown.locator('.select2-selection__clear')).toBeVisible();
+    }
+
     public async doLogout(): Promise<void>
     {
         await this.user_menu.click();

--- a/tests/e2e/specs/Form/QuestionTypes/actors.spec.ts
+++ b/tests/e2e/specs/Form/QuestionTypes/actors.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from "crypto";
+import { test } from '../../../fixtures/glpi_fixture';
+import { Profiles } from "../../../utils/Profiles";
+import { getWorkerEntityId } from '../../../utils/WorkerEntities';
+import { FormPage } from "../../../pages/FormPage";
+
+test('Can clear the default value of an actor question in the form editor', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const form = new FormPage(page);
+
+    const uuid = randomUUID();
+    const form_id = await api.createItem('Glpi\\Form\\Form', {
+        name: `Form - ${uuid}`,
+        entities_id: getWorkerEntityId(),
+    });
+    await form.goto(form_id);
+
+    const question = await form.addQuestion('Actor question');
+    await form.setQuestionType(question, 'Actors');
+
+    const default_value_dropdown = form
+        .getDropdownByLabel('Select an actor...', question)
+        .filter({ visible: true });
+    await form.doSetDropdownValue(default_value_dropdown, 'glpi', false);
+
+    await form.assertDropdownIsClearable(default_value_dropdown);
+});
+
+test('Can clear a selected actor when answering a form', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const form = new FormPage(page);
+
+    const uuid = randomUUID();
+    const form_id = await api.createItem('Glpi\\Form\\Form', {
+        name: `Form - ${uuid}`,
+        entities_id: getWorkerEntityId(),
+    });
+    await form.goto(form_id);
+
+    const question = await form.addQuestion('Actor question');
+    await form.setQuestionType(question, 'Actors');
+    await form.doSetActive();
+    await form.doSaveFormEditor();
+
+    await form.doPreviewForm();
+
+    const answer_dropdown = form.getDropdownByLabel('Actor question');
+    await form.doSetDropdownValue(answer_dropdown, 'glpi', false);
+
+    await form.assertDropdownIsClearable(answer_dropdown);
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45180
- In V10, a single-select actor question (Acteur, Demandeur, Observateur, Assigne) could be cleared back to empty once a value was selected, via select2's clear button.
- In V11 this clear button had disappeared, so once an actor was chosen it could no longer be unselected, breaking form logic that relies on the actor field being empty.
- This restores the clear button both when answering a form and when setting the default value in the form editor.

## Screenshots (if appropriate):


