### PR TITLE
Fix undefined array key warning in Search::giveItem when name is missing

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6934,7 +6934,7 @@ final class SQLProvider implements SearchProviderInterface
                     } elseif (isset($field_data['trans_name']) && !empty($field_data['trans_name'])) {
                         $out .= \htmlescape($field_data['trans_name']);
                     } else {
-                        $out .= \htmlescape($field_data['name'] ?: '');
+                        $out .= \htmlescape($field_data['name'] ?? '');
                     }
                 }
             }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes #24697
- When a search result row has no name value (for example a contract created with only a name and no other data), the final else branch in Search::giveItem reads `$data[$ID][$k]['name']` without a guard and PHP 8 logs an Undefined array key warning. Fall back to an empty string, same as the `?? ''` already used a few lines above at line 7904.
