### PR TITLE
fix (users list habilitations) error when sorting the user habilitations tab columns

### DIFF
--- a/src/Profile_User.php
+++ b/src/Profile_User.php
@@ -149,10 +149,15 @@ class Profile_User extends CommonDBRelation
         $start       = (int) ($_GET["start"] ?? 0);
         $limit       = $_SESSION["glpilist_limit"];
         $sort        = $_GET["sort"] ?? "";
-        $order       = strtoupper($_GET["order"] ?? "");
+        $order       = strtoupper($_GET["order"] ?? "") === 'DESC' ? 'DESC' : 'ASC';
+        // Map the displayed column keys to their actual SQL columns.
+        $sort_columns = [
+            'entity'  => 'glpi_entities.completename',
+            'profile' => 'glpi_profiles.name',
+        ];
         $sort_params = [];
-        if ($sort !== '') {
-            $sort_params = [$sort => $order === 'DESC' ? 'DESC' : 'ASC'];
+        if (isset($sort_columns[$sort])) {
+            $sort_params = [$sort_columns[$sort] . ' ' . $order];
         }
         $iterator = self::getListForItem($user, $start, $limit, $sort_params);
         $total_num = self::countForItem($user);

--- a/tests/functional/Profile_UserTest.php
+++ b/tests/functional/Profile_UserTest.php
@@ -523,4 +523,55 @@ class Profile_UserTest extends DbTestCase
             $html
         );
     }
+
+    public function testShowForUserColumnSorting(): void
+    {
+        // Sorting the habilitations tab by a column must build a valid
+        // ORDER BY clause (no sql error) and actually sort the result
+        $this->login();
+
+        $entity     = getItemByTypeName(\Entity::class, '_test_root_entity');
+        $admin      = getItemByTypeName(Profile::class, 'Admin');
+        $technician = getItemByTypeName(Profile::class, 'Technician');
+
+        $user = $this->createItem(User::class, [
+            'name'         => $this->getUniqueString(),
+            '_profiles_id' => $admin->getId(),
+            '_entities_id' => $entity->getId(),
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id'    => $user->getId(),
+            'profiles_id' => $technician->getId(),
+            'entities_id' => $entity->getId(),
+        ]);
+
+        $admin_links = (new Profile_User())->find([
+            'users_id'    => $user->getId(),
+            'profiles_id' => $admin->getId(),
+        ]);
+        $tech_links = (new Profile_User())->find([
+            'users_id'    => $user->getId(),
+            'profiles_id' => $technician->getId(),
+        ]);
+        $admin_link_id = sprintf('name="item[Profile_User][%d]"', array_key_first($admin_links));
+        $tech_link_id  = sprintf('name="item[Profile_User][%d]"', array_key_first($tech_links));
+
+        // Ascending order by profile name: admin must come before technician
+        $_GET['sort']  = 'profile';
+        $_GET['order'] = 'ASC';
+        ob_start();
+        Profile_User::showForUser($user);
+        $html_asc = ob_get_clean();
+
+        // Descending order by profile name: technician must come before admin
+        $_GET['order'] = 'DESC';
+        ob_start();
+        Profile_User::showForUser($user);
+        $html_desc = ob_get_clean();
+
+        unset($_GET['sort'], $_GET['order']);
+
+        $this->assertLessThan(strpos($html_asc, $tech_link_id), strpos($html_asc, $admin_link_id));
+        $this->assertLessThan(strpos($html_desc, $admin_link_id), strpos($html_desc, $tech_link_id));
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45376
- Sorting by column in a user's permissions tab caused an SQL error.
The sort criterion was passed as an associative array, which was misinterpreted by the query builder.
-> Mapping the keys to the SQL columns and constructing the ordey by clause in the expected format.




