### PR TITLE
Fix(Search): skip criteria without a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.
+- Fixed a PHP warning when a search filter criterion has no target field.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.
-- Fixed a PHP warning when a search filter criterion has no target field.
 
 ### Deprecated
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -4850,6 +4850,9 @@ final class SQLProvider implements SearchProviderInterface
                             $sql .= "$LINK ($sub_sql)";
                         }
                     }
+                } elseif (!isset($criterion['field'])) {
+                    // No field to filter on
+                    continue;
                 } elseif (
                     isset($meta_searchopt[$criterion['field']]["usehaving"])
                     || ($meta && "AND NOT" === $criterion['link'])

--- a/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
+++ b/tests/functional/Glpi/Search/Provider/SQLProviderTest.php
@@ -41,6 +41,8 @@ use Glpi\Tests\DbTestCase;
 use Html;
 use Search;
 
+use function Safe\strtotime;
+
 class SQLProviderTest extends DbTestCase
 {
     public function testGetLeftJoinCriteria()
@@ -80,6 +82,23 @@ class SQLProviderTest extends DbTestCase
             ' LEFT JOIN `glpi_tickets` ON (`glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_1` OR `glpi_tickets`.`id` = `glpi_tickets_tickets`.`tickets_id_2`)',
             $it->analyseJoins($item_item_revert_join)
         );
+    }
+
+    /**
+     * A criterion without 'field' or 'criteria' must be skipped, not throw a warning.
+     */
+    public function testConstructCriteriaSQLIgnoresCriterionWithoutField()
+    {
+        $criteria = [
+            [
+                'link'  => 'AND',
+                'value' => 'foo',
+            ],
+        ];
+
+        $sql = SQLProvider::constructCriteriaSQL($criteria, ['itemtype' => 'Ticket'], []);
+
+        $this->assertSame('', $sql);
     }
 
     /**


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45392
- Deleting the last condition inside a search criteria group, without deleting the group itself, produces a criterion with neither a target field nor sub-criteria.
- Such an empty group triggered a PHP "Undefined array key" warning wherever it was evaluated, including notification target filters (e.g. when closing a ticket implicitly adds a followup).
- An empty group now contributes no restriction, matching the expected "no condition" semantics, instead of raising a warning.

## Screenshots (if appropriate):
