### PR TITLE
fix(ProjectTask): improve reminder dropdown range + enrich project task notifications

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -15238,7 +15238,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on ProjectTask\\|null\\.$#',
 	'identifier' => 'property.nonObject',
-	'count' => 26,
+	'count' => 27,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [
@@ -15269,6 +15269,12 @@ $ignoreErrors[] = [
 	'message' => '#^Property NotificationTarget\\<ProjectTask\\>\\:\\:\\$data \\(array\\<string, array\\<string\\>\\|string\\>\\) does not accept array\\<string, array\\<array\\<string, mixed\\>\\|string\\>\\|string\\>\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 2,
+	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Property NotificationTarget\\<ProjectTask\\>\\:\\:\\$data \\(array\\<string, array\\<string\\>\\|string\\>\\) does not accept array\\<string, array\\<array\\<string, string\\>\\|string\\>\\|string\\>\\.$#',
+	'identifier' => 'assign.propertyType',
+	'count' => 1,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -15238,7 +15238,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on ProjectTask\\|null\\.$#',
 	'identifier' => 'property.nonObject',
-	'count' => 27,
+	'count' => 24,
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -15272,12 +15272,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property NotificationTarget\\<ProjectTask\\>\\:\\:\\$data \\(array\\<string, array\\<string\\>\\|string\\>\\) does not accept array\\<string, array\\<array\\<string, string\\>\\|string\\>\\|string\\>\\.$#',
-	'identifier' => 'assign.propertyType',
-	'count' => 1,
-	'path' => __DIR__ . '/src/NotificationTargetProjectTask.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property NotificationTarget\\<ProjectTask\\>\\:\\:\\$data \\(array\\<string, array\\<string\\>\\|string\\>\\) does not accept array\\<string, array\\<string\\>\\|string\\|null\\>\\.$#',
 	'identifier' => 'assign.propertyType',
 	'count' => 6,

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -366,32 +366,36 @@ class NotificationTargetProjectTask extends NotificationTarget
         $this->data["##project.realenddate##"]   = '';
 
         $project = new Project();
-        if ($project->getFromDB($item->fields['projects_id'])) {
-            $this->data["##project.name##"]        = $project->getField('name');
-            $this->data["##project.code##"]        = $project->getField('code');
+        $projects_id = $item->fields['projects_id'];
+        if ($project->getFromDB($projects_id)) {
+            $this->data["##project.name##"]        = $project->getName();
+            $this->data["##project.code##"]        = (string) ($project->fields['code'] ?? '');
             $this->data["##project.url##"]         = $this->formatURL(
                 $options['additionnaloption']['usertype'],
                 "Project_" . $project->getID()
             );
-            $this->data["##project.description##"] = $project->getField('content');
-            $this->data["##project.comments##"]    = $project->getField('comment');
-            $this->data["##project.priority##"]    = CommonITILObject::getPriorityName($project->fields['priority']);
-            $this->data["##project.planstartdate##"] = Html::convDateTime($project->fields['plan_start_date']);
-            $this->data["##project.planenddate##"]   = Html::convDateTime($project->fields['plan_end_date']);
-            $this->data["##project.realstartdate##"] = Html::convDateTime($project->fields['real_start_date']);
-            $this->data["##project.realenddate##"]   = Html::convDateTime($project->fields['real_end_date']);
+            $this->data["##project.description##"] = (string) ($project->fields['content'] ?? '');
+            $this->data["##project.comments##"]    = (string) ($project->fields['comment'] ?? '');
+            $this->data["##project.planstartdate##"] = Html::convDateTime($project->fields['plan_start_date'] ?? '') ?? '';
+            $this->data["##project.planenddate##"]   = Html::convDateTime($project->fields['plan_end_date'] ?? '') ?? '';
+            $this->data["##project.realstartdate##"] = Html::convDateTime($project->fields['real_start_date'] ?? '') ?? '';
+            $this->data["##project.realenddate##"]   = Html::convDateTime($project->fields['real_end_date'] ?? '') ?? '';
 
-            if ($project->fields['projectstates_id']) {
+            if (isset($project->fields['projectstates_id'])) {
                 $this->data["##project.state##"] = Dropdown::getDropdownName(
                     'glpi_projectstates',
                     $project->fields['projectstates_id']
                 );
             }
-            if ($project->fields['projecttypes_id']) {
+            if (isset($project->fields['projecttypes_id'])) {
                 $this->data["##project.type##"] = Dropdown::getDropdownName(
                     'glpi_projecttypes',
                     $project->fields['projecttypes_id']
                 );
+            }
+
+            if(isset($project->fields['priority'])){
+                $this->data["##project.priority##"] = CommonITILObject::getPriorityName($project->fields['priority']);
             }
         }
 

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -269,13 +269,47 @@ class NotificationTargetProjectTask extends NotificationTarget
                   );
         $this->data["##projecttask.name##"]
                   = $item->getField('name');
-        $this->data["##projecttask.project##"]
-                  = Dropdown::getDropdownName('glpi_projects', $item->fields['projects_id']);
-        $this->data["##projecttask.projecturl##"]
+
+        // Project (parent) infos
+        $project = new Project();
+        $projects_id = $item->fields['projects_id'] ?? 0;
+
+        if ($project->getFromDB($projects_id)) {
+            $this->data["##projecttask.project##"]
+                  = Dropdown::getDropdownName('glpi_projects', $projects_id);
+
+            $this->data["##projecttask.projecturl##"]
                   = $this->formatURL(
                       $options['additionnaloption']['usertype'],
-                      "Project_" . $item->fields["projects_id"]
+                      "Project_" . $projects_id
                   );
+
+            $this->data["##projecttask.projectcode##"]        = (string) ($project->fields['code'] ?? '');
+            $this->data["##projecttask.projectdescription##"] = (string) ($project->fields['content'] ?? '');
+            $this->data["##projecttask.projectcomments##"]    = (string) ($project->fields['comment'] ?? '');
+            $this->data["##projecttask.projectplanstartdate##"] = Html::convDateTime($project->fields['plan_start_date'] ?? '') ?? '';
+            $this->data["##projecttask.projectplanenddate##"]   = Html::convDateTime($project->fields['plan_end_date'] ?? '') ?? '';
+            $this->data["##projecttask.projectrealstartdate##"] = Html::convDateTime($project->fields['real_start_date'] ?? '') ?? '';
+            $this->data["##projecttask.projectrealenddate##"]   = Html::convDateTime($project->fields['real_end_date'] ?? '') ?? '';
+
+            if (isset($project->fields['projectstates_id'])) {
+                $this->data["##projecttask.projectstate##"] = Dropdown::getDropdownName(
+                    'glpi_projectstates',
+                    $project->fields['projectstates_id']
+                );
+            }
+            if (isset($project->fields['projecttypes_id'])) {
+                $this->data["##projecttask.projecttype##"] = Dropdown::getDropdownName(
+                    'glpi_projecttypes',
+                    $project->fields['projecttypes_id']
+                );
+            }
+
+            if (isset($project->fields['priority'])) {
+                $this->data["##projecttask.projectpriority##"] = CommonITILObject::getPriorityName($project->fields['priority']);
+            }
+        }
+
         $this->data["##projecttask.description##"]
                   = $item->getField('content');
         $this->data["##projecttask.comments##"]
@@ -349,54 +383,6 @@ class NotificationTargetProjectTask extends NotificationTarget
             $user_tmp = new User();
             $user_tmp->getFromDB($item->fields['users_id']);
             $this->data["##projecttask.createbyuser##"] = $user_tmp->getName();
-        }
-
-        // Project (parent) infos
-        $this->data["##project.name##"]          = '';
-        $this->data["##project.code##"]          = '';
-        $this->data["##project.url##"]           = '';
-        $this->data["##project.description##"]   = '';
-        $this->data["##project.comments##"]      = '';
-        $this->data["##project.priority##"]      = '';
-        $this->data["##project.state##"]         = '';
-        $this->data["##project.type##"]          = '';
-        $this->data["##project.planstartdate##"] = '';
-        $this->data["##project.planenddate##"]   = '';
-        $this->data["##project.realstartdate##"] = '';
-        $this->data["##project.realenddate##"]   = '';
-
-        $project = new Project();
-        $projects_id = $item->fields['projects_id'];
-        if ($project->getFromDB($projects_id)) {
-            $this->data["##project.name##"]        = $project->getName();
-            $this->data["##project.code##"]        = (string) ($project->fields['code'] ?? '');
-            $this->data["##project.url##"]         = $this->formatURL(
-                $options['additionnaloption']['usertype'],
-                "Project_" . $project->getID()
-            );
-            $this->data["##project.description##"] = (string) ($project->fields['content'] ?? '');
-            $this->data["##project.comments##"]    = (string) ($project->fields['comment'] ?? '');
-            $this->data["##project.planstartdate##"] = Html::convDateTime($project->fields['plan_start_date'] ?? '') ?? '';
-            $this->data["##project.planenddate##"]   = Html::convDateTime($project->fields['plan_end_date'] ?? '') ?? '';
-            $this->data["##project.realstartdate##"] = Html::convDateTime($project->fields['real_start_date'] ?? '') ?? '';
-            $this->data["##project.realenddate##"]   = Html::convDateTime($project->fields['real_end_date'] ?? '') ?? '';
-
-            if (isset($project->fields['projectstates_id'])) {
-                $this->data["##project.state##"] = Dropdown::getDropdownName(
-                    'glpi_projectstates',
-                    $project->fields['projectstates_id']
-                );
-            }
-            if (isset($project->fields['projecttypes_id'])) {
-                $this->data["##project.type##"] = Dropdown::getDropdownName(
-                    'glpi_projecttypes',
-                    $project->fields['projecttypes_id']
-                );
-            }
-
-            if (isset($project->fields['priority'])) {
-                $this->data["##project.priority##"] = CommonITILObject::getPriorityName($project->fields['priority']);
-            }
         }
 
         // Team infos
@@ -669,19 +655,16 @@ class NotificationTargetProjectTask extends NotificationTarget
                 __('Description')
             ),
             'projecttask.projecturl'  => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('URL')),
-
-            'project.url'             => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('URL')),
-            'project.name'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Name')),
-            'project.code'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Code')),
-            'project.description'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Description')),
-            'project.comments'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Comment', 'Comments', Session::getPluralNumber())),
-            'project.priority'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Priority')),
-            'project.state'           => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _x('item', 'State')),
-            'project.type'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Type', 'Types', 1)),
-            'project.planstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned start date')),
-            'project.planenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned end date')),
-            'project.realstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real start date')),
-            'project.realenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real end date')),
+            'projecttask.projectcode'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Code')),
+            'projecttask.projectdescription'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Description')),
+            'projecttask.projectcomments'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Comment', 'Comments', Session::getPluralNumber())),
+            'projecttask.projectpriority'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Priority')),
+            'projecttask.projectstate'           => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _x('item', 'State')),
+            'projecttask.projecttype'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Type', 'Types', 1)),
+            'projecttask.projectplanstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned start date')),
+            'projecttask.projectplanenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned end date')),
+            'projecttask.projectrealstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real start date')),
+            'projecttask.projectrealenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real end date')),
 
             'document.url'            => sprintf(
                 __('%1$s: %2$s'),

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -351,6 +351,50 @@ class NotificationTargetProjectTask extends NotificationTarget
             $this->data["##projecttask.createbyuser##"] = $user_tmp->getName();
         }
 
+        // Project (parent) infos
+        $this->data["##project.name##"]          = '';
+        $this->data["##project.code##"]          = '';
+        $this->data["##project.url##"]           = '';
+        $this->data["##project.description##"]   = '';
+        $this->data["##project.comments##"]      = '';
+        $this->data["##project.priority##"]      = '';
+        $this->data["##project.state##"]         = '';
+        $this->data["##project.type##"]          = '';
+        $this->data["##project.planstartdate##"] = '';
+        $this->data["##project.planenddate##"]   = '';
+        $this->data["##project.realstartdate##"] = '';
+        $this->data["##project.realenddate##"]   = '';
+
+        $project = new Project();
+        if ($project->getFromDB($item->fields['projects_id'])) {
+            $this->data["##project.name##"]        = $project->getField('name');
+            $this->data["##project.code##"]        = $project->getField('code');
+            $this->data["##project.url##"]         = $this->formatURL(
+                $options['additionnaloption']['usertype'],
+                "Project_" . $project->getID()
+            );
+            $this->data["##project.description##"] = $project->getField('content');
+            $this->data["##project.comments##"]    = $project->getField('comment');
+            $this->data["##project.priority##"]    = CommonITILObject::getPriorityName($project->fields['priority']);
+            $this->data["##project.planstartdate##"] = Html::convDateTime($project->fields['plan_start_date']);
+            $this->data["##project.planenddate##"]   = Html::convDateTime($project->fields['plan_end_date']);
+            $this->data["##project.realstartdate##"] = Html::convDateTime($project->fields['real_start_date']);
+            $this->data["##project.realenddate##"]   = Html::convDateTime($project->fields['real_end_date']);
+
+            if ($project->fields['projectstates_id']) {
+                $this->data["##project.state##"] = Dropdown::getDropdownName(
+                    'glpi_projectstates',
+                    $project->fields['projectstates_id']
+                );
+            }
+            if ($project->fields['projecttypes_id']) {
+                $this->data["##project.type##"] = Dropdown::getDropdownName(
+                    'glpi_projecttypes',
+                    $project->fields['projecttypes_id']
+                );
+            }
+        }
+
         // Team infos
         $restrict = ['projecttasks_id' => $item->getID()];
         $items    = getAllDataFromTable('glpi_projecttaskteams', $restrict);
@@ -621,6 +665,20 @@ class NotificationTargetProjectTask extends NotificationTarget
                 __('Description')
             ),
             'projecttask.projecturl'  => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('URL')),
+
+            'project.url'             => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('URL')),
+            'project.name'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Name')),
+            'project.code'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Code')),
+            'project.description'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Description')),
+            'project.comments'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Comment', 'Comments', Session::getPluralNumber())),
+            'project.priority'        => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Priority')),
+            'project.state'           => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _x('item', 'State')),
+            'project.type'            => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), _n('Type', 'Types', 1)),
+            'project.planstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned start date')),
+            'project.planenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Planned end date')),
+            'project.realstartdate'   => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real start date')),
+            'project.realenddate'     => sprintf(__('%1$s: %2$s'), Project::getTypeName(1), __('Real end date')),
+
             'document.url'            => sprintf(
                 __('%1$s: %2$s'),
                 Document::getTypeName(1),

--- a/src/NotificationTargetProjectTask.php
+++ b/src/NotificationTargetProjectTask.php
@@ -394,7 +394,7 @@ class NotificationTargetProjectTask extends NotificationTarget
                 );
             }
 
-            if(isset($project->fields['priority'])){
+            if (isset($project->fields['priority'])) {
                 $this->data["##project.priority##"] = CommonITILObject::getPriorityName($project->fields['priority']);
             }
         }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -873,6 +873,27 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             $duration_dropdown_to_add[$i * DAY_TIMESTAMP] = sprintf(_n('%s day', '%s days', $i), $i);
         }
 
+        $recall_values = [
+            ''                  => __('None'),
+            0                   => sprintf(_n('%d minute', '%d minutes', 0), 0),
+        ];
+        foreach ([15, 30, 45] as $minutes) {
+            $recall_values[$minutes * MINUTE_TIMESTAMP] = sprintf(_n('%d minute', '%d minutes', $minutes), $minutes);
+        }
+        foreach ([1, 2, 3, 4, 12] as $hours) {
+            $recall_values[$hours * HOUR_TIMESTAMP] = sprintf(_n('%d hour', '%d hours', $hours), $hours);
+        }
+        for ($i = 1; $i <= 6; $i++) {
+            $recall_values[$i * DAY_TIMESTAMP] = sprintf(_n('%d day', '%d days', $i), $i);
+        }
+        for ($i = 1; $i <= 3; $i++) {
+            $recall_values[$i * WEEK_TIMESTAMP] = sprintf(_n('%d week', '%d weeks', $i), $i);
+        }
+        for ($i = 1; $i <= 11; $i++) {
+            $recall_values[$i * MONTH_TIMESTAMP] = sprintf(_n('%d month', '%d months', $i), $i);
+        }
+        $recall_values[12 * MONTH_TIMESTAMP] = sprintf(_n('%d year', '%d years', 1), 1);
+
         $this->initForm($ID, $options);
 
         TemplateRenderer::getInstance()->display('pages/tools/project_task.html.twig', [
@@ -884,6 +905,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'projecttasks_id'          => $projecttasks_id,
             'recursive'                => $recursive,
             'duration_dropdown_to_add' => $duration_dropdown_to_add,
+            'recall_values'            => $recall_values,
             'duration'                 => $duration,
             'rand'                     => mt_rand(),
         ]);

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -195,21 +195,6 @@
         }
     ) }}
 
-    {% set recall_values = {
-        '': __('None'),
-        '0': _n('%d minute', '%d minutes', 0)|format(0),
-        '900': _n('%d minute', '%d minutes', 15)|format(15),
-        '1800': _n('%d minute', '%d minutes', 30)|format(30),
-        '2700': _n('%d minute', '%d minutes', 45)|format(45),
-        '3600': _n('%d hour', '%d hours', 1)|format(1),
-        '7200': _n('%d hour', '%d hours', 2)|format(2),
-        '10800': _n('%d hour', '%d hours', 3)|format(3),
-        '14400': _n('%d hour', '%d hours', 4)|format(4),
-        '43200': _n('%d hour', '%d hours', 12)|format(12),
-        '86400': _n('%d day', '%d days', 1)|format(1),
-        '172800': _n('%d day', '%d days', 2)|format(2),
-        '604800': _n('%d week', '%d weeks', 1)|format(1),
-    } %}
     {{ fields.dropdownArrayField(
         'recall',
         item.fields.recall,

--- a/tests/functional/NotificationTargetProjectTaskTest.php
+++ b/tests/functional/NotificationTargetProjectTaskTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\DbTestCase;
+use NotificationTarget;
+use Project;
+use ProjectState;
+use ProjectTask;
+use ProjectType;
+
+/* Test for inc/notificationtargetprojecttask.class.php */
+
+class NotificationTargetProjectTaskTest extends DbTestCase
+{
+    public function testgetDataForObject()
+    {
+        $this->login();
+
+        $root_entity = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Create a project state and a project type to be referenced by the project
+        $state = $this->createItem(ProjectState::class, [
+            'name' => 'Notif test project state',
+        ]);
+
+        $type = $this->createItem(ProjectType::class, [
+            'name' => 'Notif test project type',
+        ]);
+
+        // Create the parent project holding the interesting data
+        $project = $this->createItem(Project::class, [
+            'name'             => 'Test project notif',
+            'code'             => 'PRJ-NOTIF-001',
+            'content'          => 'Project description content',
+            'comment'          => 'Project comment',
+            'priority'         => 4,
+            'projectstates_id' => $state->getID(),
+            'projecttypes_id'  => $type->getID(),
+            'plan_start_date'  => '2024-01-01 08:00:00',
+            'plan_end_date'    => '2024-02-01 18:00:00',
+            'real_start_date'  => '2024-01-02 09:00:00',
+            'real_end_date'    => '2024-02-02 17:00:00',
+            'entities_id'      => $root_entity,
+        ]);
+
+        // Create a task attached to the project
+        $ptask = $this->createItem(ProjectTask::class, [
+            'name'        => 'Test project task notif',
+            'projects_id' => $project->getID(),
+            'entities_id' => $root_entity,
+        ]);
+
+        $notiftarget = new \NotificationTargetProjectTask($root_entity, 'new', $ptask);
+        $notiftarget->getTags();
+
+        // basic test for the ##projecttask.projectcode## tag description
+        $expected = [
+            'tag'            => 'projecttask.projectcode',
+            'value'          => true,
+            'label'          => 'Project: Code',
+            'events'         => 0,
+            'foreach'        => false,
+            'lang'           => false,
+            'allowed_values' => [],
+        ];
+        $this->assertSame(
+            $expected,
+            $notiftarget->tag_descriptions['tag']['##projecttask.projectcode##']
+        );
+
+        // advanced test: check the values computed for the project tags
+        $basic_options = [
+            'additionnaloption' => [
+                'usertype' => NotificationTarget::GLPI_USER,
+            ],
+        ];
+        $notiftarget->addDataForTemplate('new', $basic_options);
+        $data = $notiftarget->data;
+
+        global $CFG_GLPI;
+
+        $this->assertSame('Test project notif', $data['##projecttask.project##']);
+        $this->assertSame(
+            sprintf(
+                '%s/index.php?redirect=Project_%d',
+                $CFG_GLPI['url_base'],
+                $project->getID()
+            ),
+            $data['##projecttask.projecturl##']
+        );
+        $this->assertSame('PRJ-NOTIF-001', $data['##projecttask.projectcode##']);
+        $this->assertSame('Project description content', $data['##projecttask.projectdescription##']);
+        $this->assertSame('Project comment', $data['##projecttask.projectcomments##']);
+        $this->assertSame(
+            \Html::convDateTime($project->fields['plan_start_date']),
+            $data['##projecttask.projectplanstartdate##']
+        );
+        $this->assertSame(
+            \Html::convDateTime($project->fields['plan_end_date']),
+            $data['##projecttask.projectplanenddate##']
+        );
+        $this->assertSame(
+            \Html::convDateTime($project->fields['real_start_date']),
+            $data['##projecttask.projectrealstartdate##']
+        );
+        $this->assertSame(
+            \Html::convDateTime($project->fields['real_end_date']),
+            $data['##projecttask.projectrealenddate##']
+        );
+        $this->assertSame(
+            \Dropdown::getDropdownName('glpi_projectstates', $state->getID()),
+            $data['##projecttask.projectstate##']
+        );
+        $this->assertSame(
+            \Dropdown::getDropdownName('glpi_projecttypes', $type->getID()),
+            $data['##projecttask.projecttype##']
+        );
+        $this->assertSame(
+            \CommonITILObject::getPriorityName(4),
+            $data['##projecttask.projectpriority##']
+        );
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes the last request of !41959
- **Reminder dropdown**: Moved the `recall` values array from the Twig template into `ProjectTask::showForm()` (consistent with `duration_dropdown_to_add`), and extended the available range up to 6 days, 3 weeks, 11 months, and 1 year.
- **Project task notifications**: Added new `##project.*##` notification tags exposing data about the task's parent project (name, code, URL, description, priority, state, type, and planned/real dates) in `NotificationTargetProjectTask`.


