### PR TITLE
fix(ui): Marketplace plugin UI state not dynamically updating

### DIFF
--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -82,6 +82,28 @@ $(document).ready(function() {
                         if (version_span.length > 0) {
                             version_span.html(`<i class="ti ti-git-branch"></i> ${new_version}`);
                         }
+
+                        var main_div = li.find('.main');
+                        if (main_div.hasClass('bg-warning-subtle')) {
+                            main_div.removeClass('bg-warning-subtle');
+
+                            var alert_div = $('.marketplace .alert-important.alert-warning');
+                            if (alert_div.length > 0) {
+                                var text_div = alert_div.children('div');
+                                var text = text_div.text();
+                                var matches = text.match(/\d+/);
+                                if (matches && matches.length > 0) {
+                                    var count = parseInt(matches[0], 10);
+                                    if (count > 1) {
+                                        text_div.text(text.replace(count, count - 1));
+                                    } else {
+                                        alert_div.remove();
+                                    }
+                                } else {
+                                    alert_div.remove();
+                                }
+                            }
+                        }
                     }
 
                     displayAjaxMessageAfterRedirect();

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -76,24 +76,24 @@ $(document).ready(function() {
                     html = html.replace('cleaned', '');
                     buttons.html(html);
 
-                    var new_version = buttons.find('.new-version').data('new-version');
+                    const new_version = buttons.find('.new-version').data('new-version');
                     if (new_version) {
-                        var version_span = li.find('.misc-right .version');
+                        const version_span = li.find('.misc-right .version');
                         if (version_span.length > 0) {
                             version_span.html(`<i class="ti ti-git-branch"></i> ${new_version}`);
                         }
 
-                        var main_div = li.find('.main');
+                        const main_div = li.find('.main');
                         if (main_div.hasClass('bg-warning-subtle')) {
                             main_div.removeClass('bg-warning-subtle');
 
-                            var alert_div = $('.marketplace .alert-important.alert-warning');
+                            const alert_div = $('.marketplace .alert-important.alert-warning');
                             if (alert_div.length > 0) {
-                                var text_div = alert_div.children('div');
-                                var text = text_div.text();
-                                var matches = text.match(/\d+/);
+                                const text_div = alert_div.children('div');
+                                const text = text_div.text();
+                                const matches = text.match(/\d+/);
                                 if (matches && matches.length > 0) {
-                                    var count = parseInt(matches[0], 10);
+                                    const count = parseInt(matches[0], 10);
                                     if (count > 1) {
                                         text_div.text(text.replace(count, count - 1));
                                     } else {

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -75,6 +75,15 @@ $(document).ready(function() {
                 } else {
                     html = html.replace('cleaned', '');
                     buttons.html(html);
+
+                    var new_version = buttons.find('.new-version').data('new-version');
+                    if (new_version) {
+                        var version_span = li.find('.misc-right .version');
+                        if (version_span.length > 0) {
+                            version_span.html('<i class="ti ti-git-branch"></i> ' + new_version);
+                        }
+                    }
+
                     displayAjaxMessageAfterRedirect();
                     addTooltips();
                 }

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -75,6 +75,15 @@ $(document).ready(function() {
                 } else {
                     html = html.replace('cleaned', '');
                     buttons.html(html);
+                    
+                    var new_version = buttons.find('.new-version').data('new-version');
+                    if (new_version) {
+                        var version_span = li.find('.misc-right .version');
+                        if (version_span.length > 0) {
+                            version_span.html('<i class="ti ti-git-branch"></i> ' + new_version);
+                        }
+                    }
+                    
                     displayAjaxMessageAfterRedirect();
                     addTooltips();
                 }

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -839,6 +839,10 @@ JS;
             );
         }
 
+        if ($exists) {
+            $buttons .= "<span class='d-none new-version' data-new-version='" . htmlescape($plugin_inst->getField('version')) . "'></span>";
+        }
+
         return $buttons;
     }
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When updating or installing a plugin via the GLPI Marketplace, the UI correctly exposed the action buttons (e.g. "Enable") upon completion. However, the rest of the plugin card and the global marketplace UI did not dynamically update to reflect the new state, requiring a manual page refresh.

This PR addresses multiple frontend UI state inconsistencies that occur after a successful plugin update via AJAX:

1. **Version String**: The displayed version string for the plugin failed to dynamically update (Closes #25056). The backend now passes the latest version back in a hidden `data-new-version` attribute alongside the buttons, which the frontend extracts to update the version string dynamically.
2. **Updatable Background State**: The `.bg-warning-subtle` highlight class is now correctly stripped from the plugin card's `.main` container once the plugin has been successfully updated.
3. **Updatable Plugins Counter**: The global "X plugin(s) to update" warning alert counter is now correctly decremented without refreshing the page. If the count reaches 0, the alert is automatically removed from the DOM.

## Changes Made
* **`src/Glpi/Marketplace/View.php`**: Modified `getButtons()` to append the plugin's latest version inside a hidden `<span class="new-version" data-new-version="...">` alongside the buttons HTML when the plugin exists locally.
* **`js/marketplace.js`**: Updated the AJAX `.done()` callback handling marketplace actions to extract the `data-new-version` attribute and update the `span.version` DOM element. Added logic to remove `.bg-warning-subtle` and decrement the `alert-important` global updatable counter dynamically.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/af8e5279-97d5-46bf-9e46-e50e954a890b
