### PR TITLE
fix(ui): display of renamed items in AJAX dropdowns

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1814,8 +1814,8 @@ function setupAjaxDropdown(config) {
 
     $('#' + field_id).on('select2:selecting', function (e) {
         if (e.params && e.params.args && e.params.args.data) {
-            var data = e.params.args.data;
-            var option = this.querySelector(`option[value="${CSS.escape(String(data.id))}"]`);
+            const data = e.params.args.data;
+            const option = this.querySelector(`option[value="${CSS.escape(String(data.id))}"]`);
             if (option) {
                 option.text = data.text;
             }

--- a/js/common.js
+++ b/js/common.js
@@ -1812,6 +1812,16 @@ function setupAjaxDropdown(config) {
         }
     });
 
+    $('#' + field_id).on('select2:selecting', function (e) {
+        if (e.params && e.params.args && e.params.args.data) {
+            var data = e.params.args.data;
+            var option = this.querySelector(`option[value="${CSS.escape(String(data.id))}"]`);
+            if (option) {
+                option.text = data.text;
+            }
+        }
+    });
+
     return select2_el;
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -1813,7 +1813,7 @@ function setupAjaxDropdown(config) {
     });
 
     $('#' + field_id).on('select2:selecting', function (e) {
-        if (e.params && e.params.args && e.params.args.data) {
+        if (e?.params?.args?.data) {
             const data = e.params.args.data;
             const option = this.querySelector(`option[value="${CSS.escape(String(data.id))}"]`);
             if (option) {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When an item (e.g., Software) is renamed from another tab, returning to an active tab and searching for it in an already-loaded AJAX dropdown successfully retrieves and displays the new name in the search results. However, clicking the item to select it causes the dropdown to revert and incorrectly display the old name (Closes #22905).

**Cause**
When an item is selected from AJAX results, Select2 checks if an `<option>` element with the corresponding ID already exists in the underlying `<select>` element. If it does (which happens because the item was present when the page initially loaded), Select2 reuses it. Because the `<option>` tag in the DOM still contains the old name, Select2 extracts the old text from it and uses it for the selection display, ignoring the newly fetched text from the AJAX payload.

**Solution**
Added a `select2:selecting` event listener to `setupAjaxDropdown` within `js/common.js`. This intercepts the selection just before Select2 applies it. It retrieves the latest text from the AJAX data payload and updates the underlying `<option>` element's text in the DOM. Consequently, when Select2 extracts the text to display the selection, it uses the correct, up-to-date name.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/7dd1816b-99da-4e9c-83e1-937071017169

