### PR TITLE
[HLAPI] GraphQL lazier type and schema resolution

### DIFF
--- a/src/Glpi/Api/HL/Controller/KanbanController.php
+++ b/src/Glpi/Api/HL/Controller/KanbanController.php
@@ -68,7 +68,7 @@ class KanbanController extends AbstractController
             'KanbanView' => [
                 'x-version-introduced' => '2.4.0',
                 'type' => Doc\Schema::TYPE_ARRAY,
-                'x-graphql-resolver' => self::graphQLResolverKanbanView(...),
+                'x-graphql-resolver' => [self::class, 'graphQLResolverKanbanView'],
                 'x-graphql-query-args' => [
                     'itemtype' => ['type' => Type::string()],
                     'items_id' => ['type' => Type::int()],
@@ -254,7 +254,7 @@ class KanbanController extends AbstractController
      * @param ResolveInfo $info
      * @return KanbanViewState|null
      */
-    private static function graphQLResolverKanbanView(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
+    public static function graphQLResolverKanbanView(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
     {
         if ($context->fullyResolved ?? false) {
             return $source[$info->fieldName];

--- a/src/Glpi/Api/HL/Controller/ServiceCatalogController.php
+++ b/src/Glpi/Api/HL/Controller/ServiceCatalogController.php
@@ -134,7 +134,7 @@ final class ServiceCatalogController extends AbstractController
                 'type' => Doc\Schema::TYPE_OBJECT,
                 'x-version-introduced' => '2.4.0',
                 'readOnly' => true,
-                'x-graphql-resolver' => self::graphQLResolveServiceCatalogInfo(...),
+                'x-graphql-resolver' => [self::class, 'graphQLResolveServiceCatalogInfo'],
                 'x-singleton' => true,
                 'properties' => [
                     'helpdesk_home_title' => ['type' => Doc\Schema::TYPE_STRING],
@@ -226,7 +226,7 @@ final class ServiceCatalogController extends AbstractController
      * @param ResolveInfo $info
      * @return mixed
      */
-    private static function graphQLResolveServiceCatalogInfo(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
+    public static function graphQLResolveServiceCatalogInfo(mixed $source, array $args, stdClass $context, ResolveInfo $info): mixed
     {
         if ($context->fullyResolved ?? false) {
             return $source[$info->fieldName];

--- a/src/Glpi/Api/HL/Doc/SchemaReference.php
+++ b/src/Glpi/Api/HL/Doc/SchemaReference.php
@@ -36,7 +36,7 @@
 namespace Glpi\Api\HL\Doc;
 
 use ArrayAccess;
-use Glpi\Api\HL\OpenAPIGenerator;
+use Glpi\Api\HL\Schemas;
 
 /**
  * @implements ArrayAccess<'ref', string>
@@ -62,7 +62,7 @@ final class SchemaReference implements ArrayAccess
      */
     public static function resolveRef($ref, string $controller, array $attributes, string $api_version): ?array
     {
-        $known_schemas = OpenAPIGenerator::getComponentSchemas($api_version);
+        $known_schemas = Schemas::getInstance($api_version)->getAllSchemas();
         if (!is_string($ref) && $ref !== null) {
             $ref = $ref['ref'];
         }

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -37,10 +37,10 @@ namespace Glpi\Api\HL\GraphQL;
 use CommonDBTM;
 use DBConnection;
 use Glpi\Api\HL\APIException;
-use Glpi\Api\HL\OpenAPIGenerator;
 use Glpi\Api\HL\ResourceAccessor;
 use Glpi\Api\HL\RightConditionNotMetException;
 use Glpi\Api\HL\RSQL\RSQLException;
+use Glpi\Api\HL\Schemas;
 use Glpi\Api\HL\Search;
 use Glpi\Api\HL\Search\SearchContext;
 use Glpi\DBAL\QueryFunction;
@@ -76,7 +76,7 @@ class DefaultResolvers
      */
     private function getSchemaForObjectName(string $name): ?array
     {
-        return OpenAPIGenerator::getComponentSchemas($this->api_version)[$name] ?? null;
+        return Schemas::getInstance($this->api_version)->getSchema($name);
     }
 
     /**

--- a/src/Glpi/Api/HL/GraphQL/SchemaGenerator.php
+++ b/src/Glpi/Api/HL/GraphQL/SchemaGenerator.php
@@ -34,11 +34,13 @@
 
 namespace Glpi\Api\HL\GraphQL;
 
-use Glpi\Api\HL\OpenAPIGenerator;
+use Glpi\Api\HL\Schemas;
 use Glpi\Debug\Profiler;
+use GraphQL\Type\Definition\NamedType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
+use LogicException;
 
 final readonly class SchemaGenerator
 {
@@ -48,32 +50,65 @@ final readonly class SchemaGenerator
 
     public function getSchema(): Schema
     {
+        global $GLPI_CACHE;
+
         $query_type_config = [
             'name' => 'Query',
             'fields' => [],
         ];
-        Profiler::getInstance()->start('OpenAPI Component Schemas Retrieval', Profiler::CATEGORY_HLAPI);
-        $component_schemas = OpenAPIGenerator::getComponentSchemas($this->api_version);
-        Profiler::getInstance()->stop('OpenAPI Component Schemas Retrieval');
-        foreach ($component_schemas as $schema_name => $schema_info) {
-            $has_custom_resolver = array_key_exists('x-graphql-resolver', $schema_info);
-            $should_have_query = (
-                !str_starts_with($schema_name, '_')
-                && (
-                    (isset($schema_info['x-itemtype']) && !$has_custom_resolver)
-                    || ($has_custom_resolver && $schema_info['x-graphql-resolver'] !== null)
-                )
-            );
-            if (!$should_have_query) {
-                continue;
+
+        $query_schema_info = $GLPI_CACHE->get('graphql_query_schema_info_' . $this->api_version);
+
+        if ($query_schema_info === null) {
+            $query_schema_info = [];
+            Profiler::getInstance()->start('OpenAPI Component Schemas Retrieval', Profiler::CATEGORY_HLAPI);
+            $component_schemas = Schemas::getInstance($this->api_version)->getAllSchemas();
+            Profiler::getInstance()->stop('OpenAPI Component Schemas Retrieval');
+            foreach ($component_schemas as $schema_name => $schema_info) {
+                $has_custom_resolver = array_key_exists('x-graphql-resolver', $schema_info);
+                $should_have_query = (
+                    !str_starts_with($schema_name, '_')
+                    && (
+                        (isset($schema_info['x-itemtype']) && !$has_custom_resolver)
+                        || ($has_custom_resolver && $schema_info['x-graphql-resolver'] !== null)
+                    )
+                );
+                if (!$should_have_query) {
+                    continue;
+                }
+                $query_args = [];
+                foreach ($schema_info['x-graphql-query-args'] ?? [] as $arg_name => $arg_type) {
+                    if (count(array_keys($arg_type)) !== 1 || !isset($arg_type['type'])) {
+                        throw new LogicException("Types in 'x-graphql-query-args' must be an array with a single key 'type'.");
+                    }
+                    if (!($arg_type['type'] instanceof NamedType) || !in_array($arg_type['type']->name(), Type::BUILT_IN_SCALAR_NAMES, true)) {
+                        throw new LogicException("Types in 'x-graphql-query-args' can only be instances of built-in scalar types to allow proper serialization.");
+                    }
+                    $query_args[$arg_name] = $arg_type['type']->name();
+                }
+                $query_schema_info[$schema_name] = [
+                    'has_custom_resolver' => $has_custom_resolver,
+                    'is_singleton' => $schema_info['x-singleton'] ?? false,
+                    'query_args' => $query_args,
+                    'resolver' => $has_custom_resolver ? $schema_info['x-graphql-resolver'] : null,
+                ];
             }
-            if ($schema_info['x-singleton'] ?? false) {
+            $GLPI_CACHE->set('graphql_query_schema_info_' . $this->api_version, $query_schema_info);
+        }
+
+        foreach ($query_schema_info as $schema_name => $schema_info) {
+            if ($schema_info['is_singleton'] ?? false) {
+                // load type from name
+                $query_args = array_map(
+                    static fn($arg_type) => ['type' => Type::builtInScalars()[$arg_type]],
+                    $schema_info['query_args'] ?? []
+                );
                 $query_type_config['fields'][$schema_name] = [
                     'type' => fn(): Type => Types::load($schema_name, $this->api_version),
-                    'args' => $schema_info['x-graphql-query-args'] ?? [],
+                    'args' => $query_args,
                 ];
-                if ($has_custom_resolver) {
-                    $query_type_config['fields'][$schema_name]['resolve'] = $schema_info['x-graphql-resolver'];
+                if (isset($schema_info['resolver'])) {
+                    $query_type_config['fields'][$schema_name]['resolve'] = ($schema_info['resolver'])(...);
                 }
             } else {
                 $query_type_config['fields'][$schema_name] = [
@@ -89,8 +124,10 @@ final readonly class SchemaGenerator
                 ];
             }
         }
+        /** @phpstan-ignore-next-line */
         return new Schema([
             'query' => new ObjectType($query_type_config),
+            'typeLoader' => fn(string $sn): Type => Types::load($sn, $this->api_version),
         ]);
     }
 }

--- a/src/Glpi/Api/HL/GraphQL/Types.php
+++ b/src/Glpi/Api/HL/GraphQL/Types.php
@@ -35,11 +35,12 @@
 namespace Glpi\Api\HL\GraphQL;
 
 use Glpi\Api\HL\Doc as Doc;
-use Glpi\Api\HL\OpenAPIGenerator;
+use Glpi\Api\HL\Schemas;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\UnionType;
+use LogicException;
 
 use function Safe\strtotime;
 
@@ -51,8 +52,11 @@ class Types
     public static function load(string $type_name, string $api_version): Type
     {
         if (!isset(self::$types[$type_name])) {
-            $schemas = OpenAPIGenerator::getComponentSchemas($api_version);
-            self::$types[$type_name] = self::convertRESTSchemaToGraphQLSchema($type_name, $schemas[$type_name], $api_version);
+            $schema = Schemas::getInstance($api_version)->getSchema($type_name);
+            if ($schema === null) {
+                throw new LogicException("Schema for type {$type_name} not found");
+            }
+            self::$types[$type_name] = self::convertRESTSchemaToGraphQLSchema($type_name, $schema, $api_version);
         }
         return self::$types[$type_name];
     }

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -35,12 +35,9 @@
 
 namespace Glpi\Api\HL;
 
-use CommonGLPI;
 use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Middleware\ResultFormatterMiddleware;
-use Glpi\Debug\Profiler;
 use Glpi\OAuth\Server;
-use ReflectionClass;
 use Session;
 
 use function Safe\preg_match;
@@ -93,19 +90,9 @@ final class OpenAPIGenerator
     private string $api_version;
 
     /**
-     * @var array<string, array<string, mixed>>
-     */
-    private static array $component_schemas_cache = [];
-
-    /**
      * @var OpenAPISchema
      */
     private array $schema;
-
-    public static function clearComponentSchemasCache(): void
-    {
-        self::$component_schemas_cache = [];
-    }
 
     public function __construct(Router $router, string $api_version)
     {
@@ -187,124 +174,9 @@ EOT;
         ];
     }
 
-    /**
-     * @param string $api_version
-     * @return array<string, mixed>
-     * @throws \ReflectionException
-     */
-    public static function getComponentSchemas(string $api_version): array
-    {
-        if (isset(self::$component_schemas_cache[$api_version])) {
-            return self::$component_schemas_cache[$api_version];
-        }
-
-        $schemas = [];
-
-        $controllers = Router::getInstance()->getControllers();
-        foreach ($controllers as $controller) {
-            Profiler::getInstance()->start('OpenAPI Component Schemas Retrieval for ' . $controller::class, Profiler::CATEGORY_HLAPI);
-            $known_schemas = $controller::getKnownSchemas($api_version);
-            $short_name = (new ReflectionClass($controller))->getShortName();
-            $controller_name = str_replace('Controller', '', $short_name);
-            foreach ($known_schemas as $schema_name => $known_schema) {
-                // Ignore schemas starting with an underscore. They are only used internally.
-                if (str_starts_with($schema_name, '_')) {
-                    continue;
-                }
-                $calculated_name = $schema_name;
-                if (isset($schemas[$schema_name])) {
-                    // For now, set the new calculated name to the short name of the controller + the schema name
-                    $calculated_name = $controller_name . ' - ' . $schema_name;
-                    // Change the existing schema name to its own calculated name
-                    $other_short_name = (new ReflectionClass($schemas[$schema_name]['x-controller']))->getShortName();
-                    $other_calculated_name = str_replace('Controller', '', $other_short_name) . ' - ' . $schema_name;
-                    $schemas[$other_calculated_name] = $schemas[$schema_name];
-                    unset($schemas[$schema_name]);
-                }
-                if (!isset($known_schema['description']) && isset($known_schema['x-itemtype'])) {
-                    /** @var class-string<CommonGLPI> $itemtype */
-                    $itemtype = $known_schema['x-itemtype'];
-                    $known_schema['description'] = $itemtype::getTypeName(1);
-                }
-
-                // Add properties that have 'required' flags to a 'required' array on the nearest parent object
-                // We add the 'required' on individual properties so that it works well with the API version filtering
-                $fn_hoist_required_flags = static function (&$schema_part) use (&$fn_hoist_required_flags) {
-                    if (is_array($schema_part)) {
-                        if (isset($schema_part['properties']) && is_array($schema_part['properties'])) {
-                            $required_fields = [];
-                            foreach ($schema_part['properties'] as $prop_name => &$prop_value) {
-                                if (is_array($prop_value)) {
-                                    if (isset($prop_value['required']) && $prop_value['required'] === true) {
-                                        $required_fields[] = $prop_name;
-                                        unset($prop_value['required']);
-                                    }
-                                    // Recurse into the property value
-                                    $fn_hoist_required_flags($prop_value);
-                                }
-                            }
-                            unset($prop_value);
-                            if (count($required_fields) > 0) {
-                                $schema_part['required'] = $required_fields;
-                            }
-                        }
-                    }
-                };
-                $fn_hoist_required_flags($known_schema);
-
-                self::resolveCompositionAndDiscriminators($known_schema);
-
-                $schemas[$calculated_name] = $known_schema;
-                $schemas[$calculated_name]['x-controller'] = $controller::class;
-                $schemas[$calculated_name]['x-schemaname'] = $schema_name;
-            }
-            Profiler::getInstance()->stop('OpenAPI Component Schemas Retrieval for ' . $controller::class);
-        }
-
-        return self::$component_schemas_cache[$api_version] = $schemas;
-    }
-
-    /**
-     * Resolve schemas using composition/polymorphism (anyOf, oneOf, allOf).
-     * Also resolves discriminator mappings.
-     * @param array<string, mixed> $schema The schema (or sub-schema when called recursively) to resolve
-     * @return void
-     */
-    private static function resolveCompositionAndDiscriminators(array &$schema): void
-    {
-        if (isset($schema['properties']) && is_array($schema['properties'])) {
-            foreach ($schema['properties'] as &$property) {
-                self::resolveCompositionAndDiscriminators($property);
-            }
-        } elseif (isset($schema['items']) && is_array($schema['items'])) {
-            self::resolveCompositionAndDiscriminators($schema['items']);
-        } else {
-            if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
-                $resolved_anyof = [];
-                foreach ($schema['anyOf'] as $anyof_schema_name) {
-                    $component_ref = [
-                        '$ref' => '#/components/schemas/' . $anyof_schema_name,
-                    ];
-                    $resolved_anyof[] = $component_ref;
-                }
-                $schema['anyOf'] = $resolved_anyof;
-            }
-            if (isset($schema['discriminator']['mapping']) && is_array($schema['discriminator']['mapping'])) {
-                $resolved_mapping = [];
-                foreach ($schema['discriminator']['mapping'] as $mapping_key => $mapping_schema_name) {
-                    $component_ref = [
-                        '$ref' => '#/components/schemas/' . $mapping_schema_name,
-                    ];
-                    $resolved_mapping[$mapping_key] = $component_ref;
-                }
-                $schema['discriminator']['mapping'] = $resolved_mapping;
-            }
-        }
-    }
-
     private function getComponentReference(string $name, string $controller): ?array
     {
-        $components = self::getComponentSchemas($this->api_version);
+        $components = Schemas::getInstance($this->api_version)->getAllSchemas();
         // Try matching by name and controller first
         $match = null;
         $is_ref_array = str_ends_with($name, '[]');
@@ -406,7 +278,7 @@ EOT;
             return $this->schema;
         }
 
-        $component_schemas = self::getComponentSchemas($this->api_version);
+        $component_schemas = Schemas::getInstance($this->api_version)->getAllSchemas();
         ksort($component_schemas);
         /** @phpstan-var OpenAPISchema $schema */
         $schema = [

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -327,6 +327,16 @@ EOT;
         return self::$instance;
     }
 
+    public function getRegisteredController(string $controller_class): ?AbstractController
+    {
+        foreach ($this->controllers as $controller) {
+            if ($controller::class === $controller_class) {
+                return $controller;
+            }
+        }
+        return null;
+    }
+
     /**
      * @return Request|null
      * @internal Only intended to be used by tests

--- a/src/Glpi/Api/HL/Schemas.php
+++ b/src/Glpi/Api/HL/Schemas.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Api\HL;
+
+use CommonGLPI;
+use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Debug\Profiler;
+use Psr\SimpleCache\InvalidArgumentException;
+use ReflectionClass;
+
+/**
+ * Manages access to the pseudo-OpenAPI schemas used for the OpenAPI schemas and GraphQL Types.
+ * Allow lazy loading of the schemas and caching them for performance.
+ */
+final class Schemas
+{
+    private string $api_version;
+
+    /**
+     * Array of hints to locate schemas for controllers. The key is the schema name, the value is the controller name.
+     * @var array<string, string>
+     */
+    private array $controller_schema_hints = [];
+
+    /**
+     * @var array<string, array<string, mixed>> Cache of loaded schemas. The key is the schema name, the value is the schema array.
+     */
+    private array $schemas_cache = [];
+
+    /**
+     * @var array<string, self> Cache of Schemas instances by API version.
+     */
+    private static array $instance_cache = [];
+
+    public function __construct(?string $api_version = null)
+    {
+        global $GLPI_CACHE;
+
+        $this->api_version = Router::normalizeAPIVersion($api_version ?? Router::API_VERSION);
+
+        try {
+            // Load known hints
+            $this->controller_schema_hints = $GLPI_CACHE->get('hlapi_controller_schema_hints_' . $this->api_version, []);
+        } catch (InvalidArgumentException) {
+            // No-op
+        }
+    }
+
+    public static function getInstance(?string $api_version = null): self
+    {
+        $api_version = Router::normalizeAPIVersion($api_version ?? Router::API_VERSION);
+        if (!isset(self::$instance_cache[$api_version])) {
+            self::$instance_cache[$api_version] = new self($api_version);
+        }
+        return self::$instance_cache[$api_version];
+    }
+
+    public function loadAllSchemas(): void
+    {
+        $this->schemas_cache = [];
+        $controllers = Router::getInstance()->getControllers();
+        foreach ($controllers as $controller) {
+            $this->loadSchemasFromController($controller);
+        }
+    }
+
+    /**
+     * Get all known schemas, loading them if necessary.
+     * @param bool $force If true, force reloading of all schemas even if they are already cached.
+     * @return array<string, array<string, mixed>> The array of all known schemas, keyed by schema name.
+     */
+    public function getAllSchemas(bool $force = false): array
+    {
+        if ($force || $this->schemas_cache === []) {
+            $this->loadAllSchemas();
+        }
+        return $this->schemas_cache;
+    }
+
+    private function loadSchemasFromController(AbstractController $controller): void
+    {
+        Profiler::getInstance()->start('Schemas Retrieval for ' . $controller::class, Profiler::CATEGORY_HLAPI);
+        $known_schemas = $controller::getKnownSchemas($this->api_version);
+        $controller_rc = new ReflectionClass($controller);
+        $controller_name = str_replace('Controller', '', $controller_rc->getShortName());
+        foreach ($known_schemas as $schema_name => $known_schema) {
+            // Add/update a hint to locate the schema for this controller
+            $this->controller_schema_hints[$schema_name] = $controller_rc->getName();
+            // Ignore schemas starting with an underscore. They are only used internally.
+            if (str_starts_with($schema_name, '_')) {
+                continue;
+            }
+            $calculated_name = $schema_name;
+            if (isset($this->schemas_cache[$schema_name])) {
+                //TODO throw exception and clean up cases in SchemaReference and OpenAPIGenerator where resolution of schema names is done by controller name + schema name.
+                // does not affect any core schemas, but some plugins may have taken advantage of this behavior.
+                //throw new LogicException('Duplicate schema name "' . $schema_name . '" found in controller ' . $controller::class . '. Schema names must be unique across all controllers.');
+                // For now, set the new calculated name to the short name of the controller + the schema name
+                $calculated_name = $controller_name . ' - ' . $schema_name;
+                // Change the existing schema name to its own calculated name
+                $other_short_name = (new ReflectionClass($this->schemas_cache[$schema_name]['x-controller']))->getShortName();
+                $other_calculated_name = str_replace('Controller', '', $other_short_name) . ' - ' . $schema_name;
+                $this->schemas_cache[$other_calculated_name] = $this->schemas_cache[$schema_name];
+                unset($this->schemas_cache[$schema_name]);
+            }
+            if (!isset($known_schema['description']) && isset($known_schema['x-itemtype'])) {
+                /** @var class-string<CommonGLPI> $itemtype */
+                $itemtype = $known_schema['x-itemtype'];
+                $known_schema['description'] = $itemtype::getTypeName(1);
+            }
+
+            // Add properties that have 'required' flags to a 'required' array on the nearest parent object
+            // We add the 'required' on individual properties so that it works well with the API version filtering
+            $fn_hoist_required_flags = static function (&$schema_part) use (&$fn_hoist_required_flags) {
+                if (is_array($schema_part)) {
+                    if (isset($schema_part['properties']) && is_array($schema_part['properties'])) {
+                        $required_fields = [];
+                        foreach ($schema_part['properties'] as $prop_name => &$prop_value) {
+                            if (is_array($prop_value)) {
+                                if (isset($prop_value['required']) && $prop_value['required'] === true) {
+                                    $required_fields[] = $prop_name;
+                                    unset($prop_value['required']);
+                                }
+                                // Recurse into the property value
+                                $fn_hoist_required_flags($prop_value);
+                            }
+                        }
+                        unset($prop_value);
+                        if (count($required_fields) > 0) {
+                            $schema_part['required'] = $required_fields;
+                        }
+                    }
+                }
+            };
+            $fn_hoist_required_flags($known_schema);
+
+            self::resolveCompositionAndDiscriminators($known_schema);
+
+            $this->schemas_cache[$calculated_name] = $known_schema;
+            $this->schemas_cache[$calculated_name]['x-controller'] = $controller::class;
+            $this->schemas_cache[$calculated_name]['x-schemaname'] = $schema_name;
+        }
+        // Save the updated hints to the cache
+        try {
+            global $GLPI_CACHE;
+            $GLPI_CACHE->set('hlapi_controller_schema_hints_' . $this->api_version, $this->controller_schema_hints);
+        } catch (InvalidArgumentException) {
+            // No-op
+        }
+        Profiler::getInstance()->stop('Schemas Retrieval for ' . $controller::class);
+    }
+
+    /**
+     * Resolve schemas using composition/polymorphism (anyOf, oneOf, allOf).
+     * Also resolves discriminator mappings.
+     * @param array<string, mixed> $schema The schema (or sub-schema when called recursively) to resolve
+     * @return void
+     */
+    private static function resolveCompositionAndDiscriminators(array &$schema): void
+    {
+        if (isset($schema['properties']) && is_array($schema['properties'])) {
+            foreach ($schema['properties'] as &$property) {
+                self::resolveCompositionAndDiscriminators($property);
+            }
+        } elseif (isset($schema['items']) && is_array($schema['items'])) {
+            self::resolveCompositionAndDiscriminators($schema['items']);
+        } else {
+            if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
+                $resolved_anyof = [];
+                foreach ($schema['anyOf'] as $anyof_schema_name) {
+                    $component_ref = [
+                        '$ref' => '#/components/schemas/' . $anyof_schema_name,
+                    ];
+                    $resolved_anyof[] = $component_ref;
+                }
+                $schema['anyOf'] = $resolved_anyof;
+            }
+            if (isset($schema['discriminator']['mapping']) && is_array($schema['discriminator']['mapping'])) {
+                $resolved_mapping = [];
+                foreach ($schema['discriminator']['mapping'] as $mapping_key => $mapping_schema_name) {
+                    $component_ref = [
+                        '$ref' => '#/components/schemas/' . $mapping_schema_name,
+                    ];
+                    $resolved_mapping[$mapping_key] = $component_ref;
+                }
+                $schema['discriminator']['mapping'] = $resolved_mapping;
+            }
+        }
+    }
+
+    /**
+     * @param string $schema_name
+     * @return array<string, mixed>|null The schema array if found, or null if not found
+     */
+    public function getSchema(string $schema_name): ?array
+    {
+        if (!array_key_exists($schema_name, $this->schemas_cache)) {
+            // Schema not found in the cache, see if we at least know which controller it belongs to
+            if (array_key_exists($schema_name, $this->controller_schema_hints)) {
+                $controller_name = $this->controller_schema_hints[$schema_name];
+                $controller_class = Router::getInstance()->getRegisteredController($controller_name);
+                if ($controller_class !== null) {
+                    $this->loadSchemasFromController($controller_class);
+                } else {
+                    // We know the controller name but it is not registered, maybe the hints are outdated
+                    $this->loadAllSchemas();
+                }
+            } else {
+                // We don't know which controller it belongs to, load all schemas
+                $this->loadAllSchemas();
+            }
+        }
+        if (array_key_exists($schema_name, $this->schemas_cache)) {
+            return $this->schemas_cache[$schema_name];
+        }
+        // Not in cache and was not found
+        return null;
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Continuing the unintended trend of big performance improvements every HLAPI v2 bugfix version.

When I [rewrote the GraphQL implementation](https://github.com/glpi-project/glpi/pull/22855) to use real resolvers, I also added lazy GraphQL type loading to improve performance. This still required loading every schema from every controller and as the HLAPI grows, now over 350 schemas, this is getting slower especially for schemas that rely on some computed data.

This PR makes type and schema resolution even lazier.
- Moves the schema resolution to a new `Schemas` class
- Changes `x-graphql-resolver` calls (Added in v2.4) to be serializable
- Adds type resolver at the schema level
- Caches known Query fields with just the information needed for the query itself, per API version
- Caches hints for which controller a specific schema can be found in to limit the number of schemas that need initialized for a specific request

```graphql
{ Computer(filter: "name=like=Bulk*", limit: 20) { id name entity { id completename } status { id name } manufacturer { id name } serial type {id name} model {id name} } }
```

| Request method | 20 results | 100 results | 500 results | 1000 results |
| ---------------------- | ------------- | -------------- | --------------- | ---------------- |
| Web (AJAX search request within GLPI with same columns visible) | 84ms | 106ms | 204ms | 360ms |
| REST (/Computer from Insomnia, overfetched) | 130ms | 149ms | 340ms | 551ms |
| GraphQL (Before from Insomnia) | 142ms | 160ms | 243ms | 334ms |
| GraphQL (After from Insomnia) | 77ms | 112ms | 185ms | 290ms |
| GraphQL (After with direct Router::handleRequest call) | 29ms | 45ms | 125ms | 218ms |

Finally with most of the overhead gone from the GraphQL side, you should see tangible time benefits from using GraphQL to fetch only the required fields instead of a single REST call which would return more than needed. It is also more competitive with the Web UI search at lower result counts. There is still quite a bit of overhead from Symfony and GLPI which affects all of these metrics except the "direct Router::handleRequest" calls.

I would say this is the last big performance improvement for HLAPI, but I thought the same thing with the GraphQL rewrite and there is no lack of motivation to continue optimizing.