### PR TITLE
fix(central): add READGROUP rights to Group View tab

### DIFF
--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3912,42 +3912,31 @@ JAVASCRIPT;
     {
         global $DB;
 
-        if (
-            !Session::haveRightsOr(self::$rightname, [CREATE, self::READALL, self::READASSIGN])
-            && !Session::haveRightsOr('ticketvalidation', TicketValidation::getValidateRights())
-        ) {
+        $ticket_validation_rights = Session::haveRightsOr('ticketvalidation', TicketValidation::getValidateRights());
+
+        if (!Session::haveRightsOr(self::$rightname, [self::READALL, self::READASSIGN, self::READGROUP, self::READMY]) && !$ticket_validation_rights) {
             return false;
         }
 
+        $search_users_id = [0];
+        $search_assign = [0];
+        $search_observer = [0];
         $SELECT = ['glpi_tickets.id', 'glpi_tickets.date_mod'];
         $JOINS = [];
         $WHERE = [
             'glpi_tickets.is_deleted' => 0,
         ];
-        $search_users_id = [
-            'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-            'glpi_tickets_users.type'     => CommonITILActor::REQUESTER,
-        ];
-        $search_assign = [
-            'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-            'glpi_tickets_users.type'     => CommonITILActor::ASSIGN,
-        ];
-        $search_observer = [
-            'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-            'glpi_tickets_users.type'     => CommonITILActor::OBSERVER,
-        ];
 
         if ($showgrouptickets) {
-            $search_users_id  = [0];
-            $search_assign = [0];
-
             if (count($_SESSION['glpigroups'])) {
-                $search_assign = [
-                    'glpi_groups_tickets.groups_id'  => $_SESSION['glpigroups'],
-                    'glpi_groups_tickets.type'       => CommonITILActor::ASSIGN,
-                ];
+                if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READASSIGN])) {
+                    $search_assign = [
+                        'glpi_groups_tickets.groups_id'  => $_SESSION['glpigroups'],
+                        'glpi_groups_tickets.type'       => CommonITILActor::ASSIGN,
+                    ];
+                }
 
-                if (Session::haveRight(self::$rightname, self::READGROUP)) {
+               if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READGROUP])) {
                     $search_users_id = [
                         'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
                         'glpi_groups_tickets.type'      => CommonITILActor::REQUESTER,
@@ -3957,6 +3946,23 @@ JAVASCRIPT;
                         'glpi_groups_tickets.type'      => CommonITILActor::OBSERVER,
                     ];
                 }
+            }
+        } else {
+            if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READMY]) || $ticket_validation_rights) {
+                $search_users_id = [
+                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
+                    'glpi_tickets_users.type'     => CommonITILActor::REQUESTER,
+                ];
+                $search_observer = [
+                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
+                    'glpi_tickets_users.type'     => CommonITILActor::OBSERVER,
+                ];
+            }
+            if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READASSIGN]) || $ticket_validation_rights) {
+                $search_assign = [
+                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
+                    'glpi_tickets_users.type'     => CommonITILActor::ASSIGN,
+                ];
             }
         }
 

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3936,7 +3936,7 @@ JAVASCRIPT;
                     ];
                 }
 
-               if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READGROUP])) {
+                if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READGROUP])) {
                     $search_users_id = [
                         'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
                         'glpi_groups_tickets.type'      => CommonITILActor::REQUESTER,

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -3927,41 +3927,61 @@ JAVASCRIPT;
             'glpi_tickets.is_deleted' => 0,
         ];
 
+        $table = $showgrouptickets ? Group_Ticket::getTable() : Ticket_User::getTable();
+        $reject_assign_user = [];
+        $reject_requester_or_assign_user = [];
+
         if ($showgrouptickets) {
             if (count($_SESSION['glpigroups'])) {
+                $reject_assign_user = [
+                    $table . '.groups_id' => $_SESSION['glpigroups'],
+                    $table . '.type'      => CommonITILActor::ASSIGN,
+                ];
+                $reject_requester_or_assign_user = [
+                    $table . '.groups_id' => $_SESSION['glpigroups'],
+                    $table . '.type'      => [CommonITILActor::ASSIGN, CommonITILActor::REQUESTER],
+                ];
                 if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READASSIGN])) {
                     $search_assign = [
-                        'glpi_groups_tickets.groups_id'  => $_SESSION['glpigroups'],
-                        'glpi_groups_tickets.type'       => CommonITILActor::ASSIGN,
+                        $table . '.groups_id'  => $_SESSION['glpigroups'],
+                        $table . '.type'       => CommonITILActor::ASSIGN,
                     ];
                 }
 
                 if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READGROUP])) {
                     $search_users_id = [
-                        'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
-                        'glpi_groups_tickets.type'      => CommonITILActor::REQUESTER,
+                        $table . '.groups_id' => $_SESSION['glpigroups'],
+                        $table . '.type'      => CommonITILActor::REQUESTER,
                     ];
                     $search_observer = [
-                        'glpi_groups_tickets.groups_id' => $_SESSION['glpigroups'],
-                        'glpi_groups_tickets.type'      => CommonITILActor::OBSERVER,
+                        $table . '.groups_id' => $_SESSION['glpigroups'],
+                        $table . '.type'      => CommonITILActor::OBSERVER,
                     ];
                 }
             }
         } else {
+            $reject_assign_user = [
+                $table . '.users_id' => Session::getLoginUserID(),
+                $table . '.type'     => CommonITILActor::ASSIGN,
+            ];
+            $reject_requester_or_assign_user = [
+                $table . '.users_id' => Session::getLoginUserID(),
+                $table . '.type'     => [CommonITILActor::ASSIGN, CommonITILActor::REQUESTER],
+            ];
             if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READMY]) || $ticket_validation_rights) {
                 $search_users_id = [
-                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-                    'glpi_tickets_users.type'     => CommonITILActor::REQUESTER,
+                    $table . '.users_id' => Session::getLoginUserID(),
+                    $table . '.type'     => CommonITILActor::REQUESTER,
                 ];
                 $search_observer = [
-                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-                    'glpi_tickets_users.type'     => CommonITILActor::OBSERVER,
+                    $table . '.users_id' => Session::getLoginUserID(),
+                    $table . '.type'     => CommonITILActor::OBSERVER,
                 ];
             }
             if (Session::haveRightsOr(self::$rightname, [self::READALL, self::READASSIGN]) || $ticket_validation_rights) {
                 $search_assign = [
-                    'glpi_tickets_users.users_id' => Session::getLoginUserID(),
-                    'glpi_tickets_users.type'     => CommonITILActor::ASSIGN,
+                    $table . '.users_id' => Session::getLoginUserID(),
+                    $table . '.type'     => CommonITILActor::ASSIGN,
                 ];
             }
         }
@@ -4062,15 +4082,21 @@ JAVASCRIPT;
                     $WHERE,
                     $search_observer,
                     [
-                        'glpi_tickets.status'   => [
+                        Ticket::getTable() . '.status'   => [
                             self::INCOMING,
                             self::PLANNED,
                             self::ASSIGNED,
                             self::WAITING,
                         ],
-                        'NOT'                   => [
-                            $search_assign,
-                            $search_users_id,
+                    ],
+                    [
+                        Ticket::getTable() . '.id' => [
+                            'NOT IN',
+                            new QuerySubQuery([
+                                'SELECT' => $table . '.tickets_id',
+                                'FROM'   => $table,
+                                'WHERE'  => $reject_requester_or_assign_user,
+                            ]),
                         ],
                     ]
                 );
@@ -4143,13 +4169,22 @@ JAVASCRIPT;
                     $WHERE,
                     $search_users_id,
                     [
-                        'glpi_tickets.status'   => [
+                        Ticket::getTable() . '.status'   => [
                             self::INCOMING,
                             self::PLANNED,
                             self::ASSIGNED,
                             self::WAITING,
                         ],
-                        'NOT' => $search_assign,
+                    ],
+                    [
+                        Ticket::getTable() . '.id' => [
+                            'NOT IN',
+                            new QuerySubQuery([
+                                'SELECT' => $table . '.tickets_id',
+                                'FROM'   => $table,
+                                'WHERE'  => $reject_assign_user,
+                            ]),
+                        ],
                     ]
                 );
         }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -11193,11 +11193,11 @@ HTML,
      */
     #[DataProvider('showCentralListRightsProvider')]
     public function testShowCentralListRights(
-            string $status,
-            array $rights,
-            array $expected_tickets,
-            bool $showgrouptickets,
-            array $validation_rights = [],
+        string $status,
+        array $rights,
+        array $expected_tickets,
+        bool $showgrouptickets,
+        array $validation_rights = [],
     ): void {
         $this->login();
 
@@ -11245,7 +11245,9 @@ HTML,
             $group_assign, $waiting_requester, $waiting_observer, $waiting_assign,
             $waiting_group_requester, $waiting_group_observer, $waiting_group_assign,
             $solved_requestbyself, $solved_group_requester,
-        ] = $this->createItems(Ticket::class, [
+        ] = $this->createItems(
+            Ticket::class,
+            [
                 [
                     'name' => 'incoming_requestbyself',
                     'content' => 'incoming requester ticket content',

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10811,10 +10811,10 @@ HTML,
 
     /**
      * Data provider for testShowCentralListRights
-     * Provides different scenarios with ticket statuses, user rights, and expected tickets to be shown in the central list.
      */
     public static function showCentralListRightsProvider(): iterable
     {
+        // "waiting": tickets on hold, assigned to the user or their group.
         yield [
             'status'           => 'waiting',
             'rights'           => [],
@@ -10824,15 +10824,22 @@ HTML,
 
         yield [
             'status'           => 'waiting',
+            'rights'           => [CREATE],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['waiting_assign'],
+            'expected_tickets' => ['waiting_assign', 'waiting_requestbyself_assign', 'waiting_observer_assign', 'waiting_requestbyself_observer_assign'],
             'showgrouptickets' => false,
         ];
 
         yield [
             'status'           => 'waiting',
             'rights'           => [Ticket::READASSIGN],
-            'expected_tickets' => ['waiting_assign'],
+            'expected_tickets' => ['waiting_assign', 'waiting_requestbyself_assign', 'waiting_observer_assign', 'waiting_requestbyself_observer_assign'],
             'showgrouptickets' => false,
         ];
 
@@ -10854,21 +10861,21 @@ HTML,
             'status'            => 'waiting',
             'rights'            => [],
             'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
-            'expected_tickets'  => ['waiting_assign'],
+            'expected_tickets'  => ['waiting_assign', 'waiting_requestbyself_assign', 'waiting_observer_assign', 'waiting_requestbyself_observer_assign'],
             'showgrouptickets'  => false,
         ];
 
         yield [
             'status'           => 'waiting',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['waiting_group_assign'],
+            'expected_tickets' => ['waiting_group_assign', 'waiting_group_requester_assign', 'waiting_group_observer_assign', 'waiting_group_requester_observer_assign'],
             'showgrouptickets' => true,
         ];
 
         yield [
             'status'           => 'waiting',
             'rights'           => [Ticket::READASSIGN],
-            'expected_tickets' => ['waiting_group_assign'],
+            'expected_tickets' => ['waiting_group_assign', 'waiting_group_requester_assign', 'waiting_group_observer_assign', 'waiting_group_requester_observer_assign'],
             'showgrouptickets' => true,
         ];
 
@@ -10894,17 +10901,18 @@ HTML,
             'showgrouptickets'  => true,
         ];
 
+        // "process": tickets to handle (incoming/planned/assigned), assigned to the user or their group.
         yield [
             'status'           => 'process',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['assign'],
+            'expected_tickets' => ['incoming_assign', 'incoming_requestbyself_assign', 'incoming_observer_assign', 'incoming_requestbyself_observer_assign'],
             'showgrouptickets' => false,
         ];
 
         yield [
             'status'           => 'process',
             'rights'           => [Ticket::READASSIGN],
-            'expected_tickets' => ['assign'],
+            'expected_tickets' => ['incoming_assign', 'incoming_requestbyself_assign', 'incoming_observer_assign', 'incoming_requestbyself_observer_assign'],
             'showgrouptickets' => false,
         ];
 
@@ -10923,16 +10931,24 @@ HTML,
         ];
 
         yield [
+            'status'            => 'process',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['incoming_assign', 'incoming_requestbyself_assign', 'incoming_observer_assign', 'incoming_requestbyself_observer_assign'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
             'status'           => 'process',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['group_assign'],
+            'expected_tickets' => ['incoming_group_assign', 'incoming_group_requester_assign', 'incoming_group_observer_assign', 'incoming_group_requester_observer_assign'],
             'showgrouptickets' => true,
         ];
 
         yield [
             'status'           => 'process',
             'rights'           => [Ticket::READASSIGN],
-            'expected_tickets' => ['group_assign'],
+            'expected_tickets' => ['incoming_group_assign', 'incoming_group_requester_assign', 'incoming_group_observer_assign', 'incoming_group_requester_observer_assign'],
             'showgrouptickets' => true,
         ];
 
@@ -10950,6 +10966,15 @@ HTML,
             'showgrouptickets' => true,
         ];
 
+        yield [
+            'status'            => 'process',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        // "toapprove": solved tickets requested by the user (or their group), pending approval.
         yield [
             'status'           => 'toapprove',
             'rights'           => [],
@@ -11029,85 +11054,247 @@ HTML,
             'showgrouptickets'  => true,
         ];
 
+        // "tovalidate": tickets awaiting the user's validation, directly or via a group.
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [],
             'expected_tickets' => [],
             'showgrouptickets' => false,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => false,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READMY],
-            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => false,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READASSIGN],
-            'expected_tickets' => [],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => false,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READGROUP],
-            'expected_tickets' => [],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => false,
         ];
 
         yield [
-            'status'            => 'requestbyself',
+            'status'            => 'tovalidate',
             'rights'            => [],
             'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
-            'expected_tickets'  => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'expected_tickets'  => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets'  => false,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READALL],
-            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester'],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => true,
         ];
 
         yield [
-            'status'           => 'requestbyself',
-            'rights'           => [Ticket::READGROUP],
-            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester'],
+            'status'           => 'tovalidate',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
             'showgrouptickets' => true,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'tovalidate',
             'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'tovalidate',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['tovalidate_user', 'tovalidate_group'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'tovalidate',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['tovalidate_user', 'tovalidate_group'],
+            'showgrouptickets'  => true,
+        ];
+
+        // "validation.rejected": assigned tickets whose validation was refused.
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['rejected_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['rejected_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'validation.rejected',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['rejected_assign'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['rejected_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['rejected_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'validation.rejected',
+            'rights'           => [Ticket::READGROUP],
             'expected_tickets' => [],
             'showgrouptickets' => true,
         ];
 
         yield [
-            'status'           => 'requestbyself',
+            'status'           => 'validation.rejected',
             'rights'           => [Ticket::READMY],
             'expected_tickets' => [],
             'showgrouptickets' => true,
         ];
 
         yield [
-            'status'            => 'requestbyself',
+            'status'            => 'validation.rejected',
             'rights'            => [],
             'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
             'expected_tickets'  => [],
             'showgrouptickets'  => true,
         ];
 
+        // "solution.rejected": assigned tickets whose solution was refused.
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['solution_rejected_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['solution_rejected_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'solution.rejected',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['solution_rejected_assign'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['solution_rejected_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['solution_rejected_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'solution.rejected',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'solution.rejected',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        // "observed": tickets the user (or their group) observes, excluding ones also requested or assigned.
         yield [
             'status'           => 'observed',
             'rights'           => [],
@@ -11186,19 +11373,180 @@ HTML,
             'expected_tickets'  => [],
             'showgrouptickets'  => true,
         ];
+
+        // "survey": closed tickets with a pending satisfaction survey.
+        yield [
+            'status'           => 'survey',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['survey_requester'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['survey_requester'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'survey',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['survey_requester'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READASSIGN, Ticket::SURVEY],
+            'expected_tickets' => ['survey_recipient'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['survey_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['survey_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'survey',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'survey',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        // "requestbyself": tickets requested by the user (or their group), excluding ones also assigned.
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself', 'incoming_requestbyself_observer', 'waiting_requestbyself_observer'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself', 'incoming_requestbyself_observer', 'waiting_requestbyself_observer'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'requestbyself',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['incoming_requestbyself', 'waiting_requestbyself', 'incoming_requestbyself_observer', 'waiting_requestbyself_observer'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester', 'incoming_group_requester_observer', 'waiting_group_requester_observer'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester', 'incoming_group_requester_observer', 'waiting_group_requester_observer'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'requestbyself',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
     }
 
     /**
      * Test that the central list of tickets shows the correct tickets based on user rights.
      */
-    #[DataProvider('showCentralListRightsProvider')]
-    public function testShowCentralListRights(
-        string $status,
-        array $rights,
-        array $expected_tickets,
-        bool $showgrouptickets,
-        array $validation_rights = [],
-    ): void {
+    public function testShowCentralListRights(): void
+    {
         $this->login();
 
         // Create a test user and assign rights
@@ -11219,13 +11567,18 @@ HTML,
             'is_recursive' => 0,
         ]);
 
-        foreach ($rights as $right) {
-            $this->addRightToProfile($profile->fields['name'], Ticket::$rightname, $right);
-        }
+        // Fetched once so their rights can be reset between provider cases below.
+        $ticket_profile_right = new ProfileRight();
+        $ticket_profile_right->getFromDBByCrit([
+            'profiles_id' => $profile->getID(),
+            'name'        => Ticket::$rightname,
+        ]);
 
-        foreach ($validation_rights as $right) {
-            $this->addRightToProfile($profile->fields['name'], TicketValidation::$rightname, $right);
-        }
+        $validation_profile_right = new ProfileRight();
+        $validation_profile_right->getFromDBByCrit([
+            'profiles_id' => $profile->getID(),
+            'name'        => TicketValidation::$rightname,
+        ]);
 
         $group = $this->createItem(Group::class, [
             'name' => 'testShowCentralListRights group',
@@ -11240,12 +11593,7 @@ HTML,
         $entities_id = $this->getTestRootEntity(true);
 
         // Create tickets with various statuses and assignments
-        [
-            $requester, $observer, $assign, $group_requester, $group_observer,
-            $group_assign, $waiting_requester, $waiting_observer, $waiting_assign,
-            $waiting_group_requester, $waiting_group_observer, $waiting_group_assign,
-            $solved_requestbyself, $solved_group_requester,
-        ] = $this->createItems(
+        $incoming_tickets = $this->createItems(
             Ticket::class,
             [
                 [
@@ -11265,6 +11613,36 @@ HTML,
                 [
                     'name' => 'incoming_assign',
                     'content' => 'assign ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_requestbyself_observer',
+                    'content' => 'incoming requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_observer' => $user->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_requestbyself_assign',
+                    'content' => 'incoming requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_observer_assign',
+                    'content' => 'incoming requester ticket content',
+                    '_users_id_observer' => $user->getID(),
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_requestbyself_observer_assign',
+                    'content' => 'incoming requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_observer' => $user->getID(),
                     '_users_id_assign' => $user->getID(),
                     'entities_id' => $entities_id,
                 ],
@@ -11289,6 +11667,42 @@ HTML,
                     'entities_id' => $entities_id,
                 ],
                 [
+                    'name' => 'incoming_group_requester_observer',
+                    'content' => 'incoming group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_observer' => $group->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_requester_assign',
+                    'content' => 'incoming group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_observer_assign',
+                    'content' => 'incoming group requester ticket content',
+                    '_groups_id_observer' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_requester_observer_assign',
+                    'content' => 'incoming group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_observer' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+
+        $waiting_tickets = $this->createItems(
+            Ticket::class,
+            [
+                [
                     'name' => 'waiting_requestbyself',
                     'content' => 'waiting requester ticket content',
                     '_users_id_requester' => $user->getID(),
@@ -11305,6 +11719,39 @@ HTML,
                 [
                     'name' => 'waiting_assign',
                     'content' => 'waiting assign ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_requestbyself_observer',
+                    'content' => 'waiting requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_observer' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_requestbyself_assign',
+                    'content' => 'waiting requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_observer_assign',
+                    'content' => 'waiting observer ticket content',
+                    '_users_id_observer' => $user->getID(),
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_requestbyself_observer_assign',
+                    'content' => 'waiting requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    '_users_id_observer' => $user->getID(),
                     '_users_id_assign' => $user->getID(),
                     'status' => Ticket::WAITING,
                     'entities_id' => $entities_id,
@@ -11331,6 +11778,45 @@ HTML,
                     'entities_id' => $entities_id,
                 ],
                 [
+                    'name' => 'waiting_group_requester_observer',
+                    'content' => 'waiting group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_observer' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_requester_assign',
+                    'content' => 'waiting group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_observer_assign',
+                    'content' => 'waiting group observer ticket content',
+                    '_groups_id_observer' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_requester_observer_assign',
+                    'content' => 'waiting group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    '_groups_id_observer' => $group->getID(),
+                    '_groups_id_assign' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+
+        $solved_tickets = $this->createItems(
+            Ticket::class,
+            [
+                [
                     'name' => 'solved_requestbyself',
                     'content' => 'solved requester ticket content',
                     '_users_id_requester' => $user->getID(),
@@ -11347,54 +11833,321 @@ HTML,
             ]
         );
 
-        $this->updateItem(Ticket::class, $assign->getID(), [
-            'status' => Ticket::INCOMING,
+        // GLPI modifies changes the status to ASSIGNED when a technician is assigned to a new ticket.
+        // We reassign the "INCOMING" status.
+        foreach ($incoming_tickets as $incoming_ticket) {
+            $this->updateItem(Ticket::class, $incoming_ticket->getID(), [
+                'status' => Ticket::INCOMING,
+            ]);
+        }
+
+        [$tovalidate_user_ticket, $tovalidate_group_ticket, $tovalidate_closed_ticket, $tovalidate_accepted_ticket] = $this->createItems(
+            Ticket::class,
+            [
+                [
+                    'name' => 'tovalidate_user',
+                    'content' => 'tovalidate ticket content',
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'tovalidate_group',
+                    'content' => 'tovalidate ticket content',
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'tovalidate_closed',
+                    'content' => 'tovalidate ticket content',
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'tovalidate_accepted',
+                    'content' => 'tovalidate ticket content',
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+        $tovalidate_tickets = [$tovalidate_user_ticket, $tovalidate_group_ticket, $tovalidate_closed_ticket, $tovalidate_accepted_ticket];
+
+        // Waiting validation targeting the user directly.
+        $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $tovalidate_user_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
         ]);
-        $this->updateItem(Ticket::class, $group_assign->getID(), [
-            'status' => Ticket::INCOMING,
+
+        // Waiting validation targeting one of the user's groups
+        $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $tovalidate_group_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => Group::class,
+            'items_id_target' => $group->getID(),
         ]);
+
+        // Waiting validation, but the ticket itself is closed.
+        $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $tovalidate_closed_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
+        ]);
+        $this->updateItem(Ticket::class, $tovalidate_closed_ticket->getID(), [
+            'status' => Ticket::CLOSED,
+        ]);
+
+        // Validation already answered.
+        $tovalidate_accepted_validation = $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $tovalidate_accepted_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
+        ]);
+
+        [$rejected_assign_ticket, $rejected_group_assign_ticket, $rejected_closed_ticket] = $this->createItems(
+            Ticket::class,
+            [
+                [
+                    'name' => 'rejected_assign',
+                    'content' => 'rejected ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::SOLVED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'rejected_group_assign',
+                    'content' => 'rejected group ticket content',
+                    '_groups_id_assign' => $group->getID(),
+                    'status' => Ticket::SOLVED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'rejected_closed',
+                    'content' => 'rejected closed ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::SOLVED,
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+        $rejected_tickets = [$rejected_assign_ticket, $rejected_group_assign_ticket, $rejected_closed_ticket];
+
+        $rejected_assign_validation = $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $rejected_assign_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
+        ]);
+
+        $rejected_group_assign_validation = $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $rejected_group_assign_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
+        ]);
+
+        $rejected_closed_validation = $this->createItem(TicketValidation::class, [
+            'tickets_id'      => $rejected_closed_ticket->getID(),
+            'entities_id'     => $entities_id,
+            'itemtype_target' => User::class,
+            'items_id_target' => $user->getID(),
+        ]);
+        $this->updateItem(Ticket::class, $rejected_closed_ticket->getID(), [
+            'status' => Ticket::CLOSED,
+        ]);
+
+        [$solution_rejected_assign_ticket, $solution_rejected_group_assign_ticket, $solution_rejected_closed_ticket] = $this->createItems(
+            Ticket::class,
+            [
+                [
+                    'name' => 'solution_rejected_assign',
+                    'content' => 'solution rejected ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'solution_rejected_group_assign',
+                    'content' => 'solution rejected group ticket content',
+                    '_groups_id_assign' => $group->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'solution_rejected_closed',
+                    'content' => 'solution rejected closed ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+        $solution_rejected_tickets = [$solution_rejected_assign_ticket, $solution_rejected_group_assign_ticket, $solution_rejected_closed_ticket];
+
+        foreach ($solution_rejected_tickets as $solution_rejected_ticket) {
+            $solution = $this->createItem(ITILSolution::class, [
+                'itemtype' => Ticket::class,
+                'items_id' => $solution_rejected_ticket->getID(),
+                'content'  => 'content',
+            ]);
+            $this->updateItem(ITILSolution::class, $solution->getID(), [
+                'status' => CommonITILValidation::REFUSED,
+            ]);
+        }
+
+        // The solution is refused above, but the ticket itself gets closed:.
+        $this->updateItem(Ticket::class, $solution_rejected_closed_ticket->getID(), [
+            'status' => Ticket::CLOSED,
+        ]);
+
+        [
+            $survey_requester_ticket,
+            $survey_group_requester_ticket,
+            $survey_recipient_ticket,
+            $survey_answered_ticket,
+            $survey_expired_ticket,
+        ] = $this->createItems(
+            Ticket::class,
+            [
+                [
+                    'name' => 'survey_requester',
+                    'content' => 'survey ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::CLOSED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'survey_group_requester',
+                    'content' => 'survey group ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    'status' => Ticket::CLOSED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'survey_recipient',
+                    'content' => 'survey recipient ticket content',
+                    'users_id_recipient' => $user->getID(),
+                    '_skip_auto_assign' => true,
+                    'status' => Ticket::CLOSED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'survey_answered',
+                    'content' => 'survey answered ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::CLOSED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'survey_expired',
+                    'content' => 'survey expired ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::CLOSED,
+                    // Closed more than Entity::MAX_INQUEST_DURATION_DAYS days ago: must NOT appear.
+                    'date' => '2020-01-01 00:00:00',
+                    'closedate' => '2020-01-01 00:00:00',
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+        $survey_tickets = [
+            $survey_requester_ticket,
+            $survey_group_requester_ticket,
+            $survey_recipient_ticket,
+            $survey_answered_ticket,
+            $survey_expired_ticket,
+        ];
+
+        foreach ([$survey_requester_ticket, $survey_group_requester_ticket, $survey_recipient_ticket] as $survey_ticket) {
+            $this->createItem(TicketSatisfaction::class, [
+                'tickets_id' => $survey_ticket->getID(),
+                'type'       => CommonITILSatisfaction::TYPE_INTERNAL,
+                'date_begin' => $_SESSION['glpi_currenttime'],
+            ]);
+        }
+
+        // Survey already answered: must NOT appear.
+        $this->createItem(TicketSatisfaction::class, [
+            'tickets_id'    => $survey_answered_ticket->getID(),
+            'type'          => CommonITILSatisfaction::TYPE_INTERNAL,
+            'date_begin'    => $_SESSION['glpi_currenttime'],
+            'date_answered' => $_SESSION['glpi_currenttime'],
+        ]);
+
+        $this->createItem(TicketSatisfaction::class, [
+            'tickets_id' => $survey_expired_ticket->getID(),
+            'type'       => CommonITILSatisfaction::TYPE_INTERNAL,
+            'date_begin' => '2020-01-01 00:00:00',
+        ]);
+
+        $tickets = array_merge(
+            $incoming_tickets,
+            $waiting_tickets,
+            $solved_tickets,
+            $tovalidate_tickets,
+            $rejected_tickets,
+            $solution_rejected_tickets,
+            $survey_tickets
+        );
 
         // Log in as the test user and change to the created profile
         $this->login($user->fields['name'], 'testShowCentralListRights_password');
 
         Session::changeProfile($profile->getID());
 
-        // Show the central list of tickets and capture the output
-        $output = Ticket::showCentralList(0, $status, $showgrouptickets, false);
+        // Answering a validation is only allowed to its target, so this must happen
+        // once logged in as the test user.
+        $this->updateItem(TicketValidation::class, $tovalidate_accepted_validation->getID(), [
+            'status' => CommonITILValidation::ACCEPTED,
+        ]);
+        foreach ([$rejected_assign_validation, $rejected_group_assign_validation, $rejected_closed_validation] as $validation) {
+            $this->updateItem(TicketValidation::class, $validation->getID(), [
+                'status'             => CommonITILValidation::REFUSED,
+                'comment_validation' => 'refused for test purposes',
+            ]);
+        }
 
-        $all_tickets = [
-            'incoming_requestbyself'    => $requester,
-            'incoming_observed'         => $observer,
-            'incoming_group_requester'  => $group_requester,
-            'incoming_group_observed'   => $group_observer,
-            'assign'                    => $assign,
-            'group_assign'              => $group_assign,
-            'waiting_requestbyself'     => $waiting_requester,
-            'waiting_observed'          => $waiting_observer,
-            'waiting_assign'            => $waiting_assign,
-            'waiting_group_requester'   => $waiting_group_requester,
-            'waiting_group_observed'    => $waiting_group_observer,
-            'waiting_group_assign'      => $waiting_group_assign,
-            'solved_requestbyself'      => $solved_requestbyself,
-            'solved_group_requester'    => $solved_group_requester,
-        ];
+        // Run every provider case
+        foreach (self::showCentralListRightsProvider() as $case) {
+            $status = $case['status'];
+            $rights = $case['rights'];
+            $expected_tickets = $case['expected_tickets'];
+            $showgrouptickets = $case['showgrouptickets'];
+            $validation_rights = $case['validation_rights'] ?? [];
 
-        // Extract ticket IDs from the output using regex
-        preg_match_all('/ticket\.form\.php\?id=(\d+)/', (string) $output, $matches);
-        $found_ids = array_map('intval', $matches[1]);
+            $this->updateItem(ProfileRight::class, $ticket_profile_right->getID(), ['rights' => 0]);
+            $this->updateItem(ProfileRight::class, $validation_profile_right->getID(), ['rights' => 0]);
 
-        // Assert that the number of found tickets matches the expected count
-        $this->assertCount(
-            count($expected_tickets),
-            $found_ids,
-        );
+            foreach ($rights as $right) {
+                $this->addRightToProfile($profile->fields['name'], Ticket::$rightname, $right);
+            }
+            foreach ($validation_rights as $right) {
+                $this->addRightToProfile($profile->fields['name'], TicketValidation::$rightname, $right);
+            }
 
-        // Assert that each expected ticket is present in the found IDs
-        foreach ($all_tickets as $name => $ticket) {
-            $this->assertSame(
-                in_array($name, $expected_tickets, true),
-                in_array($ticket->getID(), $found_ids, true),
+            Session::changeProfile($profile->getID());
+
+            // Show the central list of tickets and capture the output
+            $output = Ticket::showCentralList(0, $status, $showgrouptickets, false);
+
+            // Extract ticket IDs from the output using regex
+            preg_match_all('/ticket\.form\.php\?id=(\d+)/', (string) $output, $matches);
+            $found_ids = array_map('intval', $matches[1]);
+
+            // Assert that the number of found tickets matches the expected count
+            $this->assertCount(
+                count($expected_tickets),
+                $found_ids,
             );
+
+            // Assert that each expected ticket is present in the found IDs
+            foreach ($tickets as $ticket) {
+                $name = $ticket->fields['name'];
+                $this->assertSame(
+                    in_array($name, $expected_tickets, true),
+                    in_array($ticket->getID(), $found_ids, true),
+                );
+            }
         }
     }
 }

--- a/tests/functional/TicketTest.php
+++ b/tests/functional/TicketTest.php
@@ -10809,4 +10809,590 @@ HTML,
         $this->assertContains($doc->getID(), $found_docs);
     }
 
+    /**
+     * Data provider for testShowCentralListRights
+     * Provides different scenarios with ticket statuses, user rights, and expected tickets to be shown in the central list.
+     */
+    public static function showCentralListRightsProvider(): iterable
+    {
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['waiting_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['waiting_assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'waiting',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['waiting_assign'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['waiting_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['waiting_group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'waiting',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'waiting',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['assign'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => ['group_assign'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'process',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['solved_requestbyself'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['solved_requestbyself'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'toapprove',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['solved_requestbyself'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['solved_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['solved_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'toapprove',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'toapprove',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'requestbyself',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['incoming_requestbyself', 'waiting_requestbyself'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['incoming_group_requester', 'waiting_group_requester'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'requestbyself',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'requestbyself',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_observed', 'waiting_observed'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => ['incoming_observed', 'waiting_observed'],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => [],
+            'showgrouptickets' => false,
+        ];
+
+        yield [
+            'status'            => 'observed',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => ['incoming_observed', 'waiting_observed'],
+            'showgrouptickets'  => false,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READALL],
+            'expected_tickets' => ['incoming_group_observed', 'waiting_group_observed'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READGROUP],
+            'expected_tickets' => ['incoming_group_observed', 'waiting_group_observed'],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READASSIGN],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'           => 'observed',
+            'rights'           => [Ticket::READMY],
+            'expected_tickets' => [],
+            'showgrouptickets' => true,
+        ];
+
+        yield [
+            'status'            => 'observed',
+            'rights'            => [],
+            'validation_rights' => [TicketValidation::VALIDATEINCIDENT],
+            'expected_tickets'  => [],
+            'showgrouptickets'  => true,
+        ];
+    }
+
+    /**
+     * Test that the central list of tickets shows the correct tickets based on user rights.
+     */
+    #[DataProvider('showCentralListRightsProvider')]
+    public function testShowCentralListRights(
+            string $status,
+            array $rights,
+            array $expected_tickets,
+            bool $showgrouptickets,
+            array $validation_rights = [],
+    ): void {
+        $this->login();
+
+        // Create a test user and assign rights
+        $user = $this->createItem(User::class, [
+            'name' => 'testShowCentralListRights_user',
+            'password' => 'testShowCentralListRights_password',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $profile = $this->createItem(Profile::class, [
+            'name' => 'testShowCentralListRights profile',
+        ]);
+
+        $this->createItem(Profile_User::class, [
+            'profiles_id'  => $profile->getID(),
+            'users_id'     => $user->getID(),
+            'entities_id'  => $this->getTestRootEntity(true),
+            'is_recursive' => 0,
+        ]);
+
+        foreach ($rights as $right) {
+            $this->addRightToProfile($profile->fields['name'], Ticket::$rightname, $right);
+        }
+
+        foreach ($validation_rights as $right) {
+            $this->addRightToProfile($profile->fields['name'], TicketValidation::$rightname, $right);
+        }
+
+        $group = $this->createItem(Group::class, [
+            'name' => 'testShowCentralListRights group',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $this->createItem(Group_User::class, [
+            'groups_id' => $group->getID(),
+            'users_id'  => $user->getID(),
+        ]);
+
+        $entities_id = $this->getTestRootEntity(true);
+
+        // Create tickets with various statuses and assignments
+        [
+            $requester, $observer, $assign, $group_requester, $group_observer,
+            $group_assign, $waiting_requester, $waiting_observer, $waiting_assign,
+            $waiting_group_requester, $waiting_group_observer, $waiting_group_assign,
+            $solved_requestbyself, $solved_group_requester,
+        ] = $this->createItems(Ticket::class, [
+                [
+                    'name' => 'incoming_requestbyself',
+                    'content' => 'incoming requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_observed',
+                    'content' => 'observer ticket content',
+                    '_users_id_observer' => $user->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_assign',
+                    'content' => 'assign ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_requester',
+                    'content' => 'group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_observed',
+                    'content' => 'group observer ticket content',
+                    '_groups_id_observer' => $group->getID(),
+                    'status' => Ticket::INCOMING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'incoming_group_assign',
+                    'content' => 'group assign ticket content',
+                    '_groups_id_assign' => $group->getID(),
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_requestbyself',
+                    'content' => 'waiting requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_observed',
+                    'content' => 'waiting observer ticket content',
+                    '_users_id_observer' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_assign',
+                    'content' => 'waiting assign ticket content',
+                    '_users_id_assign' => $user->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_requester',
+                    'content' => 'waiting group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_observed',
+                    'content' => 'waiting group observer ticket content',
+                    '_groups_id_observer' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'waiting_group_assign',
+                    'content' => 'waiting group assign ticket content',
+                    '_groups_id_assign' => $group->getID(),
+                    'status' => Ticket::WAITING,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'solved_requestbyself',
+                    'content' => 'solved requester ticket content',
+                    '_users_id_requester' => $user->getID(),
+                    'status' => Ticket::SOLVED,
+                    'entities_id' => $entities_id,
+                ],
+                [
+                    'name' => 'solved_group_requester',
+                    'content' => 'solved group requester ticket content',
+                    '_groups_id_requester' => $group->getID(),
+                    'status' => Ticket::SOLVED,
+                    'entities_id' => $entities_id,
+                ],
+            ]
+        );
+
+        $this->updateItem(Ticket::class, $assign->getID(), [
+            'status' => Ticket::INCOMING,
+        ]);
+        $this->updateItem(Ticket::class, $group_assign->getID(), [
+            'status' => Ticket::INCOMING,
+        ]);
+
+        // Log in as the test user and change to the created profile
+        $this->login($user->fields['name'], 'testShowCentralListRights_password');
+
+        Session::changeProfile($profile->getID());
+
+        // Show the central list of tickets and capture the output
+        $output = Ticket::showCentralList(0, $status, $showgrouptickets, false);
+
+        $all_tickets = [
+            'incoming_requestbyself'    => $requester,
+            'incoming_observed'         => $observer,
+            'incoming_group_requester'  => $group_requester,
+            'incoming_group_observed'   => $group_observer,
+            'assign'                    => $assign,
+            'group_assign'              => $group_assign,
+            'waiting_requestbyself'     => $waiting_requester,
+            'waiting_observed'          => $waiting_observer,
+            'waiting_assign'            => $waiting_assign,
+            'waiting_group_requester'   => $waiting_group_requester,
+            'waiting_group_observed'    => $waiting_group_observer,
+            'waiting_group_assign'      => $waiting_group_assign,
+            'solved_requestbyself'      => $solved_requestbyself,
+            'solved_group_requester'    => $solved_group_requester,
+        ];
+
+        // Extract ticket IDs from the output using regex
+        preg_match_all('/ticket\.form\.php\?id=(\d+)/', (string) $output, $matches);
+        $found_ids = array_map('intval', $matches[1]);
+
+        // Assert that the number of found tickets matches the expected count
+        $this->assertCount(
+            count($expected_tickets),
+            $found_ids,
+        );
+
+        // Assert that each expected ticket is present in the found IDs
+        foreach ($all_tickets as $name => $ticket) {
+            $this->assertSame(
+                in_array($name, $expected_tickets, true),
+                in_array($ticket->getID(), $found_ids, true),
+            );
+        }
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45696
- The “Group View” tab did not display tickets assigned to the group to which the user belongs because the READGROUP permission was not taken into account.

The fix also removes the checks on the creation permission, as this permission does not determine whether or not a user can view a ticket.

The READMY permission, which allows users to view these tickets, was also not taken into account.

## Screenshots (if appropriate):

<img width="890" height="274" alt="image" src="https://github.com/user-attachments/assets/e76838ad-781d-4112-ae0d-b24e04ed4377" />



