### PR TITLE
Fix Access denied when editing SLA/OLA criteria and actions

### DIFF
--- a/ajax/viewsubitem.php
+++ b/ajax/viewsubitem.php
@@ -47,9 +47,29 @@ if (
     ($item = getItemForItemtype($_POST['type']))
     && ($parent = getItemForItemtype($_POST['parenttype']))
 ) {
+    $parent_fk = $parent::getForeignKeyField();
+    $parent_id = $_POST[$parent_fk] ?? null;
+
+    // SLA/OLA forms send their parent identifier as rules_id.
     if (
-        isset($_POST[$parent::getForeignKeyField()], $_POST["id"])
-        && $parent->getFromDB($_POST[$parent::getForeignKeyField()])
+        $parent_id === null
+        && isset($_POST['rules_id'])
+        && (
+            $parent instanceof SlaLevel
+            || $parent instanceof OlaLevel
+        )
+        && (
+            $item instanceof RuleCriteria
+            || $item instanceof RuleAction
+        )
+    ) {
+        $parent_id = $_POST['rules_id'];
+    }
+
+    if (
+        $parent_id !== null
+        && isset($_POST["id"])
+        && $parent->getFromDB($parent_id)
     ) {
         $item->showForm($_POST["id"], ['parent' => $parent]);
     } else {

--- a/ajax/viewsubitem.php
+++ b/ajax/viewsubitem.php
@@ -47,29 +47,9 @@ if (
     ($item = getItemForItemtype($_POST['type']))
     && ($parent = getItemForItemtype($_POST['parenttype']))
 ) {
-    $parent_fk = $parent::getForeignKeyField();
-    $parent_id = $_POST[$parent_fk] ?? null;
-
-    // SLA/OLA forms send their parent identifier as rules_id.
     if (
-        $parent_id === null
-        && isset($_POST['rules_id'])
-        && (
-            $parent instanceof SlaLevel
-            || $parent instanceof OlaLevel
-        )
-        && (
-            $item instanceof RuleCriteria
-            || $item instanceof RuleAction
-        )
-    ) {
-        $parent_id = $_POST['rules_id'];
-    }
-
-    if (
-        $parent_id !== null
-        && isset($_POST["id"])
-        && $parent->getFromDB($parent_id)
+        isset($_POST[$parent::getForeignKeyField()], $_POST["id"])
+        && $parent->getFromDB($_POST[$parent::getForeignKeyField()])
     ) {
         $item->showForm($_POST["id"], ['parent' => $parent]);
     } else {

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1166,7 +1166,7 @@ TWIG, $twig_params);
                             $('#viewaction{$rules_id}{$rand}').load(CFG_GLPI.root_doc + '/ajax/viewsubitem.php',{
                                 type: '" . jsescape($this->ruleactionclass) . "',
                                 parenttype: '" . jsescape($rule_class) . "',
-                                rules_id: $rules_id,
+                                {$this->rules_id_field}: $rules_id,
                                 id: action_id
                             });
                         }
@@ -1280,10 +1280,10 @@ TWIG, $twig_params);
                         }
                         const criteria_id = $(e.currentTarget).data('id');
                         if (criteria_id) {
-                            $('#viewcriteria{$rules_id}{$rand}').load(CFG_GLPI.root_doc + '/ajax/viewsubitem.php',{
+                            $('#viewcriteria{$rules_id}{$rand}').load('/ajax/viewsubitem.php',{
                                 type: '" . jsescape($this->rulecriteriaclass) . "',
                                 parenttype: '" . jsescape($rule_class) . "',
-                                rules_id: $rules_id,
+                                {$this->rules_id_field}: $rules_id,
                                 id: criteria_id
                             });
                         }


### PR DESCRIPTION
## Description

Fixes an issue where editing existing SLA/OLA criteria and actions always results in an "Access denied" message, even for Super-Admin users.

Creating new criteria/actions works correctly, but opening an existing one fails because the AJAX request (`ajax/viewsubitem.php`) expects the parent identifier using the object's foreign key (`slalevels_id` / `olalevels_id`), while the SLA/OLA editor submits it as `rules_id`.

This patch adds backward compatibility for SLA/OLA criteria and actions by accepting `rules_id` when the parent object is `SlaLevel` or `OlaLevel`.

## Steps to reproduce

1. Create an SLA or OLA.
2. Add a criterion or action.
3. Save it.
4. Try to edit the existing criterion/action.
5. "Access denied" is displayed.

## Expected behavior

Existing SLA/OLA criteria and actions should open normally for editing.

## Actual behavior

Editing always fails with "Access denied".

