### PR TITLE
fix(ui): sidebar active state desync when opening links in new tabs

### DIFF
--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -120,12 +120,21 @@ $(function() {
                return;
             }
 
+            // find the clicked dropdown item, handling clicks on inner elements (icons, spans)
+            var dropdownItem = orig_event.target.closest('.dropdown-item');
+
             // prevent menu links to close menu (waiting the page redirection)
-            if (orig_event.target.className.indexOf('dropdown-item') !== false) {
-               for (var item of document.querySelectorAll('#menu_{{ rand }} .dropdown-item')) {
-                  item.classList.remove('active');
+            if (dropdownItem) {
+               // Only change the active state if it's a normal click (no modifiers, left click)
+               var isModifierClick = orig_event.ctrlKey || orig_event.metaKey || orig_event.shiftKey || orig_event.altKey || orig_event.button === 1;
+
+               if (!isModifierClick) {
+                  for (var item of document.querySelectorAll('#menu_{{ rand }} .dropdown-item')) {
+                     item.classList.remove('active');
+                  }
+                  dropdownItem.classList.add('active');
                }
-               orig_event.target.classList.add('active');
+               
                event.preventDefault();
             }
          }

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -120,12 +120,20 @@ $(function() {
                return;
             }
 
+            // find the clicked dropdown item, handling clicks on inner elements (icons, spans)
+            var dropdownItem = orig_event.target.closest('.dropdown-item');
+
             // prevent menu links to close menu (waiting the page redirection)
-            if (orig_event.target.className.indexOf('dropdown-item') !== false) {
-               for (var item of document.querySelectorAll('#menu_{{ rand }} .dropdown-item')) {
-                  item.classList.remove('active');
+            if (dropdownItem) {
+               // only change the active state if it's a normal click (no modifiers, left click)
+               var isModifierClick = orig_event.ctrlKey || orig_event.metaKey || orig_event.shiftKey || orig_event.altKey || orig_event.button === 1;
+
+               if (!isModifierClick) {
+                  for (var item of document.querySelectorAll('#menu_{{ rand }} .dropdown-item')) {
+                     item.classList.remove('active');
+                  }
+                  dropdownItem.classList.add('active');
                }
-               orig_event.target.classList.add('active');
                event.preventDefault();
             }
          }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

# Description
When a user opens a sidebar menu item in a new tab using a keyboard modifier (`Ctrl` + Click on Windows / `Cmd` + Click on macOS) or a middle-click, the sidebar's active/selected state in the current tab immediately changes to the newly clicked item, causing a visual desync with the actual page content currently being viewed (Closes #25046).

Additionally, the click detection was slightly flawed and could trigger incorrectly on inner elements (like icons or text spans) instead of the link itself.

### Changes Made
- Updated the JavaScript handler in `templates/layout/parts/menu.html.twig` to correctly identify when a link is opened in a new tab/window by checking the underlying `MouseEvent` for modifier keys (`ctrlKey`, `metaKey`, `shiftKey`, `altKey`) and middle-clicks (`button === 1`).
- Bypassed eagerly applying the `active` CSS class to the clicked item if the click involved a modifier key.
- Replaced a fragile `className.indexOf('dropdown-item') !== false` check with `closest('.dropdown-item')` to reliably detect clicks on the dropdown item or its children (icons/text).

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/62ee2187-62eb-42ca-bb13-c915661bf419
