### PR TITLE
Upgrade dependencies to get latest security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,9 +2289,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2701,10 +2701,19 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
-            "integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
             "cpu": [
                 "arm64"
             ],
@@ -2714,19 +2723,19 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.1.0"
+                "@img/sharp-libvips-darwin-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
-            "integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
             "cpu": [
                 "x64"
             ],
@@ -2736,19 +2745,38 @@
                 "darwin"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.1.0"
+                "@img/sharp-libvips-darwin-x64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-freebsd-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
-            "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
             "cpu": [
                 "arm64"
             ],
@@ -2762,9 +2790,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
-            "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
             "cpu": [
                 "x64"
             ],
@@ -2778,11 +2806,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
-            "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2794,11 +2825,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
-            "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2810,11 +2844,33 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
-            "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2826,11 +2882,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
-            "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2842,11 +2901,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
-            "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2858,11 +2920,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
-            "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2874,11 +2939,14 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
-            "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2890,33 +2958,39 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
-            "integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
             "cpu": [
                 "arm"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.1.0"
+                "@img/sharp-libvips-linux-arm": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
-            "integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2924,43 +2998,99 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.1.0"
+                "@img/sharp-libvips-linux-arm64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.3.2"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
-            "integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.1.0"
+                "@img/sharp-libvips-linux-s390x": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
-            "integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2968,43 +3098,49 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.1.0"
+                "@img/sharp-libvips-linux-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
-            "integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
-            "integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -3012,38 +3148,54 @@
                 "linux"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
-            "integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
-            "cpu": [
-                "wasm32"
-            ],
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.4.3"
+                "@emnapi/runtime": "^1.11.1"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-webcontainers-wasm32": {
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@img/sharp-wasm32": "0.35.3"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
-            "integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
             "cpu": [
                 "arm64"
             ],
@@ -3053,16 +3205,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
-            "integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
             "cpu": [
                 "ia32"
             ],
@@ -3072,16 +3224,16 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": "^20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
-            "integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
             "cpu": [
                 "x64"
             ],
@@ -3091,7 +3243,7 @@
                 "win32"
             ],
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
@@ -7744,19 +7896,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/color": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1",
-                "color-string": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=12.5.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -7773,34 +7912,6 @@
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
-        },
-        "node_modules/color-string": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
-        "node_modules/color/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
         },
         "node_modules/colord": {
             "version": "2.9.3",
@@ -9087,9 +9198,9 @@
             "license": "MIT"
         },
         "node_modules/dompurify": {
-            "version": "3.4.11",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+            "version": "3.4.12",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+            "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
@@ -16288,59 +16399,67 @@
             }
         },
         "node_modules/sharp": {
-            "version": "0.34.2",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
-            "integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
-            "hasInstallScript": true,
+            "version": "0.35.3",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "color": "^4.2.3",
-                "detect-libc": "^2.0.4",
-                "semver": "^7.7.2"
+                "@img/colour": "^1.1.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.8.5"
             },
             "engines": {
-                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+                "node": ">=20.9.0"
             },
             "funding": {
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.34.2",
-                "@img/sharp-darwin-x64": "0.34.2",
-                "@img/sharp-libvips-darwin-arm64": "1.1.0",
-                "@img/sharp-libvips-darwin-x64": "1.1.0",
-                "@img/sharp-libvips-linux-arm": "1.1.0",
-                "@img/sharp-libvips-linux-arm64": "1.1.0",
-                "@img/sharp-libvips-linux-ppc64": "1.1.0",
-                "@img/sharp-libvips-linux-s390x": "1.1.0",
-                "@img/sharp-libvips-linux-x64": "1.1.0",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
-                "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
-                "@img/sharp-linux-arm": "0.34.2",
-                "@img/sharp-linux-arm64": "0.34.2",
-                "@img/sharp-linux-s390x": "0.34.2",
-                "@img/sharp-linux-x64": "0.34.2",
-                "@img/sharp-linuxmusl-arm64": "0.34.2",
-                "@img/sharp-linuxmusl-x64": "0.34.2",
-                "@img/sharp-wasm32": "0.34.2",
-                "@img/sharp-win32-arm64": "0.34.2",
-                "@img/sharp-win32-ia32": "0.34.2",
-                "@img/sharp-win32-x64": "0.34.2"
+                "@img/sharp-darwin-arm64": "0.35.3",
+                "@img/sharp-darwin-x64": "0.35.3",
+                "@img/sharp-freebsd-wasm32": "0.35.3",
+                "@img/sharp-libvips-darwin-arm64": "1.3.2",
+                "@img/sharp-libvips-darwin-x64": "1.3.2",
+                "@img/sharp-libvips-linux-arm": "1.3.2",
+                "@img/sharp-libvips-linux-arm64": "1.3.2",
+                "@img/sharp-libvips-linux-ppc64": "1.3.2",
+                "@img/sharp-libvips-linux-riscv64": "1.3.2",
+                "@img/sharp-libvips-linux-s390x": "1.3.2",
+                "@img/sharp-libvips-linux-x64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+                "@img/sharp-linux-arm": "0.35.3",
+                "@img/sharp-linux-arm64": "0.35.3",
+                "@img/sharp-linux-ppc64": "0.35.3",
+                "@img/sharp-linux-riscv64": "0.35.3",
+                "@img/sharp-linux-s390x": "0.35.3",
+                "@img/sharp-linux-x64": "0.35.3",
+                "@img/sharp-linuxmusl-arm64": "0.35.3",
+                "@img/sharp-linuxmusl-x64": "0.35.3",
+                "@img/sharp-webcontainers-wasm32": "0.35.3",
+                "@img/sharp-win32-arm64": "0.35.3",
+                "@img/sharp-win32-ia32": "0.35.3",
+                "@img/sharp-win32-x64": "0.35.3"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/sharp/node_modules/detect-libc": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-            "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/sharp/node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -16464,21 +16583,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
-        },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-            "license": "MIT",
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "license": "MIT"
         },
         "node_modules/slash": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -146,8 +146,11 @@
         "webpack-dev-server": "^5.2.5"
     },
     "overrides": {
+        "@tabler/icons-webfont": {
+            "sharp": "^0.35.0"
+        },
         "monaco-editor": {
-            "dompurify": "^3.4.0"
+            "dompurify": "^3.4.12"
         },
         "qs": "^6.15.1",
         "uuid": "^14.0.0",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes the following issues:
```
dompurify  <=3.4.11
DOMPurify: `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements. - https://github.com/advisories/GHSA-c2j3-45gr-mqc4
fix available via `npm audit fix --force`
Will install monaco-editor@0.53.0, which is a breaking change
node_modules/dompurify
  monaco-editor  >=0.54.0-dev-20250909
  Depends on vulnerable versions of dompurify
  node_modules/monaco-editor

sharp  <0.35.0
Severity: high
sharp inherited vulnerabilities in libvips: CVE-2026-33327, CVE-2026-33328, CVE-2026-35590, CVE-2026-35591 - https://github.com/advisories/GHSA-f88m-g3jw-g9cj
fix available via `npm audit fix`
node_modules/sharp
  @tabler/icons-webfont  3.32.0 - 3.36.0
  Depends on vulnerable versions of sharp
  node_modules/@tabler/icons-webfont

```