### PR TITLE
Fix: preserve dynamic LDAP rights on SSO login

### DIFF
--- a/src/RuleRightCollection.php
+++ b/src/RuleRightCollection.php
@@ -120,8 +120,8 @@ class RuleRightCollection extends RuleCollection
             $rule_parameters["MAIL_SERVER"] = $params_lower["mail_server"] ?? "";
         }
 
-        //LDAP type method
-        if ($params_lower["type"] == Auth::LDAP) {
+        //LDAP type, or any auth type given a LDAP connection (e.g. SSO with a linked LDAP source)
+        if ($params_lower["type"] == Auth::LDAP || !empty($params_lower["connection"])) {
             //Get all the field to retrieve to be able to process rule matching
             $rule_fields = $this->getFieldsToLookFor();
 

--- a/src/User.php
+++ b/src/User.php
@@ -1498,6 +1498,35 @@ class User extends CommonDBTM implements TreeBrowseInterface
     }
 
     /**
+     * Rebuild a LDAP connection from the user's recorded auths_id/user_dn, so RuleRight
+     * LDAP-attribute criteria can be evaluated outside of an actual LDAP authentication.
+     *
+     * @return array<string, mixed> Empty if no LDAP connection could be established.
+     */
+    private function getLdapConnectionForRules(): array
+    {
+        if (empty($this->fields['auths_id']) || empty($this->fields['user_dn'])) {
+            return [];
+        }
+
+        $config_ldap = new AuthLDAP();
+        if (!$config_ldap->getFromDB($this->fields['auths_id'])) {
+            return [];
+        }
+
+        $connection = $config_ldap->connect();
+        if (!$connection) {
+            return [];
+        }
+
+        return [
+            'connection'  => $connection,
+            'userdn'      => $this->fields['user_dn'],
+            'ldap_server' => $this->fields['auths_id'],
+        ];
+    }
+
+    /**
      * Force authorization assignment rules to be processed for this user
      * @return void
      */
@@ -1510,11 +1539,14 @@ class User extends CommonDBTM implements TreeBrowseInterface
         $result = $rules->processAllRules(
             $groups_id,
             $this->fields,
-            [
-                'type' => $this->fields['authtype'],
-                'login' => $this->fields['name'],
-                'email' => UserEmail::getDefaultForUser($this->getID()),
-            ]
+            array_merge(
+                [
+                    'type' => $this->fields['authtype'],
+                    'login' => $this->fields['name'],
+                    'email' => UserEmail::getDefaultForUser($this->getID()),
+                ],
+                $this->getLdapConnectionForRules()
+            )
         );
 
         $this->input = $result;
@@ -2855,11 +2887,14 @@ class User extends CommonDBTM implements TreeBrowseInterface
                 $groups_id = array_column($groups, 'id');
             }
 
-            $this->fields = $rule->processAllRules($groups_id, $this->fields, [
-                'type'   => Auth::EXTERNAL,
-                'email'  => $this->fields["_emails"] ?? [],
-                'login'  => $this->fields["name"],
-            ]);
+            $this->fields = $rule->processAllRules($groups_id, $this->fields, array_merge(
+                [
+                    'type'   => Auth::EXTERNAL,
+                    'email'  => $this->fields["_emails"] ?? [],
+                    'login'  => $this->fields["name"],
+                ],
+                $this->getLdapConnectionForRules()
+            ));
 
             $this->willProcessRuleRight();
 

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -35,6 +35,12 @@
 namespace tests\units;
 
 use AuthLDAP;
+use function Safe\ldap_add;
+use function Safe\ldap_delete;
+use function Safe\ldap_mod_add;
+use function Safe\ldap_mod_del;
+use function Safe\ldap_mod_replace;
+use function Safe\ldap_rename;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\RuleBuilder;
@@ -2372,6 +2378,55 @@ class AuthLdapTest extends DbTestCase
             'users_id' => $users_id,
         ]);
         $this->assertCount(1, $gus);
+    }
+
+
+    /**
+     * Non-regression: reapplyRightRules() must preserve LDAP-attribute-based dynamic rights on Auth::EXTERNAL.
+     */
+    #[RequiresPhpExtension('ldap')]
+    public function testReapplyRightRulesPreservesLdapAttributeRuleOnExternalAuth(): void
+    {
+        $rule_builder = new RuleBuilder(__FUNCTION__, RuleRight::class);
+        $rule_builder->setEntity(0)
+            ->setIsRecursive(1)
+            ->addCriteria('employeenumber', \Rule::PATTERN_IS, 8)
+            ->addAction('assign', 'profiles_id', 5) // 'normal' profile
+            ->addAction('assign', 'entities_id', 1); // '_test_child_1' entity
+        $this->createRule($rule_builder);
+
+        // Real LDAP sync: assigns the dynamic profile/entity and records auths_id/user_dn.
+        $this->realLogin('brazil6', 'password', false);
+        $users_id = \User::getIdByName('brazil6');
+        $this->assertGreaterThan(0, $users_id);
+
+        $user = new \User();
+        $this->assertTrue($user->getFromDB($users_id));
+        $this->assertNotEmpty($user->fields['auths_id']);
+        $this->assertNotEmpty($user->fields['user_dn']);
+
+        // Simulate the SSO/OAuth login context: the plugin authenticates the
+        // user as Auth::EXTERNAL and calls reapplyRightRules() on the already
+        // LDAP-synced User object.
+        $user->fields['authtype'] = \Auth::EXTERNAL;
+        $user->reapplyRightRules();
+
+        $pu = Profile_User::getForUser($users_id, true);
+        $found = false;
+        foreach ($pu as $right) {
+            if (
+                isset($right['entities_id']) && $right['entities_id'] == 1
+                && isset($right['profiles_id']) && $right['profiles_id'] == 5
+                && isset($right['is_dynamic']) && $right['is_dynamic'] == 1
+            ) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue(
+            $found,
+            'Dynamic right based on a LDAP attribute criterion was purged on Auth::EXTERNAL reapplyRightRules()'
+        );
     }
 
 

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -35,12 +35,6 @@
 namespace tests\units;
 
 use AuthLDAP;
-use function Safe\ldap_add;
-use function Safe\ldap_delete;
-use function Safe\ldap_mod_add;
-use function Safe\ldap_mod_del;
-use function Safe\ldap_mod_replace;
-use function Safe\ldap_rename;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\RuleBuilder;
@@ -54,6 +48,13 @@ use Profile_User;
 use Psr\Log\LogLevel;
 use RuleRight;
 use UserTitle;
+
+use function Safe\ldap_add;
+use function Safe\ldap_delete;
+use function Safe\ldap_mod_add;
+use function Safe\ldap_mod_del;
+use function Safe\ldap_mod_replace;
+use function Safe\ldap_rename;
 
 /* Test for inc/authldap.class.php */
 

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -49,13 +49,6 @@ use Psr\Log\LogLevel;
 use RuleRight;
 use UserTitle;
 
-use function Safe\ldap_add;
-use function Safe\ldap_delete;
-use function Safe\ldap_mod_add;
-use function Safe\ldap_mod_del;
-use function Safe\ldap_mod_replace;
-use function Safe\ldap_rename;
-
 /* Test for inc/authldap.class.php */
 
 class AuthLdapTest extends DbTestCase


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45248
- Users authenticating through an external SSO/OAuth provider could lose profiles and groups previously assigned by rules based on LDAP attributes.
- Each SSO login re-evaluated authorization rules without the LDAP data needed to match those criteria, so any dynamic right depending on an LDAP attribute was silently revoked.
- The LDAP connection is now rebuilt from the user's last known LDAP source before re-evaluating the rules, so LDAP-attribute-based rights are preserved across SSO logins.

## Screenshots (if appropriate):


