### PR TITLE
FIX / Fix crash on IP network address list with unresolved item type

### DIFF
--- a/src/IPAddress.php
+++ b/src/IPAddress.php
@@ -288,11 +288,15 @@ class IPAddress extends CommonDBChild
         $networkport = new NetworkPort();
         $networkname = new NetworkName();
         foreach ($it as $data) {
-            if (!array_key_exists($data['item_type'], $item_objs)) {
-                $item_objs[$data['item_type']] = getItemForItemtype($data['item_type']);
+            $item_link = '';
+            if ($data['item_type'] !== null) {
+                if (!array_key_exists($data['item_type'], $item_objs)) {
+                    $item_objs[$data['item_type']] = getItemForItemtype($data['item_type']);
+                }
+                $linked_item = $item_objs[$data['item_type']];
+                $linked_item->getFromDB($data['item_id']);
+                $item_link = $linked_item->getLink();
             }
-            $linked_item = $item_objs[$data['item_type']];
-            $linked_item->getFromDB($data['item_id']);
             $networkport->getFromDB($data['port_id']);
             $networkname->getFromDB($data['name_id']);
 
@@ -300,7 +304,7 @@ class IPAddress extends CommonDBChild
                 'itemtype' => self::class,
                 'id'       => $data['id'],
                 'ipaddress' => $data['ip'],
-                'item' => $linked_item->getLink(),
+                'item' => $item_link,
                 'port_id' => $networkport->getLink(),
                 'name_id' => $networkname->getLink(),
                 'entity' => $data['entity'],

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -190,6 +190,11 @@ class IPNetwork extends CommonImplicitTreeDropdown
     }
 
 
+    public function post_getEmpty()
+    {
+        $this->fields['network'] = '';
+    }
+
     /**
      * When we load the object, we fill the "network" field with the correct address/netmask values
      **/

--- a/tests/functional/IPAddressTest.php
+++ b/tests/functional/IPAddressTest.php
@@ -291,4 +291,42 @@ class IPAddressTest extends DbTestCase
             $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
         }
     }
+
+    public function testShowForItemWithOrphanNetworkName()
+    {
+        $this->login();
+
+        $ipNetwork = new \IPNetwork();
+        $ipnetwork_id = $ipNetwork->add([
+            'name'         => 'orphan-test-network',
+            'network'      => '10.20.30.0 / 255.255.255.0',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+            'addressable'  => 0,
+        ]);
+        $this->assertGreaterThan(0, (int) $ipnetwork_id);
+        $this->assertTrue($ipNetwork->getFromDB($ipnetwork_id));
+
+        // A NetworkName not linked to any NetworkPort (itemtype = '') makes
+        // IPAddress::getCriteriaLinkedToNetwork() return a NULL item_type for
+        // its IPAddress, which used to crash IPAddress::showForItem().
+        $networkName = new \NetworkName();
+        $networkname_id = $networkName->add([
+            'name'          => 'orphan-name',
+            '_ipaddresses'  => [-1 => '10.20.30.5'],
+            'entities_id'   => 0,
+            'items_id'      => 0,
+            'itemtype'      => '',
+            'fqdns_id'      => 0,
+            'comment'       => '',
+            'ipnetworks_id' => 0,
+        ]);
+        $this->assertGreaterThan(0, (int) $networkname_id);
+
+        ob_start();
+        \IPAddress::showForItem($ipNetwork);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('10.20.30.5', $output);
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45513
- Opening the "IP addresses" tab of an `IPNetwork` crashed with a `TypeError` whenever an address was linked to a `NetworkName` with no resolvable item type (orphaned data, e.g. from a disabled plugin or inventory import). Fixed by skipping item resolution for these rows in `IPAddress::showForItem()`, rendering an empty "Item" cell instead.

- The "Add" form for a new `IPNetwork` crashed with a Twig error, because the virtual `network` field was never initialized for a new (empty) item. Fixed by adding `IPNetwork::post_getEmpty()` to initialize it.

## Screenshots :

Before: 
<img width="1453" height="734" alt="Capture d’écran du 2026-07-28 10-57-23" src="https://github.com/user-attachments/assets/2af599ec-e26f-4157-abb6-9a2acc26a468" />

After:
<img width="1453" height="406" alt="Capture d’écran du 2026-07-28 11-05-17" src="https://github.com/user-attachments/assets/ea925788-d9e6-4a3e-981d-9fd90efcacdc" />



