### PR TITLE
Fix (ticket) category dropdown not reinitialized when KB article is linked

### DIFF
--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -523,7 +523,11 @@ $(function() {
 var reloadCategory = function() {
     var type = $('[name=type]').val();
 
-    $('#category_block_{{ rand }} .field-container').load(
+    // Only target the category's own field container. When the category is linked to a
+    // knowledge base category, the injected FAQ article contains its own `.field-container`
+    // elements; loading into several elements at once prevents jQuery from executing the
+    // response scripts, so the category select2 is never (re)initialized (empty dropdown).
+    $('#category_block_{{ rand }} .field-container').first().load(
         '{{ path("ajax/dropdownTicketCategories.php") }}',
         {
             'type': type,

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -164,6 +164,7 @@
             {% set cat_params = field_options|merge({
                'entity': item.fields['entities_id'],
                'disabled': (not (canupdate or can_requester)),
+               'container_id': 'category_field_container' ~ rand,
             }) %}
             {% if item.isNewItem() %}
                {% set cat_params = cat_params|merge({
@@ -522,12 +523,8 @@ $(function() {
 
 var reloadCategory = function() {
     var type = $('[name=type]').val();
-
-    // Only target the category's own field container. When the category is linked to a
-    // knowledge base category, the injected FAQ article contains its own `.field-container`
-    // elements; loading into several elements at once prevents jQuery from executing the
-    // response scripts, so the category select2 is never (re)initialized (empty dropdown).
-    $('#category_block_{{ rand }} .field-container').first().load(
+   // Target only the category field to avoid conflicts with other field-container elements in the KB
+    $('#category_field_container{{ rand }}').load(
         '{{ path("ajax/dropdownTicketCategories.php") }}',
         {
             'type': type,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !44727
- When the ITIL category has a linked knowledge base containing an article, that article injects its own .field-container elements into the same block. The js selector in reloadCategory() would then match multiple elements, which prevented .load() from executing the scripts in the AJAX response: as a result, the category’s Select2 was never reset after a type change. The fix targets only the first .field-container (the one for the category).



## Screenshots (if appropriate):
[video](https://github.com/user-attachments/assets/389de1cf-79be-4341-b366-ba018704fb3c)


