### PR TITLE
Sort project tasks using hierarchical structure when planned start date is missing

### DIFF
--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -707,7 +707,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      *
      * @param int $ID ID of the project
      *
-     * @return array of tasks ordered by dates
+     * @return array of tasks ordered by dates or by hierarchical order if no start dates are set
      **/
     public static function getAllForProject($ID)
     {
@@ -741,7 +741,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
      * @since 9.5.0
      * @param int $ID ID of the project task
      *
-     * @return array of tasks ordered by dates
+     * @return array of tasks ordered by dates or by hierarchical order if no start dates are set
      **/
     public static function getAllForProjectTask($ID)
     {

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1488,8 +1488,13 @@ TWIG, $twig_params);
         }
 
         $ordered = [];
-        $visit = static function ($father_id) use (&$visit, &$children, &$by_id, &$ordered) {
+        $visited = [];
+        $visit = static function ($father_id) use (&$visit, &$children, &$by_id, &$ordered, &$visited) {
             foreach ($children[$father_id] ?? [] as $id) {
+                if (isset($visited[$id])) {
+                    continue;
+                }
+                $visited[$id] = true;
                 $ordered[] = $by_id[$id];
                 $visit($id);
             }

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -725,6 +725,14 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         foreach ($iterator as $data) {
             $tasks[] = $data;
         }
+
+        if (
+            !array_filter($tasks, static fn($task) => !empty($task['plan_start_date']) || !empty($task['real_start_date']))
+        ) {
+            // If no task has plan dates, sort by hierarchy
+            $tasks = self::sortProjectTasksByHierarchy($tasks);
+        }
+
         return $tasks;
     }
 
@@ -751,6 +759,14 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         foreach ($iterator as $data) {
             $tasks[] = $data;
         }
+
+        if (
+            !array_filter($tasks, static fn($task) => !empty($task['plan_start_date']) || !empty($task['real_start_date']))
+        ) {
+            // If no task has plan dates, sort by hierarchy
+            $tasks = self::sortProjectTasksByHierarchy($tasks);
+        }
+
         return $tasks;
     }
 
@@ -1372,7 +1388,7 @@ TWIG, $twig_params);
                 'itemtype' => static::class,
                 'id' => $data['id'],
                 // Used to reorder entries hierarchically when there is no plan_start_date to sort on
-                '_father_id' => $data['projecttasks_id'],
+                'projecttasks_id' => $data['projecttasks_id'],
                 'row_class' => $data['is_deleted'] ? 'table-danger' : '',
                 'name' => $task->getLink(['comments' => true]),
                 'tname' => $data['transname2'] ?? $data['tname'],
@@ -1413,7 +1429,8 @@ TWIG, $twig_params);
             $_GET['sort'] === 'plan_start_date'
             && !array_filter($entries, static fn($entry) => !empty($entry['plan_start_date']))
         ) {
-            $entries = self::sortEntriesByHierarchy($entries);
+            $entries = self::sortProjectTasksByHierarchy($entries);
+            $order = 'none'; // No order to apply, as the order is already set by the hierarchy
         }
 
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
@@ -1454,20 +1471,20 @@ TWIG, $twig_params);
      * sort an array task entries (as built by self::showFor())
      * using hierarchical order (father followed by its children, recursively)
      *
-     * Entries whose father (see '_father_id') is not part of the given list are considered roots;
+     * Entries whose father (see 'projecttasks_id') is not part of the given list are considered roots;
      * siblings keep their relative order from the input list.
      *
-     * @param list<array<string, mixed>> $entries Flat list of entries, each holding at least 'id' and '_father_id'
+     * @param list<array<string, mixed>> $entries Flat list of entries, each holding at least 'id' and 'projecttasks_id'
      *
      * @return list<array<string, mixed>> sorted entries
      **/
-    private static function sortEntriesByHierarchy(array $entries): array
+    public static function sortProjectTasksByHierarchy(array $entries): array
     {
         $by_id      = [];
         $children   = [];
         foreach ($entries as $entry) {
             $by_id[$entry['id']] = $entry;
-            $children[$entry['_father_id']][] = $entry['id'];
+            $children[$entry['projecttasks_id']][] = $entry['id'];
         }
 
         $ordered = [];

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -719,7 +719,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'WHERE'  => [
                 'projects_id'  => $ID,
             ],
-            'ORDERBY'   => ['plan_start_date', 'real_start_date'],
+            'ORDERBY'   => ['plan_start_date', 'real_start_date', 'id'],
         ]);
 
         foreach ($iterator as $data) {
@@ -753,7 +753,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
             'WHERE'  => [
                 'projecttasks_id'  => $ID,
             ],
-            'ORDERBY'   => ['plan_start_date', 'real_start_date'],
+            'ORDERBY'   => ['plan_start_date', 'real_start_date', 'id'],
         ]);
 
         foreach ($iterator as $data) {

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1292,7 +1292,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         if (empty($_GET["sort"]) || !isset($columns[$_GET["sort"]])) {
             $_GET['sort'] = 'plan_start_date';
         }
-        $criteria['ORDERBY'] = [$_GET["sort"] . " $order"];
+        $criteria['ORDERBY'] = [$_GET["sort"] . " $order", 'id ASC'];
 
         $canedit = $item::class === Project::class && $item->canEdit($ID);
 
@@ -1371,6 +1371,8 @@ TWIG, $twig_params);
             $entry = [
                 'itemtype' => static::class,
                 'id' => $data['id'],
+                // Used to reorder entries hierarchically when there is no plan_start_date to sort on
+                '_father_id' => $data['projecttasks_id'],
                 'row_class' => $data['is_deleted'] ? 'table-danger' : '',
                 'name' => $task->getLink(['comments' => true]),
                 'tname' => $data['transname2'] ?? $data['tname'],
@@ -1405,6 +1407,15 @@ TWIG, $twig_params);
             $entries[] = $entry;
         }
 
+        // If sorting on the planned start date but none of the displayed tasks have one set,
+        // sort using hierarchical order (father followed by its children, recursively)
+        if (
+            $_GET['sort'] === 'plan_start_date'
+            && !array_filter($entries, static fn($entry) => !empty($entry['plan_start_date']))
+        ) {
+            $entries = self::sortEntriesByHierarchy($entries);
+        }
+
         TemplateRenderer::getInstance()->display('components/datatable.html.twig', [
             'is_tab' => true,
             'nofilter' => true,
@@ -1437,6 +1448,45 @@ TWIG, $twig_params);
                 ],
             ],
         ]);
+    }
+
+    /**
+     * sort an array task entries (as built by self::showFor())
+     * using hierarchical order (father followed by its children, recursively)
+     *
+     * Entries whose father (see '_father_id') is not part of the given list are considered roots;
+     * siblings keep their relative order from the input list.
+     *
+     * @param list<array<string, mixed>> $entries Flat list of entries, each holding at least 'id' and '_father_id'
+     *
+     * @return list<array<string, mixed>> sorted entries
+     **/
+    private static function sortEntriesByHierarchy(array $entries): array
+    {
+        $by_id      = [];
+        $children   = [];
+        foreach ($entries as $entry) {
+            $by_id[$entry['id']] = $entry;
+            $children[$entry['_father_id']][] = $entry['id'];
+        }
+
+        $ordered = [];
+        $visit = static function ($father_id) use (&$visit, &$children, &$by_id, &$ordered) {
+            foreach ($children[$father_id] ?? [] as $id) {
+                $ordered[] = $by_id[$id];
+                $visit($id);
+            }
+        };
+
+        // Roots are the tasks whose father is not part of the current list
+        // (either they have no father, or their father is out of the displayed scope).
+        foreach (array_keys($children) as $father_id) {
+            if (!isset($by_id[$father_id])) {
+                $visit($father_id);
+            }
+        }
+
+        return $ordered;
     }
 
 

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -1474,6 +1474,7 @@ TWIG, $twig_params);
      * Entries whose father (see 'projecttasks_id') is not part of the given list are considered roots;
      * siblings keep their relative order from the input list.
      *
+     *
      * @param list<array<string, mixed>> $entries Flat list of entries, each holding at least 'id' and 'projecttasks_id'
      *
      * @return list<array<string, mixed>> sorted entries
@@ -1489,8 +1490,8 @@ TWIG, $twig_params);
 
         $ordered = [];
         $visited = [];
-        $visit = static function ($father_id) use (&$visit, &$children, &$by_id, &$ordered, &$visited) {
-            foreach ($children[$father_id] ?? [] as $id) {
+        $visit = static function ($parent_id) use (&$visit, &$children, &$by_id, &$ordered, &$visited) {
+            foreach ($children[$parent_id] ?? [] as $id) {
                 if (isset($visited[$id])) {
                     continue;
                 }
@@ -1502,9 +1503,18 @@ TWIG, $twig_params);
 
         // Roots are the tasks whose father is not part of the current list
         // (either they have no father, or their father is out of the displayed scope).
-        foreach (array_keys($children) as $father_id) {
-            if (!isset($by_id[$father_id])) {
-                $visit($father_id);
+        foreach (array_keys($children) as $parent_id) {
+            if (!isset($by_id[$parent_id])) {
+                $visit($parent_id);
+            }
+        }
+
+        // Check for tasks that are still unvisited because they are not reachable from any root
+        foreach ($by_id as $id => $entry) {
+            if (!isset($visited[$id])) {
+                $visited[$id] = true;
+                $ordered[] = $entry;
+                $visit($id);
             }
         }
 

--- a/tests/functional/ProjectTaskTest.php
+++ b/tests/functional/ProjectTaskTest.php
@@ -606,6 +606,62 @@ class ProjectTaskTest extends DbTestCase
         );
     }
 
+    public function testSortProjectTasksByHierarchy()
+    {
+        $project = $this->createItem('Project', [
+            'name' => __FUNCTION__,
+        ]);
+
+        $task_A = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task A',
+        ]);
+        $task_B = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task B',
+        ]);
+
+        $task_B1 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task B.1',
+            'projecttasks_id' => $task_B->getID(),
+        ]);
+        $task_A1 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task A.1',
+            'projecttasks_id' => $task_A->getID(),
+        ]);
+
+        $task_A2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task A.2',
+            'projecttasks_id' => $task_A1->getID(),
+        ]);
+        $task_B2 = $this->createItem('ProjectTask', [
+            'projects_id'     => $project->getID(),
+            'name'            => 'Task B.2',
+            'projecttasks_id' => $task_B1->getID(),
+        ]);
+
+        $tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $project->getID(), 'ORDER' => 'id ASC'] );
+
+        // Sort tasks by planned start date
+        $sorted_tasks = ProjectTask::sortProjectTasksByHierarchy($tasks);
+
+        // Check the order of the sorted tasks
+        $this->assertEquals(
+            [
+                $task_A->fields,
+                $task_A1->fields,
+                $task_A2->fields,
+                $task_B->fields,
+                $task_B1->fields,
+                $task_B2->fields,
+            ],
+            $sorted_tasks
+        );
+    }
+
     protected function testAutochangeStateProvider()
     {
         $config = new \Config();

--- a/tests/functional/ProjectTaskTest.php
+++ b/tests/functional/ProjectTaskTest.php
@@ -662,6 +662,35 @@ class ProjectTaskTest extends DbTestCase
         );
     }
 
+    public function testSortProjectTasksByHierarchyWithMutualCycle()
+    {
+        $task_a = ['id' => 10, 'projecttasks_id' => 20, 'name' => 'A'];
+        $task_b = ['id' => 20, 'projecttasks_id' => 10, 'name' => 'B'];
+
+        $sorted_tasks = ProjectTask::sortProjectTasksByHierarchy([$task_a, $task_b]);
+
+        $this->assertEquals([$task_a, $task_b], $sorted_tasks);
+    }
+
+    public function testSortProjectTasksByHierarchyWithCycleAndNormalTasks()
+    {
+        // A normal, well-formed root and child, alongside a corrupted cycle (A and B are each
+        // other's father) that itself has a well-formed child (C) hanging off of it.
+        $root       = ['id' => 1, 'projecttasks_id' => 0, 'name' => 'Root'];
+        $root_child = ['id' => 2, 'projecttasks_id' => 1, 'name' => 'Root child'];
+        $task_a     = ['id' => 10, 'projecttasks_id' => 20, 'name' => 'A'];
+        $task_b     = ['id' => 20, 'projecttasks_id' => 10, 'name' => 'B'];
+        $task_c     = ['id' => 30, 'projecttasks_id' => 10, 'name' => 'C (child of A)'];
+
+        $tasks = [$root, $root_child, $task_a, $task_b, $task_c];
+
+        $sorted_tasks = ProjectTask::sortProjectTasksByHierarchy($tasks);
+
+        // The normal tree is sorted as usual, and the cyclic tasks (plus whatever hangs off of
+        // them) are appended instead of being dropped; nothing is lost nor duplicated.
+        $this->assertEquals($tasks, $sorted_tasks);
+    }
+
     protected function testAutochangeStateProvider()
     {
         $config = new \Config();

--- a/tests/functional/ProjectTaskTest.php
+++ b/tests/functional/ProjectTaskTest.php
@@ -643,7 +643,7 @@ class ProjectTaskTest extends DbTestCase
             'projecttasks_id' => $task_B1->getID(),
         ]);
 
-        $tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $project->getID(), 'ORDER' => 'id ASC'] );
+        $tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $project->getID(), 'ORDER' => 'id ASC']);
 
         // Sort tasks by hierarchy
         $sorted_tasks = ProjectTask::sortProjectTasksByHierarchy($tasks);

--- a/tests/functional/ProjectTaskTest.php
+++ b/tests/functional/ProjectTaskTest.php
@@ -645,7 +645,7 @@ class ProjectTaskTest extends DbTestCase
 
         $tasks = getAllDataFromTable(ProjectTask::getTable(), ['projects_id' => $project->getID(), 'ORDER' => 'id ASC'] );
 
-        // Sort tasks by planned start date
+        // Sort tasks by hierarchy
         $sorted_tasks = ProjectTask::sortProjectTasksByHierarchy($tasks);
 
         // Check the order of the sorted tasks


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45760
- Before this fix, `ProjectTask::showFor()` sorted project tasks by `plan_start_date ASC` when no sort/order `GET` parameters were provided, but it had no fallback sorting when none of the project tasks had a `plan_start_date` set. In that case, project tasks were displayed in whatever order MySQL happened to return them.
- This fix sorts project tasks according to their hierarchical structure (father -> child -> subchild -> ...) when no `plan_start_date` is set for any project task, or when no sort/order `GET` parameters are provided.
- It also adds a secondary sort by `id ASC` to the `plan_start_date` sorting, ensuring that tasks with the same plan_start_date are not left in an undefined order.