### PR TITLE
Fix: resolve template using request type in Forms destinations

### DIFF
--- a/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
+++ b/src/Glpi/Form/Destination/AbstractCommonITILFormDestination.php
@@ -55,6 +55,7 @@ use Glpi\Form\Destination\CommonITILField\LocationField;
 use Glpi\Form\Destination\CommonITILField\ObserverField;
 use Glpi\Form\Destination\CommonITILField\RequesterField;
 use Glpi\Form\Destination\CommonITILField\RequestSourceField;
+use Glpi\Form\Destination\CommonITILField\RequestTypeField;
 use Glpi\Form\Destination\CommonITILField\TemplateField;
 use Glpi\Form\Destination\CommonITILField\TitleField;
 use Glpi\Form\Destination\CommonITILField\UrgencyField;
@@ -176,6 +177,19 @@ abstract class AbstractCommonITILFormDestination implements FormDestinationInter
             $answers_set
         );
         $already_applied_fields[] = ITILCategoryField::class;
+
+        // Applied early for template resolution, then re-applied in the loop below so the form answer still prevails over a predefined type
+        $request_type_field = current(array_filter(
+            $fields_to_apply,
+            fn($field) => $field instanceof RequestTypeField
+        ));
+        if ($request_type_field !== false) {
+            $input = $request_type_field->applyConfiguratedValueToInputUsingAnswers(
+                $request_type_field->getConfig($form, $config, $answers_set),
+                $input,
+                $answers_set
+            );
+        }
 
         // Compute and apply template predefined template fields
         $input = $this->applyPredefinedTemplateFields($input);

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/TemplateFieldTest.php
@@ -35,6 +35,12 @@
 namespace tests\units\Glpi\Form\Destination\CommonITILField;
 
 use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryField;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldConfig;
+use Glpi\Form\Destination\CommonITILField\ITILCategoryFieldStrategy;
+use Glpi\Form\Destination\CommonITILField\RequestTypeField;
+use Glpi\Form\Destination\CommonITILField\RequestTypeFieldConfig;
+use Glpi\Form\Destination\CommonITILField\RequestTypeFieldStrategy;
 use Glpi\Form\Destination\CommonITILField\TemplateField;
 use Glpi\Form\Destination\CommonITILField\TemplateFieldConfig;
 use Glpi\Form\Destination\CommonITILField\TemplateFieldStrategy;
@@ -42,6 +48,7 @@ use Glpi\Form\Form;
 use Glpi\Tests\AbstractDestinationFieldTest;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use ITILCategory;
 use Override;
 use Ticket;
 use TicketTemplate;
@@ -208,6 +215,132 @@ final class TemplateFieldTest extends AbstractDestinationFieldTest
             ),
             expected_tickettemplates_id: $default_template->getID()
         );
+    }
+
+    /**
+     * A category can link a different template per request type; the resolved template must match the applied type, not an assumed default
+     */
+    public function testDefaultTemplateIsResolvedUsingRequestType(): void
+    {
+        $demand_template = $this->createItem(
+            TicketTemplate::class,
+            ['name' => 'Template for demand']
+        );
+        $itilcategory = $this->createItem(
+            ITILCategory::class,
+            [
+                'name'                       => 'Category with demand template',
+                'tickettemplates_id_demand'  => $demand_template->getID(),
+            ]
+        );
+
+        $form = $this->createAndGetFormWithTicketDestination();
+        $this->login();
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            [
+                'config' => [
+                    TemplateField::getKey() => (new TemplateFieldConfig(
+                        strategy: TemplateFieldStrategy::DEFAULT_TEMPLATE,
+                    ))->jsonSerialize(),
+                    ITILCategoryField::getKey() => (new ITILCategoryFieldConfig(
+                        strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                        specific_itilcategory_id: $itilcategory->getID(),
+                    ))->jsonSerialize(),
+                    RequestTypeField::getKey() => (new RequestTypeFieldConfig(
+                        strategy: RequestTypeFieldStrategy::SPECIFIC_VALUE,
+                        specific_request_type: Ticket::DEMAND_TYPE,
+                    ))->jsonSerialize(),
+                ],
+            ],
+            ["config"],
+        );
+
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            [],
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        $this->assertEquals(Ticket::DEMAND_TYPE, $ticket->fields['type']);
+        $this->assertEquals($demand_template->getID(), $ticket->fields['tickettemplates_id']);
+    }
+
+    /**
+     * The form's request type answer must still prevail over a type predefined on the resolved template
+     */
+    public function testRequestTypeAnswerPrevailsOverPredefinedTemplateType(): void
+    {
+        $template = $this->createItem(
+            TicketTemplate::class,
+            ['name' => 'Template predefining incident type']
+        );
+        $this->createItem(
+            TicketTemplatePredefinedField::class,
+            [
+                'tickettemplates_id' => $template->getID(),
+                'num'                => 14, // Type
+                'value'              => Ticket::INCIDENT_TYPE,
+            ]
+        );
+        $itilcategory = $this->createItem(
+            ITILCategory::class,
+            [
+                'name'                         => 'Category with incident template',
+                'tickettemplates_id_incident'  => $template->getID(),
+                'tickettemplates_id_demand'    => $template->getID(),
+            ]
+        );
+
+        $form = $this->createAndGetFormWithTicketDestination();
+        $this->login();
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            [
+                'config' => [
+                    TemplateField::getKey() => (new TemplateFieldConfig(
+                        strategy: TemplateFieldStrategy::DEFAULT_TEMPLATE,
+                    ))->jsonSerialize(),
+                    ITILCategoryField::getKey() => (new ITILCategoryFieldConfig(
+                        strategy: ITILCategoryFieldStrategy::SPECIFIC_VALUE,
+                        specific_itilcategory_id: $itilcategory->getID(),
+                    ))->jsonSerialize(),
+                    RequestTypeField::getKey() => (new RequestTypeFieldConfig(
+                        strategy: RequestTypeFieldStrategy::SPECIFIC_VALUE,
+                        specific_request_type: Ticket::DEMAND_TYPE,
+                    ))->jsonSerialize(),
+                ],
+            ],
+            ["config"],
+        );
+
+        $answers_handler = AnswersHandler::getInstance();
+        $answers = $answers_handler->saveAnswers(
+            $form,
+            [],
+            getItemByTypeName(\User::class, TU_USER, true)
+        );
+
+        $created_items = $answers->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        $ticket = current($created_items);
+
+        $this->assertEquals(Ticket::DEMAND_TYPE, $ticket->fields['type']);
     }
 
     private function checkTemplateFieldConfiguration(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45358

When a ticket is created from a Forms/Service Catalog destination, the predefined ticket template of the ITIL category is applied before the request type (incident or demand) of the form is applied to the input.

Since a category can link to a different template for each request type, the previous resolution used a fixed incident fallback, which could result in the incorrect template being applied.

Now, the request type is applied to the input before the template resolution runs and then reapplied afterwards, so the form answer still takes precedence over any predefined type on the resolved template.
