### PR TITLE
Fix: 'If' notification conditions fail to match with special chars

### DIFF
--- a/src/NotificationTemplate.php
+++ b/src/NotificationTemplate.php
@@ -512,8 +512,8 @@ class NotificationTemplate extends CommonDBTM
                             $condition_value = __($condition_value);
                         }
 
-                        // Compare data value and condition value
-                        $condition_ok = $condition_value == $data_value;
+                        $condition_ok = html_entity_decode($condition_value, ENT_QUOTES)
+                            == html_entity_decode($data_value, ENT_QUOTES);
                     }
                 }
 

--- a/tests/functional/NotificationTemplateTest.php
+++ b/tests/functional/NotificationTemplateTest.php
@@ -255,4 +255,67 @@ HTML,
             $this->assertStringNotContainsString("<br><br>-- ", $data['content_html']);
         }
     }
+
+    public static function processIfProvider(): iterable
+    {
+        yield 'condition with an apostrophe' => [
+            'template' => "##IFproblem.action=Mise à jour d'une tâche##UPDATED##ENDIFproblem.action##",
+            'data'     => ['##problem.action##' => htmlspecialchars("Mise à jour d'une tâche")],
+            'expected' => 'UPDATED',
+        ];
+
+        yield 'condition without special characters' => [
+            'template' => '##IFproblem.action=Nouvelle tâche##CREATED##ENDIFproblem.action##',
+            'data'     => ['##problem.action##' => htmlspecialchars('Nouvelle tâche')],
+            'expected' => 'CREATED',
+        ];
+
+        yield 'condition with an ampersand' => [
+            'template' => '##IFcategory.name=R&D##MATCH##ENDIFcategory.name##',
+            'data'     => ['##category.name##' => htmlspecialchars('R&D')],
+            'expected' => 'MATCH',
+        ];
+
+        yield 'condition with angle brackets' => [
+            'template' => '##IFticket.title=<urgent>##MATCH##ENDIFticket.title##',
+            'data'     => ['##ticket.title##' => htmlspecialchars('<urgent>')],
+            'expected' => 'MATCH',
+        ];
+
+        yield 'non-matching condition' => [
+            'template' => "##IFproblem.action=Mise à jour d'une tâche##UPDATED##ENDIFproblem.action##",
+            'data'     => ['##problem.action##' => htmlspecialchars('Nouvelle tâche')],
+            'expected' => '',
+        ];
+
+        yield 'IF/ELSE block with an apostrophe' => [
+            'template' => "##IFproblem.action=Mise à jour d'une tâche##UPDATED##ENDIFproblem.action####ELSEproblem.action##OTHER##ENDELSEproblem.action##",
+            'data'     => ['##problem.action##' => htmlspecialchars('Nouvelle tâche')],
+            'expected' => 'OTHER',
+        ];
+
+        yield 'several IF blocks' => [
+            'template' => "##IFproblem.action=Nouvelle tâche##CREATED##ENDIFproblem.action####IFproblem.action=Mise à jour d'une tâche##UPDATED##ENDIFproblem.action##",
+            'data'     => ['##problem.action##' => htmlspecialchars("Mise à jour d'une tâche")],
+            'expected' => 'UPDATED',
+        ];
+
+        yield 'existence check' => [
+            'template' => '##IFticket.category##HAS-CATEGORY##ENDIFticket.category##',
+            'data'     => ['##ticket.category##' => htmlspecialchars('Hardware')],
+            'expected' => 'HAS-CATEGORY',
+        ];
+
+        yield 'existence check with an empty value' => [
+            'template' => '##IFticket.category##HAS-CATEGORY##ENDIFticket.category##',
+            'data'     => ['##ticket.category##' => ''],
+            'expected' => '',
+        ];
+    }
+
+    #[DataProvider('processIfProvider')]
+    public function testProcessIf(string $template, array $data, string $expected): void
+    {
+        $this->assertEquals($expected, NotificationTemplate::processIf($template, $data));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45740
- `##IFxxx=value##...##ENDIFxxx##` condition tags in notification templates failed to match when the data value contained a special character that gets HTML encoded (example: an apostrophe).
- For example, the `##IFproblem.action=Mise à jour d'une tâche##` condition never matched in the HTML version of the notification, while the apostrophe-free "Nouvelle tâche" condition worked fine.

### cause

When rendering the HTML part of a notification, `NotificationTemplate` HTML-escapes every plain-text tag value via `getDataForHtml()` (`nl2br(htmlescape($value))`) before `NotificationTemplate::process()` evaluates `##IF##` conditions. `processIf()` then compared this HTML-escaped data value against the condition text typed in the template using a strict `==`.

### Fix 

`processIf()` now decodes HTML entities on both sides of the comparison (`html_entity_decode(..., ENT_QUOTES)`) before the strict equality check.

