### PR TITLE
fix(license): duplicate items in software license dropdown

### DIFF
--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -659,11 +659,37 @@ class Item_SoftwareLicense extends CommonDBRelation
                 ]
             );
 
-            $p = ['idtable'            => '__VALUE__',
+            $used = [];
+            $iterator = $DB->request([
+                'SELECT' => ['itemtype', 'items_id'],
+                'FROM'   => self::getTable(),
+                'WHERE'  => [
+                    'softwarelicenses_id' => $searchID,
+                    'is_deleted'          => 0,
+                ],
+            ]);
+            foreach ($iterator as $data) {
+                $used[$data['itemtype']][$data['items_id']] = $data['items_id'];
+            }
+
+            $iterator = $DB->request([
+                'SELECT' => ['users_id'],
+                'FROM'   => SoftwareLicense_User::getTable(),
+                'WHERE'  => [
+                    'softwarelicenses_id' => $searchID,
+                ],
+            ]);
+            foreach ($iterator as $data) {
+                $used['User'][$data['users_id']] = $data['users_id'];
+            }
+
+            $p = [
+                'idtable'            => '__VALUE__',
                 'rand'                  => $rand,
                 'name'                  => "items_id",
                 'width'                 => 'unset',
-                'entity_restrict'    => $entity_restrict,
+                'entity_restrict'       => $entity_restrict,
+                'used'                  => $used,
             ];
 
             Ajax::updateItemOnSelectEvent(

--- a/src/Item_SoftwareLicense.php
+++ b/src/Item_SoftwareLicense.php
@@ -659,11 +659,37 @@ class Item_SoftwareLicense extends CommonDBRelation
                 ]
             );
 
-            $p = ['idtable'            => '__VALUE__',
+            $used = [];
+            $iterator = $DB->request([
+                'SELECT' => ['itemtype', 'items_id'],
+                'FROM'   => self::getTable(),
+                'WHERE'  => [
+                    'softwarelicenses_id' => $searchID,
+                    'is_deleted'          => 0
+                ]
+            ]);
+            foreach ($iterator as $data) {
+                $used[$data['itemtype']][$data['items_id']] = $data['items_id'];
+            }
+
+            $iterator = $DB->request([
+                'SELECT' => ['users_id'],
+                'FROM'   => SoftwareLicense_User::getTable(),
+                'WHERE'  => [
+                    'softwarelicenses_id' => $searchID,
+                ]
+            ]);
+            foreach ($iterator as $data) {
+                $used['User'][$data['users_id']] = $data['users_id'];
+            }
+
+            $p = [
+                'idtable'            => '__VALUE__',
                 'rand'                  => $rand,
                 'name'                  => "items_id",
                 'width'                 => 'unset',
-                'entity_restrict'    => $entity_restrict,
+                'entity_restrict'       => $entity_restrict,
+                'used'                  => $used,
             ];
 
             Ajax::updateItemOnSelectEvent(


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

### Description
When navigating to the **Affected items** tab of a License, the dropdown to add new items (such as Computers) was failing to exclude items that were already linked to the license (Closes #24950).

This happened because the dropdown initialization did not pass the `used` array parameter during the AJAX request, which is required for `dropdownAllItems.php` to filter out already-linked assets. As a result, items like computers incorrectly reappeared as available to be added.

This PR fixes the issue by querying both `glpi_items_softwarelicenses` and `glpi_softwarelicenses_users` to build the `used` array and correctly passing it along in the `$p` array to the AJAX dropdown handler.

## Screenshots (if appropriate):

<img width="1201" height="624" alt="image" src="https://github.com/user-attachments/assets/9e1b3934-746f-421c-abb2-94da013b387b" />
