### PR TITLE
Fix: stop leaking LDAP batch mode across requests

### DIFF
--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -466,7 +466,6 @@ class AuthLDAP extends CommonDBTM
                     $ma->addMessage($item->getErrorMessage(ERROR_RIGHT));
                     return;
                 }
-                User::enableLdapGroupBatchMode();
                 $mode         = (int) ($input['mode'] ?? self::ACTION_IMPORT);
                 $authldaps_id = (int) ($input['authldaps_id'] ?? 0);
                 foreach ($ids as $id) {
@@ -477,6 +476,7 @@ class AuthLDAP extends CommonDBTM
                             ],
                             $mode,
                             $authldaps_id,
+                            true,
                             true
                         )
                     ) {
@@ -2640,6 +2640,8 @@ TWIG, $twig_params);
      * @param int $action synchronize (self::ACTION_SYNCHRONIZE) or import (self::ACTION_IMPORT)
      * @param int $ldap_server ID of the LDAP server to use
      * @param bool $display display message information on redirect (false by default)
+     * @param bool $batch_mode True when called from a loop importing/syncing many users
+     *                         (massive action or CLI sync), enabling the per-group query cache.
      *
      * @return array|bool  with state, else false
      * @throws SodiumException
@@ -2648,7 +2650,8 @@ TWIG, $twig_params);
         array $params,
         $action,
         $ldap_server,
-        $display = false
+        $display = false,
+        bool $batch_mode = false
     ) {
         global $DB;
 
@@ -2718,7 +2721,8 @@ TWIG, $twig_params);
                             $config_ldap->fields,
                             $user_dn,
                             $login,
-                            ($action === self::ACTION_IMPORT)
+                            ($action === self::ACTION_IMPORT),
+                            $batch_mode
                         )
                     ) {
                         //Get the ID by sync field (Used to check if restoration is needed)

--- a/src/Glpi/Console/Ldap/SynchronizeUsersCommand.php
+++ b/src/Glpi/Console/Ldap/SynchronizeUsersCommand.php
@@ -382,7 +382,6 @@ class SynchronizeUsersCommand extends AbstractCommand
                 $users_progress_bar = new ProgressBar($output, count($users));
                 $users_progress_bar->start();
 
-                User::enableLdapGroupBatchMode();
                 foreach ($users as $user) {
                     $users_progress_bar->advance(1);
 
@@ -425,7 +424,9 @@ class SynchronizeUsersCommand extends AbstractCommand
                             'user_field'       => $user_field,
                         ],
                         $action,
-                        $server_id
+                        $server_id,
+                        false,
+                        true
                     );
 
                     if (false !== $result) {

--- a/src/User.php
+++ b/src/User.php
@@ -105,13 +105,6 @@ class User extends CommonDBTM implements TreeBrowseInterface
 
     private ?array $entities = null;
 
-    private static bool $ldap_group_batch_mode = false;
-
-    public static function enableLdapGroupBatchMode(): void
-    {
-        self::$ldap_group_batch_mode = true;
-    }
-
     public function getCloneRelations(): array
     {
         return [
@@ -2224,10 +2217,12 @@ class User extends CommonDBTM implements TreeBrowseInterface
      * @param array    $ldap_method        LDAP method
      * @param string   $userdn             Basedn of the user
      * @param string   $login              User login
+     * @param bool     $batch_mode         True when called from a loop importing/syncing many users
+     *                                     (massive action or CLI sync), enabling the per-group query cache.
      *
      * @return bool true if search is applicable, false otherwise
      */
-    private function getFromLDAPGroupDiscret($ldap_connection, array $ldap_method, $userdn, $login)
+    private function getFromLDAPGroupDiscret($ldap_connection, array $ldap_method, $userdn, $login, bool $batch_mode = false)
     {
         global $DB;
 
@@ -2236,9 +2231,9 @@ class User extends CommonDBTM implements TreeBrowseInterface
             return false;
         }
 
-        // Only use M-queries-per-group cache in batch mode; FPM spawns a new process per login so the cache never reuses.
+        // Only use M-queries-per-group cache in batch mode: it only pays off when reused across many users in the same loop.
         if (
-            self::$ldap_group_batch_mode
+            $batch_mode
             && str_contains($ldap_method["group_member_field"], AuthLDAP::MATCHING_RULE_IN_CHAIN_OID)
             && !empty($ldap_method["group_field"])
         ) {
@@ -2409,10 +2404,12 @@ class User extends CommonDBTM implements TreeBrowseInterface
      * @param string   $userdn          Basedn of the user
      * @param string   $login           User Login
      * @param bool  $import          true for import, false for update
+     * @param bool  $batch_mode      True when called from a loop importing/syncing many users
+     *                               (massive action or CLI sync), enabling the per-group query cache.
      *
      * @return bool true if found / false if not
      */
-    public function getFromLDAP($ldap_connection, array $ldap_method, $userdn, $login, $import = true)
+    public function getFromLDAP($ldap_connection, array $ldap_method, $userdn, $login, $import = true, bool $batch_mode = false)
     {
         global $CFG_GLPI, $DB;
 
@@ -2547,7 +2544,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                 ($ldap_method["group_search_type"] == 1)
                 || ($ldap_method["group_search_type"] == 2)
             ) {
-                $this->getFromLDAPGroupDiscret($ldap_connection, $ldap_method, $userdn, $login);
+                $this->getFromLDAPGroupDiscret($ldap_connection, $ldap_method, $userdn, $login, $batch_mode);
             }
 
             ///Only process rules if working on the master database

--- a/tests/functional/UserTest.php
+++ b/tests/functional/UserTest.php
@@ -2682,12 +2682,6 @@ class UserTest extends DbTestCase
         $this->assertStringStartsWith(__FUNCTION__ . '_2', $tree[0]['title']);
     }
 
-    public function testLdapGroupBatchModeDefaultsFalse(): void
-    {
-        $prop = (new \ReflectionClass(User::class))->getProperty('ldap_group_batch_mode');
-        $this->assertFalse($prop->getValue(null));
-    }
-
     /**
      * Verify that getFromLDAPGroupDiscret() routes to the cached path only when
      * batch mode is enabled and the LDAP_MATCHING_RULE_IN_CHAIN OID is present.
@@ -2733,9 +2727,6 @@ class UserTest extends DbTestCase
         );
         $this->assertFalse($result);
 
-        // Batch mode required: cached path is only active during batch sync.
-        User::enableLdapGroupBatchMode();
-
         // CHAIN OID present + batch mode + group_field set → cached path → true.
         // No groups with ldap_group_dn exist in DB, so no ldap_search is fired.
         $result = $this->callPrivateMethod(
@@ -2746,7 +2737,8 @@ class UserTest extends DbTestCase
                 'group_member_field' => 'member:' . AuthLDAP::MATCHING_RULE_IN_CHAIN_OID,
             ]),
             'uid=testuser,dc=example,dc=com',
-            'testuser'
+            'testuser',
+            true
         );
         $this->assertTrue($result);
         $this->assertEmpty($user->fields['_groups'] ?? []);
@@ -2785,7 +2777,6 @@ class UserTest extends DbTestCase
 
         $userdn = 'uid=cachetest,dc=example,dc=com';
 
-        User::enableLdapGroupBatchMode();
         $user1 = new User();
 
         // First call — DB has no groups with ldap_group_dn, cache is primed as empty.
@@ -2795,7 +2786,8 @@ class UserTest extends DbTestCase
             null,
             $ldap_method,
             $userdn,
-            'cachetest'
+            'cachetest',
+            true
         );
         $this->assertTrue($result);
         $this->assertEmpty($user1->fields['_groups'] ?? []);
@@ -2816,7 +2808,8 @@ class UserTest extends DbTestCase
             null,
             $ldap_method,
             $userdn,
-            'cachetest'
+            'cachetest',
+            true
         );
         $this->assertTrue($result);
         $this->assertEmpty($user2->fields['_groups'] ?? []);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45085
- It corrects #24762, which restricted an expensive AD nested-group cache to batch imports/synchronizations, but relied on a shared flag that could stay stuck on for unrelated logins served by the same PHP-FPM worker afterwards, randomly slowing them down.
- The batch mode is now passed explicitly on each call instead of being stored as a shared flag.

## Screenshots (if appropriate):
