### PR TITLE
Add a default/fallback reauth strategy always available.

### DIFF
--- a/src/Glpi/Security/ReAuth/FallbackReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/FallbackReAuthStrategy.php
@@ -36,18 +36,48 @@ declare(strict_types=1);
 
 namespace Glpi\Security\ReAuth;
 
-enum ReAuthStrategyEnum: string
-{
-    case TOTP = 'totp';
-    case PASSWORD = 'password';
-    case FALLBACK = 'fallback';
+use Override;
 
-    public function createStrategy(): ReAuthStrategyInterface
+/**
+ * Fallback re-authentication strategy.
+ *
+ * Always available and always succeeds: it only displays a confirmation
+ * message in the prompt. It exists so that a user who has no other strategy
+ * available (e.g. no local password and no TOTP) is never left without a way
+ * to pass the re-authentication step.
+ *
+ * As it provides no real identity check, it has the lowest priority and is
+ * only selected when no stronger strategy is available.
+ */
+final class FallbackReAuthStrategy implements ReAuthStrategyInterface
+{
+    #[Override]
+    public function verify(int $users_id, string $user_input): bool
     {
-        return match ($this) {
-            self::TOTP => new TOTPReAuthStrategy(),
-            self::PASSWORD => new PasswordReAuthStrategy(),
-            self::FALLBACK => new FallbackReAuthStrategy(),
-        };
+        return true;
+    }
+
+    #[Override]
+    public function isAvailable(int $users_id, int $entities_id = 0): bool
+    {
+        return true;
+    }
+
+    #[Override]
+    public function getLabel(): string
+    {
+        return __('Confirmation');
+    }
+
+    #[Override]
+    public function getPromptTemplate(): string
+    {
+        return 'pages/reauth/fallback_form.html.twig';
+    }
+
+    #[Override]
+    public function getPriority(): int
+    {
+        return 0;
     }
 }

--- a/templates/pages/reauth/fallback_form.html.twig
+++ b/templates/pages/reauth/fallback_form.html.twig
@@ -1,0 +1,33 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+<p class="text-muted mb-0">{{ __('Please confirm that you want to perform this sensitive action.') }}</p>

--- a/tests/functional/Glpi/Security/ReAuth/FallbackReAuthStrategyTest.php
+++ b/tests/functional/Glpi/Security/ReAuth/FallbackReAuthStrategyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Security\ReAuth;
+
+use Glpi\Security\ReAuth\FallbackReAuthStrategy;
+use Glpi\Tests\DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use User;
+
+#[Group('reauth')]
+class FallbackReAuthStrategyTest extends DbTestCase
+{
+    public static function usersProvider(): iterable
+    {
+        // [use_test_user]
+        yield 'known user'   => [true];
+        yield 'unknown user' => [false];
+    }
+
+    /**
+     * The fallback strategy is always available: it is the last-resort strategy so a user is
+     * never left without a way to pass the re-authentication step, even for an unknown user id.
+     */
+    #[DataProvider('usersProvider')]
+    public function testIsAvailableIsAlwaysTrue(bool $use_test_user): void
+    {
+        // --- arrange ---
+        $strategy = new FallbackReAuthStrategy();
+        $users_id = $use_test_user ? getItemByTypeName(User::class, TU_USER, true) : 999999;
+
+        // --- act + assert ---
+        $this->assertTrue($strategy->isAvailable($users_id));
+    }
+
+    public static function verifyProvider(): iterable
+    {
+        // [use_test_user, user_input]
+        yield 'known user, empty input'   => [true, ''];
+        yield 'known user, any input'     => [true, 'whatever'];
+        yield 'unknown user, empty input' => [false, ''];
+        yield 'unknown user, any input'   => [false, 'whatever'];
+    }
+
+    /** verify() always succeeds: the fallback only asks for a confirmation, it checks nothing. */
+    #[DataProvider('verifyProvider')]
+    public function testVerifyAlwaysSucceeds(bool $use_test_user, string $user_input): void
+    {
+        // --- arrange ---
+        $strategy = new FallbackReAuthStrategy();
+        $users_id = $use_test_user ? getItemByTypeName(User::class, TU_USER, true) : 999999;
+
+        // --- act + assert ---
+        $this->assertTrue($strategy->verify($users_id, $user_input));
+    }
+
+    /** Test $strategy->getPromptTemplate(), $strategy->getPriority() & $strategy->getLabel() */
+    public function testMetadata(): void
+    {
+        // --- arrange ---
+        $strategy = new FallbackReAuthStrategy();
+
+        // --- act + assert ---
+        $this->assertSame('pages/reauth/fallback_form.html.twig', $strategy->getPromptTemplate());
+        // Lowest priority: the fallback is only picked when no stronger strategy is available.
+        $this->assertSame(0, $strategy->getPriority());
+        $this->assertNotEmpty($strategy->getLabel());
+    }
+}

--- a/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
+++ b/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
@@ -233,6 +233,26 @@ class ReAuthManagerTest extends DbTestCase
         $this->assertSame([], $manager->getRequestedPostData());
     }
 
+    /**
+     * When the user has no stronger strategy available (no local password, no TOTP), the
+     * always-available fallback strategy is selected and its confirmation prompt is used.
+     */
+    public function testFallbackStrategyIsSelectedWhenNoStrongStrategyAvailable(): void
+    {
+        global $DB;
+
+        // --- arrange : logged-in user stripped of every strong strategy ---
+        $this->login();
+        $users_id = (int) $_SESSION['glpiID'];
+        // Direct DB update to bypass the business layer, which would not let us clear the password/2FA fields.
+        $DB->update('glpi_users', ['password' => '', '2fa' => null], ['id' => $users_id]);
+        $manager = new ReAuthManager();
+
+        // --- act + assert : the fallback prompt is used and any input is accepted ---
+        $this->assertSame('pages/reauth/fallback_form.html.twig', $manager->getPromptTemplate());
+        $this->assertTrue($manager->verify('no-check-is-done'));
+    }
+
     /** Throws InvalidArgumentException when a non-CommonGLPI class is passed. */
     public function testAtLeastOneItemTypeRequiresReauthenticationThrowsOnInvalidType(): void
     {


### PR DESCRIPTION
Provide a new reauth strategy always available (fallback).

In some case (not a db user, no oauth server supporting reauth) no reauth strategy may be available. It triggers an exception.
This pr solve this cases, no more exception, always a strategy available.

It currently just display a message and always successfully `verify`.
