### PR TITLE
[a11y] Fixes around decorative icons

### DIFF
--- a/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
+++ b/js/src/vue/CustomObject/FieldPreview/FieldDisplay.vue
@@ -313,7 +313,10 @@
                             <template v-slot:field_label>{{ sortable_field.label }}</template>
                             <template v-slot:field_markers>
                                 <span v-if="parseInt(sortable_field.field_options.required ?? 0) === 1" class="required">*</span>
-                                <i v-if="parseInt(sortable_field.field_options.readonly ?? 0) === 1" class="ti ti-pencil-off ms-2" :title="__('Readonly')"></i>
+                                <template v-if="parseInt(sortable_field.field_options.readonly ?? 0) === 1">
+                                    <i class="ti ti-pencil-off ms-2" :title="__('Readonly')" aria-hidden="true"></i>
+                                    <span class="visually-hidden">{{ __('Readonly') }}</span>
+                                </template>
                             </template>
                             <template v-slot:field_options>
                                 <template v-for="(field_option_value, field_option_name) in sortable_field.field_options" :key="field_option_name">

--- a/js/src/vue/Kanban/TeamBadgeProvider.js
+++ b/js/src/vue/Kanban/TeamBadgeProvider.js
@@ -220,7 +220,7 @@ export class TeamBadgeProvider {
         context.fillText(initials, this.team_image_size / 2, this.team_image_size / 2);
         const src = canvas.toDataURL("image/png");
         const name = team_member['name'];
-        return `<span><img src="${_.escape(src)}" title="${_.escape(name)}" data-bs-toggle="tooltip" data-bs-placement="top" data-placeholder-users-id="${_.escape(team_member["id"])}"/></span>`;
+        return `<span><img src="${_.escape(src)}" alt="${_.escape(name)}" title="${_.escape(name)}" data-bs-toggle="tooltip" data-bs-placement="top" data-placeholder-users-id="${_.escape(team_member["id"])}"/></span>`;
     }
 
     /**
@@ -235,7 +235,8 @@ export class TeamBadgeProvider {
 
         return `
             <span class="badge badge-pill" style="background-color: ${_.escape(bg_color)}; font-size: ${(this.team_image_size / 2)}px; height: 26px; padding: 0.25em;">
-                <i class="${_.escape(icon)}" title="${_.escape(name)}" data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                <i class="${_.escape(icon)}" title="${_.escape(name)}" data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                <span class="visually-hidden">${_.escape(name)}</span>
             </span>
         `;
     }
@@ -252,6 +253,7 @@ export class TeamBadgeProvider {
         const context = canvas.getContext('2d');
         context.fillText(`+${overflow_count}`, this.team_image_size / 2, this.team_image_size / 2);
         const src = canvas.toDataURL("image/png");
-        return `<span class="position-relative"><img src="${_.escape(src)}" title="${__('%d other team members').replace('%d', overflow_count)}" data-bs-toggle="tooltip" data-bs-placement="top"></span>`;
+        const label = _.escape(__('%d other team members').replace('%d', overflow_count));
+        return `<span class="position-relative"><img src="${_.escape(src)}" alt="${label}" title="${label}" data-bs-toggle="tooltip" data-bs-placement="top"></span>`;
     }
 }

--- a/js/src/vue/Planning/PlanningEvent.vue
+++ b/js/src/vue/Planning/PlanningEvent.vue
@@ -66,7 +66,10 @@
         <span class="fc-time me-1 text-nowrap">{{ time_hour }}</span>
         <span class="fc-title">
             {{ event_info.event.title }}
-            <i v-if="icon_class" :class="icon_class" :title="icon_alt" :aria-label="icon_alt" class="ms-1"></i>
+            <template v-if="icon_class">
+                <i :class="icon_class" :title="icon_alt" class="ms-1" aria-hidden="true"></i>
+                <span class="visually-hidden">{{ icon_alt }}</span>
+            </template>
         </span>
     </div>
     <span class="event_type"></span>

--- a/js/src/vue/Reservations/ReservationEvent.vue
+++ b/js/src/vue/Reservations/ReservationEvent.vue
@@ -47,7 +47,10 @@
         <span class="fc-time me-1 text-nowrap">{{ event_info.timeText.split(':')[0].padStart(2, 0) }}</span>
         <span class="fc-title">
             {{ event_info.event.title }}
-            <i v-if="icon_class" :class="icon_class" :title="icon_alt" :aria-label="icon_alt" class="ms-1 align-text-bottom"></i>
+            <template v-if="icon_class">
+                <i :class="icon_class" :title="icon_alt" class="ms-1 align-text-bottom" aria-hidden="true"></i>
+                <span class="visually-hidden">{{ icon_alt }}</span>
+            </template>
         </span>
     </div>
 </template>

--- a/src/Appliance_Item_Relation.php
+++ b/src/Appliance_Item_Relation.php
@@ -225,7 +225,7 @@ class Appliance_Item_Relation extends CommonDBRelation
 
         return "<ul class='mb-0'>$relations_str</ul>
          <span class='cursor-pointer add_relation' data-appliances-items-id='{$appliances_items_id}'>
-            <i class='ti ti-plus' title='" . __s('New relation') . "'></i>
+            <i class='ti ti-plus' title='" . __s('New relation') . "' aria-hidden='true'></i>
             <span class='visually-hidden'>" . __s('New relation') . "</span>
          </span>
       </td>";

--- a/src/Cable.php
+++ b/src/Cable.php
@@ -111,7 +111,7 @@ class Cable extends CommonDBTM implements AssignableItemInterface, StateInterfac
         $links = [];
         if (static::canView()) {
             $insts = "<i class=\"fas fa-ethernet pointer\" title=\"" . htmlescape(Socket::getTypeName(Session::getPluralNumber()))
-            . "\"></i><span class=\"visually-hidden\">" . htmlescape(Socket::getTypeName(Session::getPluralNumber())) . "</span>";
+            . "\" aria-hidden=\"true\"></i><span class=\"visually-hidden\">" . htmlescape(Socket::getTypeName(Session::getPluralNumber())) . "</span>";
             $links[$insts] = Socket::getSearchURL(false);
         }
         if (count($links)) {

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5789,7 +5789,10 @@ class CommonDBTM extends CommonGLPI
             }
         }
         if ($title !== null) {
-            $mark = "<i class='ti ti-wand' title='$title'></i>";
+            $mark = sprintf(
+                '<span><i class="ti ti-wand" title="%1$s" aria-hidden="true"></i><span class="visually-hidden">%1$s</span></span>',
+                $title
+            );
         }
         return $mark;
     }

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5167,16 +5167,29 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     /**
      * Get status icon
      *
-     * @param int $status
+     * @param int  $status
+     * @param bool $with_name Expose the status name as a visually hidden text. Pass `false` when
+     *                        the caller already displays that name next to the icon, otherwise
+     *                        assistive technologies announce it twice.
      * @return string
      *
      * @since 9.3
      */
-    public static function getStatusIcon($status)
+    public static function getStatusIcon($status, bool $with_name = true)
     {
         $class = htmlescape(static::getStatusClass($status));
         $label = htmlescape(static::getStatus($status));
-        return "<i class='$class me-1' title='$label' data-bs-toggle='tooltip'></i>";
+        // An `<i>` maps to `role=generic`, which cannot carry an accessible name: the status is
+        // exposed through a visually hidden text instead.
+        $name = $with_name
+            ? sprintf('<span class="visually-hidden">%s</span>', $label)
+            : '';
+        return sprintf(
+            '<span><i class="%1$s me-1" title="%2$s" data-bs-toggle="tooltip" aria-hidden="true"></i>%3$s</span>',
+            $class,
+            $label,
+            $name
+        );
     }
 
     /**
@@ -7916,7 +7929,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 if (((string) $log_row['field']) !== '') {
                     $content = sprintf(__s("%s: %s"), htmlescape($log_row['field']), $content);
                 }
-                $content = "<i class='ti ti-history me-1' title='" . __s("Log entry") . "' data-bs-toggle='tooltip'></i>" . $content;
+                $content = "<i class='ti ti-history me-1' title='" . __s("Log entry") . "' data-bs-toggle='tooltip' aria-hidden='true'></i>"
+                    . "<span class='visually-hidden'>" . __s("Log entry") . "</span>" . $content;
                 $user_id = 0;
                 // try to extract ID from "user_name" (which was created using User::getNameForLog)
                 if (preg_match('/ \((\d+)\)$/', $log_row["user_name"], $m)) {

--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -492,7 +492,7 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
             return htmlescape(NOT_AVAILABLE);
         }
 
-        $icon_tag = '<i class="fas %1$s me-1" title="%2$s" data-bs-toggle="tooltip"></i>%2$s';
+        $icon_tag = '<i class="fas %1$s me-1" title="%2$s" data-bs-toggle="tooltip" aria-hidden="true"></i>%2$s';
 
         $link_type = $link_types[$value];
         $resolved_value = $inverted && isset($link_type['inverse']) ? $link_types[$link_type['inverse']] : $link_type;

--- a/src/Database.php
+++ b/src/Database.php
@@ -488,8 +488,9 @@ class Database extends CommonDBChild
         $links = [];
         $label = htmlescape(DatabaseInstance::getTypeName(Session::getPluralNumber()));
         if (static::canView()) {
-            $insts = "<i class=\"ti ti-database-import\" title=\"$label\""
-            . "></i><span class='d-none d-xxl-block'>$label</span>";
+            $insts = "<i class=\"ti ti-database-import\" title=\"$label\" aria-hidden='true'></i>"
+            . "<span class='d-none d-xxl-block' aria-hidden='true'>$label</span>"
+            . "<span class='visually-hidden'>$label</span>";
             $links[$insts] = DatabaseInstance::getSearchURL(false);
         }
         if (count($links)) {

--- a/src/Glpi/Features/Inventoriable.php
+++ b/src/Glpi/Features/Inventoriable.php
@@ -214,12 +214,20 @@ HTML;
         echo '</tr>';
 
         echo '<tr class="tab_bg_1">';
+        $status_label = __s('Ask agent about its current status');
+        $inventory_label = __s('Request agent to proceed an new inventory');
         echo '<td>' . __s('Agent status');
-        echo "<i id='update-status' class='ti ti-refresh' style='float: right;cursor: pointer;' title='" . __s('Ask agent about its current status') . "'></i>";
+        echo "<button type='button' id='update-status' class='btn btn-sm btn-icon btn-ghost-secondary' style='float: right;' title='$status_label'>"
+            . "<i class='ti ti-refresh' aria-hidden='true'></i>"
+            . "<span class='visually-hidden'>$status_label</span>"
+            . "</button>";
         echo '</td>';
         echo '<td id="agent_status">' . __s('Unknown') . '</td>';
         echo '<td>' . __s('Request inventory');
-        echo "<i id='update-inventory' class='ti ti-refresh' style='float: right;cursor: pointer;' title='" . __s('Request agent to proceed an new inventory') . "'></i>";
+        echo "<button type='button' id='update-inventory' class='btn btn-sm btn-icon btn-ghost-secondary' style='float: right;' title='$inventory_label'>"
+            . "<i class='ti ti-refresh' aria-hidden='true'></i>"
+            . "<span class='visually-hidden'>$inventory_label</span>"
+            . "</button>";
         echo '</td>';
         echo '<td id="inventory_status">' . __s('None') . '</td>';
         echo '</tr>';

--- a/src/Glpi/Form/Dropdown/FormActorsDropdown.php
+++ b/src/Glpi/Form/Dropdown/FormActorsDropdown.php
@@ -81,17 +81,17 @@ final class FormActorsDropdown extends AbstractRightsDropdown
                     (data.itemtype && data.itemtype === 'User')
                     || (data.id && data.id.startsWith('users_id-'))
                 ) {
-                    icon = '<i class="ti ti-user mx-1" title="' + title + '"></i>';
+                    icon = '<i class="ti ti-user mx-1" title="' + title + '" aria-hidden="true"></i>';
                 } else if (
                     (data.itemtype && data.itemtype === 'Group')
                     || (data.id && data.id.startsWith('groups_id-'))
                 ) {
-                    icon = '<i class="ti ti-users mx-1" title="' + title + '"></i>';
+                    icon = '<i class="ti ti-users mx-1" title="' + title + '" aria-hidden="true"></i>';
                 } else if (
                     (data.itemtype && data.itemtype === 'Supplier')
                     || (data.id && data.id.startsWith('suppliers_id-'))
                 ) {
-                    icon = '<i class="ti ti-package mx-1" title="' + title + '"></i>';
+                    icon = '<i class="ti ti-package mx-1" title="' + title + '" aria-hidden="true"></i>';
                 }
 
                 return $('<span class="actor_entry">' + icon + text + '</span>');

--- a/src/Glpi/Inventory/Inventory.php
+++ b/src/Glpi/Inventory/Inventory.php
@@ -596,8 +596,10 @@ class Inventory
         ];
         $links = [];
         foreach ($classes as $class) {
-            $entry = "<i class=\"" . \htmlescape($class::getIcon()) . " pointer\" title=\"" . \htmlescape($class::getTypeName(Session::getPluralNumber()))
-            . "\"></i><span class=\"d-none d-xxl-block\">" . \htmlescape($class::getTypeName(Session::getPluralNumber())) . "</span>";
+            $label = \htmlescape($class::getTypeName(Session::getPluralNumber()));
+            $entry = "<i class=\"" . \htmlescape($class::getIcon()) . " pointer\" title=\"$label\" aria-hidden=\"true\"></i>"
+            . "<span class=\"d-none d-xxl-block\" aria-hidden=\"true\">$label</span>"
+            . "<span class=\"visually-hidden\">$label</span>";
             $links[$entry] = $class::getSearchURL(false);
         }
 
@@ -629,7 +631,9 @@ class Inventory
                 'title' => Lockedfield::getTypeName(Session::getPluralNumber()),
                 'page'  => Lockedfield::getSearchURL(false),
                 'links' => [
-                    "<i class=\"ti ti-plus\" title=\"" . __s('Add global lock') . "\"></i><span class='d-none d-xxl-block'>" . __s('Add global lock') . "</span>" => Lockedfield::getFormURL(false),
+                    "<i class=\"ti ti-plus\" title=\"" . __s('Add global lock') . "\" aria-hidden=\"true\"></i>"
+                    . "<span class=\"d-none d-xxl-block\" aria-hidden=\"true\">" . __s('Add global lock') . "</span>"
+                    . "<span class=\"visually-hidden\">" . __s('Add global lock') . "</span>" => Lockedfield::getFormURL(false),
                 ] + $links,
                 'lists_itemtype' => Lockedfield::class,
             ];

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -7232,19 +7232,19 @@ final class SQLProvider implements SearchProviderInterface
                 case 'glpi_changes.status':
                     $status = Change::getStatus($data[$ID][0]['name']);
                     return "<span class='text-nowrap'>"
-                        . Change::getStatusIcon($data[$ID][0]['name']) . "&nbsp;" . \htmlescape($status)
+                        . Change::getStatusIcon($data[$ID][0]['name'], false) . "&nbsp;" . \htmlescape($status)
                         . "</span>";
 
                 case 'glpi_problems.status':
                     $status = Problem::getStatus($data[$ID][0]['name']);
                     return "<span class='text-nowrap'>"
-                        . Problem::getStatusIcon($data[$ID][0]['name']) . "&nbsp;" . \htmlescape($status)
+                        . Problem::getStatusIcon($data[$ID][0]['name'], false) . "&nbsp;" . \htmlescape($status)
                         . "</span>";
 
                 case 'glpi_tickets.status':
                     $status = Ticket::getStatus($data[$ID][0]['name']);
                     return "<span class='text-nowrap'>"
-                        . Ticket::getStatusIcon($data[$ID][0]['name']) . "&nbsp;" . \htmlescape($status)
+                        . Ticket::getStatusIcon($data[$ID][0]['name'], false) . "&nbsp;" . \htmlescape($status)
                         . "</span>";
 
                 case 'glpi_projectstates.name':
@@ -7515,7 +7515,10 @@ final class SQLProvider implements SearchProviderInterface
                         $icon_class = "ti ti-eye-off not-published";
                         $icon_title = __s("This item is not published yet");
                     }
-                    return "<div class='kb'> <i class='$icon_class' title='$icon_title'></i> <a href='" . \htmlescape($href) . "'>" . \htmlescape($name) . "</a></div>";
+                    $icon = $icon_title !== ''
+                        ? "<i class='$icon_class' title='$icon_title' aria-hidden='true'></i><span class='visually-hidden'>$icon_title</span> "
+                        : '';
+                    return "<div class='kb'> $icon<a href='" . \htmlescape($href) . "'>" . \htmlescape($name) . "</a></div>";
                 case "glpi_certificates.date_expiration":
                     if (
                         !in_array($orig_id, [151, 158, 181, 186])

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -194,8 +194,9 @@ class Group_User extends CommonDBRelation
 
         $group = new Group();
         $entries = [];
-        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '"></i>';
-        $no_icon  = '<span class="visually-hidden" aria-label="' . __s('No') . '"></span>';
+        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '" aria-hidden="true"></i>'
+            . '<span class="visually-hidden">' . __s('Yes') . '</span>';
+        $no_icon  = '<span class="visually-hidden">' . __s('No') . '</span>';
         foreach ($groups as $data) {
             if (!$group->getFromDB($data["id"])) {
                 continue;
@@ -461,8 +462,9 @@ class Group_User extends CommonDBRelation
 
         $tmpgrp = new Group();
         $entries = [];
-        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '"></i>';
-        $no_icon  = '<span class="visually-hidden" aria-label="' . __s('No') . '"></span>';
+        $yes_icon = '<i class="ti ti-check" title="' . __s('Yes') . '" aria-hidden="true"></i>'
+            . '<span class="visually-hidden">' . __s('Yes') . '</span>';
+        $no_icon  = '<span class="visually-hidden">' . __s('No') . '</span>';
         for ($i = $start, $j = 0; ($i < $number) && ($j < $_SESSION['glpilist_limit']); $i++, $j++) {
             $data = $used[$i];
             $user->getFromDB($data["id"]);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2070,8 +2070,11 @@ TWIG, $twig_params);
                     $icon_class = "ti-eye-off not-published";
                     $fa_title = __s("This item is not published yet");
                 }
+                $icon = $fa_title !== ''
+                    ? "<i class='ti $icon_class' title='$fa_title' aria-hidden='true'></i><span class='visually-hidden'>$fa_title</span> "
+                    : '';
                 echo $output::showItem(
-                    "<div class='kb'>$toadd <i class='ti $icon_class' title='$fa_title'></i> <a $href>" . Html::resume_text($name, 80) . "</a></div>
+                    "<div class='kb'>$toadd $icon<a $href>" . Html::resume_text($name, 80) . "</a></div>
                                    <div class='kb_resume'>" . Html::resume_text(RichText::getTextFromHtml($answer, false, false), 600) . "</div>",
                     $item_num,
                     $row_num
@@ -2262,7 +2265,8 @@ TWIG, $twig_params);
                                 <td class="text-start">
                                     <div class="kb">
                                         {% if data['is_faq'] %}
-                                            <i class="ti ti-help faq" title="{{ faq_tooltip }}"></i>
+                                            <i class="ti ti-help faq" title="{{ faq_tooltip }}" aria-hidden="true"></i>
+                                            <span class="visually-hidden">{{ faq_tooltip }}</span>
                                         {% endif %}
                                         <a href="{{ 'KnowbaseItem'|itemtype_form_path(data['id']) }}" class="{{ data['is_faq'] ? 'faq' : 'knowbase' }}"
                                            title="{{ name }}">{{ name|u.truncate(80, '(...)') }}</a>

--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -1003,7 +1003,7 @@ class NetworkPort extends CommonDBChild
                                     break;
                             }
                             $output .= sprintf(
-                                '<i class="ti ti-circle-filled %s" title="%s"></i> <span class="visually-hidden">%s</span>',
+                                '<i class="ti ti-circle-filled %s" title="%s" aria-hidden="true"></i> <span class="visually-hidden">%s</span>',
                                 htmlescape($state_class),
                                 htmlescape($state_title),
                                 htmlescape($state_title)
@@ -1214,7 +1214,7 @@ class NetworkPort extends CommonDBChild
                                     break;
                             }
                             $output .= sprintf(
-                                '<i class="ti %s" title="%s"></i> <span class="visually-hidden">%s</span>',
+                                '<i class="ti %s" title="%s" aria-hidden="true"></i> <span class="visually-hidden">%s</span>',
                                 htmlescape($co_class),
                                 htmlescape($title),
                                 htmlescape($title)
@@ -1222,7 +1222,10 @@ class NetworkPort extends CommonDBChild
                             break;
                         case 41:
                             if ($port['ifstatus'] == 1) {
-                                $output .= sprintf("<i class='ti ti-circle-filled text-green' title='%s'></i>", __s('Connected'));
+                                $output .= sprintf(
+                                    "<i class='ti ti-circle-filled text-green' title='%1\$s' aria-hidden='true'></i><span class='visually-hidden'>%1\$s</span>",
+                                    __s('Connected')
+                                );
                             } elseif (!empty($port['lastup'])) {
                                 $time = strtotime(date('Y-m-d H:i:s')) - strtotime($port['lastup']);
                                 $output .= htmlescape(Html::timestampToString($time, false));

--- a/src/NetworkPortConnectionLog.php
+++ b/src/NetworkPortConnectionLog.php
@@ -126,7 +126,8 @@ class NetworkPortConnectionLog extends CommonDBRelation
                 );
 
                 $entries[] = [
-                    'status' => '<i class="ti ' . $co_class . '" title="' . $title . '"></i>',
+                    'status' => '<i class="ti ' . $co_class . '" title="' . $title . '" aria-hidden="true"></i>'
+                        . '<span class="visually-hidden">' . $title . '</span>',
                     'date' => $row['date'],
                     'connected_item' => sprintf(
                         __s('%1$s on %2$s'),

--- a/src/PDU_Rack.php
+++ b/src/PDU_Rack.php
@@ -421,28 +421,39 @@ class PDU_Rack extends CommonDBRelation
                     echo "<tr style='background-color: " . htmlescape($bg_color) . "; color: " . htmlescape($fg_color) . ";'>";
                     echo "<td class='rack_position'>";
                     $current_pdu['position'] = (int) $current_pdu['position'];
+                    $icon_class = null;
+                    $icon_label = "";
+
                     if ($current_pdu['racked']) {
-                        echo "<i class='" . htmlescape(Rack::getIcon()) . "'
-                           title='" . __s("Racked") . " (" . $current_pdu['position'] . ")'></i>";
+                        $icon_class = htmlescape(Rack::getIcon());
+                        $icon_label = __s("Racked");
                     } else {
                         switch ($current_pdu['side']) {
                             case self::SIDE_LEFT:
-                                echo "<i class='ti ti-arrow-left'
-                                 title='" . __s("On left") . " (" . $current_pdu['position'] . ")'></i>";
+                                $icon_class = "ti ti-arrow-left";
+                                $icon_label = __s("On left");
                                 break;
                             case self::SIDE_RIGHT:
-                                echo "<i class='ti ti-arrow-right'
-                                 title='" . __s("On right") . " (" . $current_pdu['position'] . ")'></i>";
+                                $icon_class = "ti ti-arrow-right";
+                                $icon_label = __s("On right");
                                 break;
                             case self::SIDE_TOP:
-                                echo "<i class='ti ti-arrow-up'
-                                 title='" . __s("On top") . " (" . $current_pdu['position'] . ")'></i>";
+                                $icon_class = "ti ti-arrow-up";
+                                $icon_label = __s("On top");
                                 break;
                             case self::SIDE_BOTTOM:
-                                echo "<i class='ti ti-arrow-down'
-                                 title='" . __s("On bottom") . " (" . $current_pdu['position'] . ")'></i>";
+                                $icon_class = "ti ti-arrow-down";
+                                $icon_label = __s("On bottom");
                                 break;
                         }
+                    }
+                    if ($icon_class !== null) {
+                        $icon_label .= " ({$current_pdu['position']})";
+                        echo sprintf(
+                            '<i class="%1$s" title="%2$s" aria-hidden="true"></i><span class="visually-hidden">%2$s</span>',
+                            $icon_class,
+                            $icon_label
+                        );
                     }
                     echo "</td>";
 

--- a/src/Planning.php
+++ b/src/Planning.php
@@ -267,7 +267,7 @@ class Planning extends CommonGLPI
         }
         $class = self::getStatusClass($status);
         $color = self::getStatusColor($status);
-        return "<i class='itilstatus $class $color me-1' title='$label' data-bs-toggle='tooltip'></i><span>" . $label . "</span>";
+        return "<i class='itilstatus $class $color me-1' title='$label' data-bs-toggle='tooltip' aria-hidden='true'></i><span>" . $label . "</span>";
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -238,10 +238,11 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInter
             || Session::haveRight('projecttask', ProjectTask::READMY)
         ) {
             $pic_validate = '
-            <i class="ti ti-eye-check" title="' . __s('My tasks') . '"></i>
-            <span class="d-none d-xxl-block">
+            <i class="ti ti-eye-check" title="' . __s('My tasks') . '" aria-hidden="true"></i>
+            <span class="d-none d-xxl-block" aria-hidden="true">
                ' . __s('My tasks') . '
             </span>
+            <span class="visually-hidden">' . __s('My tasks') . '</span>
          ';
 
             $links[$pic_validate] = ProjectTask::getMyTasksURL(false);
@@ -1872,7 +1873,8 @@ TWIG, $twig_params);
                 $content .= htmlescape(reset($typematches)['name']) . '&nbsp;';
             }
             if (array_key_exists('is_milestone', $item) && $item['is_milestone']) {
-                $content .= "&nbsp;<i class='ti ti-directions-filled' title='" . __s('Milestone') . "'></i>&nbsp;";
+                $content .= "&nbsp;<i class='ti ti-directions-filled' title='" . __s('Milestone') . "' aria-hidden='true'></i>"
+                    . "<span class='visually-hidden'>" . __s('Milestone') . "</span>&nbsp;";
             }
             if (isset($item['_steps']) && count($item['_steps'])) {
                 $done = count(array_filter($item['_steps'], static fn($step) => (int) $step['percent_done'] === 100));

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -1967,7 +1967,7 @@ TWIG, $twig_params);
 
         $active = $this->fields['is_active'];
         $data['is_active'] = sprintf(
-            '<i class="ti ti-circle-filled %s" title="%s"></i>',
+            '<i class="ti ti-circle-filled %1$s" title="%2$s" aria-hidden="true"></i><span class="visually-hidden">%2$s</span>',
             $active ? 'text-success' : 'text-danger',
             $active ? __s('Rule is active') : __s('Rule is inactive'),
         );

--- a/src/SavedSearch.php
+++ b/src/SavedSearch.php
@@ -747,7 +747,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
 
                 if ($error) {
                     $info_message = __s('A fatal error occurred while executing this saved search. It is not able to be used.');
-                    $count = "<span class='ti ti-alert-triangle-filled' title='$info_message'></span>";
+                    $count = "<span class='ti ti-alert-triangle-filled' title='$info_message' aria-hidden='true'></span>"
+                        . "<span class='visually-hidden'>$info_message</span>";
                 } elseif (isset($search_data['data']['totalcount'])) {
                     $count = $search_data['data']['totalcount'];
                 } else {
@@ -755,7 +756,8 @@ class SavedSearch extends CommonDBTM implements ExtraVisibilityCriteria
                                 ? __s('Count for this saved search has been disabled.')
                                 : __s('Counting this saved search would take too long, it has been skipped.');
                     // no count, just inform the user
-                    $count = "<span class='ti ti-info-circle' title='$info_message'></span>";
+                    $count = "<span class='ti ti-info-circle' title='$info_message' aria-hidden='true'></span>"
+                        . "<span class='visually-hidden'>$info_message</span>";
                 }
 
                 $data['count'] = $count;

--- a/templates/components/form/basic_inputs_macros.html.twig
+++ b/templates/components/form/basic_inputs_macros.html.twig
@@ -494,15 +494,25 @@
         'additional_attributes': {},
     }|merge(options) %}
 
+    {# Check if button is not label-less #}
+    {% if label is empty and options.icon_title is empty %}
+        {% do call('trigger_error', [
+            'A button must be given either a `label` or an `icon_title` to be named.',
+            constant('E_USER_WARNING')
+        ]) %}
+    {% endif %}
+
     <button class="{{ options.class }}" type="{{ type }}" name="{{ name }}" value="{{ value }}"
         {% for attr, value in options.additional_attributes %}
             {{ attr }}="{{ value }}"
         {% endfor %}>
         {% if options.icon is not empty %}
-            <i class="{{ options.icon }}" title="{{ options.icon_title }}"></i>
+            <i class="{{ options.icon }}" title="{{ options.icon_title }}" aria-hidden="true"></i>
         {% endif %}
         {% if label is not empty %}
             <span>{{ label }}</span>
+        {% elseif options.icon_title is not empty %}
+            <span class="visually-hidden">{{ options.icon_title }}</span>
         {% endif %}
     </button>
 {% endmacro %}
@@ -552,7 +562,8 @@
             -
             {{ __('Last inventory value was:') ~ ' ' ~ options.locked_value }}{% endset %}
         {% endif %}
-        <i class="ti ti-lock" title="{{ locked_title }}" data-bs-toggle="tooltip"></i>
+        <i class="ti ti-lock" title="{{ locked_title }}" data-bs-toggle="tooltip" aria-hidden="true"></i>
+        <span class="visually-hidden">{{ locked_title }}</span>
         {% endset %}
     {% endif %}
 

--- a/templates/components/form/header_content.html.twig
+++ b/templates/components/form/header_content.html.twig
@@ -168,7 +168,8 @@
                {% endif %}
                <span class="form-check-label mb-0 mx-2">
                   {{ __('Child entities') }}
-                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip" role="img"></i>
+                  <i class="ti ti-info-circle ms-1" title="{{ comment }}" data-bs-toggle="tooltip" role="img" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{ comment }}</span>
                </span>
             </label>
          </span>

--- a/templates/components/form/inventory_info.html.twig
+++ b/templates/components/form/inventory_info.html.twig
@@ -97,26 +97,34 @@
          {% endif %}
 
          <div class="mb-3 col-12 col-sm-4">
-            <label class="form-label" >
+            <div class="form-label">
                {{ __('Agent status') }}
-               <i id="update-status" class="ti ti-refresh d-inline-block" role="button" data-bs-toggle="tooltip" title="{{ __('Ask agent about its current status') }}"></i>
-            </label>
-            <span id='agent_status'>{{ __('Unknown') }}</span>
+               <button type="button" id="update-status" class="btn btn-sm btn-icon btn-ghost-secondary"
+                       data-bs-toggle="tooltip" title="{{ __('Ask agent about its current status') }}">
+                  <i class="ti ti-refresh" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{ __('Ask agent about its current status') }}</span>
+               </button>
+            </div>
+            <span id='agent_status' aria-live="polite">{{ __('Unknown') }}</span>
          </div>
 
          <div class="mb-3 col-12 col-sm-4">
-            <label class="form-label" >
+            <div class="form-label">
                {{ __('Request inventory') }}
-               <i id="update-inventory" class="ti ti-refresh d-inline-block" role="button" data-bs-toggle="tooltip" title="{{ __('Request agent to proceed an new inventory') }}"></i>
-            </label>
-            <span id='inventory_status'>{{ __('Unknown') }}</span>
+               <button type="button" id="update-inventory" class="btn btn-sm btn-icon btn-ghost-secondary"
+                       data-bs-toggle="tooltip" title="{{ __('Request agent to proceed an new inventory') }}">
+                  <i class="ti ti-refresh" aria-hidden="true"></i>
+                  <span class="visually-hidden">{{ __('Request agent to proceed an new inventory') }}</span>
+               </button>
+            </div>
+            <span id='inventory_status' aria-live="polite">{{ __('Unknown') }}</span>
          </div>
       </div>
 
       <script>
       $(function () {
          $('#update-status').on('click', function() {
-            var icon = $(this);
+            var icon = $(this).find('i');
             icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',
@@ -137,7 +145,7 @@
          });
 
          $('#update-inventory').on('click', function() {
-            var icon = $(this);
+            var icon = $(this).find('i');
             icon.addClass('icon-rotate');
             $.ajax({
                type: 'POST',

--- a/templates/components/itilobject/fields/status.html.twig
+++ b/templates/components/itilobject/fields/status.html.twig
@@ -59,7 +59,7 @@
 {% else %}
    {% set field_options = field_options|merge({'center': true}) %}
    {% set status_field %}
-      {{ item.getStatusIcon(item.fields['status'])|raw }}
+      {{ item.getStatusIcon(item.fields['status'], false)|raw }}
       {{ item.getStatus(item.fields['status']) }}
 
       {% if item.canReopen() %}

--- a/templates/components/itilobject/footer.html.twig
+++ b/templates/components/itilobject/footer.html.twig
@@ -110,7 +110,9 @@
             {% if item.canSolve() and not item.checkRequiredFieldsFilled() %}
                <i class="ti ti-alert-triangle text-warning me-2 d-flex align-items-center"
                   data-bs-toggle="tooltip" data-bs-placement="top"
-                  title="{{ __('Solving this %s is not possible as one or more mandatory field is not filled')|format(item.getTypeName(1)) }}"></i>
+                  title="{{ __('Solving this %s is not possible as one or more mandatory field is not filled')|format(item.getTypeName(1)) }}"
+                  aria-hidden="true"></i>
+               <span class="visually-hidden">{{ __('Solving this %s is not possible as one or more mandatory field is not filled')|format(item.getTypeName(1)) }}</span>
             {% endif %}
 
             <div class="ms-auto"></div>

--- a/templates/components/itilobject/service_levels.html.twig
+++ b/templates/components/itilobject/service_levels.html.twig
@@ -270,17 +270,20 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
                     <i class="ti ti-flag-check text-success mx-1"
                        title="{{ __('%s completed')|format(__('OLA')) }}"
                        data-bs-toggle="tooltip"
-                       data-bs-placement="left" ></i>
+                       data-bs-placement="left" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('%s completed')|format(__('OLA')) }}</span>
                 {% elseif la.is_late %}
                     <i class="ti ti-flag-exclamation text-danger mx-1"
                        title="{{ __('%s is late')|format(__('OLA')) }}"
                        data-bs-toggle="tooltip"
-                       data-bs-placement="left" ></i>
+                       data-bs-placement="left" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('%s is late')|format(__('OLA')) }}</span>
                 {% else %} {# ola running #}
                     <i class="ti ti-flag text-secondary mx-1"
                        title="{{ __('%s not completed')|format(__('OLA')) }}"
                        data-bs-toggle="tooltip"
-                       data-bs-placement="left" ></i>
+                       data-bs-placement="left" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('%s not completed')|format(__('OLA')) }}</span>
                 {% endif %}
              </span>
             <span>{{ la.due_time|formatted_datetime }}</span>
@@ -300,7 +303,8 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
                     <span class="badge bg-info-lt ms-0 ms-sm-1">
                         <i class="ti ti-clock me-1"
                            title="{{ __('Next escalation: %s')|format(la.nextaction.fields['date']|formatted_datetime) }}"
-                           data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                           data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ __('Next escalation: %s')|format(la.nextaction.fields['date']|formatted_datetime) }}</span>
                         <span title="{{ __('%1$s: %2$s')|format(_n('Escalation level', 'Escalation levels', 1), get_item_name(la.level)) }}"
                               data-bs-toggle="tooltip" data-bs-placement="top">
                            {{ get_item_name(la.level) }}
@@ -312,7 +316,8 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
                 <span class="badge bg-info-lt ms-0 ms-sm-1">
                     <i class="ti ti-users me-1"
                        title="{{ __('Ola group: %s')|format(_n('Group', 'Groups', 1), la.group_name) }}"
-                       data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                       data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('Ola group: %s')|format(_n('Group', 'Groups', 1), la.group_name) }}</span>
                     <span title="{{ __('%1$s: %2$s')|format(_n('Group', 'Groups', 1), la.group_name) }}"
                           data-bs-toggle="tooltip" data-bs-placement="top">
                        {{ la.group_name }}
@@ -362,7 +367,8 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
             <i class="ti ti-flag text-secondary mx-1"
                title="{{ __('OLA') }}"
                data-bs-toggle="tooltip"
-               data-bs-placement="left"></i> {{ la.due_time|formatted_datetime }}
+               data-bs-placement="left" aria-hidden="true"></i>
+            <span class="visually-hidden">{{ __('OLA') }}</span> {{ la.due_time|formatted_datetime }}
         {% endif %}
 
         {% if options.display_associatedsla_field %}
@@ -380,7 +386,8 @@ Handle only linked ola, not ola ttr and tto defined using datetime fields
                     <span class="badge bg-info-lt ms-0 ms-sm-1">
                         <i class="ti ti-clock me-1"
                            title="{{ __('Next escalation: %s')|format(la.nextaction.fields['date']|formatted_datetime) }}"
-                           data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                           data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ __('Next escalation: %s')|format(la.nextaction.fields['date']|formatted_datetime) }}</span>
                         <span title="{{ __('%1$s: %2$s')|format(_n('Escalation level', 'Escalation levels', 1), get_item_name(la.level)) }}"
                               data-bs-toggle="tooltip" data-bs-placement="top">
                            {{ get_item_name(la.level) }}

--- a/templates/components/itilobject/timeline/form_document_item.html.twig
+++ b/templates/components/itilobject/timeline/form_document_item.html.twig
@@ -94,7 +94,8 @@
                         </div>
                         <div class="col-12 col-xl-6">
                             {% set doc_private_lbl %}
-                                <i class="ti ti-eye-off me-1" title="{{ __('Private') }}"></i>
+                                <i class="ti ti-eye-off me-1" title="{{ __('Private') }}" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ __('Private') }}</span>
                             {% endset %}
                             {{ fields.sliderField(
                                 'is_private',

--- a/templates/components/itilobject/timeline/form_followup.html.twig
+++ b/templates/components/itilobject/timeline/form_followup.html.twig
@@ -131,7 +131,8 @@
 
                         {% set fup_template_lbl %}
                            <i class="{{ 'ITILFollowupTemplate'|itemtype_icon }} me-1"
-                              title="{{ _n('Followup template', 'Followup templates', get_plural_number()) }}"></i>
+                              title="{{ _n('Followup template', 'Followup templates', get_plural_number()) }}" aria-hidden="true"></i>
+                           <span class="visually-hidden">{{ _n('Followup template', 'Followup templates', get_plural_number()) }}</span>
                         {% endset %}
                         {{ fields.dropdownField(
                            'ITILFollowupTemplate',
@@ -149,7 +150,8 @@
                         ) }}
 
                         {% set fup_source_lbl %}
-                           <i class="ti ti-inbox me-1" title="{{ __('Source of followup') }}"></i>
+                           <i class="ti ti-inbox me-1" title="{{ __('Source of followup') }}" aria-hidden="true"></i>
+                           <span class="visually-hidden">{{ __('Source of followup') }}</span>
                         {% endset %}
                         {{ fields.dropdownField(
                            'RequestType',
@@ -169,7 +171,8 @@
                         ) }}
 
                         {% set fup_private_lbl %}
-                           <i class="ti ti-eye-off me-1" title="{{ __('Private') }}"></i>
+                           <i class="ti ti-eye-off me-1" title="{{ __('Private') }}" aria-hidden="true"></i>
+                           <span class="visually-hidden">{{ __('Private') }}</span>
                         {% endset %}
                         {{ fields.sliderField(
                            'is_private',
@@ -189,7 +192,8 @@
                         {% if candedit and can_update_kb and not nokb %}
                            {% set fup_to_kb_lbl %}
                               <i class="ti ti-device-floppy me-1" title="{{ __('Save and add to the knowledge base') }}"
-                                 data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                                 data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                              <span class="visually-hidden">{{ __('Save and add to the knowledge base') }}</span>
                            {% endset %}
                            {{ fields.sliderField(
                               '_fup_to_kb',

--- a/templates/components/itilobject/timeline/form_solution.html.twig
+++ b/templates/components/itilobject/timeline/form_solution.html.twig
@@ -130,7 +130,8 @@
 
                         {% set sol_template_lbl %}
                            <i class="{{ 'SolutionTemplate'|itemtype_icon }} me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                              title="{{ _n('Solution template', 'Solution templates', get_plural_number()) }}"></i>
+                              title="{{ _n('Solution template', 'Solution templates', get_plural_number()) }}" aria-hidden="true"></i>
+                           <span class="visually-hidden">{{ _n('Solution template', 'Solution templates', get_plural_number()) }}</span>
                         {% endset %}
                         {{ fields.dropdownField(
                            'SolutionTemplate',
@@ -151,7 +152,8 @@
 
                      {% set sol_type_lbl %}
                         <i class="ti ti-tag me-1" title="{{ 'SolutionType'|itemtype_name }}"
-                           data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                           data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ 'SolutionType'|itemtype_name }}</span>
                      {% endset %}
                      {% set sol_search = {} %}
                      {% if item.getType() == 'Ticket' %}
@@ -182,7 +184,8 @@
 
                     {% set link_kb_lbl %}
                         <i class="ti ti-link me-1" data-bs-toggle="tooltip" data-bs-placement="top"
-                           title="{{ __('Link to knowledge base entry #%id')|replace({'%id': ''}) }}"></i>
+                           title="{{ __('Link to knowledge base entry #%id')|replace({'%id': ''}) }}" aria-hidden="true"></i>
+                        <span class="visually-hidden">{{ __('Link to knowledge base entry #%id')|replace({'%id': ''}) }}</span>
                     {% endset %}
                     {{ fields.sliderField(
                        'kb_linked_id',
@@ -201,7 +204,8 @@
                      {% if candedit and can_update_kb and not nokb %}
                         {% set sol_to_kb_lbl %}
                            <i class="ti ti-device-floppy me-1" title="{{ __('Save and add to the knowledge base') }}"
-                              data-bs-toggle="tooltip" data-bs-placement="top"></i>
+                              data-bs-toggle="tooltip" data-bs-placement="top" aria-hidden="true"></i>
+                           <span class="visually-hidden">{{ __('Save and add to the knowledge base') }}</span>
                         {% endset %}
                         {{ fields.sliderField(
                            '_sol_to_kb',

--- a/templates/components/itilobject/timeline/form_task_main_form.html.twig
+++ b/templates/components/itilobject/timeline/form_task_main_form.html.twig
@@ -88,8 +88,8 @@
                 {% set task_template_lbl %}
                     <i
                         class="{{ 'TaskTemplate'|itemtype_icon }} me-1"
-                        title="{{ _n('Task template', 'Task templates', get_plural_number()) }}"
-                    ></i>
+                        title="{{ _n('Task template', 'Task templates', get_plural_number()) }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _n('Task template', 'Task templates', get_plural_number()) }}</span>
                 {% endset %}
                 {{ fields.dropdownField(
                     'TaskTemplate',
@@ -108,8 +108,8 @@
                 {% set task_date_lbl %}
                     <i
                         class="ti ti-calendar me-1"
-                        title="{{ _n('Date', 'Dates', 1) }}"
-                    ></i>
+                        title="{{ _n('Date', 'Dates', 1) }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _n('Date', 'Dates', 1) }}</span>
                 {% endset %}
                 {{ fields.datetimeField(
                     'date',
@@ -124,7 +124,8 @@
 
                 {# Category #}
                 {% set task_category_lbl %}
-                    <i class="ti ti-tag me-1" title="{{ _n('Category', 'Categories', 1) }}"></i>
+                    <i class="ti ti-tag me-1" title="{{ _n('Category', 'Categories', 1) }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ _n('Category', 'Categories', 1) }}</span>
                 {% endset %}
                 {{ fields.dropdownField(
                     'TaskCategory',
@@ -144,7 +145,8 @@
 
                 {# Status #}
                 {% set task_state_lbl %}
-                    <i class="ti ti-list-check me-1" title="{{ __('Status') }}"></i>
+                    <i class="ti ti-list-check me-1" title="{{ __('Status') }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('Status') }}</span>
                 {% endset %}
 
                 {% set task_state %}
@@ -163,7 +165,8 @@
                 ) }}
 
                 {% set task_private_lbl %}
-                    <i class="ti ti-eye-off me-1" title="{{ __('Private') }}"></i>
+                    <i class="ti ti-eye-off me-1" title="{{ __('Private') }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('Private') }}</span>
                 {% endset %}
                 {{ fields.sliderField(
                     'is_private',
@@ -186,8 +189,8 @@
                         class="ti ti-device-floppy me-1"
                         title="{{ __('Save and add to the knowledge base') }}"
                         data-bs-toggle="tooltip"
-                        data-bs-placement="top"
-                    ></i>
+                        data-bs-placement="top" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('Save and add to the knowledge base') }}</span>
                 {% endset %}
                 {{ fields.sliderField(
                     '_task_to_kb',
@@ -203,7 +206,8 @@
 
                 {# Duration #}
                 {% set task_actiontime_lbl %}
-                    <i class="ti ti-stopwatch me-1" title="{{ __('Duration') }}"></i>
+                    <i class="ti ti-stopwatch me-1" title="{{ __('Duration') }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ __('Duration') }}</span>
                 {% endset %}
 
                 {% if subitem.fields['actiontime'] <= 360000 %}
@@ -230,7 +234,8 @@
 
                 {# User #}
                 {% set task_user_lbl %}
-                    <i class="ti ti-user me-1" title="{{ 'User'|itemtype_name }}"></i>
+                    <i class="ti ti-user me-1" title="{{ 'User'|itemtype_name }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ 'User'|itemtype_name }}</span>
                 {% endset %}
                 {{ fields.dropdownField(
                     'User',
@@ -248,7 +253,8 @@
 
                 {# Group #}
                 {% set task_group_lbl %}
-                    <i class="ti ti-users me-1" title="{{ 'Group'|itemtype_name }}"></i>
+                    <i class="ti ti-users me-1" title="{{ 'Group'|itemtype_name }}" aria-hidden="true"></i>
+                    <span class="visually-hidden">{{ 'Group'|itemtype_name }}</span>
                 {% endset %}
                 {{ fields.dropdownField(
                     'Group',

--- a/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
+++ b/templates/components/itilobject/timeline/pending_reasons_messages.html.twig
@@ -74,13 +74,15 @@
             {% if next_bump %}
 
                 <i class="ti ti-clock ms-2" title="{{ __("Next automatic follow-up scheduled on %s")|format(next_bump|formatted_date) }}"
-                   data-bs-toggle="tooltip"></i>
+                   data-bs-toggle="tooltip" aria-hidden="true"></i>
+                <span class="visually-hidden">{{ __("Next automatic follow-up scheduled on %s")|format(next_bump|formatted_date) }}</span>
             {% endif %}
 
          {% set resolve = pending_reason_item_parent.getAutoResolvedate() %}
          {% if resolve %}
             <i class="ti ti-player-stop-filled ms-2" title="{{ __("Automatic resolution scheduled on %s")|format(resolve|formatted_date) }}"
-               data-bs-toggle="tooltip"></i>
+               data-bs-toggle="tooltip" aria-hidden="true"></i>
+            <span class="visually-hidden">{{ __("Automatic resolution scheduled on %s")|format(resolve|formatted_date) }}</span>
         {% endif %}
         {% endif %}
    </span>

--- a/templates/components/itilobject/timeline/timeline_item_header.html.twig
+++ b/templates/components/itilobject/timeline/timeline_item_header.html.twig
@@ -103,7 +103,9 @@
       {% if is_private %}
          <span class="is-private ms-2" title="{{ __('This entry is "internal" (visible only to technicians)') }}" data-testid="private-followup-hint"
                data-bs-toggle="tooltip" data-bs-placement="bottom">
-            <i class="ti ti-eye-off" aria-label="{{ __('Private') }}"></i>
+            {# aria-label is not exposed on a generic element, the label needs to be real text. #}
+            <i class="ti ti-eye-off" aria-hidden="true"></i>
+            <span class="visually-hidden">{{ __('Private') }}</span>
          </span>
       {% endif %}
    </div>

--- a/templates/components/kanban/item_panels/default_panel.html.twig
+++ b/templates/components/kanban/item_panels/default_panel.html.twig
@@ -35,7 +35,7 @@
       <div class="card-header d-block">
          <h5 class="card-title d-flex justify-content-between w-100">
             <a href="{{ itemtype|itemtype_form_path(item_fields.id) }}">
-               <i class="{{ itemtype|itemtype_icon }}" title="{{ itemtype|itemtype_name }}"></i>
+               <i class="{{ itemtype|itemtype_icon }}" title="{{ itemtype|itemtype_name }}" aria-hidden="true"></i>
                {{ item_fields.name }}
             </a>
             <button type="button" class="btn-link" aria-label="{{ _x('button', 'Close') }}"><i class="ti ti-x" aria-hidden="true"></i></button>

--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -56,7 +56,7 @@
             <div class="col-auto">
                <button class="btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria" type="button" data-rowid="{{ row_id }}"
                        data-bs-toggle="tooltip" data-bs-placement="left" title="{{ __('Delete a rule') }}">
-                  <i class="ti ti-square-rounded-minus" alt="-"></i>
+                  <i class="ti ti-square-rounded-minus" aria-hidden="true"></i>
                </button>
             </div>
          {% endif %}

--- a/templates/components/search/query_builder/criteria_group.html.twig
+++ b/templates/components/search/query_builder/criteria_group.html.twig
@@ -37,7 +37,7 @@
       <div class="col-auto">
          <button class="btn btn-sm btn-icon btn-ghost-secondary remove-search-criteria" type="button" data-rowid="{{ row_id }}"
                  data-bs-toggle="tooltip" data-bs-placement="left" title="{{ __('Delete a rule') }}">
-            <i class="ti ti-square-rounded-minus" alt="-"></i>
+            <i class="ti ti-square-rounded-minus" aria-hidden="true"></i>
          </button>
       </div>
       <div class="col-auto">

--- a/templates/components/search/query_builder/sort/criteria.html.twig
+++ b/templates/components/search/query_builder/sort/criteria.html.twig
@@ -62,7 +62,7 @@
         <div class="col-auto">
             <button class="btn btn-sm btn-icon btn-ghost-secondary remove-order-criteria" type="button" data-rowid="{{ rowid }}"
                     data-bs-toggle="tooltip" data-bs-placement="left" title="{{ __('Delete a sort') }}">
-                <i class="ti ti-square-rounded-minus" alt="-"></i>
+                <i class="ti ti-square-rounded-minus" aria-hidden="true"></i>
             </button>
         </div>
 

--- a/templates/layout/parts/saved_searches_list.html.twig
+++ b/templates/layout/parts/saved_searches_list.html.twig
@@ -61,7 +61,8 @@
       <div class="d-flex flex-nowrap align-items-center">
          {% if search['is_private'] == 1 %}
          <i class="ti ti-lock fs-5 text-muted me-1" title="{{ __('private') }}"
-            data-bs-toggle="tooltip" data-bs-placement="right"></i>
+            data-bs-toggle="tooltip" data-bs-placement="right" aria-hidden="true"></i>
+         <span class="visually-hidden">{{ __('private') }}</span>
          {% endif %}
          <span class="badge bg-secondary text-secondary-fg">
             {{ search['count']|raw }}

--- a/templates/pages/setup/dropdowns_list.html.twig
+++ b/templates/pages/setup/dropdowns_list.html.twig
@@ -62,7 +62,8 @@
                                  {% if is_entity_assign %}
                                     <i class="{{ 'Entity'|itemtype_icon }} fs-4"
                                        data-bs-toggle="tooltip"
-                                       title="{{ __('Entity management') }}"></i>
+                                       title="{{ __('Entity management') }}" aria-hidden="true"></i>
+                                    <span class="visually-hidden">{{ __('Entity management') }}</span>
                                  {% endif %}
                               </div>
                            </div>

--- a/templates/pages/setup/general/performance.html.twig
+++ b/templates/pages/setup/general/performance.html.twig
@@ -34,7 +34,7 @@
 
 {% macro icon_msg(message, icon) %}
    <td class="icons_block">
-      <i class="{{ icon }}" title="{{ message }}" data-bs-toggle="tooltip"></i>
+      <i class="{{ icon }}" title="{{ message }}" data-bs-toggle="tooltip" aria-hidden="true"></i>
       <span class="visually-hidden">{{ message }}</span>
    </td>
 {% endmacro %}

--- a/templates/pages/tools/search_knowbaseitem.html.twig
+++ b/templates/pages/tools/search_knowbaseitem.html.twig
@@ -53,7 +53,8 @@
                     {% for result in results %}
                         <div class="list-group-item d-flex" data-knowbaseitem-id="{{ result.id }}" role="listitem">
                             <div class="col-auto">
-                                <i class="{{ result.icon }}" title="{{ result.icon_title }}"></i>
+                                <i class="{{ result.icon }}" title="{{ result.icon_title }}" aria-hidden="true"></i>
+                                <span class="visually-hidden">{{ result.icon_title }}</span>
                             </div>
                             <div class="col">
                                 <div class="fs-2">{{ result.name }}</div>

--- a/tests/functional/Tools/Command/CheckDecorativeIconsCommandTest.php
+++ b/tests/functional/Tools/Command/CheckDecorativeIconsCommandTest.php
@@ -37,6 +37,7 @@ namespace tests\functional\Tools\Command;
 use Glpi\Tests\GLPITestCase;
 use Glpi\Tools\Command\CheckDecorativeIconsCommand;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class CheckDecorativeIconsCommandTest extends GLPITestCase
@@ -197,13 +198,62 @@ class CheckDecorativeIconsCommandTest extends GLPITestCase
 
         $tester = new CommandTester(new CheckDecorativeIconsCommand());
         $tester->execute(['--directory' => $this->test_dir]);
-        $this->assertStringNotContainsString('manual decision', $tester->getDisplay());
+        $this->assertStringNotContainsString('[names-its-control]', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
 
         $tester = new CommandTester(new CheckDecorativeIconsCommand());
-        $tester->execute(['--directory' => $this->test_dir, '--show-review' => true]);
-        $this->assertStringContainsString('manual decision', $tester->getDisplay());
+        $tester->execute(['--directory' => $this->test_dir, '--show-review' => null]);
+        $this->assertStringContainsString('[names-its-control]', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
+    }
+
+    public function testReviewListCanBeFilteredByCategory(): void
+    {
+        file_put_contents(
+            $this->test_dir . '/template.html.twig',
+            '<button type="button"><i class="ti ti-plus" title="Add"></i></button>'
+            . '<i class="ti ti-x" onclick="close()"></i>'
+        );
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--show-review' => 'interactive']);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('[interactive]', $display);
+        $this->assertStringNotContainsString('[names-its-control]', $display);
+    }
+
+    public function testReviewCountsAreSummarisedAfterTheListing(): void
+    {
+        file_put_contents(
+            $this->test_dir . '/named.html.twig',
+            '<button type="button"><i class="ti ti-plus" title="Add"></i></button>'
+        );
+        file_put_contents(
+            $this->test_dir . '/clickable.html.twig',
+            '<i class="ti ti-x" onclick="close()"></i>'
+        );
+
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+        $tester->execute(['--directory' => $this->test_dir, '--show-review' => 'interactive']);
+
+        $display = $tester->getDisplay();
+
+        // The counts cover every category, even the ones the filter left out.
+        $this->assertStringContainsString('2 icon(s) need a manual decision.', $display);
+        $this->assertStringContainsString('interactive: 1, names-its-control: 1', $display);
+        $this->assertGreaterThan(
+            strpos($display, '[interactive]'),
+            strpos($display, 'need a manual decision.')
+        );
+    }
+
+    public function testUnknownReviewCategoryIsRejected(): void
+    {
+        $tester = new CommandTester(new CheckDecorativeIconsCommand());
+
+        $this->expectException(InvalidOptionException::class);
+        $tester->execute(['--directory' => $this->test_dir, '--show-review' => 'not-a-category']);
     }
 
     public function testSuccessOnCleanDirectory(): void

--- a/tests/js/vue/Planning/PlanningEvent.test.js
+++ b/tests/js/vue/Planning/PlanningEvent.test.js
@@ -134,10 +134,11 @@ describe('Planning/PlanningEvent Vue Component', () => {
         const popoverInstance = window.bootstrap.Popover.mock.results[0]?.value;
 
         expect(component.find('.fc-time').text()).toBe('10');
-        expect(component.find('.fc-title').text()).toBe('Test event');
+        expect(component.find('.fc-title').text()).toBe('Test event Event icon');
         expect(component.find('i.ti-calendar-event').exists()).toBe(true);
         expect(component.find('i.ti-calendar-event').attributes('title')).toBe('Event icon');
-        expect(component.find('i.ti-calendar-event').attributes('aria-label')).toBe('Event icon');
+        expect(component.find('i.ti-calendar-event').attributes('aria-hidden')).toBe('true');
+        expect(component.find('.fc-title .visually-hidden').text()).toBe('Event icon');
 
         // Unmount cleanup check
         component.unmount();

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -40,6 +40,7 @@ use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -79,6 +80,20 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
      */
     private const VERDICT_REVIEW = 'review';
 
+    /**
+     * Why an icon needs a human decision. Each entry is a follow-up of its own, hence the
+     * `--show-review` filter: they are not fixed by the same kind of change.
+     *
+     * @var array<string, string>
+     */
+    private const REVIEW_CATEGORIES = [
+        'interactive' => 'are the interactive control itself, they should become real buttons',
+        'styled-as-control' => 'are styled as an interactive control, they should become real buttons',
+        'names-its-control' => 'hold the only name of their control, that name must move up to the control itself',
+        'unnamed-control' => 'are the only content of a control that has no name at all, that control needs a label first',
+        'carries-a-name' => 'carry a name of their own, replace it with a visually hidden text if it carries meaning',
+    ];
+
     #[Override]
     protected function isPluginOptionAvailable(): bool
     {
@@ -110,8 +125,12 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         $this->addOption(
             'show-review',
             null,
-            InputOption::VALUE_NONE,
-            'Also list the icons that cannot be fixed automatically'
+            InputOption::VALUE_OPTIONAL,
+            sprintf(
+                'Also list the icons that cannot be fixed automatically. You can filter on those categories: %s',
+                implode(', ', array_keys(self::REVIEW_CATEGORIES))
+            ),
+            false
         );
     }
 
@@ -131,6 +150,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
             );
 
         $fix = (bool) $input->getOption('fix');
+        $shown_categories = $this->getCategoriesToShow($input);
         $fixable_count = 0;
         $review = [];
         $failed_files = [];
@@ -149,12 +169,11 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
 
             foreach ($icons as $icon) {
                 if ($icon['verdict'] === self::VERDICT_REVIEW) {
-                    $review[] = sprintf(
-                        '%s:%d %s (%s)',
+                    $review[$icon['reason']][] = sprintf(
+                        '%s:%d %s',
                         $relative_path,
                         $icon['line'],
-                        trim($icon['tag']),
-                        $icon['reason']
+                        $this->flatten($icon['tag']),
                     );
                     continue;
                 }
@@ -165,7 +184,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
                         '<fg=red>%s:%d</> %s',
                         $relative_path,
                         $icon['line'],
-                        trim($icon['tag'])
+                        $this->flatten($icon['tag'])
                     ),
                     $fix ? OutputInterface::VERBOSITY_VERBOSE : OutputInterface::VERBOSITY_NORMAL
                 );
@@ -181,14 +200,23 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
             }
         }
 
-        if ($input->getOption('show-review') && $review !== []) {
-            $this->io->section(
-                sprintf('%d icon(s) need a manual decision (name carried by the icon, or interactive icon)', count($review))
-            );
-            foreach ($review as $line) {
+        foreach ($shown_categories as $category) {
+            $lines = $review[$category] ?? [];
+            if ($lines === []) {
+                continue;
+            }
+
+            $this->io->section(sprintf(
+                'Icons that %s [%s]',
+                self::REVIEW_CATEGORIES[$category],
+                $category
+            ));
+            foreach ($lines as $line) {
                 $this->io->writeln('<fg=yellow>‣ ' . $line . '</>');
             }
         }
+
+        $this->reportReviewSummary($shown_categories, $review);
 
         if ($fixable_count === 0) {
             $this->io->success('All decorative icons are hidden from assistive technologies.');
@@ -271,6 +299,78 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         }
 
         return $icons;
+    }
+
+    /**
+     * Collapse a tag onto a single line, so that one reported icon stays one readable line.
+     */
+    private function flatten(string $tag): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $tag));
+    }
+
+    /**
+     * Print full review summary
+     *
+     * @param list<string> $shown_categories
+     * @param array<string, list<string>> $review
+     */
+    private function reportReviewSummary(array $shown_categories, array $review): void
+    {
+        if ($shown_categories === [] || $review === []) {
+            return;
+        }
+
+        $total = array_sum(array_map('count', $review));
+
+        $per_category = [];
+        foreach (array_keys(self::REVIEW_CATEGORIES) as $category) {
+            if (($count = count($review[$category] ?? [])) > 0) {
+                $per_category[] = sprintf('%s: %d', $category, $count);
+            }
+        }
+
+        $this->io->newLine();
+        $this->io->writeln(sprintf('<fg=yellow>%d icon(s) need a manual decision.</>', $total));
+        $this->io->writeln('<fg=yellow>' . implode(', ', $per_category) . '</>');
+    }
+
+    /**
+     * Resolve `--show-review` into the list of categories to print.
+     *
+     * The option defaults to `false` so that "not given" stays distinguishable from "given without
+     * a value", which Symfony reports as `null`.
+     *
+     * @return list<string>
+     */
+    private function getCategoriesToShow(InputInterface $input): array
+    {
+        $requested = $input->getOption('show-review');
+
+        if ($requested === false) {
+            return [];
+        }
+
+        if ($requested === null || $requested === '') {
+            return array_keys(self::REVIEW_CATEGORIES);
+        }
+
+        $categories = array_filter(array_map('trim', explode(',', (string) $requested)));
+
+        $unknown = array_diff($categories, array_keys(self::REVIEW_CATEGORIES));
+        if ($unknown !== []) {
+            throw new InvalidOptionException(sprintf(
+                'Unknown review category "%s". Expected any of: %s.',
+                implode('", "', $unknown),
+                implode(', ', array_keys(self::REVIEW_CATEGORIES))
+            ));
+        }
+
+        // Keep the declaration order, so that the output does not depend on how the option is typed.
+        return array_values(array_filter(
+            array_keys(self::REVIEW_CATEGORIES),
+            static fn(string $category): bool => in_array($category, $categories, true)
+        ));
     }
 
     /**
@@ -367,7 +467,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
     }
 
     /**
-     * Return why the icon needs a human decision, or null when it can safely be hidden.
+     * Return the review category the icon falls into, or null when it can safely be hidden.
      */
     private function getReviewReason(string $attrs, bool $names_its_control): ?string
     {
@@ -376,26 +476,24 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         // An icon that is the control itself is reported as such first: the name it carries is a
         // consequence of that, not the problem to solve.
         if (preg_match('/\b(?:onclick|href|tabindex|contenteditable|data-bs-toggle=(?![\'"]?tooltip)|v-on:click|@click)/i', $attrs) === 1) {
-            return 'is the interactive control itself, it should become a real button';
+            return 'interactive';
         }
 
         if (
             preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) === 1
             && preg_match('/\b(?:btn|pointer|cursor-pointer)\b/', $matches['value']) === 1
         ) {
-            return 'is styled as an interactive control, it should become a real button';
+            return 'styled-as-control';
         }
 
         if ($names_its_control) {
-            return $carries_a_name
-                // Hiding the icon would drop its title too: an aria-hidden subtree contributes
-                // nothing to the accessible name computation.
-                ? 'holds the only name of its control, move that name up to the control itself'
-                : 'is the only content of a control that has no name at all, that control needs a label first';
+            // Hiding the icon would drop its title too: an aria-hidden subtree contributes nothing
+            // to the accessible name computation.
+            return $carries_a_name ? 'names-its-control' : 'unnamed-control';
         }
 
         if ($carries_a_name) {
-            return 'carries a name of its own, replace it with a visually hidden text if it carries meaning';
+            return 'carries-a-name';
         }
 
         return null;


### PR DESCRIPTION
Another bunch of ((quite simple) fixes around decorative icons.

I've also improved a bit the check command and add a filter on category.
Last commit is a button replacement, which have a very low impact (inventory information).

Can be reviewed per commit.