### PR TITLE
fix(ui): modal redirection and empty form display for legacy items

### DIFF
--- a/front/domainrecord.form.php
+++ b/front/domainrecord.form.php
@@ -71,6 +71,9 @@ if (isset($_POST["add"])) {
     Html::back();
 } elseif (isset($_GET['_in_modal'])) {
     Html::popHeader(DomainRecord::getTypeName(Session::getPluralNumber()), in_modal: true);
+    if (!empty($_GET["id"])) {
+        $record->getFromDB($_GET["id"]);
+    }
     $record->showForm($_GET["id"], ['domains_id' => $_GET['domains_id'] ?? null]);
     Html::popFooter();
 } else {

--- a/front/group.form.php
+++ b/front/group.form.php
@@ -101,6 +101,9 @@ if (isset($_POST["add"])) {
     Html::back();
 } elseif (isset($_GET['_in_modal'])) {
     Html::popHeader(Group::getTypeName(Session::getPluralNumber()), in_modal: true);
+    if (!empty($_GET["id"])) {
+        $group->getFromDB($_GET["id"]);
+    }
     $group->showForm($_GET["id"]);
     Html::popFooter();
 } elseif (isset($_POST["replace"])) {

--- a/front/project.form.php
+++ b/front/project.form.php
@@ -121,7 +121,10 @@ if (isset($_POST["add"])) {
     Html::back();
 } elseif (isset($_GET['_in_modal'])) {
     Html::popHeader(Budget::getTypeName(1), in_modal: true);
-    $project->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
+    if (!empty($_GET["id"])) {
+        $project->getFromDB($_GET["id"]);
+    }
+    $project->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"] ?? null]);
     Html::popFooter();
 } else {
     if (isset($_GET['showglobalkanban']) && $_GET['showglobalkanban']) {

--- a/front/projecttask.form.php
+++ b/front/projecttask.form.php
@@ -125,7 +125,10 @@ if (isset($_POST["add"])) {
     Html::back();
 } elseif (isset($_GET['_in_modal'])) {
     Html::popHeader(ProjectTask::getTypeName(1), in_modal: true);
-    $task->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"]]);
+    if (!empty($_GET["id"])) {
+        $task->getFromDB($_GET["id"]);
+    }
+    $task->showForm($_GET["id"], ['withtemplate' => $_GET["withtemplate"] ?? null]);
     Html::popFooter();
 } else {
     $menus = ["tools", "project"];

--- a/src/Html.php
+++ b/src/Html.php
@@ -456,6 +456,9 @@ class Html
      **/
     public static function redirect($dest, $http_response_code = 302): never
     {
+        if (isset($_REQUEST['_in_modal']) && $_REQUEST['_in_modal'] && strpos($dest, '_in_modal=') === false) {
+            $dest .= (strpos($dest, '?') !== false ? '&' : '?') . '_in_modal=1';
+        }
         throw new RedirectException($dest, $http_response_code);
     }
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

Closes #22627.

When creating a legacy item (such as a Group) from within a modal (e.g. `[+]` button on a dropdown), and the user preference "Stay on the form after creation" (`glpibackcreated`) is enabled, two issues occur:

1. The redirection to the newly created item loses the `_in_modal=1` query parameter, causing the iframe to render the full GLPI UI (with menus and headers) instead of just the form.
2. Even if the modal state is preserved, the manual `_in_modal` display branches inside the legacy `.form.php` scripts fail to initialize the database object, resulting in a completely empty form being displayed to the user instead of the item they just created.

### Fix
- Modified `Html::redirect()` to automatically propagate the `_in_modal=1` parameter to the destination URL if the current request originated from a modal. This ensures the iframe does not break out into the full application layout.
- Added missing `$item->getFromDB($_GET["id"])` initialization calls before `$item->showForm()` in the `_in_modal` fallback blocks of the affected legacy scripts (`group.form.php`, `domainrecord.form.php`, `project.form.php`, and `projecttask.form.php`).

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/84cf5521-359f-40cf-a71d-875b5a2b75a6
