### PR TITLE
Data and Privacy Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The present file will list all changes made to the project; according to the
   If your GLPI instance is behind a reverse proxy, you should add its IP(s) the new `GLPI_TRUSTED_REVERSE_PROXIES` constant and modify the new `GLPI_REVERSE_PROXY_HEADERS` constant to include the headers your proxy uses to forward the client IP.
   Only the required HTTP headers should be listed for better security as any header not handled by the proxy could be spoofed by the client.
 - Remember me support for multiple devices at the same time.
+- `Setup > Data and Privacy` menu item to centralize all data policies and privacy related settings.
+- New automatic action "purgesessionhistory" to automate deleting old login history data based on a retention period set in `Setup > Data and Privacy`.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
@@ -26,6 +28,7 @@ The present file will list all changes made to the project; according to the
 - `status_msg` property for the cronttask (automatic actions) service in the status checker format changed from "RUNNING: %d, STUCK: %d, TOTAL: %d" to "RUNNING: %d, STUCK: %d, ERROR: %d, TOTAL: %d".
   If your monitoring relies on parsing this string, make sure it can handle the new format.
 - New `errored` property for the cronttask (automatic actions) service in the status checker to indicate the names of the errored actions requiring manual intervention.
+- "Logs purge" tab moved from `Setup > General` to `Setup > Data and Privacy` and renamed to "Historical logs".
 
 ### Deprecated
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\Application\Environment;
+use Glpi\Config\DataAndPrivacyConfig;
 use Glpi\Dashboard\Dashboard;
 use Glpi\Event;
 use Glpi\Form\AnswersSet;
@@ -417,6 +418,7 @@ $empty_data_builder = new class {
             'glpi_11_form_migration' => 0,
             'glpi_11_assets_migration' => 0,
             'must_unsanitize_db_data' => 0,
+            'login_history_retention_days' => 90,
         ];
 
         $tables['glpi_configs'] = [];
@@ -1021,6 +1023,18 @@ $empty_data_builder = new class {
                 'param' => 3,
                 'state' => CronTask::STATE_WAITING,
                 'mode' => CronTask::MODE_INTERNAL,
+                'lastrun' => null,
+                'logs_lifetime' => 30,
+                'hourmin' => 0,
+                'hourmax' => 24,
+            ], [
+                'id' => 52,
+                'itemtype' => DataAndPrivacyConfig::class,
+                'name' => 'purgesessionhistory',
+                'frequency' => DAY_TIMESTAMP,
+                'param' => null,
+                'state' => CronTask::STATE_WAITING,
+                'mode' => CronTask::MODE_EXTERNAL,
                 'lastrun' => null,
                 'logs_lifetime' => 30,
                 'hourmin' => 0,

--- a/install/migrations/update_11.0.x_to_12.0.0/crontask.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/crontask.php
@@ -39,3 +39,13 @@
 
 $migration->addField('glpi_crontasks', 'error_count', 'integer');
 $migration->addField('glpi_crontasks', 'next_run', 'timestamp');
+
+$migration->addCrontask(
+    itemtype: 'Glpi\Config\DataAndPrivacyConfig',
+    name: 'purgesessionhistory',
+    frequency: DAY_TIMESTAMP,
+    options: [
+        'state' => 1,
+        'logs_lifetime' => 30,
+    ]
+);

--- a/install/migrations/update_11.0.x_to_12.0.0/sessions.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/sessions.php
@@ -104,3 +104,7 @@ if (!$DB->fieldExists('glpi_oauth_access_tokens', 'uuid')) {
     $migration->addField('glpi_oauth_access_tokens', 'uuid', 'varchar(255) NOT NULL', ['after' => 'identifier']);
     $migration->addKey('glpi_oauth_access_tokens', 'uuid', 'uuid', 'UNIQUE');
 }
+
+$migration->addConfig([
+    'login_history_retention_days' => 90,
+], 'core');

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,7 +41,6 @@ use Glpi\Config\ConfigContainer;
 use Glpi\Config\ProxyExclusion;
 use Glpi\Config\ProxyExclusions;
 use Glpi\Dashboard\Grid;
-use Glpi\Event;
 use Glpi\Helpdesk\HelpdeskTranslation;
 use Glpi\Kernel\Kernel;
 use Glpi\Locale\LanguageRegistry;
@@ -1028,7 +1027,6 @@ class Config extends CommonDBTM
                     12 => self::createTabEntry(__('Management'), 0, $item::class, 'ti ti-wallet'),
                 ];
                 if (Config::canUpdate()) {
-                    $tabs[9]  = self::createTabEntry(__('Logs purge'), 0, $item::class, Event::getIcon());
                     $tabs[5]  = self::createTabEntry(__('System'));
                     $tabs[7]  = self::createTabEntry(__('Performance'), 0, $item::class, 'ti ti-dashboard');
                     $tabs[8]  = self::createTabEntry(__('API'), 0, $item::class, 'ti ti-api-app');
@@ -1103,10 +1101,6 @@ class Config extends CommonDBTM
 
                 case 8:
                     $item->showFormAPI();
-                    break;
-
-                case 9:
-                    $item->showFormLogs();
                     break;
 
                 case 11:
@@ -1617,26 +1611,6 @@ class Config extends CommonDBTM
             }
         }
         return $themes;
-    }
-
-    /**
-     * Logs purge form
-     *
-     * @since 9.3
-     *
-     * @return void|bool (display) Returns false if there is a rights error.
-     */
-    public function showFormLogs()
-    {
-        global $CFG_GLPI;
-
-        if (!static::canUpdate()) {
-            return false;
-        }
-        TemplateRenderer::getInstance()->display('pages/setup/general/logs_setup.html.twig', [
-            'config' => $CFG_GLPI,
-            'canedit' => static::canUpdate(),
-        ]);
     }
 
     /**

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -66,7 +66,7 @@ final class DataAndPrivacyConfig extends Config
         $menu = [];
         if (self::canView()) {
             $menu['title'] = self::getTypeName();
-            $menu['page'] = self::getFormURL(false);
+            $menu['page'] = self::getFormURL();
             $menu['icon'] = self::getIcon();
         }
         if (count($menu)) {
@@ -128,7 +128,7 @@ final class DataAndPrivacyConfig extends Config
         $logspurge_crontask = new CronTask();
         $logspurge_crontask->getFromDBbyName(PurgeLogs::class, 'PurgeLogs');
         TemplateRenderer::getInstance()->display('pages/setup/general/logs_setup.html.twig', [
-            'form_path' => self::getFormURL(false),
+            'form_path' => self::getFormURL(),
             'config' => $CFG_GLPI,
             'canedit' => self::canUpdate(),
             'logspurge_crontask' => $logspurge_crontask,
@@ -149,7 +149,7 @@ final class DataAndPrivacyConfig extends Config
         $crontask = new CronTask();
         $crontask->getFromDBbyName(self::class, 'purgesessionhistory');
         TemplateRenderer::getInstance()->display('pages/setup/data_privacy/session_retention.html.twig', [
-            'form_path' => self::getFormURL(false),
+            'form_path' => self::getFormURL(),
             'config' => $CFG_GLPI,
             'canedit' => self::canUpdate(),
             'crontask' => $crontask,

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -156,9 +156,15 @@ final class DataAndPrivacyConfig extends Config
         ]);
     }
 
+    public static function cronInfo($name)
+    {
+        return ['description' => __("Purge session history")];
+    }
+
     /**
      * @param CronTask $task
      * @return int
+     * @used-by CronTask
      */
     public static function cronPurgeSessionHistory(CronTask $task): int
     {

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -161,11 +161,6 @@ final class DataAndPrivacyConfig extends Config
         return ['description' => __("Purge session history")];
     }
 
-    /**
-     * @param CronTask $task
-     * @return int
-     * @used-by CronTask
-     */
     public static function cronPurgeSessionHistory(CronTask $task): int
     {
         global $DB, $CFG_GLPI;

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -156,7 +156,7 @@ final class DataAndPrivacyConfig extends Config
         ]);
     }
 
-    public static function cronInfo($name)
+    public static function cronInfo(string $name): array
     {
         return ['description' => __("Purge session history")];
     }

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -156,6 +156,9 @@ final class DataAndPrivacyConfig extends Config
         ]);
     }
 
+    /**
+     * @return array{description?: string, parameter?: string}
+     */
     public static function cronInfo(string $name): array
     {
         return ['description' => __("Purge session history")];

--- a/src/Glpi/Config/DataAndPrivacyConfig.php
+++ b/src/Glpi/Config/DataAndPrivacyConfig.php
@@ -32,24 +32,28 @@
  * ---------------------------------------------------------------------
  */
 
-namespace Glpi\Security;
+namespace Glpi\Config;
 
 use CommonGLPI;
 use Config;
+use CronTask;
 use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\QueryFunction;
+use Glpi\Event;
 use Log;
+use PurgeLogs;
 use Session;
 
-final class SecurityConfig extends Config
+final class DataAndPrivacyConfig extends Config
 {
     public static function getTypeName($nb = 0)
     {
-        return _x('setup', 'Security');
+        return _x('setup', 'Data and Privacy');
     }
 
     public static function getIcon()
     {
-        return 'ti ti-shield-lock';
+        return 'ti ti-file-text-shield';
     }
 
     public static function getTable($classname = null)
@@ -61,9 +65,9 @@ final class SecurityConfig extends Config
     {
         $menu = [];
         if (self::canView()) {
-            $menu['title']   = _x('setup', 'Security');
-            $menu['page']    = self::getFormURL(false);
-            $menu['icon']    = self::getIcon();
+            $menu['title'] = self::getTypeName();
+            $menu['page'] = self::getFormURL(false);
+            $menu['icon'] = self::getIcon();
         }
         if (count($menu)) {
             return $menu;
@@ -86,27 +90,22 @@ final class SecurityConfig extends Config
         }
         if (Config::canUpdate()) {
             $tabs = [];
-            $tabs[0] = self::createTabEntry(__('Password Policy'), 0, $item::class, 'ti ti-shield-lock');
-            $tabs[1] = self::createTabEntry(__('Two-factor authentication (2FA)'), 0, $item::class, 'ti ti-shield-lock');
-            $tabs[2] = self::createTabEntry(_n('Login session', 'Login sessions', Session::getPluralNumber()), 0, $item::class, 'ti ti-user-shield');
+            $tabs[0] = self::createTabEntry(__('Historical logs'), 0, $item::class, Event::getIcon());
+            $tabs[1] = self::createTabEntry(_n('Login session', 'Login sessions', Session::getPluralNumber()), 0, $item::class, 'ti ti-user-shield');
             return $tabs;
         }
         return '';
     }
-
 
     public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
     {
         if ($item instanceof self) {
             switch ($tabnum) {
                 case 0:
-                    $item->showFormPasswordPolicy();
+                    $item->showFormLogs();
                     break;
                 case 1:
-                    $item->showFormMFA();
-                    break;
-                case 2:
-                    (new SessionTracker())->showSessionList();
+                    $item->showFormSessions();
                     break;
             }
         }
@@ -114,11 +113,11 @@ final class SecurityConfig extends Config
     }
 
     /**
-     * Password policy form
+     * Logs purge form
      *
-     * @return void|false (display) Returns false if there is a rights error.
+     * @return void|bool (display) Returns false if there is a rights error.
      */
-    public function showFormPasswordPolicy()
+    private function showFormLogs()
     {
         global $CFG_GLPI;
 
@@ -126,19 +125,20 @@ final class SecurityConfig extends Config
             return false;
         }
 
-        TemplateRenderer::getInstance()->display('pages/setup/security/password_policy.html.twig', [
-            'canedit' => Session::haveRight(self::$rightname, UPDATE),
-            'config'  => $CFG_GLPI,
-            'form_path' => self::getFormURL(),
+        $logspurge_crontask = new CronTask();
+        $logspurge_crontask->getFromDBbyName(PurgeLogs::class, 'PurgeLogs');
+        TemplateRenderer::getInstance()->display('pages/setup/general/logs_setup.html.twig', [
+            'form_path' => self::getFormURL(false),
+            'config' => $CFG_GLPI,
+            'canedit' => self::canUpdate(),
+            'logspurge_crontask' => $logspurge_crontask,
         ]);
     }
 
     /**
-     * Password policy form
-     *
-     * @return void|false (display) Returns false if there is a rights error.
+     * @return false|void (display) Returns false if there is a rights error.
      */
-    public function showFormMFA()
+    private function showFormSessions()
     {
         global $CFG_GLPI;
 
@@ -146,10 +146,37 @@ final class SecurityConfig extends Config
             return false;
         }
 
-        TemplateRenderer::getInstance()->display('pages/setup/security/2fa.html.twig', [
-            'canedit' => Session::haveRight(self::$rightname, UPDATE),
-            'config'  => $CFG_GLPI,
-            'form_path' => self::getFormURL(),
+        $crontask = new CronTask();
+        $crontask->getFromDBbyName(self::class, 'purgesessionhistory');
+        TemplateRenderer::getInstance()->display('pages/setup/data_privacy/session_retention.html.twig', [
+            'form_path' => self::getFormURL(false),
+            'config' => $CFG_GLPI,
+            'canedit' => self::canUpdate(),
+            'crontask' => $crontask,
         ]);
+    }
+
+    /**
+     * @param CronTask $task
+     * @return int
+     */
+    public static function cronPurgeSessionHistory(CronTask $task): int
+    {
+        global $DB, $CFG_GLPI;
+
+        $retention_days = $CFG_GLPI['login_history_retention_days'] ?? null;
+
+        if ($retention_days === null) {
+            // Safe break
+            return 0;
+        }
+
+        $DB->delete('glpi_users_sessionhistories', [
+            'NOT' => ['logged_out_at' => null],
+            ['logged_out_at' => ['<=', QueryFunction::dateSub(QueryFunction::now(), (int) $retention_days, 'DAY')]],
+        ]);
+        $rows_deleted = $DB->getAffectedRows();
+        $task->addVolume($rows_deleted);
+        return 1;
     }
 }

--- a/src/Glpi/Controller/Config/DataAndPrivacyConfigController.php
+++ b/src/Glpi/Controller/Config/DataAndPrivacyConfigController.php
@@ -90,6 +90,10 @@ final class DataAndPrivacyConfigController extends AbstractController
         }
         $config = new DataAndPrivacyConfig();
 
+        if (!$config->can($config_id, UPDATE)) {
+            throw new AccessDeniedHttpException();
+        }
+
         $update_input = $request->request->all();
         $update_input['id'] = $config_id;
         $config->update($update_input);

--- a/src/Glpi/Controller/Config/DataAndPrivacyConfigController.php
+++ b/src/Glpi/Controller/Config/DataAndPrivacyConfigController.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Config;
+
+use Config;
+use Glpi\Config\DataAndPrivacyConfig;
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Http\RedirectResponse;
+use Glpi\Security\Attribute\SecurityStrategy;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class DataAndPrivacyConfigController extends AbstractController
+{
+    #[Route(
+        path: "/front/config/dataandprivacyconfig.form.php",
+        name: "data_privacy_config_form",
+        methods: ['GET']
+    )]
+    #[SecurityStrategy(Firewall::STRATEGY_CENTRAL_ACCESS)]
+    public function showForm(Request $request): Response
+    {
+        if (!DataAndPrivacyConfig::canView()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $config_id = Config::getConfigIDForContext('core');
+        if ($config_id === null) {
+            throw new RuntimeException('Unable to find any configs for context "core"');
+        }
+        DataAndPrivacyConfig::displayFullPageForItem($config_id, ["config", DataAndPrivacyConfig::class], [
+            'formoptions'  => "data-track-changes=true",
+        ]);
+        return new Response();
+    }
+
+    #[Route(
+        path: "/front/config/dataandprivacyconfig.form.php",
+        name: "update_data_privacy_config_form",
+        methods: ['POST']
+    )]
+    #[SecurityStrategy(Firewall::STRATEGY_ADMIN_ACCESS)]
+    public function handleFormSubmission(Request $request): Response
+    {
+        $do_update = $request->request->getBoolean('update');
+        if (!$do_update) {
+            throw new BadRequestHttpException();
+        }
+
+        $config_id = Config::getConfigIDForContext('core');
+        if ($config_id === null) {
+            throw new RuntimeException('Unable to find any configs for context "core"');
+        }
+        $config = new DataAndPrivacyConfig();
+
+        $update_input = $request->request->all();
+        $update_input['id'] = $config_id;
+        $config->update($update_input);
+        return new RedirectResponse(DataAndPrivacyConfig::getFormURLWithID($config_id));
+    }
+}

--- a/src/Glpi/Security/SessionTracker.php
+++ b/src/Glpi/Security/SessionTracker.php
@@ -175,7 +175,7 @@ final class SessionTracker
      */
     public static function revokeSession(string $login_session_uid, string $reason): void
     {
-        global $DB;
+        global $DB, $CFG_GLPI;
 
         $it = $DB->request([
             'SELECT' => ['users_id', 'session_file'],
@@ -187,14 +187,18 @@ final class SessionTracker
         $users_id = $session['users_id'] ?? null;
 
         $DB->delete('glpi_users_sessions', ['login_session_uid' => $login_session_uid]);
-        $DB->update('glpi_users_sessionhistories', [
-            'logged_out_at' => Session::getCurrentTime(),
-            'logout_reason' => $reason,
-            'users_id_revoked_by' => $_SESSION['glpiID'] ?? null,
-        ], [
-            'login_session_uid' => $login_session_uid,
-            'logged_out_at' => null, // Possibility of reused session IDs since this history is kept indefinitely.
-        ]);
+        if ($CFG_GLPI['login_history_retention_days'] <= 0) {
+            $DB->delete('glpi_users_sessionhistories', ['login_session_uid' => $login_session_uid]);
+        } else {
+            $DB->update('glpi_users_sessionhistories', [
+                'logged_out_at' => Session::getCurrentTime(),
+                'logout_reason' => $reason,
+                'users_id_revoked_by' => $_SESSION['glpiID'] ?? null,
+            ], [
+                'login_session_uid' => $login_session_uid,
+                'logged_out_at' => null,
+            ]);
+        }
         if ($reason !== self::REVOKE_REASON_EXPIRED && $users_id) {
             $DB->delete('glpi_usertokens', [
                 'users_id' => $users_id,

--- a/src/Html.php
+++ b/src/Html.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinition;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\Config\ConfigContainer;
+use Glpi\Config\DataAndPrivacyConfig;
 use Glpi\Console\Application;
 use Glpi\Dashboard\Grid;
 use Glpi\Debug\Profile as DebugProfile;
@@ -913,7 +914,7 @@ TWIG,
                 'types' => [
                     AssetDefinition::class,
                     CommonDropdown::class, CommonDevice::class, Notification::class, Webhook::class,
-                    SLM::class, Config::class, SecurityConfig::class, FieldUnicity::class, CronTask::class, Auth::class,
+                    SLM::class, Config::class, SecurityConfig::class, DataAndPrivacyConfig::class, FieldUnicity::class, CronTask::class, Auth::class,
                     OAuthClient::class, MailCollector::class, Link::class, Plugin::class,
                 ],
                 'icon'  => 'ti ti-settings',

--- a/templates/pages/setup/data_privacy/session_retention.html.twig
+++ b/templates/pages/setup/data_privacy/session_retention.html.twig
@@ -1,0 +1,55 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{% extends "pages/setup/general/base_form.html.twig" %}
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{% block config_fields %}
+   {{ fields.largeTitle(__('Login session data retention'), 'ti ti-user-shield') }}
+
+    {{ fields.dropdownNumberField('login_history_retention_days', config['login_history_retention_days'], __('Retention period (days)'), {
+        min: 0,
+        max: 365,
+    }) }}
+
+    {% set crontask_config %}
+        {% if crontask.fields['state'] == 0 %}
+            <span class="badge bg-danger text-danger-fg">{{ __('Disabled') }}</span>
+        {% else %}
+            <span class="badge bg-success text-success-fg">{{ __('Enabled') }}</span>
+        {% endif %}
+        <a href="{{ crontask.getFormURLWithID(crontask.getID()) }}">
+            {{ __('Configure automatic action') }}
+        </a>
+    {% endset %}
+    {{ fields.htmlField('', crontask_config, 'CronTask'|itemtype_name) }}
+{% endblock %}

--- a/templates/pages/setup/general/logs_setup.html.twig
+++ b/templates/pages/setup/general/logs_setup.html.twig
@@ -34,7 +34,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block config_fields %}
-   {{ fields.largeTitle(__('Logs purge configuration'), 'ti ti-news') }}
+   {{ fields.largeTitle(__('Historical data retention'), 'ti ti-news') }}
 
    {% set logs_interval_options = {
       (constant('Config::DELETE_ALL')): __('Delete all'),
@@ -55,6 +55,18 @@
       label_class: 'col-xxl-5 fst-italic',
       on_change: '$(this).closest(`form`).find(`.purgelog_interval select`).val(this.value).trigger("change");'
    }) }}
+
+    {% set crontask_config %}
+        {% if logspurge_crontask.fields['state'] == 0 %}
+            <span class="badge bg-danger text-danger-fg">{{ __('Disabled') }}</span>
+        {% else %}
+            <span class="badge bg-success text-success-fg">{{ __('Enabled') }}</span>
+        {% endif %}
+        <a href="{{ logspurge_crontask.getFormURLWithID(logspurge_crontask.getID()) }}">
+            {{ __('Configure automatic action') }}
+        </a>
+    {% endset %}
+    {{ fields.htmlField('', crontask_config, 'CronTask'|itemtype_name) }}
 
    {{ fields.smallTitle(__('General')) }}
    {{ _self.log_interval_dropdown('purge_addrelation', __('Add/update relation between items'), config, logs_interval_options) }}

--- a/tests/functional/ConfigTest.php
+++ b/tests/functional/ConfigTest.php
@@ -123,7 +123,6 @@ class ConfigTest extends DbTestCase
             'Config$3'      => "Assets",
             'Config$4'      => "Assistance",
             'Config$12'     => "Management",
-            'Config$9'      => "Logs purge",
             'Config$5'      => "System",
             'Config$7'      => "Performance",
             'Config$8'      => "API",

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -498,8 +498,8 @@ class DbUtilsTest extends DbTestCase
         $this->assertGreaterThan(0, $instance->countDistinctElementsInTable('glpi_configs', 'id'));
         $this->assertGreaterThan(0, $instance->countDistinctElementsInTable('glpi_configs', 'context'));
         $this->assertGreaterThanOrEqual(2, $instance->countDistinctElementsInTable('glpi_tickets', 'entities_id'));
-        $this->assertSame(21, $instance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']));
-        $this->assertSame(27, $instance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']));
+        $this->assertSame(22, $instance->countDistinctElementsInTable('glpi_crontasks', 'itemtype', ['frequency' => '86400']));
+        $this->assertSame(28, $instance->countDistinctElementsInTable('glpi_crontasks', 'id', ['frequency' => '86400']));
         $this->assertSame(1, $instance->countDistinctElementsInTable('glpi_configs', 'context', ['name' => 'version']));
         $this->assertSame(0, $instance->countDistinctElementsInTable('glpi_configs', 'id', ['context' => 'fakecontext']));
 

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -360,6 +360,7 @@ class HtmlTest extends DbTestCase
             'SLM',
             'Config',
             'Glpi\Security\SecurityConfig',
+            'Glpi\Config\DataAndPrivacyConfig',
             'FieldUnicity',
             'CronTask',
             'Auth',


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Primary purpose is to have a place to set retention periods for login session history logs for both data storage and privacy reasons. While recent work changed from recording PHP sessions which get created multiple times per login session depending on idle periods, this data could still quickly grow in larger production environments. As there could be other settings needed to assist businesses with GDPR, LGPD, etc compliance, or retention in general, the settings should be centralized to make it easier to discover and configure those settings to meet business needs and local laws.

- Adds new `Setup > Data and Privacy` menu item.
- Moves "Logs Purge" tab from `Setup > General` to the new Data and Privacy menu item and renames it to "Historical logs purge" to align with the other labels for this type of data.
- Adds the current "PurgeLogs" automatic action enabled status and a link to the automatic action's form directly in the "Historical logs purge" form to improve discoverability and general UX.