### PR TITLE
fix(ui): port mapping squares misalignment on zoom/resize in Graphical Stencil Editor

### DIFF
--- a/css/standalone/stencil-editor.scss
+++ b/css/standalone/stencil-editor.scss
@@ -31,8 +31,15 @@
  * ---------------------------------------------------------------------
  */
 
+.cropper-scroll-container {
+    overflow-x: auto;
+    width: 100%;
+}
+
 .cropper-container {
     position: relative;
+    min-width: 800px;
+    width: 100%;
 
     cropper-canvas {
         min-height: 100px;

--- a/js/stencil-editor.js
+++ b/js/stencil-editor.js
@@ -60,6 +60,17 @@ const StencilEditor = function (container, rand, zones_definition) {
             const cropper = new window.Cropper(img);
             croppers.push(cropper);
             img.cropper = cropper;
+
+            const setAspectRatio = () => {
+                if (img.naturalWidth > 0) {
+                    $(img).closest('.cropper-container').css('aspect-ratio', `${img.naturalWidth} / ${img.naturalHeight}`);
+                }
+            };
+            if (img.complete) {
+                setAspectRatio();
+            } else {
+                img.addEventListener('load', setAspectRatio);
+            }
         });
 
         // set default state of croppers objects
@@ -73,18 +84,27 @@ const StencilEditor = function (container, rand, zones_definition) {
 
                 const cr_image = cropper.getCropperImage();
                 cr_image.$ready(() => {
-                    // center image (by stretching y axis to max)
-                    cr_image.$center('cover');
-
-                    // adapt canvas to have the same height as the image
-                    const img_rect = cr_image.getBoundingClientRect();
                     const cr_canvas = cropper.getCropperCanvas();
-                    $(container).find(cr_canvas).css('height', img_rect.height);
+                    $(cr_canvas).css({
+                        'width': '100%',
+                        'height': '100%'
+                    });
+                    cr_image.$center('contain');
 
-                    // re-center image (after heigh adjust of container, the image is off on top)
-                    cr_image.$center();
+                    const observer = new MutationObserver(() => {
+                        if (typeof _this.updateZonesPosition === 'function') {
+                            _this.updateZonesPosition();
+                        }
+                    });
+                    observer.observe(cr_image, { attributes: true, attributeFilter: ['style'] });
                 });
             });
+        });
+
+        window.addEventListener('resize', () => {
+            if (typeof _this.updateZonesPosition === 'function') {
+                _this.updateZonesPosition();
+            }
         });
 
         // global events
@@ -202,16 +222,25 @@ const StencilEditor = function (container, rand, zones_definition) {
             // load existing data
             if (Object.keys(zone).length > 1 && side == zone['side']) {
                 // set image in the state it was saved
-                cropper.getCropperImage().$setTransform(zone['image']);
+                const cr_image = cropper.getCropperImage();
+                cr_image.$setTransform(zone['image']);
 
-                // restore the selection
-                const data_sel = zone['selection'];
-                cropper.getCropperSelection().$change(
-                    data_sel['x'],
-                    data_sel['y'],
-                    data_sel['width'],
-                    data_sel['height']
-                );
+                // restore the selection using saved percentages to adapt to current canvas size
+                const cr_canvas = cropper.getCropperCanvas();
+                const can_rect = cr_canvas.getBoundingClientRect();
+                const img_rect = cr_image.getBoundingClientRect();
+
+                const img_x = img_rect.left - can_rect.left;
+                const img_y = img_rect.top - can_rect.top;
+                const img_w = img_rect.width;
+                const img_h = img_rect.height;
+
+                const sel_x = img_x + (zone['x_percent'] * img_w / 100);
+                const sel_y = img_y + (zone['y_percent'] * img_h / 100);
+                const sel_w = zone['width_percent'] * img_w / 100;
+                const sel_h = zone['height_percent'] * img_h / 100;
+
+                cropper.getCropperSelection().$change(sel_x, sel_y, sel_w, sel_h);
             }
         });
     };
@@ -364,6 +393,47 @@ const StencilEditor = function (container, rand, zones_definition) {
 
         // Enable tooltips
         $(container).find('a.defined-zone[data-bs-toggle="tooltip"]').tooltip('enable');
+        if (typeof _this.updateZonesPosition === 'function') {
+            _this.updateZonesPosition();
+        }
+    };
+
+    _this.updateZonesPosition = function () {
+        croppers.forEach((cropper) => {
+            const cr_image = cropper.getCropperImage();
+            const cr_canvas = cropper.getCropperCanvas();
+            if (!cr_image || !cr_canvas) return;
+
+            const can_rect = cr_canvas.getBoundingClientRect();
+            const img_rect = cr_image.getBoundingClientRect();
+
+            if (can_rect.width === 0 || img_rect.width === 0) return;
+
+            const img_x = img_rect.left - can_rect.left;
+            const img_y = img_rect.top - can_rect.top;
+            const img_w = img_rect.width;
+            const img_h = img_rect.height;
+            const can_w = can_rect.width;
+            const can_h = can_rect.height;
+
+            $(cropper.container).closest('.cropper-container').find(".defined-zone").each(function () {
+                const zoneIndex = $(this).data('zone-index');
+                const zone = zones[zoneIndex];
+                if (zone) {
+                    const left = (img_x + (zone['x_percent'] * img_w / 100)) / can_w * 100;
+                    const top = (img_y + (zone['y_percent'] * img_h / 100)) / can_h * 100;
+                    const width = (zone['width_percent'] * img_w / 100) / can_w * 100;
+                    const height = (zone['height_percent'] * img_h / 100) / can_h * 100;
+
+                    $(this).css({
+                        left: `${left}%`,
+                        top: `${top}%`,
+                        width: `${width}%`,
+                        height: `${height}%`
+                    });
+                }
+            });
+        });
     };
 
     // add a new zone

--- a/templates/stencil/editor.html.twig
+++ b/templates/stencil/editor.html.twig
@@ -149,15 +149,17 @@
 
     {% if id > 0 %}
         {% for picture in pictures %}
-            <div class="cropper-container mb-2">
-                <img src="{{ picture }}" class="cropper-hidden stencil-image" data-side="{{ loop.index - 1 }}">
-                {% include 'stencil/parts/zones.html.twig' with {
-                    'item': item,
-                    'stencil': stencil,
-                    'zones': zones,
-                    'current_side': loop.index - 1,
-                    'params': params
-                } only %}
+            <div class="cropper-scroll-container mb-2">
+                <div class="cropper-container">
+                    <img src="{{ picture }}" class="cropper-hidden stencil-image" data-side="{{ loop.index - 1 }}">
+                    {% include 'stencil/parts/zones.html.twig' with {
+                        'item': item,
+                        'stencil': stencil,
+                        'zones': zones,
+                        'current_side': loop.index - 1,
+                        'params': params
+                    } only %}
+                </div>
             </div>
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
This PR fixes a bug in the Graphical slot definition tab where the port mapping squares become misaligned relative to the equipment image when the browser zoom level changes, or when panning/zooming via CropperJS (Closes #23609). Additionally, it addresses an accessibility issue on smaller screens where the image could exceed the viewport width without a horizontal scrollbar, preventing data entry for ports on the far right.

### Changes
* **Dynamic Zone Positioning:** Added a `MutationObserver` on the CropperJS image element and a `resize` listener on the window. The `.defined-zone` percentages are now dynamically recalculated based on the actual image bounding rect inside the canvas, guaranteeing they stick to the image regardless of browser zoom or internal Cropper panning/zooming.
* **Canvas Aspect-Ratio Synchronization:** Set the `.cropper-container` to automatically mirror the image's natural aspect ratio, allowing `cropper-canvas` to scale properly using `contain`. This ensures the transparent PNG whitespaces are fully preserved and no cropping occurs.
* **Stable Zoom on Edit:** Replaced absolute pixel calculations with dynamic percentage-based dimension mapping when restoring selection boxes on existing ports. This fixes a bug where clicking "Edit" would warp or wildly zoom the image due to differing canvas sizes.
* **Native Horizontal Scrolling:** Wrapped the `.cropper-container` inside a `.cropper-scroll-container` with `min-width: 800px;` and `overflow-x: auto;`. This triggers a native horizontal scrollbar on small screens, allowing users to scroll to the far right of wide switches.

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/c8aef066-7d43-4697-acb2-026506bbbab9
