### PR TITLE
Fix: match manufacturer criterion in asset rules

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5781,6 +5781,11 @@ class CommonDBTM extends CommonGLPI
                 $input['_auto'] = 0;
             }
 
+            // The 'manufacturer' criterion is matched by its code, not by the 'manufacturers_id' field
+            if (isset($input['manufacturers_id'])) {
+                $input['manufacturer'] = $input['manufacturers_id'];
+            }
+
             // Add last_inventory_update
             if (!isset($this->input['last_inventory_update']) && isset($this->fields['last_inventory_update'])) {
                 $input['last_inventory_update'] = $this->fields['last_inventory_update'];

--- a/tests/functional/RuleAssetTest.php
+++ b/tests/functional/RuleAssetTest.php
@@ -862,6 +862,51 @@ class RuleAssetTest extends DbTestCase
         $this->assertSame('Comment changed', $computer->fields['comment']);
     }
 
+    public function testManufacturerCriteria()
+    {
+        $this->login();
+
+        $manufacturer = $this->createItem(\Manufacturer::class, [
+            'name' => 'Test manufacturer criteria',
+        ]);
+
+        $rule_asset = $this->createItem(\RuleAsset::class, [
+            'name'         => 'rule manufacturer criteria',
+            'match'        => 'AND',
+            'is_active'    => 1,
+            'sub_type'     => 'RuleAsset',
+            'condition'    => \RuleAsset::ONADD,
+            'is_recursive' => 1,
+        ]);
+        $this->createItem(RuleCriteria::class, [
+            'rules_id'  => $rule_asset->getID(),
+            'criteria'  => 'manufacturer',
+            'condition' => Rule::PATTERN_IS,
+            'pattern'   => $manufacturer->getID(),
+        ]);
+        $this->createItem(RuleAction::class, [
+            'rules_id'    => $rule_asset->getID(),
+            'action_type' => 'assign',
+            'field'       => 'comment',
+            'value'       => 'Comment set by manufacturer rule',
+        ]);
+
+        // Computer with the matching manufacturer must trigger the rule
+        $computer = $this->createItem(Computer::class, [
+            'name'             => 'Computer with matching manufacturer',
+            'entities_id'      => 0,
+            'manufacturers_id' => $manufacturer->getID(),
+        ]);
+        $this->assertSame('Comment set by manufacturer rule', $computer->fields['comment']);
+
+        // Computer with no manufacturer must not trigger the rule
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'Computer without matching manufacturer',
+            'entities_id' => 0,
+        ]);
+        $this->assertEmpty($computer->fields['comment']);
+    }
+
     public function testFormatInventoryNumberWithName()
     {
         $this->login();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45614
- Business rules on assets never triggered on the "Manufacturer" criterion, whatever the chosen operator.
- The rule engine now correctly receives the manufacturer value when evaluating asset business rules, so rules using this criterion trigger as expected.

## Screenshots (if appropriate):
