### PR TITLE
fix(itiltemplate): mandatory template fields not enforced when updating an ITIL object

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -1893,15 +1893,6 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             }
         }
 
-        // If category, entity, or type fields are not updated, the template is not changed.
-        if (
-            (empty($input['itilcategories_id']) || $this->fields['itilcategories_id'] == $input['itilcategories_id'])
-            && (empty($input['entities_id']) || $this->fields['entities_id'] == $input['entities_id'])
-            && (empty($input['type']) || $this->fields['type'] == $input['type'])
-        ) {
-            return $input;
-        }
-
         // First get ticket template associated: entity and type/category
         $tt = $this->getITILTemplateFromInput($input);
 
@@ -1910,9 +1901,19 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             return $input;
         }
 
-        $tpl_class = static::getTemplateClass();
-        $input[$tpl_class::getForeignKeyField()] = $tt->getID();
-        $input[static::getTemplateFormFieldName()] = $tt->getID();
+        // If category, entity, or type fields are updated, the template used by the
+        // item may have changed
+        $update_template = !(
+            (empty($input['itilcategories_id']) || $this->fields['itilcategories_id'] == $input['itilcategories_id'])
+            && (empty($input['entities_id']) || $this->fields['entities_id'] == $input['entities_id'])
+            && (empty($input['type']) || $this->fields['type'] == $input['type'])
+        );
+
+        if ($update_template) {
+            $tpl_class = static::getTemplateClass();
+            $input[$tpl_class::getForeignKeyField()] = $tt->getID();
+            $input[static::getTemplateFormFieldName()] = $tt->getID();
+        }
 
         if (count($tt->mandatory)) {
             $mandatory_missing = [];

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -203,6 +203,15 @@ class ITILSolution extends CommonDBChild
 
         $this->item = $parent_item;
 
+        if (!$this->item->checkRequiredFieldsFilled()) {
+            Session::addMessageAfterRedirect(
+                __s('Mandatory fields are not filled.'),
+                false,
+                ERROR
+            );
+            return false;
+        }
+
         // Handle template
         if (isset($input['_solutiontemplates_id'])) {
             $template = new SolutionTemplate();

--- a/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
@@ -264,6 +264,8 @@ class ITILControllerTest extends HLAPITestCase
      */
     public function testBlockOverridingParentItem()
     {
+        $this->loginWeb();
+
         $ticket = new Ticket();
         $this->assertGreaterThan(0, $tickets_id = $ticket->add([
             'name' => __FUNCTION__,

--- a/tests/functional/ITILSolutionTest.php
+++ b/tests/functional/ITILSolutionTest.php
@@ -57,7 +57,7 @@ class ITILSolutionTest extends DbTestCase
             (int) $itilobject->add([
                 'name'         => "$itemtype title",
                 'description'  => 'a description',
-                'content'      => '',
+                'content'      => 'content',
                 'entities_id'  => getItemByTypeName('Entity', '_test_root_entity', true),
             ])
         );
@@ -78,7 +78,7 @@ class ITILSolutionTest extends DbTestCase
             (int) $ticket->add([
                 'name'               => 'ticket title',
                 'description'        => 'a description',
-                'content'            => '',
+                'content'            => 'content',
                 '_users_id_assign'   => $uid,
             ])
         );
@@ -536,7 +536,7 @@ HTML,
         $ticket_id = (int) $ticket->add([
             'name'               => 'ticket title',
             'description'        => 'a description',
-            'content'            => '',
+            'content'            => 'content',
             '_users_id_requester' => $postonly_id,
             '_users_id_assign'    => $tech_id,
         ]);

--- a/tests/functional/ITILTemplateTest.php
+++ b/tests/functional/ITILTemplateTest.php
@@ -1099,4 +1099,70 @@ class ITILTemplateTest extends DbTestCase
             }
         }
     }
+
+    /**
+     * Check that when a mandatory template field is not filled, the update of an existing item is blocked
+     */
+    #[DataProvider('itilProvider')]
+    public function testBlockUpdateWhenMandatoryTemplateFieldNotFilled($itiltype)
+    {
+        $this->login();
+
+        // Create a category, an entity and a template for the given ITIL type
+        $itil_category = $this->createItem(\ITILCategory::class, [
+            'name' => 'Category for mandatory template field on update test (' . $itiltype . ')',
+        ]);
+
+        $entity = $this->createItem(\Entity::class, [
+            'name'        => 'Entity for mandatory template field on update test (' . $itiltype . ')',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+
+        $tpl_class = '\\' . $itiltype . 'Template';
+        $template = $this->createItem($tpl_class, [
+            'name' => 'Template with mandatory category for ' . $itiltype,
+        ]);
+
+        // Assign the template to the entity
+        $this->updateItem(\Entity::class, $entity->getID(), [
+            strtolower($itiltype) . 'templates_id' => $template->getID(),
+        ]);
+
+        // Create ITIL item
+        $add_input = [
+            'name'        => 'title',
+            'content'     => 'content',
+            'entities_id' => $entity->getID(),
+        ];
+        $item = $this->createItem($itiltype, $add_input);
+        $this->assertEquals(0, (int) $item->fields['itilcategories_id']);
+
+        // Set the category like mandatory field in the template
+        $tpl = new $tpl_class();
+        $mandat_class = '\\' . $itiltype . 'TemplateMandatoryField';
+        $mandat = new $mandat_class();
+        $this->createItem($mandat_class, [
+            $mandat::$items_id => $template->getID(),
+            'num'              => $mandat->getFieldNum($tpl, 'Category'),
+        ]);
+
+        // Update ITIL item without filling the mandatory category field, which should be rejected
+        $result = $item->update([
+            'id'                => $item->getID(),
+            'itilcategories_id' => 0,
+            'content'           => 'updated description',
+        ]);
+
+        $this->assertFalse($result, 'Update should be rejected: mandatory category is not filled');
+        $this->hasSessionMessageThatContains('Mandatory fields are not filled', ERROR);
+
+        $this->assertTrue($item->getFromDB($item->getID()));
+        $this->assertEquals('content', $item->fields['content'], 'Content should not have been updated');
+
+        // Filling the mandatory category should let the update succeed.
+        $this->updateItem($itiltype, $item->getID(), [
+            'itilcategories_id' => $itil_category->getID(),
+            'content'           => 'updated description',
+        ]);
+    }
 }

--- a/tests/functional/ITILTemplateTest.php
+++ b/tests/functional/ITILTemplateTest.php
@@ -1133,6 +1133,7 @@ class ITILTemplateTest extends DbTestCase
             'name'        => 'title',
             'content'     => 'content',
             'entities_id' => $entity->getID(),
+            'status' => Ticket::INCOMING,
         ];
         $item = $this->createItem($itiltype, $add_input);
         $this->assertEquals(0, (int) $item->fields['itilcategories_id']);
@@ -1159,10 +1160,29 @@ class ITILTemplateTest extends DbTestCase
         $this->assertTrue($item->getFromDB($item->getID()));
         $this->assertEquals('content', $item->fields['content'], 'Content should not have been updated');
 
+        // Check that adding a solution is also rejected when the mandatory category is not filled
+        $itilsolution = new \ITILSolution();
+        $result_itilsolution = $itilsolution->add([
+            'itemtype' => $itiltype,
+            'items_id' => $item->getID(),
+            'content'  => 'solution content',
+        ]);
+        $this->assertFalse($result_itilsolution, 'Adding a solution should be rejected: mandatory category is not filled');
+        $this->hasSessionMessageThatContains('Mandatory fields are not filled', ERROR);
+        $item->getFromDB($item->getID());
+        $this->assertEquals($item->fields['status'], Ticket::INCOMING, 'Status should not have been updated');
+
         // Filling the mandatory category should let the update succeed.
         $this->updateItem($itiltype, $item->getID(), [
             'itilcategories_id' => $itil_category->getID(),
             'content'           => 'updated description',
+        ]);
+
+        // Check that adding a solution is now allowed
+        $this->createItem(\ITILSolution::class, [
+            'itemtype' => $itiltype,
+            'items_id' => $item->getID(),
+            'content'  => 'solution content',
         ]);
     }
 }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -9388,7 +9388,7 @@ HTML,
             Ticket::class,
             [
                 'name'        => 'ITILsolution Title',
-                'content'     => '',
+                'content'     => 'content',
                 'entities_id' => 0,
                 '_actors'     => [
                     'requester' => [

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10172,6 +10172,62 @@ HTML,
     }
 
     /**
+     * A mandatory template field added to a ticket after a solution was already submitted
+     * must not prevent that solution from being validated, nor the ticket from being closed.
+     */
+    public function testValidateSolutionNotBlockedByMandatoryTemplateFieldAddedAfterward(): void
+    {
+        $this->login();
+
+        $entity = getItemByTypeName(Entity::class, '_test_root_entity');
+
+        // Create a ticket with an empty category
+        $ticket = $this->createItem(Ticket::class, [
+            'name'        => 'Ticket with empty category',
+            'content'     => 'content',
+            'entities_id' => $entity->getID(),
+        ]);
+        $this->assertEquals(0, (int) $ticket->fields['itilcategories_id']);
+
+        // Add a solution, which is waiting for approval by default
+        $solution = $this->createItem(ITILSolution::class, [
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+            'content'  => 'solution content',
+        ]);
+        $this->assertEquals(CommonITILValidation::WAITING, (int) $solution->fields['status']);
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::SOLVED, (int) $ticket->fields['status']);
+
+        // Only now, add a ticket template with the category as a mandatory field,
+        // and assign it to the ticket's entity
+        $template = $this->createItem(TicketTemplate::class, [
+            'name' => 'Template with mandatory category',
+        ]);
+        $mandatory_field = new TicketTemplateMandatoryField();
+        $this->createItem(TicketTemplateMandatoryField::class, [
+            'tickettemplates_id' => $template->getID(),
+            'num'                => $mandatory_field->getFieldNum($template, 'Category'),
+        ]);
+        $this->updateItem(Entity::class, $entity->getID(), [
+            'tickettemplates_id' => $template->getID(),
+        ]);
+
+        // Validate the solution
+        $this->createItem(ITILFollowup::class, [
+            'itemtype'  => Ticket::class,
+            'items_id'  => $ticket->getID(),
+            'add_close' => '1',
+        ], ['add_close']);
+
+        $this->assertTrue($solution->getFromDB($solution->getID()));
+        $this->assertEquals(CommonITILValidation::ACCEPTED, (int) $solution->fields['status'], 'Solution should have been accepted');
+
+        $this->assertTrue($ticket->getFromDB($ticket->getID()));
+        $this->assertEquals(Ticket::CLOSED, (int) $ticket->fields['status'], 'Ticket should have been closed');
+    }
+
+    /**
      * Data provider for testGetAssociatedDocumentsWithoutActiveSession
      * Returns different scenarios with timeline items (followup/task/solution) with various visibility and user rights
      */


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45519, !45949
- Leaving required fields blank no longer prevented a ticket from being updated

## Screenshots (if appropriate):

After fix:
<img width="370" height="156" alt="image" src="https://github.com/user-attachments/assets/8eaf76f7-cf65-46ad-b10c-18dcb686a9ef" />

