### PR TITLE
rename AbstractReAuthStrategy -> InPlaceReAuthStrategy

### DIFF
--- a/src/Glpi/Security/ReAuth/FallbackReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/FallbackReAuthStrategy.php
@@ -49,7 +49,7 @@ use Override;
  * As it provides no real identity check, it has the lowest priority and is
  * only selected when no stronger strategy is available.
  */
-final class FallbackReAuthStrategy extends AbstractReAuthStrategy
+final class FallbackReAuthStrategy extends InPlaceReAuthStrategy
 {
     #[Override]
     public function verify(int $users_id, string $user_input): bool

--- a/src/Glpi/Security/ReAuth/InPlaceReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/InPlaceReAuthStrategy.php
@@ -36,7 +36,7 @@ declare(strict_types=1);
 
 namespace Glpi\Security\ReAuth;
 
-abstract class AbstractReAuthStrategy implements ReAuthStrategyInterface
+abstract class InPlaceReAuthStrategy implements ReAuthStrategyInterface
 {
     /**
      * Verify url points to \Glpi\Controller\Security\ReAuthController::verify

--- a/src/Glpi/Security/ReAuth/LdapReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/LdapReAuthStrategy.php
@@ -50,7 +50,7 @@ use User;
  * It fails closed: if the directory is unreachable, the verification fails
  * and no bypass is granted, so the sensitive action stays protected.
  */
-final class LdapReAuthStrategy extends AbstractReAuthStrategy
+final class LdapReAuthStrategy extends InPlaceReAuthStrategy
 {
     #[Override]
     public function verify(int $users_id, string $user_input): bool

--- a/src/Glpi/Security/ReAuth/PasswordReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/PasswordReAuthStrategy.php
@@ -40,7 +40,7 @@ use Auth;
 use Override;
 use User;
 
-final class PasswordReAuthStrategy extends AbstractReAuthStrategy
+final class PasswordReAuthStrategy extends InPlaceReAuthStrategy
 {
     #[Override]
     public function verify(int $users_id, string $user_input): bool

--- a/src/Glpi/Security/ReAuth/TOTPReAuthStrategy.php
+++ b/src/Glpi/Security/ReAuth/TOTPReAuthStrategy.php
@@ -38,7 +38,7 @@ namespace Glpi\Security\ReAuth;
 
 use Glpi\Security\TOTPManager;
 
-final class TOTPReAuthStrategy extends AbstractReAuthStrategy
+final class TOTPReAuthStrategy extends InPlaceReAuthStrategy
 {
     private TOTPManager $totp_manager;
 

--- a/tests/functional/Glpi/Security/ReAuth/PasswordReAuthStrategyTest.php
+++ b/tests/functional/Glpi/Security/ReAuth/PasswordReAuthStrategyTest.php
@@ -136,7 +136,7 @@ class PasswordReAuthStrategyTest extends DbTestCase
     }
 
     /**
-     * A native strategy is verified in-process: it inherits the AbstractReAuthStrategy
+     * A native strategy is verified in-process: it inherits the InPlaceReAuthStrategy
      * defaults pointing the prompt form to the core ReAuth verify endpoint via POST.
      * All native strategies share these defaults; Password is tested here as representative.
      */

--- a/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
+++ b/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
@@ -35,7 +35,7 @@
 namespace Glpi\Tests\Glpi\Security\ReAuth;
 
 use Glpi\Controller\Security\ReAuthController;
-use Glpi\Security\ReAuth\AbstractReAuthStrategy;
+use Glpi\Security\ReAuth\InPlaceReAuthStrategy;
 use Glpi\Security\ReAuth\ReAuthManager;
 use Glpi\Security\ReAuth\ReAuthStrategyEnum;
 use Glpi\Security\ReAuth\ReAuthStrategyInterface;
@@ -150,7 +150,7 @@ trait ReAuthTrait
      *
      * By default, it behaves like a native strategy (verified in-process through the core
      * {@see ReAuthController::verify()} endpoint, inheriting the
-     * defaults from {@see AbstractReAuthStrategy}). Passing $verify_url and/or
+     * defaults from {@see InPlaceReAuthStrategy}). Passing $verify_url and/or
      * $verify_http_method models an out-of-band strategy (e.g. OAuth) whose prompt form
      * submits to an external endpoint instead, bypassing the core verify().
      */
@@ -161,7 +161,7 @@ trait ReAuthTrait
         ?string $verify_url = null,
         string $verify_http_method = 'POST',
     ): ReAuthStrategyInterface {
-        return new class ($label, $priority, $available, $verify_url, $verify_http_method) extends AbstractReAuthStrategy {
+        return new class ($label, $priority, $available, $verify_url, $verify_http_method) extends InPlaceReAuthStrategy {
             public function __construct(
                 private string $label,
                 private int $priority,


### PR DESCRIPTION
just a renaming. Abstract class intention/usage is more clear.