### PR TITLE
Update KB aside illustrations

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -543,6 +543,52 @@ export class GlpiKnowbaseArticleController
     }
 
     /**
+     * Update the article illustration displayed in the knowledge base aside
+     * tree.
+     */
+    #updateAsideIllustration()
+    {
+        if (this.#item_id === null) {
+            return;
+        }
+
+        const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
+        const containers = aside.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-illustration]`
+        );
+
+        // The illustration picker preview already holds a freshly rendered node
+        // for the selected illustration. We clone it with a different size.
+        const source = this.#getIllustrationPreviewNode();
+        for (const container of containers) {
+            if (source === null) {
+                container.replaceChildren();
+            } else {
+                const icon = source.cloneNode(true);
+                // The aside renders illustrations at size 20 (see aside.html.twig).
+                icon.setAttribute('width', '20');
+                icon.setAttribute('height', '20');
+                container.replaceChildren(icon);
+            }
+        }
+    }
+
+    /**
+     * @return {?(SVGElement|HTMLImageElement)} The rendered illustration node
+     * from the picker preview, or null when no illustration is selected.
+     */
+    #getIllustrationPreviewNode()
+    {
+        const preview = this.#container.querySelector(
+            '[data-glpi-kb-illustration-container] [data-glpi-icon-picker-value-preview]'
+        );
+        return preview?.querySelector(
+            '[data-glpi-icon-picker-value-preview-native]:not(.d-none) svg,'
+            + ' [data-glpi-icon-picker-value-preview-custom]:not(.d-none) img'
+        ) ?? null;
+    }
+
+    /**
      * @param {number} id
      * @param {HTMLInputElement} toggle
      */
@@ -1124,7 +1170,10 @@ export class GlpiKnowbaseArticleController
 
             this.#base_content = this.#original_content;
             this.#base_title = this.#original_title;
-            picker?.commit();
+            if (picker !== null) {
+                picker.commit();
+                this.#updateAsideIllustration();
+            }
 
             edit_button.classList.remove('d-none');
             save_button.classList.add('d-none');

--- a/templates/components/illustration/icon.svg.twig
+++ b/templates/components/illustration/icon.svg.twig
@@ -32,5 +32,5 @@
 
 <svg role="img" width="{{ width }}" height="{{ height }}" class="flex-shrink-0">
     <title>{{ title ?? '' }}</title>
-    <use xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
+    <use data-testid="illustration-use" xlink:href="{{ path(file_path) }}#{{ icon_id }}"/>
 </svg>

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -82,9 +82,11 @@
     >
         <div class="article-line d-flex align-items-center">
             <a class="text-dark text-hover-link text-truncate flex-grow-1" href="{{ article.link }}">
-                {% if article.illustration %}
-                    {{ render_illustration(article.illustration, 20) }}
-                {% endif %}
+                <span data-glpi-kb-article-illustration data-testid="kb-illustration">
+                    {% if article.illustration %}
+                        {{ render_illustration(article.illustration, 20) }}
+                    {% endif %}
+                </span>
                 <span data-glpi-kb-article-title>{{ article.title }}</span>
             </a>
             {% if show_actions %}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -168,6 +168,35 @@ export class KnowbaseItemPage extends GlpiPage
         return this.aside.locator(`[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${id}"]`);
     }
 
+    public getFavoriteArticleRow(id: number): Locator
+    {
+        return this.favoritesSection.locator(`[data-glpi-kb-article-id="${id}"]`);
+    }
+
+    /**
+     * The illustration slot (`<use>` element for a native icon) of an article
+     * row in the aside tree.
+     */
+    public getAsideTreeArticleIllustration(id: number): Locator
+    {
+        return this.getAsideTreeArticleRow(id)
+            .getByTestId('kb-illustration')
+            .getByTestId('illustration-use')
+        ;
+    }
+
+    /**
+     * The illustration slot (`<use>` element for a native icon) of an article
+     * row in the aside favorites section.
+     */
+    public getFavoriteArticleIllustration(id: number): Locator
+    {
+        return this.getFavoriteArticleRow(id)
+            .getByTestId('kb-illustration')
+            .getByTestId('illustration-use')
+        ;
+    }
+
     /**
      * The dots menu trigger button of an article in the aside tree.
      */

--- a/tests/e2e/specs/Knowbase/Editor/core.spec.ts
+++ b/tests/e2e/specs/Knowbase/Editor/core.spec.ts
@@ -249,4 +249,41 @@ test.describe('Knowledge Base Editor - Core', () => {
         await expect(kb.getFavoriteArticle(renamed_name)).toBeVisible();
         await expect(kb.getFavoriteArticle(original_name)).toBeHidden();
     });
+
+    test('Changing an article illustration updates it in the aside tree', async ({
+        page,
+        profile,
+        api,
+    }) => {
+        // Arrange: create an article and set is as a favorite
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+        const kb_api = new KnowbaseApi(api);
+
+        const article_id = await kb_api.createArticle({
+            name: getUniqueName(`Illustrated favorite`),
+        });
+        await kb_api.addFavorite(article_id);
+
+        await kb.goto(article_id);
+
+        // The article has no illustration yet, so the aside slots are empty.
+        await expect(kb.getAsideTreeArticleIllustration(article_id)).toBeHidden();
+        await expect(kb.getFavoriteArticleIllustration(article_id)).toBeHidden();
+
+        // Act: pick a native illustration and save.
+        await kb.editor.enterEditMode();
+        await page.getByRole('button', { name: 'Select an illustration' }).click();
+        const modal = page.getByTestId('illustration-picker-modal');
+        await expect(modal).toBeVisible();
+        await modal.getByRole('img', { name: 'Antivirus', exact: true }).click();
+        await expect(modal).toBeHidden();
+        await kb.editor.save();
+
+        // Assert: the aside is updated with the illustration.
+        await expect(kb.getFavoriteArticleIllustration(article_id))
+            .toHaveAttribute('xlink:href', /#antivirus$/);
+        await expect(kb.getAsideTreeArticleIllustration(article_id))
+            .toHaveAttribute('xlink:href', /#antivirus$/);
+    });
 });


### PR DESCRIPTION
When the illustration of an article is updated, we must make sure to also update the reference to the article in the aside.

<img width="908" height="462" alt="image" src="https://github.com/user-attachments/assets/e2919f89-3fde-43a8-b1eb-3771716c27b7" />
