### PR TITLE
Fix - Use an indexable range for date search criteria

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -50,6 +50,7 @@ use Consumable;
 use CronTask;
 use DateInterval;
 use DateTimeImmutable;
+use DateTimeZone;
 use DBConnection;
 use DBmysql;
 use DBmysqlIterator;
@@ -5496,8 +5497,8 @@ final class SQLProvider implements SearchProviderInterface
                 return null;
             }
 
-            // `!` resets unspecified fields to their "zero" value
-            $lower_bound = DateTimeImmutable::createFromFormat('!' . $format, $val);
+            // `!` resets unspecified fields to their "zero" value; force UTC as the value has no time offset.
+            $lower_bound = DateTimeImmutable::createFromFormat('!' . $format, $val, new DateTimeZone('UTC'));
             $errors      = DateTimeImmutable::getLastErrors();
             if ($lower_bound === false || ($errors !== false && ($errors['warning_count'] + $errors['error_count']) > 0)) {
                 // Out of range value, e.g. `2024-02-30`

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -48,6 +48,8 @@ use CommonITILValidation;
 use Config;
 use Consumable;
 use CronTask;
+use DateInterval;
+use DateTimeImmutable;
 use DBConnection;
 use DBmysql;
 use DBmysqlIterator;
@@ -1869,10 +1871,20 @@ final class SQLProvider implements SearchProviderInterface
                         // Specific search for datetime
                         if (in_array($searchtype, ['equals', 'notequals'])) {
                             $val = preg_replace("/:00$/", '', $val);
-                            $val = '^' . $val;
                             if ($searchtype === 'notequals') {
                                 $nott = !$nott;
                             }
+
+                            // Search the range matching the value precision (e.g. the whole day for
+                            // `2024-07-28`), as a `LIKE` pattern would not use the column index.
+                            $boundaries = isset($opt["computation"])
+                                ? null // not supported on computed fields
+                                : self::getDateTimeRangeBoundaries((string) $val);
+                            if ($boundaries !== null) {
+                                return self::getDateTimeRangeCriteria("$table.$field", $boundaries, $nott);
+                            }
+
+                            $val = '^' . $val;
                             return [new QueryExpression(self::makeTextCriteria("`$table`.`$field`", $val, $nott, ''))];
                         }
                     }
@@ -1965,6 +1977,25 @@ final class SQLProvider implements SearchProviderInterface
                     // ELSE standard search
                     // Date format modification if needed
                     $val = preg_replace('@(\d{1,2})(-|/)(\d{1,2})(-|/)(\d{4})@', '\5-\3-\1', $val);
+
+                    // The column string representation has a fixed width, so a partial date can only
+                    // be found at its beginning. It can therefore be searched as a range, which,
+                    // unlike the `LIKE` pattern used below, is able to use the column index.
+                    if (
+                        in_array($searchtype, ['contains', 'notcontains'], true)
+                        && in_array($opt["datatype"], ['date', 'datetime'], true)
+                        && !isset($opt["computation"])
+                        && preg_match('/\$$/', (string) $val) !== 1 // a trailing `$` is not a prefix search
+                    ) {
+                        $boundaries = self::getDateTimeRangeBoundaries(
+                            preg_replace('/^\^/', '', (string) $val),
+                            $opt["datatype"] === 'datetime'
+                        );
+                        if ($boundaries !== null) {
+                            return self::getDateTimeRangeCriteria("$table.$field", $boundaries, $nott);
+                        }
+                    }
+
                     if ($date_computation) {
                         return [
                             new QueryExpression(self::makeTextCriteria($date_computation, $val, $nott, '')),
@@ -5426,6 +5457,92 @@ final class SQLProvider implements SearchProviderInterface
             $sql = "($sql OR $field IS NULL)";
         }
         return " $link ($sql)";
+    }
+
+    /**
+     * Compute the range matching a partial date/time value, e.g. the whole day for `2024-07-28`.
+     *
+     * @param string $val       Partial date/time value, from `YYYY` to `YYYY-MM-DD HH:mm:ss`
+     * @param bool   $with_time Whether the compared column holds a time part
+     *
+     * @return array{0: string, 1: string}|null Lower (included) and upper (excluded) bounds,
+     *                                          or `null` if the value cannot be interpreted.
+     */
+    private static function getDateTimeRangeBoundaries(string $val, bool $with_time = true): ?array
+    {
+        $precisions = [
+            '/^\d{4}$/'                               => ['Y',           'P1Y',  false],
+            '/^\d{4}-\d{2}$/'                         => ['Y-m',         'P1M',  false],
+            '/^\d{4}-\d{2}-\d{2}$/'                   => ['Y-m-d',       'P1D',  false],
+            '/^\d{4}-\d{2}-\d{2} \d{2}$/'             => ['Y-m-d H',     'PT1H', true],
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/'       => ['Y-m-d H:i',   'PT1M', true],
+            '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/' => ['Y-m-d H:i:s', 'PT1S', true],
+        ];
+
+        $val = trim($val);
+
+        foreach ($precisions as $pattern => [$format, $interval, $has_time]) {
+            if (preg_match($pattern, $val) !== 1) {
+                continue;
+            }
+
+            if ($has_time && !$with_time) {
+                // A column without time part cannot match such a value.
+                return null;
+            }
+
+            if (str_starts_with($val, '0000')) {
+                // The legacy `0000-00-00` value would be out of the computed range.
+                return null;
+            }
+
+            // `!` resets unspecified fields to their "zero" value
+            $lower_bound = DateTimeImmutable::createFromFormat('!' . $format, $val);
+            $errors      = DateTimeImmutable::getLastErrors();
+            if ($lower_bound === false || ($errors !== false && ($errors['warning_count'] + $errors['error_count']) > 0)) {
+                // Out of range value, e.g. `2024-02-30`
+                return null;
+            }
+
+            $output_format = $with_time ? 'Y-m-d H:i:s' : 'Y-m-d';
+
+            return [
+                $lower_bound->format($output_format),
+                $lower_bound->add(new DateInterval($interval))->format($output_format),
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Build a criterion matching the given date/time range.
+     *
+     * @param string                      $column     Column to compare, as `table.field`
+     * @param array{0: string, 1: string} $boundaries Lower (included) and upper (excluded) bounds
+     * @param bool                        $nott       Is a negative search?
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function getDateTimeRangeCriteria(string $column, array $boundaries, bool $nott): array
+    {
+        [$lower_bound, $upper_bound] = $boundaries;
+
+        if ($nott) {
+            // `NULL` values are part of a negative search results
+            return [
+                'OR' => [
+                    [$column => ['<', $lower_bound]],
+                    [$column => ['>=', $upper_bound]],
+                    [$column => null],
+                ],
+            ];
+        }
+
+        return [
+            [$column => ['>=', $lower_bound]],
+            [$column => ['<', $upper_bound]],
+        ];
     }
 
     /**

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3589,12 +3589,21 @@ class SearchTest extends DbTestCase
             'expected_and'      => "false",
             'expected_and_not'  => "false",
         ];
+        // A date/time prefix is searched as a range
         yield [
             'itemtype'          => Computer::class,
             'search_option'     => 9, // last_inventory_update
             'value'             => '2023-06',
-            'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) LIKE '%2023-06%')",
-            'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) NOT LIKE '%2023-06%' OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL)",
+            'expected_and'      => "(`glpi_computers`.`last_inventory_update` >= '2023-06-01 00:00:00') AND (`glpi_computers`.`last_inventory_update` < '2023-07-01 00:00:00')",
+            'expected_and_not'  => "((`glpi_computers`.`last_inventory_update` < '2023-06-01 00:00:00') OR (`glpi_computers`.`last_inventory_update` >= '2023-07-01 00:00:00') OR (`glpi_computers`.`last_inventory_update` IS NULL))",
+        ];
+        // Any other value keeps the `LIKE` criterion
+        yield [
+            'itemtype'          => Computer::class,
+            'search_option'     => 9, // last_inventory_update
+            'value'             => '-06-',
+            'expected_and'      => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) LIKE '%-06-%')",
+            'expected_and_not'  => "(CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) NOT LIKE '%-06-%' OR CONVERT(`glpi_computers`.`last_inventory_update` USING utf8mb4) IS NULL)",
         ];
 
         // datatype=datetime (usehaving=true)
@@ -3621,12 +3630,20 @@ class SearchTest extends DbTestCase
             'expected_and'      => "false",
             'expected_and_not'  => "false",
         ];
+        // Bounds are expressed as dates, as the column holds no time part
         yield [
             'itemtype'          => \Budget::class,
             'search_option'     => 5, // begin_date
             'value'             => '2023',
-            'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) LIKE '%2023%')",
-            'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) NOT LIKE '%2023%' OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL)",
+            'expected_and'      => "(`glpi_budgets`.`begin_date` >= '2023-01-01') AND (`glpi_budgets`.`begin_date` < '2024-01-01')",
+            'expected_and_not'  => "((`glpi_budgets`.`begin_date` < '2023-01-01') OR (`glpi_budgets`.`begin_date` >= '2024-01-01') OR (`glpi_budgets`.`begin_date` IS NULL))",
+        ];
+        yield [
+            'itemtype'          => \Budget::class,
+            'search_option'     => 5, // begin_date
+            'value'             => '-06-',
+            'expected_and'      => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) LIKE '%-06-%')",
+            'expected_and_not'  => "(CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) NOT LIKE '%-06-%' OR CONVERT(`glpi_budgets`.`begin_date` USING utf8mb4) IS NULL)",
         ];
 
         // datatype=date_delay
@@ -4540,6 +4557,171 @@ class SearchTest extends DbTestCase
                     $this->cleanSQL($data['sql']['search'])
                 );
             }
+        }
+    }
+
+    /**
+     * A `datetime` "is"/"is not" criterion is searched as a range, to use the column index.
+     */
+    public static function dateTimeEqualsCriterionProvider(): iterable
+    {
+        $ticket_date = '`glpi_tickets`.`date`';
+
+        // Bounds depend on the value precision. A trailing `:00` is stripped before parsing,
+        // so a value given with seconds is handled with a minute precision.
+        $precisions = [
+            '2024-07-28'          => ['2024-07-28 00:00:00', '2024-07-29 00:00:00'],
+            '2024-07-28 14'       => ['2024-07-28 14:00:00', '2024-07-28 15:00:00'],
+            '2024-07-28 14:30'    => ['2024-07-28 14:30:00', '2024-07-28 14:31:00'],
+            '2024-07-28 14:30:00' => ['2024-07-28 14:30:00', '2024-07-28 14:31:00'],
+            '2024-07-28 14:30:15' => ['2024-07-28 14:30:15', '2024-07-28 14:30:16'],
+            '2024-07'             => ['2024-07-01 00:00:00', '2024-08-01 00:00:00'],
+            '2024'                => ['2024-01-01 00:00:00', '2025-01-01 00:00:00'],
+        ];
+
+        foreach ($precisions as $value => [$lower_bound, $upper_bound]) {
+            $value = (string) $value; // PHP casts a numeric-only key to an int
+            yield [
+                'search_option'    => 15, // date
+                'searchtype'       => 'equals',
+                'value'            => $value,
+                'expected_and'     => "({$ticket_date} >= '{$lower_bound}') AND ({$ticket_date} < '{$upper_bound}')",
+                'expected_and_not' => "(({$ticket_date} < '{$lower_bound}') OR ({$ticket_date} >= '{$upper_bound}') OR ({$ticket_date} IS NULL))",
+            ];
+            // `notequals` is the negation of `equals`
+            yield [
+                'search_option'    => 15, // date
+                'searchtype'       => 'notequals',
+                'value'            => $value,
+                'expected_and'     => "(({$ticket_date} < '{$lower_bound}') OR ({$ticket_date} >= '{$upper_bound}') OR ({$ticket_date} IS NULL))",
+                'expected_and_not' => "({$ticket_date} >= '{$lower_bound}') AND ({$ticket_date} < '{$upper_bound}')",
+            ];
+        }
+
+        // An unparsable value falls back to the `LIKE` criterion
+        foreach (['2024-02-30', '2024-13-01', 'NULL'] as $value) {
+            yield [
+                'search_option'    => 15, // date
+                'searchtype'       => 'equals',
+                'value'            => $value,
+                'expected_and'     => "({$ticket_date} LIKE '{$value}%')",
+                'expected_and_not' => "({$ticket_date} NOT LIKE '{$value}%' OR {$ticket_date} IS NULL)",
+            ];
+        }
+    }
+
+    #[DataProvider('dateTimeEqualsCriterionProvider')]
+    public function testDateTimeEqualsCriterion(
+        int $search_option,
+        string $searchtype,
+        string $value,
+        string $expected_and,
+        string $expected_and_not
+    ): void {
+        $cases = [
+            'AND'     => $expected_and,
+            'AND NOT' => $expected_and_not,
+        ];
+
+        foreach ($cases as $link => $expected_where) {
+            $data = $this->doSearch(Ticket::class, [
+                'is_deleted' => 0,
+                'start'      => 0,
+                'criteria'   => [
+                    [
+                        'link'       => $link,
+                        'field'      => $search_option,
+                        'searchtype' => $searchtype,
+                        'value'      => $value,
+                    ],
+                ],
+            ]);
+
+            $this->assertStringContainsString(
+                $expected_where,
+                $this->cleanSQL($data['sql']['search'])
+            );
+        }
+    }
+
+    /**
+     * A `contains` criterion on a date/time field is searched as a range, to use the column index.
+     */
+    public static function dateTimeContainsCriterionProvider(): iterable
+    {
+        $ticket_date = '`glpi_tickets`.`date`';
+
+        $precisions = [
+            '2024-07-28'          => ['2024-07-28 00:00:00', '2024-07-29 00:00:00'],
+            '2024-07-28 14'       => ['2024-07-28 14:00:00', '2024-07-28 15:00:00'],
+            '2024-07-28 14:30'    => ['2024-07-28 14:30:00', '2024-07-28 14:31:00'],
+            '2024-07-28 14:30:15' => ['2024-07-28 14:30:15', '2024-07-28 14:30:16'],
+            '2024-07'             => ['2024-07-01 00:00:00', '2024-08-01 00:00:00'],
+            '2024'                => ['2024-01-01 00:00:00', '2025-01-01 00:00:00'],
+            // a `DD-MM-YYYY` value is reformatted first
+            '28-07-2024'          => ['2024-07-28 00:00:00', '2024-07-29 00:00:00'],
+        ];
+
+        foreach ($precisions as $value => [$lower_bound, $upper_bound]) {
+            $value = (string) $value; // PHP casts a numeric-only key to an int
+            yield [
+                'searchtype'       => 'contains',
+                'value'            => $value,
+                'expected_and'     => "({$ticket_date} >= '{$lower_bound}') AND ({$ticket_date} < '{$upper_bound}')",
+                'expected_and_not' => "(({$ticket_date} < '{$lower_bound}') OR ({$ticket_date} >= '{$upper_bound}') OR ({$ticket_date} IS NULL))",
+            ];
+            // `notcontains` is the negation of `contains`
+            yield [
+                'searchtype'       => 'notcontains',
+                'value'            => $value,
+                'expected_and'     => "(({$ticket_date} < '{$lower_bound}') OR ({$ticket_date} >= '{$upper_bound}') OR ({$ticket_date} IS NULL))",
+                'expected_and_not' => "({$ticket_date} >= '{$lower_bound}') AND ({$ticket_date} < '{$upper_bound}')",
+            ];
+        }
+
+        // A value that is not a date/time prefix falls back to the `LIKE` criterion
+        $charset = DBConnection::getDefaultCharset();
+        $converted = "CONVERT({$ticket_date} USING {$charset})";
+        foreach (['-07-', '14:30', '2024-02-30', '2024-13-01', '0000'] as $value) {
+            yield [
+                'searchtype'       => 'contains',
+                'value'            => $value,
+                'expected_and'     => "({$converted} LIKE '%{$value}%')",
+                'expected_and_not' => "({$converted} NOT LIKE '%{$value}%' OR {$converted} IS NULL)",
+            ];
+        }
+    }
+
+    #[DataProvider('dateTimeContainsCriterionProvider')]
+    public function testDateTimeContainsCriterion(
+        string $searchtype,
+        string $value,
+        string $expected_and,
+        string $expected_and_not
+    ): void {
+        $cases = [
+            'AND'     => $expected_and,
+            'AND NOT' => $expected_and_not,
+        ];
+
+        foreach ($cases as $link => $expected_where) {
+            $data = $this->doSearch(Ticket::class, [
+                'is_deleted' => 0,
+                'start'      => 0,
+                'criteria'   => [
+                    [
+                        'link'       => $link,
+                        'field'      => 15, // date
+                        'searchtype' => $searchtype,
+                        'value'      => $value,
+                    ],
+                ],
+            ]);
+
+            $this->assertStringContainsString(
+                $expected_where,
+                $this->cleanSQL($data['sql']['search'])
+            );
         }
     }
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -4645,6 +4645,43 @@ class SearchTest extends DbTestCase
     }
 
     /**
+     * The range boundaries must not be shifted by a DST transition of the server timezone,
+     * as the compared `datetime` column holds a naive value with no time offset.
+     */
+    public function testDateTimeEqualsCriterionOnDstTransition(): void
+    {
+        global $DB;
+
+        $original_tz = date_default_timezone_get();
+        // Hack to prevent the script tz from being changed by the DB access layer
+        $DB->use_timezones = true;
+        // Clocks jump from 02:00 to 03:00 in `Europe/Paris` on this date
+        date_default_timezone_set('Europe/Paris');
+
+        try {
+            $data = $this->doSearch(Ticket::class, [
+                'is_deleted' => 0,
+                'start'      => 0,
+                'criteria'   => [
+                    [
+                        'link'       => 'AND',
+                        'field'      => 15, // date
+                        'searchtype' => 'equals',
+                        'value'      => '2024-03-31 02',
+                    ],
+                ],
+            ]);
+        } finally {
+            date_default_timezone_set($original_tz);
+        }
+
+        $this->assertStringContainsString(
+            "(`glpi_tickets`.`date` >= '2024-03-31 02:00:00') AND (`glpi_tickets`.`date` < '2024-03-31 03:00:00')",
+            $this->cleanSQL($data['sql']['search'])
+        );
+    }
+
+    /**
      * A `contains` criterion on a date/time field is searched as a range, to use the column index.
      */
     public static function dateTimeContainsCriterionProvider(): iterable


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45581
- Here is a brief description of what this PR does

Searching on a date field does not use the index defined on the column. On a large `glpi_tickets` table, filtering on a single day reads the whole table instead of a few hundred rows.

### Cause

Both the "is" and the "contains" criteria on a date/datetime field were built as a `LIKE` pattern:

```sql
WHERE `glpi_tickets`.`date` LIKE '2026-07-28%'
WHERE CONVERT(`glpi_tickets`.`date` USING utf8mb4) LIKE '%2026-07%'
```

Comparing a date/time column with a `LIKE` pattern forces MySQL to cast it into a string, which makes the index unusable. Even `FORCE INDEX` cannot help.

### Fix

Both criteria now search the range matching the precision of the searched value:

```sql
WHERE `glpi_tickets`.`date` >= '2026-07-28 00:00:00' AND `glpi_tickets`.`date` < '2026-07-29 00:00:00'
```

`EXPLAIN` goes from `type=ALL` (full table scan) to `type=range` using the column index.

Results are unchanged. The previous `LIKE` form is still used when the searched value cannot be interpreted as a date prefix (`-07-`, `2026-02-30`, `NULL`), on computed fields, and on `date_delay` fields.

### Tests

`SearchTest` covers both criteria for every precision, in the positive and negated form, plus the values that must keep the `LIKE` form.
