### PR TITLE
Fix: solve/close delay stat displayed as blank instead of '0' when equal to zero

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2462,12 +2462,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#2 \\$display_sec of static method Html\\:\\:timestampToString\\(\\) expects bool, int given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 3,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#2 \\$items_id of static method CommonDBConnexity\\:\\:getItemsAssociatedTo\\(\\) expects string, int given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5466,7 +5466,7 @@ abstract class CommonITILObject extends CommonDBTM
         if (isset($this->fields['takeintoaccount_delay_stat'])) {
             echo "<tr class='tab_bg_2'><td>" . __('Take into account') . "</td><td>";
             if ($this->fields['takeintoaccount_delay_stat'] > 0) {
-                echo Html::timestampToString($this->fields['takeintoaccount_delay_stat'], 0, false);
+                echo Html::timestampToString($this->fields['takeintoaccount_delay_stat'], false, false);
             } else {
                 echo '&nbsp;';
             }
@@ -5485,13 +5485,13 @@ abstract class CommonITILObject extends CommonDBTM
             echo "<tr class='tab_bg_2'><td>" . __('Closure') . "</td><td>";
             // close_delay_stat may legitimately be 0 (e.g. ticket closed outside
             // the calendar's working hours), so always display it if the ticket is closed.
-            echo Html::timestampToString($this->fields['close_delay_stat'], true, false);
+            echo Html::timestampToString($this->fields['close_delay_stat'], false, false);
             echo "</td></tr>";
         }
 
         echo "<tr class='tab_bg_2'><td>" . __('Pending') . "</td><td>";
         if ($this->fields['waiting_duration'] > 0) {
-            echo Html::timestampToString($this->fields['waiting_duration'], 0, false);
+            echo Html::timestampToString($this->fields['waiting_duration'], false, false);
         } else {
             echo '&nbsp;';
         }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5475,22 +5475,17 @@ abstract class CommonITILObject extends CommonDBTM
 
         if (!$this->isNotSolved()) {
             echo "<tr class='tab_bg_2'><td>" . __('Resolution') . "</td><td>";
-
-            if ($this->fields['solve_delay_stat'] > 0) {
-                echo Html::timestampToString($this->fields['solve_delay_stat'], 0, false);
-            } else {
-                echo '&nbsp;';
-            }
+            // solve_delay_stat may legitimately be 0 (e.g. ticket resolved outside
+            // the calendar's working hours), so always display it if the ticket is solved.
+            echo Html::timestampToString($this->fields['solve_delay_stat'], false, false);
             echo "</td></tr>";
         }
 
         if (in_array($this->fields['status'], $this->getClosedStatusArray())) {
             echo "<tr class='tab_bg_2'><td>" . __('Closure') . "</td><td>";
-            if ($this->fields['close_delay_stat'] > 0) {
-                echo Html::timestampToString($this->fields['close_delay_stat'], true, false);
-            } else {
-                echo '&nbsp;';
-            }
+            // close_delay_stat may legitimately be 0 (e.g. ticket closed outside
+            // the calendar's working hours), so always display it if the ticket is closed.
+            echo Html::timestampToString($this->fields['close_delay_stat'], true, false);
             echo "</td></tr>";
         }
 
@@ -6715,7 +6710,7 @@ abstract class CommonITILObject extends CommonDBTM
 
                 $solvedelay_column = "";
                 // Show only for solved tickets
-                if ($item->fields['solve_delay_stat'] > 0) {
+                if (!empty($item->fields['solvedate'])) {
                     $solvedelay_column = Html::timestampToString($item->fields['solve_delay_stat']);
                 }
                 echo Search::showItem($p['output_type'], $solvedelay_column, $item_num, $p['row_num'], $align_desc . " width='150'");


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45692
- `solve_delay_stat` and `close_delay_stat` are computed in working hours based on the entity's (or SLA's) calendar. When a ticket is created and solved/closed entirely outside the calendar's working hours (e.g. opened at 7pm, solved at 9pm on a calendar covering 8am-6pm), the elapsed working time is legitimately 0 — this is expected behavior, not a calculation bug.
- However, the display logic treated 0 the same as "not yet computed", hiding it (`&nbsp;`) instead of showing the actual value. This made it look like the delay had never been calculated, when in fact it had — correctly — resulted in zero.

### Fix

- `CommonITILObject::showStatsTimes()`: The value of `solve_delay_stat` and  `close_delay_stat` (including 0) is now always rendered.
- `CommonITILObject::showShort()` (ticket_stats list column): replaced the `solve_delay_stat > 0` check with `!empty($item->fields['solvedate'])`, since presence of a solve date — not the delay value itself — is what determines whether the column is applicable.