### PR TITLE
Fix entities where problem and change are created from asset form

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -617,7 +617,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      * "_add_fromitem"/"itemtype"/"items_id" form options), provided the
      * current user has access to that entity.
      *
-     * @param array $options
+     * @param array<string, mixed> $options
      *
      * @return int|null The asset entity, or null if it cannot be determined or is not accessible.
      */

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -622,6 +622,18 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             return false;
         }
 
+        if (
+            isset($options['_add_fromitem'])
+            && isset($options['itemtype'])
+            && is_a($options['itemtype'], CommonDBTM::class, true)
+        ) {
+            $item = new $options['itemtype']();
+            $item->getFromDB($options['items_id'][$options['itemtype']][0]);
+            if (Session::haveAccessToEntity($item->fields['entities_id'])) {
+                $options['entities_id'] = $item->fields['entities_id'];
+            }
+        }
+
         $this->restoreInputAndDefaults($ID, $options);
 
         $canupdate = !$ID || (Session::getCurrentInterface() == "central" && $this->canUpdateItem());

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -613,6 +613,34 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     }
 
     /**
+     * Resolve the entity to use for a new item created from an asset (via the
+     * "_add_fromitem"/"itemtype"/"items_id" form options), provided the
+     * current user has access to that entity.
+     *
+     * @param array $options
+     *
+     * @return int|null The asset entity, or null if it cannot be determined or is not accessible.
+     */
+    protected function getEntitiesIdFromAddFromItemOptions(array $options): ?int
+    {
+        if (
+            !isset($options['_add_fromitem'], $options['itemtype'])
+            || !is_a($options['itemtype'], CommonDBTM::class, true)
+        ) {
+            return null;
+        }
+
+        $item = new $options['itemtype']();
+        $item->getFromDB($options['items_id'][$options['itemtype']][0]);
+
+        if (!Session::haveAccessToEntity($item->fields['entities_id'])) {
+            return null;
+        }
+
+        return $item->fields['entities_id'];
+    }
+
+    /**
      * @param $ID
      * @param $options   array
      **/
@@ -622,16 +650,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             return false;
         }
 
-        if (
-            isset($options['_add_fromitem'])
-            && isset($options['itemtype'])
-            && is_a($options['itemtype'], CommonDBTM::class, true)
-        ) {
-            $item = new $options['itemtype']();
-            $item->getFromDB($options['items_id'][$options['itemtype']][0]);
-            if (Session::haveAccessToEntity($item->fields['entities_id'])) {
-                $options['entities_id'] = $item->fields['entities_id'];
-            }
+        $entities_id = $this->getEntitiesIdFromAddFromItemOptions($options);
+        if ($entities_id !== null) {
+            $options['entities_id'] = $entities_id;
         }
 
         $this->restoreInputAndDefaults($ID, $options);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3683,7 +3683,9 @@ JAVASCRIPT;
         if (isset($options['_add_fromitem']) && isset($options['itemtype']) && is_a($options['itemtype'], CommonDBTM::class, true)) {
             $item = new $options['itemtype']();
             $item->getFromDB($options['items_id'][$options['itemtype']][0]);
-            $options['entities_id'] = $item->fields['entities_id'];
+            if (Session::haveAccessToEntity($item->fields['entities_id'])) {
+                $options['entities_id'] = $item->fields['entities_id'];
+            }
         }
 
         $this->restoreInputAndDefaults($ID, $options, null, true);

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3680,12 +3680,9 @@ JAVASCRIPT;
             return false;
         }
 
-        if (isset($options['_add_fromitem']) && isset($options['itemtype']) && is_a($options['itemtype'], CommonDBTM::class, true)) {
-            $item = new $options['itemtype']();
-            $item->getFromDB($options['items_id'][$options['itemtype']][0]);
-            if (Session::haveAccessToEntity($item->fields['entities_id'])) {
-                $options['entities_id'] = $item->fields['entities_id'];
-            }
+        $entities_id = $this->getEntitiesIdFromAddFromItemOptions($options);
+        if ($entities_id !== null) {
+            $options['entities_id'] = $entities_id;
         }
 
         $this->restoreInputAndDefaults($ID, $options, null, true);

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -65,7 +65,7 @@ class ChangeTest extends DbTestCase
 
         // Login again to acess the new entity
         $this->login('glpi', 'glpi');
-        $success = \Session::changeActiveEntities($entity->getID(), true);
+        $success = Session::changeActiveEntities($entity->getID(), true);
         $this->assertTrue($success);
 
         $group = new \Group();
@@ -615,7 +615,7 @@ class ChangeTest extends DbTestCase
                 'requester' => [
                     [
                         'itemtype'  => 'User',
-                        'items_id'  => \Session::getLoginUserID(),
+                        'items_id'  => Session::getLoginUserID(),
                     ],
                 ],
             ],

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -504,6 +504,41 @@ class ChangeTest extends DbTestCase
         $this->assertNotEquals($root_entity, (int) $change->fields['entities_id']);
     }
 
+    public function testShowFormFromItemIgnoresInaccessibleItemEntity(): void
+    {
+        // Arrange: an asset in an entity the current session has no access to
+        $this->login('glpi', 'glpi');
+
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer in an entity the session cannot access',
+            'entities_id' => $item_entity,
+        ]);
+
+        $active_entity = getItemByTypeName('Entity', '_test_child_1', true);
+        // Restrict the active session to a sibling entity only (no access to
+        // the asset's entity, even though the user's profile is recursive
+        // from a common ancestor)
+        $this->assertTrue(Session::changeActiveEntities($active_entity, false));
+
+        $change = new Change();
+        $change->getEmpty();
+
+        // Act: render form for a new change created from the (inaccessible) asset
+        ob_start();
+        $change->showForm($change->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the change falls back to the active session entity, the
+        // asset entity is NOT used since the session has no access to it
+        $this->assertEquals($active_entity, (int) $change->fields['entities_id']);
+        $this->assertNotEquals($item_entity, (int) $change->fields['entities_id']);
+    }
+
     public function testShowFormClosedItem(): void
     {
         // Arrange: prepare an empty change

--- a/tests/functional/ChangeTest.php
+++ b/tests/functional/ChangeTest.php
@@ -38,8 +38,10 @@ use Change;
 use Change_User;
 use CommonITILActor;
 use CommonITILObject;
+use Computer;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Session;
 use User;
 
 /* Test for inc/change.class.php */
@@ -465,6 +467,41 @@ class ChangeTest extends DbTestCase
 
         // Assert: make sure some html was generated
         $this->assertNotEmpty($html);
+    }
+
+    public function testShowFormFromItemUsesItemEntity(): void
+    {
+        // Arrange: an asset in a sub-entity, while the current (default)
+        // session entity is its parent entity
+        $this->login('glpi', 'glpi');
+
+        $root_entity = $this->getTestRootEntity(only_id: true);
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer used to create a change from item',
+            'entities_id' => $item_entity,
+        ]);
+
+        // Active entity is the parent entity (with access to its sub-entities),
+        // which is not the same as the asset's own entity
+        $this->assertTrue(Session::changeActiveEntities($root_entity, true));
+
+        $change = new Change();
+        $change->getEmpty();
+
+        // Act: render form for a new change created from the asset
+        ob_start();
+        $change->showForm($change->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the change entity follows the asset entity, not the
+        // currently active session entity
+        $this->assertEquals($item_entity, (int) $change->fields['entities_id']);
+        $this->assertNotEquals($root_entity, (int) $change->fields['entities_id']);
     }
 
     public function testShowFormClosedItem(): void

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -36,10 +36,12 @@ namespace tests\units;
 
 use CommonITILActor;
 use CommonITILObject;
+use Computer;
 use Glpi\Tests\DbTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
 use Problem_User;
+use Session;
 use User;
 
 /* Test for inc/problem.class.php */
@@ -307,6 +309,41 @@ class ProblemTest extends DbTestCase
 
         // Assert: make sure some html was generated
         $this->assertNotEmpty($html);
+    }
+
+    public function testShowFormFromItemUsesItemEntity(): void
+    {
+        // Arrange: an asset in a sub-entity, while the current (default)
+        // session entity is its parent entity
+        $this->login('glpi', 'glpi');
+
+        $root_entity = $this->getTestRootEntity(only_id: true);
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer used to create a problem from item',
+            'entities_id' => $item_entity,
+        ]);
+
+        // Active entity is the parent entity (with access to its sub-entities),
+        // which is not the same as the asset's own entity
+        $this->assertTrue(Session::changeActiveEntities($root_entity, true));
+
+        $problem = new Problem();
+        $problem->getEmpty();
+
+        // Act: render form for a new problem created from the asset
+        ob_start();
+        $problem->showForm($problem->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the problem entity follows the asset entity, not the
+        // currently active session entity
+        $this->assertEquals($item_entity, (int) $problem->fields['entities_id']);
+        $this->assertNotEquals($root_entity, (int) $problem->fields['entities_id']);
     }
 
     public function testShowFormClosedItem(): void

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -346,6 +346,41 @@ class ProblemTest extends DbTestCase
         $this->assertNotEquals($root_entity, (int) $problem->fields['entities_id']);
     }
 
+    public function testShowFormFromItemIgnoresInaccessibleItemEntity(): void
+    {
+        // Arrange: an asset in an entity the current session has no access to
+        $this->login('glpi', 'glpi');
+
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer in an entity the session cannot access',
+            'entities_id' => $item_entity,
+        ]);
+
+        $active_entity = getItemByTypeName('Entity', '_test_child_1', true);
+        // Restrict the active session to a sibling entity only (no access to
+        // the asset's entity, even though the user's profile is recursive
+        // from a common ancestor)
+        $this->assertTrue(Session::changeActiveEntities($active_entity, false));
+
+        $problem = new Problem();
+        $problem->getEmpty();
+
+        // Act: render form for a new problem created from the (inaccessible) asset
+        ob_start();
+        $problem->showForm($problem->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the problem falls back to the active session entity, the
+        // asset entity is NOT used since the session has no access to it
+        $this->assertEquals($active_entity, (int) $problem->fields['entities_id']);
+        $this->assertNotEquals($item_entity, (int) $problem->fields['entities_id']);
+    }
+
     public function testShowFormClosedItem(): void
     {
         // Arrange: prepare an empty change

--- a/tests/functional/ProblemTest.php
+++ b/tests/functional/ProblemTest.php
@@ -65,7 +65,7 @@ class ProblemTest extends DbTestCase
 
         // Login again to access the new entity
         $this->login('glpi', 'glpi');
-        $success = \Session::changeActiveEntities($entity->getID(), true);
+        $success = Session::changeActiveEntities($entity->getID(), true);
         $this->assertTrue($success);
 
         $group = new \Group();
@@ -457,7 +457,7 @@ class ProblemTest extends DbTestCase
                 'requester' => [
                     [
                         'itemtype'  => 'User',
-                        'items_id'  => \Session::getLoginUserID(),
+                        'items_id'  => Session::getLoginUserID(),
                     ],
                 ],
             ],

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -1718,6 +1718,76 @@ class TicketTest extends DbTestCase
         $this->checkFormOutput($ticket);
     }
 
+    public function testShowFormFromItemUsesItemEntity(): void
+    {
+        // Arrange: an asset in a sub-entity, while the current (default)
+        // session entity is its parent entity
+        $this->login('glpi', 'glpi');
+
+        $root_entity = $this->getTestRootEntity(only_id: true);
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer used to create a ticket from item',
+            'entities_id' => $item_entity,
+        ]);
+
+        // Active entity is the parent entity (with access to its sub-entities),
+        // which is not the same as the asset's own entity
+        $this->assertTrue(Session::changeActiveEntities($root_entity, true));
+
+        $ticket = new Ticket();
+        $ticket->getEmpty();
+
+        // Act: render form for a new ticket created from the asset
+        ob_start();
+        $ticket->showForm($ticket->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the ticket entity follows the asset entity, not the
+        // currently active session entity
+        $this->assertEquals($item_entity, (int) $ticket->fields['entities_id']);
+        $this->assertNotEquals($root_entity, (int) $ticket->fields['entities_id']);
+    }
+
+    public function testShowFormFromItemIgnoresInaccessibleItemEntity(): void
+    {
+        // Arrange: an asset in an entity the current session has no access to
+        $this->login('glpi', 'glpi');
+
+        $item_entity = getItemByTypeName('Entity', '_test_child_2', true);
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'A computer in an entity the session cannot access',
+            'entities_id' => $item_entity,
+        ]);
+
+        $active_entity = getItemByTypeName('Entity', '_test_child_1', true);
+        // Restrict the active session to a sibling entity only (no access to
+        // the asset's entity, even though the user's profile is recursive
+        // from a common ancestor)
+        $this->assertTrue(Session::changeActiveEntities($active_entity, false));
+
+        $ticket = new Ticket();
+        $ticket->getEmpty();
+
+        // Act: render form for a new ticket created from the (inaccessible) asset
+        ob_start();
+        $ticket->showForm($ticket->getID(), [
+            '_add_fromitem' => true,
+            'itemtype'      => Computer::class,
+            'items_id'      => [Computer::class => [$computer->getID()]],
+        ]);
+        ob_get_clean();
+
+        // Assert: the ticket falls back to the active session entity, the
+        // asset entity is NOT used since the session has no access to it
+        $this->assertEquals($active_entity, (int) $ticket->fields['entities_id']);
+        $this->assertNotEquals($item_entity, (int) $ticket->fields['entities_id']);
+    }
+
     public function testFormPostOnly()
     {
         $auth = new \Auth();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45632
- Here is a brief description of what this PR does
When a problem or change was created from an asset's page, it was not created within the asset's entity; this was the case for tickets, but not for other ITIL objects.

## Screenshots (if appropriate):


