### PR TITLE
Fix preview tooltip in user-created ITIL object lists

### DIFF
--- a/templates/components/form/item_itilobject_item_list.html.twig
+++ b/templates/components/form/item_itilobject_item_list.html.twig
@@ -54,7 +54,7 @@
     {% set values = [] %}
 
     {% for data in iterator %}
-        {% set values = values|merge({(values|length) : {'id' : item.getID(), 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
+        {% set values = values|merge({(values|length) : {'id' : data["id"], 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
     {% endfor %}
 
     {% set common_columns = call(itemtype_1 ~ '::getCommonDatatableColumns', []) %}
@@ -81,7 +81,7 @@
         {% set values = [] %}
 
         {% for data in iterator2 %}
-            {% set values = values|merge({(values|length) : {'id' : item.getID(), 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
+            {% set values = values|merge({(values|length) : {'id' : data["id"], 'item_id' : data["id"], 'itemtype' : itemtype_1, 'associated_elements' : ''}}) %}
         {% endfor %}
 
         {% set common_columns = call(itemtype_1 ~ '::getCommonDatatableColumns', []) %}


### PR DESCRIPTION
## Description

Fixes an issue where only the first entry displayed the preview tooltip in the user-created ITIL object lists available from:

**Administration → Users → <User>**

The issue affected:
- Created tickets
- Created problems
- Created changes

The datatable entries were created using the parent object ID instead of the current ITIL object ID. As a result, every row shared the same identifier, preventing the preview tooltip from working correctly after the first row.

### Changes

- Use the current ITIL object ID when building datatable entries.
- Preserve the existing behavior of the linked item lists.
- Restore preview tooltips for all created ITIL objects.

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):


