### PR TITLE
fix: cleantemp cron doesn't remove tempnam()-created inventory temp files

### DIFF
--- a/phpunit/functional/Glpi/Inventory/InventoryTest.php
+++ b/phpunit/functional/Glpi/Inventory/InventoryTest.php
@@ -4648,6 +4648,31 @@ Compiled Tue 28-Sep-10 13:44 by prod_rel_team",
         $this->assertSame(countElementsInTable(\Printer::getTable()), $nbprinters);
     }
 
+    public function testCronCleantemp()
+    {
+        if (!is_dir(GLPI_INVENTORY_DIR)) {
+            mkdir(GLPI_INVENTORY_DIR);
+        }
+
+        //simulate a leftover temporary file, as created by `Inventory::setData()` through `tempnam()`
+        $old_file = tempnam(GLPI_INVENTORY_DIR, 'json_');
+        file_put_contents($old_file, '{}');
+        //older than the 12 hours threshold used by `Inventory::cronCleantemp()`
+        touch($old_file, time() - (13 * HOUR_TIMESTAMP));
+
+        //a recent temporary file must not be removed
+        $recent_file = tempnam(GLPI_INVENTORY_DIR, 'xml_');
+        file_put_contents($recent_file, '<xml/>');
+
+        $task = new \CronTask();
+        $this->assertSame(1, \Glpi\Inventory\Inventory::cronCleantemp($task));
+
+        $this->assertFileDoesNotExist($old_file);
+        $this->assertFileExists($recent_file);
+
+        unlink($recent_file);
+    }
+
     /**
      * @extensions zip
      */

--- a/src/Inventory/Inventory.php
+++ b/src/Inventory/Inventory.php
@@ -876,10 +876,13 @@ class Inventory
         $conf = new Conf();
         $temp_files = glob(GLPI_INVENTORY_DIR . '/*.{' . implode(',', $conf->knownInventoryExtensions()) . '}', GLOB_BRACE);
 
+        // Files created by `tempnam()` while an inventory is being processed (see `Inventory::setData()`).
+        $temp_files = array_merge($temp_files, glob(GLPI_INVENTORY_DIR . '/{xml_,json_}*', GLOB_BRACE));
+
         $time_limit = 60 * 60 * 12;//12 hours
         foreach ($temp_files as $temp_file) {
             //drop only inventory files that have been created more than 12 hours ago
-            if (time() - filemtime($temp_file) >= $time_limit) {
+            if (is_file($temp_file) && time() - filemtime($temp_file) >= $time_limit) {
                 unlink($temp_file);
                 $message = sprintf(__('File %1$s has been removed'), $temp_file);
                 if ($task) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45694
- Since #11550, `Inventory::setData()` writes the raw inventory payload with `tempnam(GLPI_INVENTORY_DIR, 'xml_'|'json_')`, producing extension-less filenames (xml_XXXXXXXX, json_XXXXXXXX)  under `_inventories/`. The `cleantemp` CronTask (`Inventory::cronCleantemp()`) was never updated to match this new naming, so these files are silently never cleaned, even when the task is enabled.
- Fix: added a second glob for the` tempnam()` naming pattern alongside the legacy one, and guards the removal with `is_file()`.