### PR TITLE
feat(forms): add an interface for embeddable question types

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeEmbeddableInterface.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeEmbeddableInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glpi\Form\QuestionType;
+
+use Glpi\Form\Question;
+
+/**
+ * Contract for question types that can be rendered inside a composite question.
+ *
+ * The parent question type remains responsible for storing the child
+ * question's extra data and for supplying unique input names.
+ */
+interface QuestionTypeEmbeddableInterface extends QuestionTypeInterface
+{
+    /**
+     * Render the administration controls using an input-name prefix supplied
+     * by the parent question type.
+     */
+    public function renderEmbeddedAdministrationTemplate(
+        ?Question $question,
+        string $extra_data_input_prefix,
+    ): string;
+
+    /**
+     * Render the end-user control using an input name supplied by the parent
+     * question type.
+     */
+    public function renderEmbeddedEndUserTemplate(
+        Question $question,
+        string $input_name,
+    ): string;
+}


### PR DESCRIPTION
## Summary

Introduce a dedicated interface for question types that can be rendered inside another question type.

This adds a standard contract that allows composite question types (such as table questions) to reuse administration and end-user rendering provided by other question types without relying on plugin-specific implementations.

The interface currently defines two responsibilities:

- rendering administration controls with a supplied input prefix;
- rendering end-user controls with a supplied input name.

No existing question type is modified by this change.

## Motivation

Currently there is no standard way for a question type to expose embeddable rendering.

As a result, plugins must rely on runtime capability detection (`method_exists()`) or hard dependencies between plugins.

Adding this interface provides a generic extension point that can be reused by any current or future question type.

## Backward compatibility

This change is fully backward compatible.

Existing question types continue working without modification.

Only question types implementing the new interface expose the additional capability.

## Related

- Fields PR: https://github.com/pluginsGLPI/fields/pull/1235
- Advanced Forms PR: https://github.com/pluginsGLPI/advancedforms/pull/47


