### PR TITLE
Fix: "Active" column's checkmarks not displaying in the "Users" tab when managing Groups

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -513,7 +513,7 @@ class Group_User extends CommonDBRelation
                     'label' => __('Delegatee'),
                     'filter_formatter' => 'yesno',
                 ],
-                'is_active' => [
+                'active' => [
                     'label' => __('Active'),
                     'filter_formatter' => 'yesno',
                 ],
@@ -524,7 +524,7 @@ class Group_User extends CommonDBRelation
                 'dynamic' => 'raw_html',
                 'manager' => 'raw_html',
                 'delegatee' => 'raw_html',
-                'is_active' => 'raw_html',
+                'active' => 'raw_html',
             ],
             'entries' => $entries,
             'total_number' => $number,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45363
- Here is a brief description of what this PR does

**Issue**: The "Active" column's checkmarks symbols were not displaying on the UI, when managing Users of a group.

**Changes**:
- Changed "is_active" key name to "active" in the "formatters" and "columns" inputs passed to the datatable template.

## Screenshots (if appropriate):

<img width="1252" height="207" alt="image" src="https://github.com/user-attachments/assets/e46b84f0-6e89-4ee9-b4fa-1eaaeb09bedc" />


