### PR TITLE
warning message if reauth disabled by constant.

### DIFF
--- a/src/Central.php
+++ b/src/Central.php
@@ -652,6 +652,15 @@ class Central extends CommonGLPI
                 }
             }
 
+            // Re-authentication on sensitive actions can be turned off by a constant.
+            // It lowers the security level of the whole instance: warn the administrators.
+            if (GLPI_DISABLE_REAUTH === true) {
+                $messages['warnings'][] = sprintf(
+                    __s('Re-authentication on sensitive actions is disabled by the "%s" constant.'),
+                    'GLPI_DISABLE_REAUTH'
+                ) . ' ' . __s('Remove it from your configuration to restore the expected security level.');
+            }
+
             // Check for available plugin updates
             $count = Controller::countUpdatablePlugins();
 


### PR DESCRIPTION
# Warn administrators when re-authentication is disabled

`GLPI_DISABLE_REAUTH` silently turns off re-authentication on sensitive actions, and nothing in
the UI tells administrators that the protection is off. A warning is now displayed on the Central
page when the constant is enabled.

<img width="1474" height="692" alt="image" src="https://github.com/user-attachments/assets/86276762-784c-42d3-a8bb-edb728c19675" />
