### PR TITLE
fix(kb): gracefully handle duplicate entries in knowledge base categories

### DIFF
--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -177,6 +177,33 @@ abstract class CommonTreeDropdown extends CommonDropdown
     }
 
 
+    public function addToDB()
+    {
+        try {
+            return parent::addToDB();
+        } catch (RuntimeException $e) {
+            // MySQL error 1062: Duplicate entry — handle gracefully instead of crashing
+            if (str_contains($e->getMessage(), '(1062)')) {
+                $message_text = sprintf(
+                    __('%1$s - %2$s'),
+                    $this->getTypeName(1),
+                    $this->fields['name'] ?? ''
+                );
+                Session::addMessageAfterRedirect(
+                    htmlescape(sprintf(
+                        __('Item not added: a duplicate already exists (%s)'),
+                        $message_text
+                    )),
+                    false,
+                    ERROR
+                );
+                return false;
+            }
+            throw $e;
+        }
+    }
+
+
     public function prepareInputForAdd($input)
     {
         return $this->adaptTreeFieldsFromUpdateOrAdd($input);
@@ -941,7 +968,7 @@ TWIG, $twig_params);
                     'completename' => $input['completename'],
                 ],
             ];
-            if ($this->isEntityAssign()) {
+            if ($this->isField('entities_id') && isset($input['entities_id'])) {
                 $criteria['WHERE'] += getEntitiesRestrictCriteria(
                     $this->getTable(),
                     '',
@@ -966,7 +993,7 @@ TWIG, $twig_params);
                     $fk      => ($input[$fk] ?? 0),
                 ],
             ];
-            if ($this->isEntityAssign()) {
+            if ($this->isField('entities_id') && isset($input['entities_id'])) {
                 $criteria['WHERE'] += getEntitiesRestrictCriteria(
                     $this->getTable(),
                     '',

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -177,33 +177,6 @@ abstract class CommonTreeDropdown extends CommonDropdown
     }
 
 
-    public function addToDB()
-    {
-        try {
-            return parent::addToDB();
-        } catch (RuntimeException $e) {
-            // MySQL error 1062: Duplicate entry — handle gracefully instead of crashing
-            if (str_contains($e->getMessage(), '(1062)')) {
-                $message_text = sprintf(
-                    __('%1$s - %2$s'),
-                    $this->getTypeName(1),
-                    $this->fields['name'] ?? ''
-                );
-                Session::addMessageAfterRedirect(
-                    htmlescape(sprintf(
-                        __('Item not added: a duplicate already exists (%s)'),
-                        $message_text
-                    )),
-                    false,
-                    ERROR
-                );
-                return false;
-            }
-            throw $e;
-        }
-    }
-
-
     public function prepareInputForAdd($input)
     {
         return $this->adaptTreeFieldsFromUpdateOrAdd($input);

--- a/src/KnowbaseItemCategory.php
+++ b/src/KnowbaseItemCategory.php
@@ -58,6 +58,36 @@ class KnowbaseItemCategory extends CommonTreeDropdown
         return parent::canView();
     }
 
+    public function prepareInputForAdd($input)
+    {
+        $input = parent::prepareInputForAdd($input);
+        if ($input === false) {
+            return false;
+        }
+
+        if (isset($input['name'])) {
+            $id = $this->findID($input);
+            if ($id > 0) {
+                $message_text = sprintf(
+                    __('%1$s - %2$s'),
+                    static::getTypeName(1),
+                    $input['name']
+                );
+                Session::addMessageAfterRedirect(
+                    htmlescape(sprintf(
+                        __('Item not added: a duplicate already exists (%s)'),
+                        $message_text
+                    )),
+                    false,
+                    ERROR
+                );
+                return false;
+            }
+        }
+
+        return $input;
+    }
+
     public static function getIcon()
     {
         return KnowbaseItem::getIcon();

--- a/tests/functional/KnowbaseTest.php
+++ b/tests/functional/KnowbaseTest.php
@@ -321,4 +321,32 @@ class KnowbaseTest extends DbTestCase
         ];
         $this->assertEquals($expected, $tree_with_public_faq);
     }
+
+    public function testDuplicateCategoryIsHandledGracefully(): void
+    {
+        $this->login();
+
+        $category = new \KnowbaseItemCategory();
+
+        // Create the initial category — this should succeed
+        $category_id = $category->add([
+            'name'        => 'Grafana',
+            'entities_id' => 0,
+        ]);
+        $this->assertGreaterThan(0, $category_id);
+
+        // Attempt to create a duplicate — should return false instead of throwing a RuntimeException
+        $duplicate_id = $category->add([
+            'name'        => 'Grafana',
+            'entities_id' => 0,
+        ]);
+        $this->assertFalse($duplicate_id, 'Duplicate KnowbaseItemCategory should not be inserted');
+
+        // A user-facing error message should have been queued
+        $expected_message = sprintf(
+            __('Item not added: a duplicate already exists (%s)'),
+            sprintf(__('%1$s - %2$s'), \KnowbaseItemCategory::getTypeName(1), 'Grafana')
+        );
+        $this->hasSessionMessages(ERROR, [$expected_message]);
+    }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When creating a duplicate item in a Knowledge Base Category tree dropdown, GLPI would attempt to insert the duplicate and crash with a fatal `RuntimeException` from MySQL error `1062` (Duplicate entry) instead of showing a user-friendly message (Closes #24559).

`CommonTreeDropdown::findID()` was calling `$this->isEntityAssign()` to decide whether to scope duplicate lookups by entity. However, `isEntityAssign()` internally calls `$this->getEmpty()` when `$this->fields` is not yet populated (e.g. during the `add()` lifecycle before the item is saved). `getEmpty()` wipes all populated data in `$this->fields` and replaces it with database defaults, which could cause downstream strict-mode SQL errors.

### Solution

1. **Graceful duplicate handling:** Added a duplicate check in `KnowbaseItemCategory::prepareInputForAdd()`. If a category with the exact same name and parent already exists, it gracefully intercepts the addition by queuing a user-facing error via `Session::addMessageAfterRedirect()` and returning `false`. This avoids crashing the application at the database level while intentionally keeping the validation specific to the class that actually requires a DB-level unique constraint (avoiding breakages in core tests that rely on inserting duplicates for other dropdowns like `Group` and `ITILCategory`).

2. **`getEmpty()` side-effect fix:** Replaced the two `$this->isEntityAssign()` calls in `findID()` with `$this->isField('entities_id') && isset($input['entities_id'])`. This avoids triggering `getEmpty()` mid-`add()` lifecycle while preserving the original intent: only apply entity restriction when the table has the column **and** the input actually provides an entity value.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/07ac0451-537b-49e1-8cc1-1420e52fbd39
