### PR TITLE
Fix: use friendly name for non-tree items answered in forms

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -414,7 +414,7 @@ class QuestionTypeItem extends AbstractQuestionType implements
 
         $name = $item instanceof CommonTreeDropdown
             ? $item->fields['completename']
-            : $item->fields['name'];
+            : $item->getFriendlyName();
 
         // Append additional fields to match what is displayed in renderEndUserTemplate.
         $itemtype = $answer['itemtype'];

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -35,6 +35,7 @@
 namespace tests\units\Glpi\Form\QuestionType;
 
 use Computer;
+use Contact;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeItemDefaultValueConfig;
@@ -331,6 +332,20 @@ final class QuestionTypeItemTest extends DbTestCase
                             'name'      => 'jdoe',
                             'firstname' => 'John',
                             'realname'  => 'Doe',
+                        ])->getID(),
+                    ],
+                    'expected' => 'Doe John',
+                ],
+            ],
+
+            'item is a contact' => [
+                fn(self $t) => [
+                    'answer'   => [
+                        'itemtype' => Contact::class,
+                        'items_id' => $t->createItem(Contact::class, [
+                            'name'        => 'Doe',
+                            'firstname'   => 'John',
+                            'entities_id' => $t->getTestRootEntity(true),
                         ])->getID(),
                     ],
                     'expected' => 'Doe John',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45690
- Here is a brief description of what this PR does

QuestionTypeItem::formatRawAnswer() only used getFriendlyName() for User answers and read the raw `name` field for everything else, dropping the firstname for Contact answers used to build ticket content.

## Screenshots (if appropriate):


