### PR TITLE
fix (Inventory) reset field os specific

### DIFF
--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1125,6 +1125,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
       <SERVICE_PACK>17763.8755</SERVICE_PACK>
       <VERSION>1809</VERSION>
       <HOSTID>a1b2c3d4</HOSTID>
+      <INSTALL_DATE>2025-08-13 20:32:10</INSTALL_DATE>
     </OPERATINGSYSTEM>
     <HARDWARE>
       <NAME>pc-spclear</NAME>
@@ -1155,6 +1156,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertSame('Test Company', $theos['company']);
         $this->assertSame('Windows User', $theos['owner']);
         $this->assertSame('a1b2c3d4', $theos['hostid']);
+        $this->assertSame('2025-08-13', $theos['install_date']);
 
         //second inventory: same device reinstalled under Linux, no service pack reported
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -1192,6 +1194,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertEmpty($theos['company']);
         $this->assertEmpty($theos['owner']);
         $this->assertEmpty($theos['hostid']);
+        $this->assertNull($theos['install_date']);
     }
 
     public function testLockedOsFieldKeptOnOsChange()

--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1124,6 +1124,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
       <NAME>Windows</NAME>
       <SERVICE_PACK>17763.8755</SERVICE_PACK>
       <VERSION>1809</VERSION>
+      <HOSTID>a1b2c3d4</HOSTID>
     </OPERATINGSYSTEM>
     <HARDWARE>
       <NAME>pc-spclear</NAME>
@@ -1153,6 +1154,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertTrue($ossp->getFromDBByCrit(['name' => '17763.8755']));
         $this->assertSame('Test Company', $theos['company']);
         $this->assertSame('Windows User', $theos['owner']);
+        $this->assertSame('a1b2c3d4', $theos['hostid']);
 
         //second inventory: same device reinstalled under Linux, no service pack reported
         $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
@@ -1189,6 +1191,7 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertSame(0, $theos['operatingsystemservicepacks_id']);
         $this->assertEmpty($theos['company']);
         $this->assertEmpty($theos['owner']);
+        $this->assertEmpty($theos['hostid']);
     }
 
     public function testLockedOsFieldKeptOnOsChange()

--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1191,6 +1191,95 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertEmpty($theos['owner']);
     }
 
+    public function testLockedOsFieldKeptOnOsChange()
+    {
+        $cos = new \Item_OperatingSystem();
+
+        //first inventory: a Windows host reporting a service pack and an owner
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <FULL_NAME>Microsoft Windows Server 2019 Datacenter</FULL_NAME>
+      <KERNEL_NAME>MSWin32</KERNEL_NAME>
+      <KERNEL_VERSION>10.0.17763</KERNEL_VERSION>
+      <NAME>Windows</NAME>
+      <SERVICE_PACK>17763.8755</SERVICE_PACK>
+      <VERSION>1809</VERSION>
+    </OPERATINGSYSTEM>
+    <HARDWARE>
+      <NAME>pc-splocked</NAME>
+      <WINOWNER>Windows User</WINOWNER>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sp-locked-01</SSN>
+    </BIOS>
+    <VERSIONCLIENT>GLPI-Agent_v1.16</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc-splocked</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        $computer = new \Computer();
+        $this->assertTrue($computer->getFromDBByCrit(['name' => 'pc-splocked']));
+        $computers_id = $computer->getID();
+
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->assertCount(1, $list);
+        $theos = current($list);
+        $servicepacks_id = $theos['operatingsystemservicepacks_id'];
+        $this->assertGreaterThan(0, $servicepacks_id);
+        $this->assertSame('Windows User', $theos['owner']);
+
+        //lock the service pack field so it must be preserved by the inventory
+        $lockedfield = new \Lockedfield();
+        $this->assertGreaterThan(
+            0,
+            $lockedfield->add([
+                'itemtype' => 'Item_OperatingSystem',
+                'items_id' => $theos['id'],
+                'field'    => 'operatingsystemservicepacks_id',
+            ])
+        );
+
+        //second inventory: same device reinstalled under Linux, no service pack/owner
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <FULL_NAME>Ubuntu 24.04.4 LTS</FULL_NAME>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>6.8.0-40-generic</KERNEL_VERSION>
+      <NAME>Ubuntu</NAME>
+      <VERSION>24.04.4 LTS (Noble Numbat)</VERSION>
+    </OPERATINGSYSTEM>
+    <HARDWARE>
+      <NAME>pc-splocked</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sp-locked-01</SSN>
+    </BIOS>
+    <VERSIONCLIENT>GLPI-Agent_v1.16</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc-splocked</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->assertCount(1, $list);
+        $theos = current($list);
+        //the locked service pack must have been preserved..
+        $this->assertSame($servicepacks_id, $theos['operatingsystemservicepacks_id']);
+        //..while the unlocked owner field has been cleared
+        $this->assertEmpty($theos['owner']);
+    }
+
     public function testReplayRuleOnOS()
     {
         $os = new \OperatingSystem();

--- a/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
+++ b/phpunit/functional/Glpi/Inventory/Assets/OperatingSystemTest.php
@@ -1107,6 +1107,90 @@ class OperatingSystemTest extends AbstractInventoryAsset
         $this->assertSame("a8c06c01", $theos['hostid']);
     }
 
+    public function testServicePackClearedOnOsChange()
+    {
+        $cos = new \Item_OperatingSystem();
+        $ossp = new \OperatingSystemServicePack();
+
+        //first inventory: a Windows host reporting a service pack
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <FULL_NAME>Microsoft Windows Server 2019 Datacenter</FULL_NAME>
+      <KERNEL_NAME>MSWin32</KERNEL_NAME>
+      <KERNEL_VERSION>10.0.17763</KERNEL_VERSION>
+      <NAME>Windows</NAME>
+      <SERVICE_PACK>17763.8755</SERVICE_PACK>
+      <VERSION>1809</VERSION>
+    </OPERATINGSYSTEM>
+    <HARDWARE>
+      <NAME>pc-spclear</NAME>
+      <WINCOMPANY>Test Company</WINCOMPANY>
+      <WINOWNER>Windows User</WINOWNER>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sp-clear-01</SSN>
+    </BIOS>
+    <VERSIONCLIENT>GLPI-Agent_v1.16</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc-spclear</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        $computer = new \Computer();
+        $this->assertTrue($computer->getFromDBByCrit(['name' => 'pc-spclear']));
+        $computers_id = $computer->getID();
+
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->assertCount(1, $list);
+        $theos = current($list);
+        //the service pack and Windows-specific fields have been set
+        $this->assertGreaterThan(0, $theos['operatingsystemservicepacks_id']);
+        $this->assertTrue($ossp->getFromDBByCrit(['name' => '17763.8755']));
+        $this->assertSame('Test Company', $theos['company']);
+        $this->assertSame('Windows User', $theos['owner']);
+
+        //second inventory: same device reinstalled under Linux, no service pack reported
+        $xml_source = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+<REQUEST>
+  <CONTENT>
+    <OPERATINGSYSTEM>
+      <ARCH>x86_64</ARCH>
+      <FULL_NAME>Ubuntu 24.04.4 LTS</FULL_NAME>
+      <KERNEL_NAME>linux</KERNEL_NAME>
+      <KERNEL_VERSION>6.8.0-40-generic</KERNEL_VERSION>
+      <NAME>Ubuntu</NAME>
+      <VERSION>24.04.4 LTS (Noble Numbat)</VERSION>
+    </OPERATINGSYSTEM>
+    <HARDWARE>
+      <NAME>pc-spclear</NAME>
+    </HARDWARE>
+    <BIOS>
+      <SSN>sp-clear-01</SSN>
+    </BIOS>
+    <VERSIONCLIENT>GLPI-Agent_v1.16</VERSIONCLIENT>
+  </CONTENT>
+  <DEVICEID>test-pc-spclear</DEVICEID>
+  <QUERY>INVENTORY</QUERY>
+</REQUEST>";
+
+        $this->doInventory($xml_source, true);
+
+        //still a single OS linked to the computer
+        $list = $cos->find(['itemtype' => 'Computer', 'items_id' => $computers_id]);
+        $this->assertCount(1, $list);
+        $theos = current($list);
+        //the service pack and Windows-specific fields must have been cleared
+        //as they are no longer reported
+        $this->assertSame(0, $theos['operatingsystemservicepacks_id']);
+        $this->assertEmpty($theos['company']);
+        $this->assertEmpty($theos['owner']);
+    }
+
     public function testReplayRuleOnOS()
     {
         $os = new \OperatingSystem();

--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -165,6 +165,28 @@ class OperatingSystem extends InventoryAsset
 
         if (!$ios->isNewItem()) {
             //OS exists, check for updates
+
+            // Reset OS specific fields that are no longer reported by the inventory
+            $lockeds = new \Lockedfield();
+            $locks = $lockeds->getLockedNames($ios->getType(), $ios->getID());
+            $reset_fields = [
+                //dropdown foreign keys
+                'operatingsystemversions_id'        => 0,
+                'operatingsystemservicepacks_id'    => 0,
+                'operatingsystemarchitectures_id'   => 0,
+                'operatingsystemkernelversions_id'  => 0,
+                'operatingsystemeditions_id'        => 0,
+                'licenseid'                         => '',
+                'license_number'                    => '',
+                'company'                           => '',
+                'owner'                             => '',
+            ];
+            foreach ($reset_fields as $os_field => $empty_value) {
+                if (!array_key_exists($os_field, $input_os) && !in_array($os_field, $locks, true)) {
+                    $input_os[$os_field] = $empty_value;
+                }
+            }
+
             $same = true;
             foreach ($input_os as $key => $value) {
                 if (array_key_exists($key, $ios->fields) && $ios->fields[$key] != $value) {

--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -180,6 +180,7 @@ class OperatingSystem extends InventoryAsset
                 'license_number'                    => '',
                 'company'                           => '',
                 'owner'                             => '',
+                'hostid'                            => '',
             ];
             foreach ($reset_fields as $os_field => $empty_value) {
                 if (!array_key_exists($os_field, $input_os) && !in_array($os_field, $locks, true)) {

--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -156,6 +156,27 @@ class OperatingSystem extends InventoryAsset
             'items_id'  => $this->item->fields['id'],
         ]);
 
+        if (!$ios->isNewItem()) {
+            $reset_fields = [
+                'operatingsystemversions_id'       => 0,
+                'operatingsystemservicepacks_id'   => 0,
+                'operatingsystemarchitectures_id'  => 0,
+                'operatingsystemkernelversions_id' => 0,
+                'operatingsystemeditions_id'       => 0,
+                'licenseid'                        => '',
+                'license_number'                   => '',
+                'company'                          => '',
+                'owner'                            => '',
+                'hostid'                           => '',
+                'install_date'                     => null,
+            ];
+            foreach ($reset_fields as $field => $empty_value) {
+                if (!property_exists($val, $field)) {
+                    $val->$field = $empty_value;
+                }
+            }
+        }
+
         $input_os = $this->handleInput($val, $ios) + [
             'itemtype'                          => $this->item->getType(),
             'items_id'                          => $this->item->fields['id'],
@@ -165,29 +186,6 @@ class OperatingSystem extends InventoryAsset
 
         if (!$ios->isNewItem()) {
             //OS exists, check for updates
-
-            // Reset OS specific fields that are no longer reported by the inventory
-            $lockeds = new \Lockedfield();
-            $locks = $lockeds->getLockedNames($ios->getType(), $ios->getID());
-            $reset_fields = [
-                //dropdown foreign keys
-                'operatingsystemversions_id'        => 0,
-                'operatingsystemservicepacks_id'    => 0,
-                'operatingsystemarchitectures_id'   => 0,
-                'operatingsystemkernelversions_id'  => 0,
-                'operatingsystemeditions_id'        => 0,
-                'licenseid'                         => '',
-                'license_number'                    => '',
-                'company'                           => '',
-                'owner'                             => '',
-                'hostid'                            => '',
-            ];
-            foreach ($reset_fields as $os_field => $empty_value) {
-                if (!array_key_exists($os_field, $input_os) && !in_array($os_field, $locks, true)) {
-                    $input_os[$os_field] = $empty_value;
-                }
-            }
-
             $same = true;
             foreach ($input_os as $key => $value) {
                 if (array_key_exists($key, $ios->fields) && $ios->fields[$key] != $value) {

--- a/src/Inventory/Asset/OperatingSystem.php
+++ b/src/Inventory/Asset/OperatingSystem.php
@@ -162,6 +162,7 @@ class OperatingSystem extends InventoryAsset
                 'operatingsystemservicepacks_id'   => 0,
                 'operatingsystemarchitectures_id'  => 0,
                 'operatingsystemkernelversions_id' => 0,
+                'operatingsystemkernels_id'        => 0,
                 'operatingsystemeditions_id'       => 0,
                 'licenseid'                        => '',
                 'license_number'                   => '',


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45295
- When a PC is running Windows and you switch the OS to Linux, for example, certain Windows-specific fields were not cleared.

## Screenshots (if appropriate):


