### PR TITLE
fix(ui): entity creation in modals not appearing in dropdown

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1797,6 +1797,14 @@ function setupAjaxDropdown(config) {
                     $('#' + field_id).append(newOption).trigger('change');
                 }
             });
+        })
+        .bind('appendValueToRestrict', function (e, value) {
+            if (!config.params._appended_entities) {
+                config.params._appended_entities = [];
+            }
+            if (!config.params._appended_entities.includes(parseInt(value))) {
+                config.params._appended_entities.push(parseInt(value));
+            }
         });
 
     if (config.on_change !== '') {

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2898,6 +2898,17 @@ HTML;
                     $entities[] = (int) $value;
                 }
             }
+
+            // Allow client to dynamically append newly created entities without breaking IDOR token
+            if (isset($post['_appended_entities']) && is_array($post['_appended_entities'])) {
+                foreach ($post['_appended_entities'] as $value) {
+                    // Only allow appending if the user actually has access to this entity
+                    if (Session::haveAccessToEntity((int)$value)) {
+                        $entities[] = (int) $value;
+                    }
+                }
+            }
+
             $post["entity_restrict"] = Session::getMatchingActiveEntities($entities);
         }
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2898,6 +2898,17 @@ HTML;
                     $entities[] = (int) $value;
                 }
             }
+
+            // Allow client to dynamically append newly created entities without breaking IDOR token
+            if (isset($post['_appended_entities']) && is_array($post['_appended_entities'])) {
+                foreach ($post['_appended_entities'] as $value) {
+                    // Only allow appending if the user actually has access to this entity
+                    if (Session::haveAccessToEntity((int) $value)) {
+                        $entities[] = (int) $value;
+                    }
+                }
+            }
+
             $post["entity_restrict"] = Session::getMatchingActiveEntities($entities);
         }
 

--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -101,7 +101,7 @@ class DropdownFormController extends AbstractController
                 if ($_SESSION['glpibackcreated']) {
                     $url = $dropdown->getLinkURL();
                     if ($in_modal) {
-                        $url .= "&_in_modal=1";
+                        $url .= "&_in_modal=1&_update_parent=1";
                     }
                     return new RedirectResponse($url);
                 }
@@ -193,6 +193,18 @@ class DropdownFormController extends AbstractController
                 true,
                 ...$dropdown->getSectorizedDetails()
             );
+
+            if ($request->query->has('_update_parent') && $id > 0) {
+                echo "<script>
+                    if (window.frameElement && window.frameElement.id.startsWith('iframeadd_')) {
+                        let field_id = window.frameElement.id.replace('iframeadd_', '');
+                        if (window.parent.$('#' + field_id).length) {
+                            window.parent.$('#' + field_id).trigger('appendValueToRestrict', $id);
+                        }
+                    }
+                </script>";
+            }
+
             $dropdown->showForm($id);
             Html::popFooter();
             $content = ob_get_clean();

--- a/src/Glpi/Controller/DropdownFormController.php
+++ b/src/Glpi/Controller/DropdownFormController.php
@@ -101,13 +101,17 @@ class DropdownFormController extends AbstractController
                 if ($_SESSION['glpibackcreated']) {
                     $url = $dropdown->getLinkURL();
                     if ($in_modal) {
-                        $url .= "&_in_modal=1";
+                        $url .= "&_in_modal=1&_update_parent=1";
                     }
                     return new RedirectResponse($url);
                 }
             }
 
-            return new RedirectResponse(Html::getBackUrl());
+            $url = Html::getBackUrl();
+            if ($in_modal) {
+                $url .= (strpos($url, '?') !== false ? '&' : '?') . '_update_parent=1&id=' . $newID;
+            }
+            return new RedirectResponse($url);
         }
 
         if (isset($input["purge"])) {
@@ -193,6 +197,18 @@ class DropdownFormController extends AbstractController
                 true,
                 ...$dropdown->getSectorizedDetails()
             );
+
+            if ($request->query->has('_update_parent') && $id > 0) {
+                echo "<script>
+                    if (window.frameElement && window.frameElement.id.startsWith('iframeadd_')) {
+                        let field_id = window.frameElement.id.replace('iframeadd_', '');
+                        if (window.parent.$('#' + field_id).length) {
+                            window.parent.$('#' + field_id).trigger('appendValueToRestrict', $id);
+                        }
+                    }
+                </script>";
+            }
+
             $dropdown->showForm($id);
             Html::popFooter();
             $content = ob_get_clean();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When creating a child entity via the "New user" modal, the newly created entity was not appearing in the Entity Select2 dropdown (Closes #13537). This was because the `entity_restrict` whitelist (calculated on page load) was sent with the AJAX request, and the server correctly filtered out the new entity because it was missing from that original static whitelist.

This PR fixes the issue by securely allowing the parent window to append the newly created ID to the AJAX request.

### Changes made
1. **`src/Glpi/Controller/DropdownFormController.php`**
   - Restored the behavior of notifying the parent window upon successful item creation in an iframe modal (a54d1b5c).
   - It now triggers a custom `appendValueToRestrict` event on the parent dropdown, passing the newly created ID without forcing it to be automatically selected.
2. **`js/common.js`**
   - Added an `appendValueToRestrict` event listener to Select2 dropdowns. This appends the new ID to a separate `_appended_entities` array, preserving the integrity of the IDOR-signed `entity_restrict` parameter.
3. **`src/Dropdown.php`**
   - Updated `Dropdown::getDropdownValue()` to process the `_appended_entities` parameter. 
   - After successfully validating the IDOR token for the original `entity_restrict`, the server uses `Session::haveAccessToEntity()` to strictly verify the user actually has rights to the appended IDs.
   - Securely merges the validated IDs into the `entity_restrict` whitelist before querying the database, allowing the new item to be fetched!

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/c9fad5ba-f58f-4bf9-8b7f-3f983cfc06a8
