### PR TITLE
Fix - Preserve dynamic LDAP groups when reapplying right rules

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -6612,20 +6612,26 @@ HTML;
     public function applyGroupsRules()
     {
         if (!isset($this->input["_ldap_rules"]['groups_id'])) {
-            if (isset($this->input["_ldap_rules"]) && isset($this->input['id'])) {
+            // Only remove previously auto-assigned dynamic groups when a fresh LDAP group fetch just
+            // happened (syncLdapGroups() sets this session key from a live directory read). Without
+            // fresh data, we have nothing reliable to compare against, so existing dynamic groups
+            // (e.g. from an earlier sync) are left as-is.
+            if (
+                isset($this->input["_ldap_rules"])
+                && isset($this->input['id'])
+                && isset($_SESSION['_ldap_groups'])
+            ) {
                 $group_user = new Group_User();
                 $groups = $group_user->find([
                     'users_id' => $this->input['id'],
                     'is_dynamic' => true,
                 ]);
                 foreach ($groups as $group) {
-                    if (!isset($_SESSION['_ldap_groups']) || !in_array($group['groups_id'], $_SESSION['_ldap_groups'])) {
+                    if (!in_array($group['groups_id'], $_SESSION['_ldap_groups'])) {
                         $group_user->delete($group);
                     }
                 }
-                if (isset($_SESSION['_ldap_groups'])) {
-                    unset($_SESSION['_ldap_groups']);
-                }
+                unset($_SESSION['_ldap_groups']);
             }
             return;
         }

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -2468,6 +2468,57 @@ class AuthLdapTest extends DbTestCase
         );
     }
 
+    /**
+     * reapplyRightRules() must preserve dynamic groups synced from the LDAP
+     * when the matching RuleRight does not itself assign a group.
+     */
+    #[RequiresPhpExtension('ldap')]
+    public function testReapplyRightRulesPreservesLdapSyncedGroupsOnExternalAuth(): void
+    {
+        $this->updateItem(
+            AuthLDAP::class,
+            getItemByTypeName(AuthLDAP::class, '_local_ldap', true),
+            [
+                'group_search_type' => AuthLDAP::GROUP_SEARCH_BOTH,
+            ]
+        );
+
+        $rule_builder = new RuleBuilder(__FUNCTION__, RuleRight::class);
+        $rule_builder->setEntity(0)
+            ->setIsRecursive(1)
+            ->addCriteria('employeenumber', \Rule::PATTERN_IS, 8)
+            ->addAction('assign', 'profiles_id', 5) // 'normal' profile
+            ->addAction('assign', 'entities_id', 1); // '_test_child_1' entity
+        $this->createRule($rule_builder);
+
+        // Group dynamically bound to the user via LDAP attributes, outside of any RuleRight action.
+        $group_id = $this->createItem(Group::class, [
+            'name'       => __FUNCTION__,
+            'ldap_field' => 'uid',
+            'ldap_value' => 'brazil6',
+        ])->getID();
+
+        // Real LDAP sync: assigns the dynamic profile/entity/group and records auths_id/user_dn.
+        $this->realLogin('brazil6', 'password', false);
+        $users_id = \User::getIdByName('brazil6');
+        $this->assertGreaterThan(0, $users_id);
+        $this->assertTrue(Group_User::isUserInGroup($users_id, $group_id));
+
+        $user = new \User();
+        $this->assertTrue($user->getFromDB($users_id));
+
+        // Simulate the SSO/OAuth login context: the plugin authenticates the
+        // user as Auth::EXTERNAL and calls reapplyRightRules() on the already
+        // LDAP-synced User object, without redoing a real LDAP group fetch.
+        $user->fields['authtype'] = \Auth::EXTERNAL;
+        $user->reapplyRightRules();
+
+        $this->assertTrue(
+            Group_User::isUserInGroup($users_id, $group_id),
+            'Dynamic group synced from the LDAP directory was purged on Auth::EXTERNAL reapplyRightRules()'
+        );
+    }
+
 
     /**
      * Test if rules targeting ldap criteria are working


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45464
- Here is a brief description of what this PR does

### Bug
`reapplyRightRules()` (used by SSO/OAuth logins) purges all dynamic groups whenever the matching RuleRight doesn't itself assign a group, because it can't tell "no real LDAP sync happened" apart from "the user has no groups anymore".

Follow-up to #24907, which fixed the same flow for dynamic profiles/entities but left groups untouched.

### Fix
Only purge dynamic groups when a real LDAP group fetch actually happened this cycle. Otherwise, leave existing groups untouched.