### PR TITLE
Add Playwright e2e tests for the reauth (sudo mode) flow

### DIFF
--- a/tests/e2e/pages/ReAuthPromptPage.ts
+++ b/tests/e2e/pages/ReAuthPromptPage.ts
@@ -1,0 +1,78 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { Locator, Page } from "@playwright/test";
+import { GlpiPage } from "./GlpiPage";
+
+/**
+ * Reauth ("sudo" mode) prompt shown when a user tries to reach a page that
+ * requires re-authentication without a valid reauth session.
+ *
+ * @see templates/pages/reauth/prompt.html.twig
+ */
+export class ReAuthPromptPage extends GlpiPage
+{
+    public readonly heading: Locator;
+    public readonly password_field: Locator;
+    public readonly verify_button: Locator;
+    public readonly cancel_link: Locator;
+    public readonly failure_alert: Locator;
+
+    public constructor(page: Page)
+    {
+        super(page);
+        this.heading = page.getByText('Re-authentication required');
+        // The password input has no id/label association nor an ARIA role, so
+        // getByRole()/getByLabel() cannot target it; fall back to its placeholder.
+        this.password_field = page.getByPlaceholder('Password');
+        this.verify_button = page.getByRole('button', { name: 'Verify' });
+        this.cancel_link = page.getByRole('link', { name: 'Cancel' });
+        this.failure_alert = page.getByText('Authentication failure');
+    }
+
+    /**
+     * Fill the password and submit the reauth prompt.
+     */
+    public async doVerify(password: string): Promise<void>
+    {
+        await this.password_field.fill(password);
+        await this.verify_button.click();
+    }
+
+    /**
+     * Cancel the reauth prompt, returning to the origin page.
+     */
+    public async doCancel(): Promise<void>
+    {
+        await this.cancel_link.click();
+    }
+}

--- a/tests/e2e/specs/Security/reauth.spec.ts
+++ b/tests/e2e/specs/Security/reauth.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { ReAuthPromptPage } from '../../pages/ReAuthPromptPage';
+import { Config } from '../../utils/Config';
+import { getWorkerLogin } from '../../utils/WorkerEntities';
+
+// Config requires reauth (Config::itemTypeRequiresReauthentication() === true),
+// and the e2e worker account is Super-Admin, so reaching this page with an
+// expired reauth session redirects to the prompt.
+const protected_url = '/front/config.form.php';
+
+// The e2e worker account is a local (DB_GLPI) account whose password equals its
+// login, so the password reauth strategy is the one offered on the prompt and
+// getWorkerLogin() is the valid re-authentication secret.
+
+test.describe('Reauth (sudo mode)', () => {
+    // The worker only logs in once and the `ensureReauthenticated` fixture grants
+    // reauth before each test; revoke it here so the protected page redirects to
+    // the prompt, which is exactly what these tests exercise.
+    test.beforeEach(async ({ reauth }) => {
+        await reauth.revoke();
+    });
+
+    test('redirects to the reauth prompt on a protected page', async ({ page }) => {
+        await page.goto(protected_url);
+
+        const prompt = new ReAuthPromptPage(page);
+        await expect(page).toHaveURL(/\/ReAuth\/Prompt/);
+        await expect(prompt.heading).toBeVisible();
+    });
+
+    test('grants access when the correct password is provided', async ({ page }) => {
+        await page.goto(protected_url);
+
+        const prompt = new ReAuthPromptPage(page);
+        await prompt.doVerify(getWorkerLogin());
+
+        // On success the original GET request is replayed, landing back on the
+        // protected page and leaving the prompt behind.
+        await expect(page).toHaveURL(/config\.form\.php/);
+        await expect(prompt.heading).toBeHidden();
+    });
+
+    test('rejects an incorrect password and stays on the prompt', async ({ page }) => {
+        await page.goto(protected_url);
+
+        const prompt = new ReAuthPromptPage(page);
+        await prompt.doVerify('wrong-password');
+
+        await expect(prompt.failure_alert).toBeVisible();
+        await expect(prompt.password_field).toBeVisible();
+    });
+
+    test('cancel returns to the origin page', async ({ page }) => {
+        // Reach the protected page with a referer so the prompt's Cancel target
+        // (the origin URL) is a known page rather than the default root.
+        const origin_url = `${Config.getBaseUrl()}/front/central.php`;
+        await page.goto(protected_url, { referer: origin_url });
+
+        const prompt = new ReAuthPromptPage(page);
+        await expect(prompt.heading).toBeVisible();
+
+        await prompt.doCancel();
+
+        await expect(page).toHaveURL(/central\.php/);
+    });
+});


### PR DESCRIPTION
# Add Playwright e2e tests for the reauth (sudo mode) flow

End-to-end coverage of the re-authentication prompt using the `password` strategy.

## What is tested

- The prompt is shown when reaching a protected page without a valid reauth session.
- Reauth succeeds with the correct password (the original request is replayed).
- Reauth fails with a wrong password (error shown, stays on the prompt).
- Cancel returns to the origin page.

## Run

```sh
make playwright c=tests/e2e/specs/Security/reauth.spec.ts
```

Most of work here is ai generated.
