### PR TITLE
FIX / Fix DomainRecord TTL being forced to 3600 on add

### DIFF
--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -307,7 +307,7 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
                 $input['date_creation'] = 'NULL';
             }
 
-            if (empty($input['ttl'])) {
+            if (!isset($input['ttl']) || $input['ttl'] === '') {
                 $input['ttl'] = self::DEFAULT_TTL;
             }
         }
@@ -379,6 +379,13 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
             $this->fields['data_obj'] = 'NULL';
             $this->updates[]          = 'data_obj';
         }
+    }
+
+    public function post_getEmpty()
+    {
+        // Reflect the actual default applied on add, so the form does not
+        // display "0" for a value that will really be saved as DEFAULT_TTL.
+        $this->fields['ttl'] = self::DEFAULT_TTL;
     }
 
     public function showForm($ID, array $options = [])

--- a/tests/functional/DomainRecordTest.php
+++ b/tests/functional/DomainRecordTest.php
@@ -74,4 +74,25 @@ class DomainRecordTest extends DbTestCase
         $this->assertFalse($record->prepareInputForUpdate(['domains_id' => '']));
         $this->hasSessionMessages(ERROR, ['A domain is required']);
     }
+
+    public function testPrepareInputTtl()
+    {
+        $this->login();
+        $record = new DomainRecord();
+
+        // Explicit ttl = 0 on add must be kept as-is, not coerced to the default.
+        $input = $record->prepareInputForAdd(['domains_id' => 1, 'ttl' => 0]);
+        $this->assertSame(0, $input['ttl']);
+
+        // Missing/empty ttl on add falls back to the default.
+        $input = $record->prepareInputForAdd(['domains_id' => 1]);
+        $this->assertSame(DomainRecord::DEFAULT_TTL, $input['ttl']);
+
+        $input = $record->prepareInputForAdd(['domains_id' => 1, 'ttl' => '']);
+        $this->assertSame(DomainRecord::DEFAULT_TTL, $input['ttl']);
+
+        // A fresh (empty) item should reflect the real default ttl, not 0.
+        $record->getEmpty();
+        $this->assertSame(DomainRecord::DEFAULT_TTL, $record->fields['ttl']);
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45553
- When creating a DNS record, leaving TTL at its default (0) or explicitly setting it to 0 got silently changed to 3600 on save. This was caused by a PHP quirk where an empty-value check (`empty()`) treats `0` the same as "not provided", so any TTL of 0 was replaced by the default.
- The add form also displayed `0` in the TTL field, making it look like a valid choice, even though it could never actually be saved as `0`.
- Fixed the check so `0` is only replaced by the default when the field is truly empty, and made the form show the real default (3600) instead of a misleading `0`.

## Screenshots :

Before : 
<img width="1718" height="561" alt="Capture d’écran du 2026-07-31 10-47-16" src="https://github.com/user-attachments/assets/9165796d-13f5-4f0a-ab55-b923324a0e53" />
<img width="1718" height="561" alt="Capture d’écran du 2026-07-31 10-47-55" src="https://github.com/user-attachments/assets/0edfff10-9742-444e-8323-6a48101f3b7f" />

After : 
<img width="1718" height="561" alt="Capture d’écran du 2026-07-31 10-48-43" src="https://github.com/user-attachments/assets/e55d5b81-8ccb-4fe4-8e0f-bc2bbf45af4e" />
<img width="1718" height="128" alt="Capture d’écran du 2026-07-31 10-49-00" src="https://github.com/user-attachments/assets/8ba03f40-bdfd-4e03-936b-fffaf395c263" />




