### PR TITLE
Fix #24521: SQL query error using linked custom assets

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1180,7 +1180,7 @@ final class SQLProvider implements SearchProviderInterface
 
             if (!empty($complexjoin)) {
                 if ($opt['linkfield'] === 'custom_fields') {
-                    if (!str_contains($table, '_custom_field_')) {
+                    if (!str_contains($table, '_custom_field_') && $table === 'glpi_assets_assets') {
                         $table .= "_custom_fields";
                     }
                 }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1180,9 +1180,9 @@ final class SQLProvider implements SearchProviderInterface
 
             if (!empty($complexjoin)) {
                 if ($opt['linkfield'] === 'custom_fields') {
-                  if (strpos($table, '_custom_field_') === false) {
-                     $table .= "_custom_fields";
-                  }
+                    if (!str_contains($table, '_custom_field_')) {
+                        $table .= "_custom_fields";
+                    }
                 }
                 $table .= "_" . $complexjoin;
             }

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -1179,6 +1179,11 @@ final class SQLProvider implements SearchProviderInterface
             $complexjoin = Search::computeComplexJoinID($opt['joinparams']);
 
             if (!empty($complexjoin)) {
+                if ($opt['linkfield'] === 'custom_fields') {
+                  if (strpos($table, '_custom_field_') === false) {
+                     $table .= "_custom_fields";
+                  }
+                }
                 $table .= "_" . $complexjoin;
             }
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ x] I have read the CONTRIBUTING document.
- [ x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #24521
- The SQL query in src/Glpi/Search/Provider/SQLProvider.php assumes a specific column naming convention (_custom_field_) in the SELECT clause, but the WHERE clause was missing this prefix. This causes a mismatch in the query structure.
- Added the string "_custom_field_" in the WHERE clause to align with the SELECT clause's assumption.

## Screenshots (if appropriate):


