### PR TITLE
Remove SQL space deduplication

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -4208,12 +4208,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DBmysqlIterator.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#3 \\$subject of function Safe\\\\preg_replace expects array\\<string\\>\\|string, string\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/DBmysqlIterator.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$ong of method CommonGLPI\\:\\:addDefaultFormTab\\(\\) expects array\\<string, string\\>, array\\<string, bool\\|string\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The present file will list all changes made to the project; according to the
 ### Added
 
 ### Changed
+- Fixed searching values with multiple concurrent spaces.
 
 ### Deprecated
 
@@ -18,6 +19,7 @@ The present file will list all changes made to the project; according to the
 #### Added
 
 #### Changes
+- Duplicate spaces in some SQL queries, including values, (usually ones that used subqueries) no longer removed.
 
 #### Deprecated
 

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -37,7 +37,6 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryParam;
 use Glpi\DBAL\QuerySubQuery;
 
-use function Safe\preg_replace;
 use function Safe\preg_split;
 
 /**
@@ -491,7 +490,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
      */
     public function getSql()
     {
-        return preg_replace('/ +/', ' ', $this->sql);
+        return $this->sql ?? '';
     }
 
     /**

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -176,7 +176,7 @@ class DBTest extends GLPITestCase
     public function testBuildInsert($table, $values, $expected)
     {
         $instance = new \DB();
-        $this->assertSame($expected, $instance->buildInsert($table, $values));
+        $this->assertSame($expected, $this->cleanSQL($instance->buildInsert($table, $values)));
     }
 
     public static function dataUpdate()

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -698,31 +698,31 @@ class DBmysqlIteratorTest extends DbTestCase
     public function testOperators()
     {
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => 1]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` = \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` = \'1\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['=', 1]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` = \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` = \'1\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['>', 1]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` > \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` > \'1\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['LIKE', '%bar%']]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` LIKE \'%bar%\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` LIKE \'%bar%\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['NOT' => ['a' => ['LIKE', '%bar%']]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE NOT (`a` LIKE \'%bar%\')', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE NOT (`a` LIKE \'%bar%\')', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['NOT LIKE', '%bar%']]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` NOT LIKE \'%bar%\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` NOT LIKE \'%bar%\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['<>', 1]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` <> \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` <> \'1\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['&', 1]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` & \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` & \'1\'', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['a' => ['|', 1]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE `a` | \'1\'', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE `a` | \'1\'', $this->cleanSQL($it->getSql()));
     }
 
 
@@ -889,16 +889,16 @@ class DBmysqlIteratorTest extends DbTestCase
     public function testLogical()
     {
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => [['a' => 1, 'b' => 2]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['AND' => ['a' => 1, 'b' => 2]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' AND `b` = \'2\')', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['OR' => ['a' => 1, 'b' => 2]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' OR `b` = \'2\')', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE (`a` = \'1\' OR `b` = \'2\')', $this->cleanSQL($it->getSql()));
 
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['NOT' => ['a' => 1, 'b' => 2]]]);
-        $this->assertSame('SELECT * FROM `foo` WHERE NOT (`a` = \'1\' AND `b` = \'2\')', $it->getSql());
+        $this->assertSame('SELECT * FROM `foo` WHERE NOT (`a` = \'1\' AND `b` = \'2\')', $this->cleanSQL($it->getSql()));
 
         $crit = [
             'FROM' => 'foo',
@@ -937,7 +937,7 @@ class DBmysqlIteratorTest extends DbTestCase
         ];
         $sql = "SELECT * FROM `foo` WHERE `a` = '1' AND (`b` = '2' OR NOT (`c` IN ('2', '3') AND (`d` = '4' AND `e` = '5')))";
         $it = $this->it->execute($crit);
-        $this->assertSame($sql, $it->getSql());
+        $this->assertSame($sql, $this->cleanSQL($it->getSql()));
 
         $crit = [
             'FROM'   => 'foo',
@@ -947,7 +947,7 @@ class DBmysqlIteratorTest extends DbTestCase
             ],
         ];
         $it = $this->it->execute($crit);
-        $this->assertSame("SELECT * FROM `foo` WHERE `bar` = 'baz' AND ((SELECT COUNT(*) FROM xyz) = '5')", $it->getSql());
+        $this->assertSame("SELECT * FROM `foo` WHERE `bar` = 'baz' AND ((SELECT COUNT(*) FROM xyz) = '5')", $this->cleanSQL($it->getSql()));
 
         $crit = [
             'FROM'   => 'foo',
@@ -1080,7 +1080,7 @@ class DBmysqlIteratorTest extends DbTestCase
         $it = $this->it->execute(['FROM' => 'foo', 'WHERE' => ['NOT' => ['bar' => $sub_query]]]);
         $this->assertSame(
             "SELECT * FROM `foo` WHERE NOT (`bar` IN $raw_subq)",
-            $it->getSql()
+            $this->cleanSQL($it->getSql())
         );
 
         $sub_query = new QuerySubQuery($crit, 'thesubquery');
@@ -1480,7 +1480,10 @@ class DBmysqlIteratorTest extends DbTestCase
         ];
 
         $it = $this->it->execute($criteria);
-        $this->assertSame($raw_query, $it->getSql());
+        // Assert same except for the union query alias at the end which can change based on whitepace differences
+        $expected_sql = $this->cleanSQL(preg_replace('/ AS `union_[a-f0-9]{32}`$/', ' AS `union_md5hash`', $raw_query));
+        $actual_sql = $this->cleanSQL(preg_replace('/ AS `union_[a-f0-9]{32}`$/', ' AS `union_md5hash`', $it->getSql()));
+        $this->assertSame($expected_sql, $actual_sql);
     }
 
     public function testAnalyseCrit()

--- a/tests/functional/DomainTest.php
+++ b/tests/functional/DomainTest.php
@@ -130,7 +130,7 @@ class DomainTest extends DbTestCase
             "SELECT * FROM `glpi_domains` WHERE "
             . "NOT (`date_expiration` IS NULL) AND `entities_id` = '{$entity->fields['id']}' AND `is_deleted` = '0' "
             . "AND DATEDIFF(CURDATE(), `date_expiration`) > 1 AND DATEDIFF(CURDATE(), `date_expiration`) > 0",
-            $iterator->getSql()
+            $this->cleanSQL($iterator->getSql())
         );
 
         $iterator = $DB->request(\Domain::closeExpiriesDomainsCriteria($entity->fields['id']));
@@ -138,7 +138,7 @@ class DomainTest extends DbTestCase
             "SELECT * FROM `glpi_domains` WHERE "
             . "NOT (`date_expiration` IS NULL) AND `entities_id` = '{$entity->fields['id']}' AND `is_deleted` = '0' "
             . "AND DATEDIFF(CURDATE(), `date_expiration`) > -7 AND DATEDIFF(CURDATE(), `date_expiration`) < 0",
-            $iterator->getSql()
+            $this->cleanSQL($iterator->getSql())
         );
     }
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -446,6 +446,7 @@ class SearchTest extends DbTestCase
         ];
 
         $data = $this->doSearch('Computer', $search_params);
+        $sql  = $this->cleanSQL($data['sql']['search']);
 
         $regexps = [
             // join parts
@@ -463,7 +464,7 @@ class SearchTest extends DbTestCase
         foreach ($regexps as $regexp) {
             $this->assertMatchesRegularExpression(
                 $regexp,
-                $data['sql']['search']
+                $sql
             );
         }
 
@@ -484,7 +485,7 @@ class SearchTest extends DbTestCase
         foreach ($contains as $contain) {
             $this->assertStringContainsString(
                 $contain,
-                $data['sql']['search']
+                $sql
             );
         }
     }
@@ -510,6 +511,7 @@ class SearchTest extends DbTestCase
                 ],
             ],
         ]);
+        $sql = $this->cleanSQL($data['sql']['search']);
 
         $default_charset = DBConnection::getDefaultCharset();
 
@@ -523,7 +525,7 @@ class SearchTest extends DbTestCase
         foreach ($contains as $contain) {
             $this->assertStringContainsString(
                 $contain,
-                $data['sql']['search']
+                $sql
             );
         }
 
@@ -541,13 +543,13 @@ class SearchTest extends DbTestCase
         foreach ($regexps as $regexp) {
             $this->assertMatchesRegularExpression(
                 $regexp,
-                $data['sql']['search']
+                $sql
             );
         }
 
         $this->assertDoesNotMatchRegularExpression(
             "/OR\s*\(CONVERT\(`glpi_computers`\.`date_mod` USING {$default_charset}\)\s*LIKE '%test%'\s*\)\)/",
-            $data['sql']['search']
+            $sql
         );
     }
 
@@ -2352,20 +2354,6 @@ class SearchTest extends DbTestCase
         }
     }
 
-    private function cleanSQL($sql)
-    {
-        // Clean whitespaces
-        $sql = preg_replace('/\s+/', ' ', $sql);
-
-        // Remove whitespaces around parenthesis
-        $sql = preg_replace('/\(\s+/', '(', $sql);
-        $sql = preg_replace('/\s+\)/', ')', $sql);
-
-        $sql = trim($sql);
-
-        return $sql;
-    }
-
     public function testAllAssetsFields()
     {
         global $CFG_GLPI, $DB;
@@ -2957,14 +2945,15 @@ class SearchTest extends DbTestCase
             ],
         ];
         $data = $this->doSearch('AllAssets', $search_params);
+        $sql = $this->cleanSQL($data['sql']['search']);
 
         $this->assertMatchesRegularExpression(
             "/OR\s*\(`glpi_entities`\.`completename`\s*LIKE '%test%'\s*\)/",
-            $data['sql']['search']
+            $sql
         );
         $this->assertMatchesRegularExpression(
             "/OR\s*\(`glpi_states`\.`completename`\s*LIKE '%test%'\s*\)/",
-            $data['sql']['search']
+            $sql
         );
 
         $types = [
@@ -2979,23 +2968,23 @@ class SearchTest extends DbTestCase
         foreach ($types as $type) {
             $this->assertStringContainsString(
                 "`$type`.`is_deleted` = 0",
-                $data['sql']['search']
+                $sql
             );
             $this->assertStringContainsString(
                 "AND `$type`.`is_template` = 0",
-                $data['sql']['search']
+                $sql
             );
             $this->assertStringContainsString(
                 "`$type`.`entities_id` IN ('$test_root', '$test_child_1', '$test_child_2', '$test_child_3')",
-                $data['sql']['search']
+                $sql
             );
             $this->assertStringContainsString(
                 "OR (`$type`.`is_recursive`='1' AND `$type`.`entities_id` IN (0))",
-                $data['sql']['search']
+                $sql
             );
             $this->assertMatchesRegularExpression(
                 "/`$type`\.`name` LIKE '%test%'/m",
-                $data['sql']['search']
+                $sql
             );
         }
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -65,7 +65,6 @@ use User;
 use function Safe\ob_get_clean;
 use function Safe\ob_start;
 use function Safe\preg_match;
-use function Safe\preg_replace;
 use function Safe\strtotime;
 
 class SearchTest extends DbTestCase

--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -698,4 +698,23 @@ class GLPITestCase extends TestCase
             );
         }
     }
+
+    /**
+     * Clean a SQL query string by removing extra whitespaces to make it easier to compare with another SQL query string.
+     * @param $sql
+     * @return string
+     */
+    protected function cleanSQL($sql)
+    {
+        // Clean whitespaces
+        $sql = preg_replace('/\s+/', ' ', $sql);
+
+        // Remove whitespaces around parenthesis
+        $sql = preg_replace('/\(\s+/', '(', $sql);
+        $sql = preg_replace('/\s+\)/', ')', $sql);
+
+        $sql = trim($sql);
+
+        return $sql;
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes #24868

As far as I can tell from historical commit data, `DBmysqlIterator::getSql` removed duplicate spaces from queries solely to help with SQL comparisons in tests since it isn't always easy to predict where the automatic SQL builder will add extra spaces.

A `cleanSQL` has existed in the `SearchTest` for a while now for the same reason. I moved this method to the base GLPITest class and made it protected, and then used it in the required places to make tests pass.