### PR TITLE
Use real buttons to turn on default a11y behaviour

### DIFF
--- a/js/glpi_dialog.js
+++ b/js/glpi_dialog.js
@@ -74,6 +74,11 @@ var glpi_html_dialog = function({
     buttons     = [],
     bs_focus    = true,
 } = {}) {
+    // Remember the element that triggered the dialog so focus can be restored to it when the dialog closes.
+    // Bootstrap only restores focus for modals opened through data-bs-toggle,
+    // not for those shown programmatically like this one.
+    const previously_focused = document.activeElement;
+
     if (buttons.length > 0) {
         var buttons_html = "";
         buttons.forEach(button => {
@@ -143,6 +148,12 @@ var glpi_html_dialog = function({
         show(event);
     });
     myModalEl.addEventListener('hidden.bs.modal', (event) => {
+        // restore focus to the element that opened the dialog, before the close
+        // callback runs so a caller may still redirect focus if needed
+        if (previously_focused && typeof previously_focused.focus === 'function') {
+            previously_focused.focus();
+        }
+
         // call close event
         close(event);
 

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -336,14 +336,12 @@ class Dropdown
             && !isset($_REQUEST['_in_modal'])
             && $params['addicon']
         ) {
-            $add_item_icon .= '<div class="btn btn-outline-secondary"
-                           title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . htmlescape($field_id) . '">';
+            $add_label = htmlescape(sprintf(__('Add a new %s'), $item::getTypeName(1)));
             $add_item_icon .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
-            $add_item_icon .= "<span data-bs-toggle='tooltip'>
-              <i class='ti ti-plus' aria-hidden='true'></i>
-              <span class='visually-hidden'>" . __s('Add') . "</span>
-                </span>";
-            $add_item_icon .= '</div>';
+            $add_item_icon .= '<button type="button" class="btn btn-outline-secondary"
+                           title="' . $add_label . '" data-bs-toggle="modal" data-bs-target="#add_' . htmlescape($field_id) . '">';
+            $add_item_icon .= "<i class='ti ti-plus' aria-hidden='true'></i><span class='visually-hidden'>" . $add_label . "</span>";
+            $add_item_icon .= '</button>';
         }
 
         if ($params['display_dc_position'] && method_exists($item, 'getParentRack')) {

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -323,7 +323,7 @@ HTML;
 
         if (!self::$embed) {
             if (!$mini && $can_create) {
-                $l_tb_icons .= "<i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-plus fs-toggle add-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$add_dash_label'></i>";
+                $l_tb_icons .= "<button type='button' class='btn btn-sm btn-icon btn-ghost-secondary fs-toggle add-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$add_dash_label'><i class='ti ti-plus'></i></button>";
             }
             if (!$mini && $can_clone) {
                 $r_tb_icons .= "<i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-copy fs-toggle clone-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$clone_label'></i>";

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -323,7 +323,7 @@ HTML;
 
         if (!self::$embed) {
             if (!$mini && $can_create) {
-                $l_tb_icons .= "<button type='button' class='btn btn-sm btn-icon btn-ghost-secondary fs-toggle add-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$add_dash_label'><i class='ti ti-plus'></i></button>";
+                $l_tb_icons .= "<button type='button' class='btn btn-sm btn-icon btn-ghost-secondary fs-toggle add-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$add_dash_label'><i class='ti ti-plus' aria-hidden='true'></i></button>";
             }
             if (!$mini && $can_clone) {
                 $r_tb_icons .= "<i class='btn btn-sm btn-icon btn-ghost-secondary ti ti-copy fs-toggle clone-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='$clone_label'></i>";

--- a/tests/e2e/specs/Asset/computer.spec.ts
+++ b/tests/e2e/specs/Asset/computer.spec.ts
@@ -108,7 +108,7 @@ test('Create ITIL objects from computer', async ({ page, profile, api }) => {
     await page.getByRole('tabpanel').getByText('New Problem for this item').click();
     await page.getByLabel('Title').fill('Test problem');
     await glpi_page.getRichTextByLabel('Description').fill('Problem content');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.waitForLoadState('load');
     await computer_page.goto(computer_id, 'Item_Problem$1');
     await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test problem' })).toBeVisible();
@@ -118,7 +118,7 @@ test('Create ITIL objects from computer', async ({ page, profile, api }) => {
     await page.getByRole('tabpanel').getByText('New Change for this item').click();
     await page.getByLabel('Title').fill('Test change');
     await glpi_page.getRichTextByLabel('Description').fill('Change content');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.waitForLoadState('load');
     await computer_page.goto(computer_id, 'Change_Item$1');
     await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test change' })).toBeVisible();
@@ -128,7 +128,7 @@ test('Create ITIL objects from computer', async ({ page, profile, api }) => {
     await page.getByRole('tabpanel').getByText('New Ticket for this item').click();
     await page.getByLabel('Title').fill('Test ticket');
     await glpi_page.getRichTextByLabel('Description').fill('Ticket content');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.waitForLoadState('load');
     await computer_page.goto(computer_id, 'Item_Ticket$1');
     await expect(page.getByRole('tabpanel').getByRole('link', { name: 'Test ticket' })).toBeVisible();

--- a/tests/e2e/specs/Knowbase/permissions.spec.ts
+++ b/tests/e2e/specs/Knowbase/permissions.spec.ts
@@ -114,7 +114,7 @@ test('Can add user permission', async ({ page, profile, api }) => {
         kb.getDropdownByLabel("User"),
         "glpi",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: a confirmation toast is shown and the user is added to the
     // permission list in place, without a full page reload.
@@ -142,7 +142,7 @@ test('Can add entity permission', async ({ page, profile, api }) => {
         kb.getDropdownByLabel("Child entities"),
         "No",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: entity should be added to the permission list
     const entry = page.getByTestId('permission-entry');
@@ -166,7 +166,7 @@ test('Can add entity permission (recursive)', async ({ page, profile, api }) => 
         kb.getDropdownByLabel("Add access for"),
         "Entity",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: entity should be added to the permission list
     const entry = page.getByTestId('permission-entry');
@@ -201,7 +201,7 @@ test('Can add group permission', async ({ page, profile, api }) => {
     );
     await expect(kb.getDropdownByLabel("Entity")).toBeHidden();
     await expect(kb.getDropdownByLabel("Child entities")).toBeHidden();
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: group should be added to the permission list
     const entry = page.getByTestId('permission-entry');
@@ -245,7 +245,7 @@ test('Can add group permission with recursive context', async ({
         kb.getDropdownByLabel("Child entities"),
         "Yes",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: group should be added to the permission list with context
     const entry = page.getByTestId('permission-entry');
@@ -287,7 +287,7 @@ test('Can add group permission with context', async ({ page, profile, api }) => 
         kb.getDropdownByLabel("Child entities"),
         "No",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: group should be added to the permission list with context
     const entry = page.getByTestId('permission-entry');
@@ -317,7 +317,7 @@ test('Can add profile permission', async ({ page, profile, api }) => {
     );
     await expect(kb.getDropdownByLabel("Entity")).toBeHidden();
     await expect(kb.getDropdownByLabel("Child entities")).toBeHidden();
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: profile should be added to the permission list
     const entry = page.getByTestId('permission-entry');
@@ -356,7 +356,7 @@ test('Can add profile permission with recursive context', async ({
         kb.getDropdownByLabel("Child entities"),
         "Yes",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: profile should be added to the permission list with context
     const entry = page.getByTestId('permission-entry');
@@ -393,7 +393,7 @@ test('Can add profile permission with context', async ({ page, profile, api }) =
         kb.getDropdownByLabel("Child entities"),
         "No",
     );
-    await page.getByRole('dialog').getByRole('button', { name: "Add " }).click();
+    await page.getByRole('dialog').getByRole('button', { name: "Add", exact: true }).click();
 
     // Assert: profile should be added to the permission list with context
     const entry = page.getByTestId('permission-entry');


### PR DESCRIPTION
Just relies on bootstrap defaults - so we do not need to redefine events.