### PR TITLE
Add customizable axis labels to DCRoom layouts

### DIFF
--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -161,7 +161,6 @@ ul.indexes {
     box-sizing: content-box;
     margin: 10px 0 10px 10px;
     float: left;
-    padding: 15px 0 0 15px;
     position: relative;
 
     *,
@@ -171,8 +170,11 @@ ul.indexes {
     }
 
     .blueprint {
-        margin-left: 15px;
-        width: calc(100% - 16px);
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        z-index: 1;
+        pointer-events: none;
     }
 
     .racks_add {
@@ -190,7 +192,9 @@ ul.indexes {
                 var(--tblr-border-color) 1px,
                 transparent 1px
             );
-        margin-left: 15px;
+        position: absolute;
+        inset: 0;
+        z-index: 2;
 
         .cell_add {
             height: var(--dcroom-grid-cellh);
@@ -205,7 +209,8 @@ ul.indexes {
     }
 
     .grid-stack {
-        float: left;
+        position: absolute;
+        inset: 0;
     }
 
     .grid-stack-item {
@@ -269,24 +274,97 @@ ul.indexes {
         float: left;
 
         &.indexes-x {
-            width: 100%;
+            grid-column: 2;
+            grid-row: 1;
             float: none;
             height: 15px;
-            padding-left: 15px;
 
             li {
                 float: left;
                 width: var(--dcroom-grid-cellw);
+                height: 15px;
             }
         }
 
         &.indexes-y {
-            width: 15px;
+            grid-column: 1;
+            grid-row: 2;
+            width: auto;
 
             li {
                 height: var(--dcroom-grid-cellh);
-                line-height: calc(var(--dcroom-grid-cellh) + 1px);
+                min-width: 15px;
+                display: flex;
+                justify-content: flex-end;
+                align-items: center;
             }
+        }
+    }
+
+    .dcroom-grid-layout {
+        display: grid;
+        grid-template-columns: max-content max-content;
+        grid-template-rows: 15px max-content;
+    }
+
+    .dcroom-grid-canvas {
+        grid-column: 2;
+        grid-row: 2;
+        position: relative;
+    }
+
+    .dcroom-axis-label-button,
+    .dcroom-axis-label-input {
+        box-sizing: border-box;
+        height: 100%;
+        min-width: 0;
+        border: 0;
+        border-radius: 2px;
+        padding: 0 3px;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        line-height: normal;
+    }
+
+    .dcroom-axis-label-button {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        cursor: text;
+
+        &:hover,
+        &:focus-visible {
+            background-color: var(--tblr-secondary-bg);
+            outline: 1px solid var(--tblr-border-color);
+        }
+    }
+
+    .dcroom-axis-label > span {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .indexes-x {
+        .dcroom-axis-label-button,
+        .dcroom-axis-label-input,
+        .dcroom-axis-label > span {
+            width: var(--dcroom-grid-cellw);
+        }
+    }
+
+    .indexes-y {
+        .dcroom-axis-label-button,
+        .dcroom-axis-label > span {
+            max-width: 240px;
+        }
+
+        .dcroom-axis-label-input {
+            width: 160px;
+            max-width: 240px;
         }
     }
 }

--- a/css/includes/components/_racks.scss
+++ b/css/includes/components/_racks.scss
@@ -332,6 +332,7 @@ ul.indexes {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        font-weight: 700;
         cursor: text;
 
         &:hover,
@@ -346,6 +347,7 @@ ul.indexes {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        font-weight: 700;
     }
 
     .indexes-x {

--- a/install/migrations/update_11.0.x_to_12.0.0/dcroom_axis_labels.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/dcroom_axis_labels.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/** @var Migration $migration */
+
+$migration->addField('glpi_dcrooms', 'column_labels', 'text', [
+    'value' => null,
+    'after' => 'vis_cell_height',
+]);
+$migration->addField('glpi_dcrooms', 'row_labels', 'text', [
+    'value' => null,
+    'after' => 'column_labels',
+]);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8544,6 +8544,8 @@ CREATE TABLE `glpi_dcrooms` (
   `vis_rows` int DEFAULT NULL,
   `vis_cell_width` int NOT NULL DEFAULT '40',
   `vis_cell_height` int NOT NULL DEFAULT '40',
+  `column_labels` text,
+  `row_labels` text,
   `blueprint` text,
   `datacenters_id` int unsigned NOT NULL DEFAULT '0',
   `is_deleted` tinyint NOT NULL DEFAULT '0',

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -46,6 +46,10 @@ class DCRoom extends CommonDBTM implements DCBreadcrumbInterface
 {
     use DCBreadcrumb;
 
+    public const AXIS_COLUMN = 'column';
+    public const AXIS_ROW = 'row';
+    public const AXIS_LABEL_MAX_LENGTH = 100;
+
     // From CommonDBTM
     public bool $dohistory                   = true;
     protected bool $usenotepad               = true;
@@ -446,16 +450,112 @@ class DCRoom extends CommonDBTM implements DCBreadcrumbInterface
     public function getAllPositions()
     {
         $positions = [];
+        $column_labels = $this->getAxisLabels(self::AXIS_COLUMN);
+        $row_labels = $this->getAxisLabels(self::AXIS_ROW);
         for ($x = 1; $x < (int) $this->fields['vis_cols'] + 1; ++$x) {
             for ($y = 1; $y < (int) $this->fields['vis_rows'] + 1; ++$y) {
                 $positions["$x,$y"] = sprintf(
                     __('col: %1$s, row: %2$s'),
-                    Toolbox::getBijectiveIndex($x),
-                    $y
+                    $column_labels[$x] ?? $this->getDefaultAxisLabel(self::AXIS_COLUMN, $x),
+                    $row_labels[$y] ?? $this->getDefaultAxisLabel(self::AXIS_ROW, $y)
                 );
             }
         }
         return $positions;
+    }
+
+    /**
+     * Get custom labels for an axis, indexed by their 1-based position.
+     *
+     * @return array<int, string>
+     */
+    public function getAxisLabels(string $axis): array
+    {
+        $field = $this->getAxisLabelsField($axis);
+        $decoded = json_decode($this->fields[$field] ?? '', true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $labels = [];
+        foreach ($decoded as $position => $label) {
+            if (
+                (!is_int($position) && !ctype_digit($position))
+                || (int) $position < 1
+                || !is_string($label)
+                || trim($label) === ''
+            ) {
+                continue;
+            }
+            $labels[(int) $position] = $label;
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Get the effective label for an axis position.
+     */
+    public function getAxisLabel(string $axis, int $position): string
+    {
+        $labels = $this->getAxisLabels($axis);
+        return $labels[$position] ?? $this->getDefaultAxisLabel($axis, $position);
+    }
+
+    /**
+     * Save or remove a custom label for an axis position.
+     */
+    public function updateAxisLabel(string $axis, int $position, string $label): bool
+    {
+        $dimension_field = match ($axis) {
+            self::AXIS_COLUMN => 'vis_cols',
+            self::AXIS_ROW => 'vis_rows',
+            default => throw new InvalidArgumentException('Invalid room axis.'),
+        };
+        if ($position < 1 || $position > (int) $this->fields[$dimension_field]) {
+            throw new InvalidArgumentException('Axis position is outside the room bounds.');
+        }
+
+        $label = trim($label);
+        if (mb_strlen($label, 'UTF-8') > self::AXIS_LABEL_MAX_LENGTH) {
+            throw new InvalidArgumentException('Axis label is too long.');
+        }
+
+        $labels = $this->getAxisLabels($axis);
+        if ($label === '') {
+            unset($labels[$position]);
+        } else {
+            $labels[$position] = $label;
+        }
+        ksort($labels, SORT_NUMERIC);
+
+        return $this->update([
+            'id' => $this->getID(),
+            $this->getAxisLabelsField($axis) => $labels === []
+                ? null
+                : json_encode(
+                    $labels,
+                    JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+                ),
+        ]);
+    }
+
+    private function getAxisLabelsField(string $axis): string
+    {
+        return match ($axis) {
+            self::AXIS_COLUMN => 'column_labels',
+            self::AXIS_ROW => 'row_labels',
+            default => throw new InvalidArgumentException('Invalid room axis.'),
+        };
+    }
+
+    private function getDefaultAxisLabel(string $axis, int $position): string
+    {
+        return match ($axis) {
+            self::AXIS_COLUMN => Toolbox::getBijectiveIndex($position),
+            self::AXIS_ROW => (string) $position,
+            default => throw new InvalidArgumentException('Invalid room axis.'),
+        };
     }
 
     public static function getIcon()

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Features\DCBreadcrumb;
 use Glpi\Features\DCBreadcrumbInterface;
 
+use function Safe\json_decode;
 use function Safe\preg_match;
 
 /**

--- a/src/DCRoom.php
+++ b/src/DCRoom.php
@@ -473,7 +473,12 @@ class DCRoom extends CommonDBTM implements DCBreadcrumbInterface
     public function getAxisLabels(string $axis): array
     {
         $field = $this->getAxisLabelsField($axis);
-        $decoded = json_decode($this->fields[$field] ?? '', true);
+        $value = $this->fields[$field] ?? null;
+        if (!is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
         if (!is_array($decoded)) {
             return [];
         }

--- a/src/Glpi/Controller/DCRoom/UpdateAxisLabelController.php
+++ b/src/Glpi/Controller/DCRoom/UpdateAxisLabelController.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\DCRoom;
+
+use DCRoom;
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Exception\Http\NotFoundHttpException;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class UpdateAxisLabelController extends AbstractController
+{
+    #[Route(
+        '/DCRoom/{id}/AxisLabel',
+        name: 'glpi_dcroom_axis_label_update',
+        methods: ['POST'],
+        requirements: ['id' => '\d+'],
+    )]
+    public function __invoke(int $id, Request $request): JsonResponse
+    {
+        $room = new DCRoom();
+        if (!$room->getFromDB($id)) {
+            throw new NotFoundHttpException();
+        }
+        if (!$room->can($id, UPDATE)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $payload = $request->getPayload();
+        $this->validateInputHasExactKeys($payload->all(), [
+            'axis',
+            'position',
+            'label',
+        ]);
+        $axis = $payload->getString('axis');
+        $position = $payload->getInt('position');
+        $label = $payload->getString('label');
+
+        try {
+            if (!$room->updateAxisLabel($axis, $position, $label)) {
+                throw new RuntimeException('Failed to update the room axis label.');
+            }
+        } catch (InvalidArgumentException $e) {
+            throw new BadRequestHttpException($e->getMessage(), previous: $e);
+        }
+
+        return new JsonResponse([
+            'label' => $room->getAxisLabel($axis, $position),
+        ]);
+    }
+}

--- a/src/Rack.php
+++ b/src/Rack.php
@@ -461,6 +461,28 @@ class Rack extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbIn
         $grid_w   = $cell_w * $cols;
         $grid_h   = $cell_h * $rows;
 
+        $custom_column_labels = $room->getAxisLabels(DCRoom::AXIS_COLUMN);
+        $custom_row_labels = $room->getAxisLabels(DCRoom::AXIS_ROW);
+        $column_axis_labels = [];
+        for ($position = 1; $position <= $cols; ++$position) {
+            $coordinate = Toolbox::getBijectiveIndex($position);
+            $column_axis_labels[] = [
+                'position' => $position,
+                'coordinate' => $coordinate,
+                'label' => $custom_column_labels[$position] ?? $coordinate,
+                'custom_label' => $custom_column_labels[$position] ?? '',
+            ];
+        }
+        $row_axis_labels = [];
+        for ($position = 1; $position <= $rows; ++$position) {
+            $row_axis_labels[] = [
+                'position' => $position,
+                'coordinate' => (string) $position,
+                'label' => $custom_row_labels[$position] ?? (string) $position,
+                'custom_label' => $custom_row_labels[$position] ?? '',
+            ];
+        }
+
         //fill rows
         $cells    = [];
         $outbound = [];
@@ -523,6 +545,9 @@ class Rack extends CommonDBTM implements AssignableItemInterface, DCBreadcrumbIn
             'cells' => $cells,
             'outbound' => $outbound,
             'blueprint_url' => $blueprint_url,
+            'column_axis_labels' => $column_axis_labels,
+            'row_axis_labels' => $row_axis_labels,
+            'can_edit_axis_labels' => $canedit,
         ]);
 
         return true;

--- a/templates/pages/management/dcroom_racks.html.twig
+++ b/templates/pages/management/dcroom_racks.html.twig
@@ -95,7 +95,7 @@
             </tbody>
         </table>
     {% endif %}
-    <div class="grid-room" style="width: {{ grid_w + 16 }}px; min-height: {{ grid_h + 16 }}px">
+    <div class="grid-room">
         <span class="racks_view_controls">
             {% if blueprint_url is not empty %}
                 <span class="mini_toggle active" id="toggle_blueprint">{{ __('Blueprint') }}</span>
@@ -103,22 +103,62 @@
             <span class="mini_toggle active" id="toggle_grid">{{ __('Grid') }}</span>
             <div class="clearfix"></div>
         </span>
-        <ul class="indexes indexes-x"></ul>
-        <ul class="indexes indexes-y"></ul>
-        {% if room.canCreate() %}
-            <div class="racks_add" style="width: {{ grid_w }}px"></div>
-        {% endif %}
-        <div class="grid-stack grid-stack-{{ cols }}" style="width: {{ grid_w }}px">
-            {% for cell in cells %}
-                {{ _self.get_cell(cell) }}
-            {% endfor %}
-            <div class="grid-stack-item lock-bottom" gs-no-resize="true" gs-no-move="true" gs-h="1"
-                 gs-w="{{ cols }}" gs-x="0" gs-y="{{ rows }}"></div>
+        <div class="dcroom-grid-layout">
+            <ul class="indexes indexes-x">
+                {% for axis_label in column_axis_labels %}
+                    <li class="dcroom-axis-label"
+                        data-axis="{{ constant('DCRoom::AXIS_COLUMN') }}"
+                        data-position="{{ axis_label.position }}"
+                        data-coordinate="{{ axis_label.coordinate }}"
+                        data-custom-label="{{ axis_label.custom_label }}">
+                        {% if can_edit_axis_labels %}
+                            <button type="button" class="dcroom-axis-label-button"
+                                    title="{{ axis_label.label }} ({{ __('Column') }}: {{ axis_label.coordinate }})"
+                                    aria-label="{{ __('Edit label for column %s')|format(axis_label.coordinate) }}">
+                                {{ axis_label.label }}
+                            </button>
+                        {% else %}
+                            <span title="{{ axis_label.label }} ({{ __('Column') }}: {{ axis_label.coordinate }})">{{ axis_label.label }}</span>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+            <ul class="indexes indexes-y">
+                {% for axis_label in row_axis_labels %}
+                    <li class="dcroom-axis-label"
+                        data-axis="{{ constant('DCRoom::AXIS_ROW') }}"
+                        data-position="{{ axis_label.position }}"
+                        data-coordinate="{{ axis_label.coordinate }}"
+                        data-custom-label="{{ axis_label.custom_label }}">
+                        {% if can_edit_axis_labels %}
+                            <button type="button" class="dcroom-axis-label-button"
+                                    title="{{ axis_label.label }} ({{ __('Row') }}: {{ axis_label.coordinate }})"
+                                    aria-label="{{ __('Edit label for row %s')|format(axis_label.coordinate) }}">
+                                {{ axis_label.label }}
+                            </button>
+                        {% else %}
+                            <span title="{{ axis_label.label }} ({{ __('Row') }}: {{ axis_label.coordinate }})">{{ axis_label.label }}</span>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+            <div class="dcroom-grid-canvas" style="width: {{ grid_w }}px; height: {{ grid_h }}px">
+                {% if blueprint_url is not empty %}
+                    <div class="blueprint"
+                         style="background: url('{{ blueprint_url }}') no-repeat top left/100% 100%; height: {{ grid_h }}px"></div>
+                {% endif %}
+                {% if room.canCreate() %}
+                    <div class="racks_add" style="width: {{ grid_w }}px; height: {{ grid_h }}px"></div>
+                {% endif %}
+                <div class="grid-stack grid-stack-{{ cols }}" style="width: {{ grid_w }}px">
+                    {% for cell in cells %}
+                        {{ _self.get_cell(cell) }}
+                    {% endfor %}
+                    <div class="grid-stack-item lock-bottom" gs-no-resize="true" gs-no-move="true" gs-h="1"
+                         gs-w="{{ cols }}" gs-x="0" gs-y="{{ rows }}"></div>
+                </div>
+            </div>
         </div>
-        {% if blueprint_url is not empty %}
-            <div class="blueprint"
-                 style="background: url('{{ blueprint_url }}') no-repeat top left/100% 100%; height: {{ grid_h }}px"></div>
-        {% endif %}
     </div>
 </div>
 
@@ -156,12 +196,92 @@
         disableResize: true,
     });
 
-    for (let x = 1; x <= {{ cols }}; x++) {
-        $('.indexes-x').append('<li>' + getBijectiveIndex(x) + '</li>');
-    }
-    for (let y = 1; y <= {{ rows }}; y++) {
-        $('.indexes-y').append('<li>' + y + '</li>');
-    }
+    {% if can_edit_axis_labels %}
+        const axis_labels_container = document.querySelector('#viewgraph .dcroom-grid-layout');
+        axis_labels_container.addEventListener('click', (event) => {
+            const button = event.target.closest('.dcroom-axis-label-button');
+            if (button === null) {
+                return;
+            }
+
+            const axis_label = button.closest('.dcroom-axis-label');
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'dcroom-axis-label-input';
+            input.maxLength = {{ constant('DCRoom::AXIS_LABEL_MAX_LENGTH') }};
+            input.value = axis_label.dataset.customLabel;
+            input.placeholder = axis_label.dataset.coordinate;
+            input.setAttribute('aria-label', button.getAttribute('aria-label'));
+            button.replaceWith(input);
+            input.focus();
+            input.select();
+
+            let cancelled = false;
+            let saving = false;
+            const restore_button = (restore_focus = false) => {
+                if (input.isConnected) {
+                    input.replaceWith(button);
+                }
+                if (restore_focus) {
+                    button.focus();
+                }
+            };
+            const save = async (restore_focus = false) => {
+                if (cancelled || saving || !input.isConnected) {
+                    return;
+                }
+                const label = input.value.trim();
+                if (label === axis_label.dataset.customLabel) {
+                    restore_button(restore_focus);
+                    return;
+                }
+                saving = true;
+                input.disabled = true;
+
+                try {
+                    const response = await fetch('{{ path('glpi_dcroom_axis_label_update', {'id': room.getID()}) }}', {
+                        method: 'POST',
+                        headers: {
+                            'Accept': 'application/json',
+                            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+                        },
+                        body: new URLSearchParams({
+                            axis: axis_label.dataset.axis,
+                            position: axis_label.dataset.position,
+                            label,
+                        }),
+                    });
+                    if (!response.ok) {
+                        throw new Error(`HTTP ${response.status}`);
+                    }
+                    const data = await response.json();
+                    axis_label.dataset.customLabel = label;
+                    button.textContent = data.label;
+                    const coordinate_name = axis_label.dataset.axis === '{{ constant('DCRoom::AXIS_COLUMN') }}'
+                        ? '{{ __('Column')|e('js') }}'
+                        : '{{ __('Row')|e('js') }}';
+                    button.title = `${data.label} (${coordinate_name}: ${axis_label.dataset.coordinate})`;
+                    restore_button(restore_focus);
+                } catch {
+                    restore_button(restore_focus);
+                    glpi_toast_error('{{ __('Unable to save the room axis label.')|e('js') }}');
+                }
+            };
+
+            input.addEventListener('keydown', (key_event) => {
+                if (key_event.key === 'Enter') {
+                    key_event.preventDefault();
+                    save(true);
+                } else if (key_event.key === 'Escape') {
+                    key_event.preventDefault();
+                    cancelled = true;
+                    restore_button(true);
+                }
+            });
+            input.addEventListener('blur', () => save());
+        });
+    {% endif %}
+
     // append cells for adding racks
     for (let y = 1; y <= {{ rows }}; y++) {
         for (let x = 1; x <= {{ cols }}; x++) {

--- a/tests/functional/DCRoomTest.php
+++ b/tests/functional/DCRoomTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use DCRoom;
+use Glpi\Tests\DbTestCase;
+use InvalidArgumentException;
+
+final class DCRoomTest extends DbTestCase
+{
+    public function testAxisLabels(): void
+    {
+        $this->login();
+        $room = $this->createItem(DCRoom::class, [
+            'name' => 'Room with custom axis labels',
+            'entities_id' => $this->getTestRootEntity()->getID(),
+            'vis_cols' => 3,
+            'vis_rows' => 2,
+        ]);
+
+        $this->assertSame('B', $room->getAxisLabel(DCRoom::AXIS_COLUMN, 2));
+        $this->assertSame('1', $room->getAxisLabel(DCRoom::AXIS_ROW, 1));
+
+        $this->assertTrue($room->updateAxisLabel(DCRoom::AXIS_COLUMN, 2, ' Cold aisle '));
+        $this->assertTrue($room->updateAxisLabel(DCRoom::AXIS_ROW, 1, 'Вход'));
+
+        $room->getFromDB($room->getID());
+        $this->assertSame([2 => 'Cold aisle'], $room->getAxisLabels(DCRoom::AXIS_COLUMN));
+        $this->assertSame([1 => 'Вход'], $room->getAxisLabels(DCRoom::AXIS_ROW));
+        $this->assertSame(
+            'col: Cold aisle, row: Вход',
+            $room->getAllPositions()['2,1']
+        );
+
+        $this->assertTrue($room->update([
+            'id' => $room->getID(),
+            'vis_cols' => 1,
+        ]));
+        $room->getFromDB($room->getID());
+        $this->assertSame([2 => 'Cold aisle'], $room->getAxisLabels(DCRoom::AXIS_COLUMN));
+
+        $this->assertTrue($room->update([
+            'id' => $room->getID(),
+            'vis_cols' => 3,
+        ]));
+        $this->assertTrue($room->updateAxisLabel(DCRoom::AXIS_COLUMN, 2, ''));
+        $this->assertSame('B', $room->getAxisLabel(DCRoom::AXIS_COLUMN, 2));
+        $this->assertSame([], $room->getAxisLabels(DCRoom::AXIS_COLUMN));
+    }
+
+    public function testAxisLabelValidation(): void
+    {
+        $this->login();
+        $room = $this->createItem(DCRoom::class, [
+            'name' => 'Room for axis label validation',
+            'entities_id' => $this->getTestRootEntity()->getID(),
+            'vis_cols' => 2,
+            'vis_rows' => 2,
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $room->updateAxisLabel(
+            DCRoom::AXIS_COLUMN,
+            1,
+            str_repeat('Ж', DCRoom::AXIS_LABEL_MAX_LENGTH + 1)
+        );
+    }
+}

--- a/tests/functional/Glpi/Controller/DCRoom/UpdateAxisLabelControllerTest.php
+++ b/tests/functional/Glpi/Controller/DCRoom/UpdateAxisLabelControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\DCRoom;
+
+use DCRoom;
+use Glpi\Controller\DCRoom\UpdateAxisLabelController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Tests\DbTestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+use function Safe\json_decode;
+
+final class UpdateAxisLabelControllerTest extends DbTestCase
+{
+    public function testUpdateAxisLabel(): void
+    {
+        $this->login();
+        $room = $this->createRoom();
+
+        $response = $this->callController($room->getID(), [
+            'axis' => DCRoom::AXIS_COLUMN,
+            'position' => 2,
+            'label' => 'UPS side',
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['label' => 'UPS side'], json_decode($response->getContent(), true));
+        $room->getFromDB($room->getID());
+        $this->assertSame([2 => 'UPS side'], $room->getAxisLabels(DCRoom::AXIS_COLUMN));
+    }
+
+    public function testRejectsPositionOutsideRoom(): void
+    {
+        $this->login();
+        $room = $this->createRoom();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController($room->getID(), [
+            'axis' => DCRoom::AXIS_ROW,
+            'position' => 3,
+            'label' => 'Outside',
+        ]);
+    }
+
+    public function testRequiresUpdateRight(): void
+    {
+        $this->login();
+        $room = $this->createRoom();
+        $this->login('normal', 'normal');
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->callController($room->getID(), [
+            'axis' => DCRoom::AXIS_ROW,
+            'position' => 1,
+            'label' => 'Restricted',
+        ]);
+    }
+
+    private function createRoom(): DCRoom
+    {
+        return $this->createItem(DCRoom::class, [
+            'name' => 'Room for axis label controller',
+            'entities_id' => $this->getTestRootEntity()->getID(),
+            'vis_cols' => 2,
+            'vis_rows' => 2,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function callController(int $room_id, array $parameters): JsonResponse
+    {
+        $request = new Request(request: $parameters);
+        $request->setMethod(Request::METHOD_POST);
+
+        return (new UpdateAxisLabelController())($room_id, $request);
+    }
+}


### PR DESCRIPTION
## Summary

This contribution adds customizable row and column labels to DCRoom layouts.

DCRoom currently displays generated coordinates for rack positions. However, real data centers may use their own physical naming schemes that do not match the generated GLPI coordinates.

For example, in our environment columns are identified as `010`, `020`, and `030`, while rows use operational names such as `testrow` and `prodrow`. We already use these labels in production through a custom plugin. Displaying them directly in the DCRoom layout makes the GLPI plan consistent with the actual room naming scheme and avoids maintaining a separate mapping between GLPI coordinates and physical locations.

## Changes

- Add room-specific custom labels for rows and columns.
- Store only overridden labels while preserving the existing generated coordinates as defaults.
- Render axis labels on the server as part of the DCRoom layout.
- Allow users with update permission on the DCRoom to edit labels directly on the plan.
- Support saving with Enter or when the input loses focus, and cancelling with Escape.
- Restore the generated coordinate when a custom label is cleared.
- Use custom labels in rack position selectors and other position descriptions.
- Adjust the grid layout to accommodate longer row labels.
- Add accessible labels and keyboard support for inline editing.
- Add functional coverage for label persistence, validation, permissions, and the update controller.

## Backward compatibility

Existing DCRooms keep their current generated column and row coordinates unless a custom label is defined.

Custom labels are stored as sparse per-room mappings. Clearing a label removes its override and restores the default coordinate.

The database migration only adds nullable fields to `glpi_dcrooms`; no existing room data is modified.

## Testing

- PHP syntax checks passed for all changed PHP files.
- `git diff --check` passed.
- Functional tests were added for the DCRoom model and the axis-label update controller.
- The feature was manually verified on a test GLPI installation, including display and inline editing.
- The full PHPUnit suite was not run locally because the required dependencies and test database are not configured in this checkout; CI is expected to run it.

## AI usage

OpenAI Codex was used to assist with codebase exploration, implementation and test drafting, code review, and preparation of the pull request description. The resulting changes were reviewed by the contributor and the feature was manually tested on a GLPI installation.

## Screenshot


<img width="618" height="267" alt="Screenshot_25" src="https://github.com/user-attachments/assets/96c15bbc-3f9a-465a-9451-fd1cd69383c3" />

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that cover the new behavior.
