### PR TITLE
[a11y]- Hide decorative icons

### DIFF
--- a/.github/actions/lint_misc-lint.sh
+++ b/.github/actions/lint_misc-lint.sh
@@ -3,6 +3,8 @@ set -e -u -x -o pipefail
 
 bin/console tools:licence_headers_check
 
+bin/console tools:check_decorative_icons
+
 bin/console tools:locales:extract 2>&1 | tee extract.log
 if [[ -n $(grep "warning" extract.log) ]]; then exit 1; fi
 

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,14 @@ license-headers: ## Add the missing license headers in all files
 	$(CONSOLE) tools:licence_headers_check --fix
 .PHONY: license-headers
 
+decorative-icons-check: ## Verify that decorative icons are hidden from assistive technologies
+	$(CONSOLE) tools:check_decorative_icons
+.PHONY: decorative-icons-check
+
+decorative-icons: ## Hide the decorative icons that are still exposed to assistive technologies
+	$(CONSOLE) tools:check_decorative_icons --fix
+.PHONY: decorative-icons
+
 ## —— Database —————————————————————————————————————————————————————————————————
 db-install: ## Install local development's database
 	$(CONSOLE) database:install \

--- a/ajax/dropdownMassiveAction.php
+++ b/ajax/dropdownMassiveAction.php
@@ -48,7 +48,7 @@ try {
     // language=Twig
     echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
         <div class="alert alert-warning">
-            <i class="alert-icon ti ti-alert-triangle"></i>
+            <i class="alert-icon ti ti-alert-triangle" aria-hidden="true"></i>
             <div class="alert-title">{{ title }}</div>
             <div class="text-secondary">{{ text }}</div>
         </div>

--- a/ajax/uemailUpdate.php
+++ b/ajax/uemailUpdate.php
@@ -103,7 +103,7 @@ if (
     $switch_name = $_POST['field'] . '[use_notification][]';
     echo "<div class='my-1 d-flex align-items-center'>
          <label  for='email_fup_check'>
-            <i class='ti ti-mail me-1'></i>
+            <i class='ti ti-mail me-1' aria-hidden='true'></i>
             " . __s('Email followup') . "
          </label>
          <div class='ms-2'>

--- a/front/plugin.php
+++ b/front/plugin.php
@@ -57,7 +57,7 @@ Search::show('Plugin');
 echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
     <div class="text-center my-2">
         <a href="https://plugins.glpi-project.org" class="btn btn-primary" role="button">
-            <i class="ti ti-eye"></i>
+            <i class="ti ti-eye" aria-hidden="true"></i>
             <span>{{ label }}</span>
         </a>
     </div>

--- a/js/common.js
+++ b/js/common.js
@@ -964,7 +964,7 @@ var templateItilStatus = function(option) {
             break;
     }
 
-    return $(`<span><i class="itilstatus ${classes}"></i> ${_.escape(option.text)}</span>`);
+    return $(`<span><i class="itilstatus ${classes}" aria-hidden="true"></i> ${_.escape(option.text)}</span>`);
 };
 
 var templateValidation = function(option) {
@@ -988,7 +988,7 @@ var templateValidation = function(option) {
             break;
     }
 
-    return $(`<span><i class="validationstatus ${classes}"></i> ${_.escape(option.text)}</span>`);
+    return $(`<span><i class="validationstatus ${classes}" aria-hidden="true"></i> ${_.escape(option.text)}</span>`);
 };
 
 var templateItilPriority = function(option) {
@@ -1002,7 +1002,7 @@ var templateItilPriority = function(option) {
     var color_badge = "";
 
     if (priority_color.length > 0) {
-        color_badge += `<i class='ti ti-circle-filled' style='color: ${_.escape(priority_color)}'></i>`;
+        color_badge += `<i class='ti ti-circle-filled' style='color: ${_.escape(priority_color)}' aria-hidden='true'></i>`;
     }
 
     return $(`<span>${color_badge}&nbsp;${_.escape(option.text)}</span>`);
@@ -1652,7 +1652,7 @@ function initSortableTable(element_id) {
         const sort_icon = col.find('i');
         if (sort_icon.length === 0) {
             // Add sort icon
-            col.eq(0).append(`<i class="ti ti-caret-${new_order}-filled"></i>`);
+            col.eq(0).append(`<i class="ti ti-caret-${new_order}-filled" aria-hidden="true"></i>`);
         } else {
             sort_icon.addClass(new_order === 'up' ? 'ti-caret-up-filled' : 'ti-caret-down-filled');
         }

--- a/js/impact.js
+++ b/js/impact.js
@@ -1374,21 +1374,21 @@ var GLPIImpact = {
         return [
             {
                 id             : 'goTo',
-                content        : '<i class="ti ti-external-link me-2"></i>' + __("Go to"),
+                content        : '<i class="ti ti-external-link me-2" aria-hidden="true"></i>' + __("Go to"),
                 tooltipText    : _.unescape(__("Open this element in a new tab")),
                 selector       : 'node[link]',
                 onClickFunction: this.menuOnGoTo
             },
             {
                 id             : 'showOngoing',
-                content        : '<i class="ti ti-alert-circle me-2"></i>' + __("Show ongoing tickets"),
+                content        : '<i class="ti ti-alert-circle me-2" aria-hidden="true"></i>' + __("Show ongoing tickets"),
                 tooltipText    : _.unescape(__("Show ongoing tickets for this item")),
                 selector       : 'node[hasITILObjects=1]',
                 onClickFunction: this.menuOnShowOngoing
             },
             {
                 id             : 'editEdge',
-                content        : '<i class="ti ti-edit me-2"></i>' + __("Edge properties..."),
+                content        : '<i class="ti ti-edit me-2" aria-hidden="true"></i>' + __("Edge properties..."),
                 tooltipText    : _.unescape(__("Set name for this edge")),
                 selector       : 'edge',
                 onClickFunction: this.menuOnEditEdge,
@@ -1396,7 +1396,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'editCompound',
-                content        : '<i class="ti ti-edit me-2"></i>' + __("Group properties..."),
+                content        : '<i class="ti ti-edit me-2" aria-hidden="true"></i>' + __("Group properties..."),
                 tooltipText    : _.unescape(__("Set name and/or color for this group")),
                 selector       : 'node:parent',
                 onClickFunction: this.menuOnEditCompound,
@@ -1404,7 +1404,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'removeFromCompound',
-                content        : '<i class="ti ti-home-move me-2"></i>' + __("Remove from group"),
+                content        : '<i class="ti ti-home-move me-2" aria-hidden="true"></i>' + __("Remove from group"),
                 tooltipText    : _.unescape(__("Remove this asset from the group")),
                 selector       : 'node:child',
                 onClickFunction: this.menuOnRemoveFromCompound,
@@ -1412,7 +1412,7 @@ var GLPIImpact = {
             },
             {
                 id             : 'delete',
-                content        : '<i class="ti ti-trash me-2"></i>' + __("Delete"),
+                content        : '<i class="ti ti-trash me-2" aria-hidden="true"></i>' + __("Delete"),
                 tooltipText    : _.unescape(__("Delete element")),
                 selector       : 'node, edge',
                 onClickFunction: this.menuOnDelete,
@@ -3739,7 +3739,7 @@ var GLPIImpact = {
                     str += _.escape(value["name"]);
 
                     if (isHidden) {
-                        str += '<i class="ti ti-eye-off impact-res-hidden"></i>';
+                        str += '<i class="ti ti-eye-off impact-res-hidden" aria-hidden="true"></i>';
                     }
 
                     str += "</p>";

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -261,7 +261,7 @@ var followDownloadProgress = function(button) {
                     loop();
                 } else if (!ajax_done) {
                     // set an animated icon when decompressing
-                    buttons.html('<i class="fas fa-cog fa-spin"></i>');
+                    buttons.html('<i class="fas fa-cog fa-spin" aria-hidden="true"></i>');
 
                     // display messages from backend
                     displayAjaxMessageAfterRedirect();

--- a/js/modules/Dashboard/Dashboard.js
+++ b/js/modules/Dashboard/Dashboard.js
@@ -1209,7 +1209,7 @@ class GLPIDashboard {
                     this.fitNumbers(card);
                     this.animateNumbers(card);
                 }, () => {
-                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
+                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle' aria-hidden='true'></i></div>");
                 }));
             });
 
@@ -1251,13 +1251,13 @@ class GLPIDashboard {
                         }
                     });
                     if (!has_result) {
-                        card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
+                        card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle' aria-hidden='true'></i></div>");
                     }
                 });
             }, () => {
                 $.each(requested_cards, (i2, crd) => {
                     const card = crd.card_el;
-                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle'></i></div>");
+                    card.html("<div class='empty-card card-error'><i class='ti ti-alert-triangle' aria-hidden='true'></i></div>");
                 });
             });
         }

--- a/js/modules/FileUploader.js
+++ b/js/modules/FileUploader.js
@@ -399,12 +399,12 @@ export class FileUploader
             const isSuccess = entry.status === 'success';
             const errorClass = isError ? 'border-danger bg-danger bg-opacity-10' : '';
             const statusIcon = isSuccess
-                ? '<i class="ti ti-check text-success ms-2"></i>'
+                ? '<i class="ti ti-check text-success ms-2" aria-hidden="true"></i>'
                 : '';
 
             return `
             <div class="file-uploader-item d-flex align-items-center p-2 border rounded mb-2 ${errorClass}" role="listitem" data-file-index="${_.escape(index)}">
-                <i class="ti ${_.escape(this.#getFileIcon(file.name))} me-2 text-muted"></i>
+                <i class="ti ${_.escape(this.#getFileIcon(file.name))} me-2 text-muted" aria-hidden="true"></i>
                 <div class="flex-grow-1 min-width-0">
                     <div class="fw-medium text-truncate">${_.escape(file.name)}</div>
                     <small class="text-muted">${_.escape(this.#formatFileSize(file.size))}</small>
@@ -415,7 +415,7 @@ export class FileUploader
                         class="btn btn-sm btn-ghost-danger file-uploader-remove ms-2"
                         data-index="${_.escape(index)}"
                         title="${__('Remove')}">
-                    <i class="ti ti-x"></i>
+                    <i class="ti ti-x" aria-hidden="true"></i>
                 </button>
             </div>
         `;

--- a/js/modules/Form/WebIconSelector.js
+++ b/js/modules/Form/WebIconSelector.js
@@ -217,7 +217,7 @@ export class WebIconSelector {
             if (iconset_prefix === "fa") {
                 style = "style=\"font-family: 'Font Awesome 6 Free', 'Font Awesome 6 Brands';\"";
             }
-            container.innerHTML = `<i class="${_.escape(iconset_prefix)} ${_.escape(option.id)}" ${style}></i> ${_.escape(option.id)}`;
+            container.innerHTML = `<i class="${_.escape(iconset_prefix)} ${_.escape(option.id)}" ${style} aria-hidden="true"></i> ${_.escape(option.id)}`;
             return container;
         } else {
             return option.text;

--- a/js/modules/Forms/ServiceCatalogController.js
+++ b/js/modules/Forms/ServiceCatalogController.js
@@ -293,6 +293,6 @@ export class GlpiFormServiceCatalogController
 
     getTemplateForSortSelect(data) {
         const icon = this.sort_icons[data.id];
-        return $(`<span class="w-full" title="${_.escape(data.text)}" aria-label="${_.escape(data.text)}"><i class="${_.escape(icon)}"></i></span>`);
+        return $(`<span class="w-full" title="${_.escape(data.text)}" aria-label="${_.escape(data.text)}"><i class="${_.escape(icon)}" aria-hidden="true"></i></span>`);
     }
 }

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -1015,7 +1015,7 @@ export class GlpiKnowbaseArticleController
             const end_date      = end_input.value || null;
             const original_html = apply_btn.innerHTML;
             apply_btn.disabled  = true;
-            apply_btn.innerHTML = `<i class="ti ti-loader me-1"></i>${__('Saving...')}`;
+            apply_btn.innerHTML = `<i class="ti ti-loader me-1" aria-hidden="true"></i>${__('Saving...')}`;
 
             try {
                 await post(`Knowbase/${this.#item_id}/UpdateVisibilityDates`, {
@@ -1161,7 +1161,7 @@ export class GlpiKnowbaseArticleController
 
         const original_button_html = save_button.innerHTML;
         save_button.disabled = true;
-        save_button.innerHTML = `<i class="ti ti-loader me-1"></i>${__("Saving...")}`;
+        save_button.innerHTML = `<i class="ti ti-loader me-1" aria-hidden="true"></i>${__("Saving...")}`;
 
         try {
             const body = {
@@ -1547,7 +1547,7 @@ export class GlpiKnowbaseArticleController
 
         const original_button_html = save_btn.innerHTML;
         save_btn.disabled = true;
-        save_btn.innerHTML = `<i class="ti ti-loader me-1"></i>${__("Saving...")}`;
+        save_btn.innerHTML = `<i class="ti ti-loader me-1" aria-hidden="true"></i>${__("Saving...")}`;
 
         if (this.#translation_language !== this.#default_language) {
             const body = {

--- a/js/modules/Knowbase/DocumentLinkController.js
+++ b/js/modules/Knowbase/DocumentLinkController.js
@@ -207,7 +207,7 @@ export class DocumentLinkController
         this.#listContainer.innerHTML = Array.from(this.#selectedDocuments.values())
             .map((doc) => `
                 <div class="file-uploader-item d-flex align-items-center p-2 border rounded mb-2" role="listitem">
-                    <i class="ti ti-file-symlink me-2 text-muted"></i>
+                    <i class="ti ti-file-symlink me-2 text-muted" aria-hidden="true"></i>
                     <div class="flex-grow-1 min-width-0">
                         <div class="fw-medium text-truncate">${_.escape(doc.text)}</div>
                     </div>
@@ -215,7 +215,7 @@ export class DocumentLinkController
                             class="btn btn-sm btn-ghost-danger file-uploader-remove ms-2"
                             data-glpi-kb-link-remove="${_.escape(doc.id)}"
                             title="${__('Remove')}">
-                        <i class="ti ti-x"></i>
+                        <i class="ti ti-x" aria-hidden="true"></i>
                     </button>
                 </div>
             `).join('');

--- a/js/modules/Knowbase/PermissionsFormController.js
+++ b/js/modules/Knowbase/PermissionsFormController.js
@@ -115,7 +115,7 @@ export class GlpiKnowbasePermissionsFormController
         this.#advancedVisible = false;
         this.#advancedBlock.classList.add('d-none');
         this.#advancedContent.innerHTML = '';
-        this.#advancedToggle.innerHTML = `<i class="ti ti-settings me-1"></i>${show_label}`;
+        this.#advancedToggle.innerHTML = `<i class="ti ti-settings me-1" aria-hidden="true"></i>${show_label}`;
     }
 
     async #loadVisibility(type)
@@ -236,13 +236,13 @@ export class GlpiKnowbasePermissionsFormController
                 // Show advanced options
                 this.#advancedBlock.classList.remove('d-none');
                 await this.#loadSubvisibility(this.#dropdown.value);
-                const html = `<i class="ti ti-settings me-1"></i>${hide_label}`;
+                const html = `<i class="ti ti-settings me-1" aria-hidden="true"></i>${hide_label}`;
                 this.#advancedToggle.innerHTML = html;
             } else {
                 // Hide advanced options
                 this.#advancedBlock.classList.add('d-none');
                 this.#advancedContent.innerHTML = '';
-                const html = `<i class="ti ti-settings me-1"></i>${show_label}`;
+                const html = `<i class="ti ti-settings me-1" aria-hidden="true"></i>${show_label}`;
                 this.#advancedToggle.innerHTML = html;
             }
         });

--- a/js/modules/ProgressIndicator.js
+++ b/js/modules/ProgressIndicator.js
@@ -255,7 +255,7 @@ export class ProgressIndicator
 
         const message_element = document.createElement('div');
         message_element.innerHTML = `
-            <i class="${icon_class} align-middle"></i>
+            <i class="${icon_class} align-middle" aria-hidden="true"></i>
             ${_.escape(text)}
         `;
 

--- a/js/modules/Screenshot/Screenshot.js
+++ b/js/modules/Screenshot/Screenshot.js
@@ -205,7 +205,7 @@ class Screenhot {
         const preview_item = $(`
             <div class="position-relative d-inline-block overflow-hidden upload-preview-item" data-filename="${_.escape(filename)}" style="height: ${_.escape(height)}">
                 <button class="btn btn-sm btn-danger position-absolute top-0 start-0" type="button" title="${__('Delete')}">
-                    <i class="ti ti-x"></i>
+                    <i class="ti ti-x" aria-hidden="true"></i>
                 </button>
             </div>
         `).appendTo(preview_container);
@@ -235,7 +235,7 @@ class Screenhot {
         const preview_item = $(`
             <div class="position-relative d-inline-block overflow-hidden upload-preview-item" data-filename="${_.escape(filename)}" style="height: ${_.escape(height)}">
                 <button class="btn btn-sm btn-danger position-absolute top-0 start-0" type="button" title="${__('Delete')}">
-                    <i class="ti ti-x"></i>
+                    <i class="ti ti-x" aria-hidden="true"></i>
                 </button>
             </div>
         `).appendTo(preview_container);

--- a/js/modules/TipTap/SlashCommandsExtension.js
+++ b/js/modules/TipTap/SlashCommandsExtension.js
@@ -55,7 +55,7 @@ function showImageDialog(editor, existing_attrs = null) {
 
     const title = document.createElement('div');
     title.className = 'image-dialog-header';
-    title.innerHTML = `<span>${__('Insert/Edit Image')}</span><button type="button" class="image-dialog-close" aria-label="${__('Close')}"><i class="ti ti-x"></i></button>`;
+    title.innerHTML = `<span>${__('Insert/Edit Image')}</span><button type="button" class="image-dialog-close" aria-label="${__('Close')}"><i class="ti ti-x" aria-hidden="true"></i></button>`;
     dialog.appendChild(title);
 
     const body = document.createElement('div');
@@ -82,12 +82,12 @@ function showImageDialog(editor, existing_attrs = null) {
     lock_btn.type = 'button';
     lock_btn.className = 'image-dialog-lock is-locked';
     lock_btn.title = __('Constrain proportions');
-    lock_btn.innerHTML = '<i class="ti ti-lock"></i>';
+    lock_btn.innerHTML = '<i class="ti ti-lock" aria-hidden="true"></i>';
     let ratio_locked = true;
     lock_btn.addEventListener('click', () => {
         ratio_locked = !ratio_locked;
         lock_btn.classList.toggle('is-locked', ratio_locked);
-        lock_btn.innerHTML = ratio_locked ? '<i class="ti ti-lock"></i>' : '<i class="ti ti-lock-open"></i>';
+        lock_btn.innerHTML = ratio_locked ? '<i class="ti ti-lock" aria-hidden="true"></i>' : '<i class="ti ti-lock-open" aria-hidden="true"></i>';
     });
 
     size_row.appendChild(width_group);

--- a/js/src/vue/CustomObject/FieldPreview/Field.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Field.vue
@@ -28,15 +28,15 @@
             </div>
             <div v-if="is_active" class="col-auto btn-group shadow-none field-actions">
                 <button type="button" class="btn btn-ghost-secondary btn-sm edit-field" :title="__('Edit')">
-                    <i class="ti ti-pencil"></i>
+                    <i class="ti ti-pencil" aria-hidden="true"></i>
                 </button>
                 <button type="button" class="btn btn-ghost-danger btn-sm hide-field" :title="__('Hide')">
-                    <i class="ti ti-eye-off"></i>
+                    <i class="ti ti-eye-off" aria-hidden="true"></i>
                 </button>
             </div>
             <div v-if="!is_active && customfields_id > 0" class="col-auto btn-group shadow-none field-actions">
                 <button type="button" class="btn btn-ghost-danger btn-sm purge-field" :title="_x('button', 'Delete permanently')">
-                    <i class="ti ti-trash"></i>
+                    <i class="ti ti-trash" aria-hidden="true"></i>
                 </button>
             </div>
         </div>

--- a/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
+++ b/js/src/vue/CustomObject/FieldPreview/Sidebar.vue
@@ -54,7 +54,7 @@
         <div class="align-items-center col-12">
             <div class="form-field row flex-grow-1 mx-0 my-1 new-custom-field cursor-pointer btn btn-sm btn-ghost-secondary w-100" role="button">
                 <div class="col py-2 text-center">
-                    <i class="ti ti-plus"></i>
+                    <i class="ti ti-plus" aria-hidden="true"></i>
                     {{ __('New field') }}
                 </div>
             </div>

--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -347,7 +347,7 @@
             <div class="debug-toolbar-badge d-flex">
                 <button type="button" class="btn btn-icon border-0 px-3 opacity-100 debug-logo" @click="show_toolbar = true" :disabled="show_toolbar"
                         title="Toggle debug bar" aria-label="Toggle debug bar">
-                    <i class="ti ti-bug"></i>
+                    <i class="ti ti-bug" aria-hidden="true"></i>
                 </button>
             </div>
             <div :class="'debug-toolbar-content w-100 justify-content-between align-items-center ' + (show_toolbar ? 'd-flex' : '')" v-show="show_toolbar">
@@ -360,10 +360,10 @@
                     <div class="debug-toolbar-control">
                         <button type="button" class="btn btn-icon border-0 p-1" name="toggle_content_area" @click="show_content_area = !show_content_area"
                                 title="Toggle debug content area" aria-label="Toggle debug content area">
-                            <i :class="show_content_area ? 'ti ti-square-arrow-up' : 'ti ti-square-arrow-down'"></i>
+                            <i :class="show_content_area ? 'ti ti-square-arrow-up' : 'ti ti-square-arrow-down'" aria-hidden="true"></i>
                         </button>
                         <button type="button" class="btn btn-icon border-0 p-1" title="Close" aria-label="Close" @click="show_toolbar = false">
-                            <i class="ti ti-square-x"></i>
+                            <i class="ti ti-square-x" aria-hidden="true"></i>
                         </button>
                     </div>
                 </div>

--- a/js/src/vue/Debug/Widget/HTTPRequests.vue
+++ b/js/src/vue/Debug/Widget/HTTPRequests.vue
@@ -215,8 +215,9 @@
                                 <td :title="request.url"
                                     :data-truncated="urlNeedsTruncated(request.url)">{{ request.url.substring(0, REQUEST_PATH_LENGTH) }}<button
                                         v-if="urlNeedsTruncated(request.url)" class="ms-1 badge bg-secondary text-secondary-fg" name="show_full_url"
+                                        :aria-label="__('Show full URL')"
                                         @click="expandRequestURL($event)">
-                                        <i class="ti ti-dots"></i>
+                                        <i class="ti ti-dots" aria-hidden="true"></i>
                                     </button>
                                 </td>
                                 <td>{{ request.status }}</td>

--- a/js/src/vue/Debug/Widget/HTTPRequests.vue
+++ b/js/src/vue/Debug/Widget/HTTPRequests.vue
@@ -258,7 +258,7 @@
                                 <div class="alert alert-danger">
                                     <span>No debug data was found for this request immediately after it finished. Some requests like /front/locale.php will never have data as they intentionally close the session.</span>
                                 </div>
-                                <button type="button" class="btn btn-primary" :data-request-id="current_request_id"><i class="ti ti-reload"></i>Retry</button>
+                                <button type="button" class="btn btn-primary" :data-request-id="current_request_id"><i class="ti ti-reload" aria-hidden="true"></i>Retry</button>
                             </div>
                         </div>
                     </div>

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -179,7 +179,7 @@
                                 <code class="d-block cm-s-default border-0" v-html="colorized_queries.get(query.request_id + '-' + query.num)"></code>
                             </div>
                             <button type="button" @click="copyToClipboard($event)" class="ms-1 copy-code btn btn-sm btn-ghost-secondary" title="Copy query to clipboard">
-                                <i class="ti ti-clipboard-copy"></i>
+                                <i class="ti ti-clipboard-copy" aria-hidden="true"></i>
                             </button>
                         </div>
                     </td>

--- a/js/src/vue/Debug/Widget/SearchOptions.vue
+++ b/js/src/vue/Debug/Widget/SearchOptions.vue
@@ -107,7 +107,7 @@
                         <input v-else class="form-control" :id="`itemtype${rand}`" v-model.lazy="current_itemtype">
                         <button class="btn btn-sm btn-outline-secondary" @click="itemtype_input_mode = itemtype_input_mode === 'select' ? 'input' : 'select'"
                                 title="Toggle manual input" aria-label="Toggle manual input">
-                            <i class="ti ti-switch-horizontal"></i>
+                            <i class="ti ti-switch-horizontal" aria-hidden="true"></i>
                         </button>
                     </div>
                 </div>

--- a/js/src/vue/Debug/WidgetButton.vue
+++ b/js/src/vue/Debug/WidgetButton.vue
@@ -18,7 +18,7 @@
 <template>
     <li class="debug-toolbar-widget d-inline-block p-2" :data-glpi-debug-widget-id="id">
         <button type="button" class="btn btn-icon border-0 p-1" :title="title" data-bs-toggle="tooltip" data-bs-placement="top">
-            <i v-if="icon" :class="icon + ' me-1'"></i>
+            <i v-if="icon" :class="icon + ' me-1'" aria-hidden="true"></i>
             <span class="debug-text"></span>
         </button>
     </li>

--- a/js/src/vue/EntitySelector/EntitySelector.vue
+++ b/js/src/vue/EntitySelector/EntitySelector.vue
@@ -221,7 +221,7 @@
     <div ref="entity_selector">
         <a ref="entity_dropdown_toggle" href="#" class="dropdown-item dropdown-toggle entity-dropdown-toggle" data-bs-toggle="dropdown"
            data-bs-auto-close="outside" :title="current_entity" :aria-label="__('Select the desired entity')">
-            <i class="fa-fw ti ti-stack"></i>
+            <i class="fa-fw ti ti-stack" aria-hidden="true"></i>
             <span v-text="current_entity_short"></span>
         </a>
         <div class="dropdown-menu p-3" :aria-labelledby="header_id" role="dialog" data-testid="entity-menu-dropdown">
@@ -233,11 +233,11 @@
                 <button class="btn btn-icon btn-outline-secondary" :title="__('Clear search')" :aria-label="__('Clear search')"
                    data-bs-toggle="tooltip" data-bs-placement="top"
                    @click="search_filter = ''">
-                    <i class="ti ti-x"></i>
+                    <i class="ti ti-x" aria-hidden="true"></i>
                 </button>
                 <button class="btn btn-secondary" :title="__('Select all')" :aria-label="__('Select all')"
                         data-bs-toggle="tooltip" data-bs-placement="top" @click="changeFullStructure">
-                    <i class="ti ti-eye"></i>
+                    <i class="ti ti-eye" aria-hidden="true"></i>
                 </button>
             </div>
 
@@ -256,7 +256,7 @@
                                         class="btn btn-ghost-secondary btn-sm btn-icon p-1 cursor-pointer collapse-item"
                                         @click.prevent.stop="onExpandToggleClick(node)"
                                         tabindex="-1" aria-hidden="true">
-                                    <i :class="node.expanded ? 'ti ti-chevron-down' : 'ti ti-chevron-right'"></i>
+                                    <i :class="node.expanded ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" aria-hidden="true"></i>
                                 </button>
                                 <div v-else style="width: 25px"></div>
                                 <div role="button" :class="selected_nodes.includes(node.key) ? 'fw-bold' : ''" @click.prevent.stop="changeEntity(node.key, false)" class="d-flex align-items-center">
@@ -269,7 +269,7 @@
                                         :aria-label="__('Select this entity and all its children')"
                                         @click.prevent.stop="changeEntity(node.key, true)" data-bs-toggle="tooltip" data-bs-placement="top"
                                         tabindex="-1" aria-hidden="true">
-                                    <i class="ti ti-chevrons-down"></i>
+                                    <i class="ti ti-chevrons-down" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </li>

--- a/js/src/vue/FuzzySearch/Modal.vue
+++ b/js/src/vue/FuzzySearch/Modal.vue
@@ -100,14 +100,14 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">
-                        <i class="ti ti-arrow-big-right me-2"></i>
+                        <i class="ti ti-arrow-big-right me-2" aria-hidden="true"></i>
                         {{ header_message }}
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <div class="alert alert-info d-flex" role="alert">
-                        <i class="ti ti-alert-circle-filled fa-2x me-2"></i>
+                        <i class="ti ti-alert-circle-filled fa-2x me-2" aria-hidden="true"></i>
                         <p v-html="shortcut_message"></p>
                     </div>
                     <div role="search">

--- a/js/src/vue/Kanban/AddItemForm.vue
+++ b/js/src/vue/Kanban/AddItemForm.vue
@@ -27,7 +27,7 @@
     <div class="kanban-add-form kanban-form d-flex flex-column card">
         <div class="kanban-item-header d-flex justify-content-between">
             <span class="kanban-item-title">
-                <i :class="data.itemtype_data.icon"></i>
+                <i :class="data.itemtype_data.icon" aria-hidden="true"></i>
                 {{ data.itemtype_data.name }}
             </span>
             <i class="ti ti-x cursor-pointer" :title="__('Close')" @click.prevent="emit('kanban:close_form')"></i>

--- a/js/src/vue/Kanban/Card.vue
+++ b/js/src/vue/Kanban/Card.vue
@@ -96,7 +96,7 @@
     <li :id="id" :class="`kanban-item card shadow-none ${read_only ? 'readonly' : ''} ${is_deleted ? 'deleted' : ''}`">
         <div class="kanban-item-header d-flex justify-content-between">
             <span class="kanban-item-title d-flex align-items-center">
-                <i :class="icon"></i>
+                <i :class="icon" aria-hidden="true"></i>
                 <span class="cursor-pointer" v-text="title" @click="emit('kanban:card_show_details')"></span>
             </span>
             <div class="dropdown">
@@ -107,19 +107,19 @@
                 <ul ref="card_overflow_dropdown" class="kanban-dropdown dropdown-menu" role="menu">
                     <li class="kanban-item-goto dropdown-item" v-if="form_link">
                         <a :href="form_link" class="w-100">
-                            <i class="ti ti-share-3"></i>{{ __('Go to') }}
+                            <i class="ti ti-share-3" aria-hidden="true"></i>{{ __('Go to') }}
                         </a>
                     </li>
                     <li class="kanban-item-restore dropdown-item cursor-pointer" v-if="rights.canDeleteItem() && is_deleted"
                         @click="emit('kanban:card_restore')">
                         <span>
-                            <i class="ti ti-trash-off"></i>{{ __('Restore') }}
+                            <i class="ti ti-trash-off" aria-hidden="true"></i>{{ __('Restore') }}
                         </span>
                     </li>
                     <li class="kanban-item-remove dropdown-item cursor-pointer" v-if="rights.canDeleteItem()"
                         @click="emit('kanban:card_delete')">
                         <span>
-                            <i class="ti ti-trash"></i>{{ is_deleted ? __('Purge') : __('Delete') }}
+                            <i class="ti ti-trash" aria-hidden="true"></i>{{ is_deleted ? __('Purge') : __('Delete') }}
                         </span>
                     </li>
                 </ul>
@@ -136,7 +136,7 @@
             </div>
             <div class="align-self-center kanban-item-due-date">
                 <span v-if="due_date" :title="__('Planned end date')">
-                    <i class="ti ti-calendar"></i>
+                    <i class="ti ti-calendar" aria-hidden="true"></i>
                     <span v-text="due_date"></span>
                 </span>
             </div>

--- a/js/src/vue/Kanban/Card.vue
+++ b/js/src/vue/Kanban/Card.vue
@@ -101,8 +101,9 @@
             </span>
             <div class="dropdown">
                 <button type="button" class="kanban-item-overflow-actions cursor-pointer pt-0 b-0"
-                        data-bs-toggle="dropdown" data-bs-auto-close="outside">
-                    <i class="ti ti-dots" ref="btn_overflow"></i>
+                        data-bs-toggle="dropdown" data-bs-auto-close="outside"
+                        :title="__('More actions')" :aria-label="__('More actions')">
+                    <i class="ti ti-dots" ref="btn_overflow" aria-hidden="true"></i>
                 </button>
                 <ul ref="card_overflow_dropdown" class="kanban-dropdown dropdown-menu" role="menu">
                     <li class="kanban-item-goto dropdown-item" v-if="form_link">

--- a/js/src/vue/Kanban/Column.vue
+++ b/js/src/vue/Kanban/Column.vue
@@ -208,7 +208,7 @@
                                     <li class="dropdown-trigger dropdown-item">
                                         <div class="dropdown dropend">
                                             <a href="#" class="w-100" data-bs-toggle="dropdown" data-bs-auto-close="outside">
-                                                <i class="ti ti-list"></i>{{ __('Bulk add') }}
+                                                <i class="ti ti-list" aria-hidden="true"></i>{{ __('Bulk add') }}
                                             </a>
                                             <ul id="kanban-bulk-add-dropdown" class="dropdown-menu" role="menu">
                                                 <li :id="`kanban-bulk-add-${itemtype}`" class="dropdown-item cursor-pointer"
@@ -222,7 +222,7 @@
                                     <li class="kanban-remove dropdown-item cursor-pointer" v-if="!column_data['_protected']"
                                         @click="emit('kanban:column_hide')">
                                         <span>
-                                            <i class="ti ti-trash"></i>{{ __('Delete') }}
+                                            <i class="ti ti-trash" aria-hidden="true"></i>{{ __('Delete') }}
                                         </span>
                                     </li>
                                 </ul>

--- a/js/src/vue/Kanban/Kanban.vue
+++ b/js/src/vue/Kanban/Kanban.vue
@@ -234,7 +234,7 @@
         filter_input.tokenizer.clearAutocomplete();
 
         // Refresh core tags autocomplete
-        filter_input.tokenizer.setAutocomplete('type', Object.keys(props.supported_itemtypes).map(k => `<i class="${_.escape(props.supported_itemtypes[k].icon)} me-1"></i>` + _.escape(k)));
+        filter_input.tokenizer.setAutocomplete('type', Object.keys(props.supported_itemtypes).map(k => `<i class="${_.escape(props.supported_itemtypes[k].icon)} me-1" aria-hidden="true"></i>` + _.escape(k)));
         filter_input.tokenizer.setAutocomplete('milestone', ["true", "false"]);
         filter_input.tokenizer.setAutocomplete('deleted', ["true", "false"]);
 
@@ -1388,23 +1388,23 @@
                 <div class="dropdown">
                     <button type="button" class="btn btn-outline-secondary btn-icon ms-1 kanban-extra-toolbar-options" v-if="rights.canModifyView()"
                             data-bs-toggle="dropdown" data-bs-auto-close="outside" :title="__('More actions')" :aria-label="__('More actions')">
-                        <i class="ti ti-dots-vertical"></i>
+                        <i class="ti ti-dots-vertical" aria-hidden="true"></i>
                     </button>
                     <ul class="kanban-dropdown dropdown-menu kanban-extra-toolbar-options-menu" role="menu">
                         <li class="dropdown-item cursor-pointer" @click="clearState(true)">
                             <span>
-                                <i class="ti ti-trash"></i>{{ __('Reset view') }}
+                                <i class="ti ti-trash" aria-hidden="true"></i>{{ __('Reset view') }}
                             </span>
                         </li>
                         <template v-if="debug_mode">
                             <li class="dropdown-item cursor-pointer" @click="loadState()">
-                                <span><i class="ti ti-cloud-download"></i>Load state (Debug)</span>
+                                <span><i class="ti ti-cloud-download" aria-hidden="true"></i>Load state (Debug)</span>
                             </li>
                             <li class="dropdown-item cursor-pointer" @click="saveState(true, true)">
-                                <span><i class="ti ti-cloud-upload"></i>Save state (Debug)</span>
+                                <span><i class="ti ti-cloud-upload" aria-hidden="true"></i>Save state (Debug)</span>
                             </li>
                             <li class="dropdown-item cursor-pointer" @click="refresh(false)">
-                                <span><i class="ti ti-refresh"></i>Refresh (Debug)</span>
+                                <span><i class="ti ti-refresh" aria-hidden="true"></i>Refresh (Debug)</span>
                             </li>
                         </template>
                     </ul>
@@ -1424,17 +1424,17 @@
             <ul id="kanban-item-overflow-dropdown" class="kanban-dropdown dropdown-menu d-none">
                 <li class="kanban-item-goto dropdown-item">
                     <a href="#" @click.prevent.stop="toggleSubDropdown($event)">
-                        <i class="ti ti-share-3"></i>{{ __('Go to') }}
+                        <i class="ti ti-share-3" aria-hidden="true"></i>{{ __('Go to') }}
                     </a>
                 </li>
                 <li class="kanban-item-restore dropdown-item d-none" v-if="rights.canDeleteItem()">
                     <span>
-                        <i class="ti ti-trash-off"></i>{{ __('Restore') }}
+                        <i class="ti ti-trash-off" aria-hidden="true"></i>{{ __('Restore') }}
                     </span>
                 </li>
                 <li class="kanban-item-remove dropdown-item d-none" v-if="rights.canDeleteItem()">
                     <span>
-                        <i class="ti ti-trash"></i>{{ __('Delete') }}
+                        <i class="ti ti-trash" aria-hidden="true"></i>{{ __('Delete') }}
                     </span>
                 </li>
             </ul>

--- a/js/src/vue/Kanban/Kanban.vue
+++ b/js/src/vue/Kanban/Kanban.vue
@@ -694,8 +694,8 @@
                         ${member_item}
                         ${_.escape(l.attr('data-name')) || `${_.escape(member_itemtype)} (${_.escape(member_items_id)})`}
                     </div>
-                    <button type="button" name="delete" class="btn btn-ghost-danger">
-                        <i class="ti ti-x" title="${__('Delete')}"></i>
+                    <button type="button" name="delete" class="btn btn-ghost-danger" title="${__('Delete')}" aria-label="${__('Delete')}">
+                        <i class="ti ti-x" aria-hidden="true"></i>
                     </button>
                 `);
             });

--- a/js/src/vue/Planning/PlanningFilter.vue
+++ b/js/src/vue/Planning/PlanningFilter.vue
@@ -77,7 +77,7 @@
     <li :class="`${event_type} ${expanded ? 'expanded' : ''}`" class="p-1 pe-0 d-flex flex-wrap align-items-center">
         <input type="checkbox" :id="filter_key" name="filters[]" class="form-check-input" :value="filter_key"
                :checked="filter_data.filter_data.display" @change="$emit('toggleFilter', props.filter_key, event_type, $event.target.checked, parent_filter_key)"/>
-        <i v-if="event_type !== 'event_filter'" :class="`ms-1 pb-1 actor_icon ti ti-${event_type.split('_')[0] === 'group' ? 'users' : 'user'}`"></i>
+        <i v-if="event_type !== 'event_filter'" :class="`ms-1 pb-1 actor_icon ti ti-${event_type.split('_')[0] === 'group' ? 'users' : 'user'}`" aria-hidden="true"></i>
         <label :for="filter_key" class="ps-1 overflow-hidden d-inline-block text-nowrap">
             {{ label_title }}
         </label>
@@ -92,7 +92,7 @@
             </button>
             <div v-if="event_type !== 'event_filter'" class="filter_option dropstart d-inline-block position-relative m-1">
                 <button class="btn btn-sm btn-ghost-secondary btn-icon" data-bs-toggle="dropdown" :title="_n('Action', 'Actions', 5)" :aria-label="_n('Action', 'Actions', 5)">
-                    <i class="ti ti-dots"></i>
+                    <i class="ti ti-dots" aria-hidden="true"></i>
                 </button>
                 <ul class="dropdown-menu p-0">
                     <li v-if="filter_data.params.show_delete" class="dropdown-item p-0">

--- a/js/src/vue/Planning/PlanningFiltersPanel.vue
+++ b/js/src/vue/Planning/PlanningFiltersPanel.vue
@@ -77,7 +77,7 @@
                     <button class="btn btn-sm btn-icon btn-ghost-secondary me-1"
                             @click="showAddCalendar"
                             :title="__('Add a calendar')" :aria-label="__('Add a calendar')">
-                        <i class="ti ti-circle-plus"></i>
+                        <i class="ti ti-circle-plus" aria-hidden="true"></i>
                     </button>
                 </h3>
                 <PlanningFiltersList v-show="!filters_collapsed" :active_entity="active_entity" :filters="filters.plannings"

--- a/js/src/vue/Planning/PlanningScheduler.vue
+++ b/js/src/vue/Planning/PlanningScheduler.vue
@@ -173,12 +173,12 @@
         <button v-show="current_view !== 'listFull'" ref="date_picker" class="btn btn-sm btn-ghost-secondary"
                 :title="_n('Calendar', 'Calendars', 1)"
                 :aria-label="_n('Calendar', 'Calendars', 1)">
-            <i class="ti ti-calendar"></i>
+            <i class="ti ti-calendar" aria-hidden="true"></i>
         </button>
     </Teleport>
     <Teleport v-if="full_view" defer to=".fc-toolbar-title">
         <button class="btn btn-sm btn-ghost-secondary" :title="__('Refresh')" :aria-label="__('Refresh')" @click="refresh">
-            <i class="ti ti-refresh"></i>
+            <i class="ti ti-refresh" aria-hidden="true"></i>
         </button>
     </Teleport>
     <Teleport v-if="full_view && (can_create || can_delete)" to="body">
@@ -186,13 +186,13 @@
             <ul class="list-group list-group-flush list-group-hoverable">
                 <li v-if="can_create" class="list-group-item p-0">
                     <button class="btn btn-ghost-secondary p-2 w-100 border-radius-0" @click="() => cloneEvent(event_context_menu.dataset.event_defid)">
-                        <i class="ti ti-copy"></i>
+                        <i class="ti ti-copy" aria-hidden="true"></i>
                         {{ __('Clone') }}
                     </button>
                 </li>
                 <li v-if="can_delete" class="list-group-item p-0">
                     <button class="btn btn-ghost-secondary p-2 w-100 border-radius-0" @click="() => deleteEvent(event_context_menu.dataset.event_defid)">
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                         {{ __('Delete') }}
                     </button>
                 </li>

--- a/src/Appliance.php
+++ b/src/Appliance.php
@@ -513,8 +513,8 @@ class Appliance extends CommonDBTM implements AssignableItemInterface, StateInte
 
         if ($isadmin) {
             $prefix                    = 'Appliance_Item' . MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$prefix . 'add']    = "<i class='ti ti-package'></i>" . _sx('button', 'Add an item');
-            $actions[$prefix . 'remove'] = "<i class='ti ti-package-off'></i>" . _sx('button', 'Remove an item');
+            $actions[$prefix . 'add']    = "<i class='ti ti-package' aria-hidden='true'></i>" . _sx('button', 'Add an item');
+            $actions[$prefix . 'remove'] = "<i class='ti ti-package-off' aria-hidden='true'></i>" . _sx('button', 'Remove an item');
         }
 
         KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/Appliance_Item.php
+++ b/src/Appliance_Item.php
@@ -266,7 +266,7 @@ class Appliance_Item extends CommonDBRelation
             echo "</div>";
             echo "<div class='auto'>";
             echo "<button type='submit' name='add' value='1' class='btn btn-primary ms-1'>";
-            echo "<i class='ti ti-link'></i><span>" . _sx('button', 'Add') . "</span>";
+            echo "<i class='ti ti-link' aria-hidden='true'></i><span>" . _sx('button', 'Add') . "</span>";
             echo "</button>";
             echo "</div>";
             echo "</div>"; //d-flex

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -507,7 +507,7 @@ class AuthLDAP extends CommonDBTM
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div class="text-center alert alert-danger">
-                    <i class="ti ti-alert-triangle alert-icon"></i>
+                    <i class="ti ti-alert-triangle alert-icon" aria-hidden="true"></i>
                     <div class="alert-text">
                         {{ missing_ext }}
                         <br>
@@ -1594,7 +1594,7 @@ TWIG, ['authldaps_id' => $ID]);
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div class="mb-3">
                     <div class="alert alert-warning" role="alert">
-                        <i class="alert-icon ti ti-alert-triangle"></i>
+                        <i class="alert-icon ti ti-alert-triangle" aria-hidden="true"></i>
                         <div class="alert-title">{{ warning }}</div>
                         <span class="text-secondary">{{ warning_long }}</span>
                 </div>

--- a/src/Cartridge.php
+++ b/src/Cartridge.php
@@ -1008,7 +1008,7 @@ TWIG, ['counts' => $counts, 'highlight' => $highlight]);
                                 field_class: 'col-4',
                             }) }}
                             {% set btn %}
-                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus"></i><span>{{ add_label }}</span></button>
+                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ add_label }}</span></button>
                                 <input type="hidden" name="cartridgeitems_id" value="{{ cartridgeitems_id }}">
                             {% endset %}
                             {{ fields.htmlField('', btn, null, {

--- a/src/CartridgeItem_PrinterModel.php
+++ b/src/CartridgeItem_PrinterModel.php
@@ -129,7 +129,7 @@ class CartridgeItem_PrinterModel extends CommonDBRelation
             echo "<input type='hidden' name='cartridgeitems_id' value='$instID'>";
             PrinterModel::dropdown(['used' => $used]);
             echo "</td><td class='tab_bg_2 center'>";
-            echo "<button type='submit' name='add' class='btn btn-primary'><i class='ti ti-link'></i><span>" . _sx('button', 'Add') . "</span></button>";
+            echo "<button type='submit' name='add' class='btn btn-primary'><i class='ti ti-link' aria-hidden='true'></i><span>" . _sx('button', 'Add') . "</span></button>";
             echo "</td></tr>";
             echo "</table>";
             Html::closeForm();

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -557,9 +557,9 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
         if (Session::getCurrentInterface() == 'central') {
             if (self::canUpdate()) {
                 $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'install']
-                 =  "<i class='ti ti-link'></i>" . _sx('button', 'Associate certificate');
+                 =  "<i class='ti ti-link' aria-hidden='true'></i>" . _sx('button', 'Associate certificate');
                 $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'uninstall']
-                 = "<i class='ti ti-link-off'></i>" . _sx('button', 'Dissociate certificate');
+                 = "<i class='ti ti-link-off' aria-hidden='true'></i>" . _sx('button', 'Dissociate certificate');
             }
         }
         return $actions;

--- a/src/Change.php
+++ b/src/Change.php
@@ -212,7 +212,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
         if (Session::getCurrentInterface() === 'central') {
             if (Change_Item::canCreate()) {
                 $actions['Change_Item' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item']
-                = "<i class='ti ti-plus'></i>"
+                = "<i class='ti ti-plus' aria-hidden='true'></i>"
                  . _sx('button', 'Add an item');
             }
 
@@ -1344,11 +1344,11 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                         ) {
                             foreach ($change->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $name = '<i class="fs-4 ti ti-user text-muted me-1"></i>'
+                                    $name = '<i class="fs-4 ti ti-user text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
-                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1"></i>'
+                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape($d['alternative_email']);
                                 }
                             }
@@ -1359,7 +1359,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                             && count($change->groups[CommonITILActor::REQUESTER])
                         ) {
                             foreach ($change->groups[CommonITILActor::REQUESTER] as $d) {
-                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1"></i>'
+                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1" aria-hidden="true"></i>'
                                     . htmlescape(Dropdown::getDropdownName("glpi_groups", $d["groups_id"]));
                             }
                         }

--- a/src/CommonDBConnexity.php
+++ b/src/CommonDBConnexity.php
@@ -532,8 +532,8 @@ abstract class CommonDBConnexity extends CommonDBTM
                 'unaffect' => ['unaffect'],
             ],
             'action_name'   => [
-                'affect'   => "<i class='ti ti-link'></i>" . _sx('button', 'Associate'),
-                'unaffect' => "<i class='ti ti-link-off'></i>" . _sx('button', 'Dissociate'),
+                'affect'   => "<i class='ti ti-link' aria-hidden='true'></i>" . _sx('button', 'Associate'),
+                'unaffect' => "<i class='ti ti-link-off' aria-hidden='true'></i>" . _sx('button', 'Dissociate'),
             ],
         ];
     }

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -1514,7 +1514,7 @@ class CommonDBTM extends CommonGLPI
         }
         if ($icon !== '') {
             $html .= sprintf(
-                '<i class="%s"></i> ',
+                '<i class="%s" aria-hidden="true"></i> ',
                 htmlescape($icon)
             );
         }
@@ -4211,12 +4211,12 @@ class CommonDBTM extends CommonGLPI
             if ($checkitem === null || $checkitem->isNewItem() || !$checkitem->isTemplate()) {
                 if (in_array(static::class, Appliance::getTypes(true))) {
                     $actions['Appliance' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item']
-                        = "<i class='" . htmlescape(Appliance::getIcon()) . "'></i>" . _sx('button', 'Associate to an appliance');
+                        = "<i class='" . htmlescape(Appliance::getIcon()) . "' aria-hidden='true'></i>" . _sx('button', 'Associate to an appliance');
                 }
 
                 if (in_array(static::class, $CFG_GLPI['rackable_types'])) {
                     $actions['Item_Rack' . MassiveAction::CLASS_ACTION_SEPARATOR . 'delete']
-                        = "<i class='ti ti-server-off'></i>" . _sx('button', 'Remove from a rack');
+                        = "<i class='ti ti-server-off' aria-hidden='true'></i>" . _sx('button', 'Remove from a rack');
                 }
             }
         }

--- a/src/CommonDropdown.php
+++ b/src/CommonDropdown.php
@@ -987,7 +987,7 @@ abstract class CommonDropdown extends CommonDBTM
                 $kbitem->getFromDB(reset($found_kbitem)['id']);
                 $ret .= "<div class='faqadd_block'>";
                 $ret .= "<label for='display_faq_chkbox$rand'>";
-                $ret .= "<i class='ti ti-zoom-question'></i>";
+                $ret .= "<i class='ti ti-zoom-question' aria-hidden='true'></i>";
                 $ret .= "</label>";
                 $ret .= "<input type='checkbox'  class='display_faq_chkbox' id='display_faq_chkbox$rand'>";
                 $ret .= "<div class='faqadd_entries'>";

--- a/src/CommonGLPI.php
+++ b/src/CommonGLPI.php
@@ -498,7 +498,7 @@ class CommonGLPI implements CommonGLPIInterface
         if (method_exists(static::class, 'getIcon')) {
             $icon = static::getIcon();
         }
-        $icon = $icon ? "<i class='" . htmlescape($icon) . " me-2'></i>" : '';
+        $icon = $icon ? "<i class='" . htmlescape($icon) . " me-2' aria-hidden='true'></i>" : '';
         $ong[static::class . '$main'] = '<span>' . $icon . htmlescape(static::getTypeName(1)) . '</span>';
         return $this;
     }
@@ -846,7 +846,7 @@ class CommonGLPI implements CommonGLPIInterface
             $icon = '';
         }
 
-        $icon_html = $icon !== '' ? sprintf('<i class="%s me-2"></i>', htmlescape($icon)) : '';
+        $icon_html = $icon !== '' ? sprintf('<i class="%s me-2" aria-hidden="true"></i>', htmlescape($icon)) : '';
         $counter_html = '';
         if ($nb > 0) {
             $badge_content = $total_nb !== null ? "$nb/$total_nb" : "$nb";
@@ -1196,7 +1196,7 @@ class CommonGLPI implements CommonGLPIInterface
             $list = "<a href='" . htmlescape($glpilisturl) . "' title=\"" . htmlescape($glpilisttitle) . "\"
                   class='btn btn-sm btn-icon btn-ghost-secondary me-2'
                   data-bs-toggle='tooltip' data-bs-placement='bottom'>
-                  <i class='ti ti-list-search fs-2'></i>
+                  <i class='ti ti-list-search fs-2' aria-hidden='true'></i>
                </a>";
             $list_shown = false;
 
@@ -1208,7 +1208,7 @@ class CommonGLPI implements CommonGLPIInterface
             echo "<a href='" . htmlescape("$cleantarget?id=$first$extraparamhtml") . "'
                  class='btn btn-sm btn-icon btn-ghost-secondary me-2 " . ($first >= 0 ? '' : 'bs-invisible') . "' title=\"" . __s('First') . "\"
                  data-bs-toggle='tooltip' data-bs-placement='bottom'>
-                 <i class='fs-2 ti ti-chevrons-left'></i>
+                 <i class='fs-2 ti ti-chevrons-left' aria-hidden='true'></i>
               </a>";
 
             if (!$list_shown && $prev < 0) {
@@ -1220,7 +1220,7 @@ class CommonGLPI implements CommonGLPIInterface
                  id='previouspage'
                  class='btn btn-sm btn-icon btn-ghost-secondary me-2 " . ($prev >= 0 ? '' : 'bs-invisible') . "' title=\"" . __s('Previous') . "\"
                  data-bs-toggle='tooltip' data-bs-placement='bottom'>
-                 <i class='fs-2 ti ti-chevron-left'></i>
+                 <i class='fs-2 ti ti-chevron-left' aria-hidden='true'></i>
               </a>";
             if ($prev >= 0) {
                 $js = '$("body").keydown(function(e) {
@@ -1255,7 +1255,7 @@ class CommonGLPI implements CommonGLPIInterface
                                 : __s('Deleted');
                     echo "<span class='mx-2 status rounded-1' title=\"" . $title . "\"
                         data-bs-toggle='tooltip'>
-                        <i class='ti ti-trash'></i>";
+                        <i class='ti ti-trash' aria-hidden='true'></i>";
                     echo __s('Deleted');
                     echo "</span>";
                 }
@@ -1280,7 +1280,7 @@ class CommonGLPI implements CommonGLPIInterface
                  class='btn btn-sm btn-icon btn-ghost-secondary ms-2 " . ($next >= 0 ? '' : 'bs-invisible') . "'
                  title=\"" . __s('Next') . "\"
                  data-bs-toggle='tooltip' data-bs-placement='bottom'>"
-            . "<i class='fs-2 ti ti-chevron-right'></i>
+            . "<i class='fs-2 ti ti-chevron-right' aria-hidden='true'></i>
                 </a>";
             if ($next >= 0) {
                 $js = '$("body").keydown(function(e) {
@@ -1297,7 +1297,7 @@ class CommonGLPI implements CommonGLPIInterface
                  class='btn btn-sm btn-icon btn-ghost-secondary ms-2 " . ($last >= 0 ? '' : 'bs-invisible') . "'
                  title=\"" . __s('Last') . "\"
                  data-bs-toggle='tooltip' data-bs-placement='bottom'>"
-            . "<i class='fs-2 ti ti-chevrons-right'></i></a>";
+            . "<i class='fs-2 ti ti-chevrons-right' aria-hidden='true'></i></a>";
 
             echo "</div>";
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -4117,10 +4117,10 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 || Session::haveRight(Problem::$rightname, UPDATE);
             if ($can_update_itilobject) {
                 $actions['CommonITILObject_CommonITILObject' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-                    = "<i class='ti ti-link'></i>"
+                    = "<i class='ti ti-link' aria-hidden='true'></i>"
                     . _sx('button', 'Link ITIL Object');
                 $actions['CommonITILObject_CommonITILObject' . MassiveAction::CLASS_ACTION_SEPARATOR . 'delete']
-                    = "<i class='ti ti-unlink'></i>"
+                    = "<i class='ti ti-unlink' aria-hidden='true'></i>"
                     . _sx('button', 'Unlink ITIL Object');
             }
         }
@@ -7777,7 +7777,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 if (is_a($validation_row['itemtype_target'], CommonDBTM::class, true)) {
                     $validation_target = new $validation_row['itemtype_target']();
                     if ($validation_target->getFromDB($validation_row['items_id_target'])) {
-                        $content .= " <i class='ti ti-arrow-right'></i><i class='" . htmlescape($validation_target->getIcon()) . " text-muted me-1'></i>"
+                        $content .= " <i class='ti ti-arrow-right' aria-hidden='true'></i><i class='" . htmlescape($validation_target->getIcon()) . " text-muted me-1'></i>"
                             . $validation_target->getlink();
                     }
                 }
@@ -7954,7 +7954,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             $pending_reason = $autoreminder_obj->getPendingReason();
             $content = sprintf(
                 '<span>%1$s%2$s (<span data-bs-toggle="popover" data-bs-html="true" data-bs-sanitize="true" data-bs-content="%3$s"><u>%4$s</u></span>)</span>',
-                '<i class="ti ti-refresh-alert text-warning me-1"></i>',
+                '<i class="ti ti-refresh-alert text-warning me-1" aria-hidden="true"></i>',
                 htmlescape(ITILReminder::getTypeName(1)),
                 htmlescape($autoreminder_obj->fields['content'] ?? ''),
                 htmlescape($autoreminder_obj->fields['name'])

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -725,7 +725,7 @@ abstract class CommonITILValidation extends CommonDBChild
                     break;
             }
 
-            return sprintf('<span><i class="validationstatus %s"></i> %s</span>', $classes, htmlescape($label));
+            return sprintf('<span><i class="validationstatus %s" aria-hidden="true"></i> %s</span>', $classes, htmlescape($label));
         }
 
         return $label;
@@ -1079,15 +1079,15 @@ abstract class CommonITILValidation extends CommonDBChild
                         <div class="flex-shrink-0">
                             {% if step_status == constant('CommonITILValidation::ACCEPTED') %}
                                 <span class="text-green" data-bs-toogle="tooltip" title="{{ accepted_label }}">
-                                    <i class="ti ti-check"></i>
+                                    <i class="ti ti-check" aria-hidden="true"></i>
                                 </span>
                             {% elseif step_status == constant('CommonITILValidation::REFUSED') %}
                                 <span class="text-red" data-bs-toggle="tooltip" title="{{ refused_label }}">
-                                    <i class="ti ti-ban"></i>
+                                    <i class="ti ti-ban" aria-hidden="true"></i>
                                 </span>
                             {% elseif step_status == constant('CommonITILValidation::WAITING') %}
                                 <span class="text-yellow" data-bs-toggle="tooltip" title="{{ pending_label }}">
-                                    <i class="ti ti-clock"></i>
+                                    <i class="ti ti-clock" aria-hidden="true"></i>
                                 </span>
                             {% endif %}
                         </div>
@@ -1738,7 +1738,7 @@ HTML;
                         if (($approver = $target['itemtype_target']::getById((int) $target['items_id_target'])) !== null) {
                             $user = $approver->getLink();
                         }
-                        $text = "<i class='" . \htmlescape($target['itemtype_target']::getIcon()) . " me-1'></i>" . $user . '<span class="mx-1">-</span>' . $status;
+                        $text = "<i class='" . \htmlescape($target['itemtype_target']::getIcon()) . " me-1' aria-hidden='true'></i>" . $user . '<span class="mx-1">-</span>' . $status;
                         $content = "<div class='badge_block' style='border-color: $bgcolor'><span style='background: $bgcolor'></span>&nbsp;" . $text . "</div>";
                     }
                     $out .= (empty($out) ? '' : Search::LBBR) . $content;
@@ -2020,7 +2020,7 @@ HTML;
                   <div class="alert alert-warning" role="alert">
                      <div class="d-flex">
                         <div class="me-2">
-                           <i class="ti ti-alert-triangle fs-2x"></i>
+                           <i class="ti ti-alert-triangle fs-2x" aria-hidden="true"></i>
                         </div>
                         <div>
                            <h4 class="alert-title">$title</h4>

--- a/src/CommonTreeDropdown.php
+++ b/src/CommonTreeDropdown.php
@@ -561,7 +561,7 @@ abstract class CommonTreeDropdown extends CommonDropdown
                                 {% endif %}
                             </div>
                             <div class="d-flex flex-row-reverse pe-2">
-                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus"></i><span>{{ btn_label }}</span></button>
+                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                             </div>
                         </div>
                     </form>
@@ -682,7 +682,7 @@ TWIG, $twig_params);
 
         if ($isadmin) {
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_under']
-                  = "<i class='ti ti-sitemap'></i>"
+                  = "<i class='ti ti-sitemap' aria-hidden='true'></i>"
                     . _sx('button', 'Move under');
         }
 

--- a/src/Computer.php
+++ b/src/Computer.php
@@ -404,19 +404,19 @@ class Computer extends CommonDBTM implements AssignableItemInterface, DCBreadcru
                 'Item_OperatingSystem' . MassiveAction::CLASS_ACTION_SEPARATOR . 'update'
                 => htmlescape(OperatingSystem::getTypeName()),
                 Asset_PeripheralAsset::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-                => "<i class='ti ti-plug'></i>"
+                => "<i class='ti ti-plug' aria-hidden='true'></i>"
                   . _sx('button', 'Connect'),
                 'Item_SoftwareVersion' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-                => "<i class='" . htmlescape(Software::getIcon()) . "'></i>"
+                => "<i class='" . htmlescape(Software::getIcon()) . "' aria-hidden='true'></i>"
                   . _sx('button', 'Install'),
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-                => "<i class='" . htmlescape(SoftwareLicense::getIcon()) . "'></i>"
+                => "<i class='" . htmlescape(SoftwareLicense::getIcon()) . "' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
                 'Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item'
-                => "<i class='" . htmlescape(Domain::getIcon()) . "'></i>"
+                => "<i class='" . htmlescape(Domain::getIcon()) . "' aria-hidden='true'></i>"
                     . _sx('button', 'Add a domain'),
                 'Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'remove_domain'
-                => "<i class='" . htmlescape(Domain::getIcon()) . "'></i>"
+                => "<i class='" . htmlescape(Domain::getIcon()) . "' aria-hidden='true'></i>"
                     . _sx('button', 'Remove a domain'),
             ];
 

--- a/src/Contact.php
+++ b/src/Contact.php
@@ -213,7 +213,7 @@ class Contact extends CommonDBTM
                      class="btn btn-icon btn-sm btn-ghost-secondary"
                      title="{$vcard_lbl}"
                      data-bs-toggle="tooltip" data-bs-placement="bottom">
-               <i class="ti ti-id fs-2"></i>
+               <i class="ti ti-id fs-2" aria-hidden="true"></i>
             </a>
 HTML;
             $toolbar[] = $vcard_btn;
@@ -229,7 +229,7 @@ HTML;
 
         if ($isadmin) {
             $actions['Contact_Supplier' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-               = "<i class='" . htmlescape(Supplier::getIcon()) . "'></i>" . _sx('button', 'Add a supplier');
+               = "<i class='" . htmlescape(Supplier::getIcon()) . "' aria-hidden='true'></i>" . _sx('button', 'Add a supplier');
         }
 
         return $actions;

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -414,10 +414,10 @@ class Contract extends CommonDBTM implements StateInterface
 
         if ($isadmin) {
             $prefix                    = 'Contract_Item' . MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$prefix . 'add']    = "<i class='ti ti-package'></i>" . _sx('button', 'Add an item');
-            $actions[$prefix . 'remove'] = "<i class='ti ti-package-off'></i>" . _sx('button', 'Remove an item');
+            $actions[$prefix . 'add']    = "<i class='ti ti-package' aria-hidden='true'></i>" . _sx('button', 'Add an item');
+            $actions[$prefix . 'remove'] = "<i class='ti ti-package-off' aria-hidden='true'></i>" . _sx('button', 'Remove an item');
             $actions['Contract_Supplier' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-               = "<i class='" . htmlescape(Supplier::getIcon()) . "'></i>" . _sx('button', 'Add a supplier');
+               = "<i class='" . htmlescape(Supplier::getIcon()) . "' aria-hidden='true'></i>" . _sx('button', 'Add a supplier');
         }
 
         return $actions;
@@ -1644,7 +1644,7 @@ class Contract extends CommonDBTM implements StateInterface
         if (in_array($itemtype, $CFG_GLPI["contract_types"], true)) {
             if (self::canUpdate()) {
                 $action_prefix                    = 'Contract_Item' . MassiveAction::CLASS_ACTION_SEPARATOR;
-                $actions[$action_prefix . 'add']    = "<i class='" . htmlescape(self::getIcon()) . "'></i>"
+                $actions[$action_prefix . 'add']    = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>"
                                                 . _sx('button', 'Add a contract');
                 $actions[$action_prefix . 'remove'] = _sx('button', 'Remove a contract');
             }

--- a/src/Contract_Supplier.php
+++ b/src/Contract_Supplier.php
@@ -156,7 +156,7 @@ class Contract_Supplier extends CommonDBRelation
                                 nochecklimit: true
                             }) }}
                             {% set btn %}
-                                <button type="submit" name='add' class="btn btn-primary"><i class="ti ti-link"></i><span>{{ btn_label }}</span></button>
+                                <button type="submit" name='add' class="btn btn-primary"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                             {% endset %}
                             {{ fields.htmlField('', btn, null) }}
                         </div>
@@ -276,7 +276,7 @@ TWIG, $twig_params);
                                 entity_sons: contract.fields['is_recursive']
                             }) }}
                             {% set btn %}
-                                <button type="submit" name='add' class="btn btn-primary"><i class="ti ti-link"></i><span>{{ btn_label }}</span></button>
+                                <button type="submit" name='add' class="btn btn-primary"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                             {% endset %}
                             {{ fields.htmlField('', btn, null) }}
                         </div>

--- a/src/Contract_User.php
+++ b/src/Contract_User.php
@@ -144,7 +144,7 @@ class Contract_User extends CommonDBRelation
                                 expired: false,
                             }) }}
                             {% set btn %}
-                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus me-1"></i>{{ btn_label }}</button>
+                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus me-1" aria-hidden="true"></i>{{ btn_label }}</button>
                             {% endset %}
                             {{ fields.htmlField('', btn, null) }}
                         </div>

--- a/src/Document.php
+++ b/src/Document.php
@@ -1615,16 +1615,16 @@ class Document extends CommonDBTM implements TreeBrowseInterface
 
         if (self::canApplyOn($itemtype)) {
             if (self::canView()) {
-                $actions[$action_prefix . 'add']    = "<i class='ti ti-file-plus'></i>"
+                $actions[$action_prefix . 'add']    = "<i class='ti ti-file-plus' aria-hidden='true'></i>"
                                                 . _sx('button', 'Add a document');
-                $actions[$action_prefix . 'remove'] = "<i class='ti ti-file-minus'></i>"
+                $actions[$action_prefix . 'remove'] = "<i class='ti ti-file-minus' aria-hidden='true'></i>"
                                                 . _sx('button', 'Remove a document');
             }
         }
 
         if ((is_a($itemtype, self::class, true)) && (static::canUpdate())) {
-            $actions[$action_prefix . 'add_item']    = "<i class='ti ti-package'></i>" . _sx('button', 'Add an item');
-            $actions[$action_prefix . 'remove_item'] = "<i class='ti ti-package-off'></i>" . _sx('button', 'Remove an item');
+            $actions[$action_prefix . 'add_item']    = "<i class='ti ti-package' aria-hidden='true'></i>" . _sx('button', 'Add an item');
+            $actions[$action_prefix . 'remove_item'] = "<i class='ti ti-package-off' aria-hidden='true'></i>" . _sx('button', 'Remove an item');
         }
     }
 

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -452,9 +452,9 @@ class Domain extends CommonDBTM implements AssignableItemInterface
 
         if ($_SESSION['glpiactiveprofile']['interface'] == 'central') {
             if ($isadmin) {
-                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'install']   = "<i class='ti ti-link'></i>" . _sx('button', 'Associate');
-                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'uninstall'] = "<i class='ti ti-link-off'></i>" . _sx('button', 'Dissociate');
-                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'duplicate']  = "<i class='ti ti-copy'></i>" . _sx('button', 'Duplicate');
+                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'install']   = "<i class='ti ti-link' aria-hidden='true'></i>" . _sx('button', 'Associate');
+                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'uninstall'] = "<i class='ti ti-link-off' aria-hidden='true'></i>" . _sx('button', 'Dissociate');
+                $actions['Domain' . MassiveAction::CLASS_ACTION_SEPARATOR . 'duplicate']  = "<i class='ti ti-copy' aria-hidden='true'></i>" . _sx('button', 'Duplicate');
             }
         }
         return $actions;

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -475,7 +475,7 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
                     </div>
                     <div class="mt-4 text-center">
                         <button type="button" class="btn btn-primary" id="add_new_record_btn{{ rand }}">
-                            <i class="ti ti-plus"></i>
+                            <i class="ti ti-plus" aria-hidden="true"></i>
                             <span>{{ add_new_btn_msg }}</span>
                         </button>
                         <script>

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -340,7 +340,7 @@ class Dropdown
                            title="' . __s('Add') . '" data-bs-toggle="modal" data-bs-target="#add_' . htmlescape($field_id) . '">';
             $add_item_icon .= Ajax::createIframeModalWindow('add_' . $field_id, $item->getFormURL(), ['display' => false]);
             $add_item_icon .= "<span data-bs-toggle='tooltip'>
-              <i class='ti ti-plus'></i>
+              <i class='ti ti-plus' aria-hidden='true'></i>
               <span class='visually-hidden'>" . __s('Add') . "</span>
                 </span>";
             $add_item_icon .= '</div>';
@@ -431,7 +431,7 @@ class Dropdown
             if ($itemtype === 'Location' && Location::canView()) {
                 $location_icon = "<div role='button' class='btn btn-outline-secondary' onclick='showMapForLocation(this)'
                                        data-fid='" . htmlescape($field_id) . "' title='" . __s('Display on map') . "' data-bs-toggle='tooltip' data-bs-placement='bottom'>";
-                $location_icon .= "<i class='ti ti-map'></i></div>";
+                $location_icon .= "<i class='ti ti-map' aria-hidden='true'></i></div>";
                 $icon_array[] = $location_icon;
             }
 
@@ -2811,7 +2811,7 @@ HTML;
         Dropdown::showFromArray('display_type', $values, ['rand' => $rand]);
         echo "<button type='submit' name='export' class='btn' "
              . " title=\"" . _sx('button', 'Export') . "\">"
-             . "<i class='ti ti-device-floppy'></i><span class='visually-hidden'>" . _sx('button', 'Export') . "<span>";
+             . "<i class='ti ti-device-floppy' aria-hidden='true'></i><span class='visually-hidden'>" . _sx('button', 'Export') . "<span>";
     }
 
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -2967,7 +2967,7 @@ class Entity extends CommonTreeDropdown implements
         $out = "<div class='badge bg-azure-lt m-1 py-1 " . ($inline ? "inline" : "") . "'
                    title='" . __s("Value inherited from a parent entity") . "'
                    data-bs-toggle='tooltip'>
-         <i class='ti ti-corner-right-down me-1'></i>
+         <i class='ti ti-corner-right-down me-1' aria-hidden='true'></i>
          $value
       </div>";
 
@@ -3101,7 +3101,7 @@ class Entity extends CommonTreeDropdown implements
             $title = implode(' > ', $names);
         }
         $breadcrumbs = implode(
-            '<i class="ti ti-caret-right-filled mx-1"></i>',
+            '<i class="ti ti-caret-right-filled mx-1" aria-hidden="true"></i>',
             array_map(
                 static fn(string $name) => '<span class="text-nowrap">' . htmlescape($name) . '</span>',
                 $names
@@ -3148,14 +3148,14 @@ class Entity extends CommonTreeDropdown implements
         $title       = htmlescape(implode(' > ', $names));
         $last_name   = array_pop($names);
         $breadcrumbs = implode(
-            '<i class="ti ti-caret-right-filled mx-1"></i>',
+            '<i class="ti ti-caret-right-filled mx-1" aria-hidden="true"></i>',
             array_map(
                 static fn(string $name) => '<span class="text-nowrap text-muted">' . htmlescape($name) . '</span>',
                 $names
             )
         );
 
-        $last_url  = '<i class="ti ti-caret-right-filled mx-1"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlescape($last_name) . '</a>';
+        $last_url  = '<i class="ti ti-caret-right-filled mx-1" aria-hidden="true"></i>' . '<a href="' . $entity->getLinkURL() . '" title="' . $title . '">' . htmlescape($last_name) . '</a>';
 
         return '<span class="glpi-badge" title="' . $title . '">' . $breadcrumbs . $last_url . '</span>';
     }

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -265,8 +265,8 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         $action_prefix = self::class . MassiveAction::CLASS_ACTION_SEPARATOR;
 
         if (in_array($itemtype, $CFG_GLPI['directconnect_types'], true)) {
-            $actions[$action_prefix . 'add']    = "<i class='ti ti-plug'></i>" . _sx('button', 'Connect');
-            $actions[$action_prefix . 'remove'] = "<i class='ti ti-plug-off'></i>" . _sx('button', 'Disconnect');
+            $actions[$action_prefix . 'add']    = "<i class='ti ti-plug' aria-hidden='true'></i>" . _sx('button', 'Connect');
+            $actions[$action_prefix . 'remove'] = "<i class='ti ti-plug-off' aria-hidden='true'></i>" . _sx('button', 'Disconnect');
         }
         parent::getMassiveActionsForItemtype($actions, $itemtype, $is_deleted, $checkitem);
     }
@@ -378,7 +378,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
                 $linkname = sprintf(__('%1$s (%2$s)'), $linkname, $data["id"]);
             }
             $link = $itemtype::getFormURLWithID($data["id"]);
-            $label = sprintf('<i class="%s"></i> %s', htmlescape($itemtype::getIcon()), htmlescape($linkname));
+            $label = sprintf('<i class="%s" aria-hidden="true"></i> %s', htmlescape($itemtype::getIcon()), htmlescape($linkname));
             $name = '<a href="' . htmlescape($link) . '">' . $label . '</a>';
             $entry['name'] = $name;
 
@@ -505,7 +505,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
                         {{ fields.hiddenField('itemtype_peripheral', peripheral.getType()) }}
                         {{ withtemplate ? fields.hiddenField('_no_history', 1) }}
                         <div class="d-flex flex-row-reverse">
-                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus"></i><span>{{ btn_label }}</span></button>
+                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                         </div>
                     </form>
                 </div>

--- a/src/Glpi/CustomObject/AbstractDefinition.php
+++ b/src/Glpi/CustomObject/AbstractDefinition.php
@@ -819,7 +819,7 @@ abstract class AbstractDefinition extends CommonDBTM
         switch ($field) {
             case 'icon':
                 $value = htmlescape($values[$field]);
-                return sprintf('<i class="ti %s"></i>', $value);
+                return sprintf('<i class="ti %s" aria-hidden="true"></i>', $value);
             case 'translations':
                 $translations = json_decode($values[$field], associative: true);
 

--- a/src/Glpi/Dashboard/Filters/AbstractFilter.php
+++ b/src/Glpi/Dashboard/Filters/AbstractFilter.php
@@ -188,8 +188,8 @@ abstract class AbstractFilter
             <fieldset id="filter-' . $rand . '" class="filter ' . \htmlescape($class) . '" data-filter-id="' . \htmlescape($id) . '">
                 ' . $field . '
                 <legend>' . \htmlescape($label) . '</legend>
-                <button class="btn btn-sm btn-icon btn-ghost-secondary delete-filter">
-                    <i class="ti ti-trash"></i>
+                <button class="btn btn-sm btn-icon btn-ghost-secondary delete-filter" aria-label="' . __s('Delete') . '">
+                    <i class="ti ti-trash" aria-hidden="true"></i>
                 </button>
                 ' . $js . '
             </fieldset>

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -333,10 +333,10 @@ HTML;
                 $rename = "<div class='edit-dashboard-properties'>
                <input type='text' class='dashboard-name form-control' value='{$dashboard_title}' size='1'>
                <button class='btn btn-ghost-secondary btn-icon btn-sm fs-2 ms-1 save-dashboard-name' data-bs-toggle='tooltip' data-bs-placement='bottom' title='{$save_label}'>
-                   <i class='ti ti-device-floppy' ></i>
+                   <i class='ti ti-device-floppy' aria-hidden='true' ></i>
                </button>
                <button class='btn btn-ghost-danger btn-icon btn-sm fs-2 ms-1 reset-dashboard' data-bs-toggle='tooltip' data-bs-placement='bottom' title='{$reset_label}'>
-                   <i class='ti ti-refresh' ></i>
+                   <i class='ti ti-refresh' aria-hidden='true' ></i>
                </button>
                <span class='display-message'></span>
             </div>";
@@ -345,7 +345,7 @@ HTML;
                 $rename = <<<HTML
                     <div class='edit-dashboard-properties'>
                         <button class='btn btn-ghost-danger btn-icon btn-sm fs-2 ms-1 reset-dashboard' title='{$reset_label}'>
-                           <i class='ti ti-refresh' ></i>
+                           <i class='ti ti-refresh' aria-hidden='true' ></i>
                        </button>
                     </div>
 HTML;
@@ -379,7 +379,7 @@ HTML;
                     <div class="toolbar left-toolbar mb-3 position-relative">
                         <div class='edit-dashboard-properties'>
                             <button class='btn btn-ghost-danger btn-sm ms-1 reset-dashboard'>
-                               <i class='ti ti-refresh' ></i>
+                               <i class='ti ti-refresh' aria-hidden='true' ></i>
                                {$reset_label}
                            </button>
                         </div>
@@ -428,12 +428,12 @@ HTML;
                 <div class='placeholder_info {{ is_placeholder ? "" : "d-none" }}' style="background-color: transparent; color: var(--tblr-body-color); font-size: var(--tblr-body-font-size)">
                     <div class="alert alert-info">
                         <div class="d-flex">
-                            <i class="ti ti-info-circle fs-2x me-3"></i>
+                            <i class="ti ti-info-circle fs-2x me-3" aria-hidden="true"></i>
                             <div>
                                 <h4 class="alert-title">{{ messages['placeholder_main'] }}</h4>
                                 <div class="mt-2">
                                     <button class="btn btn-info btn-sm disable-dashboard-demo me-2 {{ can_disable_demo ? '' : 'd-none' }}" type="button">
-                                        <i class="ti ti-presentation-off"></i>
+                                        <i class="ti ti-presentation-off" aria-hidden="true"></i>
                                         <span>{{ messages['disable_demo_msg'] }}</span>
                                     </button>
                                     <script>
@@ -1122,7 +1122,7 @@ HTML;
         echo "</div>";
 
         echo "<a href='#' class='btn btn-primary save_rights'>
-         <i class='ti ti-device-floppy'></i>
+         <i class='ti ti-device-floppy' aria-hidden='true'></i>
          <span>" . __s("Save") . "</span>
       </a>";
 
@@ -1152,11 +1152,11 @@ HTML;
 
         // retrieve card
         $notfound_html = "<div class='empty-card card-warning '>
-         <i class='ti ti-alert-triangle'></i>"
+         <i class='ti ti-alert-triangle' aria-hidden='true'></i>"
          . __s('empty card!') . "
       </div>";
         $render_error_html = "<div class='empty-card card-error '>
-         <i class='ti ti-alert-triangle'></i>"
+         <i class='ti ti-alert-triangle' aria-hidden='true'></i>"
          . __s('Error rendering card!')
             . "</br>"
             . \htmlescape($card_id)

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -434,7 +434,7 @@ class Widget
                data-bs-toggle="tooltip" data-bs-placement="top" title="{$alt}">
                 <span class="content">$formatted_number</span>
                 <div class="label">{$label}</div>
-                <i class="main-icon {$icon}"></i>
+                <i class="main-icon {$icon}" aria-hidden="true"></i>
             </a>
 HTML;
 
@@ -535,7 +535,7 @@ HTML;
             $numbers_html .= <<<HTML
                 <a {$href} class="line line-{$i}">
                     <span class="content" {$color}>$formatted_number</span>
-                    <i class="icon {$icon}" {$color2}></i>
+                    <i class="icon {$icon}" {$color2} aria-hidden="true"></i>
                     <span class="label" {$color2}>{$label}</span>
                 </a>
 HTML;
@@ -546,7 +546,7 @@ HTML;
         if ($nodata) {
             $numbers_html = "<span class='line empty-card no-data'>
                <span class='content'>
-                  <i class='icon ti ti-alert-triangle'></i>
+                  <i class='icon ti ti-alert-triangle' aria-hidden='true'></i>
                </span>
                <span class='label'>" . __s('No data found') . "</span>
             <span>";
@@ -611,7 +611,7 @@ HTML;
                     </div>
                 </div>
                 <span class="main-label">{$label}</span>
-                <i class="main-icon {$icon}" style="color: {$fg_color}"></i>
+                <i class="main-icon {$icon}" style="color: {$fg_color}" aria-hidden="true"></i>
             </div>
 HTML;
 
@@ -718,7 +718,7 @@ HTML;
             <div class="card g-chart {$class}" id="{$chart_id}" data-testid="dashboard-widget">
                 <div class="chart ct-chart">{$no_data_html}</div>
                 <span class="main-label">{$label}</span>
-                <i class="main-icon {$icon}"></i>
+                <i class="main-icon {$icon}" aria-hidden="true"></i>
             </div>
 HTML;
 
@@ -1207,7 +1207,7 @@ TWIG, $twig_params);
             <div class="card g-chart $class" id="{$chart_id}" data-testid="dashboard-widget">
                 <div class="chart ct-chart">$no_data_html</div>
                 <span class="main-label">{$label}</span>
-                <i class="main-icon {$icon}"></i>
+                <i class="main-icon {$icon}" aria-hidden="true"></i>
             </div>
 HTML;
 
@@ -1578,7 +1578,7 @@ TWIG, $twig_params);
             <div class="card g-chart $class" id="{$chart_id}" data-testid="dashboard-widget">
                 <div class="chart ct-chart"></div>
                 <span class="main-label">{$label}</span>
-                <i class="main-icon {$icon}"></i>
+                <i class="main-icon {$icon}" aria-hidden="true"></i>
             </div>
 HTML;
 
@@ -1815,7 +1815,7 @@ HTML;
                 <span class="main-label">
                     <a {$href}>{$label}</a>
                 </span>
-                <i class="main-icon {$icon}"></i>
+                <i class="main-icon {$icon}" aria-hidden="true"></i>
             </div>
 HTML;
 
@@ -1877,7 +1877,7 @@ HTML;
                 : "";
 
             $author = strlen($entry['author'])
-                ? "<i class='ti ti-user'></i>&nbsp;" . \htmlescape($entry['author'])
+                ? "<i class='ti ti-user' aria-hidden='true'></i>&nbsp;" . \htmlescape($entry['author'])
                 : "";
 
             $content_size = strlen($entry['content']);
@@ -1908,7 +1908,7 @@ HTML;
             $list_html = "
                 <span class='line empty-card no-data'>
                     <span class='content'>
-                        <i class='icon ti ti-alert-triangle'></i>
+                        <i class='icon ti ti-alert-triangle' aria-hidden='true'></i>
                     </span>
                     <span class='label'>" . __s('No data found') . "</span>
                 <span>
@@ -1948,7 +1948,7 @@ HTML;
                     {$label}
                     $view_all
                 </span>
-                <i class="main-icon {$icon}" style="color: {$fg_color}"></i>
+                <i class="main-icon {$icon}" style="color: {$fg_color}" aria-hidden="true"></i>
             </div>
 HTML;
 

--- a/src/Glpi/Dashboard/Widget.php
+++ b/src/Glpi/Dashboard/Widget.php
@@ -1916,7 +1916,7 @@ HTML;
         }
 
         $view_all = strlen($p['url'])
-            ? "<a href='" . \htmlescape($p['url']) . "'><i class='ti ti-eye' title='" . __s("See all") . "'></i></a>"
+            ? "<a href='" . \htmlescape($p['url']) . "' title='" . __s("See all") . "'><i class='ti ti-eye' aria-hidden='true'></i></a>"
             : "";
 
         $rand = (int) $p['rand'];

--- a/src/Glpi/Event.php
+++ b/src/Glpi/Event.php
@@ -603,7 +603,7 @@ class Event extends CommonDBTM
                 $icon = '';
             }
 
-            return '<i class="text-muted me-1 ' . \htmlescape($icon) . '"></i><span>' . \htmlescape($display_value) . '</span>';
+            return '<i class="text-muted me-1 ' . \htmlescape($icon) . '" aria-hidden="true"></i><span>' . \htmlescape($display_value) . '</span>';
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);
     }

--- a/src/Glpi/Features/Inventoriable.php
+++ b/src/Glpi/Features/Inventoriable.php
@@ -152,13 +152,13 @@ trait Inventoriable
                                 data-bs-toggle="tooltip" data-bs-placement="top"
                                 style="float: right;margin-right: .5em;"
                                 formaction="{$url}">
-                           <i class="ti ti-reload"></i>
+                           <i class="ti ti-reload" aria-hidden="true"></i>
                         </button>
 HTML;
             }
         } else {
             echo sprintf(
-                "<span style='float: right;'><i class='ti ti-ban'></i> <span class='visually-hidden'>%s</span></span>",
+                "<span style='float: right;'><i class='ti ti-ban' aria-hidden='true'></i> <span class='visually-hidden'>%s</span></span>",
                 __s('Inventory file missing')
             );
         }

--- a/src/Glpi/Features/Inventoriable.php
+++ b/src/Glpi/Features/Inventoriable.php
@@ -134,7 +134,7 @@ trait Inventoriable
             );
 
             echo sprintf(
-                "<a href='%s' style='float: right;' target='_blank'><i class='ti ti-download' title='%s'></i></a>",
+                "<a href='%s' style='float: right;' target='_blank' title='%s'><i class='ti ti-download' aria-hidden='true'></i></a>",
                 \htmlescape($href),
                 sprintf(
                     //TRANS: parameter is the name of the asset

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -821,7 +821,7 @@ trait PlanningEvent
         $out .= "<a class='btn btn-primary'
                  title='" . __("Personalization") . "'
                  onclick='$(\"#advanced_repetition$rand\").toggle()'>
-                 <i class='ti ti-settings'></i>
+                 <i class='ti ti-settings' aria-hidden='true'></i>
               </a>";
         $out .= "<div id='advanced_repetition$rand' style='display: $display_ar; max-width: 23'>";
 

--- a/src/Glpi/Form/Form.php
+++ b/src/Glpi/Form/Form.php
@@ -449,7 +449,7 @@ final class Form extends CommonDBTM implements
         $actions = parent::getSpecificMassiveActions($checkitem);
 
         $key = self::class . MassiveAction::CLASS_ACTION_SEPARATOR . "export";
-        $icon = '<i class="ti ti-file-arrow-right"></i>';
+        $icon = '<i class="ti ti-file-arrow-right" aria-hidden="true"></i>';
         $label = __s('Export form');
         $actions[$key] = $icon . $label;
 

--- a/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
+++ b/src/Glpi/Form/QuestionType/AbstractQuestionTypeSelectable.php
@@ -402,7 +402,7 @@ TWIG;
                     data-glpi-form-editor-question-extra-details
                     data-glpi-form-editor-question-option-remove
                 >
-                    <i class="ti ti-x"></i>
+                    <i class="ti ti-x" aria-hidden="true"></i>
                 </button>
             </div>
         {% endmacro %}

--- a/src/Glpi/Form/QuestionType/QuestionTypesManager.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypesManager.php
@@ -198,7 +198,7 @@ final class QuestionTypesManager
             function(item) {
                 const icons = {$js_icons};
                 return $('<span class="d-flex flex-row-reverse align-items-center gap-2">'
-                    + '<i class="' + _.escape(icons[item.id]) + '"></i>'
+                    + '<i class="' + _.escape(icons[item.id]) + '" aria-hidden="true"></i>'
                     + _.escape(item.text)
                     + '</span>');
             }
@@ -220,7 +220,7 @@ JS;
                 }
                 const icons = {$js_icons};
                 return $('<span class="d-flex align-items-center gap-2">'
-                    + '<i class="' + _.escape(icons[item.id]) + '"></i>'
+                    + '<i class="' + _.escape(icons[item.id]) + '" aria-hidden="true"></i>'
                     + _.escape(item.text)
                     + '</span>');
             }
@@ -239,7 +239,7 @@ JS;
             function(item) {
                 const icons = {$js_icons};
                 return $('<span class="d-flex flex-row-reverse align-items-center gap-2">'
-                    + '<i class="' + _.escape(icons[item.id]) + '"></i>'
+                    + '<i class="' + _.escape(icons[item.id]) + '" aria-hidden="true"></i>'
                     + _.escape(item.text)
                     + '</span>');
             }
@@ -258,7 +258,7 @@ JS;
             function(item) {
                 const icons = {$js_icons};
                 return $('<span class="d-flex align-items-center gap-1">'
-                    + '<i class="' + _.escape(icons[item.id]) + '"></i>'
+                    + '<i class="' + _.escape(icons[item.id]) + '" aria-hidden="true"></i>'
                     + _.escape(item.text)
                     + '</span>');
             }

--- a/src/Glpi/Marketplace/View.php
+++ b/src/Glpi/Marketplace/View.php
@@ -197,7 +197,7 @@ class View extends CommonGLPI
 
         if (count($messages)) {
             echo "<div class='alert alert-important alert-warning d-flex'>";
-            echo "<i class='fs-3x ti ti-alert-triangle'></i>";
+            echo "<i class='fs-3x ti ti-alert-triangle' aria-hidden='true'></i>";
             echo "<ul><li>" . implode('</li><li>', $messages) . "</li></ul>";
             echo "</div>";
         }
@@ -367,7 +367,7 @@ class View extends CommonGLPI
                 // Not completely offline. Do not treat as fully offline.
                 $msg = sprintf(__('Plugin list may be truncated due to %s services website unavailability. Please try again later.'), 'GLPI Network');
             }
-            $messages = '<li class="warning"><i class="ti ti-alert-triangle fs-3x"></i>' . htmlescape($msg) . '</li>';
+            $messages = '<li class="warning"><i class="ti ti-alert-triangle fs-3x" aria-hidden="true"></i>' . htmlescape($msg) . '</li>';
         }
 
         $plugins_li = "";
@@ -379,7 +379,7 @@ class View extends CommonGLPI
         if (!$only_lis) {
             // check writable state
             if (!Controller::hasWriteAccess()) {
-                echo "<div class='alert alert-warning'><i class='ti ti-alert-triangle fs-5x'></i>"
+                echo "<div class='alert alert-warning'><i class='ti ti-alert-triangle fs-5x' aria-hidden='true'></i>"
                       . htmlescape(sprintf(__("We can't write on the markeplace directory (%s)."), GLPI_MARKETPLACE_DIR))
                       . "<br>"
                       . __s("If you want to ease the plugins download, please check permissions and ownership of this directory.")
@@ -481,7 +481,7 @@ HTML;
                         </ul>
                         $pagination
                         <a href="mailto:{$networkmail}" class="network-mail" target="_blank">
-                            $yourplugin&nbsp;<i class="ti ti-mail"></i>
+                            $yourplugin&nbsp;<i class="ti ti-mail" aria-hidden="true"></i>
                         </a>
                     </div>
                 </div>
@@ -506,7 +506,7 @@ HTML;
                     var element = option.element;
                     var icon = $(element).data('icon');
 
-                    return $("<span><i class='" + _.escape(icon) + "'></i>&nbsp;" + _.escape(option.text) + "</span>");
+                    return $("<span><i class='" + _.escape(icon) + "' aria-hidden='true'></i>&nbsp;" + _.escape(option.text) + "</span>");
                 };
 
                 $('.sort-control').select2({
@@ -576,11 +576,11 @@ JS;
         $stars = "";
         for ($i = 1; $i < 6; $i++) {
             if ($value >= $i) {
-                $stars .= "<i class='ti ti-star-filled'></i>";
+                $stars .= "<i class='ti ti-star-filled' aria-hidden='true'></i>";
             } elseif ($value + 0.5 == $i) {
-                $stars .= "<i class='ti ti-star-half-filled'></i>";
+                $stars .= "<i class='ti ti-star-half-filled' aria-hidden='true'></i>";
             } else {
-                $stars .= "<i class='ti ti-star'></i>";
+                $stars .= "<i class='ti ti-star' aria-hidden='true'></i>";
             }
         }
 
@@ -645,7 +645,7 @@ JS;
 
         if (strlen($error)) {
             $rand = mt_rand();
-            $buttons .= "<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand'></i>";
+            $buttons .= "<i class='ti ti-alert-triangle plugin-error' id='plugin-error-$rand' aria-hidden='true'></i>";
             Html::showToolTip($error, [
                 'applyto' => "plugin-error-$rand",
             ]);
@@ -656,20 +656,20 @@ JS;
                 <button class='modify_plugin'
                         data-action='clean_plugin'
                         title='" . __s("Clean") . "'>
-                        <i class='ti ti-recycle'></i>
+                        <i class='ti ti-recycle' aria-hidden='true'></i>
                 </button>";
             if ($can_be_downloaded) {
                 $buttons .= "
                     <button class='modify_plugin'
                             data-action='download_plugin'
                             title='" . __s("Download again") . "'>
-                        <i class='ti ti-cloud-download'></i>
+                        <i class='ti ti-cloud-download' aria-hidden='true'></i>
                     </button>";
             }
         } elseif (!$is_available) {
             if (!$is_execution_suspended && !$can_run_local_install) {
                 $rand = mt_rand();
-                $buttons .= "<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand'></i>";
+                $buttons .= "<i class='ti ti-alert-triangle plugin-unavailable' id='plugin-tooltip-$rand' aria-hidden='true'></i>";
                 Html::showToolTip(
                     __s('This plugin is not available for your GLPI version.'),
                     [
@@ -702,14 +702,14 @@ JS;
                         : $plugin_data['installation_url'];
 
                     $buttons .= "<a href='" . \htmlescape($download_url) . "' target='_blank'>
-                            <button title='$warning' class='add_tooltip download_manually'><i class='ti ti-archive'></i></button>
+                            <button title='$warning' class='add_tooltip download_manually'><i class='ti ti-archive' aria-hidden='true'></i></button>
                         </a>";
                 } else {
                     $warning = __s("The plugin has an available update but its local directory contains source versioning.") . "<br>";
                     $warning .= __s("To avoid overwriting a potential branch under development, downloading is disabled.");
 
                     $buttons .= "<button title='$warning' class='add_tooltip download_manually'>
-                        <i class='ti ti-ban'></i>
+                        <i class='ti ti-ban' aria-hidden='true'></i>
                     </button>";
                 }
             }
@@ -718,7 +718,7 @@ JS;
                 $buttons .= "<button class='modify_plugin'
                                      data-action='download_plugin'
                                      title='" . __s("Download") . "'>
-                        <i class='ti ti-cloud-download'></i>
+                        <i class='ti ti-cloud-download' aria-hidden='true'></i>
                     </button>";
             } elseif ($can_be_updated) {
                 $update_title = sprintf(
@@ -733,7 +733,7 @@ JS;
                     'open_btn' => '<button data-bs-toggle="modal"
                                            data-bs-target="#updateModal' . htmlescape($plugin_inst->getField('directory')) . '"
                                            title="' . $update_title . '">
-                                       <i class="ti ti-cloud-download"></i>
+                                       <i class="ti ti-cloud-download" aria-hidden="true"></i>
                                    </button>',
                     'update_btn' => '<a href="#" class="btn btn-danger w-100 modify_plugin"
                                            data-action="update_plugin"
@@ -752,7 +752,7 @@ JS;
 
             $buttons .= "<a href='" . GLPI_NETWORK_SERVICES . "' target='_blank'>
                     <button class='add_tooltip need_offers' title='$warning'>
-                        <i class='ti ti-alert-triangle'></i>
+                        <i class='ti ti-alert-triangle' aria-hidden='true'></i>
                     </button>
                 </a>";
         }
@@ -766,7 +766,7 @@ JS;
                     'open_btn' => '<button data-bs-toggle="modal"
                                            data-bs-target="#updateModal' . \htmlescape($plugin_inst->getField('directory')) . '"
                                            title="' . __s("Update") . '">
-                                       <i class="ti ti-caret-up"></i>
+                                       <i class="ti ti-caret-up" aria-hidden="true"></i>
                                    </button>',
                     'update_btn' => '<a href="#" class="btn btn-info w-100 modify_plugin"
                                            data-action="install_plugin"
@@ -778,7 +778,7 @@ JS;
                 $buttons .= "<button class='modify_plugin'
                                      data-action='install_plugin'
                                      title='" . __s("Install") . "'>
-                        <i class='ti ti-folder-plus'></i>
+                        <i class='ti ti-folder-plus' aria-hidden='true'></i>
                     </button>";
             }
         }
@@ -789,13 +789,13 @@ JS;
                     $buttons .= "<button class='modify_plugin'
                                          data-action='disable_plugin'
                                          title='" . __s("Disable") . "'>
-                            <i class='ti ti-toggle-right-filled'></i>
+                            <i class='ti ti-toggle-right-filled' aria-hidden='true'></i>
                         </button>";
                 } else {
                     $buttons .= "<button class='modify_plugin'
                                          data-action='enable_plugin'
                                          title='" . __s("Enable") . "'>
-                            <i class='ti ti-toggle-left-filled'></i>
+                            <i class='ti ti-toggle-left-filled' aria-hidden='true'></i>
                         </button>";
                 }
             }
@@ -804,7 +804,7 @@ JS;
                 <button class="add_tooltip" data-bs-toggle="modal"
                         data-bs-target="#uninstallModal' . htmlescape($plugin_inst->getField('directory')) . '"
                         title="' . __s("Uninstall") . '">
-                    <i class="ti ti-folder-x"></i>
+                    <i class="ti ti-folder-x" aria-hidden="true"></i>
                 </button>
             ';
 
@@ -825,7 +825,7 @@ JS;
                 $config_url = "{$CFG_GLPI['root_doc']}/plugins/{$plugin_key}/{$config_page}";
                 $buttons .= "<a href='" . htmlescape($config_url) . "'>
                         <button class='add_tooltip' title='" . __s("Configure") . "'>
-                            <i class='ti ti-tool'></i>
+                            <i class='ti ti-tool' aria-hidden='true'></i>
                         </button>
                     </a>";
             }
@@ -834,7 +834,7 @@ JS;
         if ($buttons === '' && $is_execution_suspended) {
             // Add a tooltip to indicate why no action is available.
             return \sprintf(
-                '<span class="text-info" data-bs-toggle="tooltip" title="%s"><i class="ti ti-info-circle-filled"></i></span>',
+                '<span class="text-info" data-bs-toggle="tooltip" title="%s"><i class="ti ti-info-circle-filled" aria-hidden="true"></i></span>',
                 __s('The plugins maintenance actions are disabled when the plugins execution is suspended.')
             );
         }
@@ -898,7 +898,7 @@ JS;
                     <a href='" . htmlescape(GLPI_NETWORK_SERVICES) . "' target='_blank'
                        class='badge glpi-network'
                        title='" . sprintf(__s("You must have a %s subscription to get this plugin"), 'GLPI Network') . "'>
-                        <i class='ti ti-star-filled'></i>GLPI Network
+                        <i class='ti ti-star-filled' aria-hidden='true'></i>GLPI Network
                     </a>
                     <a href='" . htmlescape(GLPI_NETWORK_SERVICES) . "' target='_blank'
                        class='badge bg-azure $offerkey'
@@ -982,7 +982,7 @@ JS;
         if (!$only_li) {
             $html .= "<ul class='pagination'>";
         }
-        $html .= "<li data-page='$prev' $p_cls><i class='ti ti-chevron-left'></i></li>";
+        $html .= "<li data-page='$prev' $p_cls><i class='ti ti-chevron-left' aria-hidden='true'></i></li>";
         $dots = false;
         for ($i = 1; $i <= $nb_pages; $i++) {
             if (
@@ -1004,7 +1004,7 @@ JS;
                 : "";
             $html .= "<li data-page='$i' $current>$i</li>";
         }
-        $html .= "<li data-page='$next' $n_cls><i class='ti ti-chevron-right'></i></li>";
+        $html .= "<li data-page='$next' $n_cls><i class='ti ti-chevron-right' aria-hidden='true'></i></li>";
         $html .= "<li class='nb_plugin'>" . sprintf(_sn("%s plugin", "%s plugins", $total), $total) . "</li>";
         if (!$only_li) {
             $html .= "</ul>";

--- a/src/Glpi/RichText/RichText.php
+++ b/src/Glpi/RichText/RichText.php
@@ -549,7 +549,7 @@ HTML;
                   this.ui.registerElement({
                      name: 'download',
                      isButton: true,
-                     html: '<a class="text-white" target="_blank" download=""><i class="fa-solid fa-download"></i></a>',
+                     html: '<a class="text-white" target="_blank" download="" aria-label=' + JSON.stringify({$download_title}) + '><i class="fa-solid fa-download" aria-hidden="true"></i></a>',
                      order: 8,
                      onInit: (el, pswp) => {
                         pswp.on('change', () => {

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -7447,7 +7447,7 @@ final class SQLProvider implements SearchProviderInterface
                     if ($data[$ID][0]['is_active']) {
                         return "<a href='reservation.php?reservationitems_id="
                             . \htmlescape($data["refID"]) . "' title=\"" . __s('See planning') . "\">"
-                            . "<i class='ti ti-calendar'></i><span class='visually-hidden'>" . __s('See planning') . "</span></a>";
+                            . "<i class='ti ti-calendar' aria-hidden='true'></i><span class='visually-hidden'>" . __s('See planning') . "</span></a>";
                     } else {
                         return '';
                     }

--- a/src/Group.php
+++ b/src/Group.php
@@ -239,7 +239,7 @@ class Group extends CommonTreeDropdown
             && Session::haveRight("user", User::IMPORTEXTAUTHUSERS)
             && static::canUpdate()
         ) {
-            $links['<i class="ti ti-settings"></i><span>' . __s('LDAP directory link') . '</span>'] = "/front/ldap.group.php";
+            $links['<i class="ti ti-settings" aria-hidden="true"></i><span>' . __s('LDAP directory link') . '</span>'] = "/front/ldap.group.php";
         }
         return $links;
     }
@@ -250,13 +250,13 @@ class Group extends CommonTreeDropdown
         $actions = parent::getSpecificMassiveActions($checkitem);
         if ($isadmin) {
             $prefix                            = 'Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$prefix . 'add']            = "<i class='ti ti-user-plus'></i>"
+            $actions[$prefix . 'add']            = "<i class='ti ti-user-plus' aria-hidden='true'></i>"
                                               . _sx('button', 'Add a user');
-            $actions[$prefix . 'add_supervisor'] = "<i class='ti ti-user-star'></i>"
+            $actions[$prefix . 'add_supervisor'] = "<i class='ti ti-user-star' aria-hidden='true'></i>"
                                               . _sx('button', 'Add a manager');
-            $actions[$prefix . 'add_delegatee']  = "<i class='fas fa-user-check'></i>"
+            $actions[$prefix . 'add_delegatee']  = "<i class='fas fa-user-check' aria-hidden='true'></i>"
                                               . _sx('button', 'Add a delegatee');
-            $actions[$prefix . 'remove']         = "<i class='ti ti-user-minus'></i>"
+            $actions[$prefix . 'remove']         = "<i class='ti ti-user-minus' aria-hidden='true'></i>"
                                               . _sx('button', 'Remove a user');
         }
 

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -452,7 +452,7 @@ class Group_User extends CommonDBRelation
 
         if ($number != $all_groups) {
             echo "<div class='alert alert-primary d-flex align-items-center mb-4' role='alert'>";
-            echo "<i class='ti ti-info-circle fs-1'></i>";
+            echo "<i class='ti ti-info-circle fs-1' aria-hidden='true'></i>";
             echo "<span class='ms-2'>";
             echo __s("Some users are not listed as they are not visible from your current entity.");
             echo "</span>";

--- a/src/Html.php
+++ b/src/Html.php
@@ -2418,7 +2418,8 @@ JS;
             <input type="text" name="{$name}" value="{$value}"
                    {$required} {$disabled} data-input class="form-control rounded-start ps-2">
             <button type='button' class='btn btn-outline-secondary btn-sm' data-toggle>
-                <i class='ti ti-calendar-time'></i>
+                <i class='ti ti-calendar-time' aria-hidden='true'></i>
+                <span class='visually-hidden'>{$show_datepicker_label}</span>
             </button>
             $clear
          </div>
@@ -3545,10 +3546,12 @@ JAVASCRIPT
 
         // Back and fast backward button
         if (!$start == 0) {
-            $out .= "<th class='left'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=0" . htmlescape(jsescape($additional_params)) . "\");'>
-                     <i class='ti ti-chevrons-left' data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Start') . "\"></i></a></th>";
-            $out .= "<th class='left'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$back" . htmlescape(jsescape($additional_params)) . "\");'>
-                     <i class='ti ti-chevron-left' data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Previous') . "\"></i></a></th>";
+            $out .= "<th class='left'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=0" . htmlescape(jsescape($additional_params)) . "\");'
+                     data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Start') . "\">
+                     <i class='ti ti-chevrons-left' aria-hidden='true'></i></a></th>";
+            $out .= "<th class='left'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$back" . htmlescape(jsescape($additional_params)) . "\");'
+                     data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Previous') . "\">
+                     <i class='ti ti-chevron-left' aria-hidden='true'></i></a></th>";
         }
 
         $out .= "<td width='50%' class='tab_bg_2'>";
@@ -3567,10 +3570,12 @@ JAVASCRIPT
 
         // Forward and fast forward button
         if ($forward < $numrows) {
-            $out .= "<th class='right'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$forward" . htmlescape(jsescape($additional_params)) . "\");'>
-                     <i class='ti ti-chevron-right' data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Next') . "\"></i></a></th>";
-            $out .= "<th class='right'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$end" . htmlescape(jsescape($additional_params)) . "\");'>
-                     <i class='ti ti-chevrons-right' data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('End') . "\"></i></a></th>";
+            $out .= "<th class='right'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$forward" . htmlescape(jsescape($additional_params)) . "\");'
+                     data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('Next') . "\">
+                     <i class='ti ti-chevron-right' aria-hidden='true'></i></a></th>";
+            $out .= "<th class='right'><a class='btn btn-sm btn-icon btn-ghost-secondary' href='javascript:reloadTab(\"start=$end" . htmlescape(jsescape($additional_params)) . "\");'
+                     data-bs-toggle='tooltip' data-bs-placement='bottom' title=\"" . __s('End') . "\">
+                     <i class='ti ti-chevrons-right' aria-hidden='true'></i></a></th>";
         }
 
         // End pager

--- a/src/Html.php
+++ b/src/Html.php
@@ -2063,7 +2063,7 @@ TWIG,
                 || (isset($p['forcecreate']) && $p['forcecreate'])
             ) {
                 $out .= "<span class='btn btn-sm border-danger text-danger me-1'>
-                            <i class='ti ti-corner-left-down mt-1' style='margin-left: -2px;'></i>"
+                            <i class='ti ti-corner-left-down mt-1' style='margin-left: -2px;' aria-hidden='true'></i>"
                             . __s('Selection too large, massive action disabled.')
                         . "</span>";
                 if ($_SESSION['glpi_use_mode'] === Session::DEBUG_MODE) {
@@ -2118,7 +2118,7 @@ TWIG,
             }
             $out .= " href='#modal_massaction_content$identifier' title=\"" . htmlescape($p['title']) . "\">";
             if ($p['display_arrow']) {
-                $out .= "<i class='ti ti-corner-left-" . ($p['ontop'] ? 'down' : 'up') . " mt-1' style='margin-left: -2px;'></i>";
+                $out .= "<i class='ti ti-corner-left-" . ($p['ontop'] ? 'down' : 'up') . " mt-1' style='margin-left: -2px;' aria-hidden='true'></i>";
             }
             $out .= "<span>" . htmlescape($p['title']) . "</span>";
             $out .= "</a>";
@@ -2209,13 +2209,13 @@ TWIG,
         $calendar_tooltip = __s('Enter or select a date');
         $calendar_btn = $p['calendar_btn']
          ? "<button type='button' class='btn btn-outline-secondary btn-sm' data-toggle>
-                <i class='ti ti-calendar'></i>
+                <i class='ti ti-calendar' aria-hidden='true'></i>
                 <span class='visually-hidden'>" . $calendar_tooltip . "</span>
             </button>"
          : "";
         $clear_btn = $p['clear_btn'] && $p['maybeempty'] && $p['canedit']
          ? "<button type='button' class='btn btn-outline-secondary btn-sm' data-toggle data-clear title='" . __s('Clear') . "'>
-                    <i class='ti ti-circle-x'></i>
+                    <i class='ti ti-circle-x' aria-hidden='true'></i>
                 </button>"
          : "";
 
@@ -2405,7 +2405,7 @@ JS;
         $disabled = !$p['canedit'] ? " disabled='disabled'" : "";
         $clear    = $p['maybeempty'] && $p['canedit']
          ? "<button type='button' class='btn btn-outline-secondary btn-sm' data-toggle title='" . __s('Clear') . "'>
-                    <i class='ti ti-circle-x' data-clear></i>
+                    <i class='ti ti-circle-x' data-clear aria-hidden='true'></i>
                 </button>"
          : "";
 
@@ -2980,7 +2980,7 @@ JS;
                 $out .= "<img id='tooltip$rand' src='" . htmlescape($param['img']) . "'>";
             } else {
                 $class = htmlescape($param['awesome-class']);
-                $out .= "<span id='tooltip$rand' class='fas {$class} fa-fw'></span>";
+                $out .= "<span id='tooltip$rand' class='fas {$class} fa-fw' aria-hidden='true'></span>";
             }
 
             if ($has_wrapper) {
@@ -3447,7 +3447,7 @@ JAVASCRIPT
         $link =  $CFG_GLPI['root_doc'] . $url;
 
         echo sprintf(
-            '<a href="%1$s" %2$s target="_blank" style="margin-top:6px; display: block">%3$s <i class="ti ti-help"></i></a>',
+            '<a href="%1$s" %2$s target="_blank" style="margin-top:6px; display: block">%3$s <i class="ti ti-help" aria-hidden="true"></i></a>',
             htmlescape($link),
             !is_null($link_id) ? sprintf('id="%s"', htmlescape($link_id)) : '',
             __s('Available variables')
@@ -3726,11 +3726,11 @@ JAVASCRIPT
             echo "<th class='left'>";
             echo "<a href='" . htmlescape($fulltarget) . "&amp;start=0' class='btn btn-sm btn-ghost-secondary me-2'
                   title=\"" . __s('Start') . "\" data-bs-toggle='tooltip' data-bs-placement='top'>";
-            echo "<i class='ti ti-chevrons-left'></i>";
+            echo "<i class='ti ti-chevrons-left' aria-hidden='true'></i>";
             echo "</a>";
             echo "<a href='" . htmlescape($fulltarget) . "&amp;start=$back' class='btn btn-sm btn-ghost-secondary me-2'
                   title=\"" . __s('Previous') . "\" data-bs-toggle='tooltip' data-bs-placement='top'>";
-            echo "<i class='ti ti-chevron-left'></i>";
+            echo "<i class='ti ti-chevron-left' aria-hidden='true'></i>";
             echo "</a></th>";
         }
 
@@ -3791,11 +3791,11 @@ JAVASCRIPT
             echo "<th class='right'>";
             echo "<a href='" . htmlescape($fulltarget) . "&amp;start=$forward' class='btn btn-sm btn-ghost-secondary'
                   title=\"" . __s('Next') . "\" data-bs-toggle='tooltip' data-bs-placement='top'>
-               <i class='ti ti-chevron-right'></i>";
+               <i class='ti ti-chevron-right' aria-hidden='true'></i>";
             echo "</a>";
             echo "<a href='" . htmlescape($fulltarget) . "&amp;start=$end' class='btn btn-sm btn-ghost-secondary'
                   title=\"" . __s('End') . "\" data-bs-toggle='tooltip' data-bs-placement='top'>";
-            echo "<i class='ti ti-chevrons-right'></i>";
+            echo "<i class='ti ti-chevrons-right' aria-hidden='true'></i>";
             echo "</a>";
             echo "</th>";
         }
@@ -4538,7 +4538,7 @@ JS;
 
         $icon = "";
         if (isset($options['icon'])) {
-            $icon = sprintf('<i class="%s"></i>&nbsp;', htmlescape($options['icon']));
+            $icon = sprintf('<i class="%s" aria-hidden="true"></i>&nbsp;', htmlescape($options['icon']));
             unset($options['icon']);
         }
 

--- a/src/IPNetwork_Vlan.php
+++ b/src/IPNetwork_Vlan.php
@@ -143,7 +143,7 @@ class IPNetwork_Vlan extends CommonDBRelation
             echo "<input type='hidden' name='ipnetworks_id' value='$ID'>";
             Vlan::dropdown(['used' => $used]);
             echo "&nbsp;<button type='submit' name='add'"
-                      . " class='btn btn-primary'><i class='ti ti-link'></i><span>" . _sx('button', 'Associate') . "</span></button>";
+                      . " class='btn btn-primary'><i class='ti ti-link' aria-hidden='true'></i><span>" . _sx('button', 'Associate') . "</span></button>";
             echo "</td></tr>";
 
             echo "</table>";

--- a/src/Impact.php
+++ b/src/Impact.php
@@ -348,7 +348,7 @@ JS);
                             $path[] = htmlescape($node['label']);
                         }
                     }
-                    $separator = '<i class="ti ti-chevron-right"></i>';
+                    $separator = '<i class="ti ti-chevron-right" aria-hidden="true"></i>';
                     echo implode(" $separator ", $path);
 
                     echo '</div></td>';
@@ -1077,7 +1077,7 @@ HTML;
         echo '</div>'; // <div class="impact-side-select-itemtype">
 
         echo '<div class="impact-side-search">';
-        echo '<h4><i class="ti ti-chevron-left"></i><img><span></span></h4>';
+        echo '<h4><i class="ti ti-chevron-left" aria-hidden="true"></i><img><span></span></h4>';
         echo Html::input("impact-side-filter-assets", [
             'id' => 'impact-side-filter-assets',
             'placeholder' => __('Filter assets...'),
@@ -1087,7 +1087,7 @@ HTML;
         echo '<div class="impact-side-search-results"></div>';
 
         echo '<div class="impact-side-search-more">';
-        echo '<h4><i class="ti ti-chevron-down"></i>' . __s("More...") . '</h4>';
+        echo '<h4><i class="ti ti-chevron-down" aria-hidden="true"></i>' . __s("More...") . '</h4>';
         echo '</div>'; // <div class="impact-side-search-more">
 
         echo '<div class="impact-side-search-no-results">';
@@ -1153,20 +1153,20 @@ HTML;
         echo '</div>'; // div class="impact-side-panel">
 
         echo '<ul class="fs-1">';
-        echo '<li id="save_impact" title="' . __s("Save") . '"><i class="ti ti-device-floppy"></i></li>';
-        echo '<li id="impact_undo" class="impact-disabled" title="' . __s("Undo") . '"><i class="ti ti-arrow-back-up"></i></li>';
-        echo '<li id="impact_redo" class="impact-disabled" title="' . __s("Redo") . '"><i class="ti ti-arrow-forward-up"></i></li>';
+        echo '<li id="save_impact" title="' . __s("Save") . '"><i class="ti ti-device-floppy" aria-hidden="true"></i></li>';
+        echo '<li id="impact_undo" class="impact-disabled" title="' . __s("Undo") . '"><i class="ti ti-arrow-back-up" aria-hidden="true"></i></li>';
+        echo '<li id="impact_redo" class="impact-disabled" title="' . __s("Redo") . '"><i class="ti ti-arrow-forward-up" aria-hidden="true"></i></li>';
         echo '<li class="impact-separator"></li>';
-        echo '<li id="add_node" title="' . __s("Add asset") . '"><i class="ti ti-plus"></i></li>';
-        echo '<li id="add_edge" title="' . __s("Add relation") . '"><i class="ti ti-line"></i></li>';
-        echo '<li id="add_compound" title="' . __s("Add group") . '"><i class="ti ti-augmented-reality"></i></li>';
-        echo '<li id="delete_element" title="' . __s("Delete element") . '"><i class="ti ti-trash"></i></li>';
+        echo '<li id="add_node" title="' . __s("Add asset") . '"><i class="ti ti-plus" aria-hidden="true"></i></li>';
+        echo '<li id="add_edge" title="' . __s("Add relation") . '"><i class="ti ti-line" aria-hidden="true"></i></li>';
+        echo '<li id="add_compound" title="' . __s("Add group") . '"><i class="ti ti-augmented-reality" aria-hidden="true"></i></li>';
+        echo '<li id="delete_element" title="' . __s("Delete element") . '"><i class="ti ti-trash" aria-hidden="true"></i></li>';
         echo '<li class="impact-separator"></li>';
-        echo '<li id="export_graph" title="' . __s("Download") . '"><i class="ti ti-download"></i></li>';
-        echo '<li id="toggle_fullscreen" title="' . __s("Fullscreen") . '"><i class="ti ti-maximize"></i></li>';
-        echo '<li id="impact_settings" title="' . __s("Settings") . '"><i class="ti ti-adjustments"></i></li>';
+        echo '<li id="export_graph" title="' . __s("Download") . '"><i class="ti ti-download" aria-hidden="true"></i></li>';
+        echo '<li id="toggle_fullscreen" title="' . __s("Fullscreen") . '"><i class="ti ti-maximize" aria-hidden="true"></i></li>';
+        echo '<li id="impact_settings" title="' . __s("Settings") . '"><i class="ti ti-adjustments" aria-hidden="true"></i></li>';
         echo '</ul>';
-        echo '<span class="impact-side-toggle"><i class="ti ti-chevron-left"></i></span>';
+        echo '<span class="impact-side-toggle"><i class="ti ti-chevron-left" aria-hidden="true"></i></span>';
         echo '</div>'; // <div class="impact-side impact-side-expanded">
         echo "</td></tr>";
         echo "</table>";

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -2152,7 +2152,7 @@ HTML;
             Infocom::canApplyOn($itemtype)
             && static::canCreate()
         ) {
-            $actions[$action_name] = "<i class='" . htmlescape(self::getIcon()) . "'></i>"
+            $actions[$action_name] = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>"
                                   . __s('Enable the financial and administrative information');
         }
     }

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -791,7 +791,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                 ]);
             }
             echo "</td><td>";
-            echo "<button type='submit' class='btn btn-primary' name='add'><i class='ti ti-link'></i><span>" . _sx('button', 'Add') . "</span></button>";
+            echo "<button type='submit' class='btn btn-primary' name='add'><i class='ti ti-link' aria-hidden='true'></i><span>" . _sx('button', 'Add') . "</span></button>";
             echo "</td></tr></table>";
             Html::closeForm();
         }
@@ -808,7 +808,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
         ]);
 
         if ($canedit) {
-            echo "<button type='submit' class='btn btn-primary' name='updateall'><i class='ti ti-device-floppy'></i><span>"
+            echo "<button type='submit' class='btn btn-primary' name='updateall'><i class='ti ti-device-floppy' aria-hidden='true'></i><span>"
                 . _sx('button', 'Save') . "</span></button>";
 
             Html::closeForm();

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -911,7 +911,7 @@ class Item_Rack extends CommonDBRelation
         }
 
         if (!empty($icon)) {
-            $icon = "<i class='item_rack_icon " . htmlescape($icon) . "'></i>";
+            $icon = "<i class='item_rack_icon " . htmlescape($icon) . "' aria-hidden='true'></i>";
         }
 
         return "";

--- a/src/Item_Rack.php
+++ b/src/Item_Rack.php
@@ -875,10 +875,10 @@ class Item_Rack extends CommonDBRelation
                . (!empty($gs_item['url'])
                   ? "<a href='" . htmlescape($gs_item['url']) . "' class='itemrack_name' style='" . htmlescape($fg_color_s) . "'>" . htmlescape($gs_item['name']) . "</a>"
                   : "<span class='itemrack_name'>" . htmlescape($gs_item['name']) . "</span>") . "
-               <a href='" . htmlescape($gs_item['rel_url']) . "' class='edit_rack_item'>
+               <a href='" . htmlescape($gs_item['rel_url']) . "' class='edit_rack_item'
+                  title='" . __s("Edit rack relation") . "'>
                   <i class='fa fa-pencil-alt rel-link'
-                     style='" . htmlescape($fg_color_s) . "'
-                     title='" . __s("Edit rack relation") . "'></i>
+                     style='" . htmlescape($fg_color_s) . "' aria-hidden='true'></i>
                </a>
                $tip
             </div>

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -1016,7 +1016,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             echo "</div>";
             echo "<div class='col-auto'>";
             echo "<button type='submit' name='add' class='btn btn-primary ms-1'>";
-            echo "<i class='ti ti-link'></i>" . _sx('button', 'Install');
+            echo "<i class='ti ti-link' aria-hidden='true'></i>" . _sx('button', 'Install');
             echo "</button>";
             echo "</div>";
             echo "</div>"; // d-flex
@@ -1107,7 +1107,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             $header_end .= "<th>" . __s('Valid license') . "</th>";
             $header_end .= "<th>
                 <button class='btn btn-sm show_filters " . ($is_filtered ? "btn-secondary" : "btn-outline-secondary") . "'>
-                    <i class='ti ti-filter'></i>
+                    <i class='ti ti-filter' aria-hidden='true'></i>
                     <span class='d-none d-xl-block'>" . __s('Filter') . "</span>
                 </button></th>";
             $header_end .= "</tr>";
@@ -1226,7 +1226,7 @@ class Item_SoftwareVersion extends CommonDBRelation
             echo "</div>";
             echo "<div class='col-auto'>";
             echo "<button type='submit' name='add' class='btn btn-primary ms-1'>";
-            echo "<i class='ti ti-link'></i>" . _sx('button', 'Add');
+            echo "<i class='ti ti-link' aria-hidden='true'></i>" . _sx('button', 'Add');
             echo "</button>";
             echo "</div>";
             echo "</div>"; // d-flex

--- a/src/Itil_Project.php
+++ b/src/Itil_Project.php
@@ -200,7 +200,7 @@ class Itil_Project extends CommonDBRelation
                                     entity_restrict: entity_restrict
                                 }) }}
                                 <div>
-                                    <button class="btn btn-primary ms-3" type="submit" name="add" value=""><i class="ti ti-link"></i><span>{{ btn_msg }}</span></button>
+                                    <button class="btn btn-primary ms-3" type="submit" name="add" value=""><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_msg }}</span></button>
                                 </div>
                             </div>
                         </form>
@@ -340,7 +340,7 @@ TWIG, $twig_params);
                                 </div>
                                 <div class="col-auto">
                                     <button class="btn btn-primary ms-1" type="submit" name="add" value="">
-                                        <i class="ti ti-link"></i>
+                                        <i class="ti ti-link" aria-hidden="true"></i>
                                         {{ btn_msg }}
                                     </button>
                                 </div>

--- a/src/KnowbaseItem_Item.php
+++ b/src/KnowbaseItem_Item.php
@@ -326,7 +326,7 @@ class KnowbaseItem_Item extends CommonDBRelation
             $action_prefix = self::class . MassiveAction::CLASS_ACTION_SEPARATOR;
 
             $actions[$action_prefix . 'add']
-            = "<i class='" . htmlescape(self::getIcon()) . "'></i>"
+            = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>"
               . _sx('button', 'Link knowledgebase article');
         }
 

--- a/src/KnowbaseItem_KnowbaseItemCategory.php
+++ b/src/KnowbaseItem_KnowbaseItemCategory.php
@@ -143,7 +143,7 @@ class KnowbaseItem_KnowbaseItemCategory extends CommonDBRelation
             $action_prefix = self::class . MassiveAction::CLASS_ACTION_SEPARATOR;
 
             $actions[$action_prefix . 'add']
-            = "<i class='ma-icon ti ti-book'></i>"
+            = "<i class='ma-icon ti ti-book' aria-hidden='true'></i>"
               . _sx('button', 'Link knowledgebase article');
         }
 

--- a/src/Line.php
+++ b/src/Line.php
@@ -256,7 +256,7 @@ class Line extends CommonDBTM implements AssignableItemInterface, StateInterface
 
         $action_prefix = 'Item_Line' . MassiveAction::CLASS_ACTION_SEPARATOR;
         if (in_array($itemtype, $CFG_GLPI['line_types'], true)) {
-            $actions[$action_prefix . 'add']    = "<i class='" . htmlescape(self::getIcon()) . "'></i>"
+            $actions[$action_prefix . 'add']    = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>"
                 . _sx('button', 'Add a phone line');
             $actions[$action_prefix . 'remove'] = _sx('button', 'Remove a phone line');
         }

--- a/src/Link.php
+++ b/src/Link.php
@@ -562,13 +562,13 @@ class Link extends CommonDBTM
                 <div class="firstbloc">
                     {% if show_add %}
                         <a class="btn btn-primary ms-1" href="{{ 'ManualLink'|itemtype_form_path ~ '?itemtype=' ~ item.getType() ~ '&items_id=' ~ item.fields[item.getIndexName()] }}">
-                            <i class="ti ti-link"></i>
+                            <i class="ti ti-link" aria-hidden="true"></i>
                             <span>{{ add_msg }}</span>
                         </a>
                     {% endif %}
                     {% if show_configure %}
                         <a class="btn btn-primary ms-1" href="{{ 'Link'|itemtype_search_path }}">
-                            <i class="ti ti-settings"></i>
+                            <i class="ti ti-settings" aria-hidden="true"></i>
                             <span>{{ configure_msg }}</span>
                         </a>
                     {% endif %}
@@ -597,7 +597,7 @@ TWIG, $buttons_params);
 
                 if ($manuallink->canUpdateItem()) {
                     $actions .= '<a href="' . htmlescape(ManualLink::getFormURLWithID($row[$item->getIndexName()])) . '" title="' . _sx('button', 'Update') . '">';
-                    $actions .= '<i class="ti ti-edit"></i>';
+                    $actions .= '<i class="ti ti-edit" aria-hidden="true"></i>';
                     $actions .= '<span class="visually-hidden">' . _sx('button', 'Update') . '</span>';
                     $actions .= '</a>';
                 }
@@ -714,7 +714,7 @@ TWIG, $buttons_params);
                                  . "&itemtype=" . $item::class
                                  . "&id=" . $item->getID() . "&rank=$key";
                 $newlink         = '<a href="' . htmlescape($url) . '" target="_blank">';
-                $newlink        .= "<i class='fs-2 ti ti-link me-2'></i>";
+                $newlink        .= "<i class='fs-2 ti ti-link me-2' aria-hidden='true'></i>";
                 $linkname        = htmlescape(sprintf(__('%1$s #%2$s'), $name, $i));
                 $newlink        .= htmlescape(sprintf(__('%1$s: %2$s'), $linkname, $val));
                 $newlink        .= "</a>";

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -95,7 +95,7 @@ class Lock extends CommonGLPI
         // language=Twig
         $list_info_alert_template = <<<TWIG
             <div class="alert alert-info d-flex align-items-center" role="alert">
-                <i class="ti ti-info-circle fs-1"></i>
+                <i class="ti ti-info-circle fs-1" aria-hidden="true"></i>
                 <span class="ms-2">
                     <span class="alert-title">{{ alert_title }}</span>
                     <br>
@@ -1065,7 +1065,7 @@ TWIG, $twig_params);
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div>
-                    <i class='ti ti-corner-left-up mx-3'></i>
+                    <i class='ti ti-corner-left-up mx-3' aria-hidden='true'></i>
                     <a onclick="if ( markCheckboxes('lock_form') ) return false;" href='#'>{{ check_all_msg }}</a>
                     <span>/</span>
                     <a onclick="if ( unMarkCheckboxes('lock_form') ) return false;" href='#'>{{ uncheck_all_msg }}</a>

--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -171,7 +171,7 @@ class MailCollector extends CommonDBTM
     {
         $links = [];
         if (countElementsInTable(self::getTable()) > 0) {
-            $links["<i class='ti ti-list'></i>" . __s('Not imported emails')] = "/front/notimportedemail.php";
+            $links["<i class='ti ti-list' aria-hidden='true'></i>" . __s('Not imported emails')] = "/front/notimportedemail.php";
         }
         return $links;
     }

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -235,9 +235,9 @@ class ManualLink extends CommonDBChild
         if (str_starts_with($fields['icon'] ?? '', 'fa-')) {
             // Forces font family values to fallback on ".fab" family font if char is not available in ".fas" family.
             $html .= '<i class="fs-2 fa ' . htmlescape($fields['icon']) . '"'
-            . ' style="font-family:\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\';"></i>&nbsp;';
+            . ' style="font-family:\'Font Awesome 6 Free\', \'Font Awesome 6 Brands\';" aria-hidden="true"></i>&nbsp;';
         } elseif (str_starts_with($fields['icon'] ?? '', 'ti-')) {
-            $html .= '<i class="fs-2 ti ' . htmlescape($fields['icon']) . '"></i>&nbsp;';
+            $html .= '<i class="fs-2 ti ' . htmlescape($fields['icon']) . '" aria-hidden="true"></i>&nbsp;';
         }
         $html .= htmlescape(!empty($fields['name']) ? $fields['name'] : $fields['url']);
         $html .= '</a>';

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -583,7 +583,7 @@ class MassiveAction
             && !isAPI()
         ) {
             $actions[self::class . self::CLASS_ACTION_SEPARATOR . 'add_transfer_list']
-                  = "<i class='ti ti-corner-right-up'></i>"
+                  = "<i class='ti ti-corner-right-up' aria-hidden='true'></i>"
                     . _sx('button', 'Add to transfer list');
         }
     }
@@ -654,9 +654,9 @@ class MassiveAction
                 $actions[$self_pref . 'update'] = _sx('button', 'Update');
 
                 if ($cancreate && Toolbox::hasTrait($itemtype, Clonable::class)) {
-                    $actions[$self_pref . 'clone'] = "<i class='ti ti-copy'></i>" . _sx('button', 'Clone');
+                    $actions[$self_pref . 'clone'] = "<i class='ti ti-copy' aria-hidden='true'></i>" . _sx('button', 'Clone');
                     if ($item->maybeTemplate()) {
-                        $actions[$self_pref . 'create_template'] = "<i class='ti ti-copy'></i>" . _sx('button', 'Create template');
+                        $actions[$self_pref . 'create_template'] = "<i class='ti ti-copy' aria-hidden='true'></i>" . _sx('button', 'Create template');
                     }
                 }
             }
@@ -666,8 +666,8 @@ class MassiveAction
 
             global $CFG_GLPI;
             if ($canupdate && in_array($itemtype, $CFG_GLPI['assignable_types'], true)) {
-                $actions[$self_pref . 'associate_group'] = "<i class='ti-users-group'></i>" . _sx('button', 'Associate group');
-                $actions[$self_pref . 'dissociate_group'] = "<i class='ti-users-group'></i>" . _sx('button', 'Dissociate group');
+                $actions[$self_pref . 'associate_group'] = "<i class='ti-users-group' aria-hidden='true'></i>" . _sx('button', 'Associate group');
+                $actions[$self_pref . 'dissociate_group'] = "<i class='ti-users-group' aria-hidden='true'></i>" . _sx('button', 'Dissociate group');
             }
 
             CommonDBConnexity::getMassiveActionsForItemtype(
@@ -707,12 +707,12 @@ class MassiveAction
             // Amend comment for objects with a 'comment' field
             $item->getEmpty();
             if ($canupdate && isset($item->fields['comment'])) {
-                $actions[$self_pref . 'amend_comment'] = "<i class='ti ti-message-circle'></i>" . __s("Amend comment");
+                $actions[$self_pref . 'amend_comment'] = "<i class='ti ti-message-circle' aria-hidden='true'></i>" . __s("Amend comment");
             }
 
             // Add a note for objects with the UPDATENOTE rights
             if (Session::haveRight($item::$rightname, UPDATENOTE)) {
-                $actions[$self_pref . 'add_note'] = "<i class='ti ti-note'></i>" . __s("Add note");
+                $actions[$self_pref . 'add_note'] = "<i class='ti ti-note' aria-hidden='true'></i>" . __s("Add note");
             }
 
             // Plugin Specific actions

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -217,7 +217,7 @@ class Monitor extends CommonDBTM implements AssignableItemInterface, DCBreadcrum
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ma-icon fas fa-key'></i>"
+               => "<i class='ma-icon fas fa-key' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -275,7 +275,7 @@ class NetworkEquipment extends CommonDBTM implements AssignableItemInterface, DC
         if ($isadmin) {
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ti ti-key'></i>"
+               => "<i class='ti ti-key' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -725,7 +725,7 @@ class NetworkPort extends CommonDBChild
 
             echo "<div class='col-auto'>";
             echo "<button type='submit' name='add' value='1' class='btn btn-primary ms-1'>";
-            echo "<i class='ti ti-link'></i><span>" . _sx('button', 'Add') . "</span>";
+            echo "<i class='ti ti-link' aria-hidden='true'></i><span>" . _sx('button', 'Add') . "</span>";
             echo "</button>";
             echo "</div>";
 
@@ -1335,7 +1335,7 @@ class NetworkPort extends CommonDBChild
             $link = $asset->getLink();
         } else {
             $link = sprintf(
-                '<i class="%1$s"></i> %2$s </i>',
+                '<i class="%1$s" aria-hidden="true"></i> %2$s </i>',
                 htmlescape($asset->getIcon()),
                 $asset->getLink(),
             );
@@ -1842,7 +1842,7 @@ class NetworkPort extends CommonDBChild
 
         if ($equipment && $equipment->getFromDB($this->fields['items_id'])) {
             return sprintf(
-                '<i class="%1$s"></i> %2$s > <i class="%3$s"></i> %4$s',
+                '<i class="%1$s" aria-hidden="true"></i> %2$s > <i class="%3$s" aria-hidden="true"></i> %4$s',
                 htmlescape($equipment::getIcon()),
                 $equipment->getLink(),
                 htmlescape(self::getIcon()),

--- a/src/NetworkPort_Vlan.php
+++ b/src/NetworkPort_Vlan.php
@@ -146,7 +146,7 @@ class NetworkPort_Vlan extends CommonDBRelation
                             {{ fields.checkboxField('tagged', 0, tagged_label) }}
                         </div>
                         <div class="d-flex flex-row-reverse">
-                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link"></i><span>{{ btn_label }}</span></button>
+                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                         </div>
                     </form>
                 </div>

--- a/src/Notification_NotificationTemplate.php
+++ b/src/Notification_NotificationTemplate.php
@@ -163,7 +163,7 @@ TWIG, $twig_params);
 
             $tpl_link = $tpl->getLink();
             if (empty($tpl_link)) {
-                $tpl_link = "<i class='ti ti-alert-triangle red'></i>
+                $tpl_link = "<i class='ti ti-alert-triangle red' aria-hidden='true'></i>
                         <a href='" . htmlescape($notiftpl->getLinkUrl()) . "'>"
                          . __s("No template selected")
                       . "</a>";

--- a/src/ObjectLock.php
+++ b/src/ObjectLock.php
@@ -401,7 +401,7 @@ class ObjectLock extends CommonDBTM
                     {% set tooltip = is_locked ? locked_by_label|format(user_name, date) : text %}
 
                     <span class="badge {{ color }}" data-bs-toggle="tooltip" title="{{ tooltip }}">
-                        <i class="ti {{ icon }}"></i>
+                        <i class="ti {{ icon }}" aria-hidden="true"></i>
                         {{ text }}
                     </span>
 TWIG;

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -633,10 +633,10 @@ JAVASCRIPT;
                            style='color: " . htmlescape($fg_color) . ";'>" . htmlescape($pdu->getName()) . "
                         </a>
                      </span>
-                     <a href='" . htmlescape($rel->getLinkUrl()) . "' class='rel-link'>
+                     <a href='" . htmlescape($rel->getLinkUrl()) . "' class='rel-link'
+                        title='" . __s("Edit rack relation") . "'>
                         <i class='ti ti-pencil fa-rotate-270'
-                           style='color: " . htmlescape($fg_color) . ";'
-                           title='" . __s("Edit rack relation") . "'></i>
+                           style='color: " . htmlescape($fg_color) . ";' aria-hidden='true'></i>
                      </a>
                      $tip
                   </div>

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -452,7 +452,7 @@ class PDU_Rack extends CommonDBRelation
 
                     echo "<td>";
                     if ($pdu_m->getFromDB($pdu->fields['pdumodels_id'])) {
-                        echo "<i class='ti ti-bolt'></i>";
+                        echo "<i class='ti ti-bolt' aria-hidden='true'></i>";
                         echo htmlescape($pdu_m->fields['max_power']) . "W";
                     }
                     echo "</td>";
@@ -462,7 +462,7 @@ class PDU_Rack extends CommonDBRelation
             echo "</table>";
         }
         echo "<a id='add_pdu' class='btn btn-sm btn-ghost-secondary ms-auto mt-2'>";
-        echo "<i class='ti ti-plus'></i>";
+        echo "<i class='ti ti-plus' aria-hidden='true'></i>";
         echo "<span>" . _sx('button', "Add") . "</span>";
         echo "</a>";
         echo "</div>";
@@ -625,7 +625,7 @@ JAVASCRIPT;
                        gs-x='0' gs-y='$y'
                        style='background-color: " . htmlescape($bg_color) . "; color: " . htmlescape($fg_color) . ";'>
                   <div class='grid-stack-item-content' style='color: " . htmlescape($fg_color) . ";'>
-                     <i class='item_rack_icon ti ti-plug fa-rotate-270'></i>
+                     <i class='item_rack_icon ti ti-plug fa-rotate-270' aria-hidden='true'></i>
                      <span class='rotated_text'>
                         <a href='" . htmlescape($pdu->getLinkURL()) . "'
                            class='itemrack_name'

--- a/src/Peripheral.php
+++ b/src/Peripheral.php
@@ -198,7 +198,7 @@ class Peripheral extends CommonDBTM implements AssignableItemInterface, DCBreadc
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ti ti-key'></i>"
+               => "<i class='ti ti-key' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/Phone.php
+++ b/src/Phone.php
@@ -238,7 +238,7 @@ class Phone extends CommonDBTM implements AssignableItemInterface, StateInterfac
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ti ti-key'></i>"
+               => "<i class='ti ti-key' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -336,7 +336,7 @@ class Planning extends CommonGLPI
                     break;
 
             }
-            return $('<span><i class="itilstatus ' + classes + '"></i> ' + _.escape(option.text) + '</span>');
+            return $('<span><i class="itilstatus ' + classes + '" aria-hidden="true"></i> ' + _.escape(option.text) + '</span>');
         }
 JAVASCRIPT;
 
@@ -1140,7 +1140,7 @@ TWIG, $twig_params);
 
             echo "<div class='center'>";
             echo "<a href='" . htmlescape($url) . "' class='btn btn-outline-secondary'>"
-                . "<i class='ti ti-eye'></i>"
+                . "<i class='ti ti-eye' aria-hidden='true'></i>"
                 . "<span>" . __s("View this item in its context") . "</span>"
             . "</a>";
             echo "</div>";
@@ -1439,7 +1439,7 @@ TWIG, $twig_params);
         if (count($append_params) > 1) {
             $rand = mt_rand();
             echo "<a href='#' title=\"" . __s('Availability') . "\" data-bs-toggle='modal' data-bs-target='#planningcheck$rand'>";
-            echo "<i class='ti ti-calendar'></i>";
+            echo "<i class='ti ti-calendar' aria-hidden='true'></i>";
             echo "<span class='visually-hidden'>" . __s('Availability') . "</span>";
             echo "</a>";
             Ajax::createIframeModalWindow(

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2816,7 +2816,7 @@ class Plugin extends CommonDBTM
                     // Do not show actions if the plugins execution is suspended.
                     // These actions would require to load the plugin, we do not want this to happen.
                     return \sprintf(
-                        '<span class="text-info" data-bs-toggle="tooltip" title="%s"><i class="ti ti-info-circle-filled"></i></span>',
+                        '<span class="text-info" data-bs-toggle="tooltip" title="%s"><i class="ti ti-info-circle-filled" aria-hidden="true"></i></span>',
                         __s('The plugins maintenance actions are disabled when the plugins execution is suspended.')
                     );
                 }
@@ -2845,7 +2845,7 @@ class Plugin extends CommonDBTM
                     // Configuration button for activated or configurable plugins
                     $config_url = htmlescape("{$CFG_GLPI['root_doc']}/plugins/{$directory}/{$PLUGIN_HOOKS[Hooks::CONFIG_PAGE][$directory]}");
                     $output .= '<a href="' . $config_url . '" title="' . __s('Configure') . '">'
-                    . '<i class="ti ti-tool fs-2x"></i>'
+                    . '<i class="ti ti-tool fs-2x" aria-hidden="true"></i>'
                     . '<span class="visually-hidden">' . __s('Configure') . '</span>'
                     . '</a>'
                     . '&nbsp;';
@@ -3008,7 +3008,7 @@ class Plugin extends CommonDBTM
                 if (!empty($value)) {
                     $value = htmlescape($value);
                     return "<a href=\"" . $value . "\" target='_blank'>
-                     <i class='ti ti-external-link-alt fs-2x'></i><span class='visually-hidden'>$value</span>
+                     <i class='ti ti-external-link-alt fs-2x' aria-hidden='true'></i><span class='visually-hidden'>$value</span>
                   </a>";
                 }
                 return "&nbsp;";
@@ -3122,19 +3122,19 @@ class Plugin extends CommonDBTM
 
         if (Session::getCurrentInterface() === 'central' && Config::canUpdate()) {
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'install']
-            = "<i class='ti ti-folder-plus'></i>"
+            = "<i class='ti ti-folder-plus' aria-hidden='true'></i>"
             . __s('Install');
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'uninstall']
-            = "<i class='ti ti-folder-minus'></i>"
+            = "<i class='ti ti-folder-minus' aria-hidden='true'></i>"
             . __s('Uninstall');
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'enable']
-            = "<i class='ti ti-toggle-right-filled'></i>"
+            = "<i class='ti ti-toggle-right-filled' aria-hidden='true'></i>"
             . __s('Enable');
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'disable']
-            = "<i class='ti ti-toggle-left-filled'></i>"
+            = "<i class='ti ti-toggle-left-filled' aria-hidden='true'></i>"
             . __s('Disable');
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'clean']
-            = "<i class='ti ti-recycle'></i>"
+            = "<i class='ti ti-recycle' aria-hidden='true'></i>"
             . __s('Clean');
         }
 

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -359,7 +359,7 @@ class Printer extends CommonDBTM implements AssignableItemInterface, StateInterf
             Asset_PeripheralAsset::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);
             $actions += [
                 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add'
-               => "<i class='ti ti-key'></i>"
+               => "<i class='ti ti-key' aria-hidden='true'></i>"
                   . _sx('button', 'Add a license'),
             ];
             KnowbaseItem_Item::getMassiveActionsForItemtype($actions, self::class, false, $checkitem);

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -437,7 +437,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
         if (Session::getCurrentInterface() === 'central') {
             if (Item_Problem::canCreate()) {
                 $actions['Item_Problem' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item']
-                = "<i class='ti ti-plus'></i>"
+                = "<i class='ti ti-plus' aria-hidden='true'></i>"
                  . _sx('button', 'Add an item');
             }
 
@@ -1055,11 +1055,11 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                         ) {
                             foreach ($problem->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $name = '<i class="fs-4 ti ti-user text-muted me-1"></i>'
+                                    $name = '<i class="fs-4 ti ti-user text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
-                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1"></i>'
+                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape($d['alternative_email']);
                                 }
                             }
@@ -1070,7 +1070,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                             && count($problem->groups[CommonITILActor::REQUESTER])
                         ) {
                             foreach ($problem->groups[CommonITILActor::REQUESTER] as $d) {
-                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1"></i>'
+                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1" aria-hidden="true"></i>'
                                     . htmlescape(Dropdown::getDropdownName("glpi_groups", $d["groups_id"]));
                             }
                         }

--- a/src/Project.php
+++ b/src/Project.php
@@ -1443,7 +1443,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInter
                             {{ fields.dropdownItemsFromItemtypes('items_id', label, dropdown_params) }}
                         </div>
                         <div class="d-flex flex-row-reverse">
-                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link"></i><span>{{ btn_label }}</span></button>
+                            <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                         </div>
                     </form>
                 </div>

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1405,7 +1405,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             // language=Twig
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div class="mb-3">
-                    <a class="btn btn-primary" href="{{ 'ProjectTask'|itemtype_form_path }}?projecttasks_id={{ projecttasks_id }}&amp;projects_id={{ projects_id }}"><i class="ti ti-link"></i><span>{{ btn_label }}</span></a>
+                    <a class="btn btn-primary" href="{{ 'ProjectTask'|itemtype_form_path }}?projecttasks_id={{ projecttasks_id }}&amp;projects_id={{ projects_id }}"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></a>
                 </div>
 TWIG, $twig_params);
         }

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -123,7 +123,7 @@ class QueuedNotification extends CommonDBTM
         $actions = parent::getSpecificMassiveActions($checkitem);
 
         if ($isadmin && !$is_deleted) {
-            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'send'] = "<i class='ti ti-send'></i>" . _sx('button', 'Send');
+            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'send'] = "<i class='ti ti-send' aria-hidden='true'></i>" . _sx('button', 'Send');
         }
 
         return $actions;

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -476,7 +476,7 @@ class QueuedWebhook extends CommonDBChild
         }
         // Add a button to resend the webhook via ajax
         $btn_id = "resend-webhook-{$id}";
-        $badge .= "<button id='{$btn_id}' type='button' class='btn btn-outline-secondary btn-sm ms-1' data-id='{$id}'><i class='ti ti-send'></i>" . __s('Send') . "</button>";
+        $badge .= "<button id='{$btn_id}' type='button' class='btn btn-outline-secondary btn-sm ms-1' data-id='{$id}'><i class='ti ti-send' aria-hidden='true'></i>" . __s('Send') . "</button>";
         $badge .= Html::scriptBlock(<<<JS
             $("#{$btn_id}").click(function() {
                 var id = $(this).data('id');

--- a/src/RSSFeed.php
+++ b/src/RSSFeed.php
@@ -561,7 +561,7 @@ class RSSFeed extends CommonDBVisible implements ExtraVisibilityCriteria
         if (Toolbox::testWriteAccessToDirectory(GLPI_RSS_DIR) > 0) {
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div class="alert alert-danger">
-                    <i class="alert-icon ti ti-alert-triangle"></i>
+                    <i class="alert-icon ti ti-alert-triangle" aria-hidden="true"></i>
                     <div class="alert-title">{{ msg }}</div>
                 </div>
 TWIG, ['msg' => __('Check permissions to the directory: %s', GLPI_RSS_DIR)]);

--- a/src/Reminder.php
+++ b/src/Reminder.php
@@ -773,7 +773,7 @@ class Reminder extends CommonDBVisible implements
                         Html::convDateTime($data["end"])
                     );
                     $row['values'][] = sprintf(
-                        '<a href="%s" class="pointer float-end" title="%s"><i class="ti ti-bell"></i><span class="visually-hidden">%s</span></a>',
+                        '<a href="%s" class="pointer float-end" title="%s"><i class="ti ti-bell" aria-hidden="true"></i><span class="visually-hidden">%s</span></a>',
                         htmlescape(sprintf('%s/front/planning.php?date=%s&type=day', $CFG_GLPI['root_doc'], $date_url)),
                         htmlescape($planning_text),
                         __s('Planning')

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -550,7 +550,7 @@ class Reservation extends CommonDBChild
 
             $all = "<a class='btn btn-primary ms-2 view-all' href='reservation.php?reservationitems_id=0'>"
                . __s('View all items')
-               . "&nbsp;<i class='ti ti-eye'></i>"
+               . "&nbsp;<i class='ti ti-eye' aria-hidden='true'></i>"
             . "</a>";
         } else {
             $type = "";
@@ -1174,13 +1174,13 @@ HTML;
                 [$annee, $mois] = explode("-", $data["start_date"]);
                 $href = htmlescape($CFG_GLPI["root_doc"]) . "/front/reservation.php?reservationitems_id={$data['id']}&month=$mois&year=$annee";
                 $entry['planning'] = "<a href='$href' title='" . __s('See planning') . "'>";
-                $entry['planning'] .= "<i class='" . htmlescape(Planning::getIcon()) . "'></i>";
+                $entry['planning'] .= "<i class='" . htmlescape(Planning::getIcon()) . "' aria-hidden='true'></i>";
                 $entry['planning'] .= "<span class='visually-hidden'>" . __s('See planning') . "</span>";
                 $entry['planning'] .= "</a>";
             } elseif ($item instanceof CommonDBTM) {
                 $href = htmlescape($item::getFormURLWithID($item->getID()) . "&forcetab=Reservation$1&tab_params[defaultDate]={$data['start_date']}");
                 $entry['planning'] = "<a href='$href' title=\"" . __s('See planning') . "\">";
-                $entry['planning'] .= "<i class='" . htmlescape(Planning::getIcon()) . "'></i>";
+                $entry['planning'] .= "<i class='" . htmlescape(Planning::getIcon()) . "' aria-hidden='true'></i>";
                 $entry['planning'] .= "<span class='visually-hidden'>" . __s('See planning') . "</span>";
             }
             return $entry;
@@ -1279,16 +1279,16 @@ HTML;
                 }
             }
             if ($show_all || !$reservable) {
-                $actions[$action_prefix . 'enable'] = "<i class='" . htmlescape(self::getIcon()) . "'></i>" . __s('Authorize reservations');
+                $actions[$action_prefix . 'enable'] = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>" . __s('Authorize reservations');
             }
             if ($show_all || $reservable) {
-                $actions[$action_prefix . 'disable'] = "<i class='ti ti-calendar-off'></i>" . __s('Prohibit reservations');
+                $actions[$action_prefix . 'disable'] = "<i class='ti ti-calendar-off' aria-hidden='true'></i>" . __s('Prohibit reservations');
             }
             if ($show_all || ($reservable && !$available)) {
-                $actions[$action_prefix . 'available'] = "<i class='" . htmlescape(self::getIcon()) . "'></i>" . __s('Make available for reservations');
+                $actions[$action_prefix . 'available'] = "<i class='" . htmlescape(self::getIcon()) . "' aria-hidden='true'></i>" . __s('Make available for reservations');
             }
             if ($show_all || $available) {
-                $actions[$action_prefix . 'unavailable'] = "<i class='ti ti-calendar-off'></i>" . __s('Make unavailable for reservations');
+                $actions[$action_prefix . 'unavailable'] = "<i class='ti ti-calendar-off' aria-hidden='true'></i>" . __s('Make unavailable for reservations');
             }
         }
     }

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -339,7 +339,7 @@ class ReservationItem extends CommonDBChild
                 <input type="hidden" name="is_active" value="{{ reservable ? (toggle_state ? 0 : 1) : 1 }}">
                 {% if reservable %}
                     <button name="update" class="btn btn-{{ toggle_state ? 'danger' : 'primary' }} mx-1">
-                        <i class="{{ toggle_state ? 'ti ti-toggle-right' : 'ti ti-toggle-left' }} me-2"></i>
+                        <i class="{{ toggle_state ? 'ti ti-toggle-right' : 'ti ti-toggle-left' }} me-2" aria-hidden="true"></i>
                         {{ toggle_state_label }}
                     </button>
                     <input type="hidden" name="id" value="{{ id }}">
@@ -348,7 +348,7 @@ class ReservationItem extends CommonDBChild
                     </script>
                 {% endif %}
                 <button name="{{ toggle_reservable ? 'purge' : 'add' }}" class="btn btn-{{ toggle_reservable ? 'danger' : 'primary' }} mx-1">
-                    <i class="{{ toggle_reservable ? 'ti ti-ban' : 'ti ti-check' }} me-2"></i>
+                    <i class="{{ toggle_reservable ? 'ti ti-ban' : 'ti ti-check' }} me-2" aria-hidden="true"></i>
                     {{ toggle_reservable_label }}
                 </button>
             </form>
@@ -425,10 +425,10 @@ TWIG, $twig_params);
             {% if not reserve %}
                 <div id="makesearch" class="text-center mb-3">
                     <a class="btn btn-secondary" href="{{ path('front/reservation.php?reservationitems_id=0') }}">
-                        <i class="{{ 'Reservation'|itemtype_icon }} me-2"></i>{{ view_calendar_label }}
+                        <i class="{{ 'Reservation'|itemtype_icon }} me-2" aria-hidden="true"></i>{{ view_calendar_label }}
                     </a>
                     <button type="button" class="btn btn-secondary mw-100 d-inline-block text-truncate" onClick="$('#viewresasearch').toggleClass('d-none');$('#makesearch').toggleClass('d-none')">
-                        <i class="ti ti-search me-2"></i>{{ find_free_item_label }}
+                        <i class="ti ti-search me-2" aria-hidden="true"></i>{{ find_free_item_label }}
                     </button>
                 </div>
                 <div id="viewresasearch" class="d-none text-center">
@@ -677,7 +677,7 @@ TWIG, $twig_params);
         ]);
 
         if ($ok && Session::haveRight("reservation", self::RESERVEANITEM)) {
-            echo "<i class='ti ti-corner-left-up mx-3'></i>";
+            echo "<i class='ti ti-corner-left-up mx-3' aria-hidden='true'></i>";
             echo "<th colspan='" . ($showentity ? "5" : "4") . "'>";
             if (isset($_POST['reserve'])) {
                 echo Html::hidden('begin', ['value' => $_POST['reserve']["begin"]]);

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -646,10 +646,10 @@ class Rule extends CommonDBTM
             unset($actions[MassiveAction::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list']);
         }
         if ($isadmin) {
-            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule'] = "<i class='ti ti-arrows-vertical'></i>"
+            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'move_rule'] = "<i class='ti ti-arrows-vertical' aria-hidden='true'></i>"
                 . __s('Move');
         }
-        $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'export'] = "<i class='ti ti-file-download'></i>"
+        $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'export'] = "<i class='ti ti-file-download' aria-hidden='true'></i>"
             . _sx('button', 'Export');
 
         return $actions;
@@ -1093,7 +1093,7 @@ class Rule extends CommonDBTM
                 <div id="viewaction{{ rules_id }}{{ rand }}"></div>
                 {% if can_add_new_action %}
                     <div class="center mt-1 mb-3">
-                        <button type="button" name="add_action" class="btn btn-primary"><i class="ti ti-plus"></i><span>{{ btn_label }}</span></button>
+                        <button type="button" name="add_action" class="btn btn-primary"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                         <script>
                             $('button[name="add_action"]').on('click', () => {
                                 $('#viewaction{{ rules_id }}{{ rand }}').load('{{ path('ajax/viewsubitem.php')|e('js') }}', {{ ajax_params|json_encode|raw }});
@@ -1212,7 +1212,7 @@ TWIG, $twig_params);
             echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
                 <div id="viewcriteria{{ rules_id }}{{ rand }}"></div>
                 <div class="center mt-1 mb-3">
-                    <button type="button" name="add_criterion" class="btn btn-primary"><i class="ti ti-plus"></i><span>{{ btn_label }}</span></button>
+                    <button type="button" name="add_criterion" class="btn btn-primary"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                     <script>
                         $('button[name="add_criterion"]').on('click', () => {
                             $('#viewcriteria{{ rules_id }}{{ rand }}').load('{{ path('ajax/viewsubitem.php')|e('js') }}', {{ ajax_params|json_encode|raw }});
@@ -1948,7 +1948,7 @@ TWIG, $twig_params);
             foreach ($RuleCriterias->getRuleCriterias($this->fields['id']) as $RuleCriteria) {
                 $to_display = $this->getMinimalCriteria($RuleCriteria->fields);
                 $data['criteria'] .= '<span class="glpi-badge mb-1">'
-                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlescape', $to_display))
+                    . implode('<i class="ti ti-caret-right-filled mx-1" aria-hidden="true"></i>', array_map('htmlescape', $to_display))
                     . '</span><br />';
             }
         }
@@ -1960,7 +1960,7 @@ TWIG, $twig_params);
             foreach ($RuleAction->getRuleActions($this->fields['id']) as $RuleAction) {
                 $to_display = $this->getMinimalAction($RuleAction->fields);
                 $data['actions'] .= '<span class="glpi-badge mb-1">'
-                    . implode('<i class="ti ti-caret-right-filled mx-1"></i>', array_map('htmlescape', $to_display))
+                    . implode('<i class="ti ti-caret-right-filled mx-1" aria-hidden="true"></i>', array_map('htmlescape', $to_display))
                     . '</span><br />';
             }
         }
@@ -1984,7 +1984,7 @@ TWIG, $twig_params);
         }
 
         if ($can_edit) {
-            $data['sort'] = "<i class='ti ti-grip-horizontal grip-rule cursor-grab'></i>";
+            $data['sort'] = "<i class='ti ti-grip-horizontal grip-rule cursor-grab' aria-hidden='true'></i>";
         }
 
         return $data;

--- a/src/RuleCollection.php
+++ b/src/RuleCollection.php
@@ -685,7 +685,7 @@ HTML;
                         'content': reset_warning
                     }) }}
                 {% endif %}
-                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest"><i class="ti ti-stethoscope"></i> <span>{{ test_label }}</span></button>
+                <button type="button" class="btn btn-primary mx-1" data-bs-toggle="modal" data-bs-target="#allruletest"><i class="ti ti-stethoscope" aria-hidden="true"></i> <span>{{ test_label }}</span></button>
                 {% do call('Ajax::createIframeModalWindow', ['allruletest', test_url, {title: test_label}]) %}
                 {% if can_replay %}
                     <a class="btn btn-primary mx-1" role="button" href="{{ rule_class|itemtype_search_path }}?replay_rule=replay_rule">{{ replay_label }}</a>

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -97,17 +97,17 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
         $actions = parent::getSpecificMassiveActions($checkitem);
 
         $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'unset_default']
-                     = "<i class='ti ti-star'></i>" . __s('Unset as default');
+                     = "<i class='ti ti-star' aria-hidden='true'></i>" . __s('Unset as default');
         $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'change_count_method']
-                     = "<i class='ti ti-adjustments-alt'></i>" . __s('Change count method');
+                     = "<i class='ti ti-adjustments-alt' aria-hidden='true'></i>" . __s('Change count method');
         if (Session::haveRight(self::$rightname, UPDATE)) {
             // Everyone can create/update a private search but only users with permission to update can change visibility to public
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'change_visibility']
-                = "<i class='ti ti-eye-search'></i>" . __s('Change visibility');
+                = "<i class='ti ti-eye-search' aria-hidden='true'></i>" . __s('Change visibility');
         }
         if (Session::haveRight('transfer', READ)) {
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'change_entity']
-                     = "<i class='ti ti-corner-right-up'></i>" . __s('Change entity');
+                     = "<i class='ti ti-corner-right-up' aria-hidden='true'></i>" . __s('Change entity');
         }
         return $actions;
     }

--- a/src/Software.php
+++ b/src/Software.php
@@ -248,7 +248,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             && (countElementsInTable("glpi_rules", ['sub_type' => 'RuleSoftwareCategory']) > 0)
         ) {
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'compute_software_category']
-            = "<i class='ti ti-calculator'></i>"
+            = "<i class='ti ti-calculator' aria-hidden='true'></i>"
               . __s('Recalculate the category');
         }
 
@@ -257,7 +257,7 @@ class Software extends CommonDBTM implements TreeBrowseInterface, AssignableItem
             && (countElementsInTable("glpi_rules", ['sub_type' => 'RuleDictionnarySoftware']) > 0)
         ) {
             $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'replay_dictionnary']
-            = "<i class='ti ti-arrow-back-up'></i>"
+            = "<i class='ti ti-arrow-back-up' aria-hidden='true'></i>"
               . __s('Replay the dictionary rules');
         }
 

--- a/src/SoftwareLicense.php
+++ b/src/SoftwareLicense.php
@@ -838,7 +838,7 @@ class SoftwareLicense extends CommonTreeDropdown implements AssignableItemInterf
         $actions = parent::getSpecificMassiveActions($checkitem);
         if (static::canUpdate()) {
             $prefix                       = 'Item_SoftwareLicense' . MassiveAction::CLASS_ACTION_SEPARATOR;
-            $actions[$prefix . 'add_item']  = "<i class='ti ti-package'></i>" . _sx('button', 'Add an item');
+            $actions[$prefix . 'add_item']  = "<i class='ti ti-package' aria-hidden='true'></i>" . _sx('button', 'Add an item');
         }
 
         return $actions;

--- a/src/SoftwareLicense_User.php
+++ b/src/SoftwareLicense_User.php
@@ -189,7 +189,7 @@ class SoftwareLicense_User extends CommonDBRelation
                                 used: used,
                             }) }}
                             {% set btn %}
-                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link"></i><span>{{ btn_label }}</span></button>
+                                <button type="submit" name="add" class="btn btn-primary"><i class="ti ti-link" aria-hidden="true"></i><span>{{ btn_label }}</span></button>
                             {% endset %}
                             {{ fields.htmlField('', btn, null) }}
                         </div>

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -637,7 +637,7 @@ class Stat extends CommonGLPI
                         ]
                     );
                     $link = "<a href='" . htmlescape($url) . "' title='" . __s('View graph') . "'>"
-                      . "<i class='ti ti-graph fs-1'></i>"
+                      . "<i class='ti ti-graph fs-1' aria-hidden='true'></i>"
                       . "</a>";
                 }
                 $html_output .= $output::showItem($link, $item_num, $row_num);

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -145,9 +145,9 @@ class Supplier extends CommonDBTM
         $actions = parent::getSpecificMassiveActions($checkitem);
         if ($isadmin) {
             $actions['Contact_Supplier' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-               = "<i class='" . htmlescape(Contact::getIcon()) . "'></i>" . _sx('button', 'Add a contact');
+               = "<i class='" . htmlescape(Contact::getIcon()) . "' aria-hidden='true'></i>" . _sx('button', 'Add a contact');
             $actions['Contract_Supplier' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-               = "<i class='" . htmlescape(Contract::getIcon()) . "'></i>" . _sx('button', 'Add a contract');
+               = "<i class='" . htmlescape(Contract::getIcon()) . "' aria-hidden='true'></i>" . _sx('button', 'Add a contract');
         }
         return $actions;
     }
@@ -395,7 +395,7 @@ class Supplier extends CommonDBTM
             if ($website_url !== '') {
                 $ret .= "<a class='btn btn-icon btn-outline-secondary' href='" . htmlescape($website_url) . "'
                     target='_blank' title=\"" . __s('Web') . "\">
-                    <i class='ti ti-world' ></i>
+                    <i class='ti ti-world' aria-hidden='true' ></i>
                     </a>";
             }
         }

--- a/src/Telemetry.php
+++ b/src/Telemetry.php
@@ -491,7 +491,7 @@ class Telemetry extends CommonGLPI
                 "
                     <a href='" . htmlescape(GLPI_TELEMETRY_URI . "/reference?showmodal&uuid=" . self::getRegistrationUuid()) . "'
                        class='btn btn-sm btn-info' target='_blank'>
-                        <i class='ti ti-writing-sign me-1'></i>
+                        <i class='ti ti-writing-sign me-1' aria-hidden='true'></i>
                         %s
                     </a>
                 ",

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -2085,34 +2085,34 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
         if (Session::getCurrentInterface() === 'central') {
             if (Ticket::canUpdate() && Ticket::canDelete()) {
                 $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'merge_as_followup']
-                 = "<i class='ti ti-git-merge'></i>"
+                 = "<i class='ti ti-git-merge' aria-hidden='true'></i>"
                  . __s('Merge as Followup');
             }
 
             if (Item_Ticket::canCreate()) {
                 $actions['Item_Ticket' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_item']
-                = "<i class='ti ti-plus'></i>"
+                = "<i class='ti ti-plus' aria-hidden='true'></i>"
                  . _sx('button', 'Add an item');
             }
 
             if (ITILFollowup::canCreate()) {
                 $icon = ITILFollowup::getIcon();
                 $actions['ITILFollowup' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_followup']
-                = "<i class='" . htmlescape($icon) . "'></i>"
+                = "<i class='" . htmlescape($icon) . "' aria-hidden='true'></i>"
                  . __s('Add a new followup');
             }
 
             if (TicketTask::canCreate()) {
                 $icon = TicketTask::getIcon();
                 $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_task']
-                = "<i class='" . htmlescape($icon) . "'></i>"
+                = "<i class='" . htmlescape($icon) . "' aria-hidden='true'></i>"
                  . __s('Add a new task');
             }
 
             if (TicketValidation::canCreate()) {
                 $icon = TicketValidation::getIcon();
                 $actions['TicketValidation' . MassiveAction::CLASS_ACTION_SEPARATOR . 'submit_validation']
-                = "<i class='" . htmlescape($icon) . "'></i>"
+                = "<i class='" . htmlescape($icon) . "' aria-hidden='true'></i>"
                  . __s('Approval request');
             }
 
@@ -2122,16 +2122,16 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
             }
 
             if (Session::haveRight(self::$rightname, UPDATE)) {
-                $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_actor'] = "<i class='ti ti-user'></i>" . __s('Add an actor');
+                $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_actor'] = "<i class='ti ti-user' aria-hidden='true'></i>" . __s('Add an actor');
                 $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'update_notif'] = __s('Set notifications for all actors');
                 if (ProjectTask_Ticket::canCreate()) {
                     $actions['ProjectTask_Ticket' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-                        = "<i class='ti ti-link'></i>"
+                        = "<i class='ti ti-link' aria-hidden='true'></i>"
                         . _sx('button', 'Link project task');
                 }
                 if (Ticket_Contract::canCreate()) {
                     $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_contract']
-                        = "<i class='" . Contract::getIcon() . "'></i>"
+                        = "<i class='" . Contract::getIcon() . "' aria-hidden='true'></i>"
                         . _sx('button', 'Add contract');
                 }
 
@@ -2140,7 +2140,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
 
             if (self::canUpdate()) {
                 $actions[static::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'resolve_tickets']
-                = "<i class='ti ti-check'></i>"
+                = "<i class='ti ti-check' aria-hidden='true'></i>"
                 . __s("Resolve selected tickets");
             }
         }
@@ -4457,11 +4457,11 @@ JAVASCRIPT;
                         ) {
                             foreach ($job->users[CommonITILActor::REQUESTER] as $d) {
                                 if ($d["users_id"] > 0) {
-                                    $name = '<i class="fs-4 ti ti-user text-muted me-1"></i>'
+                                    $name = '<i class="fs-4 ti ti-user text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape(getUserName($d["users_id"]));
                                     $requesters[] = $name;
                                 } else {
-                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1"></i>'
+                                    $requesters[] = '<i class="fs-4 ti ti-mail text-muted me-1" aria-hidden="true"></i>'
                                         . htmlescape($d['alternative_email']);
                                 }
                             }
@@ -4472,7 +4472,7 @@ JAVASCRIPT;
                             && count($job->groups[CommonITILActor::REQUESTER])
                         ) {
                             foreach ($job->groups[CommonITILActor::REQUESTER] as $d) {
-                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1"></i>'
+                                $requesters[] = '<i class="fs-4 ti ti-users text-muted me-1" aria-hidden="true"></i>'
                                     . htmlescape(Dropdown::getDropdownName("glpi_groups", $d["groups_id"]));
                             }
                         }

--- a/src/Ticket_Contract.php
+++ b/src/Ticket_Contract.php
@@ -129,7 +129,7 @@ class Ticket_Contract extends CommonDBRelation
                                 nochecklimit: true
                             }) }}
                             {% set btn %}
-                                <button type="submit" class="btn btn-primary" name="add"><i class="ti ti-link me-1"></i>{{ btn_label }}</button>
+                                <button type="submit" class="btn btn-primary" name="add"><i class="ti ti-link me-1" aria-hidden="true"></i>{{ btn_label }}</button>
                             {% endset %}
                             {{ fields.htmlField('', btn, null) }}
                         </div>

--- a/src/User.php
+++ b/src/User.php
@@ -182,10 +182,10 @@ class User extends CommonDBTM implements TreeBrowseInterface
         if (Auth::useAuthExt() && Session::haveRight('user', self::IMPORTEXTAUTHUSERS)) {
             if (static::canCreate()) {
                 $ext_auth_label = __s('Add from an external source');
-                $links['<i class="ti ti-user-cog"></i><span>' . $ext_auth_label . '</span>'] = 'front/user.form.php?new=1&ext_auth=1';
+                $links['<i class="ti ti-user-cog" aria-hidden="true"></i><span>' . $ext_auth_label . '</span>'] = 'front/user.form.php?new=1&ext_auth=1';
             }
             if (static::canCreate() || static::canUpdate()) {
-                $links['<i class="ti ti-settings"></i><span>' . __s('LDAP directory link') . '</span>'] = "front/ldap.php";
+                $links['<i class="ti ti-settings" aria-hidden="true"></i><span>' . __s('LDAP directory link') . '</span>'] = "front/ldap.php";
             }
         }
         return $links;
@@ -2968,7 +2968,7 @@ class User extends CommonDBTM implements TreeBrowseInterface
                      class="btn btn-icon btn-sm btn-ghost-secondary"
                      title="{$vcard_lbl}"
                      data-bs-toggle="tooltip" data-bs-placement="bottom">
-               <i class="ti ti-id fs-2"></i>
+               <i class="ti ti-id fs-2" aria-hidden="true"></i>
             </a>
 HTML;
             $toolbar[] = $vcard_btn;
@@ -2984,7 +2984,7 @@ HTML;
                             class="btn btn-icon btn-sm btn-ghost-secondary btn-impersonate"
                             title="{$impersonate_lbl}"
                             data-bs-toggle="tooltip" data-bs-placement="bottom">
-                            <i class="ti ti-spy fs-2"></i>
+                            <i class="ti ti-spy fs-2" aria-hidden="true"></i>
                         </button>
                     </form>
 HTML;
@@ -3009,7 +3009,7 @@ JAVASCRIPT;
                        class="btn btn-icon btn-sm  btn-ghost-danger btn-impersonate"
                        title="{$error_message}"
                        data-bs-toggle="tooltip" data-bs-placement="bottom">
-                  <i class="ti ti-spy fs-2"></i>
+                  <i class="ti ti-spy fs-2" aria-hidden="true"></i>
                </button>
 HTML;
                 $toolbar[] = $impersonate_btn;
@@ -3260,34 +3260,34 @@ HTML;
 
         if ($isadmin) {
             $actions['Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-                                                         = "<i class='ti ti-users-plus'></i>"
+                                                         = "<i class='ti ti-users-plus' aria-hidden='true'></i>"
                                                            . __s('Associate to a group');
             $actions['Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'remove']
-                                                         = "<i class='ti ti-users-minus'></i>"
+                                                         = "<i class='ti ti-users-minus' aria-hidden='true'></i>"
                                                            . __s('Dissociate from a group');
             $actions['Profile_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'add']
-                                                         = "<i class='ti ti-shield-plus'></i>"
+                                                         = "<i class='ti ti-shield-plus' aria-hidden='true'></i>"
                                                            . __s('Associate to a profile');
             $actions['Profile_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'remove']
-                                                         = "<i class='ti ti-shield-minus'></i>"
+                                                         = "<i class='ti ti-shield-minus' aria-hidden='true'></i>"
                                                            . __s('Dissociate from a profile');
             $actions['Group_User' . MassiveAction::CLASS_ACTION_SEPARATOR . 'change_group_user']
-                                                         = "<i class='ti ti-users-group'></i>"
+                                                         = "<i class='ti ti-users-group' aria-hidden='true'></i>"
                                                            . __s("Move to group");
             $actions["{$prefix}delete_emails"] = __s("Delete associated emails");
         }
 
         if (Session::haveRight(self::$rightname, self::UPDATEAUTHENT)) {
-            $actions[$prefix . 'change_authtype']        = "<i class='ti ti-user-cog'></i>"
+            $actions[$prefix . 'change_authtype']        = "<i class='ti ti-user-cog' aria-hidden='true'></i>"
                                                       . _sx('button', 'Change the authentication method');
-            $actions[$prefix . 'force_user_ldap_update'] = "<i class='ti ti-refresh'></i>"
+            $actions[$prefix . 'force_user_ldap_update'] = "<i class='ti ti-refresh' aria-hidden='true'></i>"
                                                       . __s('Force synchronization');
-            $actions[$prefix . 'clean_ldap_fields'] = "<i class='ti ti-recycle'></i>"
+            $actions[$prefix . 'clean_ldap_fields'] = "<i class='ti ti-recycle' aria-hidden='true'></i>"
                                                     . __s('Clean LDAP fields and force synchronisation');
-            $actions[$prefix . 'disable_2fa']           = "<i class='ti ti-shield-off'></i>"
+            $actions[$prefix . 'disable_2fa']           = "<i class='ti ti-shield-off' aria-hidden='true'></i>"
                                                       . __s('Disable 2FA');
-            $actions[$prefix . 'send_pw_reset'] = "<i class='ti ti-mail'></i>" . __s('Send password reset email');
-            $actions[$prefix . 'reapply_rights']            = "<i class='" . htmlescape(Profile::getIcon()) . "'></i>"
+            $actions[$prefix . 'send_pw_reset'] = "<i class='ti ti-mail' aria-hidden='true'></i>" . __s('Send password reset email');
+            $actions[$prefix . 'reapply_rights']            = "<i class='" . htmlescape(Profile::getIcon()) . "' aria-hidden='true'></i>"
                                                       . __s('Reapply authorization assignment rules');
         }
         return $actions;
@@ -4752,7 +4752,7 @@ HTML;
             );
             $icons .= "<span title=\"" . __s('Import a user') . "\""
             . " data-bs-toggle='modal' data-bs-target='#userimport{$rand}'>
-            <i class='ti ti-plus'></i>
+            <i class='ti ti-plus' aria-hidden='true'></i>
             <span class='visually-hidden'>" . __s('Import a user') . "</span>
          </span>";
             $icons .= '</div>';

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -355,9 +355,9 @@ class Webhook extends CommonDBTM implements FilterableInterface
     public static function getStatusIcon($status): string
     {
         if ($status) {
-            return '<i class="ti ti-alert-triangle icon-pulse fs-2" style="color: #ff0000;"></i>';
+            return '<i class="ti ti-alert-triangle icon-pulse fs-2" style="color: #ff0000;" aria-hidden="true"></i>';
         } else {
-            return '<i class="ti ti-circle-check icon-pulse fs-2" style="color: #36d601;"></i>';
+            return '<i class="ti ti-circle-check icon-pulse fs-2" style="color: #36d601;" aria-hidden="true"></i>';
         }
     }
 

--- a/templates/central/lists/itemtype_count.html.twig
+++ b/templates/central/lists/itemtype_count.html.twig
@@ -36,7 +36,7 @@
    {% endif %}
          <span>
             {% if value.icon is defined %}
-               <i class="{{ value.icon }}"></i>
+               <i class="{{ value.icon }}" aria-hidden="true"></i>
             {% endif %}
             {{ value.text }}
          </span>

--- a/templates/central/lists/table.html.twig
+++ b/templates/central/lists/table.html.twig
@@ -36,7 +36,7 @@
         <span class="float-end">
             {% if add_link is not empty %}
                 <a href="{{ add_link }}" title="{{ __('Add') }}">
-                    <i class="ti ti-plus"></i>
+                    <i class="ti ti-plus" aria-hidden="true"></i>
                 </a>
             {% endif %}
         </span>

--- a/templates/central/messages.html.twig
+++ b/templates/central/messages.html.twig
@@ -33,7 +33,7 @@
 <div class="message-area">
    {% if messages.errors is defined and messages.errors|length > 0 %}
       <div class="alert alert-important alert-danger d-flex" role="alert">
-         <i class="ti ti-alert-triangle fs-3x"></i>
+         <i class="ti ti-alert-triangle fs-3x" aria-hidden="true"></i>
          <ul>
             {% for error in messages.errors %}
                <li>{{ error|raw }}</li>
@@ -43,7 +43,7 @@
    {% endif %}
    {% if messages.warnings is defined and messages.warnings|length > 0 %}
       <div class="alert alert-important alert-warning d-flex" role="alert">
-         <i class="ti ti-alert-triangle fs-3x"></i>
+         <i class="ti ti-alert-triangle fs-3x" aria-hidden="true"></i>
          <ul>
             {% for warning in messages.warnings %}
                <li>{{ warning|raw }}</li>
@@ -53,7 +53,7 @@
    {% endif %}
    {% if messages.infos is defined and messages.infos|length > 0 %}
       <div class="alert alert-important alert-info d-flex" role="alert">
-         <i class="ti ti-info-circle fs-3x"></i>
+         <i class="ti ti-info-circle fs-3x" aria-hidden="true"></i>
          <ul>
             {% for info in messages.infos %}
                <li>{{ info|raw }}</li>

--- a/templates/components/dashboard/reset.html.twig
+++ b/templates/components/dashboard/reset.html.twig
@@ -45,7 +45,7 @@
         </div>
         <div class="flex-row-reverse">
             <button type="button" class="btn btn-danger" name="confirm-reset-dashboard">
-                <i class="ti ti-refresh-alert me-1 alert-icon"></i>
+                <i class="ti ti-refresh-alert me-1 alert-icon" aria-hidden="true"></i>
                 {{ __('Reset to default') }}
             </button>
         </div>

--- a/templates/components/dashboard/widget_form.html.twig
+++ b/templates/components/dashboard/widget_form.html.twig
@@ -226,10 +226,10 @@
    <div class="modal-footer">
       <button type="submit" class="btn btn-primary {{ edit ? 'edit-widget' : 'add-widget' }}">
          {% if edit %}
-            <i class="ti ti-device-floppy"></i>
+            <i class="ti ti-device-floppy" aria-hidden="true"></i>
             <span>{{ _x('button', 'Update') }}</span>
          {% else %}
-            <i class="ti ti-plus"></i>
+            <i class="ti ti-plus" aria-hidden="true"></i>
             <span>{{ _x('button', 'Add') }}</span>
          {% endif %}
       </button>

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -180,7 +180,7 @@
                             <th scope="col">
                                 {% if not nosort and not (column is array and column['nosort'] is defined) %}
                                     <a href="{{ sort_href }}">
-                                    <i class="{{ sort_icon }}"></i>
+                                    <i class="{{ sort_icon }}" aria-hidden="true"></i>
                                 {% endif %}
                                 <span>{{ raw_header ? column_label|raw : column_label }}</span>
                                 {% if not nosort and not (column is array and column['nosort'] is defined) %}
@@ -194,13 +194,13 @@
                                <span class="float-end log-toolbar mb-0">
                                    {% if nofilter is not defined %}
                                        <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
-                                           <i class="ti ti-filter"></i>
+                                           <i class="ti ti-filter" aria-hidden="true"></i>
                                            <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                                        </button>
                                    {% endif %}
                                    {% if csv_url|length %}
                                        <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
-                                           <i class="ti ti-download"></i>
+                                           <i class="ti ti-download" aria-hidden="true"></i>
                                            <span class="d-none d-xl-block">{{ __('Export') }}</span>
                                        </a>
                                    {% endif %}
@@ -366,7 +366,7 @@
                                             {% endif %}
                                         {% elseif formatter == 'yesno' %}
                                             {% if entry[colkey] == 1 %}
-                                                <div aria-label="{{ __('Yes') }}"><i class="ti ti-circle-check"></i></div>
+                                                <div aria-label="{{ __('Yes') }}"><i class="ti ti-circle-check" aria-hidden="true"></i></div>
                                             {% else %}
                                                 <div aria-label="{{ __('No') }}"></div>
                                             {% endif %}

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -296,13 +296,13 @@
         {% if editable and options.addCalendarButton %}
             {% set calendar_icon = options.enableTime ? 'ti ti-calendar-time' : 'ti ti-calendar' %}
             <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
-                <i class="{{ calendar_icon }}"></i>
+                <i class="{{ calendar_icon }}" aria-hidden="true"></i>
                 <span class="visually-hidden">{{ __('Enter or select a date') }}</span>
             </button>
             {# maybeempty has no distinct purpose, but it was here first #}
             {% if options.clearable or options.maybeempty %}
                 <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="tooltip" data-bs-placement="bottom" data-clear title="{{ __('Clear') }}">
-                    <i class="ti ti-circle-x"></i>
+                    <i class="ti ti-circle-x" aria-hidden="true"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/templates/components/form/buttons.html.twig
+++ b/templates/components/form/buttons.html.twig
@@ -51,7 +51,7 @@
                   value="1"
                   aria-label="{{ _x('button', 'Add') }}"
                >
-                  <i class="ti ti-plus"></i>
+                  <i class="ti ti-plus" aria-hidden="true"></i>
                   <span>{{ _x('button', 'Add') }}</span>
                </button>
             {% else %}
@@ -62,7 +62,7 @@
                   value="1"
                   aria-label="{{ _x('button', 'Save') }}"
                >
-                  <i class="ti ti-device-floppy"></i>
+                  <i class="ti ti-device-floppy" aria-hidden="true"></i>
                   <span>{{ _x('button', 'Save') }}</span>
                </button>
             {% endif %}
@@ -79,7 +79,7 @@
                   value="1"
                   aria-label="{{ _x('button', 'Save') }}"
                >
-                  <i class="ti ti-device-floppy"></i>
+                  <i class="ti ti-device-floppy" aria-hidden="true"></i>
                   <span>{{ _x('button', 'Save') }}</span>
                </button>
             {% endif %}
@@ -94,7 +94,7 @@
                         value="1"
                         aria-label="{{ _x('button', 'Restore') }}"
                      >
-                        <i class="ti ti-trash-off"></i>
+                        <i class="ti ti-trash-off" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Restore') }}</span>
                      </button>
                   {% endif %}
@@ -117,7 +117,7 @@
                            onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
                            aria-label="{{ _x('button', 'Delete permanently') }}"
                         >
-                           <i class="ti ti-trash"></i>
+                           <i class="ti ti-trash" aria-hidden="true"></i>
                            <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                         {% if show_keep_devices %}
@@ -143,7 +143,7 @@
                            value="1"
                            aria-label="{{ _x('button', 'Delete permanently') }}"
                         >
-                           <i class="ti ti-trash"></i>
+                           <i class="ti ti-trash" aria-hidden="true"></i>
                            <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                      {% endif %}
@@ -155,7 +155,7 @@
                         value="1"
                         aria-label="{{ _x('button', 'Put in trashbin') }}"
                      >
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Put in trashbin') }}</span>
                      </button>
                   {% endif %}
@@ -181,7 +181,7 @@
                <button class="btn {{ val.btn_class ?? 'btn-outline-secondary' }} me-2 {{ val.add_class ?? '' }}" type="{{ val.type ?? 'submit' }}" name="{{ key }}" value="1" title="{{ val.title ?? '' }}" onclick="{{ val.onclick ?? '' }}" {{ extra_attribs|raw }}>
                   {% if val is iterable %}
                      {% if val.icon is defined %}
-                        <i class="{{ val.icon }}"></i>
+                        <i class="{{ val.icon }}" aria-hidden="true"></i>
                      {% endif %}
                      <span>{{ val.text|default('') }}</span>
                   {% else %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -41,7 +41,7 @@
          <h4 class="card-title {{ icon|length ? 'ms-5' : '' }}">
             {% if icon|length %}
                <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-                  <i class="fs-2x {{ icon }}"></i>
+                  <i class="fs-2x {{ icon }}" aria-hidden="true"></i>
                </div>
             {% endif %}
             {{ label }}
@@ -66,7 +66,7 @@
          <h{{ level }} class="card-subtitle fs-4 {{ icon|length ? 'ms-4' : '' }}">
             {% if icon|length %}
                <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-                  <i class="fs-2x {{ icon }}"></i>
+                  <i class="fs-2x {{ icon }}" aria-hidden="true"></i>
                </div>
             {% endif %}
              <span class="ms-2">{{ label }}</span>
@@ -396,7 +396,7 @@
              {%- endset -%}
             <button type="button" class="btn p-2 position-absolute top-0 start-0" title="{{ __('Delete') }}"
                     onclick="{{ clear_js }}">
-               <i class="ti ti-x"></i>
+               <i class="ti ti-x" aria-hidden="true"></i>
             </button>
          {% endif %}
       </div>

--- a/templates/components/form/file_uploader.html.twig
+++ b/templates/components/form/file_uploader.html.twig
@@ -39,10 +39,10 @@
            class="visually-hidden"
            data-glpi-file-uploader-input>
     <div class="file-uploader-dropzone-content">
-        <i class="ti ti-cloud-upload file-uploader-dropzone-icon"></i>
+        <i class="ti ti-cloud-upload file-uploader-dropzone-icon" aria-hidden="true"></i>
         <p class="file-uploader-dropzone-title">{{ __('Drop files here or click to browse') }}</p>
         <span class="btn btn-outline-primary btn-sm mt-2" aria-hidden="true">
-            <i class="ti ti-folder-open me-1"></i>{{ __('Browse Files') }}
+            <i class="ti ti-folder-open me-1" aria-hidden="true"></i>{{ __('Browse Files') }}
         </span>
     </div>
 </label>

--- a/templates/components/form/genericdate_picker.html.twig
+++ b/templates/components/form/genericdate_picker.html.twig
@@ -40,7 +40,7 @@
          data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Enter or select a date') }}">
         <input type="text" name="{{ name }}" data-input class="form-control rounded-start ps-2">
         <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle>
-            <i class="ti ti-calendar-time"></i>
+            <i class="ti ti-calendar-time" aria-hidden="true"></i>
             <span class="visually-hidden">{{ __('Enter or select a date') }}</span>
         </button>
     </div>

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -86,12 +86,12 @@
          {% set icon = item.getIcon() %}
          {% if not in_navheader and icon|length > 0 %}
             <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-               <i class="{{ icon }} fa-2x"></i>
+               <i class="{{ icon }} fa-2x" aria-hidden="true"></i>
             </div>
          {% endif %}
          <span {% if in_navheader %} class="status rounded-1 me-1" {% endif %}>
             {% if in_navheader %}
-               <i class="{{ icon }}"></i>
+               <i class="{{ icon }}" aria-hidden="true"></i>
             {% endif %}
             {% if withtemplate == 1 and item.id > 0 %}
                {{ _n('Template', 'Templates', 1) }} - {{ nametype }} - {{ template_name }}
@@ -103,7 +103,7 @@
          </span>
          {% if in_navheader and item.isField('is_dynamic') and item.fields['is_dynamic'] %}
             <span class="mx-1 status rounded-1" title="{{ __('Automatic Inventory') }}" data-bs-toggle="tooltip">
-               <i class="{{ call('Agent::getIcon') }}"></i>
+               <i class="{{ call('Agent::getIcon') }}" aria-hidden="true"></i>
             </span>
          {% endif %}
       {% endif %}
@@ -115,7 +115,7 @@
          title="{{ title }}"
          data-bs-toggle="tooltip"
       >
-         <i class="ti ti-trash"></i>
+         <i class="ti ti-trash" aria-hidden="true"></i>
          {{ __('Deleted') }}
       </span>
       {% endif %}
@@ -133,7 +133,7 @@
    {% if item.isEntityAssign() and is_multi_entities_mode() and item is not instanceof('Entity') %}
       {% set single_actions_ms_auto = false %}
        <div class="badge entity-name mx-1 px-2 ms-auto align-items-center col" title="{{ entity_name }}" style="min-width: 100px; max-width: fit-content;">
-           <i class="ti ti-stack me-2"></i>
+           <i class="ti ti-stack me-2" aria-hidden="true"></i>
            <div class="overflow-hidden text-truncate text-nowrap">
                <span class="float-end ps-1">{{ entity_name }}</span>
            </div>

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -34,7 +34,7 @@
 <div class="card m-n2 border-0 shadow-none">
    <div class="card-header">
       <div class="ribbon ribbon-bookmark ribbon-top ribbon-start bg-blue s-1">
-         <i class="ti ti-cloud-download fa-2x"></i>
+         <i class="ti ti-cloud-download fa-2x" aria-hidden="true"></i>
       </div>
       <h4 class="card-title ps-5">
          {{ __('Inventory information') }}
@@ -45,11 +45,11 @@
             class="btn btn-sm btn-secondary ms-auto" target="_blank"
             data-bs-toggle="tooltip" data-bs-placement="right"
             title="{{ __('Download "%1$s" inventory file')|format(get_item_name(item)) }}">
-            <i class="ti ti-download"></i>
+            <i class="ti ti-download" aria-hidden="true"></i>
          </a>
       {% else %}
          <span class="ms-auto" data-bs-toggle="tooltip" data-bs-placement="right" title="{{ __('Inventory file missing') }}">
-            <i class="ti ti-ban"></i>
+            <i class="ti ti-ban" aria-hidden="true"></i>
             <span class="visually-hidden">{{ __('Inventory file missing') }}</span>
          </span>
       {% endif %}
@@ -61,7 +61,7 @@
          <div class="mb-3 col-12 col-sm-4">
             <label class="form-label" >{{ agent.getTypeName() }}</label>
             <span>
-               <i class="{{ agent.getIcon() }}"></i>
+               <i class="{{ agent.getIcon() }}" aria-hidden="true"></i>
                {{ get_item_link(agent) }}
             </span>
          </div>

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -91,7 +91,7 @@
       {% endif %}
          <div class="col-auto">
             <button class="btn btn-primary ms-1" type="submit" name="add">
-               <i class="{{ add_button_icon ?? 'ti ti-link' }}"></i>
+               <i class="{{ add_button_icon ?? 'ti ti-link' }}" aria-hidden="true"></i>
                <span>{{ add_button_label ?? _x('button', 'Add') }}</span>
             </button>
          </div>
@@ -100,7 +100,7 @@
                {% set target_form_path = (target_itemtype|itemtype_form_path ~ "?_" ~ source_itemtype|itemtype_foreign_key ~ "=" ~ source_items_id) %}
                {% set create_url = create_link['url'] is defined ? create_link['url'] : target_form_path %}
                <a href="{{ create_url }}" class="btn btn-primary">
-                  <i class="ti ti-plus"></i>
+                  <i class="ti ti-plus" aria-hidden="true"></i>
                   <span>{{ button_label }}</span>
                </a>
          </div>

--- a/templates/components/form/single-action.html.twig
+++ b/templates/components/form/single-action.html.twig
@@ -43,7 +43,7 @@
    <button class="btn {{ onlyicon ? 'btn-icon' : 'dropdown-toggle' }} btn-outline-secondary" type="button"
            id="single-action" data-bs-toggle="dropdown" aria-haspopup="true"
            aria-expanded="false">
-      <i class="ti ti-dots-vertical"></i>
+      <i class="ti ti-dots-vertical" aria-hidden="true"></i>
       {% if not onlyicon %}
          <span>{{ _n('Action', 'Actions', get_plural_number()) }}</span>
       {% endif %}

--- a/templates/components/group/info_card.html.twig
+++ b/templates/components/group/info_card.html.twig
@@ -43,7 +43,7 @@
       <div class="text-muted">
          {% if group['comment']|length > 0 %}
             <div>
-               <i class="ti ti-notes"></i>
+               <i class="ti ti-notes" aria-hidden="true"></i>
                {{ group['comment'] }}
             </div>
          {% endif %}

--- a/templates/components/helpdesk_forms/delegation_alert.html.twig
+++ b/templates/components/helpdesk_forms/delegation_alert.html.twig
@@ -85,7 +85,7 @@
                         aria-expanded="false"
                         aria-label="{{ __('Address to send the notification') }}"
                     >
-                        <i class="ti ti-mail-cog"></i>
+                        <i class="ti ti-mail-cog" aria-hidden="true"></i>
                     </button>
                     <div class="dropdown-menu p-3 pt-1 rounded-3" style="width: 250px">
                         {{ fields.textField(

--- a/templates/components/helpdesk_forms/service_catalog_item.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_item.html.twig
@@ -62,7 +62,7 @@
                             {{ item.getServiceCatalogItemTitle() }}
                         </h2>
                         {% if is_pinned %}
-                            <i class="ti ti-pin ms-auto"></i>
+                            <i class="ti ti-pin ms-auto" aria-hidden="true"></i>
                         {% endif %}
                     </div>
                     <div

--- a/templates/components/helpdesk_forms/service_catalog_items.html.twig
+++ b/templates/components/helpdesk_forms/service_catalog_items.html.twig
@@ -118,7 +118,7 @@
                     aria-label="{{ __('First page') }}"
                     {{ current_page <= 1 ? 'aria-disabled="true"' : '' }}
                 >
-                    <i class="ti ti-chevrons-left"></i>
+                    <i class="ti ti-chevrons-left" aria-hidden="true"></i>
                 </a>
             </li>
             <li class="page-item {{ current_page <= 1 ? 'disabled' : '' }}">
@@ -130,7 +130,7 @@
                     aria-label="{{ __('Previous page') }}"
                     {{ current_page <= 1 ? 'aria-disabled="true"' : '' }}
                 >
-                    <i class="ti ti-chevron-left"></i>
+                    <i class="ti ti-chevron-left" aria-hidden="true"></i>
                 </a>
             </li>
 
@@ -169,7 +169,7 @@
                     aria-label="{{ __('Next page') }}"
                     {{ current_page >= total_pages ? 'aria-disabled="true"' : '' }}
                 >
-                    <i class="ti ti-chevron-right"></i>
+                    <i class="ti ti-chevron-right" aria-hidden="true"></i>
                 </a>
             </li>
             <li class="page-item {{ current_page >= total_pages ? 'disabled' : '' }}">
@@ -181,7 +181,7 @@
                     aria-label="{{ __('Last page') }}"
                     {{ current_page >= total_pages ? 'aria-disabled="true"' : '' }}
                 >
-                    <i class="ti ti-chevrons-right"></i>
+                    <i class="ti ti-chevrons-right" aria-hidden="true"></i>
                 </a>
             </li>
         </ul>

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -59,7 +59,7 @@
                             aria-selected="true"
                         >
                             <div class="d-flex align-items-center">
-                                <i class="ti ti-photo-scan fa-lg me-2"></i>
+                                <i class="ti ti-photo-scan fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Pick an illustration") }}
                             </div>
                         </a>
@@ -75,7 +75,7 @@
                             aria-selected="false"
                         >
                             <div class="d-flex align-items-center">
-                                <i class="ti ti-file-upload fa-lg me-2"></i>
+                                <i class="ti ti-file-upload fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Upload your own illustration") }}
                             </div>
                         </a>
@@ -94,7 +94,7 @@
                         <span class="input-icon-addon">
                             <i
                                 class="ti ti-search"
-                                data-glpi-icon-picker-filter-default-icon
+                                data-glpi-icon-picker-filter-default-icon aria-hidden="true"
                             ></i>
                             <span class="spinner-border spinner-border d-none" role="status" aria-hidden="true" data-glpi-icon-picker-filter-loading-icon></span>
                         </span>

--- a/templates/components/infocom.html.twig
+++ b/templates/components/infocom.html.twig
@@ -43,7 +43,7 @@
                <input type="hidden" name="itemtype" value="{{ item.getType() }}" />
                <input type="hidden" name="items_id" value="{{ item.fields['id'] }}" />
                <button type="submit" class="btn btn-primary" name="add" value="1">
-                  <i class="ti ti-coins"></i>
+                  <i class="ti ti-coins" aria-hidden="true"></i>
                   <span>{{ __('Enable the financial and administrative information') }}</span>
                </button>
          </div>
@@ -340,14 +340,14 @@
                      <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">
                         {% if can_global_update %}
                            <button class="btn btn-primary me-2" type="submit" name="update">
-                              <i class="ti ti-device-floppy"></i>
+                              <i class="ti ti-device-floppy" aria-hidden="true"></i>
                               <span>{{ _x('button', 'Save') }}</span>
                            </button>
                         {% endif %}
 
                         {% if can_global_purge %}
                            <button class="btn btn-outline-danger me-2" type="submit" name="purge">
-                              <i class="ti ti-trash"></i>
+                              <i class="ti ti-trash" aria-hidden="true"></i>
                               <span>{{ _x('button', 'Delete permanently') }}</span>
                            </button>
                         {% endif %}

--- a/templates/components/itilobject/actors/assign_to_me.html.twig
+++ b/templates/components/itilobject/actors/assign_to_me.html.twig
@@ -37,5 +37,5 @@
         class="btn btn-icon btn-sm btn-ghost-secondary float-end mt-1 ms-1"
         title="{{ __('Associate myself') }}"
         data-bs-toggle="tooltip" data-bs-placement="top">
-   <i class="ti ti-user"></i>
+   <i class="ti ti-user" aria-hidden="true"></i>
 </button>

--- a/templates/components/itilobject/actors/field.html.twig
+++ b/templates/components/itilobject/actors/field.html.twig
@@ -142,7 +142,7 @@
                               data-bs-toggle="tooltip" data-bs-placement="top"
                               title="{{ __('Email followup')|e('html')|e('js') }}"
                               type="button">
-                        <i class="ti ${icon_class} notify-icon"></i>
+                        <i class="ti ${icon_class} notify-icon" aria-hidden="true"></i>
                     </button>`;
             }
             {% endif %}

--- a/templates/components/itilobject/actors/main.html.twig
+++ b/templates/components/itilobject/actors/main.html.twig
@@ -161,7 +161,7 @@
     <div class="modal-content">
       <div class="modal-header">
          <h5 class="modal-title">
-            <i class="ti ti-mail"></i>
+            <i class="ti ti-mail" aria-hidden="true"></i>
             &nbsp;{{ __('Edit notification settings') }}
          </h5>
          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Close') }}"></button>
@@ -180,7 +180,7 @@
                <label class="form-check-label" for="use_notification">{{ __('Email followup') }}</label>
             </div>
             <div id="alert_notification_disable" class='alert alert-info d-flex align-items-center mb-4 d-none' role='alert'>
-               <i class='ti ti-info-circle fs-2x'></i>
+               <i class='ti ti-info-circle fs-2x' aria-hidden='true'></i>
                <span class='ms-2'>
                   {{ __('Notifications are disabled because:') }}
                   <ul>
@@ -196,11 +196,11 @@
       </div>
       <div class="modal-footer">
          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
-            <i class="ti ti-x"></i>
+            <i class="ti ti-x" aria-hidden="true"></i>
             <span>{{ __('Close') }}</span>
          </button>
          <button type="button" class="btn btn-primary" id="saveActorNotifySettings">
-            <i class="ti ti-device-floppy"></i>
+            <i class="ti ti-device-floppy" aria-hidden="true"></i>
             <span>{{ __('Save') }}</span>
          </button>
       </div>

--- a/templates/components/itilobject/add_items.html.twig
+++ b/templates/components/itilobject/add_items.html.twig
@@ -35,7 +35,7 @@
       {{ my_items_dropdown|raw }}
       {{ all_items_dropdown|raw }}
       <a href="javascript:itemAction{{ rand }}('add');" class="btn btn-sm btn-outline-secondary">
-         <i class="ti ti-plus"></i>
+         <i class="ti ti-plus" aria-hidden="true"></i>
          <span>{{ _x('button', 'Add') }}</span>
       </a>
    {% endif %}

--- a/templates/components/itilobject/answer.html.twig
+++ b/templates/components/itilobject/answer.html.twig
@@ -49,7 +49,7 @@
                         <button class="btn btn-sm btn-ghost-secondary float-end mb-1 close-itil-answer"
                               data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block"
                               aria-label="{{ __('Close') }}">
-                           <i class="fs-2 ti ti-x"></i>
+                           <i class="fs-2 ti ti-x" aria-hidden="true"></i>
                         </button>
                      </div>
                      <div>

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -65,7 +65,7 @@
       {% if item.canReopen() %}
          <a href="{{ item.getLinkURL() }}&amp;_openfollowup=1"
             class="btn btn-ghost-secondary">
-            <i class="ti ti-folder-open"></i>
+            <i class="ti ti-folder-open" aria-hidden="true"></i>
             <span>{{ __('Reopen') }}</span>
          </a>
       {% endif %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -48,7 +48,7 @@
    <section class="accordion-item" aria-label="{{ item.getTypeName(1) }}">
       <div class="accordion-header" id="heading-main-item">
          <button class="accordion-button {{ main_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#item-main" aria-expanded="true" aria-controls="ticket-main">
-            <i class="ti ti-alert-circle item-icon"></i>
+            <i class="ti ti-alert-circle item-icon" aria-hidden="true"></i>
             <span class='status-recall'>
                 {{ item.getStatusIcon(item.fields['status'])|raw }}
             </span>
@@ -272,7 +272,7 @@
    <section class="accordion-item" aria-label="{{ __('Actors') }}">
       <div class="accordion-header" id="heading-actor" title="{{ __('Actors') }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ actors_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#actors" aria-expanded="true" aria-controls="actors">
-            <i class="ti ti-users"></i>
+            <i class="ti ti-users" aria-hidden="true"></i>
             <span class="item-title">
                 {{ __('Actors') }}
             </span>
@@ -298,7 +298,7 @@
           <section class="accordion-item" aria-label="{{ __('Notes') }}">
              <div class="accordion-header" id="notes-heading" title="{{ __('Notes') }}" data-bs-toggle="tooltip">
                 <button class="accordion-button {{ notes_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#notes" aria-expanded="true" aria-controls="notes">
-                   <i class="ti ti-notes"></i>
+                   <i class="ti ti-notes" aria-hidden="true"></i>
                    <span class="item-title">
                       {{ __('Entity notes') }}
                    </span>
@@ -328,7 +328,7 @@
       <section class="accordion-item" aria-label="{{ _n('Item', 'Items', get_plural_number()) }}">
          <div class="accordion-header" id="items-heading" title="{{ _n('Item', 'Items', get_plural_number()) }}" data-bs-toggle="tooltip">
             <button class="accordion-button {{ items_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#items" aria-expanded="true" aria-controls="items">
-               <i class="ti ti-package"></i>
+               <i class="ti ti-package" aria-hidden="true"></i>
                <span class="item-title">
                     {{ _n('Item', 'Items', get_plural_number()) }}
                 </span>
@@ -357,7 +357,7 @@
          <section class="accordion-item" aria-label="{{ _n('Service level', 'Service levels', get_plural_number()) }}">
             <div class="accordion-header" id="service-levels-heading" title="{{ _n('Service level', 'Service levels', get_plural_number()) }}" data-bs-toggle="tooltip">
                <button class="accordion-button {{ servicelevels_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#service-levels" aria-expanded="true" aria-controls="service-levels">
-                  <i class="ti ti-alarm"></i>
+                  <i class="ti ti-alarm" aria-hidden="true"></i>
                   <span class="item-title">
                      {{ _n('Service level', 'Service levels', get_plural_number()) }}
                   </span>
@@ -393,7 +393,7 @@
       <section class="accordion-item" aria-label="{{ __('Analysis') }}">
          <div class="accordion-header" id="analysis-heading" title="{{ __("Analysis") }}" data-bs-toggle="tooltip">
             <button class="accordion-button {{ analysis_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#analysis" aria-expanded="true" aria-controls="analysis">
-               <i class="ti ti-eyeglass"></i>
+               <i class="ti ti-eyeglass" aria-hidden="true"></i>
                <span class="item-title">
                     {{ __("Analysis") }}
                </span>
@@ -440,7 +440,7 @@
       <section class="accordion-item" aria-label="{{ __('Plans') }}">
          <div class="accordion-header" id="plans-heading" title="{{ __("Plans") }}" data-bs-toggle="tooltip">
             <button class="accordion-button {{ plans_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#plans" aria-expanded="true" aria-controls="plans">
-               <i class="ti ti-checkup-list"></i>
+               <i class="ti ti-checkup-list" aria-hidden="true"></i>
                <span class="item-title">
                     {{ __("Plans") }}
                </span>
@@ -474,7 +474,7 @@
    <section class="accordion-item" aria-label="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}">
       <div class="accordion-header" id="linked_itilobjects-heading" title="{{ 'CommonITILObject_CommonITILObject'|itemtype_name(nb_linked_itilobjects) }}" data-bs-toggle="tooltip">
          <button class="accordion-button {{ linked_itilobjects_show ? "" : "collapsed" }}" type="button" data-bs-toggle="collapse" data-bs-target="#linked_itilobjects" aria-expanded="true" aria-controls="linked_itilobjects">
-            <i class="ti ti-link"></i>
+            <i class="ti ti-link" aria-hidden="true"></i>
             {% if item.isNewItem() and (params['_link']['items_id_2'] ?? 0) > 0 %}
                {% set nb_linked_itilobjects = 1 %}
             {% endif %}

--- a/templates/components/itilobject/fields_panel.html.twig
+++ b/templates/components/itilobject/fields_panel.html.twig
@@ -496,8 +496,9 @@
    {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITIL_INFO_SECTION'), {"item": item, 'options': params}) }}
 
     <span class="d-none d-md-block">
-        <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2">
-            <i class="ti ti-caret-left-filled"></i>
+        <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary position-absolute bottom-0 start-0 mb-2"
+                aria-label="{{ __('Toggle panels width') }}">
+            <i class="ti ti-caret-left-filled" aria-hidden="true"></i>
         </button>
     </span>
 </div>

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -64,7 +64,7 @@
                      type="button"
                      aria-label="{{ default_action_data.label }}"
                   >
-                     <i class="{{ default_action_data.icon }}"></i>
+                     <i class="{{ default_action_data.icon }}" aria-hidden="true"></i>
                      <span>{{ default_action_data.label }}</span>
                   </button>
 
@@ -73,7 +73,7 @@
                         {% for action, timeline_itemtype in main_actions_itemtypes %}
                         {% if loop.index0 > 0 %}
                               <button class="btn btn-primary answer-action action-{{ action }}" data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
-                                 <i class="{{ timeline_itemtype.icon }}"></i>
+                                 <i class="{{ timeline_itemtype.icon }}" aria-hidden="true"></i>
                                  <span>{{ timeline_itemtype.short_label }}</span>
                               </button>
                               {% endif %}
@@ -92,7 +92,7 @@
                                  {% if loop.index0 > 0 %}
                                  <li aria-label="{{ timeline_itemtype.label }}"><a class="dropdown-item action-{{ action }} answer-action" href="#"
                                     data-bs-toggle="collapse" data-bs-target="#new-{{ timeline_itemtype.class }}-block">
-                                    <i class="{{ timeline_itemtype.icon }}"></i>
+                                    <i class="{{ timeline_itemtype.icon }}" aria-hidden="true"></i>
                                     <span>{{ timeline_itemtype.label }}</span>
                                  </a></li>
                                  {% endif %}
@@ -117,7 +117,7 @@
 
             {% if item.canDeleteItem() and is_helpdesk %}
                <button class="btn btn-ghost-danger me-2" type="submit" name="delete" form="itil-form">
-                  <i class="ti ti-trash me-1"></i>
+                  <i class="ti ti-trash me-1" aria-hidden="true"></i>
                   <span>{{ __("Cancel ticket") }}</span>
                </button>
             {% endif %}
@@ -150,7 +150,7 @@
                   title="{{ _x('button', 'Add') }}"
                   aria-label="{{ _x('button', 'Add') }}"
                >
-                  <i class="ti ti-plus"></i>
+                  <i class="ti ti-plus" aria-hidden="true"></i>
                   <span class="d-none d-lg-block">{{ _x('button', 'Add') }}</span>
                </button>
             {% else %}
@@ -170,7 +170,7 @@
                         title="{{ _x('button', 'Save') }}"
                         aria-label="{{ _x('button', 'Save') }}"
                      >
-                        <i class="ti ti-device-floppy"></i>
+                        <i class="ti ti-device-floppy" aria-hidden="true"></i>
                         <span class="d-none d-xl-block">{{ _x('button', 'Save') }}</span>
                      </button>
                   {% endif %}
@@ -185,21 +185,21 @@
                      {% if item.isDeleted() %}
                         <button class="btn btn-outline-secondary btn-square" type="submit" name="restore" form="itil-form"
                               title="{{ _x('button', 'Restore') }}">
-                           <i class="ti ti-trash-off"></i>
+                           <i class="ti ti-trash-off" aria-hidden="true"></i>
                            <span class="d-none d-lg-block">{{ _x('button', 'Restore') }}</span>
                         </button>
 
                         <button class="btn btn-outline-danger btn-square" type="submit" name="purge" form="itil-form"
                               title="{{ _x('button', 'Delete permanently') }}"
                               onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
-                           <i class="ti ti-trash"></i>
+                           <i class="ti ti-trash" aria-hidden="true"></i>
                            <span class="d-none d-lg-block">{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                      {% else %}
                         <button class="btn btn-outline-danger btn-square" type="submit" name="delete" form="itil-form"
                               title="{{ _x('button', 'Put in trashbin') }}"
                                 data-bs-toggle="tooltip" data-bs-placement="top">
-                           <i class="ti ti-trash"></i>
+                           <i class="ti ti-trash" aria-hidden="true"></i>
                         </button>
                      {% endif %}
                   {% endif %}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -132,11 +132,13 @@
          <div class="form-buttons {{ form_btns_cls }} d-flex justify-content-between ms-auto ms-lg-0 my-n2 py-2 pe-3 card-footer border-top-0 position-relative">
             <span class="d-none d-lg-block ms-n3"
                   data-bs-toggle="tooltip" data-bs-placement="top" title="{{ __('Toggle panels width') }}">
-               <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary px-0">
-                  <i class="{{ switch_btn_cls }}"></i>
+               <button type="button" class="switch-panel-width btn btn-icon btn-ghost-secondary px-0"
+                       aria-label="{{ __('Toggle panels width') }}">
+                  <i class="{{ switch_btn_cls }}" aria-hidden="true"></i>
                </button>
-               <button type="button" class="collapse-panel btn btn-icon btn-ghost-secondary px-0 mr-1">
-                  <i class="ti ti-caret-right-filled"></i>
+               <button type="button" class="collapse-panel btn btn-icon btn-ghost-secondary px-0 mr-1"
+                       aria-label="{{ __('Collapse') }}">
+                  <i class="ti ti-caret-right-filled" aria-hidden="true"></i>
                </button>
             </span>
 
@@ -155,7 +157,7 @@
                </button>
             {% else %}
                {# Use style= instead of d-flex: utility classes add !important on display, breaking jQuery .hide() #}
-               <div class="btn-group flex-row-reverse" role="group" id="right-actions" style="display:flex">
+               <div class="btn-group flex-row-reverse" role="group" id="right-actions" data-testid="right-actions" style="display:flex">
                   {% set is_locked = params['locked'] is defined and params['locked'] %}
                   {% set display_save_btn = not is_locked and (canupdate or can_requester or canpriority or canassign or canassigntome) %}
 

--- a/templates/components/itilobject/linked_itilobjects.html.twig
+++ b/templates/components/itilobject/linked_itilobjects.html.twig
@@ -80,7 +80,7 @@
                                 class="btn btn-sm btn-ghost-danger"
                                 title="{{ _x('button', 'Unlink') }}"
                                 data-bs-toggle="tooltip">
-                           <i class="ti ti-unlink"></i>
+                           <i class="ti ti-unlink" aria-hidden="true"></i>
                         </button>
                      </div>
                   {% endif %}
@@ -109,7 +109,7 @@
       <button class="btn btn-sm btn-ghost-secondary {{ has_pending_link ? 'd-none' : '' }}" type="button"
               data-bs-toggle="collapse" data-bs-target="#link_itilobject_dropdowns"
               aria-expanded="false" aria-controls="link_itilobject_dropdowns" onclick="$(this).hide();">
-         <i class="ti ti-plus"></i>
+         <i class="ti ti-plus" aria-hidden="true"></i>
          <span>{{ __('Add') }}</span>
       </button>
 

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -451,7 +451,8 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
             data-bs-toggle="modal"
             data-bs-target="#{{ assign_la_id }}"
             aria-expanded="false"
-            aria-controls="{{ assign_la_id }}">
+            aria-controls="{{ assign_la_id }}"
+            aria-label="{{ __('Assign a SLA') }}">
         <i class="ti ti-stopwatch slt pointer"
            title="{{ __('Assign a SLA') }}"
            data-bs-toggle="tooltip" data-bs-placement="top"></i>

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -84,7 +84,7 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
 
             {# state flag #}
             <div class="align-middle my-2 me-2">
-                <i class="ti ti-flag text-secondary mx-1"></i>
+                <i class="ti ti-flag text-secondary mx-1" aria-hidden="true"></i>
             </div>
 
             {# datetime field #}
@@ -159,7 +159,7 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
 
             {# state flag #}
             <div class="align-middle my-2 me-2">
-                <i class="ti ti-flag text-secondary mx-1"></i>
+                <i class="ti ti-flag text-secondary mx-1" aria-hidden="true"></i>
             </div>
 
             {# datetime field #}
@@ -288,7 +288,7 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
 
             <span class="level_name badge itil-badge bg-body border-info ms-1 flex-column flex-sm-row">
                 <span class="d-flex align-items-center">
-                     <i class="ti ti-stopwatch slt me-1"></i>
+                     <i class="ti ti-stopwatch slt me-1" aria-hidden="true"></i>
                      <span class="text-truncate"
                            title="{{ get_item_comment(la.class, la.olas_id) }}"
                            data-bs-toggle="tooltip" data-bs-placement="top">
@@ -368,7 +368,7 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
         {% if options.display_associatedsla_field %}
             <span class="level_name badge itil-badge bg-body border-info ms-1 flex-column flex-sm-row">
                 <span class="d-flex align-items-center">
-                     <i class="ti ti-stopwatch slt me-1"></i>
+                     <i class="ti ti-stopwatch slt me-1" aria-hidden="true"></i>
                      <span class="text-truncate"
                            title="{{ get_item_comment(la.class, la.id) }}"
                            data-bs-toggle="tooltip" data-bs-placement="top">
@@ -463,7 +463,7 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
         add_confirmation_message|join('<br />'),
         {
             'id': assign_la_id,
-            'confirm_label': '<i class="ti ti-stopwatch me-1"></i>' ~ __('Assign'),
+            'confirm_label': '<i class="ti ti-stopwatch me-1" aria-hidden="true"></i>' ~ __('Assign'),
             'confirm_event': 'toggleAssignLA_' ~ assign_la_id ~ '()',
         }|merge(options)
     ) }}

--- a/templates/components/itilobject/timeline/approbation_form.html.twig
+++ b/templates/components/itilobject/timeline/approbation_form.html.twig
@@ -68,12 +68,12 @@
 
                <div class="card-footer">
                   <button class="btn btn-outline-danger me-2" name="add_reopen">
-                     <i class="ti ti-x"></i>
+                     <i class="ti ti-x" aria-hidden="true"></i>
                      <span>{{ __('Refuse') }}</span>
                   </button>
 
                   <button class="btn btn-outline-success" name="add_close">
-                     <i class="ti ti-check"></i>
+                     <i class="ti ti-check" aria-hidden="true"></i>
                      <span>{{ __('Approve') }}</span>
                   </button>
                </div>

--- a/templates/components/itilobject/timeline/document/document_list_item.html.twig
+++ b/templates/components/itilobject/timeline/document/document_list_item.html.twig
@@ -50,7 +50,7 @@
     {% if entry_i['link'] %}
         <div class="col-auto">
             <a href="{{ entry_i['link'] }}" target="_blank">
-                <i class="ti ti-external-link"></i>
+                <i class="ti ti-external-link" aria-hidden="true"></i>
                 {{ entry_i['name'] }}
             </a>
         </div>
@@ -66,7 +66,7 @@
         <div class="col-auto">
             <span class="badge bg-warning text-dark" title="{{ __('Private') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
-                <i class="ti ti-lock"></i>
+                <i class="ti ti-lock" aria-hidden="true"></i>
             </span>
         </div>
     {% endif %}
@@ -77,7 +77,7 @@
                 <a href="{{ 'Document'|itemtype_form_path(entry_i['id']) }}"
                    class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
                    data-bs-toggle="tooltip" data-bs-placement="top">
-                    <i class="ti ti-edit"></i>
+                    <i class="ti ti-edit" aria-hidden="true"></i>
                 </a>
             {% endif %}
 
@@ -88,7 +88,7 @@
                     <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
                             title="{{ _x('button', 'Delete permanently') }}"
                             data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                     </button>
                 </form>
             {% endif %}
@@ -102,7 +102,7 @@
                     <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
                             title="{{ blacklisted_title }}"
                             data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-ban {{ blacklisted_class }}"></i>
+                        <i class="ti ti-ban {{ blacklisted_class }}" aria-hidden="true"></i>
                     </button>
                 </form>
             {% endif %}

--- a/templates/components/itilobject/timeline/document/post_figure_content.html.twig
+++ b/templates/components/itilobject/timeline/document/post_figure_content.html.twig
@@ -38,7 +38,7 @@
         {% if is_private %}
             <span class="badge bg-warning text-dark mb-1" title="{{ __('Private') }}"
                   data-bs-toggle="tooltip" data-bs-placement="top">
-                <i class="ti ti-lock"></i>
+                <i class="ti ti-lock" aria-hidden="true"></i>
             </span>
         {% endif %}
 
@@ -46,7 +46,7 @@
             <a href="{{ 'Document'|itemtype_form_path(document['item']['id']) }}"
                class="btn btn-sm btn-ghost-secondary" title="{{ _x('button', 'Edit') }}"
                data-bs-toggle="tooltip" data-bs-placement="top">
-                <i class="ti ti-edit"></i>
+                <i class="ti ti-edit" aria-hidden="true"></i>
             </a>
         {% endif %}
 
@@ -57,7 +57,7 @@
                 <button type="submit" class="btn btn-sm btn-ghost-secondary" name="delete_document"
                         title="{{ _x('button', 'Delete permanently') }}"
                         data-bs-toggle="tooltip" data-bs-placement="top">
-                    <i class="ti ti-trash"></i>
+                    <i class="ti ti-trash" aria-hidden="true"></i>
                 </button>
             </form>
         {% endif %}
@@ -72,7 +72,7 @@
                 <button type="submit" class="btn btn-sm btn-ghost-secondary" name="update"
                         title="{{ blacklisted_title }}"
                         data-bs-toggle="tooltip" data-bs-placement="top">
-                    <i class="ti ti-ban {{ blacklisted_class }}"></i>
+                    <i class="ti ti-ban {{ blacklisted_class }}" aria-hidden="true"></i>
                 </button>
             </form>
         {% endif %}

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -92,8 +92,9 @@
             class="btn btn-icon btn-ghost-secondary open-timeline-filter-popover me-2"
             data-bs-toggle="collapse"
             data-bs-target="#filter-timeline-popover"
-            data-bs-trigger="click">
-         <i class="ti ti-filter"></i>
+            data-bs-trigger="click"
+            aria-label="{{ __('Timeline filter') }}">
+         <i class="ti ti-filter" aria-hidden="true"></i>
       </button>
    </div>
 

--- a/templates/components/itilobject/timeline/filter_timeline.html.twig
+++ b/templates/components/itilobject/timeline/filter_timeline.html.twig
@@ -109,7 +109,7 @@
                            {{ filter_button['checked'] ? 'checked' : '' }}
                            data-itemtype="{{ filter_button['itemtype'] }}" />
                      <label class="form-check-label" for="timeline-filter-{{ filter_key }}" role="button">
-                        <i class="{{ filter_button['icon'] }} ms-2"></i>
+                        <i class="{{ filter_button['icon'] }} ms-2" aria-hidden="true"></i>
                         {{ filter_button['title'] }}
                      </label>
                   </div>
@@ -125,7 +125,7 @@
                class="btn btn-icon btn-ghost-secondary view-timeline-todo-list me-1"
                aria-label="{{ __('View TODO list') }}"
                data-testid="view-todo-list">
-            <i class="ti ti-list-check"></i>
+            <i class="ti ti-list-check" aria-hidden="true"></i>
          </button>
       </div>
    {% endif %}

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -60,13 +60,13 @@
                         <div class="d-inline" role="group" aria-labelledby="upload_source_label">
                             {% if can_screenshot %}
                                 <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenshot">
-                                    <i class="ti ti-photo"></i>
+                                    <i class="ti ti-photo" aria-hidden="true"></i>
                                     <span>{{ __('Screenshot') }}</span>
                                 </button>
                             {% endif %}
                             {% if can_screenrecord %}
                                 <button class="btn btn-sm btn-secondary me-2 d-none" type="button" name="add_screenrecording">
-                                    <i class="ti ti-camera"></i>
+                                    <i class="ti ti-camera" aria-hidden="true"></i>
                                     <span>{{ __('Screen recording') }}</span>
                                 </button>
                             {% endif %}
@@ -129,7 +129,7 @@
                     {% if (subitem.fields['id'] ?? 0) <= 0 %}
                         <div class="input-group">
                             <button class="btn btn-primary" type="submit" name="add">
-                                <i class="ti ti-file-plus"></i>
+                                <i class="ti ti-file-plus" aria-hidden="true"></i>
                                 <span>{{ _x('button', 'Add a new file') }}</span>
                             </button>
                         </div>

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -57,14 +57,14 @@
          <div class="timeline-badges">
             {% if entry_i['requesttypes_id'] %}
                <span class="badge bg-blue-lt" title="{{ __('Source of followup') }}">
-                  <i class="ti ti-inbox me-1"></i>
+                  <i class="ti ti-inbox me-1" aria-hidden="true"></i>
                   {{ get_item_name('RequestType', entry_i['requesttypes_id']) }}
                </span>
             {% endif %}
 
             {% if entry_i['sourceitems_id'] %}
                <span class="badge bg-blue-lt">
-                  <i class="ti ti-git-merge me-1"></i>
+                  <i class="ti ti-git-merge me-1" aria-hidden="true"></i>
                   {% set merged_badge %}
                      <span class="badge">
                         {{ get_item_link('Ticket', entry_i['sourceitems_id']) }}
@@ -76,7 +76,7 @@
 
             {% if entry_i['sourceof_items_id'] %}
                <span class="badge bg-blue-lt">
-                  <i class="ti ti-git-merge me-1"></i>
+                  <i class="ti ti-git-merge me-1" aria-hidden="true"></i>
                   {% set promoted_badge %}
                      <span class="badge">
                         {{ get_item_link('Ticket', entry_i['sourceof_items_id']) }}
@@ -219,7 +219,7 @@
                      >
                         <span class="d-inline-flex align-items-center" title="{{ __("Set the status to pending") }}"
                               data-bs-toggle="tooltip" data-bs-placement="top" role="button">
-                           <i class="ti ti-player-pause-filled me-2"></i>
+                           <i class="ti ti-player-pause-filled me-2" aria-hidden="true"></i>
                            <label class="form-check form-switch mt-2">
                               <input type="hidden"   name="pending" value="0" />
                               <input type="checkbox" name="pending" value="1" class="form-check-input"
@@ -251,7 +251,7 @@
                         name="add"
                         aria-label="{{ _x('button', 'Add') }}"
                      >
-                        <i class="ti ti-plus"></i>
+                        <i class="ti ti-plus" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Add') }}</span>
                      </button>
                     {{ pending_reasons|raw }}
@@ -260,14 +260,14 @@
                {% else %}
                   <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                   <button class="btn btn-primary me-2" type="submit" name="update">
-                     <i class="ti ti-device-floppy"></i>
+                     <i class="ti ti-device-floppy" aria-hidden="true"></i>
                      <span>{{ _x('button', 'Save') }}</span>
                   </button>
 
                   {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                      <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                              onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Delete permanently') }}</span>
                      </button>
                   {% endif %}

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -58,7 +58,7 @@
          <div class="timeline-badges">
             {% if entry_i['solutiontypes_id'] %}
                <span class="badge bg-blue-lt">
-                  <i class="ti ti-tag me-1"></i>
+                  <i class="ti ti-tag me-1" aria-hidden="true"></i>
                   {{ get_item_name('SolutionType', entry_i['solutiontypes_id']) }}
                </span>
             {% endif %}
@@ -94,7 +94,7 @@
 
             {% if item.getType() == 'Ticket' and item.countOpenChildrenOfSameType() > 0 %}
                <div class="alert alert-important alert-warning">
-                  <i class="ti ti-info-circle fs-2x me-2"></i>
+                  <i class="ti ti-info-circle fs-2x me-2" aria-hidden="true"></i>
                   <span>{{ __('Warning: non closed children tickets depends on current ticket. Are you sure you want to close it?') }}</span>
                </div>
             {% endif %}
@@ -223,13 +223,13 @@
                <div class="d-flex card-footer mx-n3 mb-n3">
                   {% if (subitem.fields['id'] ?? 0) <= 0 %}
                      <button class="btn btn-primary me-2" type="submit" name="add">
-                        <i class="ti ti-plus"></i>
+                        <i class="ti ti-plus" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Add') }}</span>
                      </button>
                   {% else %}
                      <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                      <button class="btn btn-primary me-2" type="submit" name="update">
-                        <i class="ti ti-device-floppy"></i>
+                        <i class="ti ti-device-floppy" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Save') }}</span>
                      </button>
                   {% endif %}

--- a/templates/components/itilobject/timeline/form_task.html.twig
+++ b/templates/components/itilobject/timeline/form_task.html.twig
@@ -66,7 +66,7 @@
 
             {% if entry_i['groups_id_tech'] %}
                <span class="badge bg-orange-lt">
-                  <i class="ti ti-users me-1"></i>
+                  <i class="ti ti-users me-1" aria-hidden="true"></i>
                   {{ get_item_link('Group', entry_i['groups_id_tech'], {'enable_anonymization': true}) }}
                </span>
             {% endif %}
@@ -79,14 +79,14 @@
 
             {% if entry_i['actiontime'] %}
                <span class="actiontime badge bg-orange-lt">
-                  <i class="ti ti-stopwatch me-1"></i>
+                  <i class="ti ti-stopwatch me-1" aria-hidden="true"></i>
                   {{ entry_i['actiontime']|formatted_duration }}
                </span>
             {% endif %}
 
             {% if entry_i['begin'] %}
                <span class="planification badge bg-orange-lt">
-                  <i class="ti ti-calendar me-1"></i>
+                  <i class="ti ti-calendar me-1" aria-hidden="true"></i>
                   {{ entry_i['begin']|formatted_datetime }}
                   &rArr;
                   {{ entry_i['end']|formatted_datetime }}
@@ -95,7 +95,7 @@
 
             {% if entry_i['sourceitems_id'] %}
                <span class="badge bg-blue-lt">
-                  <i class="ti ti-git-merge me-1"></i>
+                  <i class="ti ti-git-merge me-1" aria-hidden="true"></i>
                   {% set merged_badge %}
                      <span class="badge">
                         {{ get_item_link('Ticket', entry_i['sourceitems_id']) }}
@@ -107,7 +107,7 @@
 
             {% if entry_i['sourceof_items_id'] %}
                <span class="badge bg-blue-lt">
-                  <i class="ti ti-git-merge me-1"></i>
+                  <i class="ti ti-git-merge me-1" aria-hidden="true"></i>
                   {% set promoted_badge %}
                      <span class="badge">
                         {{ get_item_link('Ticket', entry_i['sourceof_items_id']) }}

--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -293,12 +293,12 @@
                     </script>
                     <button id="unplan{{ rand }}" class="btn btn-outline-warning" type="submit" name="unplan"
                             onclick="return confirm('{{ __('Confirm the deletion of planning?')|e('js') }}');">
-                        <i class="fas ti ti-calendar-off"></i>
+                        <i class="fas ti ti-calendar-off" aria-hidden="true"></i>
                         <span>{{ __('Unplan') }}</span>
                     </button>
                 {% elseif item.isAllowedStatus(item.fields['status'], constant('CommonITILObject::PLANNED')) or constant('CommonITILObject::PLANNED') not in item.getAllStatusArray() %}
                     <button id="plan{{ rand }}" class="btn btn-outline-secondary text-truncate" onclick="showPlanUpdate{{ rand }}(true)" type="button">
-                        <i class="ti ti-calendar"></i>
+                        <i class="ti ti-calendar" aria-hidden="true"></i>
                         <span>{{ __('Plan this task') }}</span>
                     </button>
                 {% endif %}
@@ -323,7 +323,7 @@
                         data-bs-placement="top"
                         role="button"
                     >
-                        <i class="ti ti-player-pause-filled me-2"></i>
+                        <i class="ti ti-player-pause-filled me-2" aria-hidden="true"></i>
                         <label class="form-check form-switch mt-2">
                         <input type="hidden" name="pending" value="0"/>
                         <input
@@ -366,7 +366,7 @@
                     name="add"
                     aria-label="{{ _x('button', 'Add') }}"
                 >
-                <i class="ti ti-plus"></i>
+                <i class="ti ti-plus" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Add') }}</span>
                 </button>
                 {% if disable_pending_reasons is not defined or disable_pending_reasons == false %}
@@ -376,14 +376,14 @@
         {% else %}
             <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
             <button class="btn btn-primary me-2" type="submit" name="update">
-                <i class="ti ti-device-floppy"></i>
+                <i class="ti ti-device-floppy" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Save') }}</span>
             </button>
 
             {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                 <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                         onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
-                <i class="ti ti-trash"></i>
+                <i class="ti ti-trash" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Delete permanently') }}</span>
                 </button>
             {% endif %}

--- a/templates/components/itilobject/timeline/form_validation.html.twig
+++ b/templates/components/itilobject/timeline/form_validation.html.twig
@@ -45,7 +45,7 @@
          {% if (entry_i['comment_submission'] ?? '')|length %}
             <div class='alert alert-info mt-2'>
                 <div class='d-flex'>
-                    <div><i class='ti ti-quote me-2'></i></div>
+                    <div><i class='ti ti-quote me-2' aria-hidden='true'></i></div>
                     <div class="rich_text_container">
                         {{ entry_i['comment_submission']|enhanced_html({
                             'user_mentions': true,
@@ -58,7 +58,7 @@
          {% if entry_i['comment_validation'] is defined and entry_i['comment_validation']|length %}
             <div class='alert alert-info mt-2'>
                 <div class='d-flex'>
-                    <div><i class='ti ti-quote me-2'></i></div>
+                    <div><i class='ti ti-quote me-2' aria-hidden='true'></i></div>
                     <div class="rich_text_container">
                         {{ entry_i['comment_validation']|enhanced_html({
                             'user_mentions': true,
@@ -108,11 +108,11 @@
 
                <div class="validation-footer">
                   <button type="submit" class="btn btn-outline-green" name="approval_action" value="approve">
-                     <i class="ti ti-thumb-up"></i>
+                     <i class="ti ti-thumb-up" aria-hidden="true"></i>
                      <span class="validation-label">{{ __('Approve') }}</span>
                   </button>
                   <button type="submit" class="btn btn-outline-red" name="approval_action" value="refuse">
-                     <i class="ti ti-thumb-down"></i>
+                     <i class="ti ti-thumb-down" aria-hidden="true"></i>
                      <span class="validation-label">{{ __('Refuse') }}</span>
                   </button>
                </div>
@@ -159,11 +159,11 @@
 
          <div class="validation-footer">
             <button type="submit" class="btn btn-outline-green" name="approval_action" value="approve">
-               <i class="ti ti-thumb-up"></i>
+               <i class="ti ti-thumb-up" aria-hidden="true"></i>
                <span class="validation-label">{{ __('Approve') }}</span>
             </button>
             <button type="submit" class="btn btn-outline-red" name="approval_action" value="refuse">
-               <i class="ti ti-thumb-down"></i>
+               <i class="ti ti-thumb-down" aria-hidden="true"></i>
                <span class="validation-label">{{ __('Refuse') }}</span>
             </button>
          </div>
@@ -298,20 +298,20 @@
             <div class="d-flex justify-content-center card-footer">
                 {% if subitem.fields['id'] <= 0 %}
                     <button class="btn btn-primary me-2" type="submit" name="add">
-                        <i class="ti ti-plus"></i>
+                        <i class="ti ti-plus" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Add') }}</span>
                     </button>
                 {% else %}
                     <input type="hidden" name="id" value="{{ subitem.fields['id'] }}" />
                     <button class="btn btn-primary me-2" type="submit" name="update">
-                        <i class="ti ti-device-floppy"></i>
+                        <i class="ti ti-device-floppy" aria-hidden="true"></i>
                         <span>{{ _x('button', 'Save') }}</span>
                     </button>
 
                     {% if subitem.can(subitem.fields['id'], constant('PURGE')) %}
                         <button class="btn btn-outline-danger me-2" type="submit" name="purge"
                                 onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
-                            <i class="ti ti-trash"></i>
+                            <i class="ti ti-trash" aria-hidden="true"></i>
                             <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                     {% endif %}

--- a/templates/components/itilobject/timeline/knowledge_item.html.twig
+++ b/templates/components/itilobject/timeline/knowledge_item.html.twig
@@ -37,7 +37,7 @@
 {% set search_button %}
     <button type="button" class="btn btn-secondary overflow-hidden text-nowrap" name="{{ btn_name }}"
         title="{{ __('Search in the knowledge base') }}" data-bs-toggle="tooltip" data-bs-placement="top">
-    <i class="ti ti-search"></i>
+    <i class="ti ti-search" aria-hidden="true"></i>
     </button>
 {% endset %}
 

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -64,7 +64,7 @@
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="more-actions-{{ entry_rand }}">
                             <li><a class="dropdown-item edit-timeline-item" href="#">
-                            <i class="ti ti-edit"></i>
+                            <i class="ti ti-edit" aria-hidden="true"></i>
                             <span>{{ __('Edit') }}</span>
                             </a></li>
                         </ul>

--- a/templates/components/itilobject/timeline/main_description.html.twig
+++ b/templates/components/itilobject/timeline/main_description.html.twig
@@ -59,8 +59,8 @@
 
                   {% if canupdate %}
                     <div class="dropdown ms-auto timeline-item-buttons">
-                        <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="fas ti ti-dots-vertical"></i>
+                        <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ __('More actions') }}">
+                            <i class="fas ti ti-dots-vertical" aria-hidden="true"></i>
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="more-actions-{{ entry_rand }}">
                             <li><a class="dropdown-item edit-timeline-item" href="#">
@@ -71,8 +71,8 @@
                     </div>
                   {% endif %}
 
-                  <button class="btn btn-sm btn-ghost-secondary close-edit-content d-none ms-auto">
-                     <i class="ti ti-x"></i>
+                  <button class="btn btn-sm btn-ghost-secondary close-edit-content d-none ms-auto" aria-label="{{ _x('button', 'Close') }}">
+                     <i class="ti ti-x" aria-hidden="true"></i>
                   </button>
                </div>
 

--- a/templates/components/itilobject/timeline/pending_reasons.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons.html.twig
@@ -42,7 +42,7 @@
       <div class="col-12 col-sm-4" title="{{ "PendingReason"|itemtype_name }}"
            data-bs-toggle="tooltip" data-bs-placement="top">
          {% set pendingreasons_lbl %}
-            <i class="ti ti-tags"></i>
+            <i class="ti ti-tags" aria-hidden="true"></i>
          {% endset %}
          {% set pending_reasons_id_script %}
             <script>
@@ -128,7 +128,7 @@
                   false
                ]) %}
                {% set pendingreasons_frequency_lbl %}
-                  <i class="ti ti-reload"></i>
+                  <i class="ti ti-reload" aria-hidden="true"></i>
                {% endset %}
                {{ fields.field(
                   'followup_frequency',
@@ -154,7 +154,7 @@
                      false
                ]) %}
                {% set pendingreasons_resolution_lbl %}
-                  <i class="ti ti-check"></i>
+                  <i class="ti ti-check" aria-hidden="true"></i>
                {% endset %}
                {{ fields.field(
                   'followups_before_resolution',

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -36,12 +36,12 @@
 {% set pending_reason_contexts = {
    'pending': {
       'className' : 'badge bg-blue-lt',
-      'icon' : '<i class="ti ti-player-pause-filled me-1"></i>',
+      'icon' : '<i class="ti ti-player-pause-filled me-1" aria-hidden="true"></i>',
       'text': __('Pending'),
    },
    'done': {
       'className' : 'badge bg-transparent text-muted',
-      'icon' : '<i class="ti ti-check me-1"></i>',
+      'icon' : '<i class="ti ti-check me-1" aria-hidden="true"></i>',
       'text' : __('Done'),
    }
 } %}

--- a/templates/components/itilobject/timeline/simple_form.html.twig
+++ b/templates/components/itilobject/timeline/simple_form.html.twig
@@ -99,7 +99,7 @@
    {% if not is_new_item and show_form and not (params['template_preview'] ?? false) %}
       <div class="d-flex card-footer mx-n3 mb-n3">
          <button class="btn btn-primary me-2" type="submit" name="update">
-            <i class="ti ti-device-floppy"></i>
+            <i class="ti ti-device-floppy" aria-hidden="true"></i>
             <span>{{ _x('button', 'Save') }}</span>
          </button>
       </div>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -89,8 +89,8 @@
 
       {% if actions|length %}
          <div class="dropdown ms-2">
-            <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false">
-               <i class="ti ti-dots-vertical"></i>
+            <button class="btn btn-sm btn-ghost-secondary timeline-more-actions" type="button" id="more-actions-{{ entry_rand }}" data-bs-toggle="dropdown" aria-expanded="false" aria-label="{{ __('More actions') }}">
+               <i class="ti ti-dots-vertical" aria-hidden="true"></i>
             </button>
             <ul class="dropdown-menu" aria-labelledby="more-actions-{{ entry_rand }}">
                {% for action in actions %}
@@ -108,7 +108,7 @@
       {% endif %}
    </div>
 
-   <button class="btn btn-sm btn-ghost-secondary close-edit-content d-none ms-auto">
-      <i class="ti ti-x"></i>
+   <button class="btn btn-sm btn-ghost-secondary close-edit-content d-none ms-auto" aria-label="{{ _x('button', 'Close') }}">
+      <i class="ti ti-x" aria-hidden="true"></i>
    </button>
 </div>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -50,7 +50,7 @@
          {% set edit_btn %}
             <li>
                <a class="dropdown-item edit-timeline-item" href="#">
-                  <i class="ti ti-edit"></i>
+                  <i class="ti ti-edit" aria-hidden="true"></i>
                   <span>{{ __('Edit') }}</span>
                </a>
             </li>
@@ -63,7 +63,7 @@
             {% set promoted_btn %}
                <li>
                   <a class="dropdown-item text-warning" href="{{ 'Ticket'|itemtype_form_path(entry_i['sourceof_items_id']) }}">
-                     <i class="ti ti-git-branch"></i>
+                     <i class="ti ti-git-branch" aria-hidden="true"></i>
                      <span>{{ __('%s was already promoted')|format(entry['type']|itemtype_name) }}</span>
                   </a>
                </li>
@@ -78,7 +78,7 @@
             {% set promote_btn %}
                <li>
                   <a class="dropdown-item" href="{{ 'Ticket'|itemtype_form_path ~ promote_url }}">
-                     <i class="ti ti-git-branch"></i>
+                     <i class="ti ti-git-branch" aria-hidden="true"></i>
                      <span>{{ __('Promote to Ticket') }}</span>
                   </a>
                </li>

--- a/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header_badges.html.twig
@@ -40,7 +40,7 @@
             data-bs-toggle="tooltip" data-bs-placement="bottom"
          {% endif %}
       >
-         <i class="ti ti-clock me-1"></i>
+         <i class="ti ti-clock me-1" aria-hidden="true"></i>
          <a href="#{{ anchor }}">
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
                {{ date_creation|relative_datetime }}
@@ -62,7 +62,7 @@
       {% endset %}
       {% set group_span %}
          <span id="group_{{ random() }}" class="d-inline-flex align-items-center">
-            <i class="ti ti-users ms-1 me-1"></i>
+            <i class="ti ti-users ms-1 me-1" aria-hidden="true"></i>
             {{ get_item_link('Group', entry['item']['items_id_target'], {
                'enable_anonymization': enable_anonymization
             })|raw }}
@@ -97,7 +97,7 @@
                data-bs-toggle="tooltip" data-bs-placement="bottom"
             {% endif %}
          >
-            <i class="ti ti-clock me-1"></i>
+            <i class="ti ti-clock me-1" aria-hidden="true"></i>
             {% if timeline_display_date == constant('Config::TIMELINE_RELATIVE_DATE') %}
                {{ date_mod|relative_datetime }}
             {% else %}

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -42,7 +42,7 @@
          </h5>
          <h6 class="card-subtitle">
             {% if item_fields.is_milestone ?? false %}
-               <i class="ti ti-directions-filled me-2"></i>{{ __('Milestone') }}
+               <i class="ti ti-directions-filled me-2" aria-hidden="true"></i>{{ __('Milestone') }}
             {% endif %}
          </h6>
       </div>

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -38,7 +38,7 @@
                <i class="{{ itemtype|itemtype_icon }}" title="{{ itemtype|itemtype_name }}"></i>
                {{ item_fields.name }}
             </a>
-            <button type="button" class="btn-link"><i class="ti ti-x"></i></button>
+            <button type="button" class="btn-link" aria-label="{{ _x('button', 'Close') }}"><i class="ti ti-x" aria-hidden="true"></i></button>
          </h5>
          <h6 class="card-subtitle">
             {% if item_fields.is_milestone ?? false %}
@@ -68,7 +68,7 @@
 
          <h5 class="d-flex justify-content-between">
             <span>{{ __('Team') }}</span>
-            <button type="button" class="btn-link kanban-item-edit-team"><i class="ti ti-plus"></i></button>
+            <button type="button" class="btn-link kanban-item-edit-team" aria-label="{{ __('Add a team member') }}"><i class="ti ti-plus" aria-hidden="true"></i></button>
          </h5>
          {% if team is not empty %}
             {% set item = itemtype|itemtype_class %}

--- a/templates/components/logs.html.twig
+++ b/templates/components/logs.html.twig
@@ -51,11 +51,11 @@
             <th>
                <span class="float-end log-toolbar mb-0">
                   <button class="btn btn-sm show_filters {{ filters|length > 0 ? 'btn-secondary active' : 'btn-outline-secondary' }}">
-                     <i class="ti ti-filter"></i>
+                     <i class="ti ti-filter" aria-hidden="true"></i>
                      <span class="d-none d-xl-block">{{ __('Filter') }}</span>
                   </button>
                   <a href="{{ csv_url }}" class="btn btn-sm text-capitalize btn-outline-secondary">
-                     <i class="ti ti-download"></i>
+                     <i class="ti ti-download" aria-hidden="true"></i>
                      <span class="d-none d-xl-block">{{ __('Export') }}</span>
                   </a>
                </span>

--- a/templates/components/notepad/form.html.twig
+++ b/templates/components/notepad/form.html.twig
@@ -40,7 +40,7 @@
 <div class="d-flex mb-3 justify-content-between align-items-center">
     {% if canedit %}
         <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#new-note-form" aria-label="{{ _x('button', 'Add a note') }}">
-            <i class="ti ti-link"></i>
+            <i class="ti ti-link" aria-hidden="true"></i>
             <span>{{ _x('button', 'Add a note') }}</span>
         </button>
     {% else %}
@@ -57,7 +57,7 @@
                data-collapse-text="{{ __('Collapse all') }}"
                data-expand-title="{{ __('Expand all') }}"
                data-collapse-title="{{ __('Collapse all') }}">
-                <i class="ti ti-eye"></i>
+                <i class="ti ti-eye" aria-hidden="true"></i>
                 <span>{{ __('Collapse all') }}</span>
             </a>
         </small>
@@ -71,7 +71,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <h3 class="modal-title">
-                            <i class="ti ti-notes"></i>
+                            <i class="ti ti-notes" aria-hidden="true"></i>
                             {{ __('Add a note') }}
                         </h3>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -127,7 +127,7 @@
                     aria-controls="{{ id }}"
                     data-testid="note-container"
                 >
-                    <i class="ti ti-notes"></i>
+                    <i class="ti ti-notes" aria-hidden="true"></i>
                     {% set title = '#' ~ note['id'] ~ ' - ' ~ note['date_creation']|formatted_datetime %}
                     {% if note['date_mod'] != note['date_creation'] %}
                         {% set title = title ~ ' (' ~ __('Last update on %s')|format(note['date_mod']|formatted_datetime) ~ ')' %}
@@ -163,7 +163,7 @@
                                         data-id="{{ id }}"
                                         aria-label="{{ __("Delete") }}"
                                     >
-                                        <i class="ti ti-trash"></i>
+                                        <i class="ti ti-trash" aria-hidden="true"></i>
                                         <span>{{ __('Delete') }}</span>
                                     </button>
 
@@ -175,7 +175,7 @@
                                         data-bs-target="#edit-{{ id }}"
                                         aria-label="{{ __("Edit") }}"
                                     >
-                                        <i class="ti ti-edit"></i>
+                                        <i class="ti ti-edit" aria-hidden="true"></i>
                                         <span>{{ __('Edit') }}</span>
                                     </button>
                                 </span>
@@ -205,7 +205,7 @@
 
                                     <div class="modal-header">
                                         <h3 class="modal-title">
-                                            <i class="ti ti-notes"></i>
+                                            <i class="ti ti-notes" aria-hidden="true"></i>
                                             {{ __('Edit a note') }}
                                         </h3>
                                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -238,7 +238,7 @@
                                                 onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');"
                                                 data-bs-toggle="tooltip" data-bs-position="top"
                                                 title="{{ _x('button', 'Delete permanently') }}">
-                                            <i class="ti ti-trash"></i>
+                                            <i class="ti ti-trash" aria-hidden="true"></i>
                                         </button>
 
                                         <button
@@ -248,7 +248,7 @@
                                             class="btn btn-primary"
                                             aria-label="{{ __('Update') }}"
                                         >
-                                            <i class="ti ti-device-floppy"></i>
+                                            <i class="ti ti-device-floppy" aria-hidden="true"></i>
                                             <span>{{ __('Update') }}</span>
                                         </button>
                                     </div>

--- a/templates/components/pager.html.twig
+++ b/templates/components/pager.html.twig
@@ -127,12 +127,12 @@
 
             <li class="page-item {% if is_first_page %}disabled{% endif %}">
                 <a class="page-link d-flex page-link-start" href="{{ href|replace({'%start%': 0}) }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Start') }}" data-start="0" {% if is_first_page %}aria-disabled="true"{% endif %}>
-                    <i class="ti ti-chevrons-left"></i>
+                    <i class="ti ti-chevrons-left" aria-hidden="true"></i>
                 </a>
             </li>
             <li class="page-item {% if is_first_page %}disabled{% endif %}">
                 <a class="page-link d-flex page-link-prev" href="{{ href|replace({'%start%': back}) }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Previous') }}" data-start="{{ back }}" {% if is_first_page %}aria-disabled="true"{% endif %}>
-                    <i class="ti ti-chevron-left"></i>
+                    <i class="ti ti-chevron-left" aria-hidden="true"></i>
                 </a>
             </li>
 
@@ -164,12 +164,12 @@
 
             <li class="page-item {% if is_last_page %}disabled{% endif %}">
                 <a class="page-link d-flex page-link-next" href="{{ href|replace({'%start%': forward}) }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Next') }}" data-start="{{ forward }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
-                    <i class="ti ti-chevron-right"></i>
+                    <i class="ti ti-chevron-right" aria-hidden="true"></i>
                 </a>
             </li>
             <li class="page-item {% if is_last_page %}disabled{% endif %}">
                 <a class="page-link d-flex page-link-last" href="{{ href|replace({'%start%': end}) }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('End') }}" data-start="{{ end }}" {% if is_last_page %}aria-disabled="true"{% endif %}>
-                    <i class="ti ti-chevrons-right"></i>
+                    <i class="ti ti-chevrons-right" aria-hidden="true"></i>
                 </a>
             </li>
         {% endif %}

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -50,7 +50,7 @@
             <figure itemprop="associatedMedia" itemscope itemtype="https://schema.org/ImageObject" class="d-flex flex-column me-2">
                   {% if img['_video'] ?? false %}
                      <span class="bg-black pswp-trigger pointer d-flex justify-content-center align-items-center">
-                        <i class="ti ti-video-filled"></i>
+                        <i class="ti ti-video-filled" aria-hidden="true"></i>
                      </span>
                   {% else %}
                      <a href="{{ img['src']|escape }}" itemprop="contentUrl" data-index="0">

--- a/templates/components/photoswipe.html.twig
+++ b/templates/components/photoswipe.html.twig
@@ -127,7 +127,7 @@
                this.ui.registerElement({
                   name: 'download',
                   isButton: true,
-                  html: '<a class="text-white" target="_blank" download=""><i class="fa-solid fa-download"></i></a>',
+                  html: '<a class="text-white" target="_blank" download="" aria-label=' + JSON.stringify(__('Download')) + '><i class="fa-solid fa-download" aria-hidden="true"></i></a>',
                   order: 8,
                   onInit: (el, pswp) => {
                      pswp.on('change', () => {

--- a/templates/components/plugin_update_modal.html.twig
+++ b/templates/components/plugin_update_modal.html.twig
@@ -41,7 +41,7 @@
             <div class="modal-status bg-info"></div>
             <div
                 class="modal-body text-center py-4">
-                <i class="fa-2x ti ti-info-circle mb-2 text-info"></i>
+                <i class="fa-2x ti ti-info-circle mb-2 text-info" aria-hidden="true"></i>
                 <h3>{{ _x('button', 'Update?') }}</h3>
                 <div class="text-muted">{{ __('A new update is available for the %s plugin.')|escape|format('<strong>' ~ plugin_name|escape ~ '</strong>')|raw }}</div>
                 <div class="text-muted">{{ __('Update to version %s?')|escape|format('<strong><code>' ~ to_version|escape ~ '</strong></code>')|raw }}</div>

--- a/templates/components/printer_graph_buttons.html.twig
+++ b/templates/components/printer_graph_buttons.html.twig
@@ -71,7 +71,7 @@
 <div class="d-flex gap-2 w-full">
     <div id="select_range_dropdown" class="dropdown">
         <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="ti ti-calendar me-2"></i>
+            <i class="ti ti-calendar me-2" aria-hidden="true"></i>
             {{ start_date and end_date ? __('Custom range') ~ ': ' ~ start_date|split('T')[0] ~ ' - ' ~ end_date|split('T')[0] : timerange_presets[interval] }}
         </button>
         <ul class="dropdown-menu">
@@ -83,7 +83,7 @@
             <li><hr class="dropdown-divider"></li>
             <li id="show_custom_range" class="d-flex align-items-center">
                 <span class="dropdown-item {{ start_date and end_date ? 'active' }}" href="#">
-                    <i class="ti ti-plus {{ start_date and end_date ? 'rotate-45' : 'rotate-90' }}"></i>
+                    <i class="ti ti-plus {{ start_date and end_date ? 'rotate-45' : 'rotate-90' }}" aria-hidden="true"></i>
                     {{ __('Custom range') }}
                 </span>
             </li>
@@ -99,7 +99,7 @@
     </div>
     <div id="select_format_dropdown" class="dropdown">
         <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-        <i class="ti ti-chart-dots-3 me-2"></i>
+        <i class="ti ti-chart-dots-3 me-2" aria-hidden="true"></i>
             {{ format_presets[format] }}
         </button>
         <ul class="dropdown-menu">
@@ -112,7 +112,7 @@
     </div>
     <div id="compare_printers_dropdown" class="dropdown">
         <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-        <i class="ti ti-git-compare me-2"></i>
+        <i class="ti ti-git-compare me-2" aria-hidden="true"></i>
             {{ __('Compare') }}
         </button>
         <ul class="dropdown-menu">
@@ -136,7 +136,7 @@
         </ul>
     </div>
     <a href="{{ path(export_url) }}" target="_blank" class="btn btn-sm btn-icon btn-ghost-secondary me-0 me-sm-1 px-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Export to CSV') }}">
-         <i class="ti fs-2 ti-file-download"></i>
+         <i class="ti fs-2 ti-file-download" aria-hidden="true"></i>
       </a>
 </div>
 

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -181,6 +181,7 @@
                         title="{{ __('Toggle browse') }}"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
+                        aria-pressed="{{ data['search']['browse']|default(false) == 1 ? 'true' : 'false' }}"
                         onclick="toogle('browse','','',''); {{ submit_search_form }};"
                     >
                         <i class="ti {{ data['search']['browse']|default(false) == 1 ? "ti-checkbox" : "ti-square" }}" aria-hidden="true"></i>
@@ -197,6 +198,7 @@
                         title="{{ __('Show the trashbin') }}"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
+                        aria-pressed="{{ data['search']['is_deleted'] == 1 ? 'true' : 'false' }}"
                         onclick="toogle('is_deleted','','',''); {{ submit_search_form }};"
                     >
                         <i class="ti {{ data['search']['is_deleted'] == 1 ? "ti-checkbox" : "ti-square" }}" aria-hidden="true"></i>
@@ -214,6 +216,7 @@
                         title="{{ __('Show unpublished') }}"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
+                        aria-pressed="{{ show_unpublished ? 'true' : 'false' }}"
                         onclick="toogle('unpublished','','',''); {{ submit_search_form }};"
                     >
                         <i

--- a/templates/components/search/controls.html.twig
+++ b/templates/components/search/controls.html.twig
@@ -72,14 +72,14 @@
                     <button type="button" class="btn btn-icon btn-sm p-1 {{ active_savedsearch_class }} btn-ghost-secondary show-saved-searches"
                         data-itemtype="{{ itemtype }}"
                         title="{{ __('Show saved searches') }}"  data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-bookmarks"></i>
+                        <i class="ti ti-bookmarks" aria-hidden="true"></i>
                     </button>
                     {% if not user_pref('show_search_form') %}
                         {% set active_filter_class = is_filter_active ? "btn-active-search" : "btn-ghost-secondary" %}
                         <button class="btn btn-sm py-1 show-search-filters {{ active_filter_class }} btn-ghost-secondary dropdown-toggle" type="button"
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside"
                                 data-testid="search-filters-button">
-                            <i class="ti ti-list-search"></i>
+                            <i class="ti ti-list-search" aria-hidden="true"></i>
                             {% if active_search_name|length %}
                                 <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ active_search_name }}" data-bs-toggle="tooltip" data-bs-placement="top">
                                     {{ active_search_name }}
@@ -100,7 +100,7 @@
                     <button class="btn btn-sm py-1 show-search-sorts {{ active_sort_class }} btn-ghost-secondary dropdown-toggle me-1 me-xl-2" type="button"
                                 data-bs-toggle="dropdown" data-bs-auto-close="outside"
                                 data-testid="search-sorts-button">
-                        <i class="ti ti-arrows-sort"></i>
+                        <i class="ti ti-arrows-sort" aria-hidden="true"></i>
                         {% set sort_names = (active_sort_name|length ? active_sort_name : __("Sort")) %}
                         <span class="d-none d-xl-inline-block text-truncate" style="max-width: 250px" title="{{ sort_names }}" data-bs-toggle="tooltip" data-bs-placement="top">
                             {{ sort_names }}
@@ -152,7 +152,7 @@
                             <label class="btn btn-icon btn-sm btn-pill px-2 py-1 {{ table_class }}" title="{{ __('Show as table') }}"
                                 for="show_as_table"
                                 data-bs-toggle="tooltip" data-bs-placement="top">
-                                <i class="ti ti-table"></i>
+                                <i class="ti ti-table" aria-hidden="true"></i>
                             </label >
 
                         {% set located_class = (data['search']['as_map'] == 1 ? "btn-ghost-info" : "") %}
@@ -169,7 +169,7 @@
                         <label class="btn btn-icon btn-sm btn-pill px-2 py-1 {{ located_class }}" title="{{ __('Show as map') }}"
                             for="show_as_map"
                             data-bs-toggle="tooltip" data-bs-placement="top">
-                            <i class="ti ti-map-2"></i>
+                            <i class="ti ti-map-2" aria-hidden="true"></i>
                         </label >
                     </div>
                 {% endif %}
@@ -183,9 +183,9 @@
                         data-bs-placement="top"
                         onclick="toogle('browse','','',''); {{ submit_search_form }};"
                     >
-                        <i class="ti {{ data['search']['browse']|default(false) == 1 ? "ti-checkbox" : "ti-square" }}"></i>
+                        <i class="ti {{ data['search']['browse']|default(false) == 1 ? "ti-checkbox" : "ti-square" }}" aria-hidden="true"></i>
                         <span class="d-flex align-bottom">
-                            <i class="ti ti-subtask"></i>
+                            <i class="ti ti-subtask" aria-hidden="true"></i>
                         </span>
                     </button>
                 {% endif %}
@@ -199,9 +199,9 @@
                         data-bs-placement="top"
                         onclick="toogle('is_deleted','','',''); {{ submit_search_form }};"
                     >
-                        <i class="ti {{ data['search']['is_deleted'] == 1 ? "ti-checkbox" : "ti-square" }}"></i>
+                        <i class="ti {{ data['search']['is_deleted'] == 1 ? "ti-checkbox" : "ti-square" }}" aria-hidden="true"></i>
                         <span class="d-flex align-bottom">
-                            <i class="ti ti-trash"></i>
+                            <i class="ti ti-trash" aria-hidden="true"></i>
                         </span>
                     </button>
                 {% endif %}
@@ -218,10 +218,10 @@
                     >
                         <i
                             class="ti {{ show_unpublished ? "ti-checkbox" : "ti-square" }}"
-                            data-testid="unpublished-{{ show_unpublished ? "on" : "off" }}"
+                            data-testid="unpublished-{{ show_unpublished ? "on" : "off" }}" aria-hidden="true"
                         ></i>
                         <span class="d-flex align-bottom">
-                            <i class="ti ti-eye-off"></i>
+                            <i class="ti ti-eye-off" aria-hidden="true"></i>
                         </span>
                     </button>
                 {% endif %}
@@ -232,7 +232,7 @@
                         type="button"
                         title="{{ __('Select default items to show') }}"
                         data-bs-toggle="tooltip" data-bs-placement="top">
-                        <i class="ti ti-table-row"></i>
+                        <i class="ti ti-table-row" aria-hidden="true"></i>
                     </button>
                     <template id="displaypreference_modal_template{{ rand }}">
                         {{ include('components/search/displaypreference_modal.html.twig', {
@@ -245,7 +245,7 @@
                 {% if not user_pref('show_search_form') %}
                     <button type="button" class="btn btn-icon btn-sm p-1 btn-ghost-secondary refresh-search"
                         title="{{ __('Refresh') }}"  data-bs-toggle="tooltip" data-bs-placement="top" data-bs-trigger="hover">
-                        <i class="ti ti-refresh"></i>
+                        <i class="ti ti-refresh" aria-hidden="true"></i>
                     </button>
                 {% endif %}
 
@@ -253,7 +253,7 @@
                     <button class="dropdown-toggle btn btn-sm btn-ghost-secondary" type="button" name="export" id="dropdown-export-{{ rand }}"
                             data-bs-toggle="dropdown" aria-expanded="false" data-bs-popper-config='{"strategy":"fixed"}'>
                         <span title="{{ __("Export") }}" data-bs-toggle="tooltip" data-bs-placement="top">
-                            <i id="export_dropdown_icon" class="ti ti-download"></i>
+                            <i id="export_dropdown_icon" class="ti ti-download" aria-hidden="true"></i>
                         </span>
                     </button>
                     {% set exporthref = path('/front/report.dynamic.php') ~ "?" ~ {
@@ -265,52 +265,52 @@
                     <div class="dropdown-menu" style="z-index: 10001" aria-labelledby="dropdown-export-{{ rand }}" role="menu">
                         <div role="separator"><h6 class="dropdown-header">{{ __("Current page") }}</h6></div>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}" role="menuitem">
-                            <i class="ti ti-file-type-pdf"></i>
+                            <i class="ti ti-file-type-pdf" aria-hidden="true"></i>
                             {{- __('Landscape PDF') -}}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::PDF_OUTPUT_PORTRAIT') }}" role="menuitem">
-                            <i class="ti ti-file-type-pdf"></i>
+                            <i class="ti ti-file-type-pdf" aria-hidden="true"></i>
                             {{ __('Portrait PDF') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::CSV_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-type-csv"></i>
+                            <i class="ti ti-file-type-csv" aria-hidden="true"></i>
                             {{ __('CSV') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::ODS_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-spreadsheet"></i>
+                            <i class="ti ti-file-spreadsheet" aria-hidden="true"></i>
                             {{ __('Spreadsheet (%s)')|format('ODS') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=' ~ constant('Search::XLSX_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-spreadsheet"></i>
+                            <i class="ti ti-file-spreadsheet" aria-hidden="true"></i>
                             {{ __('Spreadsheet (%s)')|format('XLSX') }}
                         </a>
                         <hr class="dropdown-divider">
                         <div role="separator"><h6 class="dropdown-header">{{ __("All pages") }}</h6></div>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::PDF_OUTPUT_LANDSCAPE') }}" role="menuitem">
-                            <i class="ti ti-file-type-pdf"></i>
+                            <i class="ti ti-file-type-pdf" aria-hidden="true"></i>
                             {{ __('Landscape PDF') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::PDF_OUTPUT_PORTRAIT') }}" role="menuitem">
-                            <i class="ti ti-file-type-pdf"></i>
+                            <i class="ti ti-file-type-pdf" aria-hidden="true"></i>
                             {{ __('Portrait PDF') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::CSV_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-type-csv"></i>
+                            <i class="ti ti-file-type-csv" aria-hidden="true"></i>
                             {{ __('CSV') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::ODS_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-spreadsheet"></i>
+                            <i class="ti ti-file-spreadsheet" aria-hidden="true"></i>
                             {{ __('Spreadsheet (%s)')|format('ODS') }}
                         </a>
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::XLSX_OUTPUT') }}" role="menuitem">
-                            <i class="ti ti-file-spreadsheet"></i>
+                            <i class="ti ti-file-spreadsheet" aria-hidden="true"></i>
                             {{ __('Spreadsheet (%s)')|format('XLSX') }}
                         </a>
                         {% if itemtype != 'Stat' %}
                         <hr class="dropdown-divider">
                         <a class="dropdown-item" href="{{ exporthref ~ '&display_type=-' ~ constant('Search::NAMES_OUTPUT') }}"
                            id="copy_names_to_clipboard" role="menuitem">
-                            <i class="ti ti-copy"></i>
+                            <i class="ti ti-copy" aria-hidden="true"></i>
                             {{ __('Copy names to clipboard') }}
                         </a>
                         {% endif %}

--- a/templates/components/search/criteria_filter.html.twig
+++ b/templates/components/search/criteria_filter.html.twig
@@ -36,7 +36,7 @@
     <div class="col-12 search-container container">
         {# Info section detailling the purpose of the filter #}
         <div class="alert alert-info mt-1">
-            <h3 class="fw-normal"><i class="ti ti-info-circle me-1"></i>{{ info_title }}</h3>
+            <h3 class="fw-normal"><i class="ti ti-info-circle me-1" aria-hidden="true"></i>{{ info_title }}</h3>
             <p class="text-muted">{{ info_description }}</p>
         </div>
 
@@ -60,7 +60,7 @@
               <p class="empty-title">{{ __("No filter found") }}</p>
               <p class="empty-subtitle text-muted">{{ __("There is no filter defined yet for this item.") }}</p>
               <div class="empty-action">
-                <button id="enable_filter_action" type="button" class="btn btn-primary"><i class="ti ti-plus me-2"></i>{{ __("Create a filter") }}</button>
+                <button id="enable_filter_action" type="button" class="btn btn-primary"><i class="ti ti-plus me-2" aria-hidden="true"></i>{{ __("Create a filter") }}</button>
               </div>
             </div>
         </div>

--- a/templates/components/search/criteria_filter_actions.html.twig
+++ b/templates/components/search/criteria_filter_actions.html.twig
@@ -36,7 +36,7 @@
         type="submit"
         name="save_filters"
     >
-        <i class="ti ti-device-floppy"></i>
+        <i class="ti ti-device-floppy" aria-hidden="true"></i>
         <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
         <span class="d-none d-sm-block">{{ __("Save") }}</span>
     </button>
@@ -45,7 +45,7 @@
         class="btn btn-outline-danger me-1 {{ show_delete ? "" : "d-none" }}"
         name="delete_filters"
     >
-        <i class="ti ti-trash"></i>
+        <i class="ti ti-trash" aria-hidden="true"></i>
         <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
         <span class="d-none d-sm-block">{{ __("Delete") }}</span>
     </button>

--- a/templates/components/search/display_data.html.twig
+++ b/templates/components/search/display_data.html.twig
@@ -53,7 +53,7 @@
 
                 {% if count > (start + constant('Search::GLOBAL_DISPLAY_COUNT')) %}
                     <a class="btn btn-ghost-secondary" href="{{ href }}">
-                        <i class="ti ti-eye"></i>
+                        <i class="ti ti-eye" aria-hidden="true"></i>
                         <span>{{ __('View all') }}</span>
                     </a>
                 {% endif %}

--- a/templates/components/search/displaypreference_config.html.twig
+++ b/templates/components/search/displaypreference_config.html.twig
@@ -43,7 +43,7 @@
         {% if is_global %}
             <div class="my-1 me-1">
                 <div class="alert alert-secondary">
-                    <i class="ti ti-info-circle"></i>
+                    <i class="ti ti-info-circle" aria-hidden="true"></i>
                     <i>{{ __('These preferences are used by everyone that does not have a personal view configured.') }}</i>
                 </div>
             </div>
@@ -52,7 +52,7 @@
             <div class="alert alert-warning mt-3">
                 {{ __('No personal criteria. Create personal parameters?') }}
                 <button type="button" class="btn btn-primary ms-3" name="activate" value="1">
-                    <i class="ti ti-plus"></i>
+                    <i class="ti ti-plus" aria-hidden="true"></i>
                     <span>{{ __('Create') }}</span>
                 </button>
             </div>
@@ -61,7 +61,7 @@
                 {% if available_to_add|length > 0 %}
                     {% set add_opt_btn %}
                         <button type="button" name="add_opt" class="btn btn-primary w-100 w-sm-auto ms-sm-1 mt-2 mt-sm-0">
-                            <i class="ti ti-plus"></i>
+                            <i class="ti ti-plus" aria-hidden="true"></i>
                             <span>{{ _x('button', 'Add') }}</span>
                         </button>
                     {% endset %}
@@ -103,19 +103,19 @@
             <ul class="list-group">
                 {% for opt in entries|filter(v => (v['fixed'] ?? false) == true) %}
                     <li data-opt-id="{{ opt['id'] }}" data-fixed="true" class="list-group-item py-2 disabled px-2">
-                        <i class="ti ti-grip-vertical bs-invisible"></i>
+                        <i class="ti ti-grip-vertical bs-invisible" aria-hidden="true"></i>
                         <span>{{ opt['name'] }}</span>
                     </li>
                 {% endfor %}
                 {% for opt in entries|filter(v => (v['fixed'] ?? false) != true) %}
                     {% set name_prefix = opt['group'] is not empty ? (opt['group']) : '' %}
                     <li data-opt-id="{{ opt['id'] }}" class="{{ can_edit ? 'cursor-grab' : '' }} list-group-item py-2 d-flex px-2 align-items-center">
-                        <i class="ti ti-grip-vertical{{ can_edit ? '' : ' bs-invisible' }}"></i>
+                        <i class="ti ti-grip-vertical{{ can_edit ? '' : ' bs-invisible' }}" aria-hidden="true"></i>
                         <span class="flex-fill ms-1">{{ name_prefix ~ opt['name'] }}</span>
                         <span>
                             {% if can_edit and (opt['noremove'] is not defined or opt['noremove'] != true) %}
                                 <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
-                                    <i class="ti ti-x"></i>
+                                    <i class="ti ti-x" aria-hidden="true"></i>
                                 </button>
                             {% endif %}
                         </span>
@@ -219,11 +219,11 @@
                 const tbody = specific_form.find(`ul.list-group`);
                 tbody.append(`
                <li data-opt-id="${num}" class="cursor-grab list-group-item py-2 d-flex px-2 align-items-center">
-                  <i class="ti ti-grip-vertical"></i>
+                  <i class="ti ti-grip-vertical" aria-hidden="true"></i>
                   <span class="flex-fill ms-1">${label}</span>
                   <span>
                         <button type="button" name="remove_opt" class="btn btn-icon btn-sm btn-ghost-danger" title="{{ _x('button', 'Delete permanently') }}">
-                           <i class="ti ti-x"></i>
+                           <i class="ti ti-x" aria-hidden="true"></i>
                         </button>
                   </span>
                </li>

--- a/templates/components/search/displaypreference_list.html.twig
+++ b/templates/components/search/displaypreference_list.html.twig
@@ -42,7 +42,7 @@
         {% endif %}
 
                     <a role="button" class="btn btn-sm btn-ghost-secondary" id="select-all-itemtypes">
-                        <i class="ti ti-copy-check"></i>
+                        <i class="ti ti-copy-check" aria-hidden="true"></i>
                         <span>{{ __('Select/unselect all') }}</span>
                     </a>
 
@@ -62,7 +62,7 @@
                                     </span>
                                 {% endif %}
                                 <button type="button" class="btn btn-ghost-secondary p-0 btn-itemtype-pref overflow-hidden" data-itemtype="{{ pref['itemtype'] }}" title="{{ name }}">
-                                    <i class="{{ pref['itemtype']|itemtype_icon }} me-1"></i>
+                                    <i class="{{ pref['itemtype']|itemtype_icon }} me-1" aria-hidden="true"></i>
                                     <span class="text-truncate">
                                         {{ name }}
                                     </span>

--- a/templates/components/search/map.html.twig
+++ b/templates/components/search/map.html.twig
@@ -145,7 +145,7 @@
                       this._div = L.DomUtil.create('div', 'fail_info');
                       const error_message = '{{ __('An error occurred loading data :(')|e('js') }}';
                       const reload_message = '{{ __('Reload')|e('js') }}'
-                      this._div.innerHTML = `${_.escape(error_message)}<br/><span id='reload_data'><i class='ti ti-refresh'></i>${_.escape(reload_message)}</span>`;
+                      this._div.innerHTML = `${_.escape(error_message)}<br/><span id='reload_data'><i class='ti ti-refresh' aria-hidden='true'></i>${_.escape(reload_message)}</span>`;
                       return this._div;
                   };
                   fail_info.addTo(map_elt);

--- a/templates/components/search/query_builder/main.html.twig
+++ b/templates/components/search/query_builder/main.html.twig
@@ -76,7 +76,7 @@
                   <input type="checkbox" class="form-check-input ms-0 me-1 mt-0 default-filter" role="button"
                         {{ p.nodefault is defined ? '' : 'checked' }} autocomplete="off" {{ (can_disablefilter) ? '' : 'disabled' }} />
                   <span class="form-check-label mb-1 mb-sm-0">
-                     <i class="fs-2 ti ti-filter"></i>
+                     <i class="fs-2 ti ti-filter" aria-hidden="true"></i>
                   </span>
                </label>
                <span title="{{ p.defaultfilter['comment'] }}">{{ p.defaultfilter['name'] }}</span>
@@ -102,17 +102,17 @@
 
       <div class="card-footer d-flex search_actions">
          <button id="addsearchcriteria{{ rand }}" class="btn btn-sm btn-ghost-secondary me-1" type="button">
-            <i class="ti ti-square-plus"></i>
+            <i class="ti ti-square-plus" aria-hidden="true"></i>
             <span class="d-none d-sm-block">{{ __('rule') }}</span>
          </button>
          {% if linked is defined and linked|length > 0 %}
             <button id="addmetasearchcriteria{{ rand }}" class="btn btn-sm btn-ghost-secondary me-1" type="button">
-               <i class="ti ti-circle-plus"></i>
+               <i class="ti ti-circle-plus" aria-hidden="true"></i>
                <span class="d-none d-sm-block">{{ __('global rule') }}</span>
             </button>
          {% endif %}
          <button id="addcriteriagroup{{ rand }}" class="btn btn-sm btn-ghost-secondary me-1" type="button">
-            <i class="ti ti-code-plus"></i>
+            <i class="ti ti-code-plus" aria-hidden="true"></i>
             <span class="d-none d-sm-block">{{ __('group') }}</span>
          </button>
          {% if mainform %}
@@ -121,7 +121,7 @@
                 {% if (showaction) %}
                 {# Display submit button #}
                 <button class="btn {{ p['is_criteria_filter'] ? 'btn-ghost-secondary' : 'btn-sm btn-primary' }}" type="button" name="{{ p['actionname'] }}">
-                    <i class="ti ti-search"></i>
+                    <i class="ti ti-search" aria-hidden="true"></i>
                     <span class="d-none d-sm-block">{{ p['actionvalue'] }}</span>
                 </button>
                 {% endif %}
@@ -136,7 +136,7 @@
                 <a class="btn btn-sm btn-outline-secondary btn-icon px-2 search-reset"
                    data-bs-toggle="tooltip" data-bs-placement="bottom"
                    href="{{ p['target'] ~ ('?' in p['target'] ? '&' : '?') ~ "reset=reset" }}" title="{{ __('Blank') }}">
-                    <i class="ti ti-square-x"></i>
+                    <i class="ti ti-square-x" aria-hidden="true"></i>
                 </a>
                 {% elseif p['forcereset'] %}
                 <input type="hidden" name="reset" value="reset">

--- a/templates/components/search/query_builder/metacriteria.html.twig
+++ b/templates/components/search/query_builder/metacriteria.html.twig
@@ -36,8 +36,9 @@
 <div class="list-group-item border-0 metacriteria p-2" id="{{ row_id }}">
    <div class="row g-1">
       <div class="col-auto">
-         <button class="btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria" type="button" data-rowid="{{ row_id }}">
-            <i class="ti ti-square-rounded-minus" alt="-" title="{{ __('Delete a global rule') }}"></i>
+         <button class="btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria" type="button" data-rowid="{{ row_id }}"
+                 title="{{ __('Delete a global rule') }}" aria-label="{{ __('Delete a global rule') }}">
+            <i class="ti ti-square-rounded-minus" aria-hidden="true"></i>
          </button>
       </div>
       <div class="col-auto">

--- a/templates/components/search/query_builder/sort/criteria.html.twig
+++ b/templates/components/search/query_builder/sort/criteria.html.twig
@@ -49,9 +49,9 @@
 
         let container = document.createElement('span');
         if (option.id === 'ASC') {
-            container.innerHTML = '<i class="ti ti-sort-ascending me-1"></i>' + _.escape(option.text);
+            container.innerHTML = '<i class="ti ti-sort-ascending me-1" aria-hidden="true"></i>' + _.escape(option.text);
         } else if (option.id === 'DESC') {
-            container.innerHTML = '<i class="ti ti-sort-descending me-1"></i>' + _.escape(option.text);
+            container.innerHTML = '<i class="ti ti-sort-descending me-1" aria-hidden="true"></i>' + _.escape(option.text);
         }
 
         return container;

--- a/templates/components/search/query_builder/sort/main.html.twig
+++ b/templates/components/search/query_builder/sort/main.html.twig
@@ -54,20 +54,20 @@
 
     <div class="card-footer d-flex sort_actions">
         <button id="addsort{{ rand }}" class="btn btn-sm btn-ghost-secondary me-1 add_sort" type="button">
-            <i class="ti ti-square-plus"></i>
+            <i class="ti ti-square-plus" aria-hidden="true"></i>
             <span class="d-none d-sm-block">{{ __('Add another sort') }}</span>
         </button>
 
         <div class="btn-group ms-auto me-1">
             <button class="btn btn-sm btn-primary trigger-sort" type="button" name="sort">
-                <i class="ti ti-arrows-sort"></i>
+                <i class="ti ti-arrows-sort" aria-hidden="true"></i>
                 <span class="d-none d-sm-block">{{ __("Sort") }}</span>
             </button>
 
             <button class="btn btn-sm btn-icon px-2 sort-reset" type="button"
                 data-bs-toggle="tooltip" data-bs-placement="bottom"
                 title="{{ __('Reset sort') }}">
-                <i class="ti ti-square-x"></i>
+                <i class="ti ti-square-x" aria-hidden="true"></i>
             </a>
         </div>
     </div>

--- a/templates/components/search/status_area.html.twig
+++ b/templates/components/search/status_area.html.twig
@@ -32,7 +32,7 @@
 
 <div class="status-area">
     <span class="alert alert-warning p-1 m-0 d-flex align-items-center">
-        <i class="ti ti-alert-triangle d-flex align-items-center justify-content-center flex-shrink-0"></i>
+        <i class="ti ti-alert-triangle d-flex align-items-center justify-content-center flex-shrink-0" aria-hidden="true"></i>
         <span>{{ status_message|raw }}</span>
     {% if extra_message is defined %}
         <span class="form-help flex-shrink-0" data-bs-toggle="popover" data-bs-placement="bottom" data-bs-html="true" data-bs-content="{{ extra_message }}">

--- a/templates/components/search/table.html.twig
+++ b/templates/components/search/table.html.twig
@@ -89,7 +89,7 @@
                   {% set sort_icon = sort_order == 'ASC' ? 'ti ti-caret-down-filled' : (sort_order == 'DESC' ? 'ti ti-caret-up-filled' : '') %}
                   {{ col_name }}
                   {% if can_sort %}
-                     <span class="sort-indicator"><i class="{{ sort_icon }}"></i><span class="sort-num">{{ sorts|length > 1 ? sort_num : '' }}</span></span>
+                     <span class="sort-indicator"><i class="{{ sort_icon }}" aria-hidden="true"></i><span class="sort-num">{{ sorts|length > 1 ? sort_num : '' }}</span></span>
                   {% endif %}
                </th>
             {% endfor %}

--- a/templates/components/supplier/info_card.html.twig
+++ b/templates/components/supplier/info_card.html.twig
@@ -43,37 +43,37 @@
         <div class="text-muted">
             {% if supplier['registration_number']|length > 0 %}
                 <div>
-                    <i class="ti ti-id-badge"></i>
+                    <i class="ti ti-id-badge" aria-hidden="true"></i>
                     {{ supplier['registration_number'] }}
                 </div>
             {% endif %}
             {% if supplier['comment']|length > 0 %}
                 <div>
-                    <i class="ti ti-notes"></i>
+                    <i class="ti ti-notes" aria-hidden="true"></i>
                     {{ supplier['comment'] }}
                 </div>
             {% endif %}
             {% if not supplier['phonenumber'] is empty %}
                 <div>
-                    <i class="ti ti-phone"></i>
+                    <i class="ti ti-phone" aria-hidden="true"></i>
                     <a href="tel:{{ supplier['phonenumber'] }}">{{ supplier['phonenumber'] }}</a>
                 </div>
             {% endif %}
             {% if not supplier['email'] is empty %}
                 <div>
-                    <i class="ti ti-mail"></i>
+                    <i class="ti ti-mail" aria-hidden="true"></i>
                     <a href="mailto:{{ supplier['email'] }}">{{ supplier['email'] }}</a>
                 </div>
             {% endif %}
             {% if not supplier['fax'] is empty %}
                 <div>
-                    <i class="ti ti-printer"></i>
+                    <i class="ti ti-printer" aria-hidden="true"></i>
                     {{ supplier['fax'] }}
                 </div>
             {% endif %}
             {% if not supplier['address'] is empty or not supplier['town'] is empty or not supplier['postcode'] is empty %}
                 <div>
-                    <i class="ti ti-home"></i>
+                    <i class="ti ti-home" aria-hidden="true"></i>
                     {% if not supplier['address'] is empty %}
                         {{ supplier['address'] }}
                     {% endif %}

--- a/templates/components/tab/addlink_block.html.twig
+++ b/templates/components/tab/addlink_block.html.twig
@@ -56,7 +56,7 @@
         aria-label="{{ button_label }}"
     >
 {% if button_icon is not empty %}
-        <i class="{{ button_icon }}"></i>
+        <i class="{{ button_icon }}" aria-hidden="true"></i>
 {% endif %}
         <span>{{ button_label }}</span>
     </a>

--- a/templates/components/user/create_user.html.twig
+++ b/templates/components/user/create_user.html.twig
@@ -37,7 +37,7 @@
           id="create_user_{{ item.fields['id'] }}"
           data-bs-toggle="modal"
           data-bs-target="#add_{{ item.fields['id'] }}">
-        <i class="ti ti-user-plus"></i>
+        <i class="ti ti-user-plus" aria-hidden="true"></i>
     </span>
 </span>
 <script type="text/javascript">

--- a/templates/components/user/info_card.html.twig
+++ b/templates/components/user/info_card.html.twig
@@ -54,15 +54,15 @@
 
          <div class="text-muted d-grid gap-y-1" style="grid-template-columns: auto 1fr; column-gap: 0.25rem; align-items: center;">
             {% if user.login is defined and user['login'] is not empty %}
-                <i class="ti ti-id-badge"></i>
+                <i class="ti ti-id-badge" aria-hidden="true"></i>
                 <span>{{ user['login'] }}</span>
             {% endif %}
             {% if user['email']|length > 0 %}
-               <i class="ti ti-mail"></i>
+               <i class="ti ti-mail" aria-hidden="true"></i>
                <a href="mailto:{{ user['email'] }}">{{ user['email'] }}</a>
             {% endif %}
             {% if not user['phone'] is empty or not user['phone2'] is empty %}
-               <i class="ti ti-phone"></i>
+               <i class="ti ti-phone" aria-hidden="true"></i>
                <span class="d-flex align-items-center flex-wrap gap-1">
                   {% if not user['phone'] is empty %}
                      <a href="tel:{{ user['phone'] }}">{{ user['phone'] }}</a>
@@ -76,27 +76,27 @@
                </span>
             {% endif %}
             {% if user['mobile']|length > 0 %}
-               <i class="ti ti-device-mobile"></i>
+               <i class="ti ti-device-mobile" aria-hidden="true"></i>
                <a href="tel:{{ user['mobile'] }}">{{ user['mobile'] }}</a>
             {% endif %}
             {% if user['registration_number']|length > 0 %}
-               <i class="ti ti-id-badge-2"></i>
+               <i class="ti ti-id-badge-2" aria-hidden="true"></i>
                <span>{{ user['registration_number'] }}</span>
             {% endif %}
             {% if user['locations_id'] > 0 %}
-               <i class="{{ 'Location'|itemtype_icon }}"></i>
+               <i class="{{ 'Location'|itemtype_icon }}" aria-hidden="true"></i>
                <span title="{{ 'Location'|itemtype_name }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('Location', user['locations_id']) }}</span>
             {% endif %}
             {% if user['usertitles_id'] > 0 %}
-               <i class="{{ 'UserTitle'|itemtype_icon }}"></i>
+               <i class="{{ 'UserTitle'|itemtype_icon }}" aria-hidden="true"></i>
                <span title="{{ _x('person', 'Title') }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('UserTitle', user['usertitles_id']) }}</span>
             {% endif %}
             {% if user['usercategories_id'] > 0 %}
-               <i class="{{ 'UserCategory'|itemtype_icon }}"></i>
+               <i class="{{ 'UserCategory'|itemtype_icon }}" aria-hidden="true"></i>
                <span title="{{ _n('Category', 'Categories', 1) }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('UserCategory', user['usercategories_id']) }}</span>
             {% endif %}
             {% if user['groups_id'] > 0 %}
-               <i class="{{ 'Group'|itemtype_icon }}"></i>
+               <i class="{{ 'Group'|itemtype_icon }}" aria-hidden="true"></i>
                <span title="{{ __('Default group') }}" data-bs-toggle="tooltip" data-bs-placement="top">{{ get_item_name('Group', user['groups_id']) }}</span>
             {% endif %}
          </div>
@@ -106,7 +106,7 @@
          <div class="col">
             <a class="btn btn-icon btn-sm btn-outline-secondary" href="{{ path('front/preference.php') }}"
                title="{{ __('Edit') }}" data-bs-toggle="tooltip" data-bs-placement="right">
-               <i class="ti ti-user-edit"></i>
+               <i class="ti ti-user-edit" aria-hidden="true"></i>
             </a>
          </div>
       {% endif %}

--- a/templates/components/user/link_with_tooltip.html.twig
+++ b/templates/components/user/link_with_tooltip.html.twig
@@ -33,7 +33,7 @@
 {% set rand = random() %}
 
 <span id="user_{{ rand }}" class="d-inline-flex align-items-center">
-    <i class="ti ti-user me-1"></i>
+    <i class="ti ti-user me-1" aria-hidden="true"></i>
     {{ get_item_link('User', users_id, {'enable_anonymization': enable_anonymization, 'tooltip': false}) }}
 </span>
 

--- a/templates/components/user/picture.html.twig
+++ b/templates/components/user/picture.html.twig
@@ -59,7 +59,7 @@
       {% if user is not null %}
          {{ user.getUserInitials(enable_anonymization) }}
       {% else %}
-         <i class="ti ti-user"></i>
+         <i class="ti ti-user" aria-hidden="true"></i>
       {% endif %}
    {% endif %}
 </span>

--- a/templates/error_block.html.twig
+++ b/templates/error_block.html.twig
@@ -35,7 +35,7 @@
         <div role="alert" class="alert alert-danger alert-important">
             <div class="d-flex">
                 <div class="me-2">
-                    <i class="ti ti-alert-triangle fs-2x"></i>
+                    <i class="ti ti-alert-triangle fs-2x" aria-hidden="true"></i>
                 </div>
                 <div>
                     {{ message }}

--- a/templates/install/accept_license.html.twig
+++ b/templates/install/accept_license.html.twig
@@ -35,7 +35,7 @@
 
     <p>
         <a class="btn btn-sm btn-info" target="_blank" href="https://www.gnu.org/licenses/translations.html">
-            <i class="ti ti-external-link-alt me-1"></i>
+            <i class="ti ti-external-link-alt me-1" aria-hidden="true"></i>
             {{ __("Unofficial translations are also available") }}
         </a>
     </p>
@@ -45,7 +45,7 @@
 
         <button type="submit" name="submit" class="btn btn-primary">
             {{ __("Continue") }}
-            <i class="ti ti-chevron-right ms-1"></i>
+            <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
         </button>
     </form>
 </div>

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -75,7 +75,7 @@
                         data-bs-content="{{ requirement.getValidationMessages()|join('<br />') }}">
                      <i class="{{ requirement.isValidated() ? 'ti ti-check' : (requirement.isOptional() ? 'ti ti-alert-triangle' : 'ti ti-x') }}" aria-hidden="true"></i>
                      <span class="visually-hidden">
-                        {{ requirement.isValidated() ? __('OK') : (requirement.isOptional() ? __('Warning') : __('Error')) }}
+                        {{ requirement.isValidated() ? __('OK') : (requirement.isOptional() ? __('Warning') : _n('Error', 'Errors', 1)) }}
                      </span>
                   </span>
                </td>

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -73,7 +73,7 @@
                         data-bs-html="true"
                         data-bs-custom-class="validation-messages"
                         data-bs-content="{{ requirement.getValidationMessages()|join('<br />') }}">
-                     <i class="{{ requirement.isValidated() ? 'ti ti-check' : (requirement.isOptional() ? 'ti ti-alert-triangle' : 'ti ti-x') }}"></i>
+                     <i class="{{ requirement.isValidated() ? 'ti ti-check' : (requirement.isOptional() ? 'ti ti-alert-triangle' : 'ti ti-x') }}" aria-hidden="true"></i>
                   </span>
                </td>
             </tr>

--- a/templates/install/blocks/requirements_table.html.twig
+++ b/templates/install/blocks/requirements_table.html.twig
@@ -74,6 +74,9 @@
                         data-bs-custom-class="validation-messages"
                         data-bs-content="{{ requirement.getValidationMessages()|join('<br />') }}">
                      <i class="{{ requirement.isValidated() ? 'ti ti-check' : (requirement.isOptional() ? 'ti ti-alert-triangle' : 'ti ti-x') }}" aria-hidden="true"></i>
+                     <span class="visually-hidden">
+                        {{ requirement.isValidated() ? __('OK') : (requirement.isOptional() ? __('Warning') : __('Error')) }}
+                     </span>
                   </span>
                </td>
             </tr>

--- a/templates/install/choose_language.html.twig
+++ b/templates/install/choose_language.html.twig
@@ -38,7 +38,7 @@
 
       <button type="submit" name="lang_select" class="btn btn-primary" autofocus>
          {{ __("OK") }}
-         <i class="ti ti-chevron-right ms-1"></i>
+         <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
       </button>
    </div>
 

--- a/templates/install/install.install_required.html.twig
+++ b/templates/install/install.install_required.html.twig
@@ -37,7 +37,7 @@
 {% block content_block %}
 <div class="flex-fill d-flex align-items-center justify-content-center">
     <div class="empty p-0">
-        <i class="fas fa-tools fa-3x mb-3"></i>
+        <i class="fas fa-tools fa-3x mb-3" aria-hidden="true"></i>
 
         <p class="empty-title">{{ __('GLPI setup') }}</p>
 

--- a/templates/install/post_update_step.html.twig
+++ b/templates/install/post_update_step.html.twig
@@ -32,7 +32,7 @@
 
 {% if not is_db_consistent %}
     <div class="alert alert-important alert-danger my-2 mx-4" role="alert">
-        <i class="fas fa-2x fa-exclamation-triangle align-middle"></i>
+        <i class="fas fa-2x fa-exclamation-triangle align-middle" aria-hidden="true"></i>
         {{ __('The database schema is not consistent with the current GLPI version.') }}<br />
         {{ __('It is recommended to run the "%s" command to see the differences.')|format('php bin/console database:check_schema_integrity') }}
     </div>
@@ -60,7 +60,7 @@
 <form action="update.php" method="post" data-submit-once>
    <div class="text-center">
       <button type="submit" class="btn btn-primary">
-         <i class="fas fa-thumbs-up me-1"></i>
+         <i class="fas fa-thumbs-up me-1" aria-hidden="true"></i>
          {{ __("Use GLPI") }}
       </button>
    </div>

--- a/templates/install/step0.html.twig
+++ b/templates/install/step0.html.twig
@@ -42,7 +42,7 @@
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-primary">
          {{ _x("button", "Install") }}
-         <i class="fas fa-download ms-1"></i>
+         <i class="fas fa-download ms-1" aria-hidden="true"></i>
       </button>
 
       <input type="hidden" name="update" value="no">
@@ -52,7 +52,7 @@
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-primary">
          {{ _x("button", "Upgrade") }}
-         <i class="fas fa-caret-square-up ms-1"></i>
+         <i class="fas fa-caret-square-up ms-1" aria-hidden="true"></i>
       </button>
 
       <input type="hidden" name="update" value="yes">

--- a/templates/install/step1.html.twig
+++ b/templates/install/step1.html.twig
@@ -35,7 +35,7 @@
     <div class="alert alert-danger" role="alert">
         <div class="d-flex">
             <div>
-                <i class="ti ti-alert-circle me-2"></i>
+                <i class="ti ti-alert-circle me-2" aria-hidden="true"></i>
             </div>
             <div>
                 <h4 class="alert-title">{{ __('Write access denied for configuration files') }}</h4>
@@ -61,7 +61,7 @@
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-primary">
          {{ __("Continue") }}
-         <i class="ti ti-chevron-right ms-1"></i>
+         <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
       </button>
 
       <input type="hidden" name="install" value="Etape_1">
@@ -73,7 +73,7 @@
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-warning">
          {{ __("Try again") }}
-         <i class="ti ti-reload ms-1"></i>
+         <i class="ti ti-reload ms-1" aria-hidden="true"></i>
       </button>
 
       <input type="hidden" name="install" value="Etape_0">

--- a/templates/install/step2.html.twig
+++ b/templates/install/step2.html.twig
@@ -51,7 +51,7 @@
 
    <button type="submit" name="submit" class="btn btn-primary">
       {{ __("Continue") }}
-      <i class="ti ti-chevron-right ms-1"></i>
+      <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
    </button>
 
    <input type="hidden" name="update" value="{{ update }}">

--- a/templates/install/step3.html.twig
+++ b/templates/install/step3.html.twig
@@ -41,7 +41,7 @@
 
    <form action="install.php" method="post" class="d-inline" data-submit-once>
       <button type="submit" name="submit" class="btn btn-warning">
-         <i class="ti ti-chevron-left me-1 fs-2x alert-icon"></i>
+         <i class="ti ti-chevron-left me-1 fs-2x alert-icon" aria-hidden="true"></i>
          {{ __("Back") }}
       </button>
 
@@ -98,7 +98,7 @@
 
             <button type="submit" name="submit" class="btn btn-primary">
                {{ __("Continue") }}
-               <i class="ti ti-chevron-right ms-1"></i>
+               <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
             </button>
 
             {% if update == "no" %}

--- a/templates/install/step6.html.twig
+++ b/templates/install/step6.html.twig
@@ -46,7 +46,7 @@
 <form action="install.php" method="post" data-submit-once>
    <button type="submit" name="submit" class="btn btn-primary">
       {{ __("Continue") }}
-      <i class="ti ti-chevron-right ms-1"></i>
+      <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
    </button>
 
    <input type="hidden" name="install" value="Etape_5">

--- a/templates/install/step7.html.twig
+++ b/templates/install/step7.html.twig
@@ -41,7 +41,7 @@
    <p>
    <button type="submit" name="submit" class="btn btn-primary">
       {{ __("Continue") }}
-      <i class="ti ti-chevron-right ms-1"></i>
+      <i class="ti ti-chevron-right ms-1" aria-hidden="true"></i>
    </button>
    </p>
 

--- a/templates/install/step8.html.twig
+++ b/templates/install/step8.html.twig
@@ -51,7 +51,7 @@
 
 <p class="center">
    <a class="btn btn-primary" href="../index.php">
-      <i class="fas fa-thumbs-up me-1"></i>
+      <i class="fas fa-thumbs-up me-1" aria-hidden="true"></i>
       {{ __("Use GLPI") }}
    </a>
 </p>

--- a/templates/install/update.invalid_database.html.twig
+++ b/templates/install/update.invalid_database.html.twig
@@ -34,7 +34,7 @@
 
 <form action="install.php" method="post" class="d-inline" data-submit-once>
     <button type="submit" name="submit" class="btn btn-warning">
-        <i class="ti ti-chevron-left me-1 fs-2x alert-icon"></i>
+        <i class="ti ti-chevron-left me-1 fs-2x alert-icon" aria-hidden="true"></i>
         {{ __("Back") }}
     </button>
 

--- a/templates/install/update.need_update.html.twig
+++ b/templates/install/update.need_update.html.twig
@@ -39,7 +39,7 @@
                 {% if core_requirements.hasMissingMandatoryRequirements() or core_requirements.hasMissingOptionalRequirements() %}
                     <form action="{{ path('index.php') }}" method="post">
                         <button type="submit" class="btn btn-primary">
-                            <i class="ti ti-reload"></i>{{ __('Try again') }}
+                            <i class="ti ti-reload" aria-hidden="true"></i>{{ __('Try again') }}
                         </button>
                     </form>
                 {% endif %}
@@ -54,7 +54,7 @@
                                 {{ __('The GLPI codebase has been updated. The update of the GLPI database is necessary.') }}
                             </p>
                             <button type="submit" name="continue" value="1" class="btn btn-primary">
-                                <i class="ti ti-check"></i>{{ _x('button', 'Upgrade') }}
+                                <i class="ti ti-check" aria-hidden="true"></i>{{ _x('button', 'Upgrade') }}
                             </button>
                         </form>
                     {% else %}

--- a/templates/layout/parts/breadcrumbs.html.twig
+++ b/templates/layout/parts/breadcrumbs.html.twig
@@ -34,7 +34,7 @@
    <ol class="breadcrumb breadcrumb-alternate pe-1 pe-sm-3">
       <li class="breadcrumb-item text-truncate">
       <a href="{{ index_path() }}" class="d-inline-flex align-items-center gap-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Home') }}">
-            <i class="ti ti-home-2"></i>
+            <i class="ti ti-home-2" aria-hidden="true"></i>
             {{ __('Home') }}
          </a>
       </li>
@@ -42,7 +42,7 @@
       {% if menu[sector] is defined %}
       <li class="breadcrumb-item text-truncate">
       <a href="{{ path(menu[sector]['default'] ?? '/front/central.php') }}" class="d-inline-flex align-items-center gap-1" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ menu[sector]['title'] }}">
-            <i class="{{ menu[sector]['icon'] ?? '' }}"></i>
+            <i class="{{ menu[sector]['icon'] ?? '' }}" aria-hidden="true"></i>
             {{ menu[sector]['title'] }}
          </a>
       </li>
@@ -57,7 +57,7 @@
             class="d-inline-flex align-items-center gap-1 {{ with_option ? '' : 'here' }}"
                data-bs-toggle="tooltip" data-bs-placement="bottom"
                title="{{ menu[sector]['content'][item]['title'] }}" >
-               <i class="{{ menu[sector]['content'][item]['icon'] ?? '' }}"></i>
+               <i class="{{ menu[sector]['content'][item]['icon'] ?? '' }}" aria-hidden="true"></i>
                {{ menu[sector]['content'][item]['title'] }}
             </a>
          </li>
@@ -69,7 +69,7 @@
                class="d-inline-flex align-items-center gap-1 here"
                data-bs-toggle="tooltip" data-bs-placement="bottom"
                title="{{ menu[sector]['content'][item]['options'][option]['title'] }}" >
-               <i class="{{ menu[sector]['content'][item]['options'][option]['icon'] ?? '' }}"></i>
+               <i class="{{ menu[sector]['content'][item]['options'][option]['icon'] ?? '' }}" aria-hidden="true"></i>
                {{ menu[sector]['content'][item]['options'][option]['title']|u.truncate(17, '...') }}
             </a>
          </li>

--- a/templates/layout/parts/context_links.html.twig
+++ b/templates/layout/parts/context_links.html.twig
@@ -46,7 +46,7 @@
 {% if links['add'] is defined %}
 <li class="nav-item">
    <a href="{{ path(links['add']) }}" class="btn btn-sm btn-primary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Add') }}">
-      <i class="ti ti-plus"></i>
+      <i class="ti ti-plus" aria-hidden="true"></i>
       <span class="d-none d-xxl-block">{{ __('Add') }}</span>
    </a>
 </li>
@@ -57,77 +57,77 @@
    {% elseif type == 'template' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Manage templates...') }}">
-            <i class="ti ti-template"></i>
+            <i class="ti ti-template" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Templates') }}</span>
          </a>
       </li>
    {% elseif type == 'showall' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Show all') }}">
-            <i class="ti ti-eye-check"></i>
+            <i class="ti ti-eye-check" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Show all') }}</span>
          </a>
       </li>
    {% elseif type == 'summary' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Summary') }}">
-            <i class="ti ti-notes"></i>
+            <i class="ti ti-notes" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Summary') }}</span>
          </a>
       </li>
    {% elseif type == 'summary_kanban' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Global Kanban') }}">
-            <i class="ti ti-layout-columns"></i>
+            <i class="ti ti-layout-columns" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Global Kanban') }}</span>
          </a>
       </li>
    {% elseif type == 'transfer_list' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Transfer list') }}">
-            <i class="ti ti-list-check"></i>
+            <i class="ti ti-list-check" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Transfer list') }}</span>
          </a>
       </li>
    {% elseif type == 'config' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Setup') }}">
-            <i class="ti ti-tool"></i>
+            <i class="ti ti-tool" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Setup') }}</span>
          </a>
       </li>
    {% elseif type == 'view_form_categories' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ 'Glpi\\Form\\Category'|itemtype_name(get_plural_number()) }}">
-            <i class="ti ti-folder"></i>
+            <i class="ti ti-folder" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ 'Glpi\\Form\\Category'|itemtype_name(get_plural_number()) }}</span>
          </a>
       </li>
    {% elseif type == 'all_articles' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('All articles') }}">
-            <i class="ti ti-list-search"></i>
+            <i class="ti ti-list-search" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('All articles') }}</span>
          </a>
       </li>
    {% elseif type == 'view_kb_categories' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ 'KnowbaseItemCategory'|itemtype_name(get_plural_number()) }}">
-            <i class="ti ti-folder"></i>
+            <i class="ti ti-folder" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ 'KnowbaseItemCategory'|itemtype_name(get_plural_number()) }}</span>
          </a>
       </li>
    {% elseif type == 'import_forms' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Import forms') }}">
-            <i class="ti ti-file-arrow-left"></i>
+            <i class="ti ti-file-arrow-left" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ __('Import forms') }}</span>
          </a>
       </li>
    {% elseif type == 'Glpi\\Dropdown\\DropdownDefinition' %}
       <li class="nav-item">
          <a href="{{ path(link) }}" role="button" class="btn btn-sm btn-ghost-secondary me-1 pe-2" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ 'Glpi\\Dropdown\\DropdownDefinition'|itemtype_name }}">
-            <i class="{{ 'Glpi\\Dropdown\\DropdownDefinition'|itemtype_icon }}"></i>
+            <i class="{{ 'Glpi\\Dropdown\\DropdownDefinition'|itemtype_icon }}" aria-hidden="true"></i>
             <span class="d-none d-xxl-block">{{ 'Glpi\\Dropdown\\DropdownDefinition'|itemtype_name }}</span>
          </a>
       </li>

--- a/templates/layout/parts/dcbreadcrumbs.html.twig
+++ b/templates/layout/parts/dcbreadcrumbs.html.twig
@@ -59,7 +59,7 @@
                           data-bs-toggle="tooltip"
                           title="{{ breadcrumb_item['location']['completename'] }}"
                           style="max-width: 100px;">
-                        <i class="{{ call('Location::getIcon') }}"></i>
+                        <i class="{{ call('Location::getIcon') }}" aria-hidden="true"></i>
                         {% if breadcrumb_item['location']['locations_id'] == previous_location_id %}
                            {% if previous_location_id is not null %}
                               &gt;

--- a/templates/layout/parts/goto_button.html.twig
+++ b/templates/layout/parts/goto_button.html.twig
@@ -41,7 +41,7 @@
            title="{{ shortcut }}"
            data-bs-toggle="tooltip"
            data-bs-placement="right">
-      <i class="ti ti-arrow-big-right me-1"></i>
+      <i class="ti ti-arrow-big-right me-1" aria-hidden="true"></i>
       <span class="menu-label {{ not is_vertical ? "d-block d-xl-none d-xxl-block" : "" }}">
          {{ __('Find menu') }}
       </span>

--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -55,7 +55,7 @@
          data-bs-toggle="dropdown"
          data-testid="sidebar-menu-toggle"
          aria-expanded="{{ firstlevel_shown ? 'true' : 'false' }}">
-         <i class="{{ firstlevel['icon'] ?? '' }}"></i>
+         <i class="{{ firstlevel['icon'] ?? '' }}" aria-hidden="true"></i>
          <span class="menu-label">{{ firstlevel['title'] }}</span>
       </button>
       <div class="dropdown-menu {{ firstlevel_active and is_vertical != false ? '' : 'animate__animated' }} {{ is_vertical ? 'animate__fadeInLeft' : 'animate__zoomIn' }} {{ firstlevel_shown ? 'show' : '' }}">
@@ -66,7 +66,7 @@
             {% if has_dashboard %}
                <a class="dropdown-item"
                   href="{{ path(firstlevel['default_dashboard']) }}">
-                  <i class="{{ call('Glpi\\Dashboard\\Dashboard::getIcon') }}"></i>
+                  <i class="{{ call('Glpi\\Dashboard\\Dashboard::getIcon') }}" aria-hidden="true"></i>
                   {{ __('Dashboard') }}
                </a>
             {% endif %}
@@ -76,7 +76,7 @@
                   href="{{ path(sublevel['page']) }}"
                   aria-label="{{ sublevel['title'] }}"
                   accesskey="{{ sublevel['shortcut'] ?? '' }}">
-                  <i class="{{ sublevel['icon'] ?? '' }}"></i>
+                  <i class="{{ sublevel['icon'] ?? '' }}" aria-hidden="true"></i>
                   <span class='text-wrap'>
                      {{ sublevel['title']|shortcut(sublevel['shortcut'] ?? '') }}
                   </span>
@@ -96,7 +96,7 @@
    {% elseif firstlevel['default'] is defined and (firstlevel['display'] ?? true) != false %}
       <li class="nav-item dropdown {{ firstlevel_active ? 'active' : '' }}">
          <a class="nav-link" href="{{ path(firstlevel['default']) }}">
-            <i class="{{ firstlevel['icon'] ?? '' }}"></i>
+            <i class="{{ firstlevel['icon'] ?? '' }}" aria-hidden="true"></i>
             <span class="menu-label">{{ firstlevel['title'] }}</span>
          </a>
       <li>

--- a/templates/layout/parts/objectlock_message.html.twig
+++ b/templates/layout/parts/objectlock_message.html.twig
@@ -37,7 +37,7 @@
     {% set real_profile = session('glpilocksavedprofile')|default(null) %}
     {% if not check_unlock_right or (real_profile != null and real_profile[get_static(item.fields['itemtype'], 'rightname')] b-and constant('UNLOCK')) %}
         <button type="button" class="btn btn-sm btn-primary ms-2 force-unlock-item">
-            <i class="ti ti-lock-open"></i>
+            <i class="ti ti-lock-open" aria-hidden="true"></i>
             <span>{{ __('Force unlock %1s #%2s')|format(item.fields['itemtype']|itemtype_name, item.fields['items_id']) }}</span>
         </button>
     {% endif %}
@@ -46,7 +46,7 @@
 {% if autolock_readmode %}
     <div id="message_after_lock" class="d-inline-block w-100 alert alert-warning">
         <span class="me-3">
-            <i class="ti ti-eye"></i>
+            <i class="ti ti-eye" aria-hidden="true"></i>
             {{ __('Read-only mode') }}
         </span>
         <form method="post" class="d-inline">
@@ -78,7 +78,7 @@
                 {% if show_ask_unlock %}
                     <br>
                     <button type="button" class="btn btn-sm btn-primary ask-unlock-item mt-2 me-2">
-                        <i class="ti ti-lock-open"></i>
+                        <i class="ti ti-lock-open" aria-hidden="true"></i>
                         <span>{{ __('Ask for unlock') }}</span>
                     </button>
                     <div class="d-inline-flex" style="vertical-align: sub">

--- a/templates/layout/parts/page_header.html.twig
+++ b/templates/layout/parts/page_header.html.twig
@@ -54,7 +54,7 @@
       <aside class="navbar navbar-vertical navbar-expand-lg sticky-lg-top sidebar" data-testid="sidebar" aria-label="{{ __('Sidebar') }}">
          <div class="container-fluid">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-label="{{ __('Toggle navigation') }}">
-               <span class="navbar-toggler-icon"></span>
+               <span class="navbar-toggler-icon" aria-hidden="true"></span>
             </button>
 
             <a href="{{ index_path() }}" accesskey="1" title="{{ __('Home') }}"
@@ -106,7 +106,7 @@
 
             {% elseif is_horizontal %}
                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-label="{{ __('Toggle navigation') }}">
-                  <span class="navbar-toggler-icon"></span>
+                  <span class="navbar-toggler-icon" aria-hidden="true"></span>
                </button>
 
                <a href="{{ index_path() }}" accesskey="1" title="{{ __('Home') }}"

--- a/templates/layout/parts/profile_selector.html.twig
+++ b/templates/layout/parts/profile_selector.html.twig
@@ -41,7 +41,7 @@
         aria-expanded="false"
         aria-label="{{ __("Change profile") }}"
     >
-        <i class="ti ti-user-check"></i>
+        <i class="ti ti-user-check" aria-hidden="true"></i>
         {{ (session('glpiactiveprofile')['name'] ?? '') }}
     </button>
     <div class="dropdown-menu" data-bs-popper="none">
@@ -53,7 +53,7 @@
                     class="dropdown-item {{ is_active ? 'active' : '' }}"
                     type="submit"
                 >
-                    <i class="ti ti-user-check"></i>
+                    <i class="ti ti-user-check" aria-hidden="true"></i>
                     {{ profile['name'] }}
                 </button>
                 <input type="hidden" name="id" value="{{ profile_id }}" />
@@ -69,7 +69,7 @@
 {% endif %}
 {% if not is_multi_entities_mode() %}
     <span class="dropdown-item dropdown-item-text" title="{{ current_entity }}">
-        <i class="ti ti-stack"></i>
+        <i class="ti ti-stack" aria-hidden="true"></i>
         {{ current_entity_short|u.truncate(35, '...') }}
     </span>
 {% else %}

--- a/templates/layout/parts/saved_searches.html.twig
+++ b/templates/layout/parts/saved_searches.html.twig
@@ -38,7 +38,7 @@
 <div class="card col-2 d-flex flex-column responsive-toggle {{ pinned ? 'pinned' : 'd-none' }} saved-searches-panel {{ clean_itemtype }}"
      id="saved-searches-panel-{{ rand }}">
    <div class="card-header d-flex flex-nowrap pe-0 align-items-center text-muted">
-      <i class="ti ti-star"></i>&nbsp;
+      <i class="ti ti-star" aria-hidden="true"></i>&nbsp;
       <span class="text-truncate">
          {{ _n('Saved search', 'Saved searches', 2) }}
       </span>
@@ -47,17 +47,17 @@
          <a href="{{ path('front/savedsearch.php') }}" class="btn btn-sm btn-icon btn-ghost-secondary"
             data-bs-toggle="tooltip" data-bs-placement="bottom"
             title="{{ __('Manage all saved searches') }}">
-            <i class="ti ti-settings"></i>
+            <i class="ti ti-settings" aria-hidden="true"></i>
          </a>
          <button class="btn btn-sm btn-icon btn-ghost-secondary ms-1 d-none d-md-block pin-saved-searches-panel"
                  data-bs-toggle="tooltip" data-bs-placement="bottom"
                  title="{{ __('Pin this panel for the current page') }}">
-            <i class="ti ti-pinned"></i>
+            <i class="ti ti-pinned" aria-hidden="true"></i>
          </button>
          <button class="btn btn-sm btn-icon btn-ghost-secondary ms-1 close-saved-searches-panel"
                  data-bs-toggle="tooltip" data-bs-placement="bottom"
                  title="{{ __('Close the panel') }}">
-            <i class="ti ti-x"></i>
+            <i class="ti ti-x" aria-hidden="true"></i>
          </button>
       </li>
    </div>
@@ -94,7 +94,7 @@
                 placeholder="{{ __('Filter list') }}" />
          <span class="input-group-text">
             <a href="#" class="link-secondary clear-text" role="button" title="Clear search">
-               <i class="ti ti-x fs-5"></i>
+               <i class="ti ti-x fs-5" aria-hidden="true"></i>
             </a>
          </span>
       </div>

--- a/templates/layout/parts/user_header.html.twig
+++ b/templates/layout/parts/user_header.html.twig
@@ -70,7 +70,7 @@
                      <a href="{{ path('/ajax/switchdebug.php') }}"
                         class="dropdown-item {% if is_debug_active %}bg-red-lt{% endif %}"
                         title="{{ __('Change mode') }}">
-                        <i class="ti ti-bug debug"></i>
+                        <i class="ti ti-bug debug" aria-hidden="true"></i>
                         {{ is_debug_active ? __('Debug mode enabled') : __('Debug mode disabled') }}
                      </a>
                   {% endif %}
@@ -79,14 +79,14 @@
                {# @TODO Saved searches panel #}
 
                <div class="dropdown-item">
-                  <i class="ti ti-language"></i>
+                  <i class="ti ti-language" aria-hidden="true"></i>
                   {{ call('User::showSwitchLangForm')|raw }}
                </div>
 
                <div class="dropdown-divider"></div>
 
                <a href="{{ help_url }}" class="dropdown-item" title="{{ __('Help') }}">
-                  <i class="ti ti-help"></i>
+                  <i class="ti ti-help" aria-hidden="true"></i>
                   {{ __('Help') }}
                </a>
 
@@ -94,7 +94,7 @@
                <a href="#" class="dropdown-item" title="{{ __('About') }}"
                   id="show_about_modal_{{ rand_header }}"
                   data-testid="about-link">
-                  <i class="ti ti-info-circle"></i>
+                  <i class="ti ti-info-circle" aria-hidden="true"></i>
                   {{ __('About') }}
                   {% if found_new_version is not null %}
                      <span class="badge bg-info text-dark ms-2">
@@ -107,11 +107,11 @@
                <div class="dropdown-divider"></div>
 
                <a href="{{ path('/front/preference.php') }}" class="dropdown-item" title="{{ __('My settings') }}">
-                  <i class="ti ti-user-cog"></i>
+                  <i class="ti ti-user-cog" aria-hidden="true"></i>
                   {{ __('My settings') }}
                </a>
                <a href="{{ path('/front/logout.php' ~ ((session('glpiextauth') ?: false) ? '?noAUTO=1' : '')) }}" class="dropdown-item" title="{{ __('Logout') }}">
-                  <i class="ti ti-logout"></i>
+                  <i class="ti ti-logout" aria-hidden="true"></i>
                   {{ __('Logout') }}
                </a>
             </div>

--- a/templates/maintenance.html.twig
+++ b/templates/maintenance.html.twig
@@ -38,7 +38,7 @@
 <div class="flex-fill d-flex align-items-center justify-content-center">
    <div class="container-tight py-6">
       <div class="empty">
-         <i class="ti ti-tools fs-3x mb-3"></i>
+         <i class="ti ti-tools fs-3x mb-3" aria-hidden="true"></i>
 
          <p class="empty-title">{{ __('Temporarily down for maintenance') }}</p>
 

--- a/templates/pages/2fa/2fa_config.html.twig
+++ b/templates/pages/2fa/2fa_config.html.twig
@@ -87,7 +87,7 @@
         <div class="card-body mb-n5 border-top d-flex flex-row-reverse">
             <input type="hidden" name="id" value="{{ item.fields['id'] }}">
             <button type="submit" name="update" class="btn btn-primary">
-                <i class="ti ti-device-floppy me-1"></i>
+                <i class="ti ti-device-floppy me-1" aria-hidden="true"></i>
                 {{ _x('button', 'Save') }}
             </button>
         </div>

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -54,8 +54,9 @@
                      <div>
                         <div class="btn-group d-flex">
                            <input class="form-control" alt="{{ __('2FA secret') }}" value="{{ secret }}" aria-label="{{ __('2FA secret') }}" />
-                           <button type="button" class="btn btn-icon flex-grow-0 flex-shrink-0" name="copy_secret" data-clipboard-text="{{ secret }}">
-                              <i class="ti ti-clipboard-copy"></i>
+                           <button type="button" class="btn btn-icon flex-grow-0 flex-shrink-0" name="copy_secret" data-clipboard-text="{{ secret }}"
+                                   aria-label="{{ __('Copy') }}">
+                              <i class="ti ti-clipboard-copy" aria-hidden="true"></i>
                            </button>
                            <script>
                               $(document).ready(function() {

--- a/templates/pages/2fa/macros.html.twig
+++ b/templates/pages/2fa/macros.html.twig
@@ -142,7 +142,7 @@
                 });
                 table_body.append(`<tr><td>
                             <button class="btn btn-outline-secondary" type="button" name="copy_backup_codes">
-                                <i class="ti ti-copy"></i>
+                                <i class="ti ti-copy" aria-hidden="true"></i>
                                 {{ __('Copy backup codes') }}
                             </button>
                         </td></tr>`);

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -77,8 +77,9 @@
                                 </div>
 
                                 {% if configuration_form is not null %}
-                                    <button type="button" data-bs-toggle="modal" data-bs-target="#{{ get_class(capacity)|slug }}-modal" class="ms-1 btn btn-icon btn-sm btn-ghost-secondary">
-                                        <i class="ti ti-settings"></i>
+                                    <button type="button" data-bs-toggle="modal" data-bs-target="#{{ get_class(capacity)|slug }}-modal" class="ms-1 btn btn-icon btn-sm btn-ghost-secondary"
+                                            aria-label="{{ __('Configure') }} - {{ capacity.getLabel() }}">
+                                        <i class="ti ti-settings" aria-hidden="true"></i>
                                     </button>
                                 {% endif %}
                             </div>

--- a/templates/pages/admin/assetdefinition/capacities.html.twig
+++ b/templates/pages/admin/assetdefinition/capacities.html.twig
@@ -45,7 +45,7 @@
         <div class="d-flex mb-3">
             <input type="text" placeholder="{{ _x('button', 'Search') }}" class="me-3" id="search-capacities" />
             <a role="button" class="btn btn-sm btn-ghost-secondary ms-auto" id="select-all-capacities">
-                <i class="ti ti-copy-check"></i>
+                <i class="ti ti-copy-check" aria-hidden="true"></i>
                 <span>{{ __('Select/unselect all') }}</span>
             </a>
         </div>
@@ -68,7 +68,7 @@
                             {{ item.hasCapacityEnabled(capacity) ? 'checked' : '' }} />
                     <div class="form-selectgroup-label d-flex align-items-center h-100 shadow-none p-0 px-3">
                         <span class="me-2 mt-1">
-                            <i class="{{ capacity.getIcon() }} fa-2x text-secondary"></i>
+                            <i class="{{ capacity.getIcon() }} fa-2x text-secondary" aria-hidden="true"></i>
                         </span>
                         <div class="text-start">
                             <div class="d-flex align-items-center">
@@ -88,7 +88,7 @@
                             </small>
                             {% endif %}
                             <span class="alert-capacity text-red d-none" data-capacity="{{ get_class(capacity) }}">
-                                <i class="ti ti-alert-triangle fs-2"></i>
+                                <i class="ti ti-alert-triangle fs-2" aria-hidden="true"></i>
                                 <span>
                                     {{ capacity.getCapacityUsageDescription(classname) }}
                                 </span>
@@ -113,7 +113,7 @@
                                 <div class="modal-body">{{ configuration_form|raw }}</div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
-                                        <i class="ti ti-device-floppy"></i>
+                                        <i class="ti ti-device-floppy" aria-hidden="true"></i>
                                         <span>{{ _x('button', 'OK') }}</span>
                                     </button>
                                 </div>

--- a/templates/pages/admin/assetdefinition/capacity/is_inventoriable_capacity_configuration_form.html.twig
+++ b/templates/pages/admin/assetdefinition/capacity/is_inventoriable_capacity_configuration_form.html.twig
@@ -33,7 +33,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 <div class="alert alert-info alert-important d-flex align-items-center" role="alert">
-    <i class="ti ti-info-circle me-3 fa-2x"></i>
+    <i class="ti ti-info-circle me-3 fa-2x" aria-hidden="true"></i>
     <div>
         <h4 class="alert-title">{{ __("Please select the type that represents the best the asset.") }}</h4>
         {{ __("We need this information to send the inventory file in the correct inventory engine of the GLPI framework.") }}

--- a/templates/pages/admin/customobjects/translations.html.twig
+++ b/templates/pages/admin/customobjects/translations.html.twig
@@ -98,8 +98,9 @@
                         </td>
                         <td>
                             <div title="{{ __("Edit translation") }}" class="d-inline" data-bs-toggle="tooltip" data-bs-placement="top">
-                                <button type="button" class="btn btn-sm btn-icon btn-ghost-secondary edit-translation" data-bs-toggle="modal">
-                                    <i class="ti ti-pencil"></i>
+                                <button type="button" class="btn btn-sm btn-icon btn-ghost-secondary edit-translation" data-bs-toggle="modal"
+                                        aria-label="{{ __("Edit translation") }}">
+                                    <i class="ti ti-pencil" aria-hidden="true"></i>
                                 </button>
                             </div>
                             <div title="{{ __("Delete translation") }}" class="d-inline" data-bs-toggle="tooltip" data-bs-placement="top">
@@ -108,8 +109,9 @@
                                     <input type="hidden" name="_delete_translation" value="1" />
                                     <input type="hidden" name="field" value="{{ trans_data['id'] }}" />
                                     <input type="hidden" name="language" value="{{ trans_data['language'] }}" />
-                                    <button type="submit" name="update" class="btn btn-sm btn-icon btn-ghost-danger">
-                                        <i class="ti ti-trash-x"></i>
+                                    <button type="submit" name="update" class="btn btn-sm btn-icon btn-ghost-danger"
+                                            aria-label="{{ __("Delete translation") }}">
+                                        <i class="ti ti-trash-x" aria-hidden="true"></i>
                                     </button>
                                 </form>
                             </div>

--- a/templates/pages/admin/customobjects/translations.html.twig
+++ b/templates/pages/admin/customobjects/translations.html.twig
@@ -57,7 +57,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="submit" class="btn btn-primary" name="update">
-                        <i id="translation-modal-button-icon{{ rand }}"></i>
+                        <i id="translation-modal-button-icon{{ rand }}" aria-hidden="true"></i>
                         <span id="translation-modal-button-text{{ rand }}"></span>
                     </button>
                 </div>
@@ -68,7 +68,7 @@
 
 <div class="d-flex">
     <button type="button" class="btn btn-primary add-translation" data-bs-toggle="modal" data-bs-target="#TranslationModal{{ rand }}">
-        <i class="ti ti-plus"></i>
+        <i class="ti ti-plus" aria-hidden="true"></i>
         <span>{{ __("New translation") }}</span>
     </button>
 </div>
@@ -80,8 +80,8 @@
         <table class="table">
             <thead>
             <tr>
-                <th><i class="ti ti-forms me-1"></i>{{ __('Asset name / Field') }}</th>
-                <th><i class="ti ti-language me-1"></i>{{ __("Language") }}</th>
+                <th><i class="ti ti-forms me-1" aria-hidden="true"></i>{{ __('Asset name / Field') }}</th>
+                <th><i class="ti ti-language me-1" aria-hidden="true"></i>{{ __("Language") }}</th>
                 <th># {{ __("Translations") }}</th>
                 <th></th>
             </tr>
@@ -195,7 +195,7 @@
                             ${pluralForm.id}
                             <span class="form-help" data-bs-toggle="popover" data-bs-placement="top" data-bs-html="true"
                                   data-bs-content="${helper}">
-                                <i class="ti ti-help"></i>
+                                <i class="ti ti-help" aria-hidden="true"></i>
                             </span>
                         </label>
                         <input type="text" class="form-control" id="plural_${pluralForm.id}{{ rand }}" name="plurals[${pluralForm.id}]" value="${plural_value}">

--- a/templates/pages/admin/entity/assistance.html.twig
+++ b/templates/pages/admin/entity/assistance.html.twig
@@ -109,7 +109,7 @@
     {{ fields.smallTitle(__('Automatic closing configuration')) }}
     {% if closeticket_disabled or purgeticket_disabled %}
         <div class="alert alert-info">
-            <i class="ti ti-info-circle"></i>
+            <i class="ti ti-info-circle" aria-hidden="true"></i>
             <div>
                 {{ closeticket_disabled ? __('Close ticket action is disabled.') : '' }}
                 {{ purgeticket_disabled ? __('Purge ticket action is disabled.') : '' }}

--- a/templates/pages/admin/form/access_control.html.twig
+++ b/templates/pages/admin/form/access_control.html.twig
@@ -50,7 +50,7 @@
                             class="alert alert-warning d-flex align-items-center"
                             role="alert"
                         >
-                            <i class="ti ti-alert-triangle me-2"></i>
+                            <i class="ti ti-alert-triangle me-2" aria-hidden="true"></i>
                             {{ warning }}
                         </div>
                     {% endfor %}
@@ -69,7 +69,7 @@
                     aria-label="{{ strategy.getLabel() }}"
                 >
                     <h3 class="d-flex align-items-center">
-                        <i class="{{ strategy.getIcon() }} me-2"></i>
+                        <i class="{{ strategy.getIcon() }} me-2" aria-hidden="true"></i>
                         {{ strategy.getLabel() }}
                         <label class="form-check mb-0 ms-auto form-switch">
                             <input
@@ -109,7 +109,7 @@
                         class="btn btn-primary"
                         name="update"
                     >
-                        <i class="ti ti-device-floppy me-2"></i>
+                        <i class="ti ti-device-floppy me-2" aria-hidden="true"></i>
                         {{ __("Save changes") }}
                     </button>
                 </div>

--- a/templates/pages/admin/form/access_control/direct_access.html.twig
+++ b/templates/pages/admin/form/access_control/direct_access.html.twig
@@ -52,7 +52,7 @@
             data-glpi-direct-access-refresh-url
         >
         <span class="input-icon-addon">
-            <i class="ti ti-files"></i>
+            <i class="ti ti-files" aria-hidden="true"></i>
         </span>
     </div>
     <i
@@ -80,7 +80,7 @@
         {{ config.allowUnauthenticated() ? 'checked' : '' }}
     >
     <span class="form-check-label">
-        <i class="ti ti-lock-open"></i>
+        <i class="ti ti-lock-open" aria-hidden="true"></i>
         {{ __("Allow unauthenticated users") }}
         <span class="form-help"
             data-bs-toggle="popover"

--- a/templates/pages/admin/form/condition_configuration.html.twig
+++ b/templates/pages/admin/form/condition_configuration.html.twig
@@ -69,7 +69,7 @@
                     aria-label="{{ strategy.getLabel() }}"
                     data-testid="strategy-label-{{ strategy.value }}"
                 >
-                    <i class="{{ strategy.getIcon() }} me-2"></i>
+                    <i class="{{ strategy.getIcon() }} me-2" aria-hidden="true"></i>
                     {{ strategy.getLabel() }}
                 </label>
             {% endfor %}

--- a/templates/pages/admin/form/conditional_validation_dropdown.html.twig
+++ b/templates/pages/admin/form/conditional_validation_dropdown.html.twig
@@ -70,7 +70,7 @@
                     class="{{ display_class }} align-items-center"
                     data-glpi-editor-validation-badge="{{ strategy.value }}"
                 >
-                    <i class="{{ strategy.getIcon() }} me-1"></i>
+                    <i class="{{ strategy.getIcon() }} me-1" aria-hidden="true"></i>
                     <span>{{ strategy.getLabel() }}</span>
                 </div>
             {% endfor %}
@@ -90,7 +90,7 @@
             <div class="card validation-dropdown-card">
                 <div class="card-body">
                     <h3 class="card-title d-flex align-items-center">
-                        <i class="ti ti-circuit-changeover me-2"></i>
+                        <i class="ti ti-circuit-changeover me-2" aria-hidden="true"></i>
                         {{ __('Conditional validation') }}
                     </h3>
 

--- a/templates/pages/admin/form/conditional_validation_editor.html.twig
+++ b/templates/pages/admin/form/conditional_validation_editor.html.twig
@@ -132,7 +132,7 @@
         class="d-flex align-items-center btn btn-sm btn-ghost-secondary mt-3"
         aria-label="{{ __("Add another criteria") }}"
     >
-        <i class="ti ti-plus me-1"></i>
+        <i class="ti ti-plus me-1" aria-hidden="true"></i>
         <span>{{ __("Add another criteria") }}</span>
     </button>
 {% endif %}

--- a/templates/pages/admin/form/conditional_visibility_dropdown.html.twig
+++ b/templates/pages/admin/form/conditional_visibility_dropdown.html.twig
@@ -80,7 +80,7 @@
                     data-glpi-editor-visibility-badge="{{ strategy.value }}"
                     aria-label="{{ strategy.getLabel() }}"
                 >
-                    <i class="{{ strategy.getIcon() }} me-1"></i>
+                    <i class="{{ strategy.getIcon() }} me-1" aria-hidden="true"></i>
                     <span>{{ strategy.getLabel() }}</span>
                 </div>
             {% endfor %}
@@ -101,7 +101,7 @@
             <div class="card visibility-dropdown-card" data-glpi-form-editor-on-click="stop-propagation">
                 <div class="card-body">
                     <h3 class="card-title d-flex align-items-center">
-                        <i class="ti ti-circuit-changeover me-2"></i>
+                        <i class="ti ti-circuit-changeover me-2" aria-hidden="true"></i>
                         {{ __('Conditional visibility') }}
                     </h3>
 

--- a/templates/pages/admin/form/conditional_visibility_editor.html.twig
+++ b/templates/pages/admin/form/conditional_visibility_editor.html.twig
@@ -147,7 +147,7 @@
         class="d-flex align-items-center btn btn-sm btn-ghost-secondary mt-3"
         aria-label="{{ __("Add another criteria") }}"
     >
-        <i class="ti ti-plus me-1"></i>
+        <i class="ti ti-plus me-1" aria-hidden="true"></i>
         <span>{{ __("Add another criteria") }}</span>
     </button>
 {% endif %}

--- a/templates/pages/admin/form/form_comment.html.twig
+++ b/templates/pages/admin/form/form_comment.html.twig
@@ -69,7 +69,7 @@
                     class="glpi-form-editor-question-handle ti ti-grip-horizontal cursor-grab ms-auto me-auto mt-n3 mb-n2"
                     data-glpi-form-editor-question-handle
                     draggable="true"
-                    data-glpi-form-editor-state-action
+                    data-glpi-form-editor-state-action aria-hidden="true"
                 ></i>
             </div>
             {# Display comment's title #}
@@ -138,7 +138,7 @@
                                 aria-label="{{ __('Configure visibility') }}"
                                 data-glpi-form-editor-on-click="show-visibility-dropdown"
                             >
-                                <i class="ti ti-eye-cog me-2"></i>
+                                <i class="ti ti-eye-cog me-2" aria-hidden="true"></i>
                                 <span>{{ __("Configure visibility") }}</span>
                             </button>
                         </li>

--- a/templates/pages/admin/form/form_destination.html.twig
+++ b/templates/pages/admin/form/form_destination.html.twig
@@ -39,13 +39,13 @@
 
 <div class="py-2 px-3">
     <h2 class="d-flex">
-        <i class="{{ icon }} me-2"></i>
+        <i class="{{ icon }} me-2" aria-hidden="true"></i>
         {{ _n("Destination", "Destinations", get_plural_number()) }}
     </h2>
 
     {% for warning in warnings %}
         <div class="alert alert-warning d-flex align-items-center mb-3" role="alert">
-            <i class="ti ti-alert-triangle me-2"></i>
+            <i class="ti ti-alert-triangle me-2" aria-hidden="true"></i>
             {{ warning }}
         </div>
     {% endfor %}
@@ -72,7 +72,7 @@
                     type="submit"
                     value="{{ type }}"
                 >
-                    <i class="ti ti-plus me-1"></i> {{ __("Add %s")|format(label) }}
+                    <i class="ti ti-plus me-1" aria-hidden="true"></i> {{ __("Add %s")|format(label) }}
                 </button>
             {% endfor %}
         </div>
@@ -102,7 +102,7 @@
                             aria-expanded="{{ is_expanded ? 'true' : 'false' }}"
                             data-glpi-destination-click-on-space {# Simulate how space would behave in a button instead of a div #}
                         >
-                            <i class="{{ concrete_destination ? concrete_destination.getIcon() : 'ti ti-unlink text-white' }}"></i>
+                            <i class="{{ concrete_destination ? concrete_destination.getIcon() : 'ti ti-unlink text-white' }}" aria-hidden="true"></i>
                             <span
                                 class="m-0 lh-base fw-normal glpi-form-destination-name {{ not concrete_destination ? 'text-white' : '' }}"
                             >
@@ -117,7 +117,7 @@
                                         class="{{ display_class }} badge bg-secondary-lt d-flex align-items-center ms-2"
                                         data-glpi-editor-condition-badge="{{ strategy.value }}"
                                     >
-                                        <i class="{{ strategy.getIcon() }} me-1 {{ not concrete_destination ? 'text-white' : '' }}"></i>
+                                        <i class="{{ strategy.getIcon() }} me-1 {{ not concrete_destination ? 'text-white' : '' }}" aria-hidden="true"></i>
                                         <span class="{{ not concrete_destination ? 'text-white' : '' }}">{{ strategy.getLabel() }}</span>
                                     </span>
                                 {% endfor %}

--- a/templates/pages/admin/form/form_destination_actions.html.twig
+++ b/templates/pages/admin/form/form_destination_actions.html.twig
@@ -40,7 +40,7 @@
             formaction="{{ path('/Form/%d/Destination/%d/Update'|format(form.getID(), destination.getID())) }}"
             formmethod="post"
         >
-            <i class="ti ti-device-floppy me-2"></i>
+            <i class="ti ti-device-floppy me-2" aria-hidden="true"></i>
             {{ __("Update item") }}
         </button>
         {% if destination.canPurgeItem() %}
@@ -51,7 +51,7 @@
                 formaction="{{ path('/Form/%d/Destination/%d/Purge'|format(form.getID(), destination.getID())) }}"
                 formmethod="post"
             >
-                <i class="ti ti-trash me-2"></i>
+                <i class="ti ti-trash me-2" aria-hidden="true"></i>
                 {{ __("Delete") }}
             </button>
         {% endif %}
@@ -62,7 +62,7 @@
             formaction="{{ path('/Form/%d/Destination/Add'|format(form.getID())) }}"
             formmethod="post"
         >
-            <i class="ti ti-copy me-2"></i>
+            <i class="ti ti-copy me-2" aria-hidden="true"></i>
             {{ __("Duplicate") }}
         </button>
     </div>
@@ -83,7 +83,7 @@
                     class="{{ display_class }} align-items-center"
                     data-glpi-editor-condition-badge="{{ strategy.value }}"
                 >
-                    <i class="{{ strategy.getIcon() }} me-1"></i>
+                    <i class="{{ strategy.getIcon() }} me-1" aria-hidden="true"></i>
                     <span>{{ strategy.getLabel() }}</span>
                 </div>
             {% endfor %}
@@ -105,7 +105,7 @@
             <div class="card visibility-dropdown-card" data-glpi-form-editor-on-click="stop-propagation">
                 <div class="card-body">
                     <h3 class="card-title d-flex align-items-center">
-                        <i class="ti ti-circuit-changeover me-2"></i>
+                        <i class="ti ti-circuit-changeover me-2" aria-hidden="true"></i>
                         {{ __('Conditions') }}
                     </h3>
 

--- a/templates/pages/admin/form/form_destination_commonitil_config.html.twig
+++ b/templates/pages/admin/form/form_destination_commonitil_config.html.twig
@@ -164,7 +164,7 @@
                                 aria-label="{{ __('Remove strategy') }}"
                                 data-glpi-itildestination-remove-field-config
                             >
-                                <i class="ti ti-x"></i>
+                                <i class="ti ti-x" aria-hidden="true"></i>
                             </button>
                         {% endif %}
                     </section>
@@ -176,7 +176,7 @@
                         aria-label="{{ __('Combine with another option') }}"
                         data-glpi-itildestination-add-field-config
                     >
-                        <i class="ti ti-plus me-2"></i>
+                        <i class="ti ti-plus me-2" aria-hidden="true"></i>
                         {{ __('Combine with another option') }}
                     </button>
                 {% endif %}
@@ -199,7 +199,7 @@
                         aria-label="{{ __('Combine with another option') }}"
                         data-glpi-itildestination-add-field-config
                     >
-                        <i class="ti ti-plus me-2"></i>
+                        <i class="ti ti-plus me-2" aria-hidden="true"></i>
                         {{ __('Combine with another option') }}
                     </button>
                 {% endif %}
@@ -255,7 +255,7 @@
                             aria-label="{{ __('Remove strategy') }}"
                             data-glpi-itildestination-remove-field-config
                         >
-                            <i class="ti ti-x"></i>
+                            <i class="ti ti-x" aria-hidden="true"></i>
                         </button>
                     </section>
                 {% else %}
@@ -377,7 +377,7 @@
                                 aria-controls="item-{{ rand }}-{{ loop.index }}"
                                 aria-label="{{ category.label }}"
                             >
-                                <i class="{{ category.icon }} item-icon"></i>
+                                <i class="{{ category.icon }} item-icon" aria-hidden="true"></i>
                                 <span class="item-title">{{ category.label }}</span>
                             </button>
                         </div>

--- a/templates/pages/admin/form/form_editor.html.twig
+++ b/templates/pages/admin/form/form_editor.html.twig
@@ -89,7 +89,7 @@
                                 {% if invalid_questions|length %}
                                     <div class="alert alert-danger" role="alert">
                                         <div class="alert-icon">
-                                            <i class="ti ti-exclamation-circle"></i>
+                                            <i class="ti ti-exclamation-circle" aria-hidden="true"></i>
                                         </div>
                                         <div>
                                             <h4 class="alert-heading">{{ __("These questions have an unknown type and will be deleted the next time this form is saved:") }}</h4>
@@ -210,7 +210,7 @@
                                         aria-controls="item-properties" #}
                                         aria-label="Properties"
                                     >
-                                        <i class="ti ti-alert-circle item-icon"></i>
+                                        <i class="ti ti-alert-circle item-icon" aria-hidden="true"></i>
                                         <span class="item-title">{{ __('Form properties') }}</span>
                                     </button>
                                 </div>
@@ -220,7 +220,7 @@
                                             function renderLayoutTemplateResult(data) {
                                                 const icons = {{ enum('Glpi\\Form\\RenderLayout').cases|map((case) => {(case.value): case.getIcon()})|reduce((carry, item) => carry|merge(item), {})|json_encode|raw }};
 
-                                                return $(`<span class="w-full d-flex align-items-center gap-2" title="${_.escape(data.text)}""><i class="${_.escape(icons[data.id])}"></i>${_.escape(data.text)}</span>`);
+                                                return $(`<span class="w-full d-flex align-items-center gap-2" title="${_.escape(data.text)}""><i class="${_.escape(icons[data.id])}" aria-hidden="true"></i>${_.escape(data.text)}</span>`);
                                             }
 
                                             function renderLayoutTemplateSelection(data) {
@@ -298,7 +298,7 @@
                 title="{{ __("Add") }}"
                 aria-label="{{ __("Add") }}"
             >
-                <i class="ti ti-plus me-1"></i>
+                <i class="ti ti-plus me-1" aria-hidden="true"></i>
                 <span class="d-block add-label">{{ __("Add") }}</span>
             </button>
         {% elseif can_update %}
@@ -311,7 +311,7 @@
                 title="{{ __("Save") }}"
                 aria-label="{{ __("Save") }}"
             >
-                <i class="ti ti-device-floppy me-1"></i>
+                <i class="ti ti-device-floppy me-1" aria-hidden="true"></i>
                 <span class="d-block save-label">{{ __("Save") }}</span>
             </button>
         {% endif %}
@@ -329,7 +329,7 @@
                 name="restore"
                 form="main-form"
             >
-                <i class="ti ti-trash-off me-1"></i>{{ __("Restore") }}
+                <i class="ti ti-trash-off me-1" aria-hidden="true"></i>{{ __("Restore") }}
             </button>
         {% endif %}
 
@@ -341,7 +341,7 @@
                 name="purge"
                 form="main-form"
             >
-                <i class="ti ti-trash me-1"></i>{{ _x("button", "Delete permanently") }}
+                <i class="ti ti-trash me-1" aria-hidden="true"></i>{{ _x("button", "Delete permanently") }}
             </button>
         {% endif %}
 
@@ -360,7 +360,7 @@
                 name="delete"
                 form="main-form"
             >
-                <i class="ti ti-trash me-1"></i>{{ __("Put in trashbin") }}
+                <i class="ti ti-trash me-1" aria-hidden="true"></i>{{ __("Put in trashbin") }}
             </button>
         {% endif %}
 
@@ -376,7 +376,7 @@
                 title="{{ __("Preview") }}"
                 data-glpi-form-editor-preview-action
             >
-                <i class="ti ti-eye me-1"></i>
+                <i class="ti ti-eye me-1" aria-hidden="true"></i>
                 <span class="d-none d-xl-block">{{ __("Preview") }}</span>
             </a>
             <button
@@ -389,7 +389,7 @@
                 data-glpi-form-editor-save-and-preview-action
                 data-glpi-form-editor-preview-url="{{ path('/Form/Render/' ~ item.fields.id) }}"
             >
-                <i class="ti ti-eye me-1"></i>
+                <i class="ti ti-eye me-1" aria-hidden="true"></i>
                 <span class="d-none d-xl-block">{{ __("Save and preview") }}</span>
             </button>
         </div>

--- a/templates/pages/admin/form/form_horizontal_block_toolbar.html.twig
+++ b/templates/pages/admin/form/form_horizontal_block_toolbar.html.twig
@@ -51,7 +51,7 @@
             type="button"
         >
             <span class="px-2 d-flex align-items-center">
-                <i class="ti ti-square-plus"></i>
+                <i class="ti ti-square-plus" aria-hidden="true"></i>
             </span>
         </button>
 
@@ -66,7 +66,7 @@
             type="button"
         >
             <span class="px-2 d-flex align-items-center">
-                <i class="ti ti-trash"></i>
+                <i class="ti ti-trash" aria-hidden="true"></i>
             </span>
         </button>
     </div>

--- a/templates/pages/admin/form/form_question.html.twig
+++ b/templates/pages/admin/form/form_question.html.twig
@@ -163,7 +163,7 @@
                                 class="dropdown-item"
                                 data-glpi-form-editor-on-click="show-visibility-dropdown"
                             >
-                                <i class="ti ti-eye-cog me-2"></i>
+                                <i class="ti ti-eye-cog me-2" aria-hidden="true"></i>
                                 <span>{{ __("Configure visibility") }}</span>
                             </button>
                         </li>
@@ -174,7 +174,7 @@
                                 class="dropdown-item"
                                 data-glpi-form-editor-on-click="show-validation-dropdown"
                             >
-                                <i class="ti ti-checks me-2"></i>
+                                <i class="ti ti-checks me-2" aria-hidden="true"></i>
                                 <span>{{ __("Configure validation") }}</span>
                             </button>
                         </li>
@@ -184,7 +184,7 @@
                                 class="dropdown-item"
                                 data-glpi-form-editor-on-click="copy-uuid"
                             >
-                                <i class="ti ti-id-badge me-2"></i>
+                                <i class="ti ti-id-badge me-2" aria-hidden="true"></i>
                                 <span>{{ __("Copy uuid") }}</span>
                             </button>
                         </li>

--- a/templates/pages/admin/form/form_section.html.twig
+++ b/templates/pages/admin/form/form_section.html.twig
@@ -162,7 +162,7 @@
                                             class="dropdown-item"
                                             data-glpi-form-editor-on-click="duplicate-section"
                                         >
-                                            <i class="ti ti-copy me-2"></i>
+                                            <i class="ti ti-copy me-2" aria-hidden="true"></i>
                                             <span>{{ __("Duplicate section") }}</span>
                                         </button>
                                     </li>
@@ -174,7 +174,7 @@
                                             data-bs-target="[data-glpi-form-editor-move-section-modal]"
                                             data-glpi-form-editor-on-click="build-move-section-modal-content"
                                         >
-                                            <i class="ti ti-arrows-move-vertical me-2"></i>
+                                            <i class="ti ti-arrows-move-vertical me-2" aria-hidden="true"></i>
                                             <span>{{ __("Move section") }}</span>
                                         </button>
                                     </li>
@@ -185,7 +185,7 @@
                                             aria-label="{{ __('Merge with previous section') }}"
                                             data-glpi-form-editor-on-click="merge-with-previous-section"
                                         >
-                                            <i class="ti ti-arrow-merge me-2"></i>
+                                            <i class="ti ti-arrow-merge me-2" aria-hidden="true"></i>
                                             <span>{{ __("Merge with previous section") }}</span>
                                         </button>
                                     </li>
@@ -196,7 +196,7 @@
                                             class="dropdown-item"
                                             data-glpi-form-editor-on-click="delete-section"
                                         >
-                                            <i class="ti ti-trash me-2"></i>
+                                            <i class="ti ti-trash me-2" aria-hidden="true"></i>
                                             <span>{{ __("Delete section") }}</span>
                                         </button>
                                     </li>
@@ -208,7 +208,7 @@
                                             aria-label="{{ __('Configure visibility') }}"
                                             data-glpi-form-editor-on-click="show-visibility-dropdown"
                                         >
-                                            <i class="ti ti-eye-cog me-2"></i>
+                                            <i class="ti ti-eye-cog me-2" aria-hidden="true"></i>
                                             <span>{{ __("Configure visibility") }}</span>
                                         </button>
                                     </li>

--- a/templates/pages/admin/form/form_toolbar.html.twig
+++ b/templates/pages/admin/form/form_toolbar.html.twig
@@ -62,7 +62,7 @@
             type="button"
         >
             <span class="px-2 d-flex align-items-center">
-                <i class="ti ti-circle-plus"></i>
+                <i class="ti ti-circle-plus" aria-hidden="true"></i>
             </span>
         </button>
 
@@ -77,7 +77,7 @@
             data-glpi-form-editor-on-click="add-comment"
         >
             <span class="px-2 d-flex align-items-center">
-                <i class="ti ti-letter-case"></i>
+                <i class="ti ti-letter-case" aria-hidden="true"></i>
             </span>
         </button>
 
@@ -94,7 +94,7 @@
                 data-glpi-form-editor-on-click="add-section"
                 type="button"
             >
-                <i class="ti ti-box-align-top"></i>
+                <i class="ti ti-box-align-top" aria-hidden="true"></i>
             </button>
         {% endif %}
 
@@ -110,7 +110,7 @@
                 data-glpi-form-editor-on-click="add-horizontal-layout"
             >
                 <span class="px-2 d-flex align-items-center">
-                    <i class="ti ti-layout-columns"></i>
+                    <i class="ti ti-layout-columns" aria-hidden="true"></i>
                 </span>
             </button>
         {% endif %}
@@ -127,7 +127,7 @@
                 type="button"
             >
                 <span class="px-2 d-flex align-items-center">
-                    <i class="ti ti-trash"></i>
+                    <i class="ti ti-trash" aria-hidden="true"></i>
                 </span>
             </button>
         {% endif %}

--- a/templates/pages/admin/form/form_translation.html.twig
+++ b/templates/pages/admin/form/form_translation.html.twig
@@ -95,7 +95,7 @@
             title="{{ __('Copy default value to translation') }}"
             role="button"
             aria-label="{{ __('Copy default value to translation') }}">
-            <i class="ti ti-arrow-big-right"></i>
+            <i class="ti ti-arrow-big-right" aria-hidden="true"></i>
         </a>
     </div>
 

--- a/templates/pages/admin/form/form_translations.html.twig
+++ b/templates/pages/admin/form/form_translations.html.twig
@@ -41,7 +41,7 @@
             data-bs-target="#addLanguageModal"
             aria-label="{{ __('Add language') }}"
         >
-            <i class="ti ti-plus me-1"></i>
+            <i class="ti ti-plus me-1" aria-hidden="true"></i>
             {{ __('Add language') }}
         </button>
     </div>

--- a/templates/pages/admin/form/import/step2_preview.html.twig
+++ b/templates/pages/admin/form/import/step2_preview.html.twig
@@ -62,7 +62,7 @@
                             <td class="w-50 px-4 align-middle">{{ form_name }}</td>
                             <td class="w-50 px-4 align-middle">
                                 <div class="d-flex align-items-center">
-                                    <i class="ti {{ status_icon }} me-2"></i>
+                                    <i class="ti {{ status_icon }} me-2" aria-hidden="true"></i>
                                     <div>
                                         {% for message in messages %}
                                             <span>{{ message }}</span>
@@ -83,7 +83,7 @@
                                                 title="{{ __('Remove this form from the import list') }}"
                                                 aria-label="{{ __('Remove form') }}"
                                             >
-                                                <i class="ti ti-trash"></i>
+                                                <i class="ti ti-trash" aria-hidden="true"></i>
                                             </button>
                                         {% endif %}
 

--- a/templates/pages/admin/form/import/step3_resolve_issues.html.twig
+++ b/templates/pages/admin/form/import/step3_resolve_issues.html.twig
@@ -62,7 +62,7 @@
                         <tr>
                             <td class="px-4 align-middle">
                                 <div class="d-flex align-items-center">
-                                    <i class="me-2 {{ issue.itemtype|itemtype_icon }}"></i>
+                                    <i class="me-2 {{ issue.itemtype|itemtype_icon }}" aria-hidden="true"></i>
                                     <span>{{ issue.itemtype|itemtype_name }}</span>
                                 </div>
                             </td>

--- a/templates/pages/admin/form/import/step4_execute.html.twig
+++ b/templates/pages/admin/form/import/step4_execute.html.twig
@@ -56,7 +56,7 @@
                         <td class="w-70 px-4">{{ get_item_link(form) }}</td>
                         <td class="w-30 px-4">
                             <div class="d-flex align-items-center">
-                                <i class="ti ti-check text-success me-2"></i>
+                                <i class="ti ti-check text-success me-2" aria-hidden="true"></i>
                                 <span>{{ __("Imported") }}</span>
                             </div>
                         </td>
@@ -67,7 +67,7 @@
                         <td class="w-70 px-4">{{ forms_name }}</td>
                         <td class="w-30 px-4">
                         <div class="d-flex align-items-center">
-                                <i class="ti ti-x text-danger me-2"></i>
+                                <i class="ti ti-x text-danger me-2" aria-hidden="true"></i>
                                 <span>{{ __("Not imported") }}</span>
                             </div>
                         </td>

--- a/templates/pages/admin/form/item_has_conditions_modal_base.html.twig
+++ b/templates/pages/admin/form/item_has_conditions_modal_base.html.twig
@@ -64,7 +64,7 @@
     {# Item template for conditions list #}
     <div class="d-none" data-glpi-form-editor-item-has-conditions-item-template>
         <div class="list-group-item d-flex align-items-center space-x-2 p-3">
-            <i class="ti ti-circle-x fa-lg text-danger"></i>
+            <i class="ti ti-circle-x fa-lg text-danger" aria-hidden="true"></i>
             <a href="#" class="m-0" style="font-weight: var(--tblr-font-weight-medium)"
                data-glpi-form-editor-item-has-conditions-item-name
                data-glpi-form-editor-item-has-conditions-item-selector

--- a/templates/pages/admin/form/itil_config_fields/associated_items.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/associated_items.html.twig
@@ -41,7 +41,7 @@
 >
     {% set remove_button %}
         <button type="button" class="btn btn-icon btn-outline rounded-0" data-glpi-remove-associated-item-button aria-label="{{ __('Remove item') }}">
-            <i class="ti ti-x"></i>
+            <i class="ti ti-x" aria-hidden="true"></i>
         </button>
     {% endset %}
 

--- a/templates/pages/admin/form/itil_config_fields/linked_itilobjects.html.twig
+++ b/templates/pages/admin/form/itil_config_fields/linked_itilobjects.html.twig
@@ -151,7 +151,7 @@
             aria-label="{{ __('Remove strategy') }}"
             data-glpi-itildestination-remove-field-config
         >
-            <i class="ti ti-x"></i>
+            <i class="ti ti-x" aria-hidden="true"></i>
         </button>
     </section>
 {% endfor %}

--- a/templates/pages/admin/form/move_section_modal.html.twig
+++ b/templates/pages/admin/form/move_section_modal.html.twig
@@ -82,7 +82,7 @@
                 <div class="col-auto">
                     <i
                         class="ti ti-grip-vertical"
-                        style="opacity: 0.6;"
+                        style="opacity: 0.6;" aria-hidden="true"
                     ></i>
                 </div>
                 <div

--- a/templates/pages/admin/form/question_type/actors_admin.html.twig
+++ b/templates/pages/admin/form/question_type/actors_admin.html.twig
@@ -139,7 +139,7 @@
                                 {% endif %}
                             >
                             <span class="form-check-label">
-                                <i class="{{ type|itemtype_icon }}"></i>
+                                <i class="{{ type|itemtype_icon }}" aria-hidden="true"></i>
                                 {{ type|itemtype_name(2) }}
                             </span>
                         </label>

--- a/templates/pages/admin/form/question_type/base_advanced_configuration.html.twig
+++ b/templates/pages/admin/form/question_type/base_advanced_configuration.html.twig
@@ -42,7 +42,7 @@
         title="{{ __('Advanced configuration') }}"
         aria-label="{{ __('Advanced configuration') }}"
     >
-        <i class="ti ti-settings"></i>
+        <i class="ti ti-settings" aria-hidden="true"></i>
     </button>
     <div
         style="width: 32rem"

--- a/templates/pages/admin/form/service_catalog_tab.html.twig
+++ b/templates/pages/admin/form/service_catalog_tab.html.twig
@@ -35,7 +35,7 @@
 <form method="POST" action="{{ item.getFormURL() }}" data-submit-once>
     <div class="py-2 px-3 container-narrow ms-0">
         <h2 class="d-flex align-items-center">
-            <i class="{{ icon }} me-2"></i>
+            <i class="{{ icon }} me-2" aria-hidden="true"></i>
             {{ __("Service catalog configuration") }}
             {% if item.isField('show_in_service_catalog') %}
                 <label class="form-check mb-0 ms-auto form-switch">
@@ -104,7 +104,7 @@
         {# Actions #}
         <div class="d-flex mt-4">
             <button type="submit" name="update" class="btn btn-primary ms-auto">
-                <i class="ti ti-device-floppy me-1 "></i>
+                <i class="ti ti-device-floppy me-1 " aria-hidden="true"></i>
                 {{ __("Save changes") }}
             </button>
         </div>

--- a/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
+++ b/templates/pages/admin/form/submit_button_conditional_visibility_dropdown.html.twig
@@ -61,7 +61,7 @@
                     data-glpi-editor-visibility-badge="{{ strategy.value }}"
                     data-testid="active-visibility-setting"
                 >
-                    <i class="{{ strategy.getIcon() }} me-1"></i>
+                    <i class="{{ strategy.getIcon() }} me-1" aria-hidden="true"></i>
                     <span>{{ strategy.getLabel() }}</span>
                     <span
                         class="badge text-bg-secondary ms-1"
@@ -80,7 +80,7 @@
             <div class="card visibility-dropdown-card" data-glpi-form-editor-on-click="stop-propagation">
                 <div class="card-body">
                     <h3 class="card-title d-flex align-items-center">
-                        <i class="ti ti-circuit-changeover me-2"></i>
+                        <i class="ti ti-circuit-changeover me-2" aria-hidden="true"></i>
                         {{ __('Conditional visibility') }}
                     </h3>
                     {% if allow_unauthenticated_access is defined and allow_unauthenticated_access %}

--- a/templates/pages/admin/helpdesk_home_config.html.twig
+++ b/templates/pages/admin/helpdesk_home_config.html.twig
@@ -44,7 +44,7 @@
                     class="alert alert-info d-flex align-items-center mb-3"
                     role="alert"
                 >
-                    <i class="ti ti-info-circle me-2"></i>
+                    <i class="ti ti-info-circle me-2" aria-hidden="true"></i>
                     {{ info_text }}
                 </div>
             {% endif %}
@@ -69,7 +69,7 @@
                         data-glpi-helpdesk-config-reorder-action-save
                         aria-label="{{ __("Save tiles order") }}"
                     >
-                        <i class="ti ti-device-floppy me-1"></i>
+                        <i class="ti ti-device-floppy me-1" aria-hidden="true"></i>
                         <span>{{ __("Save tiles order") }}<span>
                     </button>
                 </div>

--- a/templates/pages/admin/helpdesk_home_config_add_tile_form.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_add_tile_form.html.twig
@@ -65,11 +65,11 @@
             >
                 <i
                     class="ti ti-plus me-1"
-                    data-glpi-helpdesk-config-add-tile-submit-plus-icon
+                    data-glpi-helpdesk-config-add-tile-submit-plus-icon aria-hidden="true"
                 ></i>
                 <i
                     class="ti ti-loader-2 fa-spin me-1 d-none"
-                    data-glpi-helpdesk-config-add-tile-submit-spinner-icon
+                    data-glpi-helpdesk-config-add-tile-submit-spinner-icon aria-hidden="true"
                 ></i>
                 <span>{{ __("Add tile") }}</span>
             </button>

--- a/templates/pages/admin/helpdesk_home_config_edit_tile_form.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_edit_tile_form.html.twig
@@ -48,11 +48,11 @@
             >
                 <i
                     class="ti ti-trash me-1"
-                    data-glpi-helpdesk-config-delete-tile-icon
+                    data-glpi-helpdesk-config-delete-tile-icon aria-hidden="true"
                 ></i>
                 <i
                     class="ti ti-loader-2 fa-spin me-1 d-none"
-                    data-glpi-helpdesk-config-delete-tile-spinner-icon
+                    data-glpi-helpdesk-config-delete-tile-spinner-icon aria-hidden="true"
                 ></i>
                 <span>{{ __("Delete tile") }}<span>
             </button>
@@ -64,11 +64,11 @@
             >
                 <i
                     class="ti ti-device-floppy me-1"
-                    data-glpi-helpdesk-config-edit-tile-save-icon
+                    data-glpi-helpdesk-config-edit-tile-save-icon aria-hidden="true"
                 ></i>
                 <i
                     class="ti ti-loader-2 fa-spin me-1 d-none"
-                    data-glpi-helpdesk-config-edit-tile-save-spinner-icon
+                    data-glpi-helpdesk-config-edit-tile-save-spinner-icon aria-hidden="true"
                 ></i>
                 <span>{{ __("Save changes") }}</span>
             </button>

--- a/templates/pages/admin/helpdesk_home_config_for_empty_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_empty_entity.html.twig
@@ -76,7 +76,7 @@
                 data-glpi-helpdesk-config-tiles-empty-entity-copy-tiles
                 aria-label="{{ __("Copy parent entity configuration into this entity") }}"
             >
-                <i class="ti ti-copy me-2"></i>
+                <i class="ti ti-copy me-2" aria-hidden="true"></i>
                 {{ __("Copy parent entity configuration into this entity") }}
             </button>
             <button
@@ -85,7 +85,7 @@
                 data-glpi-helpdesk-config-tiles-empty-entity-define-tiles
                 aria-label="{{ __("Define tiles for this entity from scratch") }}"
             >
-                <i class="ti ti-settings me-2"></i>
+                <i class="ti ti-settings me-2" aria-hidden="true"></i>
                 {{ __("Define tiles for this entity from scratch") }}
             </button>
         </div>

--- a/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_for_entity.html.twig
@@ -170,7 +170,7 @@
                 name="update"
                 aria-label="{{ __("Save custom illustrations settings") }}"
             >
-                <i class="ti ti-upload me-2"></i>
+                <i class="ti ti-upload me-2" aria-hidden="true"></i>
                 {{ __("Save custom illustrations settings") }}
             </button>
         </div>
@@ -385,7 +385,7 @@
                 name="update"
                 aria-label="{{ __("Save general settings") }}"
             >
-                <i class="ti ti-upload me-2"></i>
+                <i class="ti ti-upload me-2" aria-hidden="true"></i>
                 {{ __("Save general settings") }}
             </button>
         </div>

--- a/templates/pages/admin/helpdesk_home_config_tiles.html.twig
+++ b/templates/pages/admin/helpdesk_home_config_tiles.html.twig
@@ -70,7 +70,7 @@
                                 <i
                                     class="ti ti-grip-horizontal cursor-grab ms-auto opacity-50"
                                     data-glpi-helpdesk-config-tile-handle
-                                    draggable="true"
+                                    draggable="true" aria-hidden="true"
                                 ></i>
                             {% endif %}
                         </div>
@@ -104,7 +104,7 @@
         <div class="card rounded my-2 flex-grow-1 border-dashed">
             <div class="card-body d-flex justify-content-center">
                 <div class="d-flex align-items-center">
-                    <i class="ti ti-plus me-1"></i>
+                    <i class="ti ti-plus me-1" aria-hidden="true"></i>
                     <span class="fs-3">{{ __('Add tile') }}</span>
                 </div>
             </div>

--- a/templates/pages/admin/helpdesk_home_translations.html.twig
+++ b/templates/pages/admin/helpdesk_home_translations.html.twig
@@ -40,7 +40,7 @@
             data-bs-toggle="modal"
             data-bs-target="#addLanguageModal"
         >
-            <i class="ti ti-plus me-1"></i>
+            <i class="ti ti-plus me-1" aria-hidden="true"></i>
             {{ __('Add language') }}
         </button>
     </div>

--- a/templates/pages/admin/inventory/agent.html.twig
+++ b/templates/pages/admin/inventory/agent.html.twig
@@ -157,7 +157,7 @@
                         ) }}
 
                         <div class="hr-text">
-                            <i class="ti ti-adjustments"></i>
+                            <i class="ti ti-adjustments" aria-hidden="true"></i>
                             <span>{{ __('Agent configuration') }}</span>
                         </div>
 
@@ -186,7 +186,7 @@
                         {% endfor %}
 
                         <div class="hr-text">
-                            <i class="ti ti-list"></i>
+                            <i class="ti ti-list" aria-hidden="true"></i>
                             <span>{{ __('Supported tasks') }} </span>
                             <span class="form-help" tabindex="0" aria-label="{{ __('When reported by GLPI agent via native inventory') }}"
                                   data-bs-toggle="tooltip" data-bs-trigger="hover focus" data-bs-placement="top" data-bs-html="true"
@@ -205,9 +205,9 @@
                         } %}
 
                         {% if item.fields[modulefield] %}
-                            {% set html = '<i class="ti ti-check green"></i>' %}
+                            {% set html = '<i class="ti ti-check green" aria-hidden="true"></i>' %}
                         {% else %}
-                            {% set html = '<i class="ti ti-x red"></i>' %}
+                            {% set html = '<i class="ti ti-x red" aria-hidden="true"></i>' %}
                         {% endif %}
 
                         {{ fields.htmlField('', html, modulelabel) }}

--- a/templates/pages/admin/inventory/upload_form.html.twig
+++ b/templates/pages/admin/inventory/upload_form.html.twig
@@ -57,7 +57,7 @@
 
     <button class="btn btn-primary me-2" type="submit"
             name="upload_inventory" value="1">
-        <i class="ti ti-upload"></i>
+        <i class="ti ti-upload" aria-hidden="true"></i>
         <span>{{ _x('button', 'Upload') }}</span>
     </button>
 </form>

--- a/templates/pages/admin/inventory/upload_result.html.twig
+++ b/templates/pages/admin/inventory/upload_result.html.twig
@@ -45,13 +45,13 @@
                 <div class="card-header search-header pe-0">
                     <div class='btn-group flex-wrap'>
                         <span class="btn bg-blue-lt pe-none" aria-disabled="true">
-                            <i class='ti ti-check fs-2 me-2'></i>
+                            <i class='ti ti-check fs-2 me-2' aria-hidden='true'></i>
                             {{ __('Import process is complete.') }}
                         </span>
                     </div>
                     <div class='btn-group flex-wrap ms-2'>
                         <a href="javascript:history.back();" class="btn btn-primary">
-                        <i class='ti ti-player-track-prev-filled fs-2 me-2'></i>
+                        <i class='ti ti-player-track-prev-filled fs-2 me-2' aria-hidden='true'></i>
                             {{ __('Back') }}
                         </a>
                     </div>

--- a/templates/pages/admin/ldap.groups.html.twig
+++ b/templates/pages/admin/ldap.groups.html.twig
@@ -39,7 +39,7 @@
             </div>
             <div class="list-group list-group-flush">
                <a class="list-group-item list-group-item-action" href="{{ path('front/ldap.group.import.php') }}">
-                  <i class="ti ti-users me-1"></i>
+                  <i class="ti ti-users me-1" aria-hidden="true"></i>
                   <span>{{ __('Import of new groups') }}</span>
                </a>
             </div>

--- a/templates/pages/admin/ldap.users.html.twig
+++ b/templates/pages/admin/ldap.users.html.twig
@@ -39,12 +39,12 @@
             </div>
             <div class="list-group list-group-flush">
                <a class="list-group-item list-group-item-action" href="{{ path('front/ldap.import.php') }}?mode=1&amp;action=show">
-                  <i class="ti ti-user-cog me-1"></i>
+                  <i class="ti ti-user-cog me-1" aria-hidden="true"></i>
                   <span>{{ __('Synchronizing already imported users') }}</span>
                </a>
 
                <a class="list-group-item list-group-item-action" href="{{ path('front/ldap.import.php') }}?mode=0&amp;action=show">
-                  <i class="ti ti-user-plus me-1"></i>
+                  <i class="ti ti-user-plus me-1" aria-hidden="true"></i>
                   <span>{{ __('Import new users') }}</span>
                </a>
             </div>

--- a/templates/pages/admin/logs_list.html.twig
+++ b/templates/pages/admin/logs_list.html.twig
@@ -83,8 +83,8 @@
                                class="btn {{ active_order ? "btn-outline-secondary" : "btn-ghost-secondary" }} btn-sm me-1"
                                title="{{ sort_control['label'] }}"
                                data-bs-toggle="tooltip" data-bs-placement="bottom">
-                                <i class="ti ti-sort-{{ curr_sort == 'asc' ? "ascending" : "descending" }}"></i>
-                                <i class="{{ sort_control['icon'] }}"></i>
+                                <i class="ti ti-sort-{{ curr_sort == 'asc' ? "ascending" : "descending" }}" aria-hidden="true"></i>
+                                <i class="{{ sort_control['icon'] }}" aria-hidden="true"></i>
                             </a>
                         {% endfor %}
                     </div>

--- a/templates/pages/admin/plugins/list_suspend_banner.html.twig
+++ b/templates/pages/admin/plugins/list_suspend_banner.html.twig
@@ -35,7 +35,7 @@
         {{ __('The execution of the plugins is suspended.') }}
         <form class="d-inline" action="{{ 'Plugin'|itemtype_form_path }}" method="POST">
             <button type="submit" name="action" value="resume_all_execution" class="btn btn-sm btn-primary me-1">
-                <i class="ti ti-player-play-filled"></i>
+                <i class="ti ti-player-play-filled" aria-hidden="true"></i>
                 <span>{{ __('Resume execution of all active plugins') }}</span>
             </button>
         </form>
@@ -44,7 +44,7 @@
     <div class="text-end mb-3">
         <form class="d-inline" action="{{ 'Plugin'|itemtype_form_path }}" method="POST">
             <button type="submit" name="action" value="suspend_all_execution" class="btn btn-primary me-1">
-                <i class="ti ti-player-pause-filled"></i>
+                <i class="ti ti-player-pause-filled" aria-hidden="true"></i>
                 <span>{{ __('Suspend execution of all plugins') }}</span>
             </button>
         </form>

--- a/templates/pages/admin/plugins/updatable_alert.html.twig
+++ b/templates/pages/admin/plugins/updatable_alert.html.twig
@@ -32,7 +32,7 @@
 
 {% if count > 0 %}
     <div class="alert alert-important alert-warning d-flex" role="alert">
-        <i class="ti ti-alert-triangle fs-2x me-3"></i>
+        <i class="ti ti-alert-triangle fs-2x me-3" aria-hidden="true"></i>
         <div>
             {{ _n('You have %d plugin to update', 'You have %d plugins to update', count)|format(count) }}
         </div>

--- a/templates/pages/admin/rules/backup_header.html.twig
+++ b/templates/pages/admin/rules/backup_header.html.twig
@@ -32,7 +32,7 @@
 
 {% macro btn(url, icon, label) %}
    <a class="btn btn-primary me-2" href="{{ url }}">
-      <i class="{{ icon }}"></i>
+      <i class="{{ icon }}" aria-hidden="true"></i>
       <span>{{ label }}</span>
    </a>
 {% endmacro %}

--- a/templates/pages/admin/rules/collections_list.html.twig
+++ b/templates/pages/admin/rules/collections_list.html.twig
@@ -36,7 +36,7 @@
          <div class="col-12 {{ rules_group|length > 2 ? 'col-xxl-3' : 'col-xxl-9' }}">
             <h2 class="justify-content-center my-4 d-flex align-items-center mb-6 pb-3 fs-1">
                 {% if rules_block['icon'] is defined and rules_block['icon'] is not empty %}
-                    <i class="{{ rules_block['icon'] }} me-1"></i>
+                    <i class="{{ rules_block['icon'] }} me-1" aria-hidden="true"></i>
                 {% endif %}
                 {{ rules_block['type'] }}
             </h2>
@@ -44,7 +44,7 @@
                <div class="list-group list-group-flush">
                   {% for rule in rules_block['entries'] %}
                      <a class="list-group-item list-group-item-action" href="{{ rule['link'] }}">
-                        <i class="{{ rule['icon'] }} me-1"></i>
+                        <i class="{{ rule['icon'] }} me-1" aria-hidden="true"></i>
                         <span>{{ rule['label'] }}</span>
                      </a>
                   {% endfor %}

--- a/templates/pages/admin/rules/criteria.html.twig
+++ b/templates/pages/admin/rules/criteria.html.twig
@@ -50,7 +50,7 @@
                         {% set param_itemtype = get_class(rule) ~ 'Parameter' %}
                         <button type="button" class="btn btn-outline-secondary" title="{{ __('Add a criterion') }}"
                                 data-bs-toggle="modal" data-bs-target="#addcriterion{{ rand }}">
-                            <i class="ti ti-plus"></i>
+                            <i class="ti ti-plus" aria-hidden="true"></i>
                         </button>
                         {% do call('Ajax::createIframeModalWindow', [
                             'addcriterion' ~ rand,

--- a/templates/pages/admin/rules/import.html.twig
+++ b/templates/pages/admin/rules/import.html.twig
@@ -38,7 +38,7 @@
       <input type="file" name="xml_file">
       {{ inputs.hidden('action', 'preview_import') }}
       {% set import_label %}
-         <i class="ti ti-upload"></i>
+         <i class="ti ti-upload" aria-hidden="true"></i>
          {{ _x('button', 'Import') }}
       {% endset %}
       {{ inputs.submit('import', import_label, 1) }}

--- a/templates/pages/admin/rules/index.html.twig
+++ b/templates/pages/admin/rules/index.html.twig
@@ -35,7 +35,7 @@
         {% if can_view %}
             <a class="btn flex-column" href="{{ url ?? (itemtype|itemtype_search_path) }}">
                 <div class="d-flex align-items-center">
-                    <i class="{{ itemtype|itemtype_icon }}"></i>
+                    <i class="{{ itemtype|itemtype_icon }}" aria-hidden="true"></i>
                     <span>{{ title }}</span>
                 </div>
                 <div class="text-muted">
@@ -47,7 +47,7 @@
                  data-bs-toggle="tooltip" data-bs-placement="top"
                  title="{{ __('You do not have the required permissions') }}">
                 <div class="d-flex align-items-center">
-                    <i class="{{ itemtype|itemtype_icon }}"></i>
+                    <i class="{{ itemtype|itemtype_icon }}" aria-hidden="true"></i>
                     <span>{{ title }}</span>
                 </div>
                 <div class="text-muted">
@@ -64,14 +64,14 @@
     <div class="col-12 col-lg-6">
         <ul class="process-chart">
             <li class="align-items-center d-flex justify-content-center my-4 pb-6 fs-1 fw-bold">
-                <i class="ti ti-cloud-download me-1"></i>
+                <i class="ti ti-cloud-download me-1" aria-hidden="true"></i>
                 <span>{{ __("Inventory rules") }}</span>
             </li>
 
             <li class="entry-point">
                 <span class="icon-stack fa-2x">
-                    <i class="ti ti-circle-dashed"></i>
-                    <i class="ti ti-robot sm-size"></i>
+                    <i class="ti ti-circle-dashed" aria-hidden="true"></i>
+                    <i class="ti ti-robot sm-size" aria-hidden="true"></i>
                 </span>
                 <span>{{ __('Agent sends an inventory file') }}</span>
             </li>
@@ -120,7 +120,7 @@
             ) }}
 
             <li class="end">
-                <i class="ti ti-circle-check me-1 fa-2x"></i>
+                <i class="ti ti-circle-check me-1 fa-2x" aria-hidden="true"></i>
                 <span>{{ __('The asset is created or updated in GLPI') }}</span>
             </li>
         </ul>

--- a/templates/pages/admin/rules/preview_criteria.html.twig
+++ b/templates/pages/admin/rules/preview_criteria.html.twig
@@ -74,7 +74,7 @@
             <input type="hidden" name="{{ rules_id_field }}" value="{{ rules_id }}"/>
             <input type="hidden" name="sub_type" value="{{ item.getType() }}"/>
             <button type="submit" name="test_rule" class="btn btn-primary">
-                <i class="ti ti-stethoscope"></i>
+                <i class="ti ti-stethoscope" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Test') }}</span>
             </button>
         </div>

--- a/templates/pages/admin/user.substitute.html.twig
+++ b/templates/pages/admin/user.substitute.html.twig
@@ -54,7 +54,7 @@
                      <div class="row col-12 col-sm-12 mb-4">
                         <div class="alert alert-info" style="margin: 0 auto; max-width: 900px">
                            <span>
-                              <i class="ti ti-info-circle"></i>&nbsp;{{ __('Substitutes are users who can approve or refuse tickets on your behalf.') }}
+                              <i class="ti ti-info-circle" aria-hidden="true"></i>&nbsp;{{ __('Substitutes are users who can approve or refuse tickets on your behalf.') }}
                            </span>
                         </div>
                      </div>
@@ -93,7 +93,7 @@
                         <div class="row col-12 col-sm-12 mb-4 mt-5">
                            <div class="alert alert-info" style="margin: 0 auto; max-width: 900px">
                               <span>
-                                 <i class="ti ti-info-circle"></i>&nbsp;{{ __('Delegators are users who gave you the right to approve or refuse tickets on their behalf.') }}
+                                 <i class="ti ti-info-circle" aria-hidden="true"></i>&nbsp;{{ __('Delegators are users who gave you the right to approve or refuse tickets on their behalf.') }}
                               </span>
                            </div>
                         </div>
@@ -138,7 +138,7 @@
    {% if canedit %}
          <div class="card-body mx-n2 mb-4 border-top d-flex flex-row-reverse align-items-start flex-wrap">
             <button class="btn btn-primary me-2" type="submit" name="update" value="1">
-               <i class="ti ti-device-floppy"></i>
+               <i class="ti ti-device-floppy" aria-hidden="true"></i>
                <span>{{ _x('button', 'Save') }}</span>
             </button>
          </div>

--- a/templates/pages/admin/user/user.html.twig
+++ b/templates/pages/admin/user/user.html.twig
@@ -277,7 +277,7 @@
                                     {% set change_pw_field %}
                                         {% if is_preference_form %}
                                             <a role="button" class="btn btn-outline-secondary btn-sm" href="{{ path('/front/updatepassword.php') }}">
-                                                <i class="ti ti-lock"></i>
+                                                <i class="ti ti-lock" aria-hidden="true"></i>
                                                 {{ __('Change password') }}
                                             </a>
                                         {% else %}
@@ -299,7 +299,7 @@
                                                 data-bs-target="#modal_password_{{ rand_field }}"
                                                 aria-label="{{ __('Change password') }}"
                                             >
-                                                <i class="ti ti-lock"></i>
+                                                <i class="ti ti-lock" aria-hidden="true"></i>
                                                 {{ __('Change password') }}
                                             </button>
                                             <div class="text-warning d-none" data-password-change-pending>
@@ -344,7 +344,7 @@
             {{ call_plugin_hook(constant('Glpi\\Plugin\\Hooks::POST_ITEM_FORM'), {'item': item, 'options': params}) }}
             <div class="card-body mx-n2 border-top d-flex flex-row-reverse align-items-start flex-wrap">
                 <button class="btn btn-primary me-2" type="submit" name="update" value="1">
-                    <i class="ti ti-device-floppy"></i>
+                    <i class="ti ti-device-floppy" aria-hidden="true"></i>
                     <span>{{ _x('button', 'Save') }}</span>
                 </button>
             </div>

--- a/templates/pages/assets/consumable_list.html.twig
+++ b/templates/pages/assets/consumable_list.html.twig
@@ -83,7 +83,7 @@
                                         name="add_several"
                                         class='btn btn-primary'
                                     >
-                                        <i class='ti ti-plus'></i><span>{{ _x('button', 'Add consumables') }}</span>
+                                        <i class='ti ti-plus' aria-hidden='true'></i><span>{{ _x('button', 'Add consumables') }}</span>
                                     </button>
                                 {% endset %}
 

--- a/templates/pages/assets/template_list.html.twig
+++ b/templates/pages/assets/template_list.html.twig
@@ -46,7 +46,7 @@
                         <input type="hidden" name="id" value="{{ template['id'] }}">
                         <button class="btn btn-danger me-2" type="submit" name="purge" value="1"
                                 onclick="return confirm('{{ __('Confirm the final deletion?')|e('js') }}');">
-                            <i class="ti ti-trash"></i>
+                            <i class="ti ti-trash" aria-hidden="true"></i>
                             <span>{{ _x('button', 'Delete permanently') }}</span>
                         </button>
                     {% endif %}

--- a/templates/pages/assistance/stats/single_item_pager.html.twig
+++ b/templates/pages/assistance/stats/single_item_pager.html.twig
@@ -34,7 +34,7 @@
     {% if prev > 0 %}
         <div class="d-inline-block">
             <a href="{{ target }}?{{ target_params }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ prev }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Previous') }}">
-                <i class="ti ti-chevron-left"></i>
+                <i class="ti ti-chevron-left" aria-hidden="true"></i>
             </a>
         </div>
     {% endif %}
@@ -42,7 +42,7 @@
     {% if next > 0 %}
         <div class="d-inline-block">
             <a href="{{ target }}?{{ target_params }}&amp;date1={{ _request['date1'] }}&amp;date2={{ _request['date2'] }}&amp;id={{ next }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ __('Next') }}">
-                <i class="ti ti-chevron-right"></i>
+                <i class="ti ti-chevron-right" aria-hidden="true"></i>
             </a>
         </div>
     {% endif %}

--- a/templates/pages/form_renderer.html.twig
+++ b/templates/pages/form_renderer.html.twig
@@ -225,7 +225,7 @@
                         data-glpi-form-renderer-action="previous-section"
                         class="btn btn-ghost-secondary d-none d-flex align-items-end me-2 pointer-events-none"
                     >
-                        <i class="ti ti-arrow-narrow-left-dashed me-2"></i>
+                        <i class="ti ti-arrow-narrow-left-dashed me-2" aria-hidden="true"></i>
                         {{ __("Back") }}
                     </button>
 
@@ -234,7 +234,7 @@
                         data-glpi-form-renderer-action="next-section"
                         class="btn btn-primary pointer-events-none d-flex align-items-end"
                     >
-                        <i class="ti ti-arrow-narrow-right-dashed me-2"></i>
+                        <i class="ti ti-arrow-narrow-right-dashed me-2" aria-hidden="true"></i>
                         {{ __("Continue") }}
                     </button>
                 {% endif %}
@@ -249,7 +249,7 @@
                         data-glpi-form-renderer-hidden-by-condition
                     {% endif %}
                 >
-                    <i class="ti ti-check me-2"></i>
+                    <i class="ti ti-check me-2" aria-hidden="true"></i>
                     {{ __("Submit") }}
                 </button>
             </div>
@@ -286,19 +286,19 @@
                         <li class="me-2">
                             {% if get_current_interface() == 'central' %}
                                 <a class="btn btn-outline-secondary" href="{{ path('/ServiceCatalog') }}">
-                                    <i class="ti ti-library me-1"></i>
+                                    <i class="ti ti-library me-1" aria-hidden="true"></i>
                                     <span>{{ __("Go back to service catalog") }}</span>
                                 </a>
                             {% else %}
                                 <a class="btn btn-outline-secondary" href="{{ path('/Helpdesk') }}">
-                                    <i class="ti ti-home me-1"></i>
+                                    <i class="ti ti-home me-1" aria-hidden="true"></i>
                                     <span>{{ __("Take me home") }}</span>
                                 </a>
                             {% endif %}
                         </li>
                         <li>
                             <a class="btn btn-primary" href="{{ path('/front/ticket.php?' ~ my_tickets_url_param) }}">
-                                <i class="ti ti-article me-1"></i>
+                                <i class="ti ti-article me-1" aria-hidden="true"></i>
                                 <span>{{ __("See my tickets") }}</span>
                             </a>
                         </li>

--- a/templates/pages/helpdesk/index.html.twig
+++ b/templates/pages/helpdesk/index.html.twig
@@ -53,7 +53,7 @@
                     <div id="search-overlay" class="search-overlay bg-dark"></div>
                     <div class="input-icon search-bar-container">
                         <span class="input-icon-addon">
-                            <i class="ti ti-search"></i>
+                            <i class="ti ti-search" aria-hidden="true"></i>
                         </span>
                         <input
                             id="search-input"
@@ -86,7 +86,7 @@
                     <div class="alert alert-warning alert-dismissible bg-white" role="alert">
                         <div class="d-flex mb-2">
                             <div>
-                                <i class="ti ti-alert-triangle me-1"></i>
+                                <i class="ti ti-alert-triangle me-1" aria-hidden="true"></i>
                             </div>
                             <div>
                                 {{ password_alert }}

--- a/templates/pages/login.html.twig
+++ b/templates/pages/login.html.twig
@@ -114,7 +114,7 @@
         {% if config('use_public_faq') %}
             <div class="text-center mt-4 border-top">
                 <a class="btn btn-outline-secondary mt-4" href="{{ path('front/helpdesk.faq.php') }}">
-                    <i class="ti ti-help"></i>&nbsp;
+                    <i class="ti ti-help" aria-hidden="true"></i>&nbsp;
                     {{ __('FAQ') }}
                 </a>
             </div>

--- a/templates/pages/login_error.html.twig
+++ b/templates/pages/login_error.html.twig
@@ -36,7 +36,7 @@
 <div class="alert alert-warning">
     <div class="d-flex align-items-center">
         <div class="me-4">
-            <i class="ti ti-alert-triangle fa-2x"></i>
+            <i class="ti ti-alert-triangle fa-2x" aria-hidden="true"></i>
         </div>
         <div>
             <h4 class="alert-title">
@@ -49,7 +49,7 @@
             </div>
 
             <a href="{{ login_url }}" class="btn btn-primary mt-3">
-                <i class="ti ti-login"></i>
+                <i class="ti ti-login" aria-hidden="true"></i>
                 <span>{{ __('Log in again') }}</span>
             </a>
         </div>

--- a/templates/pages/management/contract.html.twig
+++ b/templates/pages/management/contract.html.twig
@@ -49,7 +49,7 @@
       {% endif %}
       {% set warranty_expiration %}
          <span title="{{ end_title|default('') }}" data-bs-toggle="tooltip">
-            <i class="ti ti-arrow-right"></i>
+            <i class="ti ti-arrow-right" aria-hidden="true"></i>
             {{ call('Infocom::getWarrantyExpir', [
                item.fields['begin_date'],
                item.fields['duration'],
@@ -74,7 +74,7 @@
    {% if item.fields['begin_date'] is not empty and item.fields['notice'] > 0 and item.fields['duration'] is not empty %}
       {% set notice_info %}
          <span title="{{ __('Start date of notice period') }}" data-bs-toggle="tooltip">
-            <i class="ti ti-arrow-right"></i>
+            <i class="ti ti-arrow-right" aria-hidden="true"></i>
             {{ call('Infocom::getWarrantyExpir', [
                item.fields['begin_date'],
                item.fields['duration'],

--- a/templates/pages/management/dcroom_racks.html.twig
+++ b/templates/pages/management/dcroom_racks.html.twig
@@ -51,10 +51,10 @@
 
 <div id="switchview">
     <button id="sviewlist" class="btn btn-icon" title="{{ __('View as list') }}">
-        <i class="ti ti-list fs-2x"></i>
+        <i class="ti ti-list fs-2x" aria-hidden="true"></i>
     </button>
     <button id="sviewgraph" class="btn btn-icon selected" title="{{ __('View graphical representation') }}">
-        <i class="ti ti-layout-grid fs-2x"></i>
+        <i class="ti ti-layout-grid fs-2x" aria-hidden="true"></i>
     </button>
 </div>
 

--- a/templates/pages/management/domainrecord.html.twig
+++ b/templates/pages/management/domainrecord.html.twig
@@ -100,7 +100,7 @@
     }) }}
     {% set data_field_helper %}
         <button name="open_data_helper" type="button" class="btn btn-icon btn-ghost-secondary" title="{{ __('Open helper form') }}">
-            <i class="ti ti-pencil"></i>
+            <i class="ti ti-pencil" aria-hidden="true"></i>
         </button>
         <script>
             $(() => {

--- a/templates/pages/management/license_progressbar.html.twig
+++ b/templates/pages/management/license_progressbar.html.twig
@@ -116,7 +116,7 @@
         {% endif %}
     </div>
 
-    <i class="{{ selected_context.icon }}"></i>
+    <i class="{{ selected_context.icon }}" aria-hidden="true"></i>
 
     <script>
         document.addEventListener('DOMContentLoaded', function () {

--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -86,7 +86,7 @@
                 data-glpi-service-catalog-filter-items
             >
             <span class="input-icon-addon" style="font-size: 18px;">
-                <i class="ti ti-search"></i>
+                <i class="ti ti-search" aria-hidden="true"></i>
             </span>
         </div>
     </div>

--- a/templates/pages/setup/apiclient.html.twig
+++ b/templates/pages/setup/apiclient.html.twig
@@ -43,7 +43,7 @@
     ) }}
 
     <div class="hr-text">
-        <i class="ti ti-filter"></i>
+        <i class="ti ti-filter" aria-hidden="true"></i>
         <span>{{ __('Filter access') }}</span>
     </div>
     <p><em>{{ __('Leave these parameters empty to disable API access restriction') }}</em></p>

--- a/templates/pages/setup/authentication.html.twig
+++ b/templates/pages/setup/authentication.html.twig
@@ -40,30 +40,30 @@
             <div class="list-group list-group-flush">
                {% if has_profile_right('config', constant('UPDATE')) %}
                   <a class="list-group-item list-group-item-action" href="{{ path('front/auth.settings.php') }}">
-                     <i class="ti ti-adjustments me-1"></i>
+                     <i class="ti ti-adjustments me-1" aria-hidden="true"></i>
                      <span>{{ __('Setup') }}</span>
                   </a>
                {% endif %}
 
                {% if can_use_ldap %}
                   <a class="list-group-item list-group-item-action" href="{{ path('front/authldap.php') }}">
-                     <i class="{{ call('AuthLDAP::getIcon') }} me-1"></i>
+                     <i class="{{ call('AuthLDAP::getIcon') }} me-1" aria-hidden="true"></i>
                      <span>{{ 'AuthLDAP'|itemtype_name }}</span>
                   </a>
                {% else %}
                   <div class="alert alert-important alert-warning m-3">
-                    <i class="ti ti-alert-triangle me-2"></i>
+                    <i class="ti ti-alert-triangle me-2" aria-hidden="true"></i>
                     {{ __('The LDAP extension of your PHP parser isn’t installed') }}
                   </div>
                {% endif %}
 
                <a class="list-group-item list-group-item-action" href="{{ path('front/authmail.php') }}">
-                  <i class="{{ call('AuthMail::getIcon') }} me-1"></i>
+                  <i class="{{ call('AuthMail::getIcon') }} me-1" aria-hidden="true"></i>
                   <span>{{ 'AuthMail'|itemtype_name }}</span>
                </a>
 
                <a class="list-group-item list-group-item-action" href="{{ path('front/auth.others.php') }}">
-                  <i class="ti ti-login me-1"></i>
+                  <i class="ti ti-login me-1" aria-hidden="true"></i>
                   <span>{{ __('Others authentication methods') }}</span>
                </a>
             </div>

--- a/templates/pages/setup/authentication/setup.html.twig
+++ b/templates/pages/setup/authentication/setup.html.twig
@@ -37,7 +37,7 @@
     <div class="container-xl">
         <div class="card">
             <div class="card-header">
-                <h3 class="card-title"><i class="ti ti-adjustments me-1"></i>{{ __('Authentication setup') }}</h3>
+                <h3 class="card-title"><i class="ti ti-adjustments me-1" aria-hidden="true"></i>{{ __('Authentication setup') }}</h3>
             </div>
             <div class="card-body">
                 <div class="row">
@@ -66,7 +66,7 @@
                     ) }}
 
                     <div class="hr-text">
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                         <span>{{ __('Actions when a user is deleted from the LDAP directory') }}</span>
                     </div>
 
@@ -93,7 +93,7 @@
             </div>
             <div class="card-footer d-flex">
                 <button type="submit" name="update_auth" value="1" class="btn btn-primary ms-auto">
-                    <i class="ti ti-device-floppy"></i>
+                    <i class="ti ti-device-floppy" aria-hidden="true"></i>
                     <span>{{ _x('button', 'Save') }}</span>
                 </button>
             </div>

--- a/templates/pages/setup/crontask/crontask.html.twig
+++ b/templates/pages/setup/crontask/crontask.html.twig
@@ -105,7 +105,7 @@
                                         no_label: true,
                                         field_class: ''
                                     }) }}
-                                    <i class="ti ti-arrow-right mb-3"></i>
+                                    <i class="ti ti-arrow-right mb-3" aria-hidden="true"></i>
                                     {{ fields.dropdownNumberField('hourmax', item.fields['hourmax'], null, {
                                         min: 0,
                                         max: 24,
@@ -144,7 +144,7 @@
                                         {% if can_execute %}
                                             {# ID field is defined in components/form/buttons.html.twig #}
                                             <button class="btn btn-icon border-0" type="submit" name="resetdate" title="{{ __('Blank') }}">
-                                                <i class="ti ti-circle-x me-1"></i>
+                                                <i class="ti ti-circle-x me-1" aria-hidden="true"></i>
                                             </button>
                                         {% endif %}
                                     {% endif %}
@@ -166,7 +166,7 @@
                                     {% elseif can_execute and launch %}
                                         {# ID is defined in components/form/buttons.html.twig #}
                                         <button class="btn btn-primary" type="submit" name="execute" value="{{ item.fields['name'] }}">
-                                            <i class="ti ti-player-play me-1"></i>
+                                            <i class="ti ti-player-play me-1" aria-hidden="true"></i>
                                             {{ __('Execute') }}
                                         </button>
                                     {% endif %}
@@ -174,7 +174,7 @@
                                     {% if can_execute and item.fields['state'] == constant('CronTask::STATE_RUNNING') %}
                                         {# ID field is defined in components/form/buttons.html.twig #}
                                         <button class="btn btn-primary" type="submit" name="resetstate">
-                                            <i class="ti ti-circle-x me-1"></i>
+                                            <i class="ti ti-circle-x me-1" aria-hidden="true"></i>
                                             {{ __('Blank') }}
                                         </button>
                                     {% endif %}

--- a/templates/pages/setup/dropdowns_list.html.twig
+++ b/templates/pages/setup/dropdowns_list.html.twig
@@ -53,7 +53,7 @@
                            href="{{ itemtype|itemtype_search_path }}">
                            <div class="row">
                               <div class="col-auto">
-                                 <i class="{{ itemtype|itemtype_icon }}"></i>
+                                 <i class="{{ itemtype|itemtype_icon }}" aria-hidden="true"></i>
                               </div>
                               <div class="col text-truncate">
                                  {{ dropdown_label }}
@@ -85,7 +85,7 @@
    <div class="input-icon mb-3">
       <input class="form-control" placeholder="{{ __('Search') }}" id="filter-dropdown" />
       <span class="input-icon-addon">
-         <i class="ti ti-search"></i>
+         <i class="ti ti-search" aria-hidden="true"></i>
       </span>
    </div>
 

--- a/templates/pages/setup/general/base_form.html.twig
+++ b/templates/pages/setup/general/base_form.html.twig
@@ -46,7 +46,7 @@
 {% if canedit %}
         <div class="card-footer mx-n2 d-flex">
             <button type="submit" name="update" value="1" class="ms-auto btn btn-primary">
-                <i class="ti ti-device-floppy"></i>
+                <i class="ti ti-device-floppy" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Save') }}</span>
             </button>
         </div>

--- a/templates/pages/setup/general/dbreplica_setup.html.twig
+++ b/templates/pages/setup/general/dbreplica_setup.html.twig
@@ -36,7 +36,7 @@
 
 {% block config_fields %}
 <div class="hr-text">
-    <i class="ti ti-brand-mysql"></i>
+    <i class="ti ti-brand-mysql" aria-hidden="true"></i>
     <span>{{ __('Replica configuration') }}</span>
 </div>
 
@@ -62,7 +62,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-check"></i>
+    <i class="ti ti-check" aria-hidden="true"></i>
     <span>{{ __('Replication status') }}</span>
 </div>
 

--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -106,7 +106,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-list"></i>
+    <i class="ti ti-list" aria-hidden="true"></i>
     <span>{{ __('Dynamic display') }}</span>
 </div>
 
@@ -138,7 +138,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-search"></i>
+    <i class="ti ti-search" aria-hidden="true"></i>
     <span>{{ __('Search engine') }}</span>
 </div>
 
@@ -217,7 +217,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-lock"></i>
+    <i class="ti ti-lock" aria-hidden="true"></i>
     <span>{{ __('Item locks') }}</span>
 </div>
 
@@ -281,7 +281,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-layout-kanban"></i>
+    <i class="ti ti-layout-kanban" aria-hidden="true"></i>
     <span>{{ __('Project Task State') }}</span>
 </div>
 
@@ -319,7 +319,7 @@
 </div>
 
 <div class="hr-text">
-    <i class="ti ti-login"></i>
+    <i class="ti ti-login" aria-hidden="true"></i>
     <span>{{ __('Auto Login') }}</span>
 </div>
 

--- a/templates/pages/setup/general/glpinetwork_setup.html.twig
+++ b/templates/pages/setup/general/glpinetwork_setup.html.twig
@@ -56,13 +56,13 @@
         {% set registration_alert %}
             <div class="alert alert-info mb-0 d-inline-flex mt-3">
                 <div class="alert-icon">
-                    <i class="ti ti-shield-check"></i>
+                    <i class="ti ti-shield-check" aria-hidden="true"></i>
                 </div>
                 <div>
                     <h4 class="alert-heading">{{ __('A registration key is needed to use some advanced features (like the plugin marketplace) in GLPI') }}</h4>
                     <div class="alert-description">
                         <a href="{{ constant('GLPI_NETWORK_SERVICES') }}" class="btn btn-sm btn-outline-secondary me-1" target="_blank" rel="noopener noreferrer">
-                            <i class="ti ti-external-link"></i>
+                            <i class="ti ti-external-link" aria-hidden="true"></i>
                             <span>{{ __('Register on %1$s!')|format(__('GLPI Network')) }}</span>
                         </a>
                         {{ __("And retrieve your key to paste it below") }}
@@ -90,7 +90,7 @@
             {% set subscription_ok = informations['is_valid'] and informations['subscription']['is_running'] %}
             {% set alert_sub_ok %}
                 <span class="{{ subscription_ok ? 'text-success' : 'text-danger' }}">
-                    <i class="ti ti-info-circle"></i>
+                    <i class="ti ti-info-circle" aria-hidden="true"></i>
                     {{ informations['validation_message'] }}
                 </span>
             {% endset %}
@@ -115,7 +115,7 @@
 
         {% set clear_btn %}
             <button type="submit" name="reset_registration_key" value="1" class="ms-auto btn btn-outline-danger">
-                <i class="ti ti-x"></i>
+                <i class="ti ti-x" aria-hidden="true"></i>
                 <span>{{ __('Remove registration key') }}</span>
             </button>
         {% endset %}
@@ -147,7 +147,7 @@
 
     {% set btns_marketplace %}
         <a href="{{ path('/front/marketplace.php') }}" class="btn btn-outline-secondary btn-sm">
-            <i class="ti ti-arrow-narrow-right-dashed"></i>
+            <i class="ti ti-arrow-narrow-right-dashed" aria-hidden="true"></i>
             <span>{{ __('Access GLPI Network Marketplace') }}</span>
         </a>
     {% endset %}
@@ -159,7 +159,7 @@
     {% if canedit %}
         <div class="card-footer mx-n2 d-flex">
             <button type="submit" name="update" value="1" class="ms-auto btn btn-primary">
-                <i class="ti ti-device-floppy"></i>
+                <i class="ti ti-device-floppy" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Save') }}</span>
             </button>
         </div>

--- a/templates/pages/setup/general/preferences_setup.html.twig
+++ b/templates/pages/setup/general/preferences_setup.html.twig
@@ -335,7 +335,7 @@
       </div>
    {% endset %}
    <div class="hr-text my-3">
-      <i class="ti ti-palette"></i>
+      <i class="ti ti-palette" aria-hidden="true"></i>
       {# heading rather than span: adds this divider label to the heading outline (RGAA 9.1) #}
       <h5 class="m-0 fs-5 fw-medium">{{ __('Priority colors') }}</h5>
    </div>

--- a/templates/pages/setup/general/systeminfo_form.html.twig
+++ b/templates/pages/setup/general/systeminfo_form.html.twig
@@ -87,7 +87,7 @@
 
    {{ fields.smallTitle(__('GLPI update')) }}
    {% set btn_check_updates %}
-      <a class="btn btn-secondary" href="?check_version"><i class="ti ti-reload"></i>
+      <a class="btn btn-secondary" href="?check_version"><i class="ti ti-reload" aria-hidden="true"></i>
          <span>{{ __('Check if a new version is available') }}</span>
       </a>
    {% endset %}

--- a/templates/pages/setup/ldap/test_form.html.twig
+++ b/templates/pages/setup/ldap/test_form.html.twig
@@ -38,7 +38,7 @@
                     <div class="card">
                         <div class="card-body">
                             <h3 class="card-title">
-                                <i class="ti ti-stethoscope me-1"></i>
+                                <i class="ti ti-stethoscope me-1" aria-hidden="true"></i>
                                 {{ __('Test LDAP server: %s')|format(servername) }}
                             </h3>
                             <ul class="steps steps-vertical steps-counter my-4">

--- a/templates/pages/setup/ldap/user_config_form.html.twig
+++ b/templates/pages/setup/ldap/user_config_form.html.twig
@@ -34,7 +34,7 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% block form_fields %}
-    <h3 class="text-center mb-3"><i class="ti ti-user me-1"></i>{{ __('Binding to the LDAP directory') }}</h3>
+    <h3 class="text-center mb-3"><i class="ti ti-user me-1" aria-hidden="true"></i>{{ __('Binding to the LDAP directory') }}</h3>
 
     {% for field, label in fields %}
         {{ fields.textField(

--- a/templates/pages/setup/mailcollector/folder_list.html.twig
+++ b/templates/pages/setup/mailcollector/folder_list.html.twig
@@ -32,7 +32,7 @@
 
 {% macro display_folder(folder, input_id) %}
    <li class="cursor-pointer" data-input-id="{{ input_id }}">
-      <i class="ti ti-folder"></i>
+      <i class="ti ti-folder" aria-hidden="true"></i>
       <span class="folder-name" data-globalname="{{ folder['global_name'] }}">{{ folder['local_name'] }}</span>
       <ul>
          {% for subfolder in folder['children'] %}

--- a/templates/pages/setup/mailcollector/setup_form.html.twig
+++ b/templates/pages/setup/mailcollector/setup_form.html.twig
@@ -118,12 +118,12 @@
         {% set get_imap_folder_btn %}
             <div class="btn btn-outline-secondary get-imap-folder cursor-pointer{% if item.isNewItem() %} disabled{% endif %}"
                  {% if item.isNewItem() %}style="pointer-events: none;"{% endif %}>
-                <i class="ti ti-list"></i>
+                <i class="ti ti-list" aria-hidden="true"></i>
             </div>
         {% endset %}
         {# warning message when config is changed, choosing imap/folder is disabled #}
         <div class="alert alert-warning{% if not item.isNewItem() %} d-none{% endif %}" id="server-changed-warning">
-            <i class="ti ti-info-circle"></i>
+            <i class="ti ti-info-circle" aria-hidden="true"></i>
             {{ __('Server configuration has changed. Please save the collector before browsing folders.') }}
         </div>
         {{ fields.textField(

--- a/templates/pages/setup/marketplace/card.html.twig
+++ b/templates/pages/setup/marketplace/card.html.twig
@@ -34,19 +34,19 @@
     <span class="misc-right">
         <span class="license">
             {% if plugin['license'] is not empty %}
-                <i class="ti ti-license"></i>
+                <i class="ti ti-license" aria-hidden="true"></i>
                 {{ plugin['license']|html_to_text }}
             {% endif %}
         </span>
         <span class="authors">
             {% if plugin['authors'] is not empty %}
-                <i class="ti ti-users"></i>
+                <i class="ti ti-users" aria-hidden="true"></i>
                 {{ plugin['authors']|join(', ')|html_to_text }}
             {% endif %}
         </span>
         <span class="version">
             {% if plugin['version'] is not empty %}
-                <i class="ti ti-git-branch"></i>
+                <i class="ti ti-git-branch" aria-hidden="true"></i>
                 {{ plugin['version']|html_to_text }}
             {% endif %}
         </span>

--- a/templates/pages/setup/marketplace/card.html.twig
+++ b/templates/pages/setup/marketplace/card.html.twig
@@ -60,23 +60,23 @@
         {% endif %}
         <span class="links">
             {% if plugin['homepage_url'] is not empty %}
-                <a href="{{ plugin['homepage_url'] }}" target="_blank">
-                    <i class="ti ti-home-2 add_tooltip" title="{{ __('Homepage') }}"></i>
+                <a href="{{ plugin['homepage_url'] }}" target="_blank" class="add_tooltip" title="{{ __('Homepage') }}">
+                    <i class="ti ti-home-2" aria-hidden="true"></i>
                 </a>
             {% endif %}
             {% if plugin['issues_url'] is not empty %}
-                <a href="{{ plugin['issues_url'] }}" target="_blank">
-                    <i class="ti ti-bug add_tooltip" title="{{ __('Get help') }}"></i>
+                <a href="{{ plugin['issues_url'] }}" target="_blank" class="add_tooltip" title="{{ __('Get help') }}">
+                    <i class="ti ti-bug" aria-hidden="true"></i>
                 </a>
             {% endif %}
             {% if plugin['readme_url'] is not empty %}
-                <a href="{{ plugin['readme_url'] }}" target="_blank">
-                    <i class="ti ti-book add_tooltip" title="{{ __('Readme') }}"></i>
+                <a href="{{ plugin['readme_url'] }}" target="_blank" class="add_tooltip" title="{{ __('Readme') }}">
+                    <i class="ti ti-book" aria-hidden="true"></i>
                 </a>
             {% endif %}
             {% if plugin['changelog_url'] is not empty %}
-                <a href="{{ plugin['changelog_url'] }}" target="_blank">
-                    <i class="ti ti-news add_tooltip" title="{{ __('Changelog') }}"></i>
+                <a href="{{ plugin['changelog_url'] }}" target="_blank" class="add_tooltip" title="{{ __('Changelog') }}">
+                    <i class="ti ti-news" aria-hidden="true"></i>
                 </a>
             {% endif %}
         </span>

--- a/templates/pages/setup/notification/mailing_setting.html.twig
+++ b/templates/pages/setup/notification/mailing_setting.html.twig
@@ -198,12 +198,12 @@
 
         <div class="row" id="smtp_config">
             <div class="hr-text">
-                <i class="{{ 'AuthMail'|itemtype_icon }}"></i>
+                <i class="{{ 'AuthMail'|itemtype_icon }}" aria-hidden="true"></i>
                 <span>{{ 'AuthMail'|itemtype_name }}</span>
             </div>
 
             <div id="oauth_redirect_alert_{{ rand }}" class="d-flex alert alert-info mx-2">
-                <i class="ti ti-info-circle fs-2x alert-icon"></i>
+                <i class="ti ti-info-circle fs-2x alert-icon" aria-hidden="true"></i>
                 {{ __('Once the form has been validated, you will be redirected to your supplierʼs authentication page if necessary.') }}
             </div>
 
@@ -356,7 +356,7 @@
 
         <div class="card-footer mx-n2 mb-4 d-flex flex-row-reverse align-items-start flex-wrap">
             <button type="submit" name="update" value="1" class="btn btn-primary">
-                <i class="ti ti-device-floppy"></i>
+                <i class="ti ti-device-floppy" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Save') }}</span>
             </button>
             <button type="button" id="test-email-btn" class="btn btn-outline-secondary me-2" name="test_smtp_send" value="1">
@@ -412,7 +412,7 @@
     <div class="row">
         <div class="col">
             <div class="alert alert-info">
-                <i class="ti ti-info-circle fs-2x alert-icon"></i>
+                <i class="ti ti-info-circle fs-2x alert-icon" aria-hidden="true"></i>
                 {{ __('Notifications are disabled.') }}
                 <a href="{{ config('root_doc') }}/front/setup.notification.php">{{ __('See configuration') }}</a>
             </div>

--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -58,7 +58,7 @@
         </div>
     {% else %}
         <div class="alert alert-info d-flex align-items-center m-0" role="alert">
-            <i class="ti ti-info-circle me-1"></i>
+            <i class="ti ti-info-circle me-1" aria-hidden="true"></i>
             {{ __('The preview is not available for the notifications related to %s.')|format(template.fields['itemtype']|itemtype_name(get_plural_number())) }}
         </div>
     {% endif %}

--- a/templates/pages/setup/oauthclient.html.twig
+++ b/templates/pages/setup/oauthclient.html.twig
@@ -91,7 +91,7 @@
                                             mb: ''
                                         }) }}
                                         <button class="btn btn-danger btn-icon" name="remove_header" type="button" title="{{ __('Remove') }}">
-                                            <i class="ti ti-trash"></i>
+                                            <i class="ti ti-trash" aria-hidden="true"></i>
                                         </button>
                                     </div>
                                 </template>
@@ -102,7 +102,7 @@
                             }) }}
                             <div class="authorized-uri-fields mb-3">
                                 <button type="button" class="btn btn-secondary mt-3" name="add_uri">
-                                    <i class="ti ti-plus"></i>
+                                    <i class="ti ti-plus" aria-hidden="true"></i>
                                     {{ __('Add URI') }}
                                 </button>
                             </div>

--- a/templates/pages/setup/setup_notifications.html.twig
+++ b/templates/pages/setup/setup_notifications.html.twig
@@ -42,7 +42,7 @@
 
                {% if use_notifications and not has_active_mode %}
                   <div class="alert alert-important alert-warning m-3">
-                     <i class="ti ti-alert-triangle me-2"></i>
+                     <i class="ti ti-alert-triangle me-2" aria-hidden="true"></i>
                      {{ __('You must enable at least one notification mode.') }}
                   </div>
                {% endif %}
@@ -78,7 +78,7 @@
 
                <div class="card-footer">
                   <button type="submit" class="btn btn-primary">
-                     <i class="ti ti-device-floppy"></i>
+                     <i class="ti ti-device-floppy" aria-hidden="true"></i>
                      <span>{{ __('Save') }}</span>
                   </button>
                </div>
@@ -96,20 +96,20 @@
             <div class="list-group list-group-flush">
                {% if has_profile_right('config', constant('READ')) %}
                   <a href="{{ path('front/notificationtemplate.php') }}" class="list-group-item list-group-item-action">
-                     <i class="{{ 'NotificationTemplate'|itemtype_icon }}"></i>
+                     <i class="{{ 'NotificationTemplate'|itemtype_icon }}" aria-hidden="true"></i>
                      <span>{{ _n('Notification template', 'Notification templates', get_plural_number()) }}</span>
                   </a>
                {% endif %}
 
                {% if has_profile_right('notification', constant('READ')) %}
                   <a href="{{ path('front/notification.php') }}" class="list-group-item list-group-item-action">
-                     <i class="{{ 'Notification'|itemtype_icon }}"></i>
+                     <i class="{{ 'Notification'|itemtype_icon }}" aria-hidden="true"></i>
                      <span>{{ _n('Notification', 'Notifications', get_plural_number()) }}</span>
                   </a>
                {% else %}
                   <div class="list-group-item">
                      <div class="alert alert-important alert-warning m-3">
-                        <i class="ti ti-alert-triangle me-2"></i>
+                        <i class="ti ti-alert-triangle me-2" aria-hidden="true"></i>
                         {{ __('Unable to configure notifications: please configure at least one notification type using the above configuration.') }}
                      </div>
                   </div>
@@ -118,7 +118,7 @@
                {% for mode in modes %}
                   {% if can_update_config and mode['is_active'] %}
                      <a href="{{ mode['setting_url'] }}" class="list-group-item list-group-item-action">
-                        <i class="{{ mode['icon'] }}"></i>
+                        <i class="{{ mode['icon'] }}" aria-hidden="true"></i>
                         <span>{{ mode['label_settings'] }}</span>
                      </a>
                   {% endif %}

--- a/templates/pages/setup/webhook/payload_editor.html.twig
+++ b/templates/pages/setup/webhook/payload_editor.html.twig
@@ -40,11 +40,11 @@
 </div>
 <div id="webhook-payload-editor-container" data-webhook-id="{{ item.fields['id'] }}">
    <div id="webhook-payload-editor-toolbar" class="mx-1" style="font-size: 1.25em">
-      <button name="editor_save" class="btn btn-icon btn-ghost-secondary">
-         <i class="ti ti-device-floppy" title="{{ _x('button', 'Save') }}" aria-label="{{ _x('button', 'Save') }}"></i>
+      <button name="editor_save" class="btn btn-icon btn-ghost-secondary" title="{{ _x('button', 'Save') }}" aria-label="{{ _x('button', 'Save') }}">
+         <i class="ti ti-device-floppy" aria-hidden="true"></i>
       </button>
-      <button name="editor_find" class="btn btn-icon btn-ghost-secondary">
-         <i class="ti ti-search" title="{{ __('Search') }}" aria-label="{{ __('Search') }}"></i>
+      <button name="editor_find" class="btn btn-icon btn-ghost-secondary" title="{{ __('Search') }}" aria-label="{{ __('Search') }}">
+         <i class="ti ti-search" aria-hidden="true"></i>
       </button>
    </div>
    <div id="payload" class="webhook-payload-editor" style="height: 600px"></div>

--- a/templates/pages/setup/webhook/webhook_headers.html.twig
+++ b/templates/pages/setup/webhook/webhook_headers.html.twig
@@ -45,7 +45,7 @@
             }) }}
             {% set remove_btn %}
                <button class="btn btn-danger btn-icon" name="remove_header" type="button" title="{{ __('Remove') }}">
-                  <i class="ti ti-trash"></i>
+                  <i class="ti ti-trash" aria-hidden="true"></i>
                </button>
             {% endset %}
             {% set header_value_autocomplete %}
@@ -66,7 +66,7 @@
 
       <div class="custom-header-fields">
          <button class="btn btn-secondary" name="add_header" type="button">
-            <i class="ti ti-plus"></i>
+            <i class="ti ti-plus" aria-hidden="true"></i>
             {{ __('Add a custom header') }}
          </button>
       </div>

--- a/templates/pages/setup/webhook/webhook_security.html.twig
+++ b/templates/pages/setup/webhook/webhook_security.html.twig
@@ -99,7 +99,7 @@
 
         {% set cra_btn %}
             <button class="btn btn-primary me-2" type="button" name="validate_challenge" value="1">
-                <i class="ti ti-lock-check"></i>
+                <i class="ti ti-lock-check" aria-hidden="true"></i>
                 <span>{{ _x('button', 'Validate') }}</span>
             </button>
         {% endset %}
@@ -167,10 +167,10 @@
                     success: function(json_response) {
                         if (json_response.status) {
                             $('input[name="is_cra_challenge_valid"]').val(1);
-                            $('span[name="cra_result"]').html('<i class="ti ti-circle-check icon-pulse fs-2" style="color: #36d601;"></i> ' + (json_response.status_code ? json_response.status_code + ' ' : ' ') + json_response.message);
+                            $('span[name="cra_result"]').html('<i class="ti ti-circle-check icon-pulse fs-2" style="color: #36d601;" aria-hidden="true"></i> ' + (json_response.status_code ? json_response.status_code + ' ' : ' ') + json_response.message);
                         } else {
                             $('input[name="is_cra_challenge_valid"]').val(0);
-                            $('span[name="cra_result"]').html('<i class="ti ti-alert-triangle icon-pulse fs-2" style="color: #ff0000;"></i> ' + (json_response.status_code ? json_response.status_code + ' ' : ' ') + json_response.message);
+                            $('span[name="cra_result"]').html('<i class="ti ti-alert-triangle icon-pulse fs-2" style="color: #ff0000;" aria-hidden="true"></i> ' + (json_response.status_code ? json_response.status_code + ' ' : ' ') + json_response.message);
                         }
                     },
                 });

--- a/templates/pages/setup/webhook/webhooktest.html.twig
+++ b/templates/pages/setup/webhook/webhooktest.html.twig
@@ -93,7 +93,7 @@
 
                                {% set cra_btn %}
                                    <button class="btn btn-primary me-2" type="button" name="get_webhook_response" value="1">
-                                       <i class="ti ti-bolt"></i>
+                                       <i class="ti ti-bolt" aria-hidden="true"></i>
                                        <span>{{ _x('button', 'See result') }}</span>
                                    </button>
                                {% endset %}

--- a/templates/pages/tools/kb/_actions_menu.html.twig
+++ b/templates/pages/tools/kb/_actions_menu.html.twig
@@ -50,7 +50,7 @@
                         data-glpi-kb-action-param-{{ key }}="{{ param }}"
                     {% endfor %}
                 >
-                    <i class="{{ action.icon }}"></i>
+                    <i class="{{ action.icon }}" aria-hidden="true"></i>
                     <span>{{ action.label }}</span>
 
                     {% if action.counter is not null %}

--- a/templates/pages/tools/kb/article.html.twig
+++ b/templates/pages/tools/kb/article.html.twig
@@ -56,7 +56,7 @@
             data-testid="translation-mode-alert"
             data-glpi-kb-translation-alert
         >
-            <i class="ti ti-language me-2 fs-3"></i>
+            <i class="ti ti-language me-2 fs-3" aria-hidden="true"></i>
             <span>{{ __("Translation mode enabled, currently editing") }}</span>
             <select
                 class="form-select form-select-sm d-inline-block w-auto ms-2 me-auto"
@@ -70,7 +70,7 @@
                 data-testid="translation-delete-btn"
                 data-glpi-kb-translation-delete title="{{ __('Delete this translation') }}"
             >
-                <i class="ti ti-trash"></i>
+                <i class="ti ti-trash" aria-hidden="true"></i>
             </button>
             <button
                 type="button"
@@ -78,7 +78,7 @@
                 data-testid="translation-save-btn"
                 data-glpi-kb-translation-save
             >
-                <i class="ti ti-device-floppy me-1"></i>{{ __('Save') }}
+                <i class="ti ti-device-floppy me-1" aria-hidden="true"></i>{{ __('Save') }}
             </button>
             <button
                 type="button"
@@ -127,7 +127,7 @@
                                 data-glpi-share-button
                                 data-glpi-itemtype="KnowbaseItem"
                                 data-glpi-items-id="{{ item_id }}">
-                            <i class="ti ti-share me-1"></i>{{ __('Share') }}
+                            <i class="ti ti-share me-1" aria-hidden="true"></i>{{ __('Share') }}
                         </button>
                         <div class="dropdown-menu dropdown-menu-end p-3"
                              style="min-width: 360px;"
@@ -146,7 +146,7 @@
                             data-action="toggle-edit"
                             data-testid="edit-button"
                         >
-                            <i class="ti ti-edit me-1"></i>{{ __('Edit') }}
+                            <i class="ti ti-edit me-1" aria-hidden="true"></i>{{ __('Edit') }}
                         </button>
                         <button
                             type="button"
@@ -154,7 +154,7 @@
                             data-action="save"
                             data-testid="save-button"
                         >
-                            <i class="ti ti-device-floppy me-1"></i>{{ __('Save') }}
+                            <i class="ti ti-device-floppy me-1" aria-hidden="true"></i>{{ __('Save') }}
                         </button>
                         <button
                             type="button"
@@ -176,7 +176,7 @@
             <div class="text-muted d-flex align-items-center gap-3">
                 {# Last update #}
                 <div class="d-flex align-items-center" data-testid="last-update">
-                    <i class="ti ti-clock me-1 fs-3"></i>
+                    <i class="ti ti-clock me-1 fs-3" aria-hidden="true"></i>
                     <span>
                         <span>{{ __("Updated:") }}</span>
                         <time
@@ -206,7 +206,7 @@
 
                 {# Views #}
                 <div class="d-flex align-items-center">
-                    <i class="ti ti-eye me-1 fs-3"></i>
+                    <i class="ti ti-eye me-1 fs-3" aria-hidden="true"></i>
                     <span data-testid="views">
                         {% if views == 0 %}
                             {{ __("No views") }}
@@ -218,7 +218,7 @@
 
                 {# Translations count #}
                 <div class="d-flex align-items-center">
-                    <i class="ti ti-language me-1 fs-3"></i>
+                    <i class="ti ti-language me-1 fs-3" aria-hidden="true"></i>
                     <a
                         href="#"
                         class="text-muted pointer-events-none"
@@ -231,14 +231,14 @@
 
                 {# Documents count #}
                 <div class="d-flex align-items-center {{ documents_count == 0 ? 'd-none' : '' }}" data-kb-documents-count-container>
-                    <i class="ti ti-paperclip me-1 fs-3"></i>
+                    <i class="ti ti-paperclip me-1 fs-3" aria-hidden="true"></i>
                     <a href="#kb-documents" class="text-muted" data-kb-documents-count  data-testid="documents-count">
                         {{ _n("%s document", "%s documents", documents_count)|format(documents_count) }}
                     </a>
                 </div>
 
                 <div class="d-flex align-items-center {{ related_items_count == 0 ? 'd-none' : '' }}" data-kb-related-items-count-container>
-                    <i class="ti ti-link me-1 fs-3"></i>
+                    <i class="ti ti-link me-1 fs-3" aria-hidden="true"></i>
                     <a href="#kb-documents" class="text-muted" data-kb-related-items-count data-testid="related-items-count">
                         {{ _n("%s related item", "%s related items", related_items_count)|format(related_items_count) }}
                     </a>
@@ -250,7 +250,7 @@
                         class="d-flex align-items-center {{ comments_count == 0 ? 'd-none' : '' }}"
                         data-glpi-comments-counter-container
                     >
-                        <i class="ti ti-message-circle me-1 fs-3"></i>
+                        <i class="ti ti-message-circle me-1 fs-3" aria-hidden="true"></i>
                         <button
                             type="button"
                             class="btn btn-link p-0 text-muted text-decoration-none border-0"
@@ -273,7 +273,7 @@
                         data-glpi-kb-visibility-dates-indicator
                         data-testid="visibility-dates-indicator"
                     >
-                        <i class="ti ti-calendar-clock me-1 fs-3"></i>
+                        <i class="ti ti-calendar-clock me-1 fs-3" aria-hidden="true"></i>
                         <a
                             href="#"
                             class="text-muted"
@@ -307,13 +307,13 @@
                 <ul class="nav nav-underline mb-3" role="tablist">
                     <li class="nav-item" role="presentation">
                         <button class="nav-link active" id="kb-documents-tab-btn" data-bs-toggle="tab" data-bs-target="#kb-documents-tab" type="button" role="tab">
-                            <i class="ti ti-paperclip me-1"></i>{{ __('Documents') }}
+                            <i class="ti ti-paperclip me-1" aria-hidden="true"></i>{{ __('Documents') }}
                             <span class="badge bg-secondary bg-opacity-25 text-body ms-1">{{ documents_count }}</span>
                         </button>
                     </li>
                     <li class="nav-item" role="presentation">
                         <button class="nav-link" id="kb-items-tab-btn" data-bs-toggle="tab" data-bs-target="#kb-items-tab" type="button" role="tab">
-                            <i class="ti ti-link me-1"></i>{{ __('Related items') }}
+                            <i class="ti ti-link me-1" aria-hidden="true"></i>{{ __('Related items') }}
                             <span class="badge bg-secondary bg-opacity-25 text-body ms-1">{{ related_items_count }}</span>
                         </button>
                     </li>
@@ -338,7 +338,7 @@
                                 data-bs-toggle="modal"
                                 data-bs-target="#kb-add-document-modal"
                             >
-                                <i class="ti ti-plus me-1"></i>{{ __('Add Document') }}
+                                <i class="ti ti-plus me-1" aria-hidden="true"></i>{{ __('Add Document') }}
                             </button>
 
                             {# Modal for document upload/linking #}
@@ -357,7 +357,7 @@
                                                         aria-controls="kb-modal-upload-pane"
                                                         aria-selected="true"
                                                     >
-                                                        <i class="ti ti-upload me-1"></i>{{ __('Upload a file') }}
+                                                        <i class="ti ti-upload me-1" aria-hidden="true"></i>{{ __('Upload a file') }}
                                                     </button>
                                                 </li>
                                                 {% if document_idor_token is defined %}
@@ -372,7 +372,7 @@
                                                         aria-controls="kb-modal-link-pane"
                                                         aria-selected="false"
                                                     >
-                                                        <i class="ti ti-link me-1"></i>{{ __('Link a document') }}
+                                                        <i class="ti ti-link me-1" aria-hidden="true"></i>{{ __('Link a document') }}
                                                     </button>
                                                 </li>
                                                 {% endif %}
@@ -425,7 +425,7 @@
                                                             </button>
                                                             <button type="submit" class="btn btn-primary"
                                                                     data-glpi-kb-upload-submit>
-                                                                <i class="ti ti-upload me-1"></i>
+                                                                <i class="ti ti-upload me-1" aria-hidden="true"></i>
                                                                 {{ __('Upload Documents') }}
                                                             </button>
                                                         </div>
@@ -470,7 +470,7 @@
                                                         </button>
                                                         <button type="button" class="btn btn-primary"
                                                                 data-glpi-kb-link-submit>
-                                                            <i class="ti ti-link me-1"></i>
+                                                            <i class="ti ti-link me-1" aria-hidden="true"></i>
                                                             {{ __('Link Documents') }}
                                                         </button>
                                                     </div>
@@ -502,7 +502,7 @@
                             data-glpi-kb-action-param-id="{{ item_id }}"
                             data-glpi-kb-action-param-key="LinkItemModal"
                             data-glpi-kb-action-param-title="{{ __('Link to another item') }}">
-                        <i class="ti ti-link me-1"></i>{{ __('Link to another item') }}
+                        <i class="ti ti-link me-1" aria-hidden="true"></i>{{ __('Link to another item') }}
                     </button>
                     {% endif %}
                 </div>
@@ -520,7 +520,7 @@
 {% if mode == 'add' %}
     <div class="px-4 mb-2 d-flex">
         <button class="btn btn-primary ms-auto" data-glpi-kb-add-article>
-            <i class="ti ti-plus me-2"></i>
+            <i class="ti ti-plus me-2" aria-hidden="true"></i>
             {{ __("Add article") }}
         </button>
     </div>

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -178,7 +178,7 @@
             disabled="true"
             aria-label="{{ __('Clear search') }}"
         >
-            <span class="ti ti-search" data-glpi-kb-aside-search-icon></span>
+            <span class="ti ti-search" data-glpi-kb-aside-search-icon aria-hidden="true"></span>
         </button>
     </div>
 </div>
@@ -190,7 +190,7 @@
     {{ hide_favorites ? 'data-glpi-kb-aside-favorites-hidden' : '' }}
 >
     <h4 class="card-title fw-bold fs-4">
-        <i class="ti ti-star-filled me-1 fs-5 text-yellow"></i>
+        <i class="ti ti-star-filled me-1 fs-5 text-yellow" aria-hidden="true"></i>
         {{ __("Favorites") }}
     </h4>
         <ul class="kb-tree ps-0">

--- a/templates/pages/tools/kb/document_badge.html.twig
+++ b/templates/pages/tools/kb/document_badge.html.twig
@@ -41,7 +41,7 @@
         class="d-flex align-items-center gap-2 text-decoration-none"
         target="_blank"
     >
-        <i class="ti {{ doc.icon_class }} {{ doc.color_class }}"></i>
+        <i class="ti {{ doc.icon_class }} {{ doc.color_class }}" aria-hidden="true"></i>
         <span>{{ doc.filename }}</span>
     </a>
 

--- a/templates/pages/tools/kb/modal/permissions.html.twig
+++ b/templates/pages/tools/kb/modal/permissions.html.twig
@@ -99,14 +99,14 @@
                         id="visibility-advanced-toggle{{ rand }}"
                         class="btn btn-sm btn-link text-start p-0 d-none"
                     >
-                        <i class="ti ti-settings me-1"></i>{{ __('Show advanced options') }}
+                        <i class="ti ti-settings me-1" aria-hidden="true"></i>{{ __('Show advanced options') }}
                     </button>
                     <div class="ms-auto">
                         <button type="submit"
                                 id="visibility-submit-btn{{ rand }}"
                                 name="addvisibility"
                                 class="btn btn-primary d-none">
-                            <i class="ti ti-plus me-1"></i>{{ _x('button', 'Add') }}
+                            <i class="ti ti-plus me-1" aria-hidden="true"></i>{{ _x('button', 'Add') }}
                         </button>
                     </div>
                 </div>

--- a/templates/pages/tools/kb/modal/targets.html.twig
+++ b/templates/pages/tools/kb/modal/targets.html.twig
@@ -41,7 +41,7 @@
                 type="button"
                 role="tab"
             >
-                <i class="ti ti-lock me-1"></i>{{ __('Permissions') }}
+                <i class="ti ti-lock me-1" aria-hidden="true"></i>{{ __('Permissions') }}
             </button>
         </li>
     </ul>

--- a/templates/pages/tools/kb/permission_entry.html.twig
+++ b/templates/pages/tools/kb/permission_entry.html.twig
@@ -51,7 +51,7 @@
             data-bs-toggle="tooltip"
             data-bs-placement="left"
         >
-            <i class="ti {{ entry.icon }}"></i>
+            <i class="ti {{ entry.icon }}" aria-hidden="true"></i>
         </span>
     {% endif %}
 
@@ -81,7 +81,7 @@
             title="{{ __('Delete') }}"
             data-bs-toggle="tooltip"
         >
-            <i class="ti ti-trash"></i>
+            <i class="ti ti-trash" aria-hidden="true"></i>
         </button>
     {% endif %}
 </li>

--- a/templates/pages/tools/kb/related_item_badge.html.twig
+++ b/templates/pages/tools/kb/related_item_badge.html.twig
@@ -39,7 +39,7 @@
        class="d-flex align-items-center gap-2 text-decoration-none"
        title="{{ __('%1$s: %2$s')|format(item.type_name, item.name) }}"
     >
-        <i class="{{ item.icon_class }} {{ item.color_class }}"></i>
+        <i class="{{ item.icon_class }} {{ item.color_class }}" aria-hidden="true"></i>
         <span>{{ item.name }}</span>
     </a>
 

--- a/templates/pages/tools/kb/share_popover.html.twig
+++ b/templates/pages/tools/kb/share_popover.html.twig
@@ -37,7 +37,7 @@
 >
     {# "Publish to web" toggle row #}
     <div class="d-flex align-items-start gap-2">
-        <i class="ti ti-world text-secondary mt-1"></i>
+        <i class="ti ti-world text-secondary mt-1" aria-hidden="true"></i>
         <div class="flex-grow-1">
             <label class="form-check-label fw-medium" for="share-publish-toggle-{{ id }}">
                 {{ __('Publish to web') }}
@@ -76,7 +76,7 @@
                         title="{{ __('Copy link') }}"
                         aria-label="{{ __('Copy link') }}"
                         data-bs-toggle="tooltip">
-                    <i class="ti ti-copy"></i>
+                    <i class="ti ti-copy" aria-hidden="true"></i>
                 </button>
                 {% if can_edit %}
                     <button type="button"
@@ -85,7 +85,7 @@
                             title="{{ __('Regenerate link') }}"
                             aria-label="{{ __('Regenerate link') }}"
                             data-bs-toggle="tooltip">
-                        <i class="ti ti-refresh"></i>
+                        <i class="ti ti-refresh" aria-hidden="true"></i>
                     </button>
                 {% endif %}
             </div>

--- a/templates/pages/tools/kb/sidepanel/base.html.twig
+++ b/templates/pages/tools/kb/sidepanel/base.html.twig
@@ -31,7 +31,7 @@
  #}
 
 <div class="d-flex mb-3 align-items-center">
-    <i class="{% block icon %}{% endblock %} me-2"></i>
+    <i class="{% block icon %}{% endblock %} me-2" aria-hidden="true"></i>
     <h2 class="mb-0 fs-3">{% block title %}{% endblock %}</h2>
     <i
         class="ti ti-x ms-auto pointer"

--- a/templates/pages/tools/kb/sidepanel/comment.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment.html.twig
@@ -65,7 +65,7 @@
                             title="{{ __('More actions') }}"
                             aria-label="{{ __('More actions') }}"
                         >
-                            <i class="ti ti-dots-vertical"></i>
+                            <i class="ti ti-dots-vertical" aria-hidden="true"></i>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-end">
                             {% if can_edit %}
@@ -76,7 +76,7 @@
                                         data-glpi-comment-edit
                                         aria-label="{{ __('Edit comment') }}"
                                     >
-                                        <i class="ti ti-edit me-2"></i>
+                                        <i class="ti ti-edit me-2" aria-hidden="true"></i>
                                         <span>{{ __('Edit comment') }}</span>
                                     </button>
                                 </li>
@@ -89,7 +89,7 @@
                                         data-glpi-comment-delete
                                         aria-label="{{ __('Delete comment') }}"
                                     >
-                                        <i class="ti ti-trash me-2"></i>
+                                        <i class="ti ti-trash me-2" aria-hidden="true"></i>
                                         <span>{{ __('Delete comment') }}</span>
                                     </button>
                                 </li>
@@ -122,8 +122,8 @@
                         data-glpi-comment-edit-submit
                         aria-label="{{ __('Save') }}"
                     >
-                        <i class="ti ti-check" data-glpi-icon></i>
-                        <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+                        <i class="ti ti-check" data-glpi-icon aria-hidden="true"></i>
+                        <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading aria-hidden="true"></i>
                         <span>{{ __('Save') }}</span>
                     </button>
                 </div>

--- a/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comment_reply_form.html.twig
@@ -78,8 +78,8 @@
                         data-glpi-reply-submit
                         aria-label="{{ __('Reply') }}"
                     >
-                        <i class="ti ti-arrow-back-up" data-glpi-icon></i>
-                        <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+                        <i class="ti ti-arrow-back-up" data-glpi-icon aria-hidden="true"></i>
+                        <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading aria-hidden="true"></i>
                         <span>{{ __('Reply') }}</span>
                     </button>
                 </div>

--- a/templates/pages/tools/kb/sidepanel/comments.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments.html.twig
@@ -82,8 +82,8 @@
             data-glpi-add-comments-submit
             aria-label="{{ __('Add comment') }}"
         >
-            <i class="ti ti-plus" data-glpi-icon></i>
-            <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+            <i class="ti ti-plus" data-glpi-icon aria-hidden="true"></i>
+            <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading aria-hidden="true"></i>
             <span>{{ __('Add comment') }}</span>
         </button>
     </div>

--- a/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
+++ b/templates/pages/tools/kb/sidepanel/comments_thread.html.twig
@@ -92,8 +92,8 @@
                             data-glpi-reply-submit
                             aria-label="{{ __('Reply') }}"
                         >
-                            <i class="ti ti-arrow-back-up" data-glpi-icon></i>
-                            <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading></i>
+                            <i class="ti ti-arrow-back-up" data-glpi-icon aria-hidden="true"></i>
+                            <i class="ti ti-loader-2 fa-spin d-none" data-glpi-loading aria-hidden="true"></i>
                             <span>{{ __('Reply') }}</span>
                         </button>
                     </div>

--- a/templates/pages/tools/kb/sidepanel/revision_item.html.twig
+++ b/templates/pages/tools/kb/sidepanel/revision_item.html.twig
@@ -101,7 +101,7 @@
                 data-bs-toggle="tooltip"
                 data-bs-placement="left"
             >
-                <i class="ti ti-restore"></i>
+                <i class="ti ti-restore" aria-hidden="true"></i>
             </button>
         {% elseif is_revision and can_revert %}
             <button
@@ -113,7 +113,7 @@
                 data-bs-toggle="tooltip"
                 data-bs-placement="left"
             >
-                <i class="ti ti-restore"></i>
+                <i class="ti ti-restore" aria-hidden="true"></i>
             </button>
         {% endif %}
     </div>

--- a/templates/pages/tools/project_task.html.twig
+++ b/templates/pages/tools/project_task.html.twig
@@ -161,7 +161,7 @@
     {% endif %}
 
     <div class="hr-text">
-        <i class="ti ti-calendar-event"></i>
+        <i class="ti ti-calendar-event" aria-hidden="true"></i>
         <span>{{ __('Planning') }}</span>
     </div>
 
@@ -247,7 +247,7 @@
     {% endif %}
 
     <div class="hr-text">
-        <i class="ti ti-file-description"></i>
+        <i class="ti ti-file-description" aria-hidden="true"></i>
         <span>{{ __('Details') }}</span>
     </div>
 

--- a/templates/pages/tools/savedsearch/save_button.html.twig
+++ b/templates/pages/tools/savedsearch/save_button.html.twig
@@ -43,6 +43,6 @@
 
 <button type="button" name="save_bookmark_record" class="btn btn-sm px-2 btn-outline-secondary btn-icon"
         title="{{ __('Save current search') }}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-   <i class="ti ti-bookmark-plus {{ active ? 'active text-yellow' : '' }}"></i>
+   <i class="ti ti-bookmark-plus {{ active ? 'active text-yellow' : '' }}" aria-hidden="true"></i>
 </button>
 <div id="savedsearch-modal" class="modal" data-params="{{ params|json_encode }}"></div>

--- a/templates/pages/tools/search_knowbaseitem.html.twig
+++ b/templates/pages/tools/search_knowbaseitem.html.twig
@@ -61,10 +61,10 @@
                             </div>
                             <div class="col-auto">
                                 <button type="button" class="btn btn-ghost-secondary btn-sm btn-icon use-knowbaseitem pointer-events-none" title="{{ __('Use this entry') }}">
-                                    <i class="ti ti-check"></i>
+                                    <i class="ti ti-check" aria-hidden="true"></i>
                                 </button>
                                 <button type="button" class="btn btn-ghost-secondary btn-sm btn-icon view-knowbaseitem pointer-events-none" title="{{ __('Preview') }}">
-                                    <i class="ti ti-eye"></i>
+                                    <i class="ti ti-eye" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
@@ -83,11 +83,11 @@
         <div class="card preview-card border-0" style="display: none">
             <div class="d-flex">
                 <button type="button" class="btn btn-ghost-secondary back-to-results">
-                    <i class="ti ti-arrow-left"></i>
+                    <i class="ti ti-arrow-left" aria-hidden="true"></i>
                     {{ __('Back to results') }}
                 </button>
                 <button type="button" class="btn btn-primary use-knowbaseitem pointer-events-none ms-auto">
-                    <i class="ti ti-check"></i>
+                    <i class="ti ti-check" aria-hidden="true"></i>
                     {{ __('Use this entry') }}
                 </button>
             </div>

--- a/templates/password_form.html.twig
+++ b/templates/password_form.html.twig
@@ -97,7 +97,7 @@
                 </script>
             {% endif %}
 
-            {% set save_button = '<i class="ti ti-device-floppy"></i><span>' ~ __('Save new password') ~ '<span>' %}
+            {% set save_button = '<i class="ti ti-device-floppy" aria-hidden="true"></i><span>' ~ __('Save new password') ~ '<span>' %}
 
         {% elseif type == 'forget' or type == 'init' %}
             <p class="text-muted mb-4">
@@ -109,7 +109,7 @@
                     required: true,
                 }) }}
             </div>
-            {% set save_button = '<i class="ti ti-mail"></i><span>' ~ __('Send') ~ '<span>' %}
+            {% set save_button = '<i class="ti ti-mail" aria-hidden="true"></i><span>' ~ __('Send') ~ '<span>' %}
         {% endif %}
 
         <div class="form-footer d-flex flex-row-reverse">

--- a/templates/stencil/editor.html.twig
+++ b/templates/stencil/editor.html.twig
@@ -61,23 +61,23 @@
                         {% set zone_defined = (zones[zone_number] is defined) %}
                         <button type="button" data-zone-index="{{ zone_number }}" aria-label="{{ zones[zone_number]['label'] ?? zone_number }}" class="btn btn-sm btn-icon {{ zone_defined ? " btn-success" : " btn-outline-secondary" }} px-1 set-zone-data" style="min-width: 4%;">
                             <span class="overflow-hidden">{{ zones[zone_number]['label'] ?? zone_number }}</span>
-                            <i class="ti {{ zone_defined ? " ti-check" : " ti-file-unknown" }} ms-1"></i>
+                            <i class="ti {{ zone_defined ? " ti-check" : " ti-file-unknown" }} ms-1" aria-hidden="true"></i>
                         </button>
                     {% endfor %}
 
                     <template id="zone-number-template">
                         <button type="button" class="btn btn-sm btn-icon btn-outline-secondary px-1 set-zone-data" style="min-width: 4%;">
                             <span class="overflow-hidden"></span>
-                            <i class="ti ti-file-unknown ms-1"></i>
+                            <i class="ti ti-file-unknown ms-1" aria-hidden="true"></i>
                         </button>
                     </template>
 
                     <div class="d-flex gap-1 justify-content-center" style="min-width: 4%;">
                         <button type="button" name="add-new-zone" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ params['add_zone_label'] ?? __("Add zone") }}" aria-label="{{ __("Add zone") }}" class="btn btn-sm btn-ghost-secondary px-1">
-                            <i class="ti ti-plus"></i>
+                            <i class="ti ti-plus" aria-hidden="true"></i>
                         </button>
                         <button type="button" name="remove-zone" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="{{ params['remove_zone_label'] ?? __("Remove zone") }}" aria-label="{{ __("Remove zone") }}" class="btn btn-sm btn-ghost-danger px-1">
-                            <i class="ti ti-minus"></i>
+                            <i class="ti ti-minus" aria-hidden="true"></i>
                         </button>
                     </div>
                 {% endif %}
@@ -112,7 +112,7 @@
                 </div>
                 <div class="col-auto">
                     <button type="button" id="save-zone-data-{{ rand }}" class="btn btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (params['save_zone_data_label']|default(__('Save zone data')) ~ ' (' ~ _x('keyboard', 'Enter') ~ ')') }}" aria-label="{{ params['save_zone_data_label']|default(__('Save zone data')) }}">
-                        <i class="ti ti-device-floppy"></i>
+                        <i class="ti ti-device-floppy" aria-hidden="true"></i>
                         {% if params.save_zone_data_label is defined %}
                             <span>{{ params['save_zone_data_label'] }}</span>
                         {% else %}
@@ -120,11 +120,11 @@
                         {% endif %}
                     </button>
                     <button type="button" id="reset-zone-data-{{ rand }}" class="btn btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ __("Reset") }}" aria-label="{{ __('Reset') }}">
-                        <i class="ti ti-trash"></i>
+                        <i class="ti ti-trash" aria-hidden="true"></i>
                         <span>{{ __("Reset") }}</span>
                     </button>
                     <button type="button" id="cancel-zone-data-{{ rand }}" class="btn btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ (__("Cancel") ~ ' (' ~ _x('keyboard', 'Esc') ~ ')') }}">
-                        <i class="ti ti-x"></i>
+                        <i class="ti ti-x" aria-hidden="true"></i>
                         <span>{{ __("Cancel") }}</span>
                     </button>
                 </div>
@@ -134,12 +134,12 @@
         <div class="col-12 my-2" id="general-submit-{{ rand }}">
             {% if id > 0 %}
                 <button id="clear-data-{{ rand }}" type="submit" name="purge" class="btn btn-outline-danger" form="stencil-editor-form-{{ rand }}" aria-label="{{ __('Clear data') }}">
-                    <i class="ti ti-trash-x"></i>
+                    <i class="ti ti-trash-x" aria-hidden="true"></i>
                     <span>{{ __('Clear data') }}</span>
                 </button>
             {% else %}
                 <button type="submit" name="add" class="btn btn-primary" form="stencil-editor-form-{{ rand }}" aria-label="{{ __('Add') }}">
-                    <i class="ti ti-plus"></i>
+                    <i class="ti ti-plus" aria-hidden="true"></i>
                     <span>{{ __("Add") }}</span>
                 </button>
             {% endif %}

--- a/templates/twig_components/Alert/Info.html.twig
+++ b/templates/twig_components/Alert/Info.html.twig
@@ -38,7 +38,7 @@
 <div class="{{ _classes }}">
     <div class="d-flex gap-2 w-full">
         <div>
-            <i class="{{ this.resolvedIcon }} fs-2x alert-icon"></i>
+            <i class="{{ this.resolvedIcon }} fs-2x alert-icon" aria-hidden="true"></i>
         </div>
         <div class="flex-grow-1">
             {% block title %}

--- a/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
+++ b/tests/e2e/specs/Ticket/timeline_primary_action_visibility.spec.ts
@@ -82,7 +82,7 @@ for (const { form, block, open } of form_cases) {
         const ticket = new TicketPage(page);
         await ticket.goto(ticket_id);
 
-        const right_actions = page.getByRole('button', { name: 'Save', exact: true });
+        const right_actions = page.getByTestId('right-actions').getByRole('button', { name: 'Save', exact: true });
         await expect(right_actions).toBeVisible();
 
         await open(ticket, page);

--- a/tests/functional/RuleTest.php
+++ b/tests/functional/RuleTest.php
@@ -186,7 +186,7 @@ class RuleTest extends DbTestCase
         $actions = $rule->getSpecificMassiveActions();
         $this->assertSame(
             [
-                'Rule:export'     => '<i class=\'ti ti-file-download\'></i>Export',
+                'Rule:export'     => '<i class=\'ti ti-file-download\' aria-hidden=\'true\'></i>Export',
             ],
             $actions
         );
@@ -196,8 +196,8 @@ class RuleTest extends DbTestCase
         $actions = $rule->getSpecificMassiveActions();
         $this->assertSame(
             [
-                'Rule:move_rule' => '<i class=\'ti ti-arrows-vertical\'></i>Move',
-                'Rule:export'     => '<i class=\'ti ti-file-download\'></i>Export',
+                'Rule:move_rule' => '<i class=\'ti ti-arrows-vertical\' aria-hidden=\'true\'></i>Move',
+                'Rule:export'     => '<i class=\'ti ti-file-download\' aria-hidden=\'true\'></i>Export',
             ],
             $actions
         );
@@ -207,7 +207,7 @@ class RuleTest extends DbTestCase
         $actions = $rule->getSpecificMassiveActions();
         $this->assertSame(
             [
-                'Rule:export'     => '<i class=\'ti ti-file-download\'></i>Export',
+                'Rule:export'     => '<i class=\'ti ti-file-download\' aria-hidden=\'true\'></i>Export',
             ],
             $actions
         );

--- a/tests/functional/Tools/Command/CheckDecorativeIconsCommandTest.php
+++ b/tests/functional/Tools/Command/CheckDecorativeIconsCommandTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\functional\Tools\Command;
+
+use Glpi\Tests\GLPITestCase;
+use Glpi\Tools\Command\CheckDecorativeIconsCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CheckDecorativeIconsCommandTest extends GLPITestCase
+{
+    private string $test_dir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->test_dir = sys_get_temp_dir() . '/glpi_test_icons_' . uniqid();
+        if (!mkdir($this->test_dir) && !is_dir($this->test_dir)) {
+            $this->markTestSkipped('Could not create temp directory');
+        }
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeDirectory($this->test_dir);
+        parent::tearDown();
+    }
+
+    public static function fixableProvider(): iterable
+    {
+        yield 'icon next to a text label' => [
+            'template.html.twig',
+            '<button type="button"><i class="ti ti-plus"></i><span>{{ __(\'Add\') }}</span></button>',
+            '<button type="button"><i class="ti ti-plus" aria-hidden="true"></i><span>{{ __(\'Add\') }}</span></button>',
+        ];
+
+        yield 'icon of a named control' => [
+            'template.html.twig',
+            '<button type="button" aria-label="Add"><i class="ti ti-plus"></i></button>',
+            '<button type="button" aria-label="Add"><i class="ti ti-plus" aria-hidden="true"></i></button>',
+        ];
+
+        yield 'standalone icon' => [
+            'template.html.twig',
+            '<span class="badge"><i class="ti ti-lock"></i> locked</span>',
+            '<span class="badge"><i class="ti ti-lock" aria-hidden="true"></i> locked</span>',
+        ];
+
+        yield 'icon class built from a variable' => [
+            'template.html.twig',
+            '<a href="#"><i class="{{ item.icon }}"></i>{{ item.name }}</a>',
+            '<a href="#"><i class="{{ item.icon }}" aria-hidden="true"></i>{{ item.name }}</a>',
+        ];
+
+        yield 'self closing icon' => [
+            'component.vue',
+            '<button :aria-label="__(\'Add\')"><i class="ti ti-plus" /></button>',
+            '<button :aria-label="__(\'Add\')"><i class="ti ti-plus" aria-hidden="true" /></button>',
+        ];
+
+        yield 'multi line tag' => [
+            'template.html.twig',
+            "<button aria-label=\"Add\">\n    <i\n        class=\"ti ti-plus\"\n    ></i>\n</button>",
+            "<button aria-label=\"Add\">\n    <i\n        class=\"ti ti-plus\" aria-hidden=\"true\"\n    ></i>\n</button>",
+        ];
+    }
+
+    #[DataProvider('fixableProvider')]
+    public function testFixableIconsAreUpdated(string $filename, string $contents, string $expected): void
+    {
+        file_put_contents($this->test_dir . '/' . $filename, $contents);
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--fix' => true]);
+
+        $this->assertStringContainsString('Added `aria-hidden` on 1 decorative icon(s).', $tester->getDisplay());
+        $this->assertEquals($expected, file_get_contents($this->test_dir . '/' . $filename));
+    }
+
+    /**
+     * The markup often lives inside a PHP or JS string literal: reusing the wrong quoting style
+     * would break the file.
+     */
+    public function testQuotingStyleIsPreserved(): void
+    {
+        file_put_contents(
+            $this->test_dir . '/legacy.php',
+            "<?php \$out = \"<button title='x'><i class='ti ti-plus'></i></button>\";"
+        );
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--fix' => true]);
+
+        $this->assertEquals(
+            "<?php \$out = \"<button title='x'><i class='ti ti-plus' aria-hidden='true'></i></button>\";",
+            file_get_contents($this->test_dir . '/legacy.php')
+        );
+    }
+
+    public static function untouchedProvider(): iterable
+    {
+        yield 'already hidden' => [
+            '<button aria-label="Add"><i class="ti ti-plus" aria-hidden="true"></i></button>',
+        ];
+
+        yield 'flagged as presentation' => [
+            '<button aria-label="Add"><i class="ti ti-plus" role="presentation"></i></button>',
+        ];
+
+        yield 'icon holding the only name of its control' => [
+            '<button type="button"><i class="ti ti-plus" title="Add"></i></button>',
+        ];
+
+        yield 'icon being the only content of an unnamed control' => [
+            '<button type="button"><i class="ti ti-plus"></i></button>',
+        ];
+
+        yield 'interactive icon' => [
+            '<i class="ti ti-plus" onclick="doSomething()"></i>',
+        ];
+
+        yield 'icon styled as a control' => [
+            '<i class="ti ti-plus btn btn-sm"></i>',
+        ];
+
+        yield 'element holding text is not an icon' => [
+            '<i>emphasis</i>',
+        ];
+
+        yield 'empty span without an icon class' => [
+            '<span class="separator"></span>',
+        ];
+    }
+
+    #[DataProvider('untouchedProvider')]
+    public function testNonDecorativeMarkupIsLeftAlone(string $contents): void
+    {
+        file_put_contents($this->test_dir . '/template.html.twig', $contents);
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--fix' => true]);
+
+        $this->assertEquals($contents, file_get_contents($this->test_dir . '/template.html.twig'));
+    }
+
+    public function testCheckModeReportsWithoutWriting(): void
+    {
+        $contents = '<button aria-label="Add"><i class="ti ti-plus"></i></button>';
+        file_put_contents($this->test_dir . '/template.html.twig', $contents);
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir]);
+
+        $this->assertStringContainsString('template.html.twig:1', $tester->getDisplay());
+        $this->assertEquals(CheckDecorativeIconsCommand::ERROR_MISSING_ARIA_HIDDEN, $tester->getStatusCode());
+        $this->assertEquals($contents, file_get_contents($this->test_dir . '/template.html.twig'));
+    }
+
+    public function testReviewListIsOnlyShownOnDemand(): void
+    {
+        file_put_contents(
+            $this->test_dir . '/template.html.twig',
+            '<button type="button"><i class="ti ti-plus" title="Add"></i></button>'
+        );
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir]);
+        $this->assertStringNotContainsString('manual decision', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--show-review' => true]);
+        $this->assertStringContainsString('manual decision', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+    }
+
+    public function testSuccessOnCleanDirectory(): void
+    {
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir]);
+
+        $this->assertStringContainsString(
+            '[OK] All decorative icons are hidden from assistive technologies.',
+            $tester->getDisplay()
+        );
+        $this->assertEquals(0, $tester->getStatusCode());
+    }
+}

--- a/tests/src/AbstractCommonItilObject_ItemTest.php
+++ b/tests/src/AbstractCommonItilObject_ItemTest.php
@@ -70,7 +70,7 @@ abstract class AbstractCommonItilObject_ItemTest extends DbTestCase
             'items_id' => getItemByTypeName(Computer::class, '_test_pc01', true),
         ]);
         $this->assertEquals(
-            '<span class="d-flex align-items-center"><i class="ti ti-package me-2"></i>Items <span class="badge glpi-badge" data-testid="tab-count-badge">1</span></span>',
+            '<span class="d-flex align-items-center"><i class="ti ti-package me-2" aria-hidden="true"></i>Items <span class="badge glpi-badge" data-testid="tab-count-badge">1</span></span>',
             $link->getTabNameForItem($itil_item),
         );
 
@@ -80,7 +80,7 @@ abstract class AbstractCommonItilObject_ItemTest extends DbTestCase
             'items_id' => getItemByTypeName(Computer::class, '_test_pc02', true),
         ]);
         $this->assertEquals(
-            '<span class="d-flex align-items-center"><i class="ti ti-package me-2"></i>Items <span class="badge glpi-badge" data-testid="tab-count-badge">2</span></span>',
+            '<span class="d-flex align-items-center"><i class="ti ti-package me-2" aria-hidden="true"></i>Items <span class="badge glpi-badge" data-testid="tab-count-badge">2</span></span>',
             $link->getTabNameForItem($itil_item),
         );
 

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -373,6 +373,19 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
     {
         $carries_a_name = preg_match('/\b(?:title|aria-label|aria-labelledby|alt)\s*=/i', $attrs) === 1;
 
+        // An icon that is the control itself is reported as such first: the name it carries is a
+        // consequence of that, not the problem to solve.
+        if (preg_match('/\b(?:onclick|href|tabindex|contenteditable|data-bs-toggle=(?![\'"]?tooltip)|v-on:click|@click)/i', $attrs) === 1) {
+            return 'is the interactive control itself, it should become a real button';
+        }
+
+        if (
+            preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) === 1
+            && preg_match('/\b(?:btn|pointer|cursor-pointer)\b/', $matches['value']) === 1
+        ) {
+            return 'is styled as an interactive control, it should become a real button';
+        }
+
         if ($names_its_control) {
             return $carries_a_name
                 // Hiding the icon would drop its title too: an aria-hidden subtree contributes
@@ -382,18 +395,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         }
 
         if ($carries_a_name) {
-            return 'carries a name of its own while its control is already named, check what the name adds';
-        }
-
-        if (preg_match('/\b(?:onclick|href|tabindex|contenteditable|data-bs-toggle|v-on:click|@click)/i', $attrs) === 1) {
-            return 'is the interactive control itself, it should become a real button';
-        }
-
-        if (
-            preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) === 1
-            && preg_match('/\b(?:btn|pointer|cursor-pointer)\b/', $matches['value']) === 1
-        ) {
-            return 'is styled as an interactive control, it should become a real button';
+            return 'carries a name of its own, replace it with a visually hidden text if it carries meaning';
         }
 
         return null;

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -1,0 +1,472 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Tools\Command;
+
+use FilesystemIterator;
+use Override;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Icon fonts expose their glyph through a CSS `::before { content: "\eXXX" }` rule. The accessible
+ * name computation includes pseudo-element content, so a decorative icon placed inside an element
+ * that takes its name from its contents (button, link, heading, tab, option...) injects a private
+ * use area character into that name. Screen readers announce it, and it makes accessible names
+ * impossible to match reliably.
+ *
+ * Decorative icons must therefore carry `aria-hidden="true"`. This command reports the ones that
+ * do not, and can add the attribute.
+ */
+final class CheckDecorativeIconsCommand extends AbstractCommand
+{
+    /**
+     * Error code returned when some decorative icons are missing `aria-hidden`.
+     */
+    public const ERROR_MISSING_ARIA_HIDDEN = 1;
+
+    /**
+     * Directories parsed when no `--directory` option is given, relative to the project root.
+     */
+    private const DEFAULT_DIRECTORIES = ['ajax', 'front', 'js', 'src', 'templates'];
+
+    private const PARSED_EXTENSIONS = ['js', 'php', 'twig', 'vue'];
+
+    /**
+     * The icon can be fitted with `aria-hidden` without losing anything.
+     */
+    private const VERDICT_FIXABLE = 'fixable';
+
+    /**
+     * The icon carries an accessible name, or is the interactive control itself. Hiding it would
+     * remove a name instead of a glyph, so it needs a human decision.
+     */
+    private const VERDICT_REVIEW = 'review';
+
+    #[Override]
+    protected function isPluginOptionAvailable(): bool
+    {
+        return true;
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('tools:check_decorative_icons');
+        $this->setDescription('Check that decorative icons are hidden from assistive technologies.');
+
+        $this->addOption(
+            'directory',
+            'd',
+            InputOption::VALUE_OPTIONAL,
+            'Directory to parse (optional)',
+        );
+
+        $this->addOption(
+            'fix',
+            'f',
+            InputOption::VALUE_NONE,
+            'Add the missing `aria-hidden` attributes'
+        );
+
+        $this->addOption(
+            'show-review',
+            null,
+            InputOption::VALUE_NONE,
+            'Also list the icons that cannot be fixed automatically'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $project_dir = dirname(__DIR__, 3); // Root of GLPI
+
+        if ($this->isPluginCommand()) {
+            $project_dir = $this->getPluginDirectory();
+        }
+
+        $directories = ($target_dir = $input->getOption('directory')) !== null
+            ? [$target_dir]
+            : array_map(
+                static fn(string $dir): string => $project_dir . DIRECTORY_SEPARATOR . $dir,
+                self::DEFAULT_DIRECTORIES
+            );
+
+        $fix = (bool) $input->getOption('fix');
+        $fixable_count = 0;
+        $review = [];
+        $failed_files = [];
+
+        foreach ($this->getFilesToParse($directories) as $filename) {
+            if (($contents = file_get_contents($filename)) === false) {
+                throw new \RuntimeException(sprintf('Unable to read file "%s".', $filename));
+            }
+
+            $icons = $this->findIconsToReport($contents);
+            if ($icons === []) {
+                continue;
+            }
+
+            $relative_path = str_replace($project_dir . DIRECTORY_SEPARATOR, '', $filename);
+
+            foreach ($icons as $icon) {
+                if ($icon['verdict'] === self::VERDICT_REVIEW) {
+                    $review[] = sprintf(
+                        '%s:%d %s (%s)',
+                        $relative_path,
+                        $icon['line'],
+                        trim($icon['tag']),
+                        $icon['reason']
+                    );
+                    continue;
+                }
+
+                $fixable_count++;
+                $this->io->writeln(
+                    sprintf(
+                        '<fg=red>%s:%d</> %s',
+                        $relative_path,
+                        $icon['line'],
+                        trim($icon['tag'])
+                    ),
+                    $fix ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL
+                );
+            }
+
+            if (!$fix) {
+                continue;
+            }
+
+            $updated = $this->addAriaHidden($contents, $icons);
+            if ($updated !== $contents && file_put_contents($filename, $updated) === false) {
+                $failed_files[] = $relative_path;
+            }
+        }
+
+        if ($input->getOption('show-review') && $review !== []) {
+            $this->io->section(
+                sprintf('%d icon(s) need a manual decision (name carried by the icon, or interactive icon)', count($review))
+            );
+            foreach ($review as $line) {
+                $this->io->writeln('<fg=yellow>‣ ' . $line . '</>');
+            }
+        }
+
+        if ($fixable_count === 0) {
+            $this->io->success('All decorative icons are hidden from assistive technologies.');
+            return 0; // Success
+        }
+
+        if (!$fix) {
+            $this->io->error(
+                sprintf(
+                    'Found %d decorative icon(s) without `aria-hidden`. Use --fix option to fix them.',
+                    $fixable_count
+                )
+            );
+            return self::ERROR_MISSING_ARIA_HIDDEN;
+        }
+
+        if ($failed_files !== []) {
+            $this->io->error(
+                sprintf('%d file(s) cannot be updated: %s', count($failed_files), implode(', ', $failed_files))
+            );
+            return self::FAILURE;
+        }
+
+        $this->io->success(sprintf('Added `aria-hidden` on %d decorative icon(s).', $fixable_count));
+        return 0; // Success
+    }
+
+    /**
+     * Locate the icon elements that are not hidden yet, and qualify each of them.
+     *
+     * @return list<array{offset: int, length: int, tag: string, line: int, verdict: string, reason: string}>
+     */
+    private function findIconsToReport(string $contents): array
+    {
+        $icons = [];
+
+        // `[^>]*` cannot handle an attribute value containing a `>` (a Twig ternary, typically);
+        // such a tag is skipped rather than mis-parsed, and shows up in the review list instead.
+        if (preg_match_all('/<(?<tag>i|span)\b(?<attrs>[^>]*?)(?<selfclose>\/)?>/i', $contents, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === 0) {
+            return [];
+        }
+
+        foreach ($matches as $match) {
+            $tag = $match[0][0];
+            $offset = $match[0][1];
+            $attrs = $match['attrs'][0];
+            $is_span = strtolower($match['tag'][0]) === 'span';
+
+            $self_closed = ($match['selfclose'][0] ?? '') !== '';
+            $tag_name = $is_span ? 'span' : 'i';
+
+            $element_end = $this->getElementEnd($contents, $offset + strlen($tag), $self_closed, $tag_name);
+            if ($element_end === null) {
+                // Elements holding text are not icons, whatever their classes are.
+                continue;
+            }
+
+            // An empty `<i>` is always an icon in GLPI. A `<span>` needs an explicit icon class,
+            // as empty spans are also used as layout or Select2 placeholders.
+            if ($is_span && !$this->hasIconClass($attrs)) {
+                continue;
+            }
+
+            if (preg_match('/\baria-hidden\s*=/i', $attrs) === 1) {
+                continue; // Already done.
+            }
+            if (preg_match('/\brole\s*=\s*.?presentation/i', $attrs) === 1) {
+                continue; // Equivalent intent, already expressed.
+            }
+
+            $reason = $this->getReviewReason($attrs, $this->isSoleContentOfUnnamedControl($contents, $offset, $element_end));
+            $icons[] = [
+                'offset' => $offset,
+                'length' => strlen($tag),
+                'tag' => $tag,
+                'line' => substr_count($contents, "\n", 0, $offset) + 1,
+                'verdict' => $reason === null ? self::VERDICT_FIXABLE : self::VERDICT_REVIEW,
+                'reason' => $reason ?? '',
+            ];
+        }
+
+        return $icons;
+    }
+
+    /**
+     * Return the position right after the element opened at $offset, or null when it holds text.
+     */
+    private function getElementEnd(string $contents, int $offset, bool $self_closed, string $tag_name): ?int
+    {
+        if ($self_closed) {
+            return $offset;
+        }
+
+        $closing_position = stripos($contents, '</' . $tag_name, $offset);
+        if ($closing_position === false) {
+            return null; // Unbalanced markup, leave it alone.
+        }
+
+        if (trim(substr($contents, $offset, $closing_position - $offset)) !== '') {
+            return null;
+        }
+
+        $closing_end = strpos($contents, '>', $closing_position);
+
+        return $closing_end === false ? null : $closing_end + 1;
+    }
+
+    /**
+     * Tell whether the icon is the whole content of an interactive element that has no other
+     * naming source. Hiding such an icon would leave the control without any accessible name,
+     * which is worse than the stray glyph: it needs a real label first.
+     */
+    private function isSoleContentOfUnnamedControl(string $contents, int $icon_start, int $icon_end): bool
+    {
+        foreach (['button', 'a', 'label'] as $parent_tag) {
+            $parent = $this->findEnclosingOpeningTag($contents, $icon_start, $parent_tag);
+            if ($parent === null) {
+                continue;
+            }
+
+            if (trim(substr($contents, $parent['end'], $icon_start - $parent['end'])) !== '') {
+                continue; // Some text precedes the icon, the control is named by its contents.
+            }
+
+            $closing_position = stripos($contents, '</' . $parent_tag, $icon_end);
+            if ($closing_position === false) {
+                continue;
+            }
+
+            if (trim(substr($contents, $icon_end, $closing_position - $icon_end)) !== '') {
+                continue; // Some text follows the icon.
+            }
+
+            return preg_match('/\b(?:title|aria-label|aria-labelledby)\s*=/i', $parent['attrs']) !== 1;
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the opening tag of the closest still opened $tag_name element preceding $before.
+     *
+     * @return array{end: int, attrs: string}|null
+     */
+    private function findEnclosingOpeningTag(string $contents, int $before, string $tag_name): ?array
+    {
+        // Markup emitted from PHP or JS is often split across concatenated string literals, so the
+        // search is bounded: beyond that, any candidate is more likely unrelated than enclosing.
+        $window_start = max(0, $before - 2000);
+        $window = substr($contents, $window_start, $before - $window_start);
+
+        if (preg_match_all('/<' . $tag_name . '\b(?<attrs>[^>]*)>/i', $window, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === 0) {
+            return null;
+        }
+
+        $last = end($matches);
+        $opening_end = $window_start + $last[0][1] + strlen($last[0][0]);
+
+        $closing_position = stripos($contents, '</' . $tag_name, $opening_end);
+        if ($closing_position !== false && $closing_position < $before) {
+            return null; // That element is already closed, it does not enclose the icon.
+        }
+
+        return ['end' => $opening_end, 'attrs' => $last['attrs'][0]];
+    }
+
+    private function hasIconClass(string $attrs): bool
+    {
+        if (preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) !== 1) {
+            return false;
+        }
+
+        // `icon` also covers the class names built from a variable: `getIcon()`, `item.icon`,
+        // `resolvedIcon`, `itemtype_icon`, as well as the `main-icon` / `alert-icon` families.
+        return preg_match('/\bti-|\bfa-|\bfa[srlbdk]?\b|icon/i', $matches['value']) === 1;
+    }
+
+    /**
+     * Return why the icon needs a human decision, or null when it can safely be hidden.
+     */
+    private function getReviewReason(string $attrs, bool $names_its_control): ?string
+    {
+        $carries_a_name = preg_match('/\b(?:title|aria-label|aria-labelledby|alt)\s*=/i', $attrs) === 1;
+
+        if ($names_its_control) {
+            return $carries_a_name
+                // Hiding the icon would drop its title too: an aria-hidden subtree contributes
+                // nothing to the accessible name computation.
+                ? 'holds the only name of its control, move that name up to the control itself'
+                : 'is the only content of a control that has no name at all, that control needs a label first';
+        }
+
+        if ($carries_a_name) {
+            return 'carries a name of its own while its control is already named, check what the name adds';
+        }
+
+        if (preg_match('/\b(?:onclick|href|tabindex|contenteditable|data-bs-toggle|v-on:click|@click)/i', $attrs) === 1) {
+            return 'is the interactive control itself, it should become a real button';
+        }
+
+        if (
+            preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) === 1
+            && preg_match('/\b(?:btn|pointer|cursor-pointer)\b/', $matches['value']) === 1
+        ) {
+            return 'is styled as an interactive control, it should become a real button';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array{offset: int, length: int, tag: string, line: int, verdict: string, reason: string}> $icons
+     */
+    private function addAriaHidden(string $contents, array $icons): string
+    {
+        // Walk backwards so that the offsets computed above stay valid.
+        foreach (array_reverse($icons) as $icon) {
+            if ($icon['verdict'] !== self::VERDICT_FIXABLE) {
+                continue;
+            }
+
+            $tag = $icon['tag'];
+            // Reuse the quoting style already used in the tag: the markup often lives inside a PHP
+            // or JS string literal, and the wrong quote would break it.
+            $quote = preg_match('/=\s*(?<quote>["\'])/', $tag, $matches) === 1 ? $matches['quote'] : '"';
+
+            // Insert right after the last attribute, i.e. before the closing `>` and the `/` of a
+            // self closing tag.
+            $body = rtrim(substr($tag, 0, -1));
+            if (str_ends_with($body, '/')) {
+                $body = rtrim(substr($body, 0, -1));
+            }
+            $insert_at = strlen($body);
+
+            $updated_tag = substr($tag, 0, $insert_at)
+                . sprintf(' aria-hidden=%1$strue%1$s', $quote)
+                . substr($tag, $insert_at);
+
+            $contents = substr_replace($contents, $updated_tag, $icon['offset'], $icon['length']);
+        }
+
+        return $contents;
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<string>
+     */
+    private function getFilesToParse(array $directories): array
+    {
+        $files = [];
+
+        foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveCallbackFilterIterator(
+                    new RecursiveDirectoryIterator($directory, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS),
+                    static function (SplFileInfo $file): bool {
+                        if ($file->isDir()) {
+                            // Third party code, and build artifacts.
+                            return !in_array($file->getFilename(), ['lib', 'node_modules', 'vendor'], true);
+                        }
+                        return in_array(strtolower($file->getExtension()), self::PARSED_EXTENSIONS, true);
+                    }
+                )
+            );
+
+            foreach ($iterator as $file) {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
Decorative icons are not images; but content added from CSS stylesheet:

```css
.ti-plus:before { content: "\eb0b"; }   /* public/lib/tabler.css */
```

Element accessible name is therefore prefixed with `::before` text. See accessible name for "Add" button on KB permissions modal:
<img width="1137" height="654" alt="image" src="https://github.com/user-attachments/assets/405dfc3f-7e5c-4032-a091-7a6e0f5b0807" />

This is an a11y issue, and this also can cause errors on CI: something like `getByRole('button', { name: 'Add', exact: true })`
could never match that button, because its real name is "\ueb0bAdd". 
I guess this is why explicit `aria-label` have been used on some elements (this hack is fine for a11y; `aria-label` has the precedence).

There are a lot of decorative images in the code; adding a command that check/fix seem the best option. This PR does not change "useless" aria labels.

It only changes strictly decorative icons (no title/aria-label). Detected cases that are not automatically fixed can be displayed using `--show-review` flag on the command. 

To be reviewed per commit: first commit add the command, second use it to run the fix (also some tests have been fixed), and third one is a fix of some remaining issues that cannot be automatically fixed.

Example output:
```
+ bin/console tools:check_decorative_icons
src/Dropdown.php:343 <i class='ti ti-plus'>
templates/pages/tools/kb/modal/permissions.html.twig:109 <i class="ti ti-plus me-1">

 [ERROR] Found 2 decorative icon(s) without `aria-hidden`. Use --fix option to  
         fix them.                                                              
```