### PR TITLE
Fix: use correct dashboard select class on load

### DIFF
--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -135,7 +135,7 @@ class GLPIDashboard {
         this.elem_id      = "#dashboard-" + this.rand;
         this.element      = $(this.elem_id);
         this.elem_dom     = this.element[0];
-        this.current_name = $(`${this.elem_id} .dashboard-select`).val() || options.current;
+        this.current_name = $(`${this.elem_id} .dashboard_select`).val() || options.current;
         this.embed        = options.embed;
         this.token        = options.token;
         this.entities_id  = options.entities_id;

--- a/tests/js/modules/Dashboard/Dashboard.test.js
+++ b/tests/js/modules/Dashboard/Dashboard.test.js
@@ -95,6 +95,16 @@ describe('Dashboard', () => {
         expect(window.GLPIDashboard).toBeDefined();
     });
 
+    test('current_name reads the actually selected dashboard from the DOM on init', () => {
+        // The select's selected option ('current_dashboard') differs from the PHP-provided
+        // 'current' option, reproducing the case where the two can get out of sync on first load.
+        const dashboard = new GLPIDashboard({
+            'rand': '12345',
+            'current': 'stale_dashboard_from_php',
+        });
+        expect(dashboard.current_name).toBe('current_dashboard');
+    });
+
     test('saveMarkdown', () => {
         const dashboard = new GLPIDashboard({'rand': '12345'});
         $('body').find('.grid-stack-item').first().append(`<textarea name="markdown">test</textarea>`);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45574
- On first load, a dashboard could appear empty with an error icon on each card when it was not the one already showing in the selector, and the only way to display it correctly was to switch to another dashboard and back.
- The dashboard was resolved using a selector that never matched anything in the page, so it always fell back to the value computed server side instead of the one actually selected in the dropdown.

## Screenshots (if appropriate):


