### PR TITLE
fix(ui): gracefully handle open_basedir restrictions when checking SELinux binaries

### DIFF
--- a/src/Glpi/System/Requirement/SeLinux.php
+++ b/src/Glpi/System/Requirement/SeLinux.php
@@ -168,7 +168,7 @@ class SeLinux extends AbstractRequirement
 
     protected function doesSelinuxBinariesExists(): bool
     {
-        return file_exists('/usr/sbin/getenforce') && file_exists('/usr/sbin/getsebool');
+        return @file_exists('/usr/sbin/getenforce') && @file_exists('/usr/sbin/getsebool');
     }
 
     protected function doesSelinuxIsEnabledFunctionExists(): bool


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR closes #24948 by adding the `@` error suppression operator to the `file_exists` calls when checking for `getenforce` and `getsebool` binaries in `Glpi\System\Requirement\SeLinux`. 

This is consistent with other areas of the GLPI codebase where the `@` operator is used to gracefully handle file and system access limitations without polluting the logs or breaking the application. For example:
- `@is_dir($config_dir)` in `bin/console` 
- `@file_get_contents($this->keyfile)` in `src/GLPIKey.php`
- `@exec('git show...')` in `src/Config.php`
- `@fopen($path, 'c')` in `src/Glpi/Toolbox/Filesystem.php`

## Screenshots (if appropriate):

<img width="1200" height="680" alt="image" src="https://github.com/user-attachments/assets/7d4ed546-82d6-430b-abe4-74f56f6cace2" />
