### PR TITLE
Fix: don't strip record name when domain isn't a suffix

### DIFF
--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -550,14 +550,20 @@ TWIG, $twig_params);
      */
     public static function getDisplayName(Domain $domain, $name)
     {
-        $name_txt = rtrim(
-            str_replace(
-                rtrim($domain->getCanonicalName(), '.'),
-                '',
-                $name
-            ),
-            '.'
-        );
+        $canonical = rtrim($domain->getCanonicalName(), '.');
+        $suffix = '.' . $canonical;
+
+        if ($name === $canonical) {
+            $name_txt = '';
+        } elseif (str_ends_with($name, $suffix)) {
+            // Only strip the domain name when it is a genuine trailing suffix,
+            // not when it merely appears as a substring of the record name.
+            $name_txt = substr($name, 0, -strlen($suffix));
+        } else {
+            $name_txt = $name;
+        }
+
+        $name_txt = rtrim($name_txt, '.');
         if (empty($name_txt)) {
             //dns root
             $name_txt = '@';

--- a/tests/functional/DomainRecordTest.php
+++ b/tests/functional/DomainRecordTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units;
 
+use Domain;
 use DomainRecord;
 use Glpi\Tests\DbTestCase;
 
@@ -94,5 +95,21 @@ class DomainRecordTest extends DbTestCase
         // A fresh (empty) item should reflect the real default ttl, not 0.
         $record->getEmpty();
         $this->assertSame(DomainRecord::DEFAULT_TTL, $record->fields['ttl']);
+    }
+
+    public function testGetDisplayName()
+    {
+        $domain = new Domain();
+        $domain->fields['name'] = 'Test';
+
+        // Record name only textually contains the domain name as a prefix,
+        // it must not be stripped down to its trailing suffix.
+        $this->assertSame('Test2', DomainRecord::getDisplayName($domain, 'Test2'));
+
+        // Record name equal to the domain name is the DNS root.
+        $this->assertSame('@', DomainRecord::getDisplayName($domain, 'Test'));
+
+        // Record name is a genuine FQDN suffixed by the domain name.
+        $this->assertSame('www', DomainRecord::getDisplayName($domain, 'www.Test'));
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45553
- The domain records list showed a wrong, truncated name whenever a record's name textually started with its domain's name without actually being a FQDN built on that domain (for example, domain "Test" and record "Test2" displayed as "2").
- This happened because the domain name was removed from the record name wherever it matched, instead of only when it was a genuine trailing suffix.
- The domain name is now only stripped when it forms the actual suffix of the record's name.

## Screenshots (if appropriate):