### PR TITLE
KB : repair broken article action-menu toggles

### DIFF
--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -40,6 +40,8 @@ import { GlpiKnowbaseServiceCatalogPanelController } from "/js/modules/Knowbase/
 import {
     EditorActionType,
     extractParamsFromDataset,
+    isTogglePending,
+    runToggle,
     syncToggleCheckboxes,
     toggleFavorite,
     toggleField,
@@ -187,7 +189,10 @@ export class GlpiKnowbaseArticleController
         const actions = this.#container.querySelectorAll("[data-glpi-kb-action]");
         for (const action of actions) {
             action.addEventListener("click", (e) => {
-                e.preventDefault();
+                // Keep the checkbox's native toggle on direct clicks; cancelling it desyncs the UI.
+                if (!e.target.matches('input[type="checkbox"]')) {
+                    e.preventDefault();
+                }
                 try {
                     this.#executeAction(e);
                 } catch (e) {
@@ -468,14 +473,21 @@ export class GlpiKnowbaseArticleController
             case EditorActionType.TOGGLE_FAVORITE: {
                 event.stopPropagation();
                 const toggle = element.querySelector('input[type="checkbox"]');
-                if (toggle) {
-                    const clicked_on_toggle = target === toggle;
-                    if (!clicked_on_toggle) {
+                if (!toggle) {
+                    break;
+                }
+                const clicked_on_toggle = target === toggle;
+                if (isTogglePending(EditorActionType.TOGGLE_FAVORITE, params.id)) {
+                    // Ignore clicks while a request is in flight; undo any native flip.
+                    if (clicked_on_toggle) {
                         toggle.checked = !toggle.checked;
                     }
-                    this.#updateFavoritesAside(toggle.checked);
-                    this.#toggleFavorite(params.id, toggle);
+                    break;
                 }
+                if (!clicked_on_toggle) {
+                    toggle.checked = !toggle.checked;
+                }
+                this.#toggleFavorite(params.id, toggle);
                 break;
             }
             case EditorActionType.DELETE_ARTICLE:
@@ -595,12 +607,20 @@ export class GlpiKnowbaseArticleController
     async #toggleFavorite(id, toggle)
     {
         const value = toggle.checked;
-        // Reflect the change on every menu for this article, aside included.
+        this.#updateFavoritesAside(value);
         syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, value);
         try {
-            await toggleFavorite(id, value);
+            const { favorite } = await runToggle(
+                EditorActionType.TOGGLE_FAVORITE,
+                id,
+                () => toggleFavorite(id, value),
+            );
+            // Reconcile from the server's authoritative state.
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, favorite);
+            this.#updateFavoritesAside(favorite);
         } catch (e) {
             syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, !value);
+            this.#updateFavoritesAside(!value);
             throw e;
         }
     }

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -36,6 +36,8 @@ import { get, post } from "/js/modules/Ajax.js";
 import {
     EditorActionType,
     extractParamsFromDataset,
+    isTogglePending,
+    runToggle,
     syncToggleCheckboxes,
     toggleFavorite,
     toggleField,
@@ -454,7 +456,10 @@ export class GlpiKnowbaseAsideController
                 return;
             }
 
-            e.preventDefault();
+            // Keep the checkbox's native toggle on direct clicks; cancelling it desyncs the UI.
+            if (!e.target.matches('input[type="checkbox"]')) {
+                e.preventDefault();
+            }
             try {
                 this.#executeAction(e, button);
             } catch (error) {
@@ -550,7 +555,15 @@ export class GlpiKnowbaseAsideController
                 if (!toggle) {
                     break;
                 }
-                if (e.target !== toggle) {
+                const clicked_on_toggle = e.target === toggle;
+                if (isTogglePending(EditorActionType.TOGGLE_FAVORITE, id)) {
+                    // Ignore clicks while a request is in flight; undo any native flip.
+                    if (clicked_on_toggle) {
+                        toggle.checked = !toggle.checked;
+                    }
+                    break;
+                }
+                if (!clicked_on_toggle) {
                     toggle.checked = !toggle.checked;
                 }
                 this.#onToggleFavorite(id, toggle.checked);
@@ -582,12 +595,17 @@ export class GlpiKnowbaseAsideController
     async #onToggleFavorite(id, value)
     {
         this.#updateFavoritesSection(id, value);
-        // Sync every menu for this article, page-wide (aside + article header).
         syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, value);
         try {
-            await toggleFavorite(id, value);
+            const { favorite } = await runToggle(
+                EditorActionType.TOGGLE_FAVORITE,
+                id,
+                () => toggleFavorite(id, value),
+            );
+            // Reconcile from the server's authoritative state.
+            this.#updateFavoritesSection(id, favorite);
+            syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, favorite);
         } catch (error) {
-            // Revert the optimistic UI changes.
             this.#updateFavoritesSection(id, !value);
             syncToggleCheckboxes(id, EditorActionType.TOGGLE_FAVORITE, !value);
             throw error;

--- a/js/modules/Knowbase/EditorActions.js
+++ b/js/modules/Knowbase/EditorActions.js
@@ -44,6 +44,44 @@ export const EditorActionType = Object.freeze({
     OPEN_MODAL:      'OPEN_MODAL',
 });
 
+// In-flight toggle requests keyed `${type}:${id}`, to prevent overlapping add/remove races.
+const pending_toggles = new Set();
+
+function toggleKey(type, id)
+{
+    return `${type}:${id}`;
+}
+
+/**
+ * @param {string} type
+ * @param {number|string} id
+ * @returns {boolean}
+ */
+export function isTogglePending(type, id)
+{
+    return pending_toggles.has(toggleKey(type, id));
+}
+
+/**
+ * Run a toggle request while marking (type, id) in-flight; always cleared afterwards.
+ *
+ * @param {string} type
+ * @param {number|string} id
+ * @param {() => Promise<T>} request
+ * @returns {Promise<T>}
+ * @template T
+ */
+export async function runToggle(type, id, request)
+{
+    const key = toggleKey(type, id);
+    pending_toggles.add(key);
+    try {
+        return await request();
+    } finally {
+        pending_toggles.delete(key);
+    }
+}
+
 /**
  * Extract `data-glpi-kb-action-param-*` values from a dataset into a plain
  * object keyed by the (lower-cased) param name.
@@ -71,11 +109,12 @@ export function extractParamsFromDataset(dataset)
  *
  * @param {number} id
  * @param {boolean} value
- * @returns {Promise<Response>}
+ * @returns {Promise<{favorite: boolean}>} The authoritative state after the call.
  */
-export function toggleFavorite(id, value)
+export async function toggleFavorite(id, value)
 {
-    return post(`Knowbase/${id}/ToggleFavorite`, { value: value });
+    const response = await post(`Knowbase/${id}/ToggleFavorite`, { value: value });
+    return response.json();
 }
 
 /**

--- a/src/Glpi/Controller/Knowbase/ToggleFavoriteController.php
+++ b/src/Glpi/Controller/Knowbase/ToggleFavoriteController.php
@@ -39,8 +39,8 @@ use Glpi\Controller\CrudControllerTrait;
 use Glpi\Exception\Http\BadRequestHttpException;
 use KnowbaseItem_Favorite;
 use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class ToggleFavoriteController extends AbstractController
@@ -55,7 +55,7 @@ final class ToggleFavoriteController extends AbstractController
         ],
         methods: 'POST',
     )]
-    public function __invoke(int $id, Request $request): Response
+    public function __invoke(int $id, Request $request): JsonResponse
     {
         $value = $request->getPayload()->get('value');
 
@@ -70,15 +70,15 @@ final class ToggleFavoriteController extends AbstractController
             'users_id'         => $user_id,
         ];
 
-        if ($value) {
+        $favorite = new KnowbaseItem_Favorite();
+        $exists   = $favorite->getFromDBByCrit($criteria);
+
+        if ($value && !$exists) {
             $this->add(KnowbaseItem_Favorite::class, $criteria);
-        } else {
-            $favorite = new KnowbaseItem_Favorite();
-            if ($favorite->getFromDBByCrit($criteria)) {
-                $this->purge(KnowbaseItem_Favorite::class, $favorite->getID());
-            }
+        } elseif (!$value && $exists) {
+            $this->purge(KnowbaseItem_Favorite::class, $favorite->getID());
         }
 
-        return new Response(); // OK
+        return new JsonResponse(['favorite' => (bool) $value]);
     }
 }

--- a/tests/e2e/specs/Knowbase/faq.spec.ts
+++ b/tests/e2e/specs/Knowbase/faq.spec.ts
@@ -88,3 +88,32 @@ test('Can toggle FAQ from true to false', async ({ page, profile, api }) => {
     const faq_toggle_after_reload = kb.getButton('Add to FAQ');
     await expect(faq_toggle_after_reload.getByRole('checkbox')).not.toBeChecked();
 });
+
+test('Can toggle FAQ by clicking the switch itself, not only the label', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const id = await api.createItem('KnowbaseItem', {
+        name: 'My kb entry for FAQ switch-click test',
+        entities_id: getWorkerEntityId(),
+        answer: "My answer",
+        is_faq: 0,
+    });
+
+    await kb.goto(id);
+    await kb.articleActionsMenu.click();
+
+    const faq_checkbox = kb.getButton('Add to FAQ').getByRole('checkbox');
+    await expect(faq_checkbox).not.toBeChecked();
+
+    // Clicking the switch directly must toggle and persist; previously the native
+    // toggle was cancelled and the checkbox snapped back out of sync.
+    const response = page.waitForResponse(r => r.url().includes('/ToggleField'));
+    await faq_checkbox.click();
+    await response;
+    await expect(faq_checkbox).toBeChecked();
+
+    await page.reload();
+    await kb.articleActionsMenu.click();
+    await expect(kb.getButton('Add to FAQ').getByRole('checkbox')).toBeChecked();
+});

--- a/tests/functional/Glpi/Controller/Knowbase/ToggleFavoriteControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/ToggleFavoriteControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\Knowbase;
+
+use Glpi\Controller\Knowbase\ToggleFavoriteController;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+use KnowbaseItem_Favorite;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class ToggleFavoriteControllerTest extends DbTestCase
+{
+    private function callController(int $id, bool $value): JsonResponse
+    {
+        $request = Request::create(
+            '/Knowbase/' . $id . '/ToggleFavorite',
+            'POST',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['value' => $value]),
+        );
+        return (new ToggleFavoriteController())->__invoke($id, $request);
+    }
+
+    private function countFavorites(int $id): int
+    {
+        return (int) countElementsInTable(KnowbaseItem_Favorite::getTable(), [
+            'knowbaseitems_id' => $id,
+            'users_id'         => Session::getLoginUserID(),
+        ]);
+    }
+
+    private function makeArticle(): int
+    {
+        return $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Fav toggle ' . $this->getUniqueString(),
+            'answer' => '<p>x</p>',
+        ])->getID();
+    }
+
+    public function testAddFavoriteTwiceIsIdempotent(): void
+    {
+        $this->login();
+        $id = $this->makeArticle();
+
+        $this->callController($id, true);
+        $second = $this->callController($id, true); // must not throw (previously a 500)
+
+        $this->assertSame(1, $this->countFavorites($id));
+        $this->assertSame('{"favorite":true}', $second->getContent());
+    }
+
+    public function testRemoveFavoriteWhenAbsentIsNoop(): void
+    {
+        $this->login();
+        $id = $this->makeArticle();
+
+        $response = $this->callController($id, false);
+
+        $this->assertSame(0, $this->countFavorites($id));
+        $this->assertSame('{"favorite":false}', $response->getContent());
+    }
+
+    public function testToggleOnThenOff(): void
+    {
+        $this->login();
+        $id = $this->makeArticle();
+
+        $this->callController($id, true);
+        $this->assertSame(1, $this->countFavorites($id));
+
+        $this->callController($id, false);
+        $this->assertSame(0, $this->countFavorites($id));
+    }
+}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/439
- Here is a brief description of what this PR does : 

This PR fixes the toggles in the Knowledge Base article action menu, which were pretty broken.

Adding an article to favorites returned a 500 whenever it was already a favorite : the endpoint tried to insert a duplicate row and hit the unique key. It now checks before acting and just returns the current state, so it's safe to call as many times as you want. Clicking fast (or from several menus at once) could also leave the checkbox out of sync with what was actually saved. Toggle requests are now guarded against overlapping, and the checkbox is resynced from the server's response. 

Last thing: clicking the switch itself did nothing, only the text worked. Both work now. Covered by a PHPUnit test for the idempotent endpoint and e2e tests for the switch click.



