### PR TITLE
Fix: fall back to form filler when no requester resolved

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorField.php
@@ -155,6 +155,8 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
             throw new InvalidArgumentException("Unexpected config class");
         }
 
+        $has_actors = false;
+
         // Apply each configured strategy to get ITIL actors
         foreach ($config->getStrategies() as $strategy) {
             $itilactors = $strategy->getITILActors($this, $config, $answers_set);
@@ -169,10 +171,31 @@ abstract class ITILActorField extends AbstractConfigField implements Destination
                     continue;
                 }
                 $this->addActorToInput($input, $itilactor);
+                $has_actors = true;
+            }
+        }
+
+        // No strategy resolved an actor: apply the field's fallback, if any.
+        if (!$has_actors) {
+            foreach ($this->getFallbackActors($config, $answers_set) as $itilactor) {
+                if (!$this->isActorAllowed($itilactor, $input)) {
+                    continue;
+                }
+                $this->addActorToInput($input, $itilactor);
             }
         }
 
         return $input;
+    }
+
+    /**
+     * Actors to use when no configured strategy resolved any actor.
+     *
+     * @return array<array{itemtype: class-string<\CommonDBTM>, items_id: int, use_notification?: int|string, alternative_email?: string}>
+     */
+    protected function getFallbackActors(ITILActorFieldConfig $config, AnswersSet $answers_set): array
+    {
+        return [];
     }
 
     /**

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldStrategy.php
@@ -378,6 +378,12 @@ enum ITILActorFieldStrategy: string
             $actors_ids = [$actors_ids];
         }
 
+        // 0 means unset, not an actor with id 0.
+        $actors_ids = array_filter($actors_ids, fn($actor_id) => (int) $actor_id > 0);
+        if ($actors_ids === []) {
+            return null;
+        }
+
         $itemtype = getItemtypeForForeignKeyField(str_replace('_tech', '', $fk_field));
         return array_map(fn($actor_id) => [
             'itemtype' => $itemtype,

--- a/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequesterField.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Form\Destination\CommonITILField;
 
+use Glpi\Form\AnswersSet;
 use Glpi\Form\Form;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
 use Glpi\Form\QuestionType\QuestionTypeRequester;
@@ -86,5 +87,12 @@ final class RequesterField extends ITILActorField
     public function getWeight(): int
     {
         return 100;
+    }
+
+    #[Override]
+    protected function getFallbackActors(ITILActorFieldConfig $config, AnswersSet $answers_set): array
+    {
+        // A ticket must never end up with no requester.
+        return ITILActorFieldStrategy::FORM_FILLER->getITILActors($this, $config, $answers_set) ?? [];
     }
 }

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -60,12 +60,21 @@ use TicketTemplate;
 use TicketTemplatePredefinedField;
 use User;
 
+use function Safe\json_encode;
+
 final class RequesterFieldTest extends AbstractActorFieldTest
 {
     #[Override]
     public function getFieldClass(): string
     {
         return RequesterField::class;
+    }
+
+    #[Override]
+    protected function getExpectedNoMatchActors(): array
+    {
+        // Fallback: the form filler.
+        return [['itemtype' => User::class, 'items_id' => getItemByTypeName(User::class, TU_USER, true)]];
     }
 
     public function testRequesterFromTemplate(): void
@@ -445,6 +454,24 @@ final class RequesterFieldTest extends AbstractActorFieldTest
                 ['items_id' => $user1->getID()],
                 ['items_id' => $user2->getID()],
             ]
+        );
+    }
+
+    public function testFallbackToFormFillerWhenSpecificAnswerQuestionIsUnanswered(): void
+    {
+        // Sub-question never answered, must fall back to the form filler.
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+
+        $auth = $this->login();
+
+        $this->sendFormAndAssertTicketActors(
+            form: $form,
+            config: new RequesterFieldConfig(
+                strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
+                specific_question_ids: [$this->getQuestionId($form, "Requester 1")]
+            ),
+            answers: [],
+            expected_actors: [['items_id' => $auth->getUser()->getID()]]
         );
     }
 
@@ -894,6 +921,7 @@ final class RequesterFieldTest extends AbstractActorFieldTest
 
         // Check actors
         $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
+        $this->assertCount(count($expected_actors), $actors);
         foreach ($expected_actors as $expected_actor) {
             $actor = array_shift($actors);
             $this->assertArrayIsEqualToArrayOnlyConsideringListOfKeys(

--- a/tests/src/AbstractActorFieldTest.php
+++ b/tests/src/AbstractActorFieldTest.php
@@ -46,6 +46,8 @@ use Group;
 use Profile;
 use User;
 
+use function Safe\json_encode;
+
 abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
 {
     use FormTesterTrait;
@@ -58,6 +60,16 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
     );
 
     abstract public function getFieldClass(): string;
+
+    /**
+     * Expected actors when no strategy matches; overridden by fields with a fallback.
+     *
+     * @return array<array{itemtype?: class-string<\CommonDBTM>, items_id: int}>
+     */
+    protected function getExpectedNoMatchActors(): array
+    {
+        return [];
+    }
 
     public function testUserActorsFromSpecificItemQuestions(): void
     {
@@ -98,7 +110,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first computer
@@ -111,7 +123,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
                     'items_id' => $computers[0]->getID(),
                 ],
             ],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with second computer
@@ -167,7 +179,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first computer
@@ -193,7 +205,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
                     'items_id' => $computers[1]->getID(),
                 ],
             ],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
     }
 
@@ -232,7 +244,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first computer
@@ -258,7 +270,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
                     'items_id' => $computers[1]->getID(),
                 ],
             ],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
     }
 
@@ -297,7 +309,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first computer
@@ -310,7 +322,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
                     'items_id' => $computers[0]->getID(),
                 ],
             ],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with second computer
@@ -383,7 +395,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first custom asset
@@ -465,7 +477,7 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
             form: $form,
             config: $config,
             answers: [],
-            expected_actors: []
+            expected_actors: $this->getExpectedNoMatchActors()
         );
 
         // Answer with first custom asset


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45347
- When a form's requester field was configured to use the answer of a specific question that ended up never being answered (for example a conditionally hidden sub-question), the resulting ticket was created with no requester at all.
- The requester field now falls back to the user who submitted the form when no configured strategy resolves an actor, restoring the behaviour GLPI 10 Formcreator had.
- A related bug was also fixed where an asset with no owner or technician set could be counted as a resolved actor and silently suppress this fallback.

## Screenshots (if appropriate):


