### PR TITLE
fix(ui): Uncaught TypeError in Stencil Editor when removing active network port

### DIFF
--- a/js/stencil-editor.js
+++ b/js/stencil-editor.js
@@ -225,6 +225,10 @@ const StencilEditor = function (container, rand, zones_definition) {
                 && cropper.getCropperSelection().width > 0;
         })[0];
 
+        if (cropper === undefined) {
+            return;
+        }
+
         // get the different dom object
         const cr_canvas = cropper.getCropperCanvas();
         const cr_selection = cropper.getCropperSelection();
@@ -404,9 +408,23 @@ const StencilEditor = function (container, rand, zones_definition) {
             success: function () {
                 // Hide tooltip to avoid bug : tooltip doesn't disappear when dom is altered
                 $(`form#stencil-editor-form-${rand} button[name="remove-zone"][data-bs-toggle="tooltip"]`).tooltip('hide');
-                $(`form#stencil-editor-form-${rand} button.set-zone-data`).sort((a, b) => {
+                const lastBtn = $(`form#stencil-editor-form-${rand} button.set-zone-data`).sort((a, b) => {
                     return $(a).data('zone-index') - $(b).data('zone-index');
-                }).last().remove();
+                }).last();
+                
+                const removedZoneIndex = lastBtn.data('zone-index');
+                lastBtn.remove();
+                
+                if (zones[removedZoneIndex] !== undefined) {
+                    delete zones[removedZoneIndex];
+                }
+                
+                const currentZoneIndex = $(container).find(`#zone_number-${rand}`).data('zone-index');
+                if (_this.isEditorActive() && currentZoneIndex == removedZoneIndex) {
+                    _this.editorDisable();
+                } else {
+                    _this.redoZones();
+                }
             },
         });
     };


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

This PR fixes a bug where removing a network port in the Stencil Editor while its form is active throws an `Uncaught TypeError` in the browser console (Closes #23613). 

When a port was removed via the "-" icon, the original logic didn't appropriately clean up the local memory state or close the editor if that exact port was actively selected. This left the "Save port data" button active and its event listener bound. If "Save port data" was subsequently clicked, the `saveZoneData` function attempted to access a Cropper instance for a non-existent port, causing the page to crash.

**Changes:**
1. Modified `removeZone` in `js/stencil-editor.js` to track the ID of the removed zone. If the removed zone matches the currently active zone being edited, it now triggers `editorDisable()` to gracefully shut down the form. 
2. Updated `removeZone` to cleanly delete the removed zone from the `zones` object and trigger a UI redraw of the remaining zones.
3. Added a safety guard in `saveZoneData` to return gracefully instead of crashing if a valid `cropper` instance isn't found.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/1f57517c-aa82-425f-9905-aa93a12a5879
