### PR TITLE
fix: correct wrong old_id and new_id logging when updating a direct infocom field matched against a parent search option

### DIFF
--- a/src/Log.php
+++ b/src/Log.php
@@ -181,7 +181,10 @@ class Log extends CommonDBTM
                     // Linkfield or standard field not massive action enable
                     $id_search_option = $key2; // Give ID of the $SEARCHOPTION
 
-                    if ($val2['table'] == $item->getTable()) {
+                    if (
+                        $val2['table'] == $item->getTable()
+                        || ($item->getType() == 'Infocom' && $val2['linkfield'] == $key)
+                    ) {
                         $changes = [$id_search_option, $oldval ?? '', $values[$key] ?? ''];
                     } else {
                         // other cases; link field -> get data from dropdown

--- a/src/Log.php
+++ b/src/Log.php
@@ -183,7 +183,7 @@ class Log extends CommonDBTM
 
                     if (
                         $val2['table'] == $item->getTable()
-                        || ($item->getType() == 'Infocom' && $val2['linkfield'] == $key)
+                        || ($item->getType() == Infocom::class && $val2['linkfield'] == $key)
                     ) {
                         $changes = [$id_search_option, $oldval ?? '', $values[$key] ?? ''];
                     } else {

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -988,18 +988,18 @@ class LogTest extends DbTestCase
         $computer = $this->createComputer();
 
         $infocom = new \Infocom();
-        if (!$infocom->getFromDBforDevice('Computer', $computer->getID())) {
+        if (!$infocom->getFromDBforDevice(\Computer::class, $computer->getID())) {
             $this->assertGreaterThan(
                 0,
                 $infocom->add([
-                    'itemtype' => 'Computer',
+                    'itemtype' => \Computer::class,
                     'items_id' => $computer->getID(),
                 ])
             );
         }
 
         // Update a plain Infocom field that match for logging purpose a search option of the linked item (Computer)
-        $this->updateItem('Infocom', $infocom->getID(), [
+        $this->updateItem(Infocom::class, $infocom->getID(), [
             'date_creation' => '2020-01-09 11:49:15',
         ]);
 
@@ -1008,7 +1008,7 @@ class LogTest extends DbTestCase
             'FROM'  => Log::getTable(),
             'WHERE' => [
                 'items_id'         => $computer->getID(),
-                'itemtype'         => 'Computer',
+                'itemtype'         => \Computer::class,
                 'id_search_option' => 121, // date_creation
             ],
             'ORDER' => 'id DESC',

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -981,6 +981,46 @@ class LogTest extends DbTestCase
         $this->assertEquals(0, $log['new_id']);
     }
 
+    public function testInfocomDateFieldLogging(): void
+    {
+        global $DB;
+
+        $computer = $this->createComputer();
+
+        $infocom = new \Infocom();
+        if (!$infocom->getFromDBforDevice('Computer', $computer->getID())) {
+            $this->assertGreaterThan(
+                0,
+                $infocom->add([
+                    'itemtype' => 'Computer',
+                    'items_id' => $computer->getID(),
+                ])
+            );
+        }
+
+        // Update a plain Infocom field that match for logging purpose a search option of the linked item (Computer)
+        $this->updateItem('Infocom', $infocom->getID(), [
+            'date_creation' => '2020-01-09 11:49:15',
+        ]);
+
+        // Logging must not have thrown and must be recorded against the Computer, using the Computer's search option
+        $log_iterator = $DB->request([
+            'FROM'  => Log::getTable(),
+            'WHERE' => [
+                'items_id'         => $computer->getID(),
+                'itemtype'         => 'Computer',
+                'id_search_option' => 121, // date_creation
+            ],
+            'ORDER' => 'id DESC',
+            'LIMIT' => 1,
+        ]);
+
+        $this->assertEquals(1, count($log_iterator));
+        $log = $log_iterator->current();
+        $this->assertNull($log['old_id']);
+        $this->assertNull($log['new_id']);
+    }
+
     public function testLogLongValues(): void
     {
         global $DB;

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -988,7 +988,7 @@ class LogTest extends DbTestCase
 
         $computer = $this->createComputer();
 
-        $infocom = new \Infocom();
+        $infocom = new Infocom();
         if (!$infocom->getFromDBforDevice(Computer::class, $computer->getID())) {
             $this->assertGreaterThan(
                 0,

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -988,11 +988,11 @@ class LogTest extends DbTestCase
         $computer = $this->createComputer();
 
         $infocom = new \Infocom();
-        if (!$infocom->getFromDBforDevice(\Computer::class, $computer->getID())) {
+        if (!$infocom->getFromDBforDevice(Computer::class, $computer->getID())) {
             $this->assertGreaterThan(
                 0,
                 $infocom->add([
-                    'itemtype' => \Computer::class,
+                    'itemtype' => Computer::class,
                     'items_id' => $computer->getID(),
                 ])
             );
@@ -1008,7 +1008,7 @@ class LogTest extends DbTestCase
             'FROM'  => Log::getTable(),
             'WHERE' => [
                 'items_id'         => $computer->getID(),
-                'itemtype'         => \Computer::class,
+                'itemtype'         => Computer::class,
                 'id_search_option' => 121, // date_creation
             ],
             'ORDER' => 'id DESC',

--- a/tests/functional/LogTest.php
+++ b/tests/functional/LogTest.php
@@ -40,6 +40,7 @@ use Glpi\Form\AccessControl\ControlType\DirectAccessConfig;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Infocom;
 use Log;
 use PHPUnit\Framework\Attributes\DataProvider;
 


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45625
- Bug: Fixes a RuntimeException thrown when updating a plain Infocom field (e.g. date_creation) that matches a linked-item's search option by linkfield but not by table. 

Log::constructHistory() now treats this Infocom-specific match as a direct value change instead of a dropdown reference.

