### PR TITLE
Add bulk access control management for forms

### DIFF
--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -417,11 +417,7 @@ final class Form extends CommonDBTM implements
             );
 
             // Do not keep half updated data
-            try {
-                $DB->rollback();
-            } catch (Throwable $rollback_e) {
-                // Catch rollback failures so the original exception is propagated
-            }
+            $DB->rollback();
 
             // Propagate exception to ensure the server return an error code
             throw $e;
@@ -459,17 +455,283 @@ final class Form extends CommonDBTM implements
     #[Override]
     public static function showMassiveActionsSubForm(MassiveAction $ma): bool
     {
-        global $CFG_GLPI;
+        switch ($ma->getAction()) {
+            case 'export':
+                global $CFG_GLPI;
 
-        $ids = array_values($ma->getItems()[Form::class]);
-        $export_url = $CFG_GLPI['url_base'];
-        $export_url .= "/Form/Export?" . http_build_query(['ids' => $ids]);
+                $ids = array_values($ma->getItems()[Form::class]);
+                $export_url = $CFG_GLPI['url_base'];
+                $export_url .= "/Form/Export?" . http_build_query(['ids' => $ids]);
 
-        $label = __s("Click here to download the exported forms...");
-        echo "<a href=\"" . \htmlescape($export_url) . "\">$label</a>";
-        echo Html::scriptBlock("window.location.href = '" . \jsescape($export_url) . "';");
+                $label = __s("Click here to download the exported forms...");
+                echo "<a href=\"" . \htmlescape($export_url) . "\">$label</a>";
+                echo Html::scriptBlock("window.location.href = '" . \jsescape($export_url) . "';");
+                return true;
 
-        return true;
+            case 'access_controls':
+                $ids = array_values($ma->getItems()[Form::class] ?? []);
+                if ($ids === []) {
+                    return false;
+                }
+
+                $source_form = new self();
+                if (!$source_form->getFromDB($ids[0])) {
+                    return false;
+                }
+
+                $manager = FormAccessControlManager::getInstance();
+                $manager->createMissingAccessControlsForForm($source_form);
+
+                $is_single_form = count($ids) === 1;
+                $template_data = [
+                    'forms_count'    => count($ids),
+                    'is_single_form' => $is_single_form,
+                ];
+
+                if ($is_single_form) {
+                    // For one form, display the complete current access-control
+                    // configuration and save it like the regular form tab.
+                    $template_data['access_controls'] = $manager->sortAccessControls(
+                        $source_form->getAccessControls()
+                    );
+                } else {
+                    // For several forms, only add/remove allow-list entries.
+                    // Do not preload permissions from the first selected form.
+                    $allow_list_control = null;
+                    foreach ($source_form->getAccessControls() as $control) {
+                        if ($control->fields['strategy'] === AllowList::class) {
+                            $allow_list_control = $control;
+                            break;
+                        }
+                    }
+
+                    if ($allow_list_control === null) {
+                        return false;
+                    }
+
+                    $allow_list_control->fields['config'] = json_encode([
+                        'user_ids'    => [],
+                        'group_ids'   => [],
+                        'profile_ids' => [],
+                    ]);
+                    $template_data['access_control'] = $allow_list_control;
+                }
+
+                TemplateRenderer::getInstance()->display(
+                    'pages/admin/form/massive_action_access_control.html.twig',
+                    $template_data
+                );
+
+                echo Html::submit(
+                    $is_single_form ? _x('button', 'Save changes') : _x('button', 'Apply'),
+                    [
+                        'name'  => 'massiveaction',
+                        'id'    => 'access-control-submit',
+                        'icon'  => 'ti ti-device-floppy',
+                        'class' => 'btn btn-sm btn-primary mt-3',
+                        'style' => $is_single_form ? '' : 'display: none',
+                    ]
+                );
+                return true;
+        }
+
+        return false;
+    }
+
+    #[Override]
+    public static function processMassiveActionsForOneItemtype(
+        MassiveAction $ma,
+        CommonDBTM $item,
+        array $ids
+    ): void {
+        if ($ma->getAction() !== 'access_controls' || !$item instanceof self) {
+            return;
+        }
+
+        $input = $ma->getInput();
+        $is_single_form = count($ids) === 1;
+        $operation = $is_single_form
+            ? 'replace'
+            : ($input['access_control_operation'] ?? '');
+
+        if (!in_array($operation, ['replace', 'add', 'remove'], true)) {
+            foreach ($ids as $id) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+            }
+            $ma->addMessage(__s('Invalid access control operation.'));
+            return;
+        }
+
+        $submitted_controls = $input['_access_control'] ?? [];
+        if (!is_array($submitted_controls) || $submitted_controls === []) {
+            foreach ($ids as $id) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+            }
+            $ma->addMessage(__s('No access control configuration was submitted.'));
+            return;
+        }
+
+        $manager = FormAccessControlManager::getInstance();
+
+        if ($operation === 'replace') {
+            $id = (int) array_values($ids)[0];
+            $target_form = new self();
+            if (!$target_form->can($id, UPDATE)) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_NORIGHT);
+                return;
+            }
+
+            try {
+                $manager->createMissingAccessControlsForForm($target_form);
+
+                $target_controls = [];
+                foreach ($target_form->getAccessControls() as $target_control) {
+                    $target_controls[$target_control->fields['strategy']] = $target_control;
+                }
+
+                foreach ($submitted_controls as $source_control_id => $control_input) {
+                    $source_control = new FormAccessControl();
+                    if (!$source_control->getFromDB((int) $source_control_id)) {
+                        throw new RuntimeException('Source access control not found');
+                    }
+
+                    $strategy_class = $source_control->fields['strategy'];
+                    if (!isset($target_controls[$strategy_class])) {
+                        throw new RuntimeException("Target access control not found: $strategy_class");
+                    }
+
+                    $target_control = $target_controls[$strategy_class];
+                    $new_config = $source_control->createConfigFromUserInput($control_input);
+
+                    // Preserve the form-specific direct-access token.
+                    if ($strategy_class === DirectAccess::class) {
+                        $new_data = json_decode(json_encode($new_config), true);
+                        $target_config = $target_control->getConfig();
+                        $target_data = json_decode(json_encode($target_config), true);
+
+                        if (isset($target_data['token'])) {
+                            $new_data['token'] = $target_data['token'];
+                            $config_class = $target_config::class;
+                            $new_config = $config_class::jsonDeserialize($new_data);
+                        }
+                    }
+
+                    $success = $target_control->update([
+                        'id'        => $target_control->getID(),
+                        'is_active' => (int) ($control_input['is_active'] ?? 0),
+                        '_config'   => $new_config,
+                    ], true);
+
+                    if (!$success) {
+                        throw new RuntimeException('Failed to update access control');
+                    }
+                }
+
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_OK);
+            } catch (Throwable $e) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+                $ma->addMessage($e->getMessage());
+            }
+
+            return;
+        }
+
+        $source_control_id = (int) array_key_first($submitted_controls);
+        $control_input = $submitted_controls[$source_control_id];
+
+        $source_control = new FormAccessControl();
+        if (
+            !$source_control->getFromDB($source_control_id)
+            || $source_control->fields['strategy'] !== AllowList::class
+        ) {
+            foreach ($ids as $id) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+            }
+            $ma->addMessage(__s('Invalid access control configuration.'));
+            return;
+        }
+
+        $selected_entries = $source_control->createConfigFromUserInput($control_input);
+        $selected_entries_data = json_decode(json_encode($selected_entries), true);
+        $has_entries = false;
+        foreach (['user_ids', 'group_ids', 'profile_ids'] as $field) {
+            if (!empty($selected_entries_data[$field])) {
+                $has_entries = true;
+                break;
+            }
+        }
+
+        if (!$has_entries) {
+            foreach ($ids as $id) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+            }
+            $ma->addMessage(__s('No users, groups or profiles were selected.'));
+            return;
+        }
+
+        foreach ($ids as $id) {
+            $target_form = new self();
+            if (!$target_form->can($id, UPDATE)) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_NORIGHT);
+                continue;
+            }
+
+            try {
+                $manager->createMissingAccessControlsForForm($target_form);
+
+                $target_control = null;
+                foreach ($target_form->getAccessControls() as $control) {
+                    if ($control->fields['strategy'] === AllowList::class) {
+                        $target_control = $control;
+                        break;
+                    }
+                }
+
+                if ($target_control === null) {
+                    throw new RuntimeException('Allow-list access control not found');
+                }
+
+                $target_config = $target_control->getConfig();
+                $target_data = json_decode(json_encode($target_config), true);
+
+                foreach (['user_ids', 'group_ids', 'profile_ids'] as $field) {
+                    $current_values = $target_data[$field] ?? [];
+                    $selected_values = $selected_entries_data[$field] ?? [];
+
+                    if ($operation === 'add') {
+                        $target_data[$field] = array_values(array_unique([
+                            ...$current_values,
+                            ...$selected_values,
+                        ], SORT_REGULAR));
+                    } else {
+                        $target_data[$field] = array_values(array_filter(
+                            $current_values,
+                            fn($value) => !in_array($value, $selected_values),
+                        ));
+                    }
+                }
+
+                $config_class = $target_config::class;
+                $merged_config = $config_class::jsonDeserialize($target_data);
+
+                $success = $target_control->update([
+                    'id'        => $target_control->getID(),
+                    'is_active' => $operation === 'add'
+                        ? 1
+                        : (int) $target_control->fields['is_active'],
+                    '_config'   => $merged_config,
+                ], true);
+
+                if (!$success) {
+                    throw new RuntimeException('Failed to update access control entries');
+                }
+
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_OK);
+            } catch (Throwable $e) {
+                $ma->itemDone(self::class, $id, MassiveAction::ACTION_KO);
+                $ma->addMessage($e->getMessage());
+            }
+        }
     }
 
     #[Override]

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -36,9 +36,9 @@
 use Glpi\Asset\CustomFieldDefinition;
 use Glpi\Event;
 use Glpi\Features\Clonable;
-use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\SearchOption;
+use Symfony\Component\HttpFoundation\Request;
 
 use function Safe\preg_match;
 
@@ -664,6 +664,12 @@ class MassiveAction
             ) {
                 //TRANS: select action 'update' (before doing it)
                 $actions[$self_pref . 'update'] = _sx('button', 'Update');
+
+                // Keep the form access-control action next to the standard update action.
+                if ($item instanceof \Glpi\Form\Form) {
+                    $key = \Glpi\Form\Form::class . self::CLASS_ACTION_SEPARATOR . 'access_controls';
+                    $actions[$key] = "<i class='ti ti-key'></i>" . __s('Configure access controls');
+                }
 
                 if ($cancreate && Toolbox::hasTrait($itemtype, Clonable::class)) {
                     $actions[$self_pref . 'clone'] = "<i class='ti ti-copy'></i>" . _sx('button', 'Clone');
@@ -1861,9 +1867,6 @@ class MassiveAction
      **/
     public function itemDone($itemtype, $id, $result)
     {
-        /** @var Kernel $kernel */
-        global $kernel;
-
         $this->current_itemtype = (string) $itemtype;
 
         if (!isset($this->done[$itemtype])) {
@@ -1907,7 +1910,7 @@ class MassiveAction
         // Reload every X seconds to refresh the progress bar
         $refresh_delay = 5;
         if ((microtime(true) - $this->start_time) > $refresh_delay) {
-            $request = $kernel->getMainRequest();
+            $request = Request::createFromGlobals();
             Html::redirect($request->getBasePath() . $request->getPathInfo() . '?identifier=' . $this->identifier);
         }
     }

--- a/templates/pages/admin/form/massive_action_access_control.html.twig
+++ b/templates/pages/admin/form/massive_action_access_control.html.twig
@@ -1,0 +1,148 @@
+{#
+ # Access-control massive action.
+ # One form: full editor with current values.
+ # Multiple forms: choose Add/Remove, then select allow-list entries.
+ #}
+
+{# @var bool is_single_form #}
+{# @var int forms_count #}
+
+{% if is_single_form %}
+    <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
+        <i class="ti ti-info-circle me-2"></i>
+        <span>{{ __('Current access permissions for the selected form are shown below.') }}</span>
+    </div>
+
+    <div class="col-12">
+        {% for access_control in access_controls %}
+            {% set strategy = access_control.getStrategy() %}
+
+            <section
+                class="mb-4"
+                data-glpi-access-control-form
+                aria-label="{{ strategy.getLabel() }}"
+            >
+                <h3 class="d-flex align-items-center fs-4">
+                    <i class="{{ strategy.getIcon() }} me-2"></i>
+                    {{ strategy.getLabel() }}
+                    <label class="form-check mb-0 ms-auto form-switch">
+                        <input
+                            type="hidden"
+                            value="0"
+                            name="{{ access_control.getNormalizedInputName('is_active') }}"
+                        >
+                        <input
+                            aria-label="{{ __('Active') }}"
+                            data-glpi-toggle-control
+                            class="form-check-input"
+                            type="checkbox"
+                            name="{{ access_control.getNormalizedInputName('is_active') }}"
+                            value="1"
+                            {{ access_control.fields.is_active == true ? 'checked' : '' }}
+                        >
+                    </label>
+                </h3>
+
+                <div
+                    style="{{ access_control.fields.is_active == false ? 'opacity: 0.5' : '' }}"
+                    data-glpi-toggle-control-target
+                >
+                    {{ strategy.renderConfigForm(access_control)|raw }}
+                </div>
+            </section>
+        {% endfor %}
+    </div>
+{% else %}
+    <div class="d-flex flex-column align-items-center mb-3">
+        <label class="form-label mb-2" for="access-control-operation">
+            {{ __('Operation') }}
+        </label>
+        <select
+            id="access-control-operation"
+            name="access_control_operation"
+            class="form-select"
+            data-width="200px"
+        >
+            <option value="">-----</option>
+            <option value="add">{{ _x('button', 'Add') }}</option>
+            <option value="remove">{{ _x('button', 'Remove') }}</option>
+        </select>
+    </div>
+
+    {% set strategy = access_control.getStrategy() %}
+
+    <div id="access-control-operation-fields" class="w-100" style="display: none">
+        <div class="alert alert-info d-flex align-items-center justify-content-center mb-3" role="alert">
+            <i class="ti ti-info-circle me-2"></i>
+            <span>
+                {{ __('The selected entries will be added to or removed from %s selected forms.')|format(forms_count) }}
+                {{ __('Other access permissions will be kept.') }}
+            </span>
+        </div>
+
+        <section class="mb-3 text-center" aria-label="{{ strategy.getLabel() }}">
+            <h3 class="d-flex align-items-center justify-content-center fs-4">
+                <i class="{{ strategy.getIcon() }} me-2"></i>
+                {{ __('Users, groups or profiles') }}
+            </h3>
+
+            <input
+                type="hidden"
+                name="{{ access_control.getNormalizedInputName('is_active') }}"
+                value="1"
+            >
+
+            {{ strategy.renderConfigForm(access_control)|raw }}
+        </section>
+    </div>
+{% endif %}
+
+<style>
+    #access-control-operation + .select2-container
+        .select2-selection__rendered {
+        text-align: left;
+    }
+
+    .select2-container--open
+        .select2-results__option {
+        text-align: left;
+    }
+</style>
+
+<script>
+    $(() => {
+        const $operation = $("#access-control-operation");
+        if ($operation.length && $.fn.select2) {
+            $operation.select2({
+                width: "200px",
+                minimumResultsForSearch: Infinity,
+                dropdownParent: $operation.closest(".modal, form"),
+            });
+        }
+
+        $("[data-glpi-toggle-control]").on("change", function() {
+            $(this).closest("section[data-glpi-access-control-form]")
+                .find("[data-glpi-toggle-control-target]")
+                .css("opacity", this.checked ? 1 : 0.5)
+            ;
+        });
+
+        $("section[data-glpi-access-control-form] :input").on("change", function() {
+            if ($(this).data("glpi-toggle-control") !== undefined) {
+                return;
+            }
+
+            $(this).closest("section")
+                .find("[data-glpi-toggle-control]")
+                .prop("checked", true)
+                .trigger("change")
+            ;
+        });
+
+        $("#access-control-operation").on("change", function() {
+            const has_operation = this.value === "add" || this.value === "remove";
+            $("#access-control-operation-fields").toggle(has_operation);
+            $("#access-control-submit").toggle(has_operation);
+        });
+    });
+</script>


### PR DESCRIPTION
## Description

This PR adds a new massive action for Forms called **Configure access controls**.

The new action allows administrators to manage access permissions for multiple forms without opening each form individually.

### Features

- Adds a new **Configure access controls** massive action displayed after **Update**.
- Supports bulk operations:
  - **Add** access permissions.
  - **Remove** access permissions.
- Existing permissions are preserved when using **Add**.
- Only selected users, groups or profiles are removed when using **Remove**.
- No duplicate permissions are created.
- When a single form is selected, the current access configuration is displayed and can be edited directly.
- When multiple forms are selected, the administrator first chooses the operation (Add / Remove), then selects users, groups or profiles.
- The interface follows the existing GLPI massive action workflow by displaying additional options only after selecting an operation.

## Benefits

Managing permissions for many forms is currently time-consuming because each form must be opened individually.

This feature allows administrators to manage access permissions consistently across multiple forms while preserving existing configurations.

No existing behavior is changed unless the new massive action is explicitly used.


<img width="216" height="156" alt="image" src="https://github.com/user-attachments/assets/860d55ce-6115-4204-9221-0ffcc77bda76" />
<img width="390" height="270" alt="image" src="https://github.com/user-attachments/assets/75f550aa-ac47-412a-8a56-d2c94fb7746a" />
<img width="344" height="254" alt="image" src="https://github.com/user-attachments/assets/fe4bfdce-ffe3-4831-8d80-67ead2130c16" />
<img width="1128" height="438" alt="image" src="https://github.com/user-attachments/assets/e3dad066-358d-48de-ad8f-66b2bcb031e7" />
<img width="901" height="150" alt="image" src="https://github.com/user-attachments/assets/6bacdc9d-ef57-4f6a-8882-4f25dd3ba72f" />
<img width="1117" height="432" alt="image" src="https://github.com/user-attachments/assets/9375c070-0e64-497c-9329-000beaf5fcf4" />
<img width="847" height="185" alt="image" src="https://github.com/user-attachments/assets/c98d4520-ac86-464d-8e43-25cf8c304110" />

One form:

<img width="170" height="159" alt="image" src="https://github.com/user-attachments/assets/79558c86-ae94-47b8-8567-2a1e81161146" />
<img width="1132" height="542" alt="image" src="https://github.com/user-attachments/assets/a7b471aa-0fbe-4dcb-b81a-ce8c0f0f2185" />

