### PR TITLE
Drop MariaDB 10.6 support; fixes schema checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
               {
                 "include": [
                   {"php-version": "8.5", "db-image": "mariadb:12.3", "run-js-tests": true},
-                  {"php-version": "8.3", "db-image": "mariadb:10.6", "run-js-tests": false},
+                  {"php-version": "8.3", "db-image": "mariadb:10.11", "run-js-tests": false},
                   {"php-version": "8.5", "db-image": "mysql:9.7", "run-js-tests": false},
                   {"php-version": "8.5", "db-image": "mysql:8.0", "run-js-tests": false}
                 ]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ It is distributed under the GNU GENERAL PUBLIC LICENSE Version 3 - please consul
 ## Prerequisites
 
 * A web server (Apache, Nginx, IIS, etc.)
-* MariaDB >= 10.6 or MySQL >= 8.0
+* MariaDB >= 10.11 or MySQL >= 8.0
 * PHP >= 8.3
 * Mandatory PHP extensions:
     - dom, fileinfo, filter, libxml, simplexml, xmlreader, xmlwriter (these are enabled in PHP by default)

--- a/install/migrations/update_11.0.x_to_12.0.0/sessions.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/sessions.php
@@ -66,7 +66,7 @@ if (!$DB->tableExists('glpi_users_sessions')) {
             `user_agent` varchar(512) NOT NULL,
             `auth_type` tinyint NOT NULL,
             `created_at` timestamp NOT NULL,
-            `last_activity_at` timestamp NOT NULL,
+            `last_activity_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`),
             UNIQUE KEY `login_session_uid` (`login_session_uid`),
             KEY `users_id` (`users_id`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10555,7 +10555,7 @@ CREATE TABLE `glpi_users_sessions` (
     `user_agent` varchar(512) NOT NULL,
     `auth_type` tinyint NOT NULL,
     `created_at` timestamp NOT NULL,
-    `last_activity_at` timestamp NOT NULL,
+    `last_activity_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`),
     UNIQUE KEY `login_session_uid` (`login_session_uid`),
     KEY `users_id` (`users_id`),

--- a/src/Config.php
+++ b/src/Config.php
@@ -1191,9 +1191,9 @@ class Config extends CommonDBTM
         $server  = preg_match('/-MariaDB/', $raw) ? 'MariaDB' : 'MySQL';
         $version = preg_replace('/^((\d+\.?)+).*$/', '$1', $raw);
 
-        // MySQL >= 8.0 || MariaDB >= 10.6
+        // MySQL >= 8.0 || MariaDB >= 10.11
         $is_supported = $server === 'MariaDB'
-            ? version_compare($version, '10.6', '>=')
+            ? version_compare($version, '10.11', '>=')
             : version_compare($version, '8.0', '>=');
 
         return [$version => $is_supported];

--- a/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -538,6 +538,8 @@ class DatabaseSchemaIntegrityChecker
             // for example, the create query might return "UNIQUE KEY `unicity` USING HASH (`users_id`)" one side
             // and "UNIQUE KEY `unicity` (`users_id`)" on the other side, despite being the same index.
             '/(UNIQUE KEY|FULLTEXT KEY|KEY) (.*) USING (\w+)/i' => '$1 $2',
+            // Ignore ASC order in indexes fields
+            '/(`\w+`)\s* ASC/' => '$1',
         ];
         $indexes = preg_replace(array_keys($indexes_replacements), array_values($indexes_replacements), $indexes);
         if (!$this->strict) {
@@ -659,7 +661,7 @@ class DatabaseSchemaIntegrityChecker
                         $sql = substr($sql, 0, $i) . ' ' . substr($sql, $i);
                         $i++;
                     } elseif ($is_protected && preg_match('/\s/', $sql[$i + 1]) !== 1) {
-                        // Closing backtick, ensure there is a space before
+                        // Closing backtick, ensure there is a space after
                         $sql = substr($sql, 0, $i + 1) . ' ' . substr($sql, $i + 1);
                         $i++;
                     }
@@ -690,6 +692,22 @@ class DatabaseSchemaIntegrityChecker
                 $sql[$i] = ' ';
             }
 
+            // Remove duplicated whitespaces
+            if ($sql[$i] === ' ') {
+                $extraspaces = 0;
+                for ($j = $i + 1; $j < strlen($sql); $j++) {
+                    if ($sql[$j] === ' ') {
+                        $extraspaces++;
+                    } else {
+                        break;
+                    }
+                }
+                if ($extraspaces > 0) {
+                    $sql = substr($sql, 0, $i) . substr($sql, $i + $extraspaces);
+                    $i--;
+                }
+            }
+
             // Ensure there is a new line:
             // - after columns/indexes definition opening parenthesis
             // - before columns/indexes definition opening parenthesis
@@ -705,21 +723,22 @@ class DatabaseSchemaIntegrityChecker
                 $i++;
             }
 
-            if (preg_match('/\s/', $sql[$i])) {
-                if ($parenthesis_level === 2) {
-                    // Remove whitespaces between tokens in index fields list, datatype length, ...
+            if ($parenthesis_level === 2) {
+                // Normalize whitespaces between tokens in index fields list, datatype length, ...
+
+                // Remove extra whitespaces
+                if (
+                    preg_match('/\s/', $sql[$i])
+                    && (
+                        $sql[$i - 1] === ',' // whitespace after coma
+                        || $sql[$i - 1] === '(' // whitespace after parenthesis opening
+                        || $sql[$i + 1] === ')' // whitespace before parenthesis closing
+                        || $sql[$i + 1] === ',' // whitespace before coma
+                        || $sql[$i + 1] === ' ' // duplicated whitespace
+                    )
+                ) {
                     $sql = substr($sql, 0, $i) . substr($sql, $i + 1);
                     $i--;
-                } else {
-                    // Remove following whitespace chars if current char is a whitespace
-                    $extraspaces = 0;
-                    $max         = strlen($sql) - $i - 1;
-                    while ($extraspaces < $max && preg_match('/\s/', $sql[$i + 1 + $extraspaces])) {
-                        $extraspaces++;
-                    }
-                    if ($extraspaces > 0) {
-                        $sql = substr($sql, 0, $i + 1) . substr($sql, $i + 1 + $extraspaces);
-                    }
                 }
             }
         }

--- a/src/Glpi/System/Requirement/DbEngine.php
+++ b/src/Glpi/System/Requirement/DbEngine.php
@@ -69,7 +69,7 @@ class DbEngine extends AbstractRequirement
 
         switch ($server) {
             case 'MariaDB':
-                $min_version = '10.6';
+                $min_version = '10.11';
                 break;
             case 'MySQL':
             default:

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -396,6 +396,22 @@ class ConfigTest extends DbTestCase
             ], [
                 'raw'       => '10.6.7-MariaDB-1:10.6.7-2ubuntu1.1',
                 'version'   => '10.6.7',
+                'compat'    => false,
+            ], [
+                'raw'       => '10.11.18-MariaDB',
+                'version'   => '10.11.18',
+                'compat'    => true,
+            ], [
+                'raw'       => '11.4.12-MariaDB',
+                'version'   => '11.4.12',
+                'compat'    => true,
+            ], [
+                'raw'       => '11.8.8-MariaDB',
+                'version'   => '11.8.8',
+                'compat'    => true,
+            ], [
+                'raw'       => '12.3.2-MariaDB',
+                'version'   => '12.3.2',
                 'compat'    => true,
             ], [
                 'raw'       => '5.6.38-log',
@@ -408,6 +424,14 @@ class ConfigTest extends DbTestCase
             ], [
                 'raw'       => '8.0.23-standard',
                 'version'   => '8.0.23',
+                'compat'    => true,
+            ], [
+                'raw'       => '8.4.10',
+                'version'   => '8.4.10',
+                'compat'    => true,
+            ], [
+                'raw'       => '9.7.1',
+                'version'   => '9.7.1',
                 'compat'    => true,
             ],
         ];

--- a/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityCheckerTest.php
+++ b/tests/functional/Glpi/System/Diagnostic/DatabaseSchemaIntegrityCheckerTest.php
@@ -2278,4 +2278,45 @@ SQL,
             $normalized_sql
         );
     }
+
+    public function testIndexFieldOrderAreSupported(): void
+    {
+        // Arrange: get the SQL of a table that uses index with fields order
+        $sql = <<<SQL
+CREATE TABLE `glpi_objects` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `objects_id` int unsigned NOT NULL,
+  `level` int unsigned NOT NULL,
+  `valid_until` timestamp NOT NULL,
+  KEY `level` (`level` ASC),
+  KEY `validity` (`objects_id`, `valid_until`  DESC )
+) COLLATE=utf8mb4_unicode_ci DEFAULT CHARSET=utf8mb4 ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+SQL;
+
+        // Act: normalize the SQL
+        $db = $this->getDbMock();
+        $integrity_checker = new DatabaseSchemaIntegrityChecker(
+            $db,
+        );
+        $normalized_sql = $this->callPrivateMethod(
+            $integrity_checker,
+            'getNormalizedSql',
+            $sql
+        );
+
+        // Assert: the index fields order are normalized
+        $this->assertEquals(
+            <<<SQL
+CREATE TABLE `glpi_objects` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `objects_id` int unsigned NOT NULL,
+  `level` int unsigned NOT NULL,
+  `valid_until` timestamp NOT NULL,
+  KEY `level` (`level`),
+  KEY `validity` (`objects_id`,`valid_until` DESC)
+) COLLATE=utf8mb4_unicode_ci DEFAULT CHARSET=utf8mb4 ENGINE=InnoDB ROW_FORMAT=DYNAMIC
+SQL,
+            $normalized_sql
+        );
+    }
 }

--- a/tests/functional/Glpi/System/Requirement/DbConfigurationTest.php
+++ b/tests/functional/Glpi/System/Requirement/DbConfigurationTest.php
@@ -45,7 +45,7 @@ class DbConfigurationTest extends GLPITestCase
     {
         return [
             [
-                // Default variables on MySQL 8.0
+                // Default variables on MySQL
                 'version'   => '8.0.24-standard',
                 'variables' => [
                     'innodb_page_size'    => 16384,
@@ -67,7 +67,7 @@ class DbConfigurationTest extends GLPITestCase
                 ],
             ],
             [
-                // Incompatible variables on MySQL 8.0
+                // Incompatible variables on MySQL
                 'version'   => '8.0.24-standard',
                 'variables' => [
                     'innodb_page_size'    => 4096,
@@ -78,8 +78,8 @@ class DbConfigurationTest extends GLPITestCase
                 ],
             ],
             [
-                // Default variables on MariaDB 10.6
-                'version'   => '10.6.8-MariaDB',
+                // Default variables on MariaDB
+                'version'   => '10.11.18-MariaDB',
                 'variables' => [
                     'innodb_page_size'    => 16384,
                 ],
@@ -89,8 +89,8 @@ class DbConfigurationTest extends GLPITestCase
                 ],
             ],
             [
-                // Incompatible variables on MariaDB 10.6
-                'version'   => '10.6.8-MariaDB',
+                // Incompatible variables on MariaDB
+                'version'   => '10.11.18-MariaDB',
                 'variables' => [
                     'innodb_page_size'    => 4096,
                 ],

--- a/tests/functional/Glpi/System/Requirement/DbEngineTest.php
+++ b/tests/functional/Glpi/System/Requirement/DbEngineTest.php
@@ -65,34 +65,69 @@ class DbEngineTest extends GLPITestCase
                 'messages'  => ['Database engine version (8.0.23) is supported.'],
             ],
             [
+                'version'   => '8.0.23-standard',
+                'validated' => true,
+                'messages'  => ['Database engine version (8.0.23) is supported.'],
+            ],
+            [
+                'version'   => '8.4.6',
+                'validated' => true,
+                'messages'  => ['Database engine version (8.4.6) is supported.'],
+            ],
+            [
+                'version'   => '9.7.1',
+                'validated' => true,
+                'messages'  => ['Database engine version (9.7.1) is supported.'],
+            ],
+            [
                 'version'   => '10.1.48-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.6.'],
+                'messages'  => ['Database engine version (10.1.48) is not supported. Minimum required version is MariaDB 10.11.'],
             ],
             [
                 'version'   => '10.2.36-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.6.'],
+                'messages'  => ['Database engine version (10.2.36) is not supported. Minimum required version is MariaDB 10.11.'],
             ],
             [
                 'version'   => '10.3.28-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.3.28) is not supported. Minimum required version is MariaDB 10.6.'],
+                'messages'  => ['Database engine version (10.3.28) is not supported. Minimum required version is MariaDB 10.11.'],
             ],
             [
                 'version'   => '10.4.8-MariaDB-1:10.4.8+maria~bionic',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.4.8) is not supported. Minimum required version is MariaDB 10.6.'],
+                'messages'  => ['Database engine version (10.4.8) is not supported. Minimum required version is MariaDB 10.11.'],
             ],
             [
                 'version'   => '10.5.9-MariaDB',
                 'validated' => false,
-                'messages'  => ['Database engine version (10.5.9) is not supported. Minimum required version is MariaDB 10.6.'],
+                'messages'  => ['Database engine version (10.5.9) is not supported. Minimum required version is MariaDB 10.11.'],
             ],
             [
                 'version'   => '10.6.12-MariaDB',
+                'validated' => false,
+                'messages'  => ['Database engine version (10.6.12) is not supported. Minimum required version is MariaDB 10.11.'],
+            ],
+            [
+                'version'   => '10.11.18-MariaDB',
                 'validated' => true,
-                'messages'  => ['Database engine version (10.6.12) is supported.'],
+                'messages'  => ['Database engine version (10.11.18) is supported.'],
+            ],
+            [
+                'version'   => '11.4.12-MariaDB',
+                'validated' => true,
+                'messages'  => ['Database engine version (11.4.12) is supported.'],
+            ],
+            [
+                'version'   => '11.8.8-MariaDB',
+                'validated' => true,
+                'messages'  => ['Database engine version (11.8.8) is supported.'],
+            ],
+            [
+                'version'   => '12.3.2-MariaDB',
+                'validated' => true,
+                'messages'  => ['Database engine version (12.3.2) is supported.'],
             ],
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

It fixes #24806.

Each commit can be reviewed separately.

1. Add explicit default value for `glpi_users_sessions.last_activity_at`. Older MariaDB versions would force a `0000-00-00 00:00:00` default value when the field is used in an index.
2. Add index fields order support in schema checks, to properly handle `` KEY `users_id` (`users_id`, `logged_in_at` DESC) `` case.
3. Drop MariaDB 10.6 support, since it does not support fields order in indexes. MariaDB 10.11 LTS is the default version since RHEL 8.10/9.4 (05/2024), Debian Bookworm (06/2023) and Ubuntu 24.04 LTS (04/2024).