### PR TITLE
Fix (45514): Requester manager not properly added as observer in case of an "add" action type

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -9608,7 +9608,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         } else {
                             $actor_id = $actor;
                         }
-                        if (!is_numeric($actor_id)) {
+                        if (!is_numeric($actor_id) && $actor_id !== 'requester_manager') {
                             trigger_error(
                                 sprintf(
                                     'Invalid value "%s" found for additional actor in "%s".',

--- a/src/RuleCommonITILObject.php
+++ b/src/RuleCommonITILObject.php
@@ -363,6 +363,9 @@ TWIG, ['message' => __('An action related to an approval exists, but there is no
                             )
                             && $action->fields["value"] === 'requester_manager'
                         ) {
+                            if (!is_array($input['_users_id_requester'])) {
+                                $input['_users_id_requester'] = [$input['_users_id_requester']];
+                            }
                             foreach ($input['_users_id_requester'] as $user_id) {
                                 $user = new User();
                                 $user->getFromDB($user_id);

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -763,8 +763,8 @@ class RuleTicketTest extends RuleCommonITILObjectTest
         $this->assertGreaterThan(0, $tickets_id_3);
 
         $tickets_id_4 = $ticket->add([
-            'name'    => 'test manager number 3',
-            'content' => 'test manager number 3',
+            'name'    => 'test manager number 4',
+            'content' => 'test manager number 4',
             '_users_id_requester' => [$user_id],
         ]);
         $this->assertGreaterThan(0, $tickets_id_4);

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -744,6 +744,32 @@ class RuleTicketTest extends RuleCommonITILObjectTest
                 'type'          => \CommonITILActor::OBSERVER,
             ])
         );
+
+        // Now check with add action type
+        $ruleaction->delete(['id' => $action_id]);
+        $action_id_2 = $ruleaction->add($action_input = [
+            'rules_id'    => $ruletid,
+            'action_type' => 'append',
+            'field'       => '_users_id_observer',
+            'value'       => 'requester_manager',
+        ]);
+        $this->checkInput($ruleaction, $action_id_2, $action_input);
+
+        $tickets_id_3 = $ticket->add([
+            'name'    => 'test manager number 3',
+            'content' => 'test manager number 3',
+            '_users_id_requester' => $user_id,
+        ]);
+        $this->assertGreaterThan(0, $tickets_id_3);
+
+        // check manager
+        $this->assertTrue(
+            $ticket_user->getFromDBByCrit([
+                'tickets_id'    => $tickets_id_3,
+                'users_id'      => $manager_id,
+                'type'          => \CommonITILActor::OBSERVER,
+            ])
+        );
     }
 
     public function testAssignProject()

--- a/tests/functional/RuleTicketTest.php
+++ b/tests/functional/RuleTicketTest.php
@@ -762,10 +762,25 @@ class RuleTicketTest extends RuleCommonITILObjectTest
         ]);
         $this->assertGreaterThan(0, $tickets_id_3);
 
+        $tickets_id_4 = $ticket->add([
+            'name'    => 'test manager number 3',
+            'content' => 'test manager number 3',
+            '_users_id_requester' => [$user_id],
+        ]);
+        $this->assertGreaterThan(0, $tickets_id_4);
+
         // check manager
         $this->assertTrue(
             $ticket_user->getFromDBByCrit([
                 'tickets_id'    => $tickets_id_3,
+                'users_id'      => $manager_id,
+                'type'          => \CommonITILActor::OBSERVER,
+            ])
+        );
+
+        $this->assertTrue(
+            $ticket_user->getFromDBByCrit([
+                'tickets_id'    => $tickets_id_4,
                 'users_id'      => $manager_id,
                 'type'          => \CommonITILActor::OBSERVER,
             ])


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes 45514
- Here is a brief description of what this PR does
  - Fix an issue where the requester manager was not properly added to a ticket in case of an "add" action type, in ticket business rules
  - Fix an unrelevant PHP warning 
  - Added unit tests to cover new behavior
