### PR TITLE
Add Location class to document_types

### DIFF
--- a/src/autoload/CFG_GLPI.php
+++ b/src/autoload/CFG_GLPI.php
@@ -230,7 +230,7 @@ $CFG_GLPI['document_types']               = [Budget::class, CartridgeItem::class
     SoftwareLicense::class, Supplier::class, Ticket::class, User::class,
     Certificate::class, Cluster::class, ITILFollowup::class, ITILSolution::class,
     ChangeTask::class, ProblemTask::class, TicketTask::class, Appliance::class,
-    DatabaseInstance::class, Rack::class,
+    DatabaseInstance::class, Rack::class, Location::class,
 ];
 
 $CFG_GLPI['consumables_types']            = [Group::class, User::class];


### PR DESCRIPTION
#BUG
On location view, I can assign documents to a location, on document view there is no option to choose a location

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

`Location` registers the `Document_Item` tab, so documents can already be
attached from the location view. However, `Location` was missing from
`$CFG_GLPI['document_types']`. As a result `Document::getItemtypesThatCanHave()`
did not include `Location`, so the document view offered no option to pick a
location, and the relation massive actions excluded it too — the association
only worked in one direction.

This adds `Location::class` to `$CFG_GLPI['document_types']` so documents and
locations can be associated symmetrically from both sides.

## Screenshots (if appropriate):


