### PR TITLE
Fix: project Kanban hides tasks with stale saved state

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1821,7 +1821,7 @@ TWIG, $twig_params);
             ];
         }
         $criteria = [];
-        if (!empty($column_ids)) {
+        if (!empty($column_ids) && !$get_default) {
             $criteria = [
                 'projectstates_id'   => $column_ids,
             ];

--- a/tests/functional/ProjectTest.php
+++ b/tests/functional/ProjectTest.php
@@ -899,6 +899,36 @@ PLAINTEXT;
         $this->assertArrayNotHasKey($state->getID(), $columns_no_status);
     }
 
+    public function testGetKanbanColumnsReturnsTasksWhenSavedStateIsStale(): void
+    {
+        $this->login();
+
+        $state = $this->createItem(ProjectState::class, [
+            'name'        => 'In progress',
+            'color'       => '#ff0000',
+            'is_finished' => 0,
+        ]);
+
+        $project = $this->createItem(\Project::class, [
+            'name'       => 'Kanban Test Project',
+            'entities_id' => 0,
+        ]);
+
+        $this->createItem(ProjectTask::class, [
+            'name'                   => 'Task 1',
+            'projects_id'            => $project->getID(),
+            'projectstates_id'       => $state->getID(),
+            'projecttasktemplates_id' => 0,
+        ]);
+
+        // Simulate a refresh with a previously saved Kanban state that does not
+        // include the task's state (e.g. added after the state was last saved).
+        $columns = \Project::getKanbanColumns($project->getID(), 'projectstates_id', [0], true);
+
+        $this->assertArrayHasKey($state->getID(), $columns);
+        $this->assertCount(1, $columns[$state->getID()]['items']);
+    }
+
     public function testNotepadDisplayWithUpdateRights()
     {
         $this->login();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44808
- When a project's Kanban board already has a saved column state, `Project::getKanbanColumns()` still restricted the returned tasks to the states listed in that saved state, even when the caller asked for the default (unrestricted) set of columns.
- If the project states used by the tasks are not part of that saved state (for example because a state was added or changed afterwards), the Kanban columns are displayed but none of the tasks appear, even though they are correctly linked to the project.
- The task filtering criteria now honors the same "default" flag as the column list, so all tasks are shown again in that situation.

## Screenshots (if appropriate):
