### PR TITLE
Fix/45527/error message wrongly displayed

### DIFF
--- a/inc/relation.constant.php
+++ b/inc/relation.constant.php
@@ -1840,13 +1840,13 @@ foreach ($CFG_GLPI['networkport_types'] as $source_itemtype) {
 
 // Asset_PeripheralAsset specific case
 foreach ($CFG_GLPI['directconnect_types'] as $directconnect_itemtype) {
-    $target_table_key = Asset_PeripheralAsset::getTable();
+    $target_table_key = '_' . Asset_PeripheralAsset::getTable();
     $source_table     = $directconnect_itemtype::getTable();
 
     $add_mapping_entry($source_table, $target_table_key, ['itemtype_peripheral', 'items_id_peripheral']);
 }
 foreach (Asset_PeripheralAsset::getPeripheralHostItemtypes() as $peripheralhost_itemtype) {
-    $target_table_key = Asset_PeripheralAsset::getTable();
+    $target_table_key = '_' . Asset_PeripheralAsset::getTable();
     $source_table     = $peripheralhost_itemtype::getTable();
 
     $add_mapping_entry($source_table, $target_table_key, ['itemtype_asset', 'items_id_asset']);

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -126,9 +126,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
                 'items_id_peripheral' => $periph->getID(),
             ]
         );
-        if (array_key_exists('MESSAGE_AFTER_REDIRECT', $_SESSION) && count($_SESSION['MESSAGE_AFTER_REDIRECT']) > 0) {
-            $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
-        }
+        $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
 
         $this->assertTrue($periph->delete(['id' => $periph->getID()], force: true));
 

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -139,7 +139,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
 
         $peripheralMock->delete(
             [
-                'id' => $periph_id
+                'id' => $periph_id,
             ]
         );
     }

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -133,6 +133,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         $periph->delete(['id' => $periph->getID()], force: true);
 
         $this->assertTrue($_SESSION['MESSAGE_AFTER_REDIRECT'] === []);
+        $this->assertFalse((new Asset_PeripheralAsset())->getFromDB($relation->getID()));
 
     }
 }

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -100,7 +100,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
     public function testDeletePeripheralDoesNotCallCleanRelationData(): void
     {
         $computer = $this->createItem(
-            \Computer::getType(),
+            \Computer::class,
             [
                 'name'   => 'Le PC',
                 'serial' => 'qqzder45',

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -109,7 +109,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         );
 
         $periph = $this->createItem(
-            Peripheral::getType(),
+            Peripheral::class,
             [
                 'name' => 'La Souris',
                 'serial' => '12345',
@@ -118,7 +118,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
         );
 
         $relation = $this->createItem(
-            Asset_PeripheralAsset::getType(),
+            Asset_PeripheralAsset::class,
             [
                 'itemtype_asset' => 'Computer',
                 'items_id_asset' => $computer->getID(),

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -40,6 +40,7 @@ use Glpi\Asset\Capacity\HasPeripheralAssetsCapacity;
 use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use Monitor;
+use Peripheral;
 use Toolbox;
 
 class Asset_PeripheralAssetTest extends DbTestCase
@@ -98,49 +99,40 @@ class Asset_PeripheralAssetTest extends DbTestCase
 
     public function testDeletePeripheralDoesNotCallCleanRelationData(): void
     {
-        $computer = new \Computer();
-        $relation = new Asset_PeripheralAsset();
-        $peripheralMock = $this->getMockBuilder(\Peripheral::class)
-            ->onlyMethods(['cleanRelationData'])
-            ->getMock();
-
-        $peripheralMock
-            ->expects($this->never())
-            ->method('cleanRelationData');
-
-
-        $computers_id = $computer->add(
+        $computer = $this->createItem(
+            \Computer::getType(),
             [
                 'name'   => 'Le PC',
                 'serial' => 'qqzder45',
                 'entities_id' => 0,
             ]
         );
-        $this->assertGreaterThan(0, $computers_id);
 
-        $periph_id = $peripheralMock->add(
+        $periph = $this->createItem(
+            Peripheral::getType(),
             [
                 'name' => 'La Souris',
                 'serial' => '12345',
                 'entities_id'  => 0,
             ]
         );
-        $this->assertGreaterThan(0, $periph_id);
 
-        $relation_id = $relation->add(
+        $relation = $this->createItem(
+            Asset_PeripheralAsset::getType(),
             [
                 'itemtype_asset' => 'Computer',
-                'items_id_asset' => $computers_id,
+                'items_id_asset' => $computer->getID(),
                 'itemtype_peripheral' => 'Peripheral',
-                'items_id_peripheral' => $periph_id,
+                'items_id_peripheral' => $periph->getID(),
             ]
         );
-        $this->assertGreaterThan(0, $relation_id);
+        if (array_key_exists('MESSAGE_AFTER_REDIRECT', $_SESSION) && count($_SESSION['MESSAGE_AFTER_REDIRECT']) > 0) {
+            $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
+        }
 
-        $peripheralMock->delete(
-            [
-                'id' => $periph_id,
-            ]
-        );
+        $periph->delete(['id' => $periph->getID()], force: true);
+
+        $this->assertTrue($_SESSION['MESSAGE_AFTER_REDIRECT'] === []);
+
     }
 }

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -130,7 +130,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
             $_SESSION['MESSAGE_AFTER_REDIRECT'] = [];
         }
 
-        $periph->delete(['id' => $periph->getID()], force: true);
+        $this->assertTrue($periph->delete(['id' => $periph->getID()], force: true));
 
         $this->assertTrue($_SESSION['MESSAGE_AFTER_REDIRECT'] === []);
         $this->assertFalse((new Asset_PeripheralAsset())->getFromDB($relation->getID()));

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -95,4 +95,52 @@ class Asset_PeripheralAssetTest extends DbTestCase
         $this->assertIsBool($result);
         $this->assertTrue($result);
     }
+
+    public function testDeletePeripheralDoesNotCallCleanRelationData(): void
+    {
+        $computer = new \Computer();
+        $relation = new Asset_PeripheralAsset();
+        $peripheralMock = $this->getMockBuilder(\Peripheral::class)
+            ->onlyMethods(['cleanRelationData'])
+            ->getMock();
+
+        $peripheralMock
+            ->expects($this->never())
+            ->method('cleanRelationData');
+
+
+        $computers_id = $computer->add(
+            [
+                'name'   => 'Le PC',
+                'serial' => 'qqzder45',
+                'entities_id' => 0,
+            ]
+        );
+        $this->assertGreaterThan(0, $computers_id);
+
+        $periph_id = $peripheralMock->add(
+            [
+                'name' => 'La Souris',
+                'serial' => '12345',
+                'entities_id'  => 0,
+            ]
+        );
+        $this->assertGreaterThan(0, $periph_id);
+
+        $relation_id = $relation->add(
+            [
+                'itemtype_asset' => 'Computer',
+                'items_id_asset' => $computers_id,
+                'itemtype_peripheral' => 'Peripheral',
+                'items_id_peripheral' => $periph_id,
+            ]
+        );
+        $this->assertGreaterThan(0, $relation_id);
+
+        $peripheralMock->delete(
+            [
+                'id' => $periph_id
+            ]
+        );
+    }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45527
- Here is a brief description of what this PR does
  - Prevent call of  CommonDBTM::cleanRelationData() in case of a Peripheral deletion
  - Added unit test to check the method is not called when a Peripheral is deleted


