### PR TITLE
fix(45514): Requester manager not properly assigned to ticket when cr…

### DIFF
--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -280,6 +280,9 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                             unset($output[$action->fields["field"] . '_notif']);
 
                             if ($action->fields["value"] === 'requester_manager') {
+                                if(!is_array($input['_users_id_requester'])){
+                                    $input['_users_id_requester'] = [$input['_users_id_requester']];
+                                }
                                 foreach ($input['_users_id_requester'] as $user_id) {
                                     $user = new User();
                                     $user->getFromDB($user_id);

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -280,7 +280,7 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                             unset($output[$action->fields["field"] . '_notif']);
 
                             if ($action->fields["value"] === 'requester_manager') {
-                                if(!is_array($input['_users_id_requester'])){
+                                if (!is_array($input['_users_id_requester'])) {
                                     $input['_users_id_requester'] = [$input['_users_id_requester']];
                                 }
                                 foreach ($input['_users_id_requester'] as $user_id) {

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -719,11 +719,27 @@ class RuleTicketTest extends RuleCommonITILObjectTest
         ]);
         $this->assertGreaterThan(0, $tickets_id);
 
+        //Must ensure the rule will be applied with _users_id_requester being both an int and an array
+        $tickets_id_2 = $ticket->add([
+            'name'    => 'test manager number 2',
+            'content' => 'test manager number 2',
+            '_users_id_requester' => $user_id,
+        ]);
+        $this->assertGreaterThan(0, $tickets_id_2);
+
         // check manager
         $ticket_user = new \Ticket_User();
         $this->assertTrue(
             $ticket_user->getFromDBByCrit([
                 'tickets_id'    => $tickets_id,
+                'users_id'      => $manager_id,
+                'type'          => \CommonITILActor::OBSERVER,
+            ])
+        );
+
+        $this->assertTrue(
+            $ticket_user->getFromDBByCrit([
+                'tickets_id'    => $tickets_id_2,
                 'users_id'      => $manager_id,
                 'type'          => \CommonITILActor::OBSERVER,
             ])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45514
- Here is a brief description of what this PR does
  - Fix Observer assign automatic assign to a ticket created by a mail receiver


