### PR TITLE
Fix: merging tickets triggers unwanted followup/task notifications

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -6066,16 +6066,19 @@ JAVASCRIPT;
                             });
                             foreach ($users as $user) {
                                 $user['tickets_id'] = $merge_target_id;
+                                $user['_disablenotif'] = true;
                                 unset($user['id']);
                                 $tu->add($user);
                             }
                             foreach ($groups as $group) {
                                 $group['tickets_id'] = $merge_target_id;
+                                $group['_disablenotif'] = true;
                                 unset($group['id']);
                                 $gt->add($group);
                             }
                             foreach ($suppliers as $supplier) {
                                 $supplier['tickets_id'] = $merge_target_id;
+                                $supplier['_disablenotif'] = true;
                                 unset($supplier['id']);
                                 $st->add($supplier);
                             }

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5906,6 +5906,7 @@ JAVASCRIPT;
                         'date_mod'        => $ticket->fields['date_mod'],
                         'date'            => $ticket->fields['date_creation'],
                         'sourceitems_id'  => $ticket->getID(),
+                        '_disablenotif'   => true,
                     ];
                     if (!$fup->add($input)) {
                         //Cannot add followup. Abort/fail the merge
@@ -5921,6 +5922,7 @@ JAVASCRIPT;
                             $fup2['items_id'] = $merge_target_id;
                             $fup2['sourceitems_id'] = $id;
                             $fup2['content'] = $fup2['content'];
+                            $fup2['_disablenotif'] = true;
                             unset($fup2['id']);
                             if (!$fup->add($fup2)) {
                                 // Cannot add followup. Abort/fail the merge
@@ -5941,6 +5943,7 @@ JAVASCRIPT;
                             $task2['tickets_id'] = $merge_target_id;
                             $task2['sourceitems_id'] = $id;
                             $task2['content'] = $task2['content'];
+                            $task2['_disablenotif'] = true;
                             unset($task2['id']);
                             unset($task2['uuid']);
                             if (!$task->add($task2)) {

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4346,6 +4346,65 @@ class TicketTest extends DbTestCase
         ]));
     }
 
+    public function testMergeDoesNotTriggerNotifications(): void
+    {
+        global $CFG_GLPI;
+
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+
+        $this->login();
+        $_SESSION['glpiactiveprofile']['interface'] = '';
+        $this->setEntity('Root entity', true);
+
+        $user = getItemByTypeName(User::class, 'tech');
+        $this->createItem(UserEmail::class, [
+            'users_id'    => $user->getID(),
+            'is_default'  => 1,
+            'email'       => 'tech@tech.tech',
+        ]);
+
+        $ticket1 = $this->createItem(Ticket::class, [
+            'name'        => 'merge notif target',
+            'content'     => 'merge notif target',
+            'entities_id' => 0,
+            'status'      => CommonITILObject::INCOMING,
+            '_actors'     => [
+                'requester' => [
+                    ['itemtype' => 'User', 'items_id' => $user->getID(), 'use_notification' => 1],
+                ],
+            ],
+        ])->getID();
+        $ticket2 = $this->createItem(Ticket::class, [
+            'name'        => 'merge notif source',
+            'content'     => 'merge notif source',
+            'entities_id' => 0,
+            'status'      => CommonITILObject::INCOMING,
+        ])->getID();
+
+        $fup = new ITILFollowup();
+        $fup->add([
+            'itemtype'  => 'Ticket',
+            'items_id'  => $ticket2,
+            'content'   => 'source ticket followup',
+        ]);
+
+        $status = [];
+        Ticket::merge($ticket1, [$ticket2], $status, [
+            'linktypes'  => ['ITILFollowup'],
+            'link_type'  => \CommonITILObject_CommonITILObject::SON_OF,
+        ]);
+        $this->assertSame([$ticket2 => 0], $status);
+
+        // Merging must not queue any "add_followup" notification for the merged-in content
+        $queue = new \QueuedNotification();
+        $this->assertFalse($queue->getFromDBByCrit([
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket1,
+            'event'    => 'add_followup',
+        ]));
+    }
+
     /**
      * When two tickets have a SON_OF link but the child is NOT deleted (not actually merged),
      * responses added to the child must NOT be propagated to the parent.

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -4389,19 +4389,30 @@ class TicketTest extends DbTestCase
             'content'   => 'source ticket followup',
         ]);
 
+        $task = new TicketTask();
+        $task->add([
+            'tickets_id' => $ticket2,
+            'content'    => 'source ticket task',
+        ]);
+
         $status = [];
         Ticket::merge($ticket1, [$ticket2], $status, [
-            'linktypes'  => ['ITILFollowup'],
+            'linktypes'  => ['ITILFollowup', 'TicketTask'],
             'link_type'  => \CommonITILObject_CommonITILObject::SON_OF,
         ]);
         $this->assertSame([$ticket2 => 0], $status);
 
-        // Merging must not queue any "add_followup" notification for the merged-in content
+        // Merging must not queue any "add_followup"/"add_task" notification for the merged-in content
         $queue = new \QueuedNotification();
         $this->assertFalse($queue->getFromDBByCrit([
             'itemtype' => Ticket::class,
             'items_id' => $ticket1,
             'event'    => 'add_followup',
+        ]));
+        $this->assertFalse($queue->getFromDBByCrit([
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket1,
+            'event'    => 'add_task',
         ]));
     }
 


### PR DESCRIPTION

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45665
- Here is a brief description of what this PR does
Ticket::merge() copies the source ticket's content, followups and tasks onto the target ticket without disabling notifications, causing "New followup"/"New task" notifications to fire for content that is only being duplicated as part of the merge, not newly authored.

## Screenshots (if appropriate):


