### PR TITLE
fix(crontask): rename crontasks sharing the same name across itemtypes

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2876,12 +2876,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method CommonITILObject\\:\\:cronInfo\\(\\) should return array\\{description\\: string, parameter\\?\\: string\\} but returns array\\{\\}\\|array\\{description\\: string\\}\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method CommonITILObject\\:\\:dropdownImpact\\(\\) should return string but returns int\\|string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -619,7 +619,7 @@ $empty_data_builder = new class {
             ], [
                 'id' => 18,
                 'itemtype' => Ticket::class,
-                'name' => 'createinquest',
+                'name' => 'createinquestticket',
                 'frequency' => DAY_TIMESTAMP,
                 'param' => null,
                 'state' => CronTask::STATE_WAITING,
@@ -823,7 +823,7 @@ $empty_data_builder = new class {
             ], [
                 'id' => 35,
                 'itemtype' => 'Document',
-                'name' => 'cleanorphans',
+                'name' => 'cleanorphansdocument',
                 'frequency' => DAY_TIMESTAMP,
                 'param' => null,
                 'state' => CronTask::STATE_DISABLE,
@@ -895,7 +895,7 @@ $empty_data_builder = new class {
             ], [
                 'id' => 41,
                 'itemtype' => Inventory::class,
-                'name' => 'cleanorphans',
+                'name' => 'cleanorphansinventory',
                 'frequency' => DAY_TIMESTAMP,
                 'param' => null,
                 'state' => CronTask::STATE_WAITING,
@@ -931,7 +931,7 @@ $empty_data_builder = new class {
             ], [
                 'id' => 44,
                 'itemtype' => 'Change',
-                'name' => 'createinquest',
+                'name' => 'createinquestchange',
                 'frequency' => DAY_TIMESTAMP,
                 'param' => null,
                 'state' => CronTask::STATE_WAITING,

--- a/install/migrations/update_11.0.8_to_11.0.9/crontask.php
+++ b/install/migrations/update_11.0.8_to_11.0.9/crontask.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_crontasks',
+        ['name' => 'cleanorphansdocument'],
+        ['itemtype' => 'Document', 'name' => 'cleanorphans']
+    )
+);
+
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_crontasks',
+        ['name' => 'cleanorphansinventory'],
+        ['itemtype' => 'Glpi\Inventory\Inventory', 'name' => 'cleanorphans']
+    )
+);
+
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_crontasks',
+        ['name' => 'createinquestticket'],
+        ['itemtype' => 'Ticket', 'name' => 'createinquest']
+    )
+);
+
+$migration->addPostQuery(
+    $DB->buildUpdate(
+        'glpi_crontasks',
+        ['name' => 'createinquestchange'],
+        ['itemtype' => 'Change', 'name' => 'createinquest']
+    )
+);

--- a/src/Change.php
+++ b/src/Change.php
@@ -1642,9 +1642,8 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
      **/
     public static function cronInfo($name)
     {
-        switch ($name) {
-            case 'createinquestchange':
-                return ['description' => __('Generation of changes satisfaction surveys')];
+        if ($name === 'createinquestchange') {
+            return ['description' => __('Generation of changes satisfaction surveys')];
         }
         return [];
     }

--- a/src/Change.php
+++ b/src/Change.php
@@ -1632,4 +1632,32 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
             echo "<td colspan='6' ><i>" . __s('No change found.') . "</i></td></tr>";
         }
     }
+
+    /**
+     * Give cron information
+     *
+     * @param string $name  Task's name
+     *
+     * @return array Array of information
+     **/
+    public static function cronInfo($name)
+    {
+        switch ($name) {
+            case 'createinquestchange':
+                return ['description' => __('Generation of changes satisfaction surveys')];
+        }
+        return [];
+    }
+
+    /**
+     * Cron for automatically creating changes satisfaction surveys
+     *
+     * @param CronTask $task
+     *
+     * @return int (0 : nothing done - 1 : done)
+     **/
+    public static function cronCreateInquestChange($task)
+    {
+        return parent::cronCreateInquest($task);
+    }
 }

--- a/src/Change.php
+++ b/src/Change.php
@@ -1638,7 +1638,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
      *
      * @param string $name  Task's name
      *
-     * @return array Array of information
+     * @return array{description?: string}
      **/
     public static function cronInfo($name)
     {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -10907,18 +10907,6 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     }
 
     /**
-     * @param string $name
-     * @return array{description: string, parameter?: string}
-     */
-    public static function cronInfo($name)
-    {
-        return match ($name) {
-            'createinquest' => ['description' => __('Generation of satisfaction surveys')],
-            default => [],
-        };
-    }
-
-    /**
      * Cron for automatically creating surveys for ITIL Objects
      *
      * @param CronTask $task

--- a/src/Document.php
+++ b/src/Document.php
@@ -1674,7 +1674,7 @@ class Document extends CommonDBTM implements TreeBrowseInterface
     public static function cronInfo($name): array
     {
         return match ($name) {
-            'cleanorphans' => ['description' => __('Clean orphaned documents: deletes all documents that are not associated with any items.')],
+            'cleanorphansdocument' => ['description' => __('Clean orphaned documents: deletes all documents that are not associated with any items.')],
             default => [],
         };
     }
@@ -1687,7 +1687,7 @@ class Document extends CommonDBTM implements TreeBrowseInterface
      * @return int (0 : nothing done - 1 : done)
      * @used-by CronTask
      **/
-    public static function cronCleanOrphans(CronTask $task): int
+    public static function cronCleanOrphansDocument(CronTask $task): int
     {
         global $DB;
 

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -1011,7 +1011,7 @@ class Inventory
             case 'cleantemp':
                 return ['description' => __('Clean temporary files created from inventories')];
 
-            case 'cleanorphans':
+            case 'cleanorphansinventory':
                 return ['description' => __('Clean inventories orphaned files')];
         }
         return [];
@@ -1058,7 +1058,7 @@ class Inventory
      *
      * @return int
      **/
-    public static function cronCleanorphans($task)
+    public static function cronCleanOrphansInventory($task)
     {
         global $DB;
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5152,8 +5152,11 @@ JAVASCRIPT;
                     'description' => __('Automatic closed tickets purge'),
                     'parameter' => __('Maximum number of tickets purged per entity (0 = unlimited)'),
                 ];
+
+            case 'createinquestticket':
+                return ['description' => __('Generation of tickets satisfaction surveys')];
         }
-        return parent::cronInfo($name);
+        return [];
     }
 
 
@@ -5383,6 +5386,18 @@ JAVASCRIPT;
         }
 
         return ($tot > 0 ? 1 : 0);
+    }
+
+    /**
+     * Cron for automatically creating tickets satisfaction surveys
+     *
+     * @param CronTask $task
+     *
+     * @return int (0 : nothing done - 1 : done)
+     **/
+    public static function cronCreateInquestTicket($task)
+    {
+        return parent::cronCreateInquest($task);
     }
 
 

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -725,4 +725,138 @@ class ChangeTest extends DbTestCase
 
         $this->assertSame(255, mb_strlen($change->fields['name']));
     }
+
+    public function testCronSurveyCreation(): void
+    {
+        $this->login();
+
+        $root_entity_id    = $this->getTestRootEntity(true);
+        $child_1_entity_id = getItemByTypeName('Entity', '_test_child_1', true);
+        $child_2_entity_id = getItemByTypeName('Entity', '_test_child_2', true);
+
+        $twelve_hours_ago = date("Y-m-d H:i:s", strtotime('-12 hours'));
+        $six_hours_ago    = date("Y-m-d H:i:s", strtotime('-6 hours'));
+        $four_hours_ago   = date("Y-m-d H:i:s", strtotime('-4 hours'));
+        $two_hours_ago    = date("Y-m-d H:i:s", strtotime('-2 hours'));
+
+        $this->updateItem(
+            \Entity::class,
+            0,
+            [
+                'inquest_config_change' => 1, // GLPI native survey
+                'inquest_rate_change'   => 100, // always generate a survey for closed changes
+                'inquest_delay_change'  => 0, // instant survey generation
+            ]
+        );
+        foreach ([$root_entity_id, $child_1_entity_id] as $entity_id) {
+            $this->updateItem(
+                \Entity::class,
+                $entity_id,
+                [
+                    'inquest_config_change' => \Entity::CONFIG_PARENT, // inherits
+                ]
+            );
+        }
+        $this->updateItem(
+            \Entity::class,
+            $child_2_entity_id,
+            [
+                'inquest_config_change' => 1, // GLPI native survey
+                'inquest_rate_change'   => 100, // always generate a survey for closed changes
+                'inquest_delay_change'  => 0, // instant survey generation
+            ]
+        );
+
+        foreach ([0, $root_entity_id, $child_1_entity_id, $child_2_entity_id] as $entity_id) {
+            $this->updateItem(
+                \Entity::class,
+                $entity_id,
+                [
+                    'max_closedate_change' => $twelve_hours_ago,
+                ]
+            );
+        }
+
+        $original_currenttime = $_SESSION['glpi_currenttime'];
+
+        // Create a closed change on test root entity
+        $_SESSION['glpi_currenttime'] = $six_hours_ago;
+        $root_change = $this->createItem(
+            Change::class,
+            [
+                'name'        => "test root entity survey",
+                'content'     => "test root entity survey",
+                'entities_id' => $root_entity_id,
+                'status'      => CommonITILObject::CLOSED,
+            ]
+        );
+
+        // Create a closed change on test child entity 1
+        $_SESSION['glpi_currenttime'] = $four_hours_ago;
+        $child_1_change = $this->createItem(
+            Change::class,
+            [
+                'name'        => "test child entity 1 survey",
+                'content'     => "test child entity 1 survey",
+                'entities_id' => $child_1_entity_id,
+                'status'      => CommonITILObject::CLOSED,
+            ]
+        );
+
+        // Create a closed change on test child entity 2
+        $_SESSION['glpi_currenttime'] = $two_hours_ago;
+        $child_2_change = $this->createItem(
+            Change::class,
+            [
+                'name'        => "test child entity 2 survey",
+                'content'     => "test child entity 2 survey",
+                'entities_id' => $child_2_entity_id,
+                'status'      => CommonITILObject::CLOSED,
+            ]
+        );
+
+        $_SESSION['glpi_currenttime'] = $original_currenttime;
+
+        // Ensure no survey has been created yet
+        $change_satisfaction = new \ChangeSatisfaction();
+        $this->assertEquals(0, count($change_satisfaction->find(['changes_id' => $root_change->getID()])));
+        $this->assertEquals(0, count($change_satisfaction->find(['changes_id' => $child_1_change->getID()])));
+        $this->assertEquals(0, count($change_satisfaction->find(['changes_id' => $child_2_change->getID()])));
+
+        // Launch cron to create surveys
+        \CronTask::launch(
+            - \CronTask::MODE_INTERNAL, // force
+            1,
+            'createinquestchange'
+        );
+
+        // Ensure survey has been created
+        $this->assertEquals(1, count($change_satisfaction->find(['changes_id' => $root_change->getID()])));
+        $this->assertEquals(1, count($change_satisfaction->find(['changes_id' => $child_1_change->getID()])));
+        $this->assertEquals(1, count($change_satisfaction->find(['changes_id' => $child_2_change->getID()])));
+
+        // Check `max_closedate` values in DB
+        $expected_db_values = [
+            0                  => $four_hours_ago,   // last change closedate from entities that inherits the config
+            $root_entity_id    => $twelve_hours_ago, // not updated as it inherits the config
+            $child_1_entity_id => $twelve_hours_ago, // not updated as it inherits the config
+            $child_2_entity_id => $two_hours_ago,    // last change closedate from self as it has its own config
+        ];
+        $entity = new \Entity();
+        foreach ($expected_db_values as $entity_id => $date) {
+            $this->assertTrue($entity->getFromDB($entity_id));
+            $this->assertEquals($date, $entity->fields['max_closedate_change']);
+        }
+
+        // Check `max_closedate` returned by `Entity::getUsedConfig()`
+        $expected_config_values = [
+            0                  => $four_hours_ago, // last change closedate from entities that inherits the config
+            $root_entity_id    => $four_hours_ago, // inherited value
+            $child_1_entity_id => $four_hours_ago, // inherited value
+            $child_2_entity_id => $two_hours_ago,  // last change closedate from self as it has its own config
+        ];
+        foreach ($expected_config_values as $entity_id => $date) {
+            $this->assertEquals($date, \Entity::getUsedConfig('inquest_config_change', $entity_id, 'max_closedate_change'));
+        }
+    }
 }

--- a/tests/functional/CronTaskTest.php
+++ b/tests/functional/CronTaskTest.php
@@ -331,4 +331,29 @@ class CronTaskTest extends DbTestCase
             'CronTaskLog entries must not generate history entries on the parent CronTask'
         );
     }
+
+    public function testDuplicateCronTaskName()
+    {
+        global $DB;
+
+        $names = [];
+        $iterator = $DB->request([
+            'SELECT' => ['itemtype', 'name'],
+            'FROM'   => \CronTask::getTable(),
+        ]);
+
+        foreach ($iterator as $row) {
+            $names[] = $row['name'];
+        }
+
+        $duplicates = array_diff_assoc($names, array_unique($names));
+
+        $this->assertEmpty(
+            $duplicates,
+            sprintf(
+                'Some cron tasks share the same name across itemtypes: %s',
+                implode(', ', array_unique($duplicates))
+            )
+        );
+    }
 }

--- a/tests/functional/DocumentTest.php
+++ b/tests/functional/DocumentTest.php
@@ -1075,7 +1075,7 @@ class DocumentTest extends DbTestCase
         $this->assertFalse($document_2->canViewFile(['items_id' => $printer_id, 'itemtype' => \Printer::class]));
     }
 
-    public function testCronCleanorphans()
+    public function testCronCleanOrphansDocument()
     {
 
         $this->login(); // must be logged as Document_Item uses Session::getLoginUserID()
@@ -1113,7 +1113,7 @@ class DocumentTest extends DbTestCase
 
         // launch Cron for closing tickets
         $mode = - \CronTask::MODE_EXTERNAL; // force
-        \CronTask::launch($mode, 5, 'cleanorphans');
+        \CronTask::launch($mode, 5, 'cleanorphansdocument');
 
         // check documents presence
         $this->assertFalse($doc->getFromDB($did1));

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -5797,7 +5797,7 @@ HTML,
         CronTask::launch(
             - CronTask::MODE_INTERNAL, // force
             1,
-            'createinquest'
+            'createinquestticket'
         );
 
         // Ensure survey has been created


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

The “cleanorphans” and “createinquest” crontasks are associated with two itemtypes. It is not possible to select the itemtype when running a task, so GLPI will run the task with the oldest last execution date. This prevents the user from choosing which cron job to run.

This bug affects the execution of a crontask via the CLI and through the interface 

## Screenshots (if appropriate):

<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/7c742025-89bf-4e2e-b838-910c830d2b97" />

