### PR TITLE
Fix rule clone losing criteria and actions

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3908,7 +3908,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DbUtils\\:\\:getExpectedItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\<CommonGLPI\\>\\.$#',
+	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DbUtils.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1966,7 +1966,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method update\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
+	'count' => 2,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -2051,12 +2051,6 @@ $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$object_or_class of function is_a expects object\\|string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 4,
-	'path' => __DIR__ . '/src/CommonDBTM.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$object_or_class of function is_a expects object\\|string, class\\-string\\<CommonGLPI\\>\\|null given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -3914,7 +3908,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string<CommonGLPI>\\.$#',
+	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DbUtils.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2050,7 +2050,13 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$object_or_class of function is_a expects object\\|string, class\\-string\\<CommonDBTM\\>\\|null given\\.$#',
 	'identifier' => 'argument.type',
-	'count' => 5,
+	'count' => 4,
+	'path' => __DIR__ . '/src/CommonDBTM.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$object_or_class of function is_a expects object\\|string, class\\-string\\<CommonGLPI\\>\\|null given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -3908,7 +3914,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
+	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string<CommonGLPI>\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DbUtils.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -3908,7 +3908,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DbUtils\\:\\:getExpectedItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
+	'message' => '#^Method DbUtils\\:\\:getExpectedItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\<CommonGLPI\\>\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DbUtils.php',

--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1966,7 +1966,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method update\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 2,
+	'count' => 1,
 	'path' => __DIR__ . '/src/CommonDBTM.php',
 ];
 $ignoreErrors[] = [
@@ -3908,7 +3908,7 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/DbUtils.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method DbUtils\\:\\:getItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
+	'message' => '#^Method DbUtils\\:\\:getExpectedItemTypeForTable\\(\\) should return class\\-string\\<CommonDBTM\\>\\|null but returns class\\-string\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/DbUtils.php',

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1028,7 +1028,7 @@ abstract class CommonDBChild extends CommonDBConnexity
             $itemtype = Rule::class;
         }
 
-        if (getItemtypeForForeignKeyField(static::$items_id) == $itemtype) {
+        if (getTableNameForForeignKeyField(static::$items_id) === getTableForItemType($itemtype)) {
             return static::$items_id;
         }
 

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1024,15 +1024,11 @@ abstract class CommonDBChild extends CommonDBConnexity
 
     final public static function getItemField($itemtype): string
     {
-        if (!is_subclass_of($itemtype, CommonDBTM::class)) {
-            throw new RuntimeException(sprintf('%s has to be a CommonDBTM to guess its field on %s', $itemtype, static::class));
-        }
-
         if (is_subclass_of($itemtype, 'Rule') && !is_subclass_of($itemtype, 'LevelAgreementLevel')) {
             $itemtype = Rule::class;
         }
 
-        if (getTableNameForForeignKeyField(static::$items_id) === getTableForItemType($itemtype)) {
+        if (getItemtypeForForeignKeyField(static::$items_id) == $itemtype) {
             return static::$items_id;
         }
 

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1024,6 +1024,10 @@ abstract class CommonDBChild extends CommonDBConnexity
 
     final public static function getItemField($itemtype): string
     {
+        if(!is_subclass_of($itemtype, CommonDBTM::class)){
+            throw new RuntimeException($itemtype . 'has to be a CommonDBTM to guess it\'s field on ' . static::class);
+        }
+
         if (is_subclass_of($itemtype, 'Rule') && !is_subclass_of($itemtype, 'LevelAgreementLevel')) {
             $itemtype = Rule::class;
         }

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1024,7 +1024,7 @@ abstract class CommonDBChild extends CommonDBConnexity
 
     final public static function getItemField($itemtype): string
     {
-        if(!is_subclass_of($itemtype, CommonDBTM::class)){
+        if (!is_subclass_of($itemtype, CommonDBTM::class)) {
             throw new RuntimeException($itemtype . 'has to be a CommonDBTM to guess it\'s field on ' . static::class);
         }
 

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1025,7 +1025,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     final public static function getItemField($itemtype): string
     {
         if (!is_subclass_of($itemtype, CommonDBTM::class)) {
-            throw new RuntimeException($itemtype . 'has to be a CommonDBTM to guess it\'s field on ' . static::class);
+            throw new RuntimeException(sprintf('%s has to be a CommonDBTM to guess its field on %s'), $itemtype, static::class);
         }
 
         if (is_subclass_of($itemtype, 'Rule') && !is_subclass_of($itemtype, 'LevelAgreementLevel')) {

--- a/src/CommonDBChild.php
+++ b/src/CommonDBChild.php
@@ -1025,7 +1025,7 @@ abstract class CommonDBChild extends CommonDBConnexity
     final public static function getItemField($itemtype): string
     {
         if (!is_subclass_of($itemtype, CommonDBTM::class)) {
-            throw new RuntimeException(sprintf('%s has to be a CommonDBTM to guess its field on %s'), $itemtype, static::class);
+            throw new RuntimeException(sprintf('%s has to be a CommonDBTM to guess its field on %s', $itemtype, static::class));
         }
 
         if (is_subclass_of($itemtype, 'Rule') && !is_subclass_of($itemtype, 'LevelAgreementLevel')) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -924,21 +924,21 @@ class CommonDBTM extends CommonGLPI
                     continue;
                 }
 
-                // Use the itemtype expected to own the table, and not the one returned by
-                // `getItemTypeForTable()`, as the latter may be any of the classes sharing the table.
-                $itemtype = (new DbUtils())->getExpectedItemTypeForTable($tablename);
-                if (!is_a($itemtype, self::class, true)) {
+                $itemtype = getItemTypeForTable($tablename);
+                $is_clonable = $itemtype !== null
+                    && is_a($itemtype, self::class, true)
+                    && (
+                        !(new ReflectionClass($itemtype))->isAbstract()
+                        || (new ReflectionMethod($itemtype, 'getById'))->class !== self::class
+                    );
+
+                if (!$is_clonable) {
                     trigger_error(
                         sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
                         E_USER_WARNING
                     );
                     continue;
                 }
-
-                // An abstract itemtype can only be used if it is able to instanciate a concrete class
-                // by itself (see `Glpi\CustomObject\CustomObjectTrait::getById()`).
-                $is_instanciable = !(new ReflectionClass($itemtype))->isAbstract()
-                    || (new ReflectionMethod($itemtype, 'getById'))->class !== self::class;
 
                 $id_field = $itemtype::getIndexName();
 
@@ -982,30 +982,7 @@ class CommonDBTM extends CommonGLPI
                         ]
                     );
                     foreach ($result as $data) {
-                        if (!$is_instanciable) {
-                            // No row of this table can be handled.
-                            trigger_error(
-                                sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
-                                E_USER_WARNING
-                            );
-                            continue;
-                        }
-
                         $item = $itemtype::getById($data[$id_field]);
-                        if (!($item instanceof self)) {
-                            // Only this row cannot be handled, keep processing the following ones.
-                            trigger_error(
-                                sprintf(
-                                    'Unable to update relation between %s and %s tables for item %s.',
-                                    static::getTable(),
-                                    $tablename,
-                                    $data[$id_field]
-                                ),
-                                E_USER_WARNING
-                            );
-                            continue;
-                        }
-
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,15 +940,6 @@ class CommonDBTM extends CommonGLPI
                 $is_instanciable = !(new ReflectionClass($itemtype))->isAbstract()
                     || (new ReflectionMethod($itemtype, 'getById'))->class !== self::class;
 
-                if (!$is_instanciable) {
-                    // No row of this table can be handled.
-                    trigger_error(
-                        sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
-                        E_USER_WARNING
-                    );
-                    continue;
-                }
-
                 $id_field = $itemtype::getIndexName();
 
                 foreach ($fields as $field) {
@@ -991,6 +982,15 @@ class CommonDBTM extends CommonGLPI
                         ]
                     );
                     foreach ($result as $data) {
+                        if (!$is_instanciable) {
+                            // No row of this table can be handled.
+                            trigger_error(
+                                sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
+                                E_USER_WARNING
+                            );
+                            continue;
+                        }
+
                         $item = $itemtype::getById($data[$id_field]);
                         if (!($item instanceof self)) {
                             // Only this row cannot be handled, keep processing the following ones.

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -940,6 +940,15 @@ class CommonDBTM extends CommonGLPI
                 $is_instanciable = !(new ReflectionClass($itemtype))->isAbstract()
                     || (new ReflectionMethod($itemtype, 'getById'))->class !== self::class;
 
+                if (!$is_instanciable) {
+                    // No row of this table can be handled.
+                    trigger_error(
+                        sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
+                        E_USER_WARNING
+                    );
+                    continue;
+                }
+
                 $id_field = $itemtype::getIndexName();
 
                 foreach ($fields as $field) {
@@ -982,13 +991,19 @@ class CommonDBTM extends CommonGLPI
                         ]
                     );
                     foreach ($result as $data) {
-                        $item = $is_instanciable ? $itemtype::getById($data[$id_field]) : false;
+                        $item = $itemtype::getById($data[$id_field]);
                         if (!($item instanceof self)) {
+                            // Only this row cannot be handled, keep processing the following ones.
                             trigger_error(
-                                sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
+                                sprintf(
+                                    'Unable to update relation between %s and %s tables for item %s.',
+                                    static::getTable(),
+                                    $tablename,
+                                    $data[$id_field]
+                                ),
                                 E_USER_WARNING
                             );
-                            continue 3; // nothing can be done for this table
+                            continue;
                         }
 
                         $input =  [

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -924,7 +924,9 @@ class CommonDBTM extends CommonGLPI
                     continue;
                 }
 
-                $itemtype = getItemTypeForTable($tablename);
+                // Use the itemtype expected to own the table, and not the one returned by
+                // `getItemTypeForTable()`, as the latter may be any of the classes sharing the table.
+                $itemtype = (new DbUtils())->getExpectedItemTypeForTable($tablename);
                 if (!is_a($itemtype, self::class, true)) {
                     trigger_error(
                         sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
@@ -932,6 +934,11 @@ class CommonDBTM extends CommonGLPI
                     );
                     continue;
                 }
+
+                // An abstract itemtype can only be used if it is able to instanciate a concrete class
+                // by itself (see `Glpi\CustomObject\CustomObjectTrait::getById()`).
+                $is_instanciable = !(new ReflectionClass($itemtype))->isAbstract()
+                    || (new ReflectionMethod($itemtype, 'getById'))->class !== self::class;
 
                 $id_field = $itemtype::getIndexName();
 
@@ -975,7 +982,15 @@ class CommonDBTM extends CommonGLPI
                         ]
                     );
                     foreach ($result as $data) {
-                        $item = $itemtype::getById($data[$id_field]);
+                        $item = $is_instanciable ? $itemtype::getById($data[$id_field]) : false;
+                        if (!($item instanceof self)) {
+                            trigger_error(
+                                sprintf('Unable to update relations between %s and %s tables.', static::getTable(), $tablename),
+                                E_USER_WARNING
+                            );
+                            continue 3; // nothing can be done for this table
+                        }
+
                         $input =  [
                             $id_field       => $data[$id_field],
                             '_disablenotif' => true,

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -287,90 +287,111 @@ final class DbUtils
         if (isset($CFG_GLPI['glpiitemtypetables'][$table])) {
             return $CFG_GLPI['glpiitemtypetables'][$table];
         } else {
-            $inittable = $table;
-            $table     = str_replace("glpi_", "", $table);
-            $prefix    = "";
-            $pref2     = NS_GLPI;
-            $is_plugin = false;
-
-            $matches = [];
-            if (preg_match('/^plugin_([a-z0-9]+)_/', $table, $matches)) {
-                $table  = preg_replace('/^plugin_[a-z0-9]+_/', '', $table);
-                $prefix = "Plugin" . Toolbox::ucfirst($matches[1]);
-                $pref2  = NS_PLUG . ucfirst($matches[1]) . '\\';
-                $is_plugin = true;
-            }
-
-            if (strstr($table, '_')) {
-                $split = explode('_', $table);
-
-                foreach ($split as $key => $part) {
-                    $split[$key] = Toolbox::ucfirst($this->getSingular($part));
-                }
-                $table = implode('_', $split);
-            } else {
-                $table = Toolbox::ucfirst($this->getSingular($table));
-            }
-
-            $base_itemtype = $this->fixItemtypeCase($prefix . $table);
-
-            $itemtype = null;
-            if (class_exists($base_itemtype)) {
-                $class_file = (new ReflectionClass($base_itemtype))->getFileName();
-                $is_glpi_class = $class_file !== false && (
-                    str_starts_with(realpath($class_file), realpath(GLPI_ROOT))
-                    || str_starts_with(realpath($class_file), realpath(GLPI_MARKETPLACE_DIR))
-                    || str_starts_with(realpath($class_file), realpath(GLPI_PLUGIN_DOC_DIR))
-                );
-                if ($is_glpi_class) {
-                    $itemtype = $base_itemtype;
-                }
-            }
-
-            // Handle namespaces
+            $itemtype = $this->getExpectedItemTypeForTable($table);
             if ($itemtype === null) {
-                $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
+                return null;
+            }
 
-                if (class_exists($namespaced_itemtype)) {
-                    $itemtype = $namespaced_itemtype;
-                } else {
-                    // Handle namespace + db relation
-                    // On the previous step we converted all '_' into '\'
-                    // However some '_' must be kept in case of an item relation
-                    // For example, with the `glpi_namespace1_namespace2_items_filters` table
-                    // the expected itemtype is Glpi\Namespace1\Namespace2\Item_Filter
-                    // NOT Glpi\Namespace1\Namespace2\Item\Filter
-                    // To avoid this, we can revert the last '_' and check if the itemtype exists
-                    $check_alternative = $is_plugin
-                        ? substr_count($table, '_') >= 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
-                        : substr_count($table, '_') > 0 // for GLPI classes, always keep the first namespace level (Glpi\\)
-                    ;
-                    if ($check_alternative) {
-                        $last_backslash_position = strrpos($namespaced_itemtype, "\\");
-                        // Replace last '\' into '_'
-                        $alternative_namespaced_itemtype = substr_replace(
-                            $namespaced_itemtype,
-                            '_',
-                            $last_backslash_position,
-                            1
-                        );
-                        $alternative_namespaced_itemtype = $this->fixItemtypeCase($alternative_namespaced_itemtype);
+            $CFG_GLPI['glpiitemtypetables'][$table]     = $itemtype;
+            $CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;
+            return $itemtype;
+        }
+    }
 
-                        if (class_exists($alternative_namespaced_itemtype)) {
-                            $itemtype = $alternative_namespaced_itemtype;
-                        }
+    /**
+     * Returns expected itemtype for a given table.
+     * /!\ This method will only compute the expected itemtype and will not take into account the
+     * itemtype/table mapping, in which the table may be attached to any of the classes sharing it
+     * (see `self::getTableForItemType()`).
+     *
+     * @param string $table
+     *
+     * @return class-string<CommonDBTM>|null
+     *      itemtype expected to own the table name parameter,
+     *      or null if no valid itemtype is attached to the table
+     */
+    public function getExpectedItemTypeForTable(string $table): ?string
+    {
+        $table     = str_replace("glpi_", "", $table);
+        $prefix    = "";
+        $pref2     = NS_GLPI;
+        $is_plugin = false;
+
+        $matches = [];
+        if (preg_match('/^plugin_([a-z0-9]+)_/', $table, $matches)) {
+            $table  = preg_replace('/^plugin_[a-z0-9]+_/', '', $table);
+            $prefix = "Plugin" . Toolbox::ucfirst($matches[1]);
+            $pref2  = NS_PLUG . ucfirst($matches[1]) . '\\';
+            $is_plugin = true;
+        }
+
+        if (strstr($table, '_')) {
+            $split = explode('_', $table);
+
+            foreach ($split as $key => $part) {
+                $split[$key] = Toolbox::ucfirst($this->getSingular($part));
+            }
+            $table = implode('_', $split);
+        } else {
+            $table = Toolbox::ucfirst($this->getSingular($table));
+        }
+
+        $base_itemtype = $this->fixItemtypeCase($prefix . $table);
+
+        $itemtype = null;
+        if (class_exists($base_itemtype)) {
+            $class_file = (new ReflectionClass($base_itemtype))->getFileName();
+            $is_glpi_class = $class_file !== false && (
+                str_starts_with(realpath($class_file), realpath(GLPI_ROOT))
+                || str_starts_with(realpath($class_file), realpath(GLPI_MARKETPLACE_DIR))
+                || str_starts_with(realpath($class_file), realpath(GLPI_PLUGIN_DOC_DIR))
+            );
+            if ($is_glpi_class) {
+                $itemtype = $base_itemtype;
+            }
+        }
+
+        // Handle namespaces
+        if ($itemtype === null) {
+            $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
+
+            if (class_exists($namespaced_itemtype)) {
+                $itemtype = $namespaced_itemtype;
+            } else {
+                // Handle namespace + db relation
+                // On the previous step we converted all '_' into '\'
+                // However some '_' must be kept in case of an item relation
+                // For example, with the `glpi_namespace1_namespace2_items_filters` table
+                // the expected itemtype is Glpi\Namespace1\Namespace2\Item_Filter
+                // NOT Glpi\Namespace1\Namespace2\Item\Filter
+                // To avoid this, we can revert the last '_' and check if the itemtype exists
+                $check_alternative = $is_plugin
+                    ? substr_count($table, '_') >= 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
+                    : substr_count($table, '_') > 0 // for GLPI classes, always keep the first namespace level (Glpi\\)
+                ;
+                if ($check_alternative) {
+                    $last_backslash_position = strrpos($namespaced_itemtype, "\\");
+                    // Replace last '\' into '_'
+                    $alternative_namespaced_itemtype = substr_replace(
+                        $namespaced_itemtype,
+                        '_',
+                        $last_backslash_position,
+                        1
+                    );
+                    $alternative_namespaced_itemtype = $this->fixItemtypeCase($alternative_namespaced_itemtype);
+
+                    if (class_exists($alternative_namespaced_itemtype)) {
+                        $itemtype = $alternative_namespaced_itemtype;
                     }
                 }
             }
-
-            if ($itemtype !== null && ($classname = $this->getClassForItemtype($itemtype)) !== null) {
-                $CFG_GLPI['glpiitemtypetables'][$inittable] = $classname;
-                $CFG_GLPI['glpitablesitemtype'][$classname] = $inittable;
-                return $itemtype;
-            }
-
-            return null;
         }
+
+        if ($itemtype !== null) {
+            return $this->getClassForItemtype($itemtype);
+        }
+
+        return null;
     }
 
     /**

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -306,7 +306,7 @@ final class DbUtils
      *
      * @param string $table
      *
-     * @return class-string<CommonDBTM>|null
+     * @return class-string<CommonGLPI>|null
      *      itemtype expected to own the table name parameter,
      *      or null if no valid itemtype is attached to the table
      */

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -206,12 +206,19 @@ final class DbUtils
         global $CFG_GLPI;
 
         if (!isset($CFG_GLPI['glpitablesitemtype'][$itemtype])) {
+            $expected_table = $this->getExpectedTableNameForClass($itemtype);
+
             $table = is_a($itemtype, CommonDBTM::class, true)
                 ? $itemtype::getTable()
-                : $this->getExpectedTableNameForClass($itemtype);
+                : $expected_table;
 
             $CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;
-            $CFG_GLPI['glpiitemtypetables'][$table]    = $itemtype;
+
+            if ($table === $expected_table) {
+                // Do not cache result if the found table does not match the expected one, for instance
+                // if the target classname is a specific implementation of an abstract class (e.g. `RuleTicket` -> `glpi_rules`).
+                $CFG_GLPI['glpiitemtypetables'][$table] = $itemtype;
+            }
         }
 
         return $CFG_GLPI['glpitablesitemtype'][$itemtype];
@@ -287,111 +294,95 @@ final class DbUtils
         if (isset($CFG_GLPI['glpiitemtypetables'][$table])) {
             return $CFG_GLPI['glpiitemtypetables'][$table];
         } else {
-            $itemtype = $this->getExpectedItemTypeForTable($table);
-            if ($itemtype === null) {
-                return null;
+            $inittable = $table;
+            $table     = str_replace("glpi_", "", $table);
+            $prefix    = "";
+            $pref2     = NS_GLPI;
+            $is_plugin = false;
+
+            $matches = [];
+            if (preg_match('/^plugin_([a-z0-9]+)_/', $table, $matches)) {
+                $table  = preg_replace('/^plugin_[a-z0-9]+_/', '', $table);
+                $prefix = "Plugin" . Toolbox::ucfirst($matches[1]);
+                $pref2  = NS_PLUG . ucfirst($matches[1]) . '\\';
+                $is_plugin = true;
             }
 
-            $CFG_GLPI['glpiitemtypetables'][$table]     = $itemtype;
-            $CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;
-            return $itemtype;
-        }
-    }
+            if (strstr($table, '_')) {
+                $split = explode('_', $table);
 
-    /**
-     * Returns expected itemtype for a given table.
-     * /!\ This method will only compute the expected itemtype and will not take into account the
-     * itemtype/table mapping, in which the table may be attached to any of the classes sharing it
-     * (see `self::getTableForItemType()`).
-     *
-     * @param string $table
-     *
-     * @return class-string<CommonGLPI>|null
-     *      itemtype expected to own the table name parameter,
-     *      or null if no valid itemtype is attached to the table
-     */
-    public function getExpectedItemTypeForTable(string $table): ?string
-    {
-        $table     = str_replace("glpi_", "", $table);
-        $prefix    = "";
-        $pref2     = NS_GLPI;
-        $is_plugin = false;
-
-        $matches = [];
-        if (preg_match('/^plugin_([a-z0-9]+)_/', $table, $matches)) {
-            $table  = preg_replace('/^plugin_[a-z0-9]+_/', '', $table);
-            $prefix = "Plugin" . Toolbox::ucfirst($matches[1]);
-            $pref2  = NS_PLUG . ucfirst($matches[1]) . '\\';
-            $is_plugin = true;
-        }
-
-        if (strstr($table, '_')) {
-            $split = explode('_', $table);
-
-            foreach ($split as $key => $part) {
-                $split[$key] = Toolbox::ucfirst($this->getSingular($part));
-            }
-            $table = implode('_', $split);
-        } else {
-            $table = Toolbox::ucfirst($this->getSingular($table));
-        }
-
-        $base_itemtype = $this->fixItemtypeCase($prefix . $table);
-
-        $itemtype = null;
-        if (class_exists($base_itemtype)) {
-            $class_file = (new ReflectionClass($base_itemtype))->getFileName();
-            $is_glpi_class = $class_file !== false && (
-                str_starts_with(realpath($class_file), realpath(GLPI_ROOT))
-                || str_starts_with(realpath($class_file), realpath(GLPI_MARKETPLACE_DIR))
-                || str_starts_with(realpath($class_file), realpath(GLPI_PLUGIN_DOC_DIR))
-            );
-            if ($is_glpi_class) {
-                $itemtype = $base_itemtype;
-            }
-        }
-
-        // Handle namespaces
-        if ($itemtype === null) {
-            $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
-
-            if (class_exists($namespaced_itemtype)) {
-                $itemtype = $namespaced_itemtype;
+                foreach ($split as $key => $part) {
+                    $split[$key] = Toolbox::ucfirst($this->getSingular($part));
+                }
+                $table = implode('_', $split);
             } else {
-                // Handle namespace + db relation
-                // On the previous step we converted all '_' into '\'
-                // However some '_' must be kept in case of an item relation
-                // For example, with the `glpi_namespace1_namespace2_items_filters` table
-                // the expected itemtype is Glpi\Namespace1\Namespace2\Item_Filter
-                // NOT Glpi\Namespace1\Namespace2\Item\Filter
-                // To avoid this, we can revert the last '_' and check if the itemtype exists
-                $check_alternative = $is_plugin
-                    ? substr_count($table, '_') >= 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
-                    : substr_count($table, '_') > 0 // for GLPI classes, always keep the first namespace level (Glpi\\)
-                ;
-                if ($check_alternative) {
-                    $last_backslash_position = strrpos($namespaced_itemtype, "\\");
-                    // Replace last '\' into '_'
-                    $alternative_namespaced_itemtype = substr_replace(
-                        $namespaced_itemtype,
-                        '_',
-                        $last_backslash_position,
-                        1
-                    );
-                    $alternative_namespaced_itemtype = $this->fixItemtypeCase($alternative_namespaced_itemtype);
+                $table = Toolbox::ucfirst($this->getSingular($table));
+            }
 
-                    if (class_exists($alternative_namespaced_itemtype)) {
-                        $itemtype = $alternative_namespaced_itemtype;
+            $base_itemtype = $this->fixItemtypeCase($prefix . $table);
+
+            $itemtype = null;
+            if (class_exists($base_itemtype)) {
+                $class_file = (new ReflectionClass($base_itemtype))->getFileName();
+                $is_glpi_class = $class_file !== false && (
+                    str_starts_with(realpath($class_file), realpath(GLPI_ROOT))
+                    || str_starts_with(realpath($class_file), realpath(GLPI_MARKETPLACE_DIR))
+                    || str_starts_with(realpath($class_file), realpath(GLPI_PLUGIN_DOC_DIR))
+                );
+                if ($is_glpi_class) {
+                    $itemtype = $base_itemtype;
+                }
+            }
+
+            // Handle namespaces
+            if ($itemtype === null) {
+                $namespaced_itemtype = $this->fixItemtypeCase($pref2 . str_replace('_', '\\', $table));
+
+                if (class_exists($namespaced_itemtype)) {
+                    $itemtype = $namespaced_itemtype;
+                } else {
+                    // Handle namespace + db relation
+                    // On the previous step we converted all '_' into '\'
+                    // However some '_' must be kept in case of an item relation
+                    // For example, with the `glpi_namespace1_namespace2_items_filters` table
+                    // the expected itemtype is Glpi\Namespace1\Namespace2\Item_Filter
+                    // NOT Glpi\Namespace1\Namespace2\Item\Filter
+                    // To avoid this, we can revert the last '_' and check if the itemtype exists
+                    $check_alternative = $is_plugin
+                        ? substr_count($table, '_') >= 1 // for plugin classes, always keep the first+second namespace levels (GlpiPlugin\\PluginName\\)
+                        : substr_count($table, '_') > 0 // for GLPI classes, always keep the first namespace level (Glpi\\)
+                    ;
+                    if ($check_alternative) {
+                        $last_backslash_position = strrpos($namespaced_itemtype, "\\");
+                        // Replace last '\' into '_'
+                        $alternative_namespaced_itemtype = substr_replace(
+                            $namespaced_itemtype,
+                            '_',
+                            $last_backslash_position,
+                            1
+                        );
+                        $alternative_namespaced_itemtype = $this->fixItemtypeCase($alternative_namespaced_itemtype);
+
+                        if (class_exists($alternative_namespaced_itemtype)) {
+                            $itemtype = $alternative_namespaced_itemtype;
+                        }
                     }
                 }
             }
-        }
 
-        if ($itemtype !== null) {
-            return $this->getClassForItemtype($itemtype);
-        }
+            if ($itemtype !== null && ($classname = $this->getClassForItemtype($itemtype)) !== null) {
+                if ($this->getExpectedTableNameForClass($classname) === $inittable) {
+                    // Do not cache result if the found table does not match the expected one, for instance
+                    // if the target classname is a specific implementation of an abstract class (e.g. `RuleTicket` -> `glpi_rules`).
+                    $CFG_GLPI['glpiitemtypetables'][$inittable] = $classname;
+                }
 
-        return null;
+                $CFG_GLPI['glpitablesitemtype'][$classname] = $inittable;
+                return $itemtype;
+            }
+
+            return null;
+        }
     }
 
     /**

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -211,10 +211,7 @@ final class DbUtils
                 : $this->getExpectedTableNameForClass($itemtype);
 
             $CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;
-            // Only register the reverse mapping when the itemtype is the canonical owner of the table.
-            if ($this->getExpectedTableNameForClass($itemtype) === $table) {
-                $CFG_GLPI['glpiitemtypetables'][$table] = $itemtype;
-            }
+            $CFG_GLPI['glpiitemtypetables'][$table]    = $itemtype;
         }
 
         return $CFG_GLPI['glpitablesitemtype'][$itemtype];

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -211,7 +211,10 @@ final class DbUtils
                 : $this->getExpectedTableNameForClass($itemtype);
 
             $CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;
-            $CFG_GLPI['glpiitemtypetables'][$table]    = $itemtype;
+            // Only register the reverse mapping when the itemtype is the canonical owner of the table.
+            if ($this->getExpectedTableNameForClass($itemtype) === $table) {
+                $CFG_GLPI['glpiitemtypetables'][$table] = $itemtype;
+            }
         }
 
         return $CFG_GLPI['glpitablesitemtype'][$itemtype];

--- a/src/Glpi/Inventory/Asset/InventoryAsset.php
+++ b/src/Glpi/Inventory/Asset/InventoryAsset.php
@@ -42,6 +42,7 @@ use CommonDBTM;
 use CommonDropdown;
 use Computer;
 use Dropdown;
+use Glpi\Asset\Asset;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Inventory\Conf;
 use Glpi\Inventory\MainAsset\MainAsset;
@@ -289,10 +290,15 @@ abstract class InventoryAsset
                         }
                         $this->known_links[$known_key] = $new_id;
                     } elseif (preg_match('/^.+models_id/', $key)) {
+                        // Resolve concrete Model class for generic assets
+                        $model_itemtype = $key === 'assets_assetmodels_id' && $this->item instanceof Asset
+                            ? $this->item->getDefinition()->getAssetModelClassName()
+                            : getItemtypeForForeignKeyField($key);
+
                         // models that need manufacturer relation for dictionary import
                         // see CommonDCModelDropdown::$additional_fields_for_dictionnary
                         $new_id = Dropdown::importExternal(
-                            getItemtypeForForeignKeyField($key),
+                            $model_itemtype,
                             $value->$key ?? '',
                             $entities_id,
                             ['manufacturer' => $manufacturer_name]
@@ -308,6 +314,11 @@ abstract class InventoryAsset
                         }
                         $this->known_links[$known_key] = $new_id;
                     } elseif ($key !== 'entities_id' && $key !== 'states_id' && isForeignKeyField($key) && is_a($itemtype = getItemtypeForForeignKeyField($key), CommonDropdown::class, true)) {
+                        if ($key === 'assets_assettypes_id' && $this->item instanceof Asset) {
+                            // Resolve concrete Type class for generic assets
+                            $itemtype = $this->item->getDefinition()->getAssetTypeClassName();
+                        }
+
                         $foreignkey_itemtype[$key] = $itemtype;
 
                         $new_id = Dropdown::importExternal(

--- a/src/ITIL_ValidationStep.php
+++ b/src/ITIL_ValidationStep.php
@@ -126,6 +126,48 @@ abstract class ITIL_ValidationStep extends CommonDBChild
     }
 
     /**
+     * Retrieve an item from the database
+     *
+     * @param int|null $id ID of the item to get
+     *
+     * @return self|false
+     */
+    public static function getById(?int $id)
+    {
+        global $DB;
+
+        if ($id === null) {
+            return false;
+        }
+
+        $row = $DB->request([
+            'FROM'   => static::getTable(),
+            'WHERE'  => [
+                static::getTable() . '.' . static::getIndexName() => $id,
+            ],
+            'LIMIT'  => 1,
+        ])->current();
+
+        $itemtype = $row['itemtype'] ?? null;
+
+        if ($itemtype === null || !is_a($itemtype, CommonITILObject::class, true)) {
+            return false;
+        }
+
+        $instance = $itemtype::getValidationStepInstance();
+
+        if ($instance === null) {
+            return false;
+        }
+
+        if (!$instance->getFromDB($id)) {
+            return false;
+        }
+
+        return $instance;
+    }
+
+    /**
      * Validation status computed from all the attached validations.
      *
      * @return CommonITILValidation::WAITING|CommonITILValidation::ACCEPTED|CommonITILValidation::REFUSED

--- a/tests/functional/CommonDBTMTest.php
+++ b/tests/functional/CommonDBTMTest.php
@@ -2473,7 +2473,7 @@ class CommonDBTMTest extends DbTestCase
         $this->assertSame($phone->getID(), $antivirus->fields['items_id']);
     }
 
-    public function testCleanRelationDataOnTableOwnedByAbstractItemtype(): void
+    public function testCleanRelationDataOnTableOwnedByAbstractItemtypeWithGetById(): void
     {
         /** @var \DBmysql $DB */
         global $DB;
@@ -2497,14 +2497,9 @@ class CommonDBTMTest extends DbTestCase
 
         $validation_step->cleanRelationData();
 
-        $this->hasPhpLogRecordThatContains(
-            'Unable to update relations between glpi_validationsteps and glpi_itils_validationsteps tables.',
-            LogLevel::WARNING
-        );
-
-        // The row is left untouched.
+        // The row is correctly deleted.
         $this->assertSame(
-            1,
+            0,
             countElementsInTable(
                 'glpi_itils_validationsteps',
                 ['validationsteps_id' => $validation_step->getID()]

--- a/tests/functional/CommonDBTMTest.php
+++ b/tests/functional/CommonDBTMTest.php
@@ -2464,7 +2464,6 @@ class CommonDBTMTest extends DbTestCase
         // Emulate a runtime state in which the `glpi_itemantiviruses` table has been attached to the
         // deprecated `ComputerAntivirus` class, i.e. any code path resolving its table.
         getTableForItemType(\ComputerAntivirus::class);
-        $this->assertSame(\ComputerAntivirus::class, $CFG_GLPI['glpiitemtypetables']['glpi_itemantiviruses']);
 
         $this->assertTrue($manufacturer->delete(['id' => $manufacturer->getID()], true));
 

--- a/tests/functional/CommonDBTMTest.php
+++ b/tests/functional/CommonDBTMTest.php
@@ -2442,6 +2442,77 @@ class CommonDBTMTest extends DbTestCase
         $this->assertEquals("Computer A4", $items[3]->getName());
     }
 
+    public function testCleanRelationDataOnSharedTable(): void
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        $this->login();
+
+        $manufacturer = $this->createItem(\Manufacturer::class, ['name' => __FUNCTION__]);
+        $phone = $this->createItem(\Phone::class, [
+            'name'        => __FUNCTION__,
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $antivirus = $this->createItem(\ItemAntivirus::class, [
+            'name'             => __FUNCTION__,
+            'itemtype'         => \Phone::class,
+            'items_id'         => $phone->getID(),
+            'manufacturers_id' => $manufacturer->getID(),
+        ]);
+
+        // Emulate a runtime state in which the `glpi_itemantiviruses` table has been attached to the
+        // deprecated `ComputerAntivirus` class, i.e. any code path resolving its table.
+        getTableForItemType(\ComputerAntivirus::class);
+        $this->assertSame(\ComputerAntivirus::class, $CFG_GLPI['glpiitemtypetables']['glpi_itemantiviruses']);
+
+        $this->assertTrue($manufacturer->delete(['id' => $manufacturer->getID()], true));
+
+        $this->assertTrue($antivirus->getFromDB($antivirus->getID()));
+        $this->assertSame(0, $antivirus->fields['manufacturers_id']);
+        $this->assertSame(\Phone::class, $antivirus->fields['itemtype']);
+        $this->assertSame($phone->getID(), $antivirus->fields['items_id']);
+    }
+
+    public function testCleanRelationDataOnTableOwnedByAbstractItemtype(): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $this->login();
+
+        $validation_step = $this->createItem(\ValidationStep::class, [
+            'name'                                => __FUNCTION__,
+            'minimal_required_validation_percent' => 100,
+        ]);
+        $ticket = $this->createItem(\Ticket::class, ['name' => __FUNCTION__, 'content' => __FUNCTION__]);
+
+        // `glpi_itils_validationsteps` is expected to be owned by the abstract `ITIL_ValidationStep`
+        // class. Insert the row directly to not depend on the ITIL validation logic.
+        $DB->insert('glpi_itils_validationsteps', [
+            'validationsteps_id'                  => $validation_step->getID(),
+            'itemtype'                            => \Ticket::class,
+            'items_id'                            => $ticket->getID(),
+            'minimal_required_validation_percent' => 100,
+        ]);
+
+        $validation_step->cleanRelationData();
+
+        $this->hasPhpLogRecordThatContains(
+            'Unable to update relations between glpi_validationsteps and glpi_itils_validationsteps tables.',
+            LogLevel::WARNING
+        );
+
+        // The row is left untouched.
+        $this->assertSame(
+            1,
+            countElementsInTable(
+                'glpi_itils_validationsteps',
+                ['validationsteps_id' => $validation_step->getID()]
+            )
+        );
+    }
+
     public static function getTemplateProvider(): iterable
     {
         $itemtypes = [

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -205,6 +205,27 @@ class DbUtilsTest extends DbTestCase
         $this->assertSame($table, getTableForItemType($type));
     }
 
+    /**
+     * Classes sharing the table of one of their parents must not be registered as the itemtype
+     * corresponding to that table, as they are not its canonical owner.
+     */
+    public function testGetTableForItemTypeKeepsCanonicalItemtypeForTable()
+    {
+        $instance = new \DbUtils();
+
+        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleTicket::class));
+        $this->assertSame(\Rule::class, $instance->getItemTypeForTable('glpi_rules'));
+
+        $this->assertSame(
+            'glpi_notificationtargets',
+            $instance->getTableForItemType(\NotificationTargetTicket::class)
+        );
+        $this->assertSame(
+            \NotificationTarget::class,
+            $instance->getItemTypeForTable('glpi_notificationtargets')
+        );
+    }
+
     #[DataProvider('dataTableType')]
     public function testGetExpectedTableNameForClass($table, $type, $is_valid_type)
     {

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -205,27 +205,6 @@ class DbUtilsTest extends DbTestCase
         $this->assertSame($table, getTableForItemType($type));
     }
 
-    /**
-     * Classes sharing the table of one of their parents must not be registered as the itemtype
-     * corresponding to that table, as they are not its canonical owner.
-     */
-    public function testGetTableForItemTypeKeepsCanonicalItemtypeForTable()
-    {
-        $instance = new \DbUtils();
-
-        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleTicket::class));
-        $this->assertSame(\Rule::class, $instance->getItemTypeForTable('glpi_rules'));
-
-        $this->assertSame(
-            'glpi_notificationtargets',
-            $instance->getTableForItemType(\NotificationTargetTicket::class)
-        );
-        $this->assertSame(
-            \NotificationTarget::class,
-            $instance->getItemTypeForTable('glpi_notificationtargets')
-        );
-    }
-
     #[DataProvider('dataTableType')]
     public function testGetExpectedTableNameForClass($table, $type, $is_valid_type)
     {

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -244,6 +244,48 @@ class DbUtilsTest extends DbTestCase
     }
 
     #[DataProvider('dataTableType')]
+    public function testGetExpectedItemTypeForTable($table, $type, $is_valid_type)
+    {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
+
+        require_once __DIR__ . '/../../tests/fixtures/another_test.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginbarabstractstuff.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginbarfoo.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginfoobar.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginfooservice.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_search_item_filter.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_item_filter.php';
+        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
+        require_once __DIR__ . '/../../tests/fixtures/test_a_b.php';
+
+        // The itemtype/table mapping must not be taken into account.
+        $CFG_GLPI['glpiitemtypetables'][$table] = \Computer::class;
+
+        $instance = new \DbUtils();
+        if ($is_valid_type) {
+            $this->assertSame($type, $instance->getExpectedItemTypeForTable($table));
+        } else {
+            $this->assertNull($instance->getExpectedItemTypeForTable($table));
+        }
+    }
+
+    public function testGetExpectedItemTypeForTableIgnoresClassesSharingTable()
+    {
+        $instance = new \DbUtils();
+
+        $this->assertSame('glpi_itemantiviruses', $instance->getTableForItemType(\ComputerAntivirus::class));
+        $this->assertSame(\ComputerAntivirus::class, $instance->getItemTypeForTable('glpi_itemantiviruses'));
+
+        $this->assertSame(\ItemAntivirus::class, $instance->getExpectedItemTypeForTable('glpi_itemantiviruses'));
+
+        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleTicketCollection::class));
+        $this->assertSame(\RuleTicketCollection::class, $instance->getItemTypeForTable('glpi_rules'));
+
+        $this->assertSame(\Rule::class, $instance->getExpectedItemTypeForTable('glpi_rules'));
+    }
+
+    #[DataProvider('dataTableType')]
     public function testGetItemForTable($table, $type, $is_valid_type)
     {
         require_once __DIR__ . '/../../tests/fixtures/another_test.php';

--- a/tests/functional/DbUtilsTest.php
+++ b/tests/functional/DbUtilsTest.php
@@ -243,46 +243,12 @@ class DbUtilsTest extends DbTestCase
         }
     }
 
-    #[DataProvider('dataTableType')]
-    public function testGetExpectedItemTypeForTable($table, $type, $is_valid_type)
-    {
-        /** @var array $CFG_GLPI */
-        global $CFG_GLPI;
-
-        require_once __DIR__ . '/../../tests/fixtures/another_test.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginbarabstractstuff.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginbarfoo.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginfoobar.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginfooservice.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_search_item_filter.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_item_filter.php';
-        require_once __DIR__ . '/../../tests/fixtures/pluginfoo_search_a_b_c_d_e_f_g_bar.php';
-        require_once __DIR__ . '/../../tests/fixtures/test_a_b.php';
-
-        // The itemtype/table mapping must not be taken into account.
-        $CFG_GLPI['glpiitemtypetables'][$table] = \Computer::class;
-
-        $instance = new \DbUtils();
-        if ($is_valid_type) {
-            $this->assertSame($type, $instance->getExpectedItemTypeForTable($table));
-        } else {
-            $this->assertNull($instance->getExpectedItemTypeForTable($table));
-        }
-    }
-
-    public function testGetExpectedItemTypeForTableIgnoresClassesSharingTable()
+    public function testGetTableForItemtypeDoesNotConflictWithGetItemTypeForTable()
     {
         $instance = new \DbUtils();
-
-        $this->assertSame('glpi_itemantiviruses', $instance->getTableForItemType(\ComputerAntivirus::class));
-        $this->assertSame(\ComputerAntivirus::class, $instance->getItemTypeForTable('glpi_itemantiviruses'));
-
-        $this->assertSame(\ItemAntivirus::class, $instance->getExpectedItemTypeForTable('glpi_itemantiviruses'));
-
-        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleTicketCollection::class));
-        $this->assertSame(\RuleTicketCollection::class, $instance->getItemTypeForTable('glpi_rules'));
-
-        $this->assertSame(\Rule::class, $instance->getExpectedItemTypeForTable('glpi_rules'));
+        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleRight::class));
+        $this->assertSame('glpi_rules', $instance->getTableForItemType(\RuleTicket::class));
+        $this->assertSame(\Rule::class, $instance->getItemTypeForTable('glpi_rules'));
     }
 
     #[DataProvider('dataTableType')]

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -460,6 +460,59 @@ class RuleTest extends DbTestCase
         }
     }
 
+    public function testCloneMultiple()
+    {
+
+        $rule = $this->createItem(RuleTicket::class, [
+            'name'        => 'Clone with altered runtime state',
+            'is_active'   => 1,
+            'entities_id' => 0,
+            'sub_type'    => RuleTicket::class,
+            'match'       => Rule::AND_MATCHING,
+            'condition'   => \RuleCommonITILObject::ONADD,
+            'description' => '',
+        ]);
+        $rules_id = $rule->getID();
+
+        $this->createItem(\RuleCriteria::class, [
+            'rules_id'  => $rules_id,
+            'criteria'  => 'name',
+            'condition' => Rule::PATTERN_CONTAIN,
+            'pattern'   => 'printer',
+        ]);
+
+        $this->createItem(\RuleAction::class, [
+            'rules_id'    => $rules_id,
+            'action_type' => 'assign',
+            'field'       => 'urgency',
+            'value'       => '5',
+        ]);
+
+        // Resolving the table of a `Rule` subclass must not make `glpi_rules` resolve to that
+        // subclass, otherwise `CommonDBChild::getItemField()` cannot guess the `rules_id` field.
+        $this->assertSame('glpi_rules', getTableForItemType(RuleTicket::class));
+        $this->assertSame(Rule::class, getItemTypeForTable(Rule::getTable()));
+
+        $this->assertTrue($rule->cloneMultiple(2));
+
+        $clones = [
+            'Clone with altered runtime state (copy)',
+            'Clone with altered runtime state (copy 2)',
+        ];
+        foreach ($clones as $clone_name) {
+            $clone = getItemByTypeName(RuleTicket::class, $clone_name);
+            $this->assertInstanceOf(RuleTicket::class, $clone);
+            $this->assertSame(
+                1,
+                countElementsInTable(\RuleCriteria::getTable(), ['rules_id' => $clone->getID()])
+            );
+            $this->assertSame(
+                1,
+                countElementsInTable(\RuleAction::getTable(), ['rules_id' => $clone->getID()])
+            );
+        }
+    }
+
     public function testCleanDBonPurge()
     {
         $rule       = new Rule();

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -462,6 +462,8 @@ class RuleTest extends DbTestCase
 
     public function testCloneMultiple()
     {
+        /** @var array $CFG_GLPI */
+        global $CFG_GLPI;
 
         $rule = $this->createItem(RuleTicket::class, [
             'name'        => 'Clone with altered runtime state',
@@ -488,10 +490,13 @@ class RuleTest extends DbTestCase
             'value'       => '5',
         ]);
 
-        // Resolving the table of a `Rule` subclass must not make `glpi_rules` resolve to that
-        // subclass, otherwise `CommonDBChild::getItemField()` cannot guess the `rules_id` field.
-        $this->assertSame('glpi_rules', getTableForItemType(RuleTicket::class));
-        $this->assertSame(Rule::class, getItemTypeForTable(Rule::getTable()));
+        // The `glpi_rules` table may be mapped to any of the `Rule` subclasses, depending on the
+        // runtime state of the itemtype/table mapping cache. Clone must not depend on it, as
+        // `CommonDBChild::getItemField()` has to be able to guess the `rules_id` field anyway.
+        $CFG_GLPI['glpiitemtypetables'][Rule::getTable()] = RuleTicket::class;
+
+        $this->assertSame('rules_id', \RuleCriteria::getItemField(RuleTicket::class));
+        $this->assertSame('rules_id', \RuleAction::getItemField(RuleTicket::class));
 
         $this->assertTrue($rule->cloneMultiple(2));
 

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -490,11 +490,6 @@ class RuleTest extends DbTestCase
             'value'       => '5',
         ]);
 
-        // The `glpi_rules` table may be mapped to any of the `Rule` subclasses, depending on the
-        // runtime state of the itemtype/table mapping cache. Clone must not depend on it, as
-        // `CommonDBChild::getItemField()` has to be able to guess the `rules_id` field anyway.
-        $CFG_GLPI['glpiitemtypetables'][Rule::getTable()] = RuleTicket::class;
-
         $this->assertSame('rules_id', \RuleCriteria::getItemField(RuleTicket::class));
         $this->assertSame('rules_id', \RuleAction::getItemField(RuleTicket::class));
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45508
- Cloning a business rule (from the massive actions of "Business rules for tickets") sometimes creates a clone without any criteria nor action, and only one clone is created even when several copies are requested.
- The following exception is raised (it aborts the clone loop right after the rule row has been inserted, and before its relations are copied):
```
Uncaught PHP Exception RuntimeException: "Cannot guess field for itemtype Rule on RuleAction"
./src/CommonDBChild.php:1039
./src/Glpi/Features/Clonable.php:121   CommonDBChild::getItemField()
./src/Glpi/Features/Clonable.php:299   Rule->cloneRelations()
./src/Glpi/Features/Clonable.php:229   Rule->clone()
./src/MassiveAction.php:1657           Rule->cloneMultiple()
```
- The cause is most likely due to `DbUtils::getTableForItemType()` registering both directions of the itemtype/table mapping:
```
$CFG_GLPI['glpitablesitemtype'][$itemtype] = $table;   // RuleTicket => glpi_rules   OK
$CFG_GLPI['glpiitemtypetables'][$table]    = $itemtype; // glpi_rules => RuleTicket  wrong
```
`Rule::getTable()` returns `glpi_rules` for every subclass (example: `RuleTicket`). So when the table of such a subclass is resolved, `getItemTypeForTable('glpi_rules')` returns `RuleTicket` instead of `Rule` for the rest of the request.

`CommonDBChild::getItemField() ` then compares `getItemtypeForForeignKeyField('rules_id')`
(now `RuleTicket`) with `Rule::class`, does not match so it throws an exception.

### Fix : 
In `CommonDBChild::getItemField() `, compare tables rather than itemtypes. 