### PR TITLE
fix(ui): Enforce single port mapping across front and rear images in Network Equipment Models

### DIFF
--- a/js/stencil-editor.js
+++ b/js/stencil-editor.js
@@ -457,3 +457,8 @@ const StencilEditor = function (container, rand, zones_definition) {
         });
     };
 };
+
+/* eslint-disable no-undef */
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = StencilEditor;
+}

--- a/js/stencil-editor.js
+++ b/js/stencil-editor.js
@@ -61,14 +61,17 @@ const StencilEditor = function (container, rand, zones_definition) {
             croppers.push(cropper);
             img.cropper = cropper;
 
-            // clear other croppers on interaction to enforce single mapping
-            ['pointerdown', 'touchstart', 'mousedown'].forEach((eventType) => {
-                cropper.container.addEventListener(eventType, () => {
-                    croppers.forEach((c) => {
-                        if (c !== cropper) {
-                            c.getCropperSelection().$clear();
-                        }
-                    });
+            // a zone is stored on a single side, so only one cropper may hold a selection
+            cropper.getCropperSelection().addEventListener('change', (e) => {
+                if (e.detail.width <= 0 || e.detail.height <= 0) {
+                    // ignore empty selections, else clearing a cropper would clear the others back
+                    return;
+                }
+
+                croppers.forEach((other_cropper) => {
+                    if (other_cropper !== cropper) {
+                        other_cropper.getCropperSelection().$clear();
+                    }
                 });
             });
         });

--- a/js/stencil-editor.js
+++ b/js/stencil-editor.js
@@ -60,6 +60,17 @@ const StencilEditor = function (container, rand, zones_definition) {
             const cropper = new window.Cropper(img);
             croppers.push(cropper);
             img.cropper = cropper;
+
+            // clear other croppers on interaction to enforce single mapping
+            ['pointerdown', 'touchstart', 'mousedown'].forEach((eventType) => {
+                cropper.container.addEventListener(eventType, () => {
+                    croppers.forEach((c) => {
+                        if (c !== cropper) {
+                            c.getCropperSelection().$clear();
+                        }
+                    });
+                });
+            });
         });
 
         // set default state of croppers objects

--- a/tests/js/stencil-editor.test.js
+++ b/tests/js/stencil-editor.test.js
@@ -1,0 +1,151 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+require('@jest/globals');
+require('/lib/cropper.js');
+const StencilEditor = require('/js/stencil-editor.js');
+
+const rand = 1234;
+
+/**
+ * Build the minimal markup of templates/stencil/editor.html.twig for a model
+ * having both a front (side 0) and a rear (side 1) image.
+ */
+const buildEditor = (zones) => {
+    document.body.innerHTML = `
+        <div id="stencil-editor-${rand}">
+            <form id="stencil-editor-form-${rand}">
+                <input type="hidden" name="id" value="42">
+                <button type="button" data-zone-index="1" class="btn set-zone-data">
+                    <span>1</span><i class="ti ti-file-unknown"></i>
+                </button>
+                <div id="zone-data-${rand}" class="row d-none">
+                    <input type="text" id="zone_label-${rand}" value="">
+                    <input type="text" id="zone_number-${rand}" value="1">
+                </div>
+                <div id="general-submit-${rand}"></div>
+            </form>
+            <div class="cropper-container">
+                <img src="front.png" class="stencil-image" data-side="0">
+            </div>
+            <div class="cropper-container">
+                <img src="rear.png" class="stencil-image" data-side="1">
+            </div>
+        </div>
+    `;
+
+    const editor = new StencilEditor(document.getElementById(`stencil-editor-${rand}`), rand, zones);
+    const images = document.querySelectorAll('.stencil-image');
+
+    return {
+        editor,
+        front: images[0].cropper,
+        rear: images[1].cropper,
+    };
+};
+
+/**
+ * jsdom has no layout engine, so canvas and image boxes must be faked to be
+ * able to check the percent based coordinates.
+ */
+const fakeLayout = (cropper) => {
+    cropper.getCropperCanvas().getBoundingClientRect = () => ({ left: 0, top: 0, width: 200, height: 100 });
+    cropper.getCropperImage().getBoundingClientRect = () => ({ left: 10, top: 20, width: 200, height: 100 });
+};
+
+const selectionOf = (cropper) => {
+    const selection = cropper.getCropperSelection();
+
+    return { x: selection.x, y: selection.y, width: selection.width, height: selection.height };
+};
+
+describe('StencilEditor', () => {
+    beforeEach(() => {
+        window.AjaxMock.start();
+    });
+
+    afterEach(() => {
+        window.AjaxMock.end();
+        document.body.innerHTML = '';
+    });
+
+    it('drawing a zone on an image clears the selection made on the other one', () => {
+        const { editor, front, rear } = buildEditor({});
+        editor.editorEnable(1);
+
+        front.getCropperSelection().$change(10, 10, 20, 20);
+        expect(selectionOf(front)).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+
+        rear.getCropperSelection().$change(30, 40, 50, 60);
+
+        expect(selectionOf(front)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+        expect(selectionOf(rear)).toEqual({ x: 30, y: 40, width: 50, height: 60 });
+    });
+
+    it('an empty selection does not clear the other image', () => {
+        const { editor, front, rear } = buildEditor({});
+        editor.editorEnable(1);
+
+        front.getCropperSelection().$change(10, 10, 20, 20);
+
+        // a simple click on the other image produces an empty selection
+        rear.getCropperSelection().$clear();
+
+        expect(selectionOf(front)).toEqual({ x: 10, y: 10, width: 20, height: 20 });
+    });
+
+    it('saves the last drawn zone, whatever the image it has been drawn on', () => {
+        const zones = {};
+        const { editor, front, rear } = buildEditor(zones);
+        fakeLayout(rear);
+
+        window.AjaxMock.addMockResponse(new window.AjaxMockResponse('//ajax/stencil.php', 'POST', {}, () => ''));
+
+        editor.editorEnable(1);
+        $(`#zone_label-${rand}`).val('Port 1');
+        front.getCropperSelection().$change(10, 10, 20, 20);
+        rear.getCropperSelection().$change(30, 40, 50, 60);
+        editor.saveZoneData();
+
+        expect(zones[1]).toMatchObject({
+            selection: { x: 30, y: 40, width: 50, height: 60 },
+            side: 1,
+            label: 'Port 1',
+            number: '1',
+            x_percent: 10,
+            y_percent: 20,
+            width_percent: 25,
+            height_percent: 60,
+        });
+        expect(window.AjaxMock.isResponseStackEmpty()).toBeTrue();
+    });
+});


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Previously, when a Network Equipment Model had both front and rear images, the UI allowed a user to draw mapping squares for the same port on both images simultaneously. However, because the database only supports one set of coordinates per port, the secondary mapping was silently discarded upon saving, leading to confusion and data loss (Closes #23608).

This PR enforces a strict **Single Mapping** policy directly in the UI to match the database limitations.
* Modified `js/stencil-editor.js` to attach `pointerdown`, `touchstart`, and `mousedown` event listeners to the cropper instances.
* When a user interacts with the cropper on one image (e.g., drawing on the front image), any active selection on the other image (e.g., the rear image) is automatically cleared. 

This provides immediate visual feedback that a port can only exist on one visual plane at a time.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/a734269b-fcba-4ce1-9cd3-252c91514f09
