### PR TITLE
protect plugin & marketplace page plus their actions

### DIFF
--- a/ajax/marketplace.php
+++ b/ajax/marketplace.php
@@ -40,7 +40,7 @@ if (($_GET["action"] ?? null) === "get_dl_progress") {
     return;
 }
 
-Session::checkRight("config", UPDATE);
+(new Config())->checkGlobal(UPDATE);
 
 use Glpi\Marketplace\Controller as MarketplaceController;
 use Glpi\Marketplace\View as MarketplaceView;

--- a/front/marketplace.php
+++ b/front/marketplace.php
@@ -38,7 +38,7 @@ use Glpi\Marketplace\View;
 
 require_once(__DIR__ . '/_check_webserver_config.php');
 
-Session::checkRight("config", UPDATE);
+(new Config())->checkGlobal(UPDATE);
 
 if (!Controller::isWebAllowed()) {
     // Redirect to classic plugins page

--- a/front/plugin.form.php
+++ b/front/plugin.form.php
@@ -37,11 +37,7 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\Exception\Http\BadRequestHttpException;
 
-/**
- * @since 0.84
- */
-
-Session::checkRight("config", UPDATE);
+(new Config())->checkGlobal(UPDATE);
 
 $plugin = new Plugin();
 

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -38,7 +38,7 @@ use Glpi\Marketplace\View;
 
 require_once(__DIR__ . '/_check_webserver_config.php');
 
-Session::checkRight("config", UPDATE);
+(new Config())->checkGlobal(UPDATE);
 
 // This has to be called before search process is called, in order to add
 // "new" plugins in DB to be able to display them.

--- a/src/Glpi/Security/ReAuth/ReAuthManager.php
+++ b/src/Glpi/Security/ReAuth/ReAuthManager.php
@@ -37,6 +37,7 @@ declare(strict_types=1);
 namespace Glpi\Security\ReAuth;
 
 use Glpi\Application\Environment;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\RedirectException;
 use Glpi\Kernel\Kernel;
 use Glpi\Toolbox\SingletonTrait;
@@ -60,7 +61,7 @@ final class ReAuthManager
     private array $additional_strategies = [];
 
     /**
-     * @throws RedirectException
+     * @throws RedirectException|AccessDeniedHttpException
      */
     public function checkReAuthenticationOrRedirect(): void
     {
@@ -74,11 +75,18 @@ final class ReAuthManager
     /**
      * Redirect to reauth prompt and save current request data (url + post data)
      *
-     * @throws RedirectException
+     * Requests that cannot display the prompt (AJAX, or a client expecting anything else than
+     * HTML) are denied instead of being redirected.
+     *
+     * @throws RedirectException|AccessDeniedHttpException
      */
     public function redirectToReauth(): never
     {
         global $CFG_GLPI;
+
+        if (!$this->canDisplayPrompt()) {
+            throw new AccessDeniedHttpException('Re-authentication required.');
+        }
 
         $this->setRequestedTarget();
 
@@ -360,5 +368,18 @@ final class ReAuthManager
             'POST' => 'POST',
             default => throw new \LogicException(sprintf('Unsupported HTTP method for redirect: %s', $http_method)),
         };
+    }
+
+    /**
+     * Requests that cannot be answered with the prompt page are denied instead of redirected.
+     */
+    private function canDisplayPrompt(): bool
+    {
+        /** @var Kernel $kernel */
+        global $kernel;
+
+        $request = $kernel->getMainRequest();
+
+        return !$request->isXmlHttpRequest() && $request->getPreferredFormat() === 'html';
     }
 }

--- a/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
+++ b/tests/functional/Glpi/Security/ReAuth/ReAuthManagerTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Security\ReAuth;
 
 use Computer;
+use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\RedirectException;
 use Glpi\Security\ReAuth\ReAuthManager;
 use Glpi\Tests\DbTestCase;
@@ -42,6 +43,7 @@ use Glpi\Tests\Glpi\Security\ReAuth\ReAuthTrait;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use Safe\DateTime;
 use User;
 
@@ -59,8 +61,9 @@ class ReAuthManagerTest extends DbTestCase
 
     public function tearDown(): void
     {
-        // Always restore the CLI flag so the reauth branch does not leak to other tests.
-        unset($GLOBALS['GLPI_IS_COMMAND_LINE']);
+        // Always restore the request context (CLI flag included) so the reauth branch taken here
+        // does not leak to other tests.
+        $this->restoreWebContext();
         $this->resetReAuthManager();
         parent::tearDown();
     }
@@ -206,6 +209,34 @@ class ReAuthManagerTest extends DbTestCase
 
         // --- assert ---
         $this->assertSame($CFG_GLPI['root_doc'], $this->getReAuthManager()->getOriginURL());
+    }
+
+    /**
+     * Requests that cannot display the prompt are denied instead of being redirected to it.
+     */
+    #[TestWith([true, 'text/html'], 'ajax request')] // The prompt is a full page: injecting it in the current one is meaningless.
+    #[TestWith([false, 'application/json'], 'json request')] // The caller does not expect HTML at all.
+    public function testRedirectToReauthDeniesRequestsThatCannotDisplayThePrompt(
+        bool $xml_http_request,
+        string $accept
+    ): void {
+        // --- arrange ---
+        $this->fakeWebContext(
+            request_uri: '/ajax/dropdownValue.php',
+            xml_http_request: $xml_http_request,
+            accept: $accept,
+        );
+
+        // --- act ---
+        try {
+            $this->getReAuthManager()->redirectToReauth();
+            $this->fail('An AccessDeniedHttpException should have been thrown.');
+        } catch (AccessDeniedHttpException $e) {
+            // --- assert ---
+            $this->assertSame(403, $e->getStatusCode());
+            // The refusal is about the missing re-authentication, not about missing rights.
+            $this->assertSame('Re-authentication required.', $e->getMessage());
+        }
     }
 
     /** All getters return safe defaults when the re-auth session keys are absent. */

--- a/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
+++ b/tests/src/Glpi/Security/ReAuth/ReAuthTrait.php
@@ -78,6 +78,8 @@ trait ReAuthTrait
      *
      * @param array<string, string> $get
      * @param array<string, string> $post
+     * @param bool                  $xml_http_request send the request as an AJAX call
+     * @param string                $accept           Accept header, drives Request::getPreferredFormat()
      */
     private function fakeWebContext(
         string $request_uri = '/front/central.php',
@@ -85,6 +87,8 @@ trait ReAuthTrait
         array $get = [],
         array $post = [],
         string $referer = 'https://glpi.example.org/front/central.php',
+        bool $xml_http_request = false,
+        string $accept = 'text/html',
     ): void {
         // getMainRequest() falls back to Request::createFromGlobals() in the test context, so the
         // super globals must carry the exact keys Symfony reads: HTTPS (not REQUEST_SCHEME) drives
@@ -102,6 +106,12 @@ trait ReAuthTrait
         // A real web request always carries a client IP; without it SessionTracker::recordNewSession()
         // would try to insert a NULL ip_address when login() is called under the faked web context.
         $_SERVER['REMOTE_ADDR']    = '127.0.0.1';
+        $_SERVER['HTTP_ACCEPT']    = $accept;
+        if ($xml_http_request) {
+            $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        } else {
+            unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        }
         $_GET  = $get ?: $get_from_uri;
         $_POST = $post;
     }
@@ -120,6 +130,8 @@ trait ReAuthTrait
             $_SERVER['REQUEST_METHOD'],
             $_SERVER['HTTP_REFERER'],
             $_SERVER['REMOTE_ADDR'],
+            $_SERVER['HTTP_ACCEPT'],
+            $_SERVER['HTTP_X_REQUESTED_WITH'],
         );
     }
 


### PR DESCRIPTION
Protect plugin and marketplace pages and actions ((uninstall install, marketplace dowload etc)

**Additional Changes**

No redirection for AJAX/JSON requests — `ReAuthManager::redirectToReauth()` now answers a 403 instead of redirecting when the request cannot display the prompt (`src/Glpi/Security/ReAuth/ReAuthManager.php:87`). 
Marketplace actions are AJAX calls, and redirecting them made jQuery follow the 302 and inject the prompt page into the plugin button bar. 

**PR replacement**

[Previous PR](https://github.com/glpi-project/glpi/pull/25018) tried to handle reauth need on ajax calls, this one doesn't.
It means an ajax action doesn't trigger reauth. This is not a big deal because the page that contain the actions is also needing reauthentication, in other words accessing the buttons require a valid reauth. 
So only the edge case happen when reauth expire between the access to marketplace page and the click on action buttons.
This could be handled later when basic requirements are met, see note below.

**Notes for reviewers / further changes**

The AJAX refusal is silent client-side. `js/marketplace.js` has no `.fail()` on its requests and GLPI has no global `ajaxError` handler, so a refused action leaves the button spinner running with no message; the user has to reload the page to reach the prompt. Worth deciding whether this PR carries the client-side part or whether it lands separately.

--- 

