### PR TITLE
FIX / Expiration date format in certificates/domains search results

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6532,7 +6532,7 @@ final class SQLProvider implements SearchProviderInterface
                             break;
                         }
                         return "<div class='badge_block' style='border-color: " . \htmlescape($color) . "'>
-                        <span style='background: " . \htmlescape($color) . "'></span>&nbsp;" . \htmlescape($date) . "
+                        <span style='background: " . \htmlescape($color) . "'></span>&nbsp;" . \htmlescape(Html::convDate($date)) . "
                        </div>";
                     }
                     break;
@@ -6541,7 +6541,7 @@ final class SQLProvider implements SearchProviderInterface
                         && ($data[$ID][0]['name'] < $_SESSION['glpi_currenttime'])
                     ) {
                         return "<div class='badge_block' style='border-color: #cf9b9b'>
-                        <span style='background: #cf9b9b'></span>&nbsp;" . \htmlescape($data[$ID][0]['name']) . "
+                        <span style='background: #cf9b9b'></span>&nbsp;" . \htmlescape(Html::convDate($data[$ID][0]['name'])) . "
                        </div>";
                     }
 

--- a/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
+++ b/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
@@ -34,8 +34,12 @@
 
 namespace tests\units\Glpi\Search\Provider;
 
+use Certificate;
+use Domain;
 use Glpi\Search\Provider\SQLProvider;
 use Glpi\Tests\DbTestCase;
+use Html;
+use Search;
 
 class SQLProviderTest extends DbTestCase
 {
@@ -76,5 +80,89 @@ class SQLProviderTest extends DbTestCase
             ' LEFT JOIN `glpi_tickets` ON (`glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_1` OR `glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_2`)',
             $it->analyseJoins($item_item_revert_join)
         );
+    }
+
+    /**
+     * Regression test to validate that the expiration date badge shown for
+     * Certificate items in search results respects the user's configured
+     * date format instead of always displaying the raw database value.
+     *
+     * @see https://github.com/glpi-project/glpi/pull/24866
+     */
+    public function testCertificateExpirationDateBadgeRespectsDateFormat()
+    {
+        $this->login();
+
+        $expiration_date = date('Y-m-d', strtotime('-10 days'));
+
+        $this->createItem(Certificate::class, [
+            'name'            => __FUNCTION__,
+            'entities_id'     => $this->getTestRootEntity(true),
+            'date_expiration' => $expiration_date,
+        ]);
+
+        $_SESSION['glpidate_format'] = 1; // d-m-Y
+
+        $result = Search::getDatas(
+            Certificate::class,
+            [
+                'criteria' => [
+                    [
+                        'field'      => '1',
+                        'searchtype' => 'contains',
+                        'value'      => __FUNCTION__,
+                    ],
+                ],
+            ],
+            [10] // date_expiration
+        );
+
+        $this->assertTrue(isset($result['data']['rows'][0]['Certificate_10']['displayname']));
+        $displayname = $result['data']['rows'][0]['Certificate_10']['displayname'];
+
+        $this->assertStringContainsString(Html::convDate($expiration_date), $displayname);
+        $this->assertStringNotContainsString($expiration_date, $displayname);
+    }
+
+    /**
+     * Regression test to validate that the expiration date badge shown for
+     * Domain items in search results respects the user's configured date
+     * format instead of always displaying the raw database value.
+     *
+     * @see https://github.com/glpi-project/glpi/pull/24866
+     */
+    public function testDomainExpirationDateBadgeRespectsDateFormat()
+    {
+        $this->login();
+
+        $expiration_date = date('Y-m-d H:i:s', strtotime('-10 days'));
+
+        $this->createItem(Domain::class, [
+            'name'            => __FUNCTION__,
+            'entities_id'     => $this->getTestRootEntity(true),
+            'date_expiration' => $expiration_date,
+        ]);
+
+        $_SESSION['glpidate_format'] = 1; // d-m-Y
+
+        $result = Search::getDatas(
+            Domain::class,
+            [
+                'criteria' => [
+                    [
+                        'field'      => '1',
+                        'searchtype' => 'contains',
+                        'value'      => __FUNCTION__,
+                    ],
+                ],
+            ],
+            [6] // date_expiration
+        );
+
+        $this->assertTrue(isset($result['data']['rows'][0]['Domain_6']['displayname']));
+        $displayname = $result['data']['rows'][0]['Domain_6']['displayname'];
+
+        $this->assertStringContainsString(Html::convDate($expiration_date), $displayname);
+        $this->assertStringNotContainsString($expiration_date, $displayname);
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45292
- The expiration date badge shown for `Certificate` and `Domain` items in search results always displayed the raw database value (`Y-m-d`), ignoring the user's configured date format (e.g. `d-m-Y`). Probably a regression from #20601, which added the colored expiration badge but returned the raw date instead of reusing the existing `date` datatype formatting.
Now, the displayed date is wrapped with `Html::convDate()` in both cases.

## Screenshots :

Before :
<img width="2314" height="440" alt="Capture d’écran du 2026-07-16 12-08-34" src="https://github.com/user-attachments/assets/6d8e2777-0149-4d60-a41d-46d471d489eb" />

After : 
<img width="2314" height="440" alt="Capture d’écran du 2026-07-16 12-09-04" src="https://github.com/user-attachments/assets/6fa686ac-680e-4805-8454-4664282f063e" />

