### PR TITLE
fix(cli): out of range values in timestamps migration

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -6866,12 +6866,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Console/Migration/TimestampsCommand.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method update\\(\\) on DBmysql\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Console/Migration/TimestampsCommand.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$db of class Glpi\\\\System\\\\Requirement\\\\DbTimezones constructor expects DBmysql, DBmysql\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Console/Migration/TimestampsCommand.php
+++ b/src/Glpi/Console/Migration/TimestampsCommand.php
@@ -50,6 +50,16 @@ use function Safe\preg_match;
 class TimestampsCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
+     * Minimum value supported by MySQL/MariaDB TIMESTAMP type, in UTC.
+     */
+    private const TIMESTAMP_MIN_VALUE = '1970-01-01 00:00:01';
+
+    /**
+     * Maximum value supported by MySQL/MariaDB TIMESTAMP type, in UTC.
+     */
+    private const TIMESTAMP_MAX_VALUE = '2038-01-19 03:14:07';
+
+    /**
      * Error code returned when failed to migrate one table.
      *
      * @var int
@@ -129,17 +139,8 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                         $nullable = true;
                     }
 
-                    // Fix invalid zero dates
-                    $this->db->update(
-                        $table,
-                        [
-                            $column['COLUMN_NAME'] => $nullable ? null : '1970-01-01 00:00:01',
-                        ],
-                        [
-                            ['NOT' => [$column['COLUMN_NAME'] => null]],
-                            [$column['COLUMN_NAME'] => ['<', '1970-01-01 00:00:01']],
-                        ]
-                    );
+                    // Fix invalid zero dates and dates out of TIMESTAMP range
+                    $this->normalizeOutOfRangeValues($table, $column['COLUMN_NAME'], $nullable);
 
                     //guess default value
                     if (is_null($column['COLUMN_DEFAULT']) && !$nullable) { // no default
@@ -151,16 +152,12 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                     } elseif (!is_null($column['COLUMN_DEFAULT']) && strtoupper($column['COLUMN_DEFAULT']) != 'NULL') {
                         if (preg_match('/^current_timestamp(\(\))?$/i', $column['COLUMN_DEFAULT']) === 1) {
                             $default = $column['COLUMN_DEFAULT'];
-                        } elseif ($column['COLUMN_DEFAULT'] < '1970-01-01 00:00:01') {
+                        } elseif ($column['COLUMN_DEFAULT'] < self::TIMESTAMP_MIN_VALUE) {
                             // Prevent default value to be out of range (lower to min possible value)
-                            $defaultDate = new DateTime('1970-01-01 00:00:01', new DateTimeZone('UTC'));
-                            $defaultDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                            $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
-                        } elseif ($column['COLUMN_DEFAULT'] > '2038-01-19 03:14:07') {
+                            $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE));
+                        } elseif ($column['COLUMN_DEFAULT'] > self::TIMESTAMP_MAX_VALUE) {
                             // Prevent default value to be out of range (greater to max possible value)
-                            $defaultDate = new DateTime('2038-01-19 03:14:07', new DateTimeZone('UTC'));
-                            $defaultDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                            $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
+                            $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE));
                         } else {
                             $default = $this->db->quoteValue($column['COLUMN_DEFAULT']);
                         }
@@ -241,6 +238,71 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
         }
 
         return 0; // Success
+    }
+
+    private function normalizeOutOfRangeValues(string $table, string $column, bool $nullable): void
+    {
+        $min_value = $this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE);
+        $max_value = $this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE);
+
+        $this->updateOutOfRangeValues(
+            $table,
+            $column,
+            ['<', $min_value],
+            $nullable ? null : $min_value,
+            sprintf(__('less than "%s"'), $min_value)
+        );
+
+        $this->updateOutOfRangeValues(
+            $table,
+            $column,
+            ['>', $max_value],
+            $max_value,
+            sprintf(__('greater than "%s"'), $max_value)
+        );
+    }
+
+    private function updateOutOfRangeValues(
+        string $table,
+        string $column,
+        array $condition,
+        ?string $replacement,
+        string $condition_description
+    ): void {
+        $this->db->update(
+            $table,
+            [
+                $column => $replacement,
+            ],
+            [
+                ['NOT' => [$column => null]],
+                [$column => $condition],
+            ]
+        );
+
+        $affected_rows = $this->db->affectedRows();
+        if ($affected_rows <= 0) {
+            return;
+        }
+
+        $this->outputMessage(
+            '<comment>' . sprintf(
+                __('%1$s row(s) from "%2$s"."%3$s" containing values %4$s were updated to "%5$s" to fit TIMESTAMP bounds.'),
+                $affected_rows,
+                $table,
+                $column,
+                $condition_description,
+                $replacement ?? 'NULL'
+            ) . '</comment>'
+        );
+    }
+
+    private function getTimestampBoundValue(string $value): string
+    {
+        $date = new DateTime($value, new DateTimeZone('UTC'));
+        $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+        return $date->format('Y-m-d H:i:s');
     }
 
     public function getConfigurationFilesToUpdate(InputInterface $input): array

--- a/src/Glpi/Console/Migration/TimestampsCommand.php
+++ b/src/Glpi/Console/Migration/TimestampsCommand.php
@@ -50,6 +50,16 @@ use function Safe\preg_match;
 class TimestampsCommand extends AbstractCommand implements ConfigurationCommandInterface
 {
     /**
+     * Minimum value supported by MySQL/MariaDB TIMESTAMP type, in UTC.
+     */
+    private const TIMESTAMP_MIN_VALUE = '1970-01-01 00:00:01';
+
+    /**
+     * Maximum value supported by MySQL/MariaDB TIMESTAMP type, in UTC.
+     */
+    private const TIMESTAMP_MAX_VALUE = '2038-01-19 03:14:07';
+
+    /**
      * Error code returned when failed to migrate one table.
      *
      * @var int
@@ -129,17 +139,8 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                         $nullable = true;
                     }
 
-                    // Fix invalid zero dates
-                    $this->db->update(
-                        $table,
-                        [
-                            $column['COLUMN_NAME'] => $nullable ? null : '1970-01-01 00:00:01',
-                        ],
-                        [
-                            ['NOT' => [$column['COLUMN_NAME'] => null]],
-                            [$column['COLUMN_NAME'] => ['<', '1970-01-01 00:00:01']],
-                        ]
-                    );
+                    // Fix invalid zero dates and dates out of TIMESTAMP range
+                    $this->normalizeOutOfRangeValues($table, $column['COLUMN_NAME'], $nullable);
 
                     //guess default value
                     if (is_null($column['COLUMN_DEFAULT']) && !$nullable) { // no default
@@ -151,16 +152,12 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                     } elseif (!is_null($column['COLUMN_DEFAULT']) && strtoupper($column['COLUMN_DEFAULT']) != 'NULL') {
                         if (preg_match('/^current_timestamp(\(\))?$/i', $column['COLUMN_DEFAULT']) === 1) {
                             $default = $column['COLUMN_DEFAULT'];
-                        } elseif ($column['COLUMN_DEFAULT'] < '1970-01-01 00:00:01') {
+                        } elseif ($column['COLUMN_DEFAULT'] < self::TIMESTAMP_MIN_VALUE) {
                             // Prevent default value to be out of range (lower to min possible value)
-                            $defaultDate = new DateTime('1970-01-01 00:00:01', new DateTimeZone('UTC'));
-                            $defaultDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                            $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
-                        } elseif ($column['COLUMN_DEFAULT'] > '2038-01-19 03:14:07') {
+                            $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE));
+                        } elseif ($column['COLUMN_DEFAULT'] > self::TIMESTAMP_MAX_VALUE) {
                             // Prevent default value to be out of range (greater to max possible value)
-                            $defaultDate = new DateTime('2038-01-19 03:14:07', new DateTimeZone('UTC'));
-                            $defaultDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
-                            $default = $this->db->quoteValue($defaultDate->format("Y-m-d H:i:s"));
+                            $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE));
                         } else {
                             $default = $this->db->quoteValue($column['COLUMN_DEFAULT']);
                         }
@@ -241,6 +238,77 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
         }
 
         return 0; // Success
+    }
+
+    private function normalizeOutOfRangeValues(string $table, string $column, bool $nullable): void
+    {
+        $min_value = $this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE);
+        $max_value = $this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE);
+
+        $this->updateOutOfRangeValues(
+            $table,
+            $column,
+            ['<', $min_value],
+            $nullable ? null : $min_value,
+            sprintf(__('less than "%s"'), $min_value)
+        );
+
+        $this->updateOutOfRangeValues(
+            $table,
+            $column,
+            ['>', $max_value],
+            $max_value,
+            sprintf(__('greater than "%s"'), $max_value)
+        );
+    }
+
+    /**
+     * @param array<int, string> $condition
+     */
+    private function updateOutOfRangeValues(
+        string $table,
+        string $column,
+        array $condition,
+        ?string $replacement,
+        string $condition_description
+    ): void {
+        if ($this->db === null) {
+            return;
+        }
+        $this->db->update(
+            $table,
+            [
+                $column => $replacement,
+            ],
+            [
+                ['NOT' => [$column => null]],
+                [$column => $condition],
+            ]
+        );
+
+        $affected_rows = $this->db->affectedRows();
+        if ($affected_rows <= 0) {
+            return;
+        }
+
+        $this->outputMessage(
+            '<comment>' . sprintf(
+                __('%1$s row(s) from "%2$s"."%3$s" containing values %4$s were updated to "%5$s" to fit TIMESTAMP bounds.'),
+                $affected_rows,
+                $table,
+                $column,
+                $condition_description,
+                $replacement ?? 'NULL'
+            ) . '</comment>'
+        );
+    }
+
+    private function getTimestampBoundValue(string $value): string
+    {
+        $date = new DateTime($value, new DateTimeZone('UTC'));
+        $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+        return $date->format('Y-m-d H:i:s');
     }
 
     public function getConfigurationFilesToUpdate(InputInterface $input): array

--- a/src/Glpi/Console/Migration/TimestampsCommand.php
+++ b/src/Glpi/Console/Migration/TimestampsCommand.php
@@ -40,11 +40,16 @@ use DBConnection;
 use Glpi\Console\AbstractCommand;
 use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Exception\EarlyExitException;
+use Glpi\DBAL\QueryExpression;
 use Glpi\System\Requirement\DbTimezones;
 use LogicException;
 use Safe\DateTime;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Throwable;
 
 use function Safe\preg_match;
 
@@ -56,9 +61,14 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
     private const TIMESTAMP_MIN_VALUE = '1970-01-01 00:00:01';
 
     /**
-     * Maximum value supported by MySQL/MariaDB TIMESTAMP type, in UTC.
+     * Maximum value supported by the standard MariaDB (32-bit)/MySQL TIMESTAMP type, in UTC.
      */
     private const TIMESTAMP_MAX_VALUE = '2038-01-19 03:14:07';
+
+    /**
+     * Maximum value supported by the extended (64-bit) MariaDB 11.5+ TIMESTAMP type, in UTC.
+     */
+    private const TIMESTAMP_MAX_VALUE_EXTENDED = '2106-02-07 06:28:15';
 
     /**
      * Error code returned when failed to migrate one table.
@@ -74,12 +84,32 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
      */
     public const ERROR_UNABLE_TO_UPDATE_CONFIG = 2;
 
+    /**
+     * Error code returned when future dates beyond the server TIMESTAMP range are detected
+     * and explicit consent to clamp them was not given.
+     *
+     * @var int
+     */
+    public const ERROR_FUTURE_DATES_REQUIRE_CONSENT = 3;
+
+    /**
+     * Cached server TIMESTAMP upper bound (resolved once per execution).
+     * Null until resolved by {@link getTimestampMaxValue()}.
+     */
+    private ?string $timestamp_max_value = null;
+
     protected function configure()
     {
         parent::configure();
 
         $this->setName('migration:timestamps');
         $this->setDescription(__('Convert "datetime" fields to "timestamp" to use timezones.'));
+        $this->addOption(
+            'allow-future-date-clamping',
+            null,
+            InputOption::VALUE_NONE,
+            __('Authorize clamping of future dates beyond the server TIMESTAMP range without prompting.')
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -109,6 +139,8 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                 $tables[] = $table_data['TABLE_NAME'];
             }
             sort($tables);
+
+            $this->confirmFutureDateClamping($tables);
 
             $progress_message = (fn(string $table) => sprintf(__('Migrating table "%s"...'), $table));
 
@@ -156,9 +188,9 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
                         } elseif ($column['COLUMN_DEFAULT'] < self::TIMESTAMP_MIN_VALUE) {
                             // Prevent default value to be out of range (lower to min possible value)
                             $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE));
-                        } elseif ($column['COLUMN_DEFAULT'] > self::TIMESTAMP_MAX_VALUE) {
+                        } elseif ($column['COLUMN_DEFAULT'] > $this->getTimestampMaxValue()) {
                             // Prevent default value to be out of range (greater to max possible value)
-                            $default = $this->db->quoteValue($this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE));
+                            $default = $this->db->quoteValue($this->getTimestampBoundValue($this->getTimestampMaxValue()));
                         } else {
                             $default = $this->db->quoteValue($column['COLUMN_DEFAULT']);
                         }
@@ -244,7 +276,7 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
     private function normalizeOutOfRangeValues(string $table, string $column, bool $nullable): void
     {
         $min_value = $this->getTimestampBoundValue(self::TIMESTAMP_MIN_VALUE);
-        $max_value = $this->getTimestampBoundValue(self::TIMESTAMP_MAX_VALUE);
+        $max_value = $this->getTimestampBoundValue($this->getTimestampMaxValue());
 
         $this->updateOutOfRangeValues(
             $table,
@@ -310,6 +342,146 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
         $date->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
         return $date->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Resolve the server's TIMESTAMP upper bound, in UTC.
+     *
+     * Uses a behavioral probe: attempts to CAST the extended (64-bit MariaDB 11.5+) max
+     * value to TIMESTAMP. If the server accepts it, the extended range is supported;
+     * otherwise falls back to the standard 32-bit limit. The result is cached for the
+     * command lifetime.
+     */
+    private function getTimestampMaxValue(): string
+    {
+        if ($this->timestamp_max_value !== null) {
+            return $this->timestamp_max_value;
+        }
+
+        $extended = false;
+        try {
+            $iterator = $this->db->request([
+                'SELECT' => new QueryExpression(
+                    sprintf("CAST('%s' AS TIMESTAMP) AS probe", self::TIMESTAMP_MAX_VALUE_EXTENDED)
+                ),
+            ]);
+            foreach ($iterator as $row) {
+                $extended = isset($row['probe']) && $row['probe'] === self::TIMESTAMP_MAX_VALUE_EXTENDED;
+                break;
+            }
+        } catch (Throwable $e) {
+            $extended = false;
+        }
+
+        $this->timestamp_max_value = $extended
+            ? self::TIMESTAMP_MAX_VALUE_EXTENDED
+            : self::TIMESTAMP_MAX_VALUE;
+
+        return $this->timestamp_max_value;
+    }
+
+    /**
+     * Pre-scan the tables to migrate for datetime values beyond the server's TIMESTAMP
+     * upper bound and ask for explicit consent before clamping them.
+     *
+     * Pre-1970 dates are considered genuinely invalid and are clamped silently during
+     * migration; only future dates beyond the server max require consent.
+     *
+     * @param list<string> $tables
+     */
+    private function confirmFutureDateClamping(array $tables): void
+    {
+        $max_value = $this->getTimestampBoundValue($this->getTimestampMaxValue());
+
+        $affected = [];
+        $total_rows = 0;
+
+        foreach ($tables as $table) {
+            $col_iterator = $this->db->request([
+                'SELECT' => ['column_name AS COLUMN_NAME'],
+                'FROM'   => 'information_schema.columns',
+                'WHERE'  => [
+                    'table_schema' => $this->db->dbdefault,
+                    'table_name'   => $table,
+                    'data_type'    => 'datetime',
+                ],
+            ]);
+
+            foreach ($col_iterator as $column) {
+                $column_name = $column['COLUMN_NAME'];
+                $count_iterator = $this->db->request([
+                    'COUNT'  => 'cpt',
+                    'FROM'   => $table,
+                    'WHERE'  => [
+                        ['NOT' => [$column_name => null]],
+                        [$column_name => ['>', $max_value]],
+                    ],
+                ]);
+                $count = (int) ($count_iterator->current()['cpt'] ?? 0);
+                if ($count > 0) {
+                    $affected[] = ['table' => $table, 'column' => $column_name, 'rows' => $count];
+                    $total_rows += $count;
+                }
+            }
+        }
+
+        if ($total_rows === 0) {
+            return;
+        }
+
+        $this->output->writeln(
+            '<comment>' . sprintf(
+                __('%1$s row(s) with future dates beyond the server TIMESTAMP limit (%2$s) were detected and will be clamped to that limit, destroying the original values:'),
+                $total_rows,
+                $max_value
+            ) . '</comment>',
+            OutputInterface::VERBOSITY_QUIET
+        );
+        foreach ($affected as $item) {
+            $this->output->writeln(
+                '<comment>' . sprintf(
+                    __('- "%1$s"."%2$s": %3$s row(s)'),
+                    $item['table'],
+                    $item['column'],
+                    $item['rows']
+                ) . '</comment>',
+                OutputInterface::VERBOSITY_QUIET
+            );
+        }
+
+        if ($this->input->getOption('allow-future-date-clamping')) {
+            return;
+        }
+
+        if (!$this->input->getOption('no-interaction')) {
+            $question_helper = new QuestionHelper();
+            $confirmed = $question_helper->ask(
+                $this->input,
+                $this->output,
+                new ConfirmationQuestion(
+                    sprintf(
+                        __('Continue and clamp these future dates to "%s"? [yes/No]'),
+                        $max_value
+                    ),
+                    false
+                )
+            );
+            if (!$confirmed) {
+                throw new EarlyExitException(
+                    '<comment>' . __('Aborted.') . '</comment>',
+                    0
+                );
+            }
+            return;
+        }
+
+        throw new EarlyExitException(
+            '<error>' . sprintf(
+                __('Future dates beyond the server TIMESTAMP range were detected. Either fix them, run the command interactively, or pass the "%1$s" option to authorize clamping.'),
+                '--allow-future-date-clamping'
+            ) . '</error>',
+            self::ERROR_FUTURE_DATES_REQUIRE_CONSENT
+        );
     }
 
     public function getConfigurationFilesToUpdate(InputInterface $input): array

--- a/src/Glpi/Console/Migration/TimestampsCommand.php
+++ b/src/Glpi/Console/Migration/TimestampsCommand.php
@@ -41,6 +41,7 @@ use Glpi\Console\AbstractCommand;
 use Glpi\Console\Command\ConfigurationCommandInterface;
 use Glpi\Console\Exception\EarlyExitException;
 use Glpi\System\Requirement\DbTimezones;
+use LogicException;
 use Safe\DateTime;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -273,7 +274,7 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
         string $condition_description
     ): void {
         if ($this->db === null) {
-            return;
+            throw new LogicException(); // To make PHPStan happy
         }
         $this->db->update(
             $table,

--- a/src/Glpi/Console/Migration/TimestampsCommand.php
+++ b/src/Glpi/Console/Migration/TimestampsCommand.php
@@ -358,6 +358,10 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
             return $this->timestamp_max_value;
         }
 
+        if ($this->db === null) {
+            throw new LogicException(); // To make PHPStan happy
+        }
+
         $extended = false;
         try {
             $iterator = $this->db->request([
@@ -391,6 +395,10 @@ class TimestampsCommand extends AbstractCommand implements ConfigurationCommandI
      */
     private function confirmFutureDateClamping(array $tables): void
     {
+        if ($this->db === null) {
+            throw new LogicException(); // To make PHPStan happy
+        }
+
         $max_value = $this->getTimestampBoundValue($this->getTimestampMaxValue());
 
         $affected = [];

--- a/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
+++ b/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
@@ -78,12 +78,16 @@ SQL,
 
             $rows = $this->fetchRows();
 
+            $max_value = $this->getServerTimestampMaxValue();
+
             $this->assertSame(null, $rows[1]['nullable_date']);
             $this->assertSame('2020-01-01 00:00:00', $rows[1]['required_date']);
             $this->assertSame(null, $rows[2]['nullable_date']);
             $this->assertSame('1970-01-01 00:00:01', $rows[2]['required_date']);
-            $this->assertSame('2038-01-19 03:14:07', $rows[3]['nullable_date']);
-            $this->assertSame('2038-01-19 03:14:07', $rows[3]['required_date']);
+            // 2050 is within the extended (2106) range on 64-bit MariaDB 11.5+ and is preserved;
+            // on standard (32-bit / MySQL) servers it is clamped to the 2038 max.
+            $this->assertSame($max_value === '2038-01-19 03:14:07' ? '2038-01-19 03:14:07' : '2050-01-01 00:00:00', $rows[3]['nullable_date']);
+            $this->assertSame($max_value === '2038-01-19 03:14:07' ? '2038-01-19 03:14:07' : '2050-01-01 00:00:00', $rows[3]['required_date']);
 
             $display = $output->fetch();
             $this->assertStringContainsString(
@@ -95,7 +99,9 @@ SQL,
                 $display
             );
             $this->assertStringContainsString('updated to "NULL"', $display);
-            $this->assertStringContainsString('updated to "2038-01-19 03:14:07"', $display);
+            if ($max_value === '2038-01-19 03:14:07') {
+                $this->assertStringContainsString('updated to "2038-01-19 03:14:07"', $display);
+            }
         } finally {
             date_default_timezone_set($original_timezone);
         }
@@ -131,10 +137,46 @@ SQL,
 
             $rows = $this->fetchRows();
 
-            $this->assertSame('2038-01-19 03:14:07', $rows[1]['nullable_date']);
-            $this->assertSame('2038-01-19 03:14:07', $rows[1]['required_date']);
+            $max_value = $this->getServerTimestampMaxValue();
+
+            // 2050 is within the extended (2106) range on 64-bit MariaDB 11.5+ and is preserved;
+            // on standard (32-bit / MySQL) servers it is clamped to the 2038 max.
+            $expected = $max_value === '2038-01-19 03:14:07' ? '2038-01-19 03:14:07' : '2050-01-01 00:00:00';
+            $this->assertSame($expected, $rows[1]['nullable_date']);
+            $this->assertSame($expected, $rows[1]['required_date']);
             $this->assertNotSame('0000-00-00 00:00:00', $rows[1]['nullable_date']);
             $this->assertNotSame('0000-00-00 00:00:00', $rows[1]['required_date']);
+        } finally {
+            date_default_timezone_set($original_timezone);
+        }
+    }
+
+    public function testNormalizeOutOfRangeValuesClampsDatesBeyondExtendedRange(): void
+    {
+        $original_timezone = date_default_timezone_get();
+
+        try {
+            date_default_timezone_set('UTC');
+            $this->getDbHandle()->query("SET SESSION time_zone = '+00:00'");
+            $this->createTestTable();
+
+            // 2200-01-01 is beyond even the extended (2106) range and must always be clamped.
+            $this->getDbHandle()->query(
+                sprintf(
+                    "INSERT INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES (1, '2200-01-01 00:00:00', '2200-01-01 00:00:00')",
+                    self::TABLE
+                )
+            );
+
+            $command = $this->getCommand(new BufferedOutput());
+
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'nullable_date', true);
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'required_date', false);
+
+            $rows = $this->fetchRows();
+
+            $this->assertSame($this->getServerTimestampMaxValue(), $rows[1]['nullable_date']);
+            $this->assertSame($this->getServerTimestampMaxValue(), $rows[1]['required_date']);
         } finally {
             date_default_timezone_set($original_timezone);
         }
@@ -195,6 +237,30 @@ SQL,
         $this->setPrivateProperty($command, 'output', $output);
 
         return $command;
+    }
+
+    /**
+     * Probe the actual server TIMESTAMP upper bound using the same behavioral
+     * detection as the command, so tests pass on both standard (2038) and
+     * extended (2106, 64-bit MariaDB 11.5+) servers.
+     */
+    private function getServerTimestampMaxValue(): string
+    {
+        global $DB;
+
+        try {
+            $result = $DB->request([
+                'SELECT' => new \Glpi\DBAL\QueryExpression("CAST('2106-02-07 06:28:15' AS TIMESTAMP) AS probe"),
+            ]);
+            $row = $result->current();
+            if (isset($row['probe']) && $row['probe'] === '2106-02-07 06:28:15') {
+                return '2106-02-07 06:28:15';
+            }
+        } catch (\Throwable $e) {
+            // extended range not supported
+        }
+
+        return '2038-01-19 03:14:07';
     }
 
     private function fetchRows(): array

--- a/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
+++ b/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
@@ -61,7 +61,7 @@ class TimestampsCommandTest extends GLPITestCase
             $this->getDbHandle()->query(
                 sprintf(
                     <<<'SQL'
-INSERT INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES
+INSERT IGNORE INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES
    (1, NULL, '2020-01-01 00:00:00'),
    (2, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
    (3, '2050-01-01 00:00:00', '2050-01-01 00:00:00')

--- a/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
+++ b/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Console\Migration;
 
 use Glpi\Console\Migration\TimestampsCommand;
+use Glpi\DBAL\QueryExpression;
 use Glpi\Tests\GLPITestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -250,7 +251,7 @@ SQL,
 
         try {
             $result = $DB->request([
-                'SELECT' => new \Glpi\DBAL\QueryExpression("CAST('2106-02-07 06:28:15' AS TIMESTAMP) AS probe"),
+                'SELECT' => new QueryExpression("CAST('2106-02-07 06:28:15' AS TIMESTAMP) AS probe"),
             ]);
             $row = $result->current();
             if (isset($row['probe']) && $row['probe'] === '2106-02-07 06:28:15') {

--- a/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
+++ b/tests/functional/Glpi/Console/Migration/TimestampsCommandTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Console\Migration;
+
+use Glpi\Console\Migration\TimestampsCommand;
+use Glpi\Tests\GLPITestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class TimestampsCommandTest extends GLPITestCase
+{
+    private const TABLE = 'glpi_tmp_timestamp_migration_bounds';
+
+    public function tearDown(): void
+    {
+        $this->getDbHandle()->query(sprintf('DROP TABLE IF EXISTS `%s`', self::TABLE));
+
+        parent::tearDown();
+    }
+
+    public function testNormalizeOutOfRangeValues(): void
+    {
+        $original_timezone = date_default_timezone_get();
+
+        try {
+            date_default_timezone_set('UTC');
+            $this->getDbHandle()->query("SET SESSION time_zone = '+00:00'");
+            $this->createTestTable();
+
+            $this->getDbHandle()->query(
+                sprintf(
+                    <<<'SQL'
+INSERT INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES
+   (1, NULL, '2020-01-01 00:00:00'),
+   (2, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),
+   (3, '2050-01-01 00:00:00', '2050-01-01 00:00:00')
+SQL,
+                    self::TABLE
+                )
+            );
+
+            $output = new BufferedOutput();
+            $command = $this->getCommand($output);
+
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'nullable_date', true);
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'required_date', false);
+
+            $rows = $this->fetchRows();
+
+            $this->assertSame(null, $rows[1]['nullable_date']);
+            $this->assertSame('2020-01-01 00:00:00', $rows[1]['required_date']);
+            $this->assertSame(null, $rows[2]['nullable_date']);
+            $this->assertSame('1970-01-01 00:00:01', $rows[2]['required_date']);
+            $this->assertSame('2038-01-19 03:14:07', $rows[3]['nullable_date']);
+            $this->assertSame('2038-01-19 03:14:07', $rows[3]['required_date']);
+
+            $display = $output->fetch();
+            $this->assertStringContainsString(
+                'row(s) from "glpi_tmp_timestamp_migration_bounds"."nullable_date"',
+                $display
+            );
+            $this->assertStringContainsString(
+                'row(s) from "glpi_tmp_timestamp_migration_bounds"."required_date"',
+                $display
+            );
+            $this->assertStringContainsString('updated to "NULL"', $display);
+            $this->assertStringContainsString('updated to "2038-01-19 03:14:07"', $display);
+        } finally {
+            date_default_timezone_set($original_timezone);
+        }
+    }
+
+    public function testNormalizedFutureValuesCanBeConvertedToTimestamp(): void
+    {
+        $original_timezone = date_default_timezone_get();
+
+        try {
+            date_default_timezone_set('UTC');
+            $this->getDbHandle()->query("SET SESSION time_zone = '+00:00'");
+            $this->createTestTable();
+
+            $this->getDbHandle()->query(
+                sprintf(
+                    "INSERT INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES (1, '2050-01-01 00:00:00', '2050-01-01 00:00:00')",
+                    self::TABLE
+                )
+            );
+
+            $command = $this->getCommand(new BufferedOutput());
+
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'nullable_date', true);
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'required_date', false);
+
+            $this->getDbHandle()->query(
+                sprintf(
+                    'ALTER TABLE `%s` MODIFY COLUMN `nullable_date` TIMESTAMP NULL DEFAULT NULL, MODIFY COLUMN `required_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
+                    self::TABLE
+                )
+            );
+
+            $rows = $this->fetchRows();
+
+            $this->assertSame('2038-01-19 03:14:07', $rows[1]['nullable_date']);
+            $this->assertSame('2038-01-19 03:14:07', $rows[1]['required_date']);
+            $this->assertNotSame('0000-00-00 00:00:00', $rows[1]['nullable_date']);
+            $this->assertNotSame('0000-00-00 00:00:00', $rows[1]['required_date']);
+        } finally {
+            date_default_timezone_set($original_timezone);
+        }
+    }
+
+    public function testNormalizeOutOfRangeValuesDoesNotWarnWhenNoValueIsChanged(): void
+    {
+        $original_timezone = date_default_timezone_get();
+
+        try {
+            date_default_timezone_set('UTC');
+            $this->getDbHandle()->query("SET SESSION time_zone = '+00:00'");
+            $this->createTestTable();
+
+            $this->getDbHandle()->query(
+                sprintf(
+                    "INSERT INTO `%s` (`id`, `nullable_date`, `required_date`) VALUES (1, NULL, '2020-01-01 00:00:00')",
+                    self::TABLE
+                )
+            );
+
+            $output = new BufferedOutput();
+            $command = $this->getCommand($output);
+
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'nullable_date', true);
+            $this->callPrivateMethod($command, 'normalizeOutOfRangeValues', self::TABLE, 'required_date', false);
+
+            $this->assertSame('', $output->fetch());
+        } finally {
+            date_default_timezone_set($original_timezone);
+        }
+    }
+
+    private function createTestTable(): void
+    {
+        $this->getDbHandle()->query(sprintf('DROP TABLE IF EXISTS `%s`', self::TABLE));
+        $this->getDbHandle()->query(
+            sprintf(
+                <<<'SQL'
+CREATE TABLE `%s` (
+   `id` int unsigned NOT NULL,
+   `nullable_date` datetime NULL DEFAULT NULL,
+   `required_date` datetime NOT NULL,
+   PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+SQL,
+                self::TABLE
+            )
+        );
+    }
+
+    private function getCommand(BufferedOutput $output): TimestampsCommand
+    {
+        global $DB;
+
+        $command = new TimestampsCommand();
+        $this->setPrivateProperty($command, 'db', $DB);
+        $this->setPrivateProperty($command, 'output', $output);
+
+        return $command;
+    }
+
+    private function fetchRows(): array
+    {
+        $result = $this->getDbHandle()->query(
+            sprintf('SELECT `id`, `nullable_date`, `required_date` FROM `%s` ORDER BY `id`', self::TABLE)
+        );
+
+        $rows = [];
+        while ($row = $result->fetch_assoc()) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        return $rows;
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] This change requires a documentation update.

## Description
This PR closes #14842, fixing a bug where users are unable to log in after running the `glpi:migration:timestamps` command if they had future dates (e.g., `2050-01-01`) set in their `end_date` column.

### Root Cause
The pre-change code only handled values above `2038-01-19 03:14:07` when they were column defaults, via `information_schema.columns.COLUMN_DEFAULT` in `TimestampsCommand.php`. It did not handle actual stored row values like `glpi_users.end_date = '2050-01-01 00:00:00'`.

The issue is about stored data. During `ALTER TABLE ... MODIFY COLUMN ... TIMESTAMP`, MySQL/MariaDB warns on those out-of-bounds rows and coercively truncates them to `0000-00-00 00:00:00`. This causes login failures because GLPI treats that non-null past `end_date` as expired. The existing lower-bound cleanup fixed row values below `1970-01-01 00:00:01`, but there was no matching upper-bound cleanup for row values above 2038.

### Solution
To address this, we now normalize stored datetime values above the `TIMESTAMP` max limit *before* executing the column type conversion, rather than just clamping the default schema values.
- Before altering datetime columns to `TIMESTAMP`, the `TimestampsCommand` migration explicitly checks for and normalizes dates that are out of bounds.
- Dates that are below the minimum `TIMESTAMP` value (`1970-01-01 00:00:01`) are clamped to the minimum value (or `NULL` if the column is nullable). These are considered genuinely invalid and are normalized silently.
- Dates that exceed the maximum `TIMESTAMP` value are clamped to the server's actual upper bound, which is resolved at runtime via a behavioral `CAST(... AS TIMESTAMP)` probe:
  - `2106-02-07 06:28:15` on 64-bit MariaDB 11.5+ (where the extended range is supported),
  - `2038-01-19 03:14:07` on MySQL and 32-bit / older MariaDB builds.

### Explicit consent for future-date clamping
Per review feedback, invalid future dates are no longer destroyed silently. The command now requires explicit consent before clamping any row whose value exceeds the server's `TIMESTAMP` upper bound:
- A pre-scan counts and lists the affected tables/columns/rows before the migration loop.
- In interactive mode, the user is prompted with a yes/no confirmation (defaulting to **no**) listing the affected values and the clamp target.
- In non-interactive mode (`--no-interaction`), the command aborts with a clear error unless the new `--allow-future-date-clamping` flag is passed, which authorizes the clamping for automation.
- Pre-1970 dates remain silently normalized (genuinely invalid, no consent needed).

### Documentation
The `--allow-future-date-clamping` option is documented in [source/cli.rst](https://github.com/glpi-project/doc/blob/master/source/cli.rst) under the `glpi:migration:timestamps` command.

```diff
diff --git a/source/cli.rst b/source/cli.rst
index 028961f..f8df0f2 100644
--- a/source/cli.rst
+++ b/source/cli.rst
@@ -1196,6 +1196,30 @@ Description
 
 Convert "datetime" fields to "timestamp" to use timezones.
 
+Arguments/Options
+*****************
+
+There are no arguments for this command
+
+Options:
+
+.. list-table::
+
+  * - **Name**
+    - **Shortcut**
+    - **Description**
+    - **Required**
+    - **Default**
+    - **Array**
+    - **Negatable**
+  * - --allow-future-date-clamping
+    -
+    - Authorize clamping of future dates beyond the server TIMESTAMP range without prompting.
+    - No
+    - false
+    - No
+    - No
+
 
 
 ```
