### PR TITLE
Add post_prepareupdate hook

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1678,6 +1678,15 @@ class CommonDBTM extends CommonGLPI
         Plugin::doHook(Hooks::PRE_ITEM_UPDATE, $this);
         if ($this->input && is_array($this->input)) {
             $this->input = $this->prepareInputForUpdate($this->input);
+        }
+
+        if ($this->input && is_array($this->input)) {
+            // Call the plugin hook - $this->input can be altered
+            // This hook get the data altered by the object method
+            Plugin::doHook(Hooks::POST_PREPAREUPDATE, $this);
+        }
+
+        if ($this->input && is_array($this->input)) {
             $this->filterValues(!isCommandLine());
         }
 

--- a/src/Glpi/Plugin/Hooks.php
+++ b/src/Glpi/Plugin/Hooks.php
@@ -485,6 +485,16 @@ class Hooks
     public const PRE_ITEM_UPDATE           = 'pre_item_update';
 
     /**
+     * Register a function to handle the 'post_prepareupdate' lifecycle event for an item.
+     * The function is called with the item as a parameter.
+     * The function is expected to return nothing.
+     * This hook is called after the input has been modified, but before the item is added to the database.
+     * The input can be found in the `input` property of the item. Setting the `input` property to false will cancel the update process.
+     * @see CommonDBTM::prepareInputForAdd()
+     */
+    public const POST_PREPAREUPDATE           = 'post_prepareupdate';
+
+    /**
      * Register a function to handle the 'item_update' lifecycle event for an item.
      * The function is called with the item as a parameter.
      * The function is expected to return nothing.
@@ -1435,6 +1445,7 @@ class Hooks
             self::POST_SHOW_ITEM,
             self::POST_SHOW_TAB,
             self::POST_PREPAREADD,
+            self::POST_PREPAREUPDATE,
             self::SHOW_ITEM_STATS,
             self::TIMELINE_ACTIONS,
         ];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Add missing counterpart to `post_prepareadd` hook. Needed for a plugin to prevent the new ITIL template behavior in GLPI 11 which some consider to be a bug (see #25095).