### PR TITLE
FIX / Documentation page overlap on resize

### DIFF
--- a/css/includes/components/_documentation.scss
+++ b/css/includes/components/_documentation.scss
@@ -156,10 +156,7 @@
 
 @include media-breakpoint-up(sm) {
     .documentation-large {
-        // Always reserve at least the width of the fixed table-of-contents (15rem/240px),
-        // then let the content re-center itself once the viewport is wide enough.
-        // A hard breakpoint switch here previously caused the sidebar to overlap the
-        // content in a range of viewport widths just above the xxl breakpoint.
+        // Never smaller than the fixed sidebar width, to avoid overlap.
         margin-left: max(240px, calc((100% - 1000px) / 2));
     }
 }

--- a/css/includes/components/_documentation.scss
+++ b/css/includes/components/_documentation.scss
@@ -154,14 +154,12 @@
     }
 }
 
-@include media-breakpoint-down(xxl) {
+@include media-breakpoint-up(sm) {
     .documentation-large {
-        margin-left: 240px;
-    }
-}
-
-@include media-breakpoint-down(sm) {
-    .documentation-large {
-        margin-left: 0;
+        // Always reserve at least the width of the fixed table-of-contents (15rem/240px),
+        // then let the content re-center itself once the viewport is wide enough.
+        // A hard breakpoint switch here previously caused the sidebar to overlap the
+        // content in a range of viewport widths just above the xxl breakpoint.
+        margin-left: max(240px, calc((100% - 1000px) / 2));
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45249
- `front/contenttemplates/documentation.php` (the "Available variables" template documentation popup) didn't adapt well to window resizing: for viewport widths roughly between 1400px and 1480px, the fixed table-of-contents sidebar (240px wide) overlapped the main content. Replaced the two breakpoint-based rules with a single continuous expression (`margin-left: max(240px, calc((100% - 1000px) / 2))`) that always reserves at least the sidebar width and smoothly transitions to centering once there's enough space, removing the discontinuity.

## Screenshots :

Before :
<img width="1439" height="1291" alt="image_paste15445" src="https://github.com/user-attachments/assets/2b2b941b-77d7-4308-9923-68f38dec1aed" />


After : 
<img width="1840" height="926" alt="Capture d’écran du 2026-07-20 09-36-00" src="https://github.com/user-attachments/assets/193caa1f-9b02-49eb-a6ca-ce1710b5a257" />


