### PR TITLE
Fix: make helpdesk home scene illustrations responsive

### DIFF
--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -129,7 +129,10 @@ header {
         overflow: hidden;
 
         svg {
-            height: 393px;
+            width: 100%;
+            height: auto;
+            // keep that ratio so the illustration scales with the scene width without distortion.
+            aspect-ratio: 842 / 596;
         }
 
         img {
@@ -138,8 +141,13 @@ header {
             object-fit: contain;
         }
 
-        // Hide for screens smaller than 1600px
+        // Scale the illustrations down on narrower screens so they stay visible
         @media (max-width: 1600px) {
+            width: 300px;
+        }
+
+        // Hide for screens smaller than 992px
+        @media (max-width: 992px) {
             display: none;
         }
     }

--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -131,6 +131,7 @@ header {
         svg {
             width: 100%;
             height: auto;
+
             // keep that ratio so the illustration scales with the scene width without distortion.
             aspect-ratio: 842 / 596;
         }

--- a/css/helpdesk_home.scss
+++ b/css/helpdesk_home.scss
@@ -142,14 +142,26 @@ header {
             object-fit: contain;
         }
 
-        // Scale the illustrations down on narrower screens so they stay visible
+        // Hide for screens smaller than 1600px
         @media (max-width: 1600px) {
-            width: 300px;
-        }
-
-        // Hide for screens smaller than 992px
-        @media (max-width: 992px) {
             display: none;
+        }
+    }
+
+    // If the search bar is not present
+    &:has(.search-bar-container-placeholder){
+        .scene {
+            // Keep the illustrations visible below 1600px (they are hidden by
+            // default), scaling them down so they still fit.
+            @media (max-width: 1600px) {
+                display: flex;
+                width: 300px;
+            }
+
+            // Hide for screens smaller than 992px
+            @media (max-width: 992px) {
+                display: none;
+            }
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes!45400
- On smaller screens (e.g. 1366px wide), the left and right scene illustrations on the helpdesk home page disappeared, because they were hidden below 1600px.
- They now scale down and stay visible on narrower screens, and are only hidden below 992px where there's no room left beside the centered content. The SVGs keep their native aspect ratio so they scale without distortion.

## Screenshots (if appropriate):

Before (on 1366x768) : 

<img width="1776" height="1004" alt="before" src="https://github.com/user-attachments/assets/61fcc7ed-bfc2-4437-b40d-dac634819d66" />

After (on 1366x768) : 

<img width="1776" height="1004" alt="after" src="https://github.com/user-attachments/assets/a8c7e84b-f594-436b-92fe-5b8ab4c27c53" />
