### PR TITLE
KB : set hr opacity for both edit and no edit mode

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -32,6 +32,13 @@
 
 .article-container {
     max-width: 1320px !important;
+
+    hr {
+        border: none;
+        border-top: 1px solid var(--tblr-border-color);
+        margin: 1.5rem 0;
+        opacity: 1;
+    }
 }
 
 .kb-sidepanel {
@@ -397,12 +404,6 @@
                 background: none;
                 padding: 0;
             }
-        }
-
-        hr {
-            border: none;
-            border-top: 1px solid var(--tblr-border-color);
-            margin: 1.5rem 0;
         }
 
         // Tables


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.


## Description

- It fixes https://github.com/glpi-project/roadmap/issues/417
- Here is a brief description of what this PR does : set opacity by simply moving block to larger scope for KB article

## Screenshot : 

<img width="323" height="582" alt="image" src="https://github.com/user-attachments/assets/df09f613-5781-4d01-802a-97153413221b" />

