### PR TITLE
Remove handling of obsolete global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ The present file will list all changes made to the project; according to the
 - `fields.csrfField()` Twig macro in `fields_macros.html.twig`.
 - `escapeMarkupText()` javascript function.
 - `Html::link()`
+- Inclusion of the `inc/includes.php` file.
 
 #### Removed
 

--- a/inc/includes.php
+++ b/inc/includes.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,63 +32,4 @@
  * ---------------------------------------------------------------------
  */
 
-/** @var int|bool|null $AJAX_INCLUDE */
-global $AJAX_INCLUDE;
-if (isset($AJAX_INCLUDE)) {
-    trigger_error(
-        'The global `$AJAX_INCLUDE` variable has no effect anymore.',
-        E_USER_WARNING
-    );
-}
-
-/** @var string|null $SECURITY_STRATEGY */
-global $SECURITY_STRATEGY;
-if (isset($SECURITY_STRATEGY)) {
-    throw new RuntimeException('The global `$SECURITY_STRATEGY` variable has no effect anymore.');
-}
-
-/**
- * @var mixed|null $USEDBREPLICATE
- * @var mixed|null $DBCONNECTION_REQUIRED
- */
-global $USEDBREPLICATE, $DBCONNECTION_REQUIRED;
-if (isset($USEDBREPLICATE) || isset($DBCONNECTION_REQUIRED)) {
-    trigger_error(
-        'The global `$USEDBREPLICATE` and `$DBCONNECTION_REQUIRED` variables has no effect anymore. Use "DBConnection::getReadConnection()" to get the most apporpriate connection for read only operations.',
-        E_USER_WARNING
-    );
-}
-
-/**
- * @var mixed|null $PLUGINS_EXCLUDED
- * @var mixed|null $PLUGINS_INCLUDED
- */
-global $PLUGINS_EXCLUDED, $PLUGINS_INCLUDED;
-if (isset($PLUGINS_EXCLUDED) || isset($PLUGINS_INCLUDED)) {
-    trigger_error(
-        'The global `$PLUGINS_EXCLUDED` and `$PLUGINS_INCLUDED` variables has no effect anymore.',
-        E_USER_WARNING
-    );
-}
-
-/**
- * @var mixed|null $skip_db_check
- */
-global $skip_db_check;
-if (isset($skip_db_check)) {
-    trigger_error(
-        'The global `$skip_db_check` variable has no effect anymore.',
-        E_USER_WARNING
-    );
-}
-
-/**
- * @var mixed|null $dont_check_maintenance_mode
- */
-global $dont_check_maintenance_mode;
-if (isset($dont_check_maintenance_mode)) {
-    trigger_error(
-        'The global `$dont_check_maintenance_mode` variable has no effect anymore.',
-        E_USER_WARNING
-    );
-}
+Toolbox::deprecated('The `inc/includes.php` file is obsolete.');

--- a/src/Glpi/Kernel/Kernel.php
+++ b/src/Glpi/Kernel/Kernel.php
@@ -89,11 +89,6 @@ final class Kernel extends BaseKernel
         );
     }
 
-    public function __destruct()
-    {
-        $this->triggerGlobalsDeprecation();
-    }
-
     /**
      * Returns the cache root directory.
      */
@@ -276,82 +271,6 @@ final class Kernel extends BaseKernel
         // Env-specific route files.
         if (\is_file($path = $this->getProjectDir() . '/routes/' . $this->environment . '.php')) {
             (require $path)($routes->withPath($path), $this);
-        }
-    }
-
-    private function triggerGlobalsDeprecation(): void
-    {
-        if (in_array($this->getProjectDir() . '/inc/includes.php', get_included_files(), true)) {
-            // The following deprecations/warnings are already triggered in `inc/includes.php`.
-            return;
-        }
-
-        /**
-         * @var mixed|null $AJAX_INCLUDE
-         */
-        global $AJAX_INCLUDE;
-        if (isset($AJAX_INCLUDE)) {
-            trigger_error(
-                'The global `$AJAX_INCLUDE` variable has no effect anymore.',
-                E_USER_WARNING
-            );
-        }
-
-        /**
-         * @var mixed|null $SECURITY_STRATEGY
-         */
-        global $SECURITY_STRATEGY;
-        if (isset($SECURITY_STRATEGY)) {
-            trigger_error(
-                'The global `$SECURITY_STRATEGY` variable has no effect anymore.',
-                E_USER_WARNING
-            );
-        }
-
-        /**
-         * @var mixed|null $USEDBREPLICATE
-         * @var mixed|null $DBCONNECTION_REQUIRED
-         */
-        global $USEDBREPLICATE, $DBCONNECTION_REQUIRED;
-        if (isset($USEDBREPLICATE) || isset($DBCONNECTION_REQUIRED)) {
-            trigger_error(
-                'The global `$USEDBREPLICATE` and `$DBCONNECTION_REQUIRED` variables has no effect anymore. Use "DBConnection::getReadConnection()" to get the most apporpriate connection for read only operations.',
-                E_USER_WARNING
-            );
-        }
-
-        /**
-         * @var mixed|null $PLUGINS_EXCLUDED
-         * @var mixed|null $PLUGINS_INCLUDED
-         */
-        global $PLUGINS_EXCLUDED, $PLUGINS_INCLUDED;
-        if (isset($PLUGINS_EXCLUDED) || isset($PLUGINS_INCLUDED)) {
-            trigger_error(
-                'The global `$PLUGINS_EXCLUDED` and `$PLUGINS_INCLUDED` variables has no effect anymore.',
-                E_USER_WARNING
-            );
-        }
-
-        /**
-         * @var mixed|null $skip_db_check
-         */
-        global $skip_db_check;
-        if (isset($skip_db_check)) {
-            trigger_error(
-                'The global `$skip_db_check` variable has no effect anymore.',
-                E_USER_WARNING
-            );
-        }
-
-        /**
-         * @var mixed|null $dont_check_maintenance_mode
-         */
-        global $dont_check_maintenance_mode;
-        if (isset($dont_check_maintenance_mode)) {
-            trigger_error(
-                'The global `$dont_check_maintenance_mode` variable has no effect anymore.',
-                E_USER_WARNING
-            );
         }
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

These global variable have no effect anymore since GLPI 11.0.0, they can be removed now.

I did not removed the `inc/includes.php` file, but deprecate it, since it is still included by many plugins in their GLPI 11.0 version. Removing it would result in a warning where it is included, and probably pollute production logs whereas a deprecation is not logged by default on production env.