### PR TITLE
Fix: cover add-tile button rights with a regression test

### DIFF
--- a/src/Glpi/Controller/Config/Helpdesk/ShowAddTileFormController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/ShowAddTileFormController.php
@@ -48,14 +48,15 @@ final class ShowAddTileFormController extends AbstractTileController
     )]
     public function __invoke(Request $request): Response
     {
+        if (!$this->tiles_manager->canAddTile()) {
+            throw new AccessDeniedHttpException();
+        }
+
         $possible_tiles = [];
         foreach ($this->tiles_manager->getTileTypes() as $tile_type) {
             if ($tile_type::canCreate()) {
                 $possible_tiles[] = $tile_type;
             }
-        }
-        if ($possible_tiles === []) {
-            throw new AccessDeniedHttpException();
         }
 
         $possible_tiles_dropdown_values = [];

--- a/src/Glpi/Helpdesk/Tile/TilesManager.php
+++ b/src/Glpi/Helpdesk/Tile/TilesManager.php
@@ -343,6 +343,19 @@ final class TilesManager
         ]);
     }
 
+    /**
+     * Whether the current user is allowed to create at least one tile type.
+     */
+    public function canAddTile(): bool
+    {
+        foreach ($this->getTileTypes() as $tile_type) {
+            if ($tile_type::canCreate()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public function copyTilesFromParentEntity(Entity $entity): void
     {
         $parent_entity = Entity::getById($entity->fields['entities_id']);

--- a/templates/pages/admin/helpdesk_home_config_tiles.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_tiles.html.twig
@@ -83,16 +83,16 @@
         </div>
     </section>
 {% else %}
-    {# If the content is not editable and the list is empty, we need to add
-    a empty state text as the user will not see the "Add tile" button #}
-    {% if not editable %}
+    {# If the list is empty and the user will not see the "Add tile" button,
+    we need to add an empty state text instead #}
+    {% if not editable or not tiles_manager.canAddTile() %}
         <span class="text-muted">
             {{ __("There are no tiles defined for this item.") }}
         </span>
     {% endif %}
 {% endfor %}
 
-{% if editable %}
+{% if editable and tiles_manager.canAddTile() %}
     <div
         role="button"
         aria-label="{{ __('Add tile') }}"

--- a/tests/src/AbstractTileRightsTest.php
+++ b/tests/src/AbstractTileRightsTest.php
@@ -35,6 +35,7 @@
 namespace Glpi\Tests;
 
 use CommonDBTM;
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Helpdesk\Tile\Item_Tile;
 use Glpi\Helpdesk\Tile\TileInterface;
 use Glpi\Helpdesk\Tile\TilesManager;
@@ -100,6 +101,12 @@ abstract class AbstractTileRightsTest extends DbTestCase
         // least one tile type (this is what gates the "Add tile" button
         // visibility).
         $this->assertTrue(TilesManager::getInstance()->canAddTile());
+
+        // ...and the "Add tile" button must actually be rendered.
+        $this->assertStringContainsString(
+            'data-glpi-helpdesk-config-action-new-tile',
+            $this->renderTilesTemplate(),
+        );
     }
 
     /**
@@ -145,6 +152,12 @@ abstract class AbstractTileRightsTest extends DbTestCase
         // ...and TilesManager must confirm this user is not allowed to add
         // any tile type.
         $this->assertFalse(TilesManager::getInstance()->canAddTile());
+
+        // ...and the "Add tile" button must not be rendered.
+        $this->assertStringNotContainsString(
+            'data-glpi-helpdesk-config-action-new-tile',
+            $this->renderTilesTemplate(),
+        );
     }
 
     /**
@@ -210,6 +223,21 @@ abstract class AbstractTileRightsTest extends DbTestCase
         $tile_id = $item_tile->fields['items_id_tile'];
 
         return [$tile_class, $tile_id];
+    }
+
+    /**
+     * Render the "Add tile" config template for the currently logged in user.
+     */
+    private function renderTilesTemplate(): string
+    {
+        return TemplateRenderer::getInstance()->render(
+            'pages/admin/helpdesk_home_config_tiles.html.twig',
+            [
+                'tiles_manager' => TilesManager::getInstance(),
+                'tiles'         => [],
+                'editable'      => true,
+            ]
+        );
     }
 
     /**

--- a/tests/src/AbstractTileRightsTest.php
+++ b/tests/src/AbstractTileRightsTest.php
@@ -95,6 +95,11 @@ abstract class AbstractTileRightsTest extends DbTestCase
             '_items_id_item' => $linked_profile->getID(),
         ];
         $this->assertTrue((new $tile_class())->can(-1, CREATE, $create_input));
+
+        // ...and TilesManager must confirm this user is allowed to add at
+        // least one tile type (this is what gates the "Add tile" button
+        // visibility).
+        $this->assertTrue(TilesManager::getInstance()->canAddTile());
     }
 
     /**
@@ -136,6 +141,10 @@ abstract class AbstractTileRightsTest extends DbTestCase
             '_items_id_item' => $linked_profile->getID(),
         ];
         $this->assertFalse((new $tile_class())->can(-1, CREATE, $create_input));
+
+        // ...and TilesManager must confirm this user is not allowed to add
+        // any tile type.
+        $this->assertFalse(TilesManager::getInstance()->canAddTile());
     }
 
     /**


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45219
- Ensures the "Add tile" button on the helpdesk home configuration page only appears for users who actually have the rights to add a tile.

## Screenshots (if appropriate):

