### PR TITLE
Fix tests : Make front locale test independent from Transifex translations

### DIFF
--- a/tests/fixtures/locales/en_GB.php
+++ b/tests/fixtures/locales/en_GB.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+return [
+    'Active' => 'Active',
+];

--- a/tests/fixtures/locales/fr_FR.php
+++ b/tests/fixtures/locales/fr_FR.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+return [
+    'Active' => 'Activé',
+];

--- a/tests/functional/Glpi/Front/LocaleTest.php
+++ b/tests/functional/Glpi/Front/LocaleTest.php
@@ -39,30 +39,35 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class LocaleTest extends DbTestCase
 {
+    // `glpi` domain translations come from Transifex and may be reset by any sync, so a fixture domain is used instead.
+    private const TEST_DOMAIN = 'test_locale';
+
     public static function frontLocaleFileProvider(): iterable
     {
-        yield ['en_GN', 'Active'];
-        yield ['fr_FR', 'Activé'];
+        yield ['en_GN', 'en_GB', 'Active']; // unknown language, falls back to the default one
+        yield ['fr_FR', 'fr_FR', 'Activé'];
     }
 
     #[DataProvider('frontLocaleFileProvider')]
-    public function testFrontLocaleFile(string $locale, string $expected): void
+    public function testFrontLocaleFile(string $locale, string $expected_language, string $expected_translation): void
     {
         global $TRANSLATE;
 
         // Arrange: load languages
-        $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR . '/en_GB.mo', 'glpi', 'en_GB');
-        $TRANSLATE->addTranslationFile('gettext', GLPI_I18N_DIR . '/fr_FR.mo', 'glpi', 'fr_FR');
+        $TRANSLATE->addTranslationFile('phparray', FIXTURE_DIR . '/locales/en_GB.php', self::TEST_DOMAIN, 'en_GB');
+        $TRANSLATE->addTranslationFile('phparray', FIXTURE_DIR . '/locales/fr_FR.php', self::TEST_DOMAIN, 'fr_FR');
 
         // Act: render locale file
         $_GET['lang'] = $locale;
-        $_GET['domain'] = 'glpi';
+        $_GET['domain'] = self::TEST_DOMAIN;
         ob_start();
         include(GLPI_ROOT . '/front/locale.php');
         $locales = ob_get_clean();
 
-        // Assert: locales should be translated to expected string
+        // Assert: locale headers and messages should match the expected language
         $locales = json_decode($locales, true);
-        $this->assertEquals($expected, $locales['Active']);
+        $this->assertEquals($expected_language, $locales['']['language']);
+        $this->assertArrayHasKey('plural-forms', $locales['']);
+        $this->assertEquals($expected_translation, $locales['Active']);
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes CI fails since https://github.com/glpi-project/glpi/commit/119efabb279b71cc540d74c482d6c93437100ff5

- https://github.com/glpi-project/glpi/actions/runs/30254939798/job/89943321975?pr=24944 
- http://github.com/glpi-project/glpi/actions/runs/30250142947/job/89926135334?pr=24922

- Here is a brief description of what this PR does

Any string can be untranslated by a Transifex sync, so the test now uses its own `test_locale` domain with `phparray` fixtures instead of the `glpi` one. It also checks the locale headers, which is really what `front/locale.php` does: language fallback and headers read from the `.po`.

Tests only, no production code change.



