### PR TITLE
Fix: skip mapper resolution when items_id is not resolved to a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The present file will list all changes made to the project; according to the
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.
+- Fixed import of exported forms containing a condition on an item dropdown with no item selected.
 
 ### Deprecated
 

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -735,11 +735,15 @@ final class FormSerializer extends AbstractFormSerializer
                 && isset($value['items_id'])
                 && getItemForItemtype($value['itemtype'])
             ) {
-                $items_id = $mapper->getItemId(
-                    itemtype: $value['itemtype'],
-                    key: $value['items_id'],
-                );
-                $value['items_id'] = $items_id;
+                if (is_string($value['items_id'])) {
+                    $items_id = $mapper->getItemId(
+                        itemtype: $value['itemtype'],
+                        key: $value['items_id'],
+                    );
+                    $value['items_id'] = $items_id;
+                } else {
+                    $value['items_id'] = (int) $value['items_id'];
+                }
             }
 
             $data[] = new ConditionData(

--- a/src/Glpi/Form/Export/Serializer/FormSerializer.php
+++ b/src/Glpi/Form/Export/Serializer/FormSerializer.php
@@ -733,17 +733,14 @@ final class FormSerializer extends AbstractFormSerializer
                 is_array($value)
                 && isset($value['itemtype'])
                 && isset($value['items_id'])
+                && ($value['items_id'] !== 0)
                 && getItemForItemtype($value['itemtype'])
             ) {
-                if (is_string($value['items_id'])) {
-                    $items_id = $mapper->getItemId(
-                        itemtype: $value['itemtype'],
-                        key: $value['items_id'],
-                    );
-                    $value['items_id'] = $items_id;
-                } else {
-                    $value['items_id'] = (int) $value['items_id'];
-                }
+                $items_id = $mapper->getItemId(
+                    itemtype: $value['itemtype'],
+                    key: $value['items_id'],
+                );
+                $value['items_id'] = $items_id;
             }
 
             $data[] = new ConditionData(

--- a/tests/functional/Glpi/Form/Export/FormSerializerTest.php
+++ b/tests/functional/Glpi/Form/Export/FormSerializerTest.php
@@ -123,7 +123,10 @@ use PHPUnit\Framework\Attributes\Group;
 use Ramsey\Uuid\Uuid;
 use Session;
 
+use function Safe\copy;
+use function Safe\json_decode;
 use function Safe\json_encode;
+use function Safe\unlink;
 
 final class FormSerializerTest extends DbTestCase
 {
@@ -1964,6 +1967,53 @@ final class FormSerializerTest extends DbTestCase
             'itemtype' => Computer::class,
             'items_id' => 'My computer',
         ], $data['forms'][0]['destinations'][0]['conditions'][0]['value']);
+    }
+
+    public function testExportAndImportQuestionConditionWithEmptyItemsId(): void
+    {
+        $this->login();
+
+        // Arrange: create a form with a condition referencing an item
+        // question, but with no item selected (items_id = 0)
+        $builder = new FormBuilder();
+        $builder->addQuestion(
+            name: "My item question",
+            type: QuestionTypeItem::class,
+            extra_data: json_encode(new QuestionTypeItemExtraDataConfig(
+                itemtype: Computer::class
+            )),
+        );
+        $builder->addQuestion("My other question", QuestionTypeShortText::class);
+        $builder->setQuestionVisibility(
+            question_name: "My other question",
+            strategy: VisibilityStrategy::VISIBLE_IF,
+            conditions: [
+                [
+                    'logic_operator' => LogicOperator::AND,
+                    'item_name'      => "My item question",
+                    'item_type'      => Type::QUESTION,
+                    'value_operator' => ValueOperator::EQUALS,
+                    'value'          => [
+                        'itemtype' => Computer::class,
+                        'items_id' => 0,
+                    ],
+                ],
+            ],
+        );
+        $form = $this->createForm($builder);
+
+        // Act: export and import the form
+        $form_copy = $this->exportAndImportForm($form);
+
+        // Assert: import must not fail, and items_id must stay at 0
+        $questions = $form_copy->getQuestions();
+        next($questions);
+        $question = current($questions);
+        $condition_value = $question->getConfiguredConditionsData()[0]->getValue();
+        $this->assertEquals([
+            'itemtype' => Computer::class,
+            'items_id' => 0,
+        ], $condition_value);
     }
 
     public function testDeletedCategoryInDestinationIsExportedAsZero(): void


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45449
- Importing an exported form that contains a visibility condition on an item dropdown left at "no item selected" failed with an "Unknown item" error. Exporting such a condition keeps the raw item ID instead of an item name, since there is no item to look up. The import logic then wrongly tried to resolve that raw ID through the name mapper, which only knows about actual exported item names. The fix only calls the mapper when the exported value is a name to resolve, and otherwise keeps the raw ID as-is.


## Screenshots (if appropriate):


