### PR TITLE
 Fix(ProjectTask.php): Creating a project from a template clones sub-tasks in the template

### DIFF
--- a/src/Glpi/Features/CloneMapper.php
+++ b/src/Glpi/Features/CloneMapper.php
@@ -70,6 +70,16 @@ final class CloneMapper implements MapperInterface
         return $this->mapped_ids[$class][$old_id];
     }
 
+    /**
+     * Check whether an item has already been cloned during the current clone process.
+     *
+     * @param class-string<\CommonDBTM> $class
+     */
+    public function hasItemId(string $class, string|int $old_id): bool
+    {
+        return isset($this->mapped_ids[$class][$old_id]);
+    }
+
     public function cleanMappedIds(): void
     {
         $this->mapped_ids = [];

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -39,6 +39,7 @@ use Glpi\CalDAV\Traits\VobjectConverterTrait;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
 use Glpi\DBAL\QuerySubQuery;
+use Glpi\Features\CloneMapper;
 use Glpi\Features\PlanningEvent;
 use Glpi\Features\Teamwork;
 use Glpi\Features\TeamworkInterface;
@@ -588,13 +589,26 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
 
     public function post_clone($source, $history)
     {
+        if (CloneMapper::getInstance()->hasItemId(Project::class, $source->fields['projects_id'])) {
+            // The whole project is being cloned (e.g. a project is created from a template).
+            // All its tasks, including the sub-tasks of the current one, are already cloned by
+            // `Clonable::cloneRelations()`, which also takes care of remapping the parent/child
+            // relations. Cloning them here again would create duplicated tasks in the source project.
+            return;
+        }
+
         // Clone all sub-tasks of the source and link them to the cloned task
         foreach (self::getAllForProjectTask($source->getID()) as $task) {
             if ($task = self::getById($task['id'])) {
                 if (method_exists($task, 'clone')) {
-                    $task->clone([
-                        'projecttasks_id' => $this->getID(),
-                    ]);
+                    $task->clone(
+                        [
+                            'projects_id'     => $this->fields['projects_id'],
+                            'projecttasks_id' => $this->getID(),
+                        ],
+                        $history,
+                        clean_mapper: false
+                    );
                 }
             }
         }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -592,8 +592,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         if (CloneMapper::getInstance()->hasItemId(Project::class, $source->fields['projects_id'])) {
             // The whole project is being cloned (e.g. a project is created from a template).
             // All its tasks, including the sub-tasks of the current one, are already cloned by
-            // `Clonable::cloneRelations()`, which also takes care of remapping the parent/child
-            // relations. Cloning them here again would create duplicated tasks in the source project.
+            // `Clonable::cloneRelations()`.
             return;
         }
 

--- a/tests/functional/ProjectTaskTest.php
+++ b/tests/functional/ProjectTaskTest.php
@@ -449,6 +449,163 @@ class ProjectTaskTest extends DbTestCase
         $this->assertEquals($project->getID(), $clonedSubtask2->fields['projects_id']);
         $this->assertEquals($subtask2->fields['name'] . ' (copy)', $clonedSubtask2->fields['name']);
     }
+
+    public function testCloneProjectTaskClonesSubTreeOnce()
+    {
+        $project = $this->createItem('Project', [
+            'name' => __FUNCTION__,
+        ]);
+
+        // Task to be cloned, with two children, one of them having a child itself
+        $task = $this->createItem('ProjectTask', [
+            'projects_id' => $project->getID(),
+            'name'        => 'Task A',
+        ]);
+        $child1 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Task A.1',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $child1->getID(),
+            'name'            => 'Task A.1.1',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Task A.2',
+        ]);
+
+        // Unrelated task, it must not be impacted by the clone
+        $this->createItem('ProjectTask', [
+            'projects_id' => $project->getID(),
+            'name'        => 'Task B',
+        ]);
+
+        $clone_id = $task->clone();
+        $this->assertGreaterThan(0, $clone_id);
+
+        // 5 original tasks + the 4 tasks of the cloned sub-tree
+        $tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $project->getID()]);
+        $this->assertCount(9, $tasks);
+
+        // Check the hierarchy, `name => parent name` (0 when the task has no parent)
+        $names = array_column($tasks, 'name', 'id');
+        $hierarchy = [];
+        foreach ($tasks as $row) {
+            $hierarchy[$row['name']] = $row['projecttasks_id'] === 0
+                ? 0
+                : ($names[$row['projecttasks_id']] ?? 'unknown');
+        }
+        $this->assertEquals(
+            [
+                // original tasks, untouched
+                'Task A'              => 0,
+                'Task A.1'            => 'Task A',
+                'Task A.1.1'          => 'Task A.1',
+                'Task A.2'            => 'Task A',
+                'Task B'              => 0,
+                // cloned sub-tree
+                'Task A (copy)'       => 0,
+                'Task A.1 (copy)'     => 'Task A (copy)',
+                'Task A.1.1 (copy)'   => 'Task A.1 (copy)',
+                'Task A.2 (copy)'     => 'Task A (copy)',
+            ],
+            $hierarchy
+        );
+    }
+
+    public function testCloneProjectTaskInTemplate()
+    {
+        $template = $this->createItem('Project', [
+            'name'          => __FUNCTION__,
+            'is_template'   => 1,
+            'template_name' => __FUNCTION__,
+        ]);
+
+        $task = $this->createItem('ProjectTask', [
+            'projects_id' => $template->getID(),
+            'name'        => 'Task A',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $template->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Task A.1',
+        ]);
+
+        $clone_id = $task->clone();
+        $this->assertGreaterThan(0, $clone_id);
+
+        $child_clone = new ProjectTask();
+        $this->assertTrue($child_clone->getFromDBByCrit(['projecttasks_id' => $clone_id]));
+        $this->assertEquals('Task A.1 (copy)', $child_clone->fields['name']);
+        $this->assertEquals($template->getID(), $child_clone->fields['projects_id']);
+
+        // 2 original tasks + the 2 cloned ones
+        $this->assertEquals(
+            4,
+            countElementsInTable(ProjectTask::getTable(), ['projects_id' => $template->getID()])
+        );
+    }
+
+    public function testCloneProjectTaskIntoAnotherProject()
+    {
+        $source_project = $this->createItem('Project', [
+            'name' => __FUNCTION__ . ' source',
+        ]);
+        $target_project = $this->createItem('Project', [
+            'name' => __FUNCTION__ . ' target',
+        ]);
+
+        $task = $this->createItem('ProjectTask', [
+            'projects_id' => $source_project->getID(),
+            'name'        => 'Task A',
+        ]);
+        $child = $this->createItem('ProjectTask', [
+            'projects_id'     => $source_project->getID(),
+            'projecttasks_id' => $task->getID(),
+            'name'            => 'Task A.1',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $source_project->getID(),
+            'projecttasks_id' => $child->getID(),
+            'name'            => 'Task A.1.1',
+        ]);
+
+        $clone_id = $task->clone(['projects_id' => $target_project->getID()]);
+        $this->assertGreaterThan(0, $clone_id);
+
+        // Source project is left with its 3 original tasks
+        $this->assertEquals(
+            3,
+            countElementsInTable(ProjectTask::getTable(), ['projects_id' => $source_project->getID()])
+        );
+
+        // The whole sub-tree has been cloned into the target project
+        $cloned_tasks = getAllDataFromTable(
+            ProjectTask::getTable(),
+            ['projects_id' => $target_project->getID()]
+        );
+        $this->assertCount(3, $cloned_tasks);
+
+        $names = array_column($cloned_tasks, 'name', 'id');
+        $hierarchy = [];
+        foreach ($cloned_tasks as $row) {
+            $hierarchy[$row['name']] = $row['projecttasks_id'] === 0
+                ? 0
+                : ($names[$row['projecttasks_id']] ?? 'unknown');
+        }
+        $this->assertEquals(
+            [
+                'Task A (copy)'     => 0,
+                'Task A.1 (copy)'   => 'Task A (copy)',
+                'Task A.1.1 (copy)' => 'Task A.1 (copy)',
+            ],
+            $hierarchy
+        );
+    }
+
     protected function testAutochangeStateProvider()
     {
         $config = new \Config();

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -454,6 +454,92 @@ class ProjectTest extends DbTestCase
         $this->assertEquals($expected, $tasks_clone);
     }
 
+    public function testCreateFromTemplateDoesNotAlterTemplateTasks()
+    {
+        $this->login();
+
+        // Create a project template with a tasks hierarchy
+        $template = $this->createItem('Project', [
+            'name'          => __FUNCTION__,
+            'is_template'   => 1,
+            'template_name' => __FUNCTION__,
+        ]);
+        $templates_id = $template->getID();
+
+        $parent_a = $this->createItem('ProjectTask', [
+            'projects_id' => $templates_id,
+            'name'        => 'Parent task A',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $templates_id,
+            'name'            => 'Child task A.1',
+            'projecttasks_id' => $parent_a->getID(),
+        ]);
+        $child_a2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $templates_id,
+            'name'            => 'Child task A.2',
+            'projecttasks_id' => $parent_a->getID(),
+        ]);
+        // Third level, to be sure that the recursion is not partially applied
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $templates_id,
+            'name'            => 'Child task A.2.1',
+            'projecttasks_id' => $child_a2->getID(),
+        ]);
+        $parent_b = $this->createItem('ProjectTask', [
+            'projects_id' => $templates_id,
+            'name'        => 'Parent task B',
+        ]);
+        $this->createItem('ProjectTask', [
+            'projects_id'     => $templates_id,
+            'name'            => 'Child task B.1',
+            'projecttasks_id' => $parent_b->getID(),
+        ]);
+
+        $template_tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $templates_id]);
+        $this->assertCount(6, $template_tasks);
+
+        // Create a project from this template
+        $project = new \Project();
+        $projects_id = $project->add([
+            'name'   => 'Project from ' . __FUNCTION__,
+            '_oldID' => $templates_id,
+        ]);
+        $this->assertGreaterThan(0, $projects_id);
+
+        // The template tasks must be left untouched (no additional "(copy)" tasks)
+        $template_tasks_after = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $templates_id]);
+        $this->assertEquals(
+            array_column($template_tasks, 'name', 'id'),
+            array_column($template_tasks_after, 'name', 'id')
+        );
+
+        // The new project must contain the whole tasks hierarchy, exactly once
+        $new_tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $projects_id]);
+        $this->assertCount(6, $new_tasks);
+
+        $new_tasks_by_name = array_column($new_tasks, null, 'name');
+        $this->assertEquals(
+            [
+                'Parent task A'    => 0,
+                'Child task A.1'   => 'Parent task A',
+                'Child task A.2'   => 'Parent task A',
+                'Child task A.2.1' => 'Child task A.2',
+                'Parent task B'    => 0,
+                'Child task B.1'   => 'Parent task B',
+            ],
+            array_map(
+                static function (array $task) use ($new_tasks) {
+                    if ($task['projecttasks_id'] === 0) {
+                        return 0;
+                    }
+                    return array_column($new_tasks, 'name', 'id')[$task['projecttasks_id']] ?? 'unknown';
+                },
+                $new_tasks_by_name
+            )
+        );
+    }
+
     public function testCloneWithOverridenInput()
     {
         $project = $this->createItem(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes!45664
- Creating a project from a template duplicated the template's own tasks: the source template kept growing, with extra `... (copy)` / `... (copy 2)` tasks appearing for every grouped or nested task each time a project was created from it.
- This due to the fact that when creating a project from a template, each cloned task ran `ProjectTask::post_clone()`, which cloned the source task's sub-tasks without overriding the `projects_id` of the source task, even though `Clonable::cloneRelations()` already clones every task of the project — sub-tasks included — and remaps the `projecttasks_id` parent/child links afterwards.

### Fix
- `ProjectTask::post_clone()` now skips the sub-tree cloning when the parent project is itself being cloned (detected through the `CloneMapper`), since the trait already handled it. The standalone "Clone" action on a single task is unaffected.
- The sub-task clones now inherit the new parent's `projects_id`, so cloning a task into another project takes its whole sub-tree along.