### PR TITLE
fix(ui): orphaned Select2 dropdowns remaining visible when their parent container is replaced

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1244,6 +1244,9 @@ function updateItemOnEvent(dropdown_ids, target, url, params = {}, events = ['ch
                             resolved_params[k] = v;
                         }
                     });
+                    if ($.fn.select2) {
+                        $(target).find('.select2-hidden-accessible').select2('destroy');
+                    }
                     $(target).load(url, resolved_params);
                 };
                 if (conditional && (min_size_condition || force_load_condition)) {

--- a/js/common.js
+++ b/js/common.js
@@ -1244,6 +1244,7 @@ function updateItemOnEvent(dropdown_ids, target, url, params = {}, events = ['ch
                             resolved_params[k] = v;
                         }
                     });
+                    try { $(target).find('.select2-hidden-accessible').select2('destroy'); } catch(e) {}
                     $(target).load(url, resolved_params);
                 };
                 if (conditional && (min_size_condition || force_load_condition)) {

--- a/src/Ajax.php
+++ b/src/Ajax.php
@@ -789,7 +789,8 @@ JS;
         $display = true
     ) {
 
-        $out = sprintf('$("#%s").load("%s"', jsescape($toupdate), jsescape($url));
+        $out = sprintf('try { $("#%s").find(".select2-hidden-accessible").select2("destroy"); } catch(e) {}', jsescape($toupdate));
+        $out .= sprintf('$("#%s").load("%s"', jsescape($toupdate), jsescape($url));
         if (count($parameters)) {
             $out .= ",{";
             $first = true;


### PR DESCRIPTION
…AJAX

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
This PR fixes a UI bug where a Select2 sub-dropdown (e.g., triggered by selecting "Update" in Massive Actions) remains visibly stranded on the screen if the user subsequently chooses a different massive action (like "Add to transfer list") while the sub-dropdown is still open (Closes #17504).

Because GLPI's massive action sub-forms are replaced dynamically via AJAX (`jQuery.load()`), removing a Select2's underlying `<select>` element from the DOM without calling `.select2('destroy')` fails to remove its floating container popup from the `<body>`.

### Changes
- Updated `src/Ajax.php` (`updateItemJsCode()`) to automatically find and `destroy` any active `.select2-hidden-accessible` instances inside the target container right before `.load()` replaces the DOM elements.
- Applied the same fix to the client-side JavaScript equivalent `updateItemOnEvent()` in `js/common.js`.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/13fe7613-c032-456b-90dd-7e3dd004fb05
