### PR TITLE
Performance - lazy load sub items new forms in timeline

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -418,7 +418,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method can\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/ajax/timeline.php',
 ];
 $ignoreErrors[] = [

--- a/ajax/timeline.php
+++ b/ajax/timeline.php
@@ -99,7 +99,19 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
     }
 
     $id = isset($_REQUEST['id']) && (int) $_REQUEST['id'] > 0 ? $_REQUEST['id'] : null;
-    if (!$item->can($id, READ)) {
+    if ($id === null) {
+        // New sub-item: check CREATE, passing the parent link so canCreateItem() can resolve it.
+        $foreignKey = $parent::getForeignKeyField();
+        $parent_id  = (int) ($_REQUEST[$foreignKey] ?? 0);
+        $create_input = [
+            'itemtype'  => $parent->getType(),
+            'items_id'  => $parent_id,
+            $foreignKey => $parent_id,
+        ];
+        if (!$item->can(-1, CREATE, $create_input)) {
+            throw new AccessDeniedHttpException();
+        }
+    } elseif (!$item->can($id, READ)) {
         throw new AccessDeniedHttpException();
     }
 
@@ -130,7 +142,7 @@ if (($_POST['action'] ?? null) === 'change_task_state') {
         $template = 'form_task';
     } elseif (is_subclass_of($_REQUEST['type'], CommonITILValidation::class)) {
         $template = 'form_validation';
-        $params['form_mode'] = $_REQUEST['item_action'] === 'validation-answer' ? 'answer' : 'request';
+        $params['form_mode'] = ($_REQUEST['item_action'] ?? '') === 'validation-answer' ? 'answer' : 'request';
     } elseif ($id !== null && $parent->getID() >= 0) {
         $ol = ObjectLock::isLocked($_REQUEST['parenttype'], $parent->getID());
         if ($ol && (Session::getLoginUserID() != $ol->fields['users_id'])) {

--- a/css/includes/components/itilobject/_timeline.scss
+++ b/css/includes/components/itilobject/_timeline.scss
@@ -383,6 +383,12 @@
 #new-itilobject-form {
     width: 100%;
 
+    // Open the answer forms instantly, like the inline edit action: the collapse height animation
+    // otherwise stutters while the (heavy) TinyMCE editor initializes in the freshly loaded form.
+    > .collapsing {
+        transition: none;
+    }
+
     .timeline-item {
         &.ITILSolution {
             .timeline-content {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7461,6 +7461,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'template'      => 'components/itilobject/timeline/form_followup.html.twig',
             'item'          => $fup,
             'hide_in_menu'  => !$canadd_fup,
+            'lazy_load'     => true,
         ];
         $itemtypes['task'] = [
             'type'          => 'ITILTask',
@@ -7471,6 +7472,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'template'      => 'components/itilobject/timeline/form_task.html.twig',
             'item'          => $task,
             'hide_in_menu'  => !$canadd_task,
+            'lazy_load'     => true,
         ];
         $itemtypes['solution'] = [
             'type'          => 'ITILSolution',
@@ -7481,6 +7483,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'template'      => 'components/itilobject/timeline/form_solution.html.twig',
             'item'          => new ITILSolution(),
             'hide_in_menu'  => !$canadd_solution,
+            'lazy_load'     => true,
         ];
         $itemtypes['document'] = [
             'type'          => 'Document_Item',
@@ -7502,6 +7505,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 'template'      => 'components/itilobject/timeline/form_validation.html.twig',
                 'item'          => $validation,
                 'hide_in_menu'  => !$canadd_validation,
+                'lazy_load'     => true,
             ];
         }
 

--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -53,7 +53,10 @@
                         </button>
                      </div>
                      <div>
-                        {% if timeline_itemtype.template is defined %}
+                        {% if timeline_itemtype.lazy_load|default(false) %}
+                           {# Fetched on first open to keep the initial page load fast (see footer.html.twig). #}
+                           <div class="new-itil-answer-form" data-subitem-type="{{ timeline_itemtype.class }}" data-answer-loaded="false"></div>
+                        {% elseif timeline_itemtype.template is defined %}
                            {{ include(timeline_itemtype.template, {
                               'item': item,
                               'subitem': timeline_itemtype.item,

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -247,10 +247,10 @@
       setHasUnsavedChanges(true);
 
       // Load the answer form on first open, then keep it (preserves input when toggling).
-      var $placeholder = $(this).find('.new-itil-answer-form[data-answer-loaded="false"]').first();
+      const $placeholder = $(this).find('.new-itil-answer-form[data-answer-loaded="false"]').first();
       if ($placeholder.length) {
          {# Forward `_openfollowup` so the reopen flow keeps its behaviour. #}
-         var ajax_url = "{{ path('/ajax/timeline.php') }}"{% if openfollowup %} + "?_openfollowup=1"{% endif %};
+         const ajax_url = "{{ path('/ajax/timeline.php') }}"{% if openfollowup %} + "?_openfollowup=1"{% endif %};
          $placeholder
             .attr('data-answer-loaded', 'true')
             .html('<div class="d-flex justify-content-center p-3"><span class="spinner-border" role="status" aria-hidden="true"></span></div>')

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -250,15 +250,15 @@
       const $placeholder = $(this).find('.new-itil-answer-form[data-answer-loaded="false"]').first();
       if ($placeholder.length) {
          {# Forward `_openfollowup` so the reopen flow keeps its behaviour. #}
-         const ajax_url = "{{ path('/ajax/timeline.php') }}"{% if openfollowup %} + "?_openfollowup=1"{% endif %};
+         const ajax_url = "{{ path('/ajax/timeline.php')|e('js') }}"{% if openfollowup %} + "?_openfollowup=1"{% endif %};
          $placeholder
             .attr('data-answer-loaded', 'true')
             .html('<div class="d-flex justify-content-center p-3"><span class="spinner-border" role="status" aria-hidden="true"></span></div>')
             .load(ajax_url, {
                'action'     : 'viewsubitem',
                'type'       : $placeholder.data('subitem-type'),
-               'parenttype' : '{{ item.getType() }}',
-               '{{ item.getForeignKeyField() }}': {{ item.fields['id'] }},
+               'parenttype' : '{{ item.getType()|e('js') }}',
+               '{{ item.getForeignKeyField()|e('js') }}': {{ item.getID() }},
                'id'         : 0
             });
       }

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -245,6 +245,23 @@
       $("#itil-footer .main-actions").hide();
       $("#right-actions").hide();
       setHasUnsavedChanges(true);
+
+      // Load the answer form on first open, then keep it (preserves input when toggling).
+      var $placeholder = $(this).find('.new-itil-answer-form[data-answer-loaded="false"]').first();
+      if ($placeholder.length) {
+         {# Forward `_openfollowup` so the reopen flow keeps its behaviour. #}
+         var ajax_url = "{{ path('/ajax/timeline.php') }}"{% if openfollowup %} + "?_openfollowup=1"{% endif %};
+         $placeholder
+            .attr('data-answer-loaded', 'true')
+            .html('<div class="d-flex justify-content-center p-3"><span class="spinner-border" role="status" aria-hidden="true"></span></div>')
+            .load(ajax_url, {
+               'action'     : 'viewsubitem',
+               'type'       : $placeholder.data('subitem-type'),
+               'parenttype' : '{{ item.getType() }}',
+               '{{ item.getForeignKeyField() }}': {{ item.fields['id'] }},
+               'id'         : 0
+            });
+      }
    });
 
    // Restore primary actions once all top-level forms are fully hidden (direct children only, to avoid false positives from nested .collapse.show inside forms such as pending-reasons).


### PR DESCRIPTION
A somehow impressive gain we could have done since 10.0

Boss in front of me complained about our support being slow, and while I found other cause, especially in plugins code used on our support and maybe again in CSS generation, I found while parsing in performance tab of Firefox that there was 4 TinyMCE loaded for existing tickets.
So, the button to add followups or anything sub items of timeline writes their form at page load, and with TinyMCE + select2 + some bootstrap modals, it takes a lot of time.

At first, I tried to make lazy loading for TinyMCE like it was proposed by @cconard96 a while ago (I still think, it's a good idea, but probably not generalized), I found the rest of JavaScript execution still took a lot of time.

So removing these form makes a massive gain relative to raw loading time, but also perceived one, because the flashing of select2 and flatpickr on the right side panel is done after the timeline forms are loaded, and so they appear earlier.

On my laptop, served locally by a nginx+fpm, opcache and browser cache enabled, production mode, debug disabled (almost ideal conditions)
**without plugins**
- before: ~3s
- tinyce lazy load: ~2.2s
- sub form lazy load: ~1.3s

<img width="575" height="62" alt="image" src="https://github.com/user-attachments/assets/f1e3b397-139e-407a-af55-5816d3974434" />



**with 20 plugins loaded", add ~1.5s to these timings (some are very hungry and will be fixed).

---

I tested the thing manually intensively, and I tried every non-standard processes I remember (reopen of a closed ticket notably), but I may have missed some, so don't hesitate to roast the thing.

---
I go in vacations tomorrow afternoon, so I will probably don't have the time before that to finalize completely the PR. I'll try to fix tests before that.
But feel free to amend and commit it, the concept is I think good, and the gains are too important to be ignored