### PR TITLE
Upgrade dependencies to get latest security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4628,9 +4628,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "dev": true,
             "funding": [
                 {
@@ -7739,9 +7739,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -8310,9 +8310,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.12",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+            "version": "8.5.24",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
             "dev": true,
             "funding": [
                 {
@@ -8330,7 +8330,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -888,24 +888,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1039,24 +1021,6 @@
             },
             "engines": {
                 "node": ">=10.10.0"
-            }
-        },
-        "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
@@ -3127,16 +3091,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -3598,13 +3562,6 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3986,24 +3943,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/del/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/del/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/del/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4373,24 +4312,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -4832,24 +4753,6 @@
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/flat-cache/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/flat-cache/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/flat-cache/node_modules/glob": {
@@ -8817,24 +8720,6 @@
                 "rimraf": "bin.js"
             }
         },
-        "node_modules/rimraf/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9841,24 +9726,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/test-exclude/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
             }
         },
         "node_modules/test-exclude/node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "chartist-plugin-tooltips-updated": {
             "lodash": "^4.18.1"
         },
+        "brace-expansion": "^5.0.8",
         "js-yaml": "^4.2.0"
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

It fixes the following issues:
```
brace-expansion  <=5.0.7
Severity: high
brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash - https://github.com/advisories/GHSA-mh99-v99m-4gvg
fix available via `npm audit fix --force`
Will install eslint@10.8.0, which is a breaking change
node_modules/@eslint/eslintrc/node_modules/brace-expansion
node_modules/@humanwhocodes/config-array/node_modules/brace-expansion
node_modules/brace-expansion
node_modules/del/node_modules/brace-expansion
node_modules/eslint/node_modules/brace-expansion
node_modules/flat-cache/node_modules/brace-expansion
node_modules/rimraf/node_modules/brace-expansion
node_modules/test-exclude/node_modules/brace-expansion
  minimatch  2.0.0 - 10.0.2
  Depends on vulnerable versions of brace-expansion
  node_modules/@eslint/eslintrc/node_modules/minimatch
  node_modules/@humanwhocodes/config-array/node_modules/minimatch
  node_modules/@jest/reporters/node_modules/minimatch
  node_modules/del/node_modules/minimatch
  node_modules/eslint/node_modules/minimatch
  node_modules/flat-cache/node_modules/minimatch
  node_modules/jest-config/node_modules/minimatch
  node_modules/jest-runtime/node_modules/minimatch
  node_modules/rimraf/node_modules/minimatch
  node_modules/test-exclude/node_modules/minimatch
    @eslint/eslintrc  0.0.1 || >=0.1.1
    Depends on vulnerable versions of minimatch
    node_modules/@eslint/eslintrc
      eslint  0.12.0 - 2.0.0-rc.1 || 4.1.0 - 10.0.0-rc.2
      Depends on vulnerable versions of @eslint/eslintrc
      Depends on vulnerable versions of @humanwhocodes/config-array
      Depends on vulnerable versions of file-entry-cache
      Depends on vulnerable versions of minimatch
      node_modules/eslint
    @humanwhocodes/config-array  *
    Depends on vulnerable versions of minimatch
    node_modules/@humanwhocodes/config-array
    glob  4.3.0 - 10.5.0
    Depends on vulnerable versions of minimatch
    node_modules/@jest/reporters/node_modules/glob
    node_modules/del/node_modules/glob
    node_modules/flat-cache/node_modules/glob
    node_modules/jest-config/node_modules/glob
    node_modules/jest-runtime/node_modules/glob
    node_modules/rimraf/node_modules/glob
    node_modules/test-exclude/node_modules/glob
      @jest/reporters  *
      Depends on vulnerable versions of @jest/transform
      Depends on vulnerable versions of glob
      node_modules/@jest/reporters
        @jest/core  *
        Depends on vulnerable versions of @jest/reporters
        Depends on vulnerable versions of @jest/transform
        Depends on vulnerable versions of jest-config
        Depends on vulnerable versions of jest-resolve-dependencies
        Depends on vulnerable versions of jest-runner
        Depends on vulnerable versions of jest-runtime
        Depends on vulnerable versions of jest-snapshot
        node_modules/@jest/core
          jest  >=19.1.0-alpha.eed82034
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-cli
          node_modules/jest
            jest-extended  >=2.0.0
            Depends on vulnerable versions of jest
            node_modules/jest-extended
          jest-cli  >=19.1.0-alpha.eed82034
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-config
          node_modules/jest-cli
      globby  1.2.0 - 10.0.2
      Depends on vulnerable versions of glob
      node_modules/del/node_modules/globby
        del  1.2.0 - 7.1.0
        Depends on vulnerable versions of globby
        Depends on vulnerable versions of rimraf
        node_modules/del
          clean-webpack-plugin  >=2.0.0
          Depends on vulnerable versions of del
          node_modules/clean-webpack-plugin
      jest-config  >=19.1.0-alpha.eed82034
      Depends on vulnerable versions of babel-jest
      Depends on vulnerable versions of glob
      Depends on vulnerable versions of jest-circus
      Depends on vulnerable versions of jest-runner
      node_modules/jest-config
      jest-runtime  >=24.0.0-alpha.0
      Depends on vulnerable versions of @jest/globals
      Depends on vulnerable versions of @jest/transform
      Depends on vulnerable versions of glob
      Depends on vulnerable versions of jest-snapshot
      node_modules/jest-runtime
        jest-circus  >=25.2.4
        Depends on vulnerable versions of @jest/expect
        Depends on vulnerable versions of jest-runtime
        Depends on vulnerable versions of jest-snapshot
        node_modules/jest-circus
        jest-runner  >=24.0.0-alpha.0
        Depends on vulnerable versions of @jest/transform
        Depends on vulnerable versions of jest-runtime
        node_modules/jest-runner
      rimraf  2.3.0 - 3.0.2 || 4.2.0 - 5.0.10
      Depends on vulnerable versions of glob
      node_modules/flat-cache/node_modules/rimraf
      node_modules/rimraf
        flat-cache  1.3.4 - 4.0.0
        Depends on vulnerable versions of rimraf
        node_modules/flat-cache
          file-entry-cache  4.0.0 - 7.0.2
          Depends on vulnerable versions of flat-cache
          node_modules/file-entry-cache
      test-exclude  4.2.2 || 5.0.0 - 7.0.2
      Depends on vulnerable versions of glob
      Depends on vulnerable versions of minimatch
      node_modules/test-exclude
        babel-plugin-istanbul  5.0.1 - 7.0.1
        Depends on vulnerable versions of test-exclude
        node_modules/babel-plugin-istanbul
          @jest/transform  *
          Depends on vulnerable versions of babel-plugin-istanbul
          node_modules/@jest/transform
            babel-jest  >=24.0.0-alpha.0
            Depends on vulnerable versions of @jest/transform
            Depends on vulnerable versions of babel-plugin-istanbul
            node_modules/babel-jest
            jest-snapshot  >=27.0.0-next.0
            Depends on vulnerable versions of @jest/transform
            node_modules/jest-snapshot
              @jest/expect  *
              Depends on vulnerable versions of jest-snapshot
              node_modules/@jest/expect
                @jest/globals  >=28.0.0-alpha.0
                Depends on vulnerable versions of @jest/expect
                node_modules/@jest/globals
              jest-resolve-dependencies  >=27.0.0-next.0
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-resolve-dependencies

fast-uri  3.0.0 - 3.1.3
Severity: high
fast-uri vulnerable to host confusion via literal backslash authority delimiter - https://github.com/advisories/GHSA-v2hh-gcrm-f6hx
fast-uri vulnerable to host confusion via failed IDN canonicalization - https://github.com/advisories/GHSA-4c8g-83qw-93j6
fix available via `npm audit fix`
node_modules/fast-uri

postcss  <=8.5.17
Severity: high
PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure - https://github.com/advisories/GHSA-r28c-9q8g-f849
fix available via `npm audit fix`
node_modules/postcss

31 high severity vulnerabilities
```