### PR TITLE
Deprecate access to some $CFG_GLPI keys via a config container

### DIFF
--- a/.phpstan-baseline.missingType.iterableValue.php
+++ b/.phpstan-baseline.missingType.iterableValue.php
@@ -10706,12 +10706,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Console/AbstractCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Glpi\\\\Console\\\\Application\\:\\:\\$config type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Console/Application.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Console\\\\CommandLoader\\:\\:getCommandFromFile\\(\\) has parameter \\$prefixes with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
@@ -27777,12 +27771,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method SavedSearch_Alert\\:\\:restoreContext\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/SavedSearch_Alert.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method SavedSearch_Alert\\:\\:saveContext\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
 	'path' => __DIR__ . '/src/SavedSearch_Alert.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3008,12 +3008,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Config.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Offset \'lock_use_lock_item\' might not exist on array\\{typedoc_icon_dir\\: mixed, root_doc\\: mixed, proxy_exclusions\\: mixed, lock_lockprofile_id\\: mixed, \\.\\.\\.\\}\\.$#',
-	'identifier' => 'offsetAccess.notFound',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Config.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$ID of method CommonDBTM\\:\\:getFromDB\\(\\) expects int\\|string, int\\|string\\|false given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Config.php
+++ b/src/Config.php
@@ -37,6 +37,7 @@ use Glpi\Api\HL\Router;
 use Glpi\Application\Environment;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Cache\CacheManager;
+use Glpi\Config\ConfigContainer;
 use Glpi\Config\ProxyExclusion;
 use Glpi\Config\ProxyExclusions;
 use Glpi\Dashboard\Grid;
@@ -100,9 +101,6 @@ class Config extends CommonDBTM
         'glpinetwork_registration_key',
         'ldap_pass', // this one should not exist anymore, but may be present when admin restored config dump after migration
     ];
-
-    /** @var string[] */
-    public static array $saferUndisclosedFields = ['admin_email', 'replyto_email'];
 
     /**
      * Indicates whether the GLPI configuration has been loaded.
@@ -1057,6 +1055,7 @@ class Config extends CommonDBTM
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
         if ($item instanceof Preference) {
@@ -1077,7 +1076,9 @@ class Config extends CommonDBTM
                     break;
 
                 case 2:
-                    $item->showFormUserPrefs($CFG_GLPI);
+                    // Pass a plain-array copy: showFormUserPrefs() runs native
+                    // array functions on its argument (e.g. array_key_exists()).
+                    $item->showFormUserPrefs($CFG_GLPI->getArrayCopy());
                     break;
 
                 case 3:
@@ -1412,7 +1413,10 @@ class Config extends CommonDBTM
             $values[$row['name']] = $row['value'];
         }
 
-        $CFG_GLPI = array_merge($CFG_GLPI, $values);
+        // Merge per key to preserve the ConfigContainer object backing $CFG_GLPI.
+        foreach ($values as $name => $value) {
+            $CFG_GLPI[$name] = $value;
+        }
 
         if (isset($CFG_GLPI['priority_matrix'])) {
             $CFG_GLPI['priority_matrix'] = importArrayFromDB($CFG_GLPI['priority_matrix']);
@@ -1841,22 +1845,12 @@ class Config extends CommonDBTM
      */
     public static function getSafeConfig($safer = false)
     {
+        Toolbox::deprecated('Use $CFG_GLPI->getSafeConfig() instead.', true, '11.0');
+
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
-        $excludedKeys = array_flip(self::$undisclosedFields);
-        $safe_config  = array_diff_key($CFG_GLPI, $excludedKeys);
-
-        if ($safer) {
-            $excludedKeys = array_flip(self::$saferUndisclosedFields);
-            $safe_config = array_diff_key($safe_config, $excludedKeys);
-        }
-
-        // override with session values
-        foreach ($safe_config as $key => &$value) {
-            $value = $_SESSION['glpi' . $key] ?? $value;
-        }
-
-        return $safe_config;
+        return $CFG_GLPI->getSafeConfig((bool) $safer);
     }
 
 

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -46,7 +46,6 @@ use Change;
 use CommonDBTM;
 use CommonDevice;
 use CommonITILObject;
-use Config;
 use Contract;
 use Document;
 use Dropdown;
@@ -55,6 +54,7 @@ use Glpi\Api\Deprecated\DeprecatedInterface;
 use Glpi\Api\HL\Router;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Config\ConfigContainer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Exception\ForgetPasswordException;
@@ -600,7 +600,10 @@ abstract class API
      */
     protected function getGlpiConfig()
     {
-        return ['cfg_glpi' => Config::getSafeConfig()];
+        /** @var ConfigContainer $CFG_GLPI */
+        global $CFG_GLPI;
+
+        return ['cfg_glpi' => $CFG_GLPI->getSafeConfig()];
     }
 
 

--- a/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
+++ b/src/Glpi/Application/View/Extension/FrontEndAssetsExtension.php
@@ -35,10 +35,10 @@
 
 namespace Glpi\Application\View\Extension;
 
-use Config;
 use DBmysql;
 use Entity;
 use Glpi\Application\ImportMapGenerator;
+use Glpi\Config\ConfigContainer;
 use Glpi\Locale\LanguageRegistry;
 use Glpi\Toolbox\FrontEnd;
 use Glpi\UI\Theme;
@@ -321,6 +321,7 @@ class FrontEndAssetsExtension extends AbstractExtension
      */
     public function configJs(): string
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
         $cfg_glpi = [
@@ -329,7 +330,7 @@ class FrontEndAssetsExtension extends AbstractExtension
         ];
         if (Session::getLoginUserID(true) !== false) {
             // expose full config only for connected users
-            $cfg_glpi += Config::getSafeConfig(true);
+            $cfg_glpi += $CFG_GLPI->getSafeConfig(true);
         }
 
         $plugins_path = \array_combine(

--- a/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
+++ b/src/Glpi/Asset/Capacity/HasDevicesCapacity.php
@@ -139,7 +139,7 @@ class HasDevicesCapacity extends AbstractCapacity
         foreach (Item_Devices::getDeviceTypes() as $item_device_class) {
             // see `Item_Devices::itemAffinity()`
             $key = str_replace('_', '', strtolower($item_device_class)) . '_types';
-            if (array_key_exists($key, $CFG_GLPI)) {
+            if (isset($CFG_GLPI[$key])) {
                 $this->registerToTypeConfig($key, $classname);
             }
         }
@@ -175,7 +175,7 @@ class HasDevicesCapacity extends AbstractCapacity
         foreach (Item_Devices::getDeviceTypes() as $item_device_class) {
             // see `Item_Devices::itemAffinity()`
             $key = str_replace('_', '', strtolower($item_device_class)) . '_types';
-            if (array_key_exists($key, $CFG_GLPI)) {
+            if (isset($CFG_GLPI[$key])) {
                 $this->unregisterFromTypeConfig($key, $classname);
             }
         }

--- a/src/Glpi/Config/ConfigContainer.php
+++ b/src/Glpi/Config/ConfigContainer.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Config;
+
+use ArrayAccess;
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use JsonSerializable;
+use Toolbox;
+use Traversable;
+
+/**
+ * Array-like container backing the global `$CFG_GLPI` configuration.
+ *
+ * It behaves like the plain array it replaces (offset access, iteration, count,
+ * JSON serialization) but lets us flag individual keys as deprecated: reading a
+ * deprecated key emits an `E_USER_DEPRECATED` notice (once per key and request)
+ * through {@see Toolbox::deprecated()}, while still returning the real value so
+ * that legacy/plugin code keeps working unchanged.
+ *
+ * {@see self::offsetGet()} returns values **by reference** on purpose: this is
+ * what allows nested writes and appends on array values to keep working, e.g.
+ * `$CFG_GLPI['asset_types'][] = MyAsset::class;`.
+ *
+ * @implements ArrayAccess<array-key, mixed>
+ * @implements IteratorAggregate<array-key, mixed>
+ */
+final class ConfigContainer implements ArrayAccess, IteratorAggregate, Countable, JsonSerializable
+{
+    /**
+     * Config keys that are additionally hidden by {@see self::getSafeConfig()}
+     * when the `$safer` flag is set (e.g. to avoid disclosing emails).
+     */
+    private const SAFER_UNDISCLOSED_FIELDS = ['admin_email', 'replyto_email'];
+
+    /**
+     * Deprecation definitions, indexed by config key.
+     *
+     * @var array<string, array{message: string, version: ?string}>
+     */
+    private array $deprecated = [];
+
+    /**
+     * Keys for which the deprecation notice has already been emitted during the
+     * current request (used to avoid flooding the logs).
+     *
+     * @var array<string, true>
+     */
+    private array $warned = [];
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    public function __construct(private array $config) {}
+
+    /**
+     * Flag a configuration key as deprecated.
+     *
+     * @param string      $key     Configuration key to deprecate.
+     * @param string      $message Message to display when the key is read.
+     * @param string|null $version Version the deprecation starts from (see {@see Toolbox::deprecated()}).
+     */
+    public function deprecateKey(string $key, string $message, ?string $version = null): void
+    {
+        $this->deprecated[$key] = ['message' => $message, 'version' => $version];
+    }
+
+    /**
+     * @param string $offset
+     *
+     * ⚠️ Returns by reference so that nested writes/appends keep working, exactly
+     * like on a plain array (e.g. `$CFG_GLPI['asset_types'][] = ...`, or
+     * auto-vivification `$CFG_GLPI['new_registry'][$key] = ...`). To support
+     * writes to a not-yet-existing key, a missing offset is materialized as
+     * `null` before its reference is returned — mirroring PHP array behavior.
+     */
+    public function &offsetGet(mixed $offset): mixed
+    {
+        if (isset($this->deprecated[$offset]) && !isset($this->warned[$offset])) {
+            $this->warned[$offset] = true;
+            Toolbox::deprecated(
+                $this->deprecated[$offset]['message'],
+                true,
+                $this->deprecated[$offset]['version'],
+            );
+        }
+
+        if (!array_key_exists($offset, $this->config)) {
+            $this->config[$offset] = null;
+        }
+
+        return $this->config[$offset];
+    }
+
+    /**
+     * @param string|null $offset
+     */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if ($offset === null) {
+            $this->config[] = $value;
+        } else {
+            $this->config[$offset] = $value;
+        }
+    }
+
+    /**
+     * @param string $offset
+     */
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->config[$offset]);
+    }
+
+    /**
+     * @param string $offset
+     */
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->config[$offset]);
+    }
+
+    /**
+     * @return ArrayIterator<array-key, mixed>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->config);
+    }
+
+    public function count(): int
+    {
+        return count($this->config);
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->config;
+    }
+
+    /**
+     * Return a plain-array copy of the whole configuration.
+     *
+     * Escape hatch for the few core code paths that need to run native array
+     * functions (`array_keys()`, `array_diff_key()`, ...) over the full config.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function getArrayCopy(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * Return the configuration without the keys that must not be disclosed
+     * (passwords, tokens, ...), with values overridden by the current session
+     * preferences when available.
+     *
+     * @param bool $safer Also hide "safer" undisclosed fields (e.g. emails).
+     *
+     * @return array<array-key, mixed>
+     */
+    public function getSafeConfig(bool $safer = false): array
+    {
+        $safe_config = array_diff_key($this->config, array_flip(\Config::$undisclosedFields));
+
+        if ($safer) {
+            $safe_config = array_diff_key($safe_config, array_flip(self::SAFER_UNDISCLOSED_FIELDS));
+        }
+
+        // override with session values
+        foreach ($safe_config as $key => &$value) {
+            $value = $_SESSION['glpi' . $key] ?? $value;
+        }
+
+        return $safe_config;
+    }
+}

--- a/src/Glpi/Console/Application.php
+++ b/src/Glpi/Console/Application.php
@@ -37,6 +37,7 @@ namespace Glpi\Console;
 
 use DBmysql;
 use Glpi\Application\Environment;
+use Glpi\Config\ConfigContainer;
 use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Command\GlpiCommandInterface;
 use Glpi\Console\Exception\EarlyExitException;
@@ -97,7 +98,7 @@ class Application extends BaseApplication
     /**
      * Pointer to $CFG_GLPI.
      */
-    private array $config;
+    private ConfigContainer $config;
 
     private ?DBmysql $db = null;
 
@@ -105,6 +106,7 @@ class Application extends BaseApplication
 
     public function __construct(private Kernel $kernel)
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $DB, $CFG_GLPI;
 
         // preconfigure the output to correctly handle kernel boot errors
@@ -367,7 +369,7 @@ class Application extends BaseApplication
 
         // 2. Check in GLPI configuration
         if (
-            null === $lang && array_key_exists('language', $this->config)
+            null === $lang && isset($this->config['language'])
             && $this->isLanguageValid($this->config['language'])
         ) {
             $lang = $this->config['language'];
@@ -394,8 +396,7 @@ class Application extends BaseApplication
      */
     private function isLanguageValid($language)
     {
-        return array_key_exists('languages', $this->config)
-         && array_key_exists($language, $this->config['languages']);
+        return LanguageRegistry::has($language);
     }
 
     /**

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -611,7 +611,7 @@ TWIG, $twig_params);
 
         // Restore user preference defaults wiped by session_start() (mirrors PostBootListener).
         foreach ($CFG_GLPI['user_pref_field'] as $field) {
-            if (array_key_exists($field, $CFG_GLPI)) {
+            if (isset($CFG_GLPI[$field])) {
                 $_SESSION["glpi$field"] = $CFG_GLPI[$field];
             }
         }

--- a/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/SessionStart.php
@@ -123,7 +123,7 @@ class SessionStart implements EventSubscriberInterface
         // Copy the "preference" defaults to the session, if they are not already set.
         // They are set during the authentication but may be accessed in a sessionless context (cron, anonymous pages, ...).
         foreach ($CFG_GLPI['user_pref_field'] as $field) {
-            if (!\array_key_exists("glpi$field", $_SESSION) && \array_key_exists($field, $CFG_GLPI)) {
+            if (!\array_key_exists("glpi$field", $_SESSION) && isset($CFG_GLPI[$field])) {
                 $_SESSION["glpi$field"] = $CFG_GLPI[$field];
             }
         }

--- a/src/Html.php
+++ b/src/Html.php
@@ -38,6 +38,7 @@ use Glpi\Application\Environment;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetDefinitionManager;
+use Glpi\Config\ConfigContainer;
 use Glpi\Console\Application;
 use Glpi\Dashboard\Grid;
 use Glpi\Debug\Profile as DebugProfile;
@@ -5700,6 +5701,7 @@ JS);
      */
     public static function getCoreVariablesForJavascript(bool $full = false)
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
         // prevent leak of data for non logged sessions
@@ -5711,7 +5713,7 @@ JS);
         };";
 
         if ($full) {
-            $cfg_glpi = "var CFG_GLPI  = " . json_encode(Config::getSafeConfig(true), JSON_PRETTY_PRINT) . ";";
+            $cfg_glpi = "var CFG_GLPI  = " . json_encode($CFG_GLPI->getSafeConfig(true), JSON_PRETTY_PRINT) . ";";
         }
 
         $plugins_path = [];

--- a/src/NotificationSetting.php
+++ b/src/NotificationSetting.php
@@ -33,6 +33,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Config\ConfigContainer;
+
 /**
  * Abstract notifications settings class
  */
@@ -124,10 +126,11 @@ abstract class NotificationSetting extends CommonDBTM
      */
     public static function disableAll()
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
         $CFG_GLPI['use_notifications'] = 0;
-        foreach (array_keys($CFG_GLPI) as $key) {
+        foreach (array_keys($CFG_GLPI->getArrayCopy()) as $key) {
             if (str_starts_with($key, 'notifications_')) {
                 $CFG_GLPI[$key] = 0;
             }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,7 @@
 use Composer\Autoload\ClassLoader;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Cache\CacheManager;
+use Glpi\Config\ConfigContainer;
 use Glpi\Dashboard\Grid;
 use Glpi\Debug\Profiler;
 use Glpi\Event;
@@ -1677,6 +1678,7 @@ class Plugin extends CommonDBTM
      **/
     public static function registerClass($itemtype, $attrib = [])
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
 
         $plug = isPluginItemType($itemtype);
@@ -1697,7 +1699,7 @@ class Plugin extends CommonDBTM
             $attrib['assignable_types'] = true;
         }
 
-        $all_types = preg_grep('/.+_types/', array_keys($CFG_GLPI));
+        $all_types = preg_grep('/.+_types/', array_keys($CFG_GLPI->getArrayCopy()));
         $all_types[] = 'networkport_instantiations';
 
         $blacklist = ['device_types'];
@@ -1741,7 +1743,7 @@ class Plugin extends CommonDBTM
         foreach ($attrib as $key => $value) {
             if (preg_match('/^plugin[a-z]+_types$/', $key)) {
                 if ($value) {
-                    if (!array_key_exists($key, $CFG_GLPI)) {
+                    if (!isset($CFG_GLPI[$key])) {
                         $CFG_GLPI[$key] = [];
                     }
                     $CFG_GLPI[$key][] = $itemtype;

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\Config\ConfigContainer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\Error\ErrorHandler;
@@ -267,14 +268,15 @@ class SavedSearch_Alert extends CommonDBChild
      *
      * Save $_SESSION and $CFG_GLPI into the returned array
      *
-     * @return array[] which contains a copy of $_SESSION and $CFG_GLPI
+     * @return array{'$_SESSION': array<string, mixed>, '$CFG_GLPI': ConfigContainer} which contains a copy of $_SESSION and $CFG_GLPI
      */
     private static function saveContext(): array
     {
+        /** @var ConfigContainer $CFG_GLPI */
         global $CFG_GLPI;
         $context = [];
         $context['$_SESSION'] = $_SESSION;
-        $context['$CFG_GLPI'] = $CFG_GLPI;
+        $context['$CFG_GLPI'] = clone $CFG_GLPI;
         return $context;
     }
 

--- a/src/Update.php
+++ b/src/Update.php
@@ -539,7 +539,7 @@ class Update
     {
         global $CFG_GLPI;
 
-        if (!array_key_exists('dbversion', $CFG_GLPI)) {
+        if (!isset($CFG_GLPI['dbversion'])) {
             return false; // Considered as outdated if installed version is unknown.
         }
 

--- a/src/User.php
+++ b/src/User.php
@@ -302,7 +302,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
         if (isset($this->fields['id'])) {
             foreach ($CFG_GLPI['user_pref_field'] as $f) {
-                if (array_key_exists($f, $CFG_GLPI) && (!array_key_exists($f, $this->fields) || is_null($this->fields[$f]))) {
+                if (isset($CFG_GLPI[$f]) && (!array_key_exists($f, $this->fields) || is_null($this->fields[$f]))) {
                     $this->fields[$f] = $CFG_GLPI[$f];
                 }
             }

--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Config\ConfigContainer;
 use Glpi\Config\ProxyExclusions;
 use Glpi\Locale\LanguageRegistry;
 use Glpi\Marketplace\Controller;
@@ -599,3 +600,19 @@ $CFG_GLPI['environment_types'] = [Computer::class];
 
 
 $CFG_GLPI['possible_proxy_exclusions'] = new ProxyExclusions();
+
+// Wrap the config into a container so specific keys can be deprecated while
+// staying backward compatible (see Glpi\Config\ConfigContainer). Declarations
+// above still operate on a plain array; the wrapping happens once, here.
+$CFG_GLPI = new ConfigContainer($CFG_GLPI);
+
+$CFG_GLPI->deprecateKey(
+    'languages',
+    "Accessing `\$CFG_GLPI['languages']` is deprecated, use `Glpi\\Locale\\LanguageRegistry` instead.",
+    '11.0'
+);
+$CFG_GLPI->deprecateKey(
+    'main_languages',
+    "Accessing `\$CFG_GLPI['main_languages']` is deprecated, use `Glpi\\Locale\\LanguageRegistry::getMainLanguages()` instead.",
+    '11.0'
+);

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -50,6 +50,7 @@ use Generator;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\Clonable;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Socket;
 use Glpi\Tests\DbTestCase;
 use Group;
@@ -2635,9 +2636,7 @@ HTML;
 
     public function testGetLanguages()
     {
-        global $CFG_GLPI;
-
-        $this->assertCount(count($CFG_GLPI['languages']), Dropdown::getLanguages());
+        $this->assertCount(count(LanguageRegistry::all()), Dropdown::getLanguages());
     }
 
     public function testGetDropdownMyDevices()

--- a/tests/functional/GLPITest.php
+++ b/tests/functional/GLPITest.php
@@ -34,15 +34,14 @@
 
 namespace tests\units;
 
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Tests\GLPITestCase;
 
 class GLPITest extends GLPITestCase
 {
     public function testMissingLanguages()
     {
-        global $CFG_GLPI;
-
-        $know_languages = $CFG_GLPI['languages'];
+        $know_languages = LanguageRegistry::all();
         $list_languages = [];
 
         $diterator = new \DirectoryIterator(__DIR__ . '/../../locales');

--- a/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
+++ b/tests/functional/Glpi/Asset/Capacity/HasDevicesCapacityTest.php
@@ -91,7 +91,7 @@ class HasDevicesCapacityTest extends DbTestCase
                 $this->assertNotContains($classname, $CFG_GLPI['itemdevices_types']);
                 $this->assertNotContains($classname, $CFG_GLPI['itemdevices_itemaffinity']);
             }
-            foreach (array_keys($CFG_GLPI) as $config_key) {
+            foreach (array_keys($CFG_GLPI->getArrayCopy()) as $config_key) {
                 if (preg_match('/^itemdevice[a-z+]_types$/', $config_key)) {
                     if ($has_capacity) {
                         $this->assertContains($classname, $CFG_GLPI[$config_key]);

--- a/tests/functional/Glpi/Config/ConfigContainerTest.php
+++ b/tests/functional/Glpi/Config/ConfigContainerTest.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Config;
+
+use Glpi\Config\ConfigContainer;
+use Glpi\Tests\GLPITestCase;
+use Psr\Log\LogLevel;
+
+final class ConfigContainerTest extends GLPITestCase
+{
+    public function testOffsetGetReturnsStoredValue(): void
+    {
+        $config = new ConfigContainer(['app_name' => 'GLPI', 'asset_types' => ['Computer']]);
+
+        $this->assertSame('GLPI', $config['app_name']);
+        $this->assertSame(['Computer'], $config['asset_types']);
+        $this->assertNull($config['does_not_exist']);
+    }
+
+    public function testOffsetSetExistsAndUnset(): void
+    {
+        $config = new ConfigContainer([]);
+
+        $config['foo'] = 'bar';
+        $this->assertTrue(isset($config['foo']));
+        $this->assertSame('bar', $config['foo']);
+
+        $config[] = 'appended';
+        $this->assertContains('appended', $config->getArrayCopy());
+
+        unset($config['foo']);
+        $this->assertFalse(isset($config['foo']));
+    }
+
+    public function testValuesAreRealArrays(): void
+    {
+        $config = new ConfigContainer(['languages' => ['fr_FR' => ['Français'], 'en_GB' => ['English']]]);
+
+        $languages = $config['languages'];
+        $this->assertIsArray($languages);
+        $this->assertSame(['fr_FR', 'en_GB'], array_keys($languages));
+        $this->assertSame('Français', $languages['fr_FR'][0]);
+        $this->assertArrayHasKey('de_DE', array_merge($languages, ['de_DE' => ['Deutsch']]));
+    }
+
+    public function testNestedAppendPersists(): void
+    {
+        // The core relies on `$CFG_GLPI['xxx_types'][] = ...` (e.g. Plugin::registerClass).
+        $config = new ConfigContainer(['asset_types' => ['Computer']]);
+
+        $config['asset_types'][] = 'Monitor';
+        $config['asset_types'][5] = 'Phone';
+
+        $this->assertSame(['Computer', 'Monitor', 5 => 'Phone'], $config['asset_types']);
+    }
+
+    public function testNestedKeyWritePersists(): void
+    {
+        $config = new ConfigContainer(['javascript' => ['assets' => []]]);
+
+        $config['javascript']['assets']['computer'] = ['dashboard'];
+
+        $this->assertSame(['dashboard'], $config['javascript']['assets']['computer']);
+    }
+
+    public function testNestedWriteToMissingKeyAutoVivifies(): void
+    {
+        // The core relies on auto-vivification, e.g. DbUtils builds the
+        // `glpitablesitemtype` registry with `$CFG_GLPI['glpitablesitemtype'][$type] = ...`
+        // without initializing the key first.
+        $config = new ConfigContainer([]);
+
+        $config['glpitablesitemtype']['Computer'] = 'glpi_computers';
+        $config['new_types'][] = 'Foo';
+
+        $this->assertSame(['Computer' => 'glpi_computers'], $config['glpitablesitemtype']);
+        $this->assertSame(['Foo'], $config['new_types']);
+    }
+
+    public function testCreateThenAppendIntoNewKey(): void
+    {
+        $config = new ConfigContainer([]);
+
+        $config['pluginfoo_types'] = [];
+        $config['pluginfoo_types'][] = 'GlpiPlugin\\Foo\\Bar';
+
+        $this->assertSame(['GlpiPlugin\\Foo\\Bar'], $config['pluginfoo_types']);
+    }
+
+    public function testCountAndIteration(): void
+    {
+        $config = new ConfigContainer(['a' => 1, 'b' => 2, 'c' => 3]);
+
+        $this->assertCount(3, $config);
+
+        $seen = [];
+        foreach ($config as $key => $value) {
+            $seen[$key] = $value;
+        }
+        $this->assertSame(['a' => 1, 'b' => 2, 'c' => 3], $seen);
+    }
+
+    public function testJsonSerializeAndArrayCopy(): void
+    {
+        $data = ['a' => 1, 'b' => ['x' => 2]];
+        $config = new ConfigContainer($data);
+
+        $this->assertSame($data, $config->getArrayCopy());
+        $this->assertSame(json_encode($data), json_encode($config));
+    }
+
+    public function testCloneIsIndependentSnapshot(): void
+    {
+        // SavedSearch_Alert relies on `clone $CFG_GLPI` to snapshot the config.
+        $config = new ConfigContainer(['app_name' => 'GLPI']);
+        $snapshot = clone $config;
+
+        $config['app_name'] = 'CHANGED';
+
+        $this->assertSame('GLPI', $snapshot['app_name']);
+        $this->assertSame('CHANGED', $config['app_name']);
+    }
+
+    public function testDeprecatedKeyIsLoggedAsInfo(): void
+    {
+        // Integration: the E_USER_DEPRECATED emitted by Toolbox::deprecated()
+        // flows to the GLPI logger as an INFO-level record.
+        $config = new ConfigContainer(['languages' => ['fr_FR' => ['Français']]]);
+        $config->deprecateKey('languages', 'Accessing languages is deprecated, use Foo instead.', '11.0');
+
+        $reporting_level = \error_reporting(E_ALL);
+        $value = $config['languages'];
+        \error_reporting($reporting_level);
+
+        $this->assertSame(['fr_FR' => ['Français']], $value);
+        $this->hasPhpLogRecordThatContains(
+            'Accessing languages is deprecated, use Foo instead.',
+            LogLevel::INFO
+        );
+    }
+
+    public function testDeprecatedKeyEmittedOnlyOncePerKey(): void
+    {
+        $config = new ConfigContainer(['languages' => ['fr_FR' => ['Français']]]);
+        $config->deprecateKey('languages', 'deprecated', '11.0');
+
+        $count = $this->countDeprecationsWhileReading(static function () use ($config): void {
+            $config['languages'];
+            $config['languages']; // second read must NOT emit again
+            $config['languages'];
+        });
+
+        $this->assertSame(1, $count);
+    }
+
+    public function testNonDeprecatedKeyDoesNotEmitNotice(): void
+    {
+        $config = new ConfigContainer(['asset_types' => ['Computer']]);
+        $config->deprecateKey('languages', 'deprecated', '11.0');
+
+        $count = $this->countDeprecationsWhileReading(static function () use ($config): void {
+            $config['asset_types'];
+        });
+
+        $this->assertSame(0, $count);
+    }
+
+    public function testDeprecationSkippedForFutureVersion(): void
+    {
+        $config = new ConfigContainer(['legacy' => 'value']);
+        $config->deprecateKey('legacy', 'deprecated in the future', '99.0');
+
+        $count = $this->countDeprecationsWhileReading(static function () use ($config): void {
+            $config['legacy'];
+        });
+
+        $this->assertSame(0, $count);
+    }
+
+    public function testGetSafeConfigExcludesSecretsAndAppliesSession(): void
+    {
+        $config = new ConfigContainer([
+            'url_base'    => 'https://glpi.test',
+            'smtp_passwd' => 'secret',            // in Config::$undisclosedFields
+            'admin_email' => 'admin@example.com', // only excluded when $safer
+        ]);
+
+        $_SESSION['glpiurl_base'] = 'https://session.override';
+
+        $safe = $config->getSafeConfig();
+        $this->assertArrayNotHasKey('smtp_passwd', $safe);
+        $this->assertArrayHasKey('admin_email', $safe);
+        $this->assertSame('https://session.override', $safe['url_base']);
+
+        $safer = $config->getSafeConfig(true);
+        $this->assertArrayNotHasKey('smtp_passwd', $safer);
+        $this->assertArrayNotHasKey('admin_email', $safer);
+    }
+
+    /**
+     * Count the E_USER_DEPRECATED notices emitted while running the given
+     * callback, swallowing them so they don't reach the GLPI logger.
+     */
+    private function countDeprecationsWhileReading(callable $callback): int
+    {
+        $count = 0;
+        \set_error_handler(
+            static function (int $errno) use (&$count): bool {
+                if ($errno === E_USER_DEPRECATED) {
+                    $count++;
+                }
+                return true;
+            }
+        );
+        $reporting_level = \error_reporting(E_ALL);
+        try {
+            $callback();
+        } finally {
+            \error_reporting($reporting_level);
+            \restore_error_handler();
+        }
+
+        return $count;
+    }
+}

--- a/tests/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
+++ b/tests/functional/Glpi/Helpdesk/DefaultDataManagerTest.php
@@ -45,6 +45,7 @@ use Glpi\Form\FormTranslation;
 use Glpi\Helpdesk\DefaultDataManager;
 use Glpi\Helpdesk\Tile\Item_Tile;
 use Glpi\Helpdesk\Tile\TileInterface;
+use Glpi\Locale\LanguageRegistry;
 use Glpi\Session\SessionInfo;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormTesterTrait;
@@ -246,8 +247,6 @@ final class DefaultDataManagerTest extends DbTestCase
     #[DataProvider('provideFormTranslationsProvider')]
     public function testFormTranslations(string $form_name): void
     {
-        global $CFG_GLPI;
-
         $this->login();
 
         // Arrange: Get default incident form
@@ -265,7 +264,7 @@ final class DefaultDataManagerTest extends DbTestCase
         $crawler = new Crawler($content);
 
         // Assert: the translations languages table is not empty
-        foreach (array_keys($CFG_GLPI['languages']) as $language) {
+        foreach (array_keys(LanguageRegistry::all()) as $language) {
             $nodes = $crawler->filter(sprintf('#form-translation-modal-%s', $language));
             $this->assertCount(1, $nodes, sprintf("Translation modal for language '%s' should be present", $language));
         }

--- a/tests/src/GLPITestCase.php
+++ b/tests/src/GLPITestCase.php
@@ -52,6 +52,7 @@ use Dropdown;
 use Entity;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Cache\CacheManager;
+use Glpi\Config\ConfigContainer;
 use Glpi\Dashboard\Dashboard;
 use Glpi\Dashboard\Grid;
 use Glpi\Dropdown\DropdownDefinitionManager;
@@ -89,7 +90,7 @@ class GLPITestCase extends TestCase
     private $int;
     private $str;
     protected $has_failed = false;
-    private ?array $config_copy = null;
+    private ?ConfigContainer $config_copy = null;
     private array $superglobals_copy = [];
 
     private TestHandler $log_handler;
@@ -510,7 +511,9 @@ class GLPITestCase extends TestCase
         $this->superglobals_copy['SERVER'] = $_SERVER;
 
         if ($this->config_copy === null) {
-            $this->config_copy = $CFG_GLPI;
+            // Snapshot the config as an independent copy (ConfigContainer holds
+            // its data in an array property, copied by value on clone).
+            $this->config_copy = clone $CFG_GLPI;
         }
     }
 
@@ -537,7 +540,7 @@ class GLPITestCase extends TestCase
 
         // Globals
         global $CFG_GLPI, $FOOTER_LOADED, $HEADER_LOADED;
-        $CFG_GLPI = $this->config_copy;
+        $CFG_GLPI = clone $this->config_copy;
         $FOOTER_LOADED = false;
         $HEADER_LOADED = false;
 


### PR DESCRIPTION
Wrap the global $CFG_GLPI into a Glpi\Config\ConfigContainer so individual
keys can be flagged as deprecated while staying fully backward compatible.
Also move Config::getSafeConfig() logic into ConfigContainer::getSafeConfig().

The `languages` and `main_languages` keys are the first ones deprecated, following #24864.