### PR TITLE
Fix - Use massive action input instead of  in AuthLDAP

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -442,7 +442,7 @@ class AuthLDAP extends CommonDBTM
                         }
 
                         $options      = [
-                            'authldaps_id' => (int) $input['authldaps_id'],
+                            'authldaps_id' => (int) ($input['authldaps_id'] ?? 0),
                             'entities_id'  => $entity,
                             'is_recursive' => $is_recursive,
                             'type'         => $input['ldap_import_type'][$id],

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -442,7 +442,7 @@ class AuthLDAP extends CommonDBTM
                         }
 
                         $options      = [
-                            'authldaps_id' => (int) $_REQUEST['authldaps_id'],
+                            'authldaps_id' => (int) $input['authldaps_id'],
                             'entities_id'  => $entity,
                             'is_recursive' => $is_recursive,
                             'type'         => $input['ldap_import_type'][$id],
@@ -466,14 +466,16 @@ class AuthLDAP extends CommonDBTM
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     return;
                 }
+                $mode         = (int) ($input['mode'] ?? self::ACTION_IMPORT);
+                $authldaps_id = (int) ($input['authldaps_id'] ?? 0);
                 foreach ($ids as $id) {
                     if (
                         self::ldapImportUserByServerId(
                             ['method' => self::IDENTIFIER_LOGIN,
                                 'value'  => $id,
                             ],
-                            (int) $_REQUEST['mode'],
-                            (int) $_REQUEST['authldaps_id'],
+                            $mode,
+                            $authldaps_id,
                             true
                         )
                     ) {

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -941,21 +941,9 @@ class AuthLdapTest extends DbTestCase
 
         $this->assertCount(1, $results);
 
-        if ($results[0] === \MassiveAction::ACTION_OK) {
-            // LDAP directory reachable: the user must have been imported using the LDAP
-            // server from the massive action input, not the authldaps_id=0 polluting $_REQUEST.
-            $user = new \User();
-            $this->assertTrue($user->getFromDBbyName('ecuador0'));
-            $this->assertSame($ldap->getID(), $user->fields['auths_id']);
-        } else {
-            // LDAP directory unreachable in this environment: at least confirm that a
-            // connection to the CORRECT server was attempted. authldaps_id=0, coming from
-            // the polluted $_REQUEST, would fail instantly with no connection attempt at all.
-            $this->hasPhpLogRecordThatContains(
-                sprintf('Unable to bind to LDAP server `%s:%s`', $ldap->fields['host'], $ldap->fields['port']),
-                LogLevel::WARNING
-            );
-        }
+        $user = new \User();
+        $this->assertTrue($user->getFromDBbyName('ecuador0'));
+        $this->assertSame($ldap->getID(), $user->fields['auths_id']);
     }
 
     /**

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -902,6 +902,63 @@ class AuthLdapTest extends DbTestCase
     }
 
     /**
+     * `AuthLDAP::processMassiveActionsForOneItemtype()` must resolve `mode` and `authldaps_id`
+     * from the massive action input (`$ma->getInput()`), not from the `$_REQUEST` superglobal,
+     * which is not populated when the action is replayed from `$_SESSION` (see MassiveAction's
+     * "process" stage reload) and triggers "Undefined array key" warnings for every processed
+     * item otherwise.
+     */
+    public function testProcessMassiveActionsForOneItemtypeSyncIgnoresRequest()
+    {
+        $this->login();
+
+        $ldap = $this->ldap;
+
+        // Pollute the request with values that must NOT be used, to prove the massive
+        // action input is used instead.
+        $_REQUEST['mode'] = 999;
+        $_REQUEST['authldaps_id'] = 0;
+
+        $ma = $this->getMockBuilder(\MassiveAction::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAction', 'addMessage', 'getInput', 'itemDone'])
+            ->getMock();
+        $ma->method('getAction')->willReturn('sync');
+        $ma->method('addMessage')->willReturn(null);
+        $ma->method('getInput')->willReturn([
+            'mode'         => AuthLDAP::ACTION_IMPORT,
+            'authldaps_id' => $ldap->getID(),
+        ]);
+
+        $results = [];
+        $ma->method('itemDone')->willReturnCallback(function ($itemtype, $ids, $result) use (&$results) {
+            $results[] = $result;
+        });
+
+        AuthLDAP::processMassiveActionsForOneItemtype($ma, new AuthLDAP(), ['ecuador0']);
+
+        unset($_REQUEST['mode'], $_REQUEST['authldaps_id']);
+
+        $this->assertCount(1, $results);
+
+        if ($results[0] === \MassiveAction::ACTION_OK) {
+            // LDAP directory reachable: the user must have been imported using the LDAP
+            // server from the massive action input, not the authldaps_id=0 polluting $_REQUEST.
+            $user = new \User();
+            $this->assertTrue($user->getFromDBbyName('ecuador0'));
+            $this->assertSame($ldap->getID(), $user->fields['auths_id']);
+        } else {
+            // LDAP directory unreachable in this environment: at least confirm that a
+            // connection to the CORRECT server was attempted. authldaps_id=0, coming from
+            // the polluted $_REQUEST, would fail instantly with no connection attempt at all.
+            $this->hasPhpLogRecordThatContains(
+                sprintf('Unable to bind to LDAP server `%s:%s`', $ldap->fields['host'], $ldap->fields['port']),
+                LogLevel::WARNING
+            );
+        }
+    }
+
+    /**
      * Test get groups
      *
      * @return void


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45329 & https://github.com/glpi-project/glpi/pull/17235
- Here is a brief description of what this PR does

Running the "Import"/"Synchronize" massive action from the LDAP directory listing logged an "Undefined array key" warning for `mode` and `authldaps_id` on every processed entry.

`AuthLDAP::processMassiveActionsForOneItemtype()` read `$_REQUEST['mode']` / `$_REQUEST['authldaps_id']` directly instead of using `$ma->getInput()`, which is already fetched and is the correct source of massive-action data. Since `$_REQUEST` doesn't reliably carry these fields, they were silently cast to `0`, which could also make a "Synchronize" action behave like "Import" against the wrong LDAP server.

### Fix

Use `$ma->getInput()` for `mode` and `authldaps_id` (in both the `import_group` and `import`/`sync` cases), consistent with how the other fields in this method are already read.