### PR TITLE
fix: preserve saved search sort order on automatic page refresh

### DIFF
--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -829,7 +829,7 @@ final class QueryBuilder implements SearchInputInterface
             if (!isset($params[$key])) {
                 if (
                     $usesession
-                    && ($key == 'is_deleted' || $key == 'as_map' || $key == 'browse' || $key === 'unpublished' || !isset($saved_params['criteria'])) // retrieve session only if not a new request
+                    && ($key == 'is_deleted' || $key == 'as_map' || $key == 'browse' || $key === 'unpublished' || $key === 'sort' || $key === 'order' || !isset($saved_params['criteria'])) // retrieve session only if not a new request
                     && isset($_SESSION['glpisearch'][$itemtype][$key])
                 ) {
                     $params[$key] = $_SESSION['glpisearch'][$itemtype][$key];

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -1571,6 +1571,21 @@ class SearchTest extends DbTestCase
         $this->assertEquals($bk_id, $_SESSION['glpi_loaded_savedsearch']);
         $this->assertArrayNotHasKey('reset', $_SESSION['glpisearch']['Ticket']);
 
+        // Simulate a page refresh where only the URL is taken into account, and not the “sort”/“order” criteria.
+        // The sort order of the saved search must still be restored from the session and not replaced by the default
+        // sort order for that item type
+        \Search::manageParams('Ticket', [
+            'criteria' => [
+                [
+                    'field' => '5',
+                    'searchtype' => 'equals',
+                    'value' => $uid,
+                ],
+            ],
+        ], true, false);
+        $this->assertEquals([2], $_SESSION['glpisearch']['Ticket']['sort']);
+        $this->assertEquals(['DESC'], $_SESSION['glpisearch']['Ticket']['order']);
+
         // saved search criteria must survive a subsequent unrelated request (sort/pagination)
         \Search::manageParams('Ticket', ['sort' => 6, 'order' => 'ASC'], true, false);
         $this->assertEquals(

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -1574,7 +1574,7 @@ class SearchTest extends DbTestCase
         // Simulate a page refresh where only the URL is taken into account, and not the “sort”/“order” criteria.
         // The sort order of the saved search must still be restored from the session and not replaced by the default
         // sort order for that item type
-        \Search::manageParams('Ticket', [
+        $search = \Search::manageParams('Ticket', [
             'criteria' => [
                 [
                     'field' => '5',
@@ -1583,8 +1583,8 @@ class SearchTest extends DbTestCase
                 ],
             ],
         ], true, false);
-        $this->assertEquals([2], $_SESSION['glpisearch']['Ticket']['sort']);
-        $this->assertEquals(['DESC'], $_SESSION['glpisearch']['Ticket']['order']);
+        $this->assertEquals([2], $search['sort']);
+        $this->assertEquals(['DESC'], $search['order']);
 
         // saved search criteria must survive a subsequent unrelated request (sort/pagination)
         \Search::manageParams('Ticket', ['sort' => 6, 'order' => 'ASC'], true, false);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45592
- The sort order of a saved search would be reset to the default sort order when the page automatically refreshed. sort/order are now restored from the session, just like other settings.
