### PR TITLE
add (Dashboard) filter computer by operating system

### DIFF
--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1620,6 +1620,15 @@ HTML;
                 ];
             }
 
+            $cards["report_computers_by_os"] = [
+                'widgettype' => ['pie', 'donut', 'halfpie', 'halfdonut', 'summaryNumbers', 'multipleNumber', 'bar', 'hbar'],
+                'itemtype'   => "\\Computer",
+                'group'      => __('Reports'),
+                'label'      => __("Number of computers by operating system"),
+                'provider'   => "Glpi\\Dashboard\\Provider::computersByOperatingSystem",
+                'filters'    => Filter::getAppliableFilters(\Computer::getTable()),
+            ];
+
             $cards["RemindersList"] = [
                 'widgettype' => ["articleList"],
                 'label'      => sprintf(__('List of %s'), Reminder::getTypeName(Session::getPluralNumber())),

--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1623,7 +1623,7 @@ HTML;
             $cards["report_computers_by_os"] = [
                 'widgettype' => ['pie', 'donut', 'halfpie', 'halfdonut', 'summaryNumbers', 'multipleNumber', 'bar', 'hbar'],
                 'itemtype'   => "\\Computer",
-                'group'      => __('Reports'),
+                'group'      => _n('Asset', 'Assets', Session::getPluralNumber()),
                 'label'      => __("Number of computers by operating system"),
                 'provider'   => "Glpi\\Dashboard\\Provider::computersByOperatingSystem",
                 'filters'    => Filter::getAppliableFilters(\Computer::getTable()),

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -41,6 +41,7 @@ use CommonITILActor;
 use CommonITILObject;
 use CommonITILValidation;
 use CommonTreeDropdown;
+use Computer;
 use Config;
 use DBConnection;
 use ExtraVisibilityCriteria;
@@ -56,6 +57,8 @@ use Glpi\Debug\Profiler;
 use Glpi\Search\Input\QueryBuilder;
 use Group;
 use Group_Ticket;
+use Item_OperatingSystem;
+use OperatingSystem;
 use Profile_User;
 use Session;
 use Stat;
@@ -1008,14 +1011,14 @@ class Provider
 
         $default_params = [
             'label'         => "",
-            'icon'          => \Computer::getIcon(),
+            'icon'          => Computer::getIcon(),
             'apply_filters' => [],
         ];
         $params = array_merge($default_params, $params);
 
-        $c_table   = \Computer::getTable();
-        $ios_table = \Item_OperatingSystem::getTable();
-        $os_table  = \OperatingSystem::getTable();
+        $c_table   = Computer::getTable();
+        $ios_table = Item_OperatingSystem::getTable();
+        $os_table  = OperatingSystem::getTable();
 
         Profiler::getInstance()->start(__METHOD__ . ' build SQL criteria');
         $criteria = array_merge_recursive(
@@ -1033,7 +1036,7 @@ class Provider
                             $c_table   => 'id',
                             [
                                 'AND' => [
-                                    "$ios_table.itemtype" => \Computer::class,
+                                    "$ios_table.itemtype" => Computer::class,
                                 ],
                             ],
                         ],
@@ -1058,7 +1061,7 @@ class Provider
         $iterator = $DB->request($criteria);
 
         $search_criteria = self::getSearchFiltersCriteria($c_table, $params['apply_filters'])['criteria'] ?? [];
-        $url = \Computer::getSearchURL();
+        $url = Computer::getSearchURL();
 
         $data = [];
         foreach ($iterator as $result) {

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -995,6 +995,105 @@ class Provider
     }
 
 
+
+    /**
+     * Count number of computers grouped by their operating system.
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
+    public static function computersByOperatingSystem(array $params = []): array
+    {
+        $DB = DBConnection::getReadConnection();
+
+        $default_params = [
+            'label'         => "",
+            'icon'          => \Computer::getIcon(),
+            'apply_filters' => [],
+        ];
+        $params = array_merge($default_params, $params);
+
+        $c_table   = \Computer::getTable();
+        $ios_table = \Item_OperatingSystem::getTable();
+        $os_table  = \OperatingSystem::getTable();
+
+        Profiler::getInstance()->start(__METHOD__ . ' build SQL criteria');
+        $criteria = array_merge_recursive(
+            [
+                'SELECT'    => [
+                    "$os_table.name AS os_name",
+                    "$os_table.id AS os_id",
+                    'COUNT DISTINCT' => "$c_table.id AS cpt",
+                ],
+                'FROM'      => $c_table,
+                'LEFT JOIN' => [
+                    $ios_table => [
+                        'ON' => [
+                            $ios_table => 'items_id',
+                            $c_table   => 'id',
+                            [
+                                'AND' => [
+                                    "$ios_table.itemtype" => \Computer::class,
+                                ],
+                            ],
+                        ],
+                    ],
+                    $os_table => [
+                        'ON' => [
+                            $os_table  => 'id',
+                            $ios_table => 'operatingsystems_id',
+                        ],
+                    ],
+                ],
+                'WHERE'     => [
+                    "$c_table.is_deleted"  => 0,
+                    "$c_table.is_template" => 0,
+                ] + getEntitiesRestrictCriteria($c_table),
+                'GROUPBY'   => "$os_table.id",
+                'ORDERBY'   => "cpt DESC",
+            ],
+            self::getFiltersCriteria($c_table, $params['apply_filters'])
+        );
+        Profiler::getInstance()->stop(__METHOD__ . ' build SQL criteria');
+        $iterator = $DB->request($criteria);
+
+        $search_criteria = self::getSearchFiltersCriteria($c_table, $params['apply_filters'])['criteria'] ?? [];
+        $url = \Computer::getSearchURL();
+
+        $data = [];
+        foreach ($iterator as $result) {
+            $result_criteria = $search_criteria;
+            $result_criteria[] = [
+                'link'       => 'AND',
+                'field'      => 45, // operating system name
+                'searchtype' => 'equals',
+                'value'      => $result['os_id'] ?? 0,
+            ];
+
+            $data[] = [
+                'number' => $result['cpt'],
+                'label'  => $result['os_name'] ?? __('without'),
+                'url'    => $url . (str_contains($url, '?') ? '&' : '?') . Toolbox::append_params([
+                    'criteria' => $result_criteria,
+                    'reset'    => 'reset',
+                ]),
+            ];
+        }
+
+        if (count($data) === 0) {
+            $data = [
+                'nodata' => true,
+            ];
+        }
+
+        return [
+            'data'  => $data,
+            'label' => $params['label'],
+            'icon'  => $params['icon'],
+        ];
+    }
+
     /**
      * Get a list of article for an compatible item (with date,name,text fields)
      *

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -995,7 +995,6 @@ class Provider
     }
 
 
-
     /**
      * Count number of computers grouped by their operating system.
      *
@@ -1049,7 +1048,7 @@ class Provider
                 'WHERE'     => [
                     "$c_table.is_deleted"  => 0,
                     "$c_table.is_template" => 0,
-                ] + getEntitiesRestrictCriteria($c_table),
+                ] + getEntitiesRestrictCriteria($c_table, '', '', true),
                 'GROUPBY'   => "$os_table.id",
                 'ORDERBY'   => "cpt DESC",
             ],

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -664,10 +664,10 @@ class ProviderTest extends DbTestCase
     {
         $this->login();
 
-        $itemtype = $item->getType();
+        $itemtype = $item::class;
         $data = [
             Provider::bigNumberItem($item),
-            call_user_func(['\\Glpi\\Dashboard\\Provider', "bigNumber$itemtype"]),
+            call_user_func([Provider::class, "bigNumber$itemtype"]),
         ];
 
         foreach ($data as $result) {
@@ -675,7 +675,7 @@ class ProviderTest extends DbTestCase
             $this->assertArrayHasKey('url', $result);
             $this->assertArrayHasKey('label', $result);
             $this->assertArrayHasKey('icon', $result);
-            if ($item::getType() !== 'Item_DeviceSimcard') {
+            if ($item::class !== 'Item_DeviceSimcard') {
                 // Ignore count for simcards. None are added in Bootstrap process and is here for regression testing only.
                 $this->assertGreaterThan(0, $result['number']);
             }
@@ -902,7 +902,7 @@ class ProviderTest extends DbTestCase
 
         // Change author to someone else
         $tech = getItemByTypeName(User::class, 'tech');
-        $this->updateItem($reminder::getType(), $reminder->getID(), [
+        $this->updateItem($reminder::class, $reminder->getID(), [
             'users_id'  => $tech->getID(),
         ]);
         yield ['expected' => 0];
@@ -945,5 +945,57 @@ class ProviderTest extends DbTestCase
 
         // Assert: just make sure this was executed without errors
         $this->assertNotEmpty($params);
+    }
+
+    public function testComputersByOperatingSystem()
+    {
+        $this->login();
+
+        $os = new \OperatingSystem();
+        $os_id = $os->add([
+            'name' => 'test dashboard OS',
+        ]);
+        $this->assertGreaterThan(0, $os_id);
+
+        $computer = new \Computer();
+        $computer_id = $computer->add([
+            'name'        => 'test dashboard computer by os',
+            'entities_id' => 0,
+        ]);
+        $this->assertGreaterThan(0, $computer_id);
+
+        $link = new \Item_OperatingSystem();
+        $this->assertGreaterThan(
+            0,
+            $link->add([
+                'itemtype'            => \Computer::class,
+                'items_id'            => $computer_id,
+                'operatingsystems_id' => $os_id,
+            ])
+        );
+
+        $result = Provider::computersByOperatingSystem();
+        $this->assertArrayHasKey('data', $result);
+        $this->assertArrayHasKey('label', $result);
+        $this->assertArrayHasKey('icon', $result);
+
+        $nb_items = 0;
+        foreach ($result['data'] as $key => $data) {
+            if ($key === 'nodata') {
+                continue;
+            }
+
+            $this->assertArrayHasKey('number', $data);
+            $this->assertArrayHasKey('label', $data);
+            $this->assertArrayHasKey('url', $data);
+
+            $this->assertGreaterThan(0, $data['number']);
+            $this->assertIsString($data['label']);
+            $this->assertStringContainsString(\Computer::getSearchURL(), $data['url']);
+
+            $nb_items++;
+        }
+
+        $this->assertGreaterThan(0, $nb_items);
     }
 }

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -951,28 +951,20 @@ class ProviderTest extends DbTestCase
     {
         $this->login();
 
-        $os = new \OperatingSystem();
-        $os_id = $os->add([
+        $os = $this->createItem(\OperatingSystem::class, [
             'name' => 'test dashboard OS',
         ]);
-        $this->assertGreaterThan(0, $os_id);
 
-        $computer = new \Computer();
-        $computer_id = $computer->add([
+        $computer = $this->createItem(\Computer::class, [
             'name'        => 'test dashboard computer by os',
             'entities_id' => 0,
         ]);
-        $this->assertGreaterThan(0, $computer_id);
 
-        $link = new \Item_OperatingSystem();
-        $this->assertGreaterThan(
-            0,
-            $link->add([
-                'itemtype'            => \Computer::class,
-                'items_id'            => $computer_id,
-                'operatingsystems_id' => $os_id,
-            ])
-        );
+        $this->createItem(\Item_OperatingSystem::class, [
+            'itemtype'            => \Computer::class,
+            'items_id'            => $computer->getID(),
+            'operatingsystems_id' => $os->getID(),
+        ]);
 
         $result = Provider::computersByOperatingSystem();
         $this->assertArrayHasKey('data', $result);

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -38,6 +38,7 @@ use Glpi\CustomAsset\Test01Asset;
 use Glpi\CustomAsset\Test01AssetType;
 use Glpi\Dashboard\Provider;
 use Glpi\Tests\DbTestCase;
+use Item_DeviceSimcard;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Reminder;
 use Reminder_User;
@@ -655,7 +656,7 @@ class ProviderTest extends DbTestCase
         return [
             ['item' => new \Computer()],
             ['item' => new \Ticket()],
-            ['item' => new \Item_DeviceSimcard()],
+            ['item' => new Item_DeviceSimcard()],
         ];
     }
 
@@ -675,7 +676,7 @@ class ProviderTest extends DbTestCase
             $this->assertArrayHasKey('url', $result);
             $this->assertArrayHasKey('label', $result);
             $this->assertArrayHasKey('icon', $result);
-            if ($item::class !== 'Item_DeviceSimcard') {
+            if ($item::class !== Item_DeviceSimcard::class) {
                 // Ignore count for simcards. None are added in Bootstrap process and is here for regression testing only.
                 $this->assertGreaterThan(0, $result['number']);
             }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/Professional-Services/issues/80
- Adds a new dashboard card titled “computer by operating system”, migrated from the mreporting plugin.

plugins/mreporting/inc/inventory.class.php
computersByOS  l.412

## Screenshots (if appropriate):
<img width="589" height="337" alt="image" src="https://github.com/user-attachments/assets/ed2a4c1d-05aa-4d19-b154-3b85eb8ba4a7" />


