### PR TITLE
Handle ajax requests blocked by reauthentication process

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -39,6 +39,7 @@
 /* global L */
 /* global fuzzy */
 /* global glpi_html_dialog */
+/* global glpi_confirm */
 /* global glpi_toast_info, glpi_toast_warning, glpi_toast_error */
 /* global _ */
 /* global uploaded_images, removeFailedUploadImage */
@@ -1322,6 +1323,64 @@ function getAjaxCsrfToken() {
     console.warn('Csrf protection is now handled without tokens.');
     return "";
 }
+
+/**
+ * Name of the response header marking a 403 caused by a missing re-authentication.
+ *
+ * @see \Glpi\Exception\Http\ReAuthRequiredHttpException::HEADER
+ */
+const REAUTH_REQUIRED_HEADER = 'X-Glpi-Reauth-Required';
+
+// Avoid stacking one dialog per pending request when several of them are rejected at once.
+var reauth_required_dialog_shown = false;
+
+/**
+ * Offer a re-authentication when a request was rejected because it lacked one.
+ *
+ * The prompt is a full page, so it cannot be served as the answer of an AJAX request: the server
+ * answers with a 403 carrying the REAUTH_REQUIRED_HEADER header instead, and records the calling
+ * page as the one to come back to once the identity is confirmed. Sending the browser straight to
+ * the prompt is therefore enough, whether the calling page requires a re-authentication on its own
+ * or not.
+ *
+ * The rejected action is not replayed: the user has to redo it on the restored page.
+ *
+ * @param {string|null} header_value value of the REAUTH_REQUIRED_HEADER response header
+ *
+ * @returns {boolean} true if a re-authentication was required, whether the dialog was shown or not
+ */
+function handleReauthRequiredResponse(header_value) {
+    if (!header_value) {
+        return false;
+    }
+
+    if (reauth_required_dialog_shown) {
+        return true;
+    }
+    reauth_required_dialog_shown = true;
+
+    glpi_confirm({
+        title: __('Re-authentication required'),
+        message: __('This action requires you to confirm your identity.'),
+        confirm_label: __('Continue'),
+        confirm_callback: () => {
+            window.location.assign(`${CFG_GLPI.root_doc}/ReAuth/Prompt`);
+        },
+        close_callback: () => {
+            reauth_required_dialog_shown = false;
+        },
+    });
+
+    return true;
+}
+
+// Catch the re-authentication requirement on every jQuery request. Requests issued through
+// `js/modules/Ajax.js` handle it on their own, as fetch() is out of jQuery's reach.
+$(function() {
+    $(document).ajaxError(function(event, jqxhr) {
+        handleReauthRequiredResponse(jqxhr.getResponseHeader(REAUTH_REQUIRED_HEADER));
+    });
+});
 
 // init tooltips
 $(

--- a/js/modules/Ajax.js
+++ b/js/modules/Ajax.js
@@ -31,6 +31,24 @@
  */
 
 /* global glpi_toast_error */
+/* global REAUTH_REQUIRED_HEADER, handleReauthRequiredResponse */
+
+/**
+ * Report a failed response to the user.
+ *
+ * A missing re-authentication gets its own dialog offering to reach the prompt, so the generic
+ * error must not be piled on top of it.
+ *
+ * @param {Response} response
+ */
+function reportFailedResponse(response)
+{
+    if (handleReauthRequiredResponse(response.headers.get(REAUTH_REQUIRED_HEADER))) {
+        return;
+    }
+
+    glpi_toast_error(__("An unexpected error occurred."));
+}
 
 /**
  * Perform a POST request to a GLPI endpoint.
@@ -45,6 +63,10 @@
  */
 export async function post(url, values = null)
 {
+    // A rejected response is reported by reportFailedResponse(), which may pick a more specific
+    // message than the generic one of the catch block.
+    let error_reported = false;
+
     try {
         const is_plain_object = values !== null
             && !(values instanceof FormData)
@@ -70,12 +92,16 @@ export async function post(url, values = null)
 
         const response = await fetch(`${CFG_GLPI.root_doc}/${url}`, params);
         if (!response.ok) {
+            error_reported = true;
+            reportFailedResponse(response);
             throw new Error("POST request failed");
         }
 
         return response;
     } catch (e) {
-        glpi_toast_error(__("An unexpected error occurred."));
+        if (!error_reported) {
+            glpi_toast_error(__("An unexpected error occurred."));
+        }
         throw e;
     }
 }
@@ -89,6 +115,9 @@ export async function post(url, values = null)
  */
 export async function get(url)
 {
+    // @see post()
+    let error_reported = false;
+
     try {
         const params = {
             method: 'GET',
@@ -99,12 +128,16 @@ export async function get(url)
 
         const response = await fetch(`${CFG_GLPI.root_doc}/${url}`, params);
         if (!response.ok) {
+            error_reported = true;
+            reportFailedResponse(response);
             throw new Error("GET request failed");
         }
 
         return response;
     } catch (e) {
-        glpi_toast_error(__("An unexpected error occurred."));
+        if (!error_reported) {
+            glpi_toast_error(__("An unexpected error occurred."));
+        }
         throw e;
     }
 }

--- a/src/Glpi/Controller/ErrorController.php
+++ b/src/Glpi/Controller/ErrorController.php
@@ -60,6 +60,12 @@ class ErrorController extends AbstractController
 
         $status_code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 
+        // Headers carried by the exception, e.g. the marker of
+        // \Glpi\Exception\Http\ReAuthRequiredHttpException. Symfony only copies them onto the
+        // response when it had to build the error response itself (@see HttpKernel::handleThrowable()),
+        // which is not the case here, so they must be forwarded explicitly.
+        $headers = $exception instanceof HttpExceptionInterface ? $exception->getHeaders() : [];
+
         $title      = _n('Error', 'Errors', 1);
         $message    = __('An unexpected error occurred');
         $link_text  = null;
@@ -142,7 +148,8 @@ class ErrorController extends AbstractController
                     'message' => $message,
                     'trace'   => $trace,
                 ],
-                status: $status_code
+                status: $status_code,
+                headers: $headers
             );
         }
 
@@ -157,7 +164,7 @@ class ErrorController extends AbstractController
             return $this->render(
                 'error_block.html.twig',
                 $error_block_params,
-                new Response(status: $status_code)
+                new Response(status: $status_code, headers: $headers)
             );
         }
 
@@ -182,7 +189,7 @@ class ErrorController extends AbstractController
                 'link_url'      => $link_url ?? Html::getBackUrl(),
                 'link_text'     => $link_text ?? __('Return to previous page'),
             ] + $error_block_params,
-            new Response(status: $status_code)
+            new Response(status: $status_code, headers: $headers)
         );
     }
 

--- a/src/Glpi/Exception/Http/ReAuthRequiredHttpException.php
+++ b/src/Glpi/Exception/Http/ReAuthRequiredHttpException.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Glpi\Exception\Http;
+
+/**
+ * A re-authentication is required, but it cannot be asked for on this request.
+ *
+ * The re-authentication prompt is a full page: serving it as the answer to an AJAX request would
+ * make the caller inject the form somewhere in the current page, and it means nothing to a client
+ * expecting anything else than HTML. Those requests get this exception instead of the usual
+ * redirection to the prompt.
+ *
+ * It is a plain 403 carrying the {@see self::HEADER} response header, so that a client can tell it
+ * apart from a "not enough rights" 403 and offer the user a way to re-authenticate — typically by
+ * reloading the current page, which goes through the regular redirection flow.
+ */
+final class ReAuthRequiredHttpException extends AccessDeniedHttpException
+{
+    /**
+     * Response header marking the reason of the 403.
+     */
+    public const string HEADER = 'X-Glpi-Reauth-Required';
+
+    public function __construct(string $message = 'Re-authentication required.')
+    {
+        parent::__construct($message, headers: [self::HEADER => '1']);
+    }
+}

--- a/src/Glpi/Security/ReAuth/ReAuthManager.php
+++ b/src/Glpi/Security/ReAuth/ReAuthManager.php
@@ -209,7 +209,7 @@ final class ReAuthManager
      * pointless to inject it for a replayed GET request (it would only ever
      * land in $_GET).
      *
-     * @return array<string, string>
+     * @return array<array-key, mixed>
      */
     public function getRequestedPostData(): array
     {
@@ -356,7 +356,12 @@ final class ReAuthManager
         $_SESSION['glpi_reauth_requested_url'] = $url;
     }
 
-    /** @param array<string, string> $post */
+    /**
+     * Nested values are supported: query strings and POST bodies carry them, and the replay
+     * template renders them recursively.
+     *
+     * @param array<array-key, mixed> $post
+     */
     private function setRequestedData(array $post): void
     {
         $_SESSION['glpi_reauth_requested_post_data'] = $post;
@@ -375,7 +380,7 @@ final class ReAuthManager
     }
 
     /**
-     * Requests that cannot be answered with the prompt page are denied instead of redirected.
+     * Can the current request be answered with the prompt page?
      *
      * Same discrimination as {@see AccessErrorListener}:
      * an AJAX caller would inject the prompt page in the current one, and a client expecting

--- a/src/Glpi/Security/ReAuth/ReAuthManager.php
+++ b/src/Glpi/Security/ReAuth/ReAuthManager.php
@@ -37,9 +37,12 @@ declare(strict_types=1);
 namespace Glpi\Security\ReAuth;
 
 use Glpi\Application\Environment;
+use Glpi\Exception\Http\ReAuthRequiredHttpException;
 use Glpi\Exception\RedirectException;
 use Glpi\Kernel\Kernel;
+use Glpi\Kernel\Listener\ExceptionListener\AccessErrorListener;
 use Glpi\Toolbox\SingletonTrait;
+use Glpi\Toolbox\URL;
 use InvalidArgumentException;
 use RuntimeException;
 use Safe\DateTime;
@@ -60,7 +63,7 @@ final class ReAuthManager
     private array $additional_strategies = [];
 
     /**
-     * @throws RedirectException
+     * @throws RedirectException|ReAuthRequiredHttpException
      */
     public function checkReAuthenticationOrRedirect(): void
     {
@@ -74,11 +77,20 @@ final class ReAuthManager
     /**
      * Redirect to reauth prompt and save current request data (url + post data)
      *
-     * @throws RedirectException
+     * Requests that cannot display the prompt (AJAX, or a client expecting anything else than
+     * HTML) get a ReAuthRequiredHttpException instead of the redirection.
+     *
+     * @throws RedirectException|ReAuthRequiredHttpException
      */
     public function redirectToReauth(): never
     {
         global $CFG_GLPI;
+
+        if (!$this->canDisplayPrompt()) {
+            $this->setCallerPageAsTarget();
+
+            throw new ReAuthRequiredHttpException();
+        }
 
         $this->setRequestedTarget();
 
@@ -360,5 +372,92 @@ final class ReAuthManager
             'POST' => 'POST',
             default => throw new \LogicException(sprintf('Unsupported HTTP method for redirect: %s', $http_method)),
         };
+    }
+
+    /**
+     * Requests that cannot be answered with the prompt page are denied instead of redirected.
+     *
+     * Same discrimination as {@see AccessErrorListener}:
+     * an AJAX caller would inject the prompt page in the current one, and a client expecting
+     * anything else than HTML has nothing to do with it.
+     */
+    private function canDisplayPrompt(): bool
+    {
+        /** @var Kernel $kernel */
+        global $kernel;
+
+        $request = $kernel->getMainRequest();
+
+        return !$request->isXmlHttpRequest() && $request->getPreferredFormat() === 'html';
+    }
+
+    /**
+     * Record the page the current request was issued from as the target of the re-authentication.
+     *
+     * Used when the prompt cannot be served as the answer of the request: the client is expected to
+     * send the browser to the prompt on its own, so the flow must already know where to land
+     * afterwards. The rejected request itself is not a suitable target — it is an endpoint, not a
+     * page, and replaying it would display its raw answer — so the user has to redo the action once
+     * back on the page.
+     */
+    private function setCallerPageAsTarget(): void
+    {
+        $caller_page = $this->getCallerPageUrl();
+
+        // The replay is submitted as a form, and the browser rebuilds the query string of a GET
+        // from its fields: the query string must be handed over as data instead of being left in
+        // the action URL, or it would be dropped. @see setRequestedTarget()
+        $query_string = parse_url($caller_page, PHP_URL_QUERY);
+        $query_params = [];
+        if (is_string($query_string)) {
+            parse_str($query_string, $query_params);
+        }
+
+        $this->setRequestedURL(strstr($caller_page, '?', true) ?: $caller_page);
+        $this->setRequestedMethod('GET');
+        $this->setRequestedData($query_params);
+        // Cancelling the prompt leads back to where the user was, i.e. that same page. It is a
+        // plain link, so it keeps the query string.
+        $this->setOriginURL($caller_page);
+    }
+
+    /**
+     * Absolute URL of the page the current request was issued from.
+     *
+     * The `Referer` header is the only hint available, as the request URL is the endpoint that was
+     * called and not the page holding it. It cannot be trusted: it may be forged, dropped by a
+     * referrer policy, or point outside of GLPI. Only its path and query string are kept and the
+     * host is rebuilt from the current request, so an unusable value degrades into the GLPI home
+     * page instead of turning the re-authentication into an open redirection.
+     */
+    private function getCallerPageUrl(): string
+    {
+        global $CFG_GLPI;
+
+        /** @var Kernel $kernel */
+        global $kernel;
+
+        $request  = $kernel->getMainRequest();
+        $home_url = $request->getSchemeAndHttpHost() . $CFG_GLPI['root_doc'] . '/';
+
+        $referer = \Html::getRefererUrl();
+        if ($referer === null) {
+            return $home_url;
+        }
+
+        $path = parse_url($referer, PHP_URL_PATH);
+        if (!is_string($path) || !str_starts_with($path, $CFG_GLPI['root_doc'] . '/')) {
+            return $home_url;
+        }
+
+        $query        = parse_url($referer, PHP_URL_QUERY);
+        $relative_url = $path . (is_string($query) ? '?' . $query : '');
+
+        // Landing on the re-authentication flow itself would loop.
+        if (!URL::isGLPIRelativeUrl($relative_url) || $this->isReAuthRoute($relative_url)) {
+            return $home_url;
+        }
+
+        return $request->getSchemeAndHttpHost() . $relative_url;
     }
 }

--- a/tests/e2e/pages/ReAuthRequiredDialog.ts
+++ b/tests/e2e/pages/ReAuthRequiredDialog.ts
@@ -1,0 +1,67 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { Locator, Page } from "@playwright/test";
+import { GlpiPage } from "./GlpiPage";
+
+/**
+ * Dialog offering a re-authentication, shown when a request was rejected because it lacked one.
+ *
+ * The prompt is a full page, so it cannot be the answer of an AJAX request: the client gets a
+ * marked 403 and offers this dialog instead.
+ *
+ * @see handleReauthRequiredResponse() in js/common.js
+ */
+export class ReAuthRequiredDialog extends GlpiPage
+{
+    public readonly dialog: Locator;
+    public readonly continue_button: Locator;
+    public readonly cancel_button: Locator;
+
+    public constructor(page: Page)
+    {
+        super(page);
+        this.dialog = page
+            .getByRole('dialog', { name: 'Re-authentication required' })
+            .filter({ visible: true });
+        this.continue_button = this.dialog.getByRole('button', { name: 'Continue', exact: true });
+        this.cancel_button = this.dialog.getByRole('button', { name: 'Cancel', exact: true });
+    }
+
+    /**
+     * Accept the dialog, sending the browser to the re-authentication prompt.
+     */
+    public async doContinue(): Promise<void>
+    {
+        await this.continue_button.click();
+    }
+}

--- a/tests/e2e/specs/Security/reauth.spec.ts
+++ b/tests/e2e/specs/Security/reauth.spec.ts
@@ -32,8 +32,9 @@
 
 import { expect, test } from '../../fixtures/glpi_fixture';
 import { ReAuthPromptPage } from '../../pages/ReAuthPromptPage';
+import { ReAuthRequiredDialog } from '../../pages/ReAuthRequiredDialog';
 import { Config } from '../../utils/Config';
-import { getWorkerLogin } from '../../utils/WorkerEntities';
+import { getWorkerEntityId, getWorkerLogin } from '../../utils/WorkerEntities';
 
 // Config requires reauth (Config::itemTypeRequiresReauthentication() === true),
 // and the e2e worker account is Super-Admin, so reaching this page with an
@@ -80,6 +81,45 @@ test.describe('Reauth (sudo mode)', () => {
 
         await expect(prompt.failure_alert).toBeVisible();
         await expect(prompt.password_field).toBeVisible();
+    });
+
+    /**
+     * The prompt cannot be served as the answer of an AJAX request, so the client is sent to it
+     * explicitly. The calling page is deliberately one that does not require a reauth on its own:
+     * merely reloading it would never reach the prompt, and the user would be stuck retrying the
+     * action forever.
+     */
+    test('a rejected ajax request leads to the prompt and back to the calling page', async ({ page, api }) => {
+        // Computer does not require a reauth, and the id in the URL checks that the query string of
+        // the calling page survives the round trip: the replay is submitted as a form, and the
+        // browser rebuilds the query string of a GET from its fields.
+        const computer_id = await api.createItem('Computer', {
+            name: 'Reauth ajax caller',
+            entities_id: getWorkerEntityId(),
+        });
+        const calling_page = `/front/computer.form.php?id=${computer_id}`;
+        await page.goto(calling_page);
+
+        // Request a page that requires a reauth as an AJAX call: the server answers with a marked
+        // 403. Going through jQuery is what matters, as the global ajaxError handler of
+        // js/common.js is the code under test.
+        await page.evaluate((url) => {
+            const glpi = window as any;
+            void glpi.$.get(`${glpi.CFG_GLPI.root_doc}${url}`);
+        }, protected_url);
+
+        const dialog = new ReAuthRequiredDialog(page);
+        await expect(dialog.dialog).toBeVisible();
+        await dialog.doContinue();
+
+        const prompt = new ReAuthPromptPage(page);
+        await expect(page).toHaveURL(/\/ReAuth\/Prompt/);
+        await prompt.doVerify(getWorkerLogin());
+
+        // Back on the calling page, id included. The rejected action is not replayed: the user has
+        // to redo it.
+        await expect(page).toHaveURL(new RegExp(`computer\\.form\\.php\\?id=${computer_id}$`));
+        await expect(prompt.heading).toBeHidden();
     });
 
     test('cancel returns to the origin page', async ({ page }) => {

--- a/tests/functional/Glpi/Controller/ErrorControllerTest.php
+++ b/tests/functional/Glpi/Controller/ErrorControllerTest.php
@@ -39,8 +39,10 @@ use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Exception\Http\HttpException;
 use Glpi\Exception\Http\NotFoundHttpException;
+use Glpi\Exception\Http\ReAuthRequiredHttpException;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Session;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -290,5 +292,28 @@ class ErrorControllerTest extends DbTestCase
 
         $this->assertArrayHasKey('trace', $decoded_content);
         $this->assertEquals($debug_mode, $decoded_content['trace'] !== null);
+    }
+
+    /**
+     * Headers carried by the exception must reach the response, whatever its shape: Symfony drops
+     * them as soon as the error response is built by this controller instead of by the kernel.
+     *
+     * @param array<string, string> $server
+     */
+    #[TestWith([[]], 'error page')]
+    #[TestWith([['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']], 'error block')]
+    #[TestWith([['HTTP_ACCEPT' => 'application/json']], 'json')]
+    public function testExceptionHeadersAreForwardedToTheResponse(array $server): void
+    {
+        // --- arrange ---
+        $exception = new ReAuthRequiredHttpException();
+        $controller = new ErrorController();
+
+        // --- act ---
+        $response = $controller->__invoke(new Request(server: $server), $exception);
+
+        // --- assert ---
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('1', $response->headers->get(ReAuthRequiredHttpException::HEADER));
     }
 }

--- a/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
+++ b/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Security\ReAuth;
 
 use Computer;
+use Glpi\Exception\Http\ReAuthRequiredHttpException;
 use Glpi\Exception\RedirectException;
 use Glpi\Security\ReAuth\ReAuthManager;
 use Glpi\Tests\DbTestCase;
@@ -42,6 +43,7 @@ use Glpi\Tests\Glpi\Security\ReAuth\ReAuthTrait;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use Safe\DateTime;
 use User;
 
@@ -59,8 +61,9 @@ class ReAuthManagerTest extends DbTestCase
 
     public function tearDown(): void
     {
-        // Always restore the CLI flag so the reauth branch does not leak to other tests.
-        unset($GLOBALS['GLPI_IS_COMMAND_LINE']);
+        // Always restore the request context (CLI flag included) so the reauth branch taken here
+        // does not leak to other tests.
+        $this->restoreWebContext();
         $this->resetReAuthManager();
         parent::tearDown();
     }
@@ -206,6 +209,113 @@ class ReAuthManagerTest extends DbTestCase
 
         // --- assert ---
         $this->assertSame($CFG_GLPI['root_doc'], $this->getReAuthManager()->getOriginURL());
+    }
+
+    /**
+     * Requests that cannot display the prompt are denied with a marked 403 instead of being
+     * redirected, and the page they were issued from becomes the target of the re-authentication:
+     * the client only has to send the browser to the prompt, whatever the page it is on.
+     */
+    // The prompt is a full page: injecting it in the current one is meaningless.
+    #[TestWith([true, 'text/html'], 'ajax request')]
+    // The caller does not expect HTML at all.
+    #[TestWith([false, 'application/json'], 'json request')]
+    public function testRedirectToReauthDeniesRequestsThatCannotDisplayThePrompt(
+        bool $xml_http_request,
+        string $accept
+    ): void {
+        // --- arrange ---
+        $caller_page = 'https://glpi.example.org/front/user.form.php?id=2';
+        $this->fakeWebContext(
+            request_uri: '/ajax/dropdownValue.php',
+            referer: $caller_page,
+            xml_http_request: $xml_http_request,
+            accept: $accept,
+        );
+
+        // --- act ---
+        try {
+            $this->getReAuthManager()->redirectToReauth();
+            $this->fail('A ReAuthRequiredHttpException should have been thrown.');
+        } catch (ReAuthRequiredHttpException $e) {
+            // --- assert ---
+            $this->assertSame(403, $e->getStatusCode());
+            $this->assertSame('1', $e->getHeaders()[ReAuthRequiredHttpException::HEADER] ?? null);
+        }
+
+        // The denied endpoint is not the target: replaying it would display its raw answer. The
+        // user is sent back to the page instead, and has to redo the action.
+        $this->assertSame('GET', $this->getReAuthManager()->getRequestedMethod());
+        // The query string goes with the data and not in the URL, as the replayed GET is submitted
+        // as a form (see testRedirectToReauthStoresUrlWithoutGetParams).
+        $this->assertSame(
+            'https://glpi.example.org/front/user.form.php',
+            $this->getReAuthManager()->getRequestedURL()
+        );
+        $this->assertSame(['id' => '2'], $this->getReAuthManager()->getRequestedPostData());
+        // Cancelling the prompt leads back to that same page.
+        $this->assertSame($caller_page, $this->getReAuthManager()->getOriginURL());
+    }
+
+    /**
+     * A Referer that cannot be used as a landing page degrades into the GLPI home page: anything
+     * else would either loop or send the user to a page GLPI does not serve.
+     */
+    // Dropped by a referrer policy, or a client that does not send one.
+    #[TestWith([''], 'no referer')]
+    // Landing back on the re-authentication flow would loop.
+    #[TestWith(['https://glpi.example.org/ReAuth/Prompt'], 'reauth route')]
+    // A path GLPI would never serve.
+    #[TestWith(['https://glpi.example.org/front/../../etc/passwd'], 'traversal attempt')]
+    public function testDeniedRequestTargetFallsBackToHomeWhenRefererIsUnusable(string $referer): void
+    {
+        global $CFG_GLPI;
+
+        // --- arrange ---
+        $this->fakeWebContext(
+            request_uri: '/ajax/dropdownValue.php',
+            referer: $referer,
+            xml_http_request: true,
+        );
+
+        // --- act ---
+        try {
+            $this->getReAuthManager()->redirectToReauth();
+            $this->fail('A ReAuthRequiredHttpException should have been thrown.');
+        } catch (ReAuthRequiredHttpException) {
+        }
+
+        // --- assert ---
+        $home_url = 'https://glpi.example.org' . $CFG_GLPI['root_doc'] . '/';
+        $this->assertSame($home_url, $this->getReAuthManager()->getRequestedURL());
+        $this->assertSame($home_url, $this->getReAuthManager()->getOriginURL());
+    }
+
+    /**
+     * The Referer host is never reused: a forged one must not turn the re-authentication into an
+     * open redirection.
+     */
+    public function testDeniedRequestTargetIgnoresTheRefererHost(): void
+    {
+        // --- arrange ---
+        $this->fakeWebContext(
+            request_uri: '/ajax/dropdownValue.php',
+            referer: 'https://evil.example.org/front/central.php',
+            xml_http_request: true,
+        );
+
+        // --- act ---
+        try {
+            $this->getReAuthManager()->redirectToReauth();
+            $this->fail('A ReAuthRequiredHttpException should have been thrown.');
+        } catch (ReAuthRequiredHttpException) {
+        }
+
+        // --- assert : only the path was kept, the host comes from the current request ---
+        $this->assertSame(
+            'https://glpi.example.org/front/central.php',
+            $this->getReAuthManager()->getRequestedURL()
+        );
     }
 
     /** All getters return safe defaults when the re-auth session keys are absent. */

--- a/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
+++ b/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
@@ -78,6 +78,8 @@ trait ReAuthTrait
      *
      * @param array<string, string> $get
      * @param array<string, string> $post
+     * @param bool                  $xml_http_request send the request as an AJAX call
+     * @param string                $accept           Accept header, drives Request::getPreferredFormat()
      */
     private function fakeWebContext(
         string $request_uri = '/front/central.php',
@@ -85,6 +87,8 @@ trait ReAuthTrait
         array $get = [],
         array $post = [],
         string $referer = 'https://glpi.example.org/front/central.php',
+        bool $xml_http_request = false,
+        string $accept = 'text/html',
     ): void {
         // getMainRequest() falls back to Request::createFromGlobals() in the test context, so the
         // super globals must carry the exact keys Symfony reads: HTTPS (not REQUEST_SCHEME) drives
@@ -102,6 +106,12 @@ trait ReAuthTrait
         // A real web request always carries a client IP; without it SessionTracker::recordNewSession()
         // would try to insert a NULL ip_address when login() is called under the faked web context.
         $_SERVER['REMOTE_ADDR']    = '127.0.0.1';
+        $_SERVER['HTTP_ACCEPT']    = $accept;
+        if ($xml_http_request) {
+            $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        } else {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
         $_GET  = $get ?: $get_from_uri;
         $_POST = $post;
     }
@@ -120,6 +130,8 @@ trait ReAuthTrait
             $_SERVER['REQUEST_METHOD'],
             $_SERVER['HTTP_REFERER'],
             $_SERVER['REMOTE_ADDR'],
+            $_SERVER['HTTP_ACCEPT'],
+            $_SERVER['HTTP_X_REQUESTED_WITH'],
         );
     }
 


### PR DESCRIPTION
Ajax requests requiring reauth are now handled.
This is to handle edge cases (see the Notice part below).

Given a non protected page or a protected page with expired reauth triggers an ajax request requiring reauth
Then a reauth prompt is displayed.

Notice that after the reauth, the ajax requested requiring reauth is not replayed, user has to click the button again.
This is not a big deal since it won't happen very often. Pages with an ajax request requiring reauth occurs most probably on a protected page, so reauth will be triggered on that page, before the ajax request. An other possible case is that reauth expired between the main page request and the ajax request.

Most of the code is ai generated, I have no idea if the js part is done at the right place, the right way. I'll process an ai code review later to confirm it.
