### PR TITLE
Fix(Forms): display 'More actions' dropdown for comments in horizontal layout

### DIFF
--- a/css/includes/components/form/_form-editor-horizontal-layout.scss
+++ b/css/includes/components/form/_form-editor-horizontal-layout.scss
@@ -204,7 +204,7 @@
                 width: 100%;
             }
 
-            &:not([data-glpi-form-editor-active-question]) {
+            &:not([data-glpi-form-editor-active-question], [data-glpi-form-editor-active-comment]) {
                 div:has(> [data-glpi-form-editor-dynamic-input]) {
                     overflow: hidden;
                 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45507
- In the form editor, clicking the vertical dots (⋮) "More actions" button on a comment placed in a horizontal layout did not open the dropdown. It worked fine for comments in a vertical layout, and for questions in either layout.
- This was due to a horizontal-layout CSS rule that applies `overflow: hidden` to the flex container `data-glpi-form-editor-dynamic-input` for any block that is not the active question:

```
&:not([data-glpi-form-editor-active-question]) {
    div:has(> [data-glpi-form-editor-dynamic-input]) {
        overflow: hidden;
    }
}
```
- An active comment is marked `data-glpi-form-editor-active-comment` (not `active-question`), so the rule still matched it and clipped the dropdown.
- Fix: Exclude active comments from the rule as well, consistent with the other selectors in the file