### PR TITLE
FIX / Entity selector row click not submitting the form

### DIFF
--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -284,23 +284,12 @@
             searchTree();
         });
 
-        // Focusing an entity button triggers Fancytree's own "focusin" handler, which
-        // (via autoScroll) synchronously redraws the viewport extension's rows. That
-        // redraw happens between mousedown and click, so by the time "click" fires the
-        // button has already been rebuilt/detached and its external form submission
-        // (form="ch_ent_o_*"/"ch_ent_r_*") is silently cancelled by the browser.
-        // We intercept on "mousedown" (capture phase, before Fancytree's own handlers)
-        // to both read the button while the DOM is still untouched and to preventDefault
-        // the native focus shift that would trigger the redraw in the first place, then
-        // submit the form ourselves. The paired "click" listener only exists to swallow
-        // the click that still follows, so Fancytree's own click handling and the
-        // button's native default action never run (which would otherwise double-submit).
-        //
-        // The forms carry a single-use CSRF token rendered once at page load, so we also
-        // guard against firing more than one submission: without this, several rapid
-        // clicks before the resulting page navigation happens would fire multiple
-        // requests reusing the same token, and every one after the first would be
-        // rejected (the token gets consumed on first use).
+        // Fancytree redraws the row on focus, detaching the clicked button before
+        // "click" fires and silently cancelling its form submission. Intercepting
+        // "mousedown" instead lets us submit before that redraw happens; the "click"
+        // listener just swallows the click that follows (or handles keyboard
+        // activation). "submitted" prevents rapid clicks from reusing the same
+        // single-use CSRF token across several requests.
         (function() {
             const container = document.getElementById('tree_entity{{ rand }}');
             let pendingButton = null;

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -284,6 +284,80 @@
             searchTree();
         });
 
+        // Focusing an entity button triggers Fancytree's own "focusin" handler, which
+        // (via autoScroll) synchronously redraws the viewport extension's rows. That
+        // redraw happens between mousedown and click, so by the time "click" fires the
+        // button has already been rebuilt/detached and its external form submission
+        // (form="ch_ent_o_*"/"ch_ent_r_*") is silently cancelled by the browser.
+        // We intercept on "mousedown" (capture phase, before Fancytree's own handlers)
+        // to both read the button while the DOM is still untouched and to preventDefault
+        // the native focus shift that would trigger the redraw in the first place, then
+        // submit the form ourselves. The paired "click" listener only exists to swallow
+        // the click that still follows, so Fancytree's own click handling and the
+        // button's native default action never run (which would otherwise double-submit).
+        //
+        // The forms carry a single-use CSRF token rendered once at page load, so we also
+        // guard against firing more than one submission: without this, several rapid
+        // clicks before the resulting page navigation happens would fire multiple
+        // requests reusing the same token, and every one after the first would be
+        // rejected (the token gets consumed on first use).
+        (function() {
+            const container = document.getElementById('tree_entity{{ rand }}');
+            let pendingButton = null;
+            let submitted = false;
+
+            function submitEntityForm(btn) {
+                if (submitted) {
+                    return;
+                }
+                submitted = true;
+                const form = document.getElementById(btn.getAttribute('form'));
+                if (!form) {
+                    return;
+                }
+                let input = form.querySelector('input[name="id"]');
+                if (!input) {
+                    input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = 'id';
+                    form.appendChild(input);
+                }
+                input.value = btn.value;
+                form.requestSubmit();
+            }
+
+            container.addEventListener('mousedown', function(e) {
+                const btn = e.target.closest('button[type="submit"]');
+                if (!btn || !btn.getAttribute('form')) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                pendingButton = btn;
+                submitEntityForm(btn);
+            }, true);
+
+            container.addEventListener('click', function(e) {
+                if (pendingButton) {
+                    // Click that followed a mousedown we already handled: swallow it.
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    pendingButton = null;
+                    return;
+                }
+                // Keyboard activation (Enter/Space on a focused button) fires "click"
+                // directly, without a preceding mousedown, so it isn't affected by the
+                // focus-triggered redraw race and can be handled here directly.
+                const btn = e.target.closest('button[type="submit"]');
+                if (!btn || !btn.getAttribute('form')) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                submitEntityForm(btn);
+            }, true);
+        })();
+
         // when the shortcut for entity form is called
         hotkeys('ctrl+alt+e, option+command+e', async function(e) {
             e.stopPropagation();

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -156,3 +156,25 @@ test('Can switch to another entity without sub entities', async ({ page, profile
         'Root entity'
     );
 });
+
+test('Can select an entity by clicking on its row in the tree', async ({ page, profile }) => {
+    // Regression test: the entity tree (Fancytree) used to redraw the clicked
+    // row on focus, detaching the button before its form submission could go
+    // through, so the click was silently ignored.
+    await page.goto('/front/preference.php');
+    await profile.set(Profiles.SuperAdmin);
+    const glpi_page = new GlpiPage(page);
+
+    await glpi_page.doOpenEntitySelector();
+    await expect(glpi_page.active_entity).not.toHaveText(
+        'E2E worker entity 05'
+    );
+
+    // Click directly on the row's button, the same way a user does, rather
+    // than going through an API shortcut.
+    await glpi_page.doSwitchToEntityWithoutRecursion("E2E worker entity 05");
+
+    await expect(glpi_page.active_entity).toHaveText(
+        'E2E worker entity 05'
+    );
+});

--- a/tests/e2e/specs/Entity/entity_selector.spec.ts
+++ b/tests/e2e/specs/Entity/entity_selector.spec.ts
@@ -161,20 +161,23 @@ test('Can select an entity by clicking on its row in the tree', async ({ page, p
     // Regression test: the entity tree (Fancytree) used to redraw the clicked
     // row on focus, detaching the button before its form submission could go
     // through, so the click was silently ignored.
+    // The active entity breadcrumb is left-truncated, so only assert on the
+    // entity's own name rather than the full "Root entity > ..." path.
+    const entity_name = 'E2E worker entity 05';
+
     await page.goto('/front/preference.php');
     await profile.set(Profiles.SuperAdmin);
     const glpi_page = new GlpiPage(page);
 
     await glpi_page.doOpenEntitySelector();
-    await expect(glpi_page.active_entity).not.toHaveText(
-        'E2E worker entity 05'
-    );
+    await expect(glpi_page.active_entity).not.toContainText(entity_name);
+
+    // Open the entity selector
+    await glpi_page.doOpenEntitySelector();
 
     // Click directly on the row's button, the same way a user does, rather
     // than going through an API shortcut.
-    await glpi_page.doSwitchToEntityWithoutRecursion("E2E worker entity 05");
+    await glpi_page.doSwitchToEntityWithoutRecursion(entity_name);
 
-    await expect(glpi_page.active_entity).toHaveText(
-        'E2E worker entity 05'
-    );
+    await expect(glpi_page.active_entity).toContainText(entity_name);
 });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45193 & #22935 
- When using the search bar to find an entity and clicking on an entity in the selector dropdown, users could run into several different problems: sometimes a 403 or 405 error appeared in the browser console and nothing happened on screen, and sometimes, after clicking several times in a row, GLPI displayed a "not allowed" error in the interface. This is caused by a timing issue in how the entity list is rendered & how the JS library FancyTree redraw the clicked row.
This exact issue was already fixed in the next major version of GLPI (12.x), where the entity selector was rebuilt with Vue component.
The fix ensures the click is handled and the request sent before Fancytree gets a chance to redraw the row, instead of after. It also ensures that clicking several entities very quickly only ever sends one request — the first click — instead of sending several.

## Screenshots (if appropriate):

<img width="2314" height="384" alt="Capture d’écran du 2026-07-17 14-35-57" src="https://github.com/user-attachments/assets/eeaa5a6d-cf98-4a15-8b0c-01cb593acf6f" />
