### PR TITLE
Fix: reconcile migrated forms by uuid instead of name

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -621,6 +621,7 @@ class FormMigration extends AbstractPluginMigration
         $raw_forms = $this->db->request([
             'SELECT' => [
                 'id',
+                'uuid',
                 'description',
                 'content AS header',
                 'name',
@@ -639,6 +640,7 @@ class FormMigration extends AbstractPluginMigration
             $form = $this->importItem(
                 Form::class,
                 [
+                    'uuid'                  => $raw_form['uuid'],
                     'name'                  => $raw_form['name'],
                     'header'                => $raw_form['header'],
                     'description'           => $raw_form['description'],
@@ -654,12 +656,7 @@ class FormMigration extends AbstractPluginMigration
                     '_from_migration'       =>  true,
                 ],
                 [
-                    'name'                => $raw_form['name'],
-                    'entities_id'         => $raw_form['entities_id'],
-                    'forms_categories_id' => $this->getMappedItemTarget(
-                        'PluginFormcreatorCategory',
-                        $raw_form['plugin_formcreator_categories_id']
-                    )['items_id'] ?? 0,
+                    'uuid' => $raw_form['uuid'],
                 ]
             );
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -85,6 +85,7 @@ use Item_Problem;
 use Item_Ticket;
 use LogicException;
 use Override;
+use Ramsey\Uuid\Uuid;
 use Throwable;
 
 use function Safe\json_decode;
@@ -104,6 +105,14 @@ class FormMigration extends AbstractPluginMigration
      * @var array<int, array>
      */
     private array $formcreator_raw_forms = [];
+
+    /**
+     * Store the form UUIDs already consumed during the current migration run,
+     * to detect duplicate UUIDs on the Formcreator side (which has no unique
+     * constraint on this column).
+     * @var array<string, true>
+     */
+    private array $seen_form_uuids = [];
 
     public function __construct(
         DBmysql $db,
@@ -453,7 +462,7 @@ class FormMigration extends AbstractPluginMigration
                 'id', 'name', 'plugin_formcreator_categories_id', 'level',
             ],
             'glpi_plugin_formcreator_forms' => [
-                'id', 'name', 'description', 'plugin_formcreator_categories_id', 'entities_id',
+                'id', 'uuid', 'name', 'description', 'plugin_formcreator_categories_id', 'entities_id',
                 'is_recursive', 'is_visible',
             ],
             'glpi_plugin_formcreator_sections' => [
@@ -637,10 +646,30 @@ class FormMigration extends AbstractPluginMigration
         ]);
 
         foreach ($raw_forms as $raw_form) {
+            $uuid = $raw_form['uuid'];
+
+            // Formcreator has no unique constraint on this column: an empty
+            // value or a duplicate found earlier in this same migration run
+            // would otherwise make unrelated forms reconcile together.
+            if (empty($uuid) || isset($this->seen_form_uuids[$uuid])) {
+                if (!empty($uuid)) {
+                    $this->result->addMessage(
+                        MessageType::Warning,
+                        sprintf(
+                            __('Form "%s" has a UUID ("%s") already used by another form in the Formcreator data. A new UUID has been generated to avoid merging them.'),
+                            $raw_form['name'],
+                            $uuid
+                        )
+                    );
+                }
+                $uuid = (string) Uuid::uuid4();
+            }
+            $this->seen_form_uuids[$uuid] = true;
+
             $form = $this->importItem(
                 Form::class,
                 [
-                    'uuid'                  => $raw_form['uuid'],
+                    'uuid'                  => $uuid,
                     'name'                  => $raw_form['name'],
                     'header'                => $raw_form['header'],
                     'description'           => $raw_form['description'],
@@ -656,7 +685,7 @@ class FormMigration extends AbstractPluginMigration
                     '_from_migration'       =>  true,
                 ],
                 [
-                    'uuid' => $raw_form['uuid'],
+                    'uuid' => $uuid,
                 ]
             );
 

--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -107,12 +107,16 @@ class FormMigration extends AbstractPluginMigration
     private array $formcreator_raw_forms = [];
 
     /**
-     * Store the form UUIDs already consumed during the current migration run,
-     * to detect duplicate UUIDs on the Formcreator side (which has no unique
-     * constraint on this column).
+     * Source UUIDs already used in this run, to detect Formcreator duplicates.
      * @var array<string, true>
      */
     private array $seen_form_uuids = [];
+
+    /**
+     * Form IDs already reconciled in this run, excluded from the legacy fallback.
+     * @var int[]
+     */
+    private array $claimed_form_ids = [];
 
     public function __construct(
         DBmysql $db,
@@ -648,9 +652,8 @@ class FormMigration extends AbstractPluginMigration
         foreach ($raw_forms as $raw_form) {
             $uuid = $raw_form['uuid'];
 
-            // Formcreator has no unique constraint on this column: an empty
-            // value or a duplicate found earlier in this same migration run
-            // would otherwise make unrelated forms reconcile together.
+            // No unique constraint on Formcreator's side: an empty or duplicate value
+            // must not merge unrelated forms.
             if (empty($uuid) || isset($this->seen_form_uuids[$uuid])) {
                 if (!empty($uuid)) {
                     $this->result->addMessage(
@@ -662,9 +665,33 @@ class FormMigration extends AbstractPluginMigration
                         )
                     );
                 }
-                $uuid = (string) Uuid::uuid4();
+                // Deterministic, not random: a replay must regenerate the same UUID.
+                $uuid = (string) Uuid::uuid5(Uuid::NAMESPACE_URL, 'formcreator-form-' . $raw_form['id']);
             }
             $this->seen_form_uuids[$uuid] = true;
+
+            $forms_categories_id = $this->getMappedItemTarget(
+                'PluginFormcreatorCategory',
+                $raw_form['plugin_formcreator_categories_id']
+            )['items_id'] ?? 0;
+
+            $reconciliation_criteria = ['uuid' => $uuid];
+            $existing_form = new Form();
+            if (!$existing_form->getFromDBByCrit($reconciliation_criteria)) {
+                // Fallback for forms migrated before reconciliation switched from name to uuid.
+                $legacy_criteria = [
+                    'name'                => $raw_form['name'],
+                    'entities_id'         => $raw_form['entities_id'],
+                    'forms_categories_id' => $forms_categories_id,
+                ];
+                if ($this->claimed_form_ids !== []) {
+                    // Skip forms already claimed this run, to avoid re-merging them.
+                    $legacy_criteria['id'] = ['NOT IN', $this->claimed_form_ids];
+                }
+                if ($existing_form->getFromDBByCrit($legacy_criteria)) {
+                    $reconciliation_criteria = ['id' => $existing_form->getID()];
+                }
+            }
 
             $form = $this->importItem(
                 Form::class,
@@ -673,10 +700,7 @@ class FormMigration extends AbstractPluginMigration
                     'name'                  => $raw_form['name'],
                     'header'                => $raw_form['header'],
                     'description'           => $raw_form['description'],
-                    'forms_categories_id'   => $this->getMappedItemTarget(
-                        'PluginFormcreatorCategory',
-                        $raw_form['plugin_formcreator_categories_id']
-                    )['items_id'] ?? 0,
+                    'forms_categories_id'   => $forms_categories_id,
                     'entities_id'           => $raw_form['entities_id'],
                     'is_recursive'          => $raw_form['is_recursive'],
                     'is_active'             => $raw_form['is_active'],
@@ -684,10 +708,9 @@ class FormMigration extends AbstractPluginMigration
                     'render_layout'         => 'single_page',
                     '_from_migration'       =>  true,
                 ],
-                [
-                    'uuid' => $uuid,
-                ]
+                $reconciliation_criteria
             );
+            $this->claimed_form_ids[] = $form->getID();
 
             // Store the form for later use
             $this->forms[$raw_form['id']] = $form;

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -99,6 +99,7 @@ use LogicException;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Problem;
+use Ramsey\Uuid\Uuid;
 use Ticket;
 
 final class FormMigrationTest extends DbTestCase
@@ -4063,6 +4064,51 @@ final class FormMigrationTest extends DbTestCase
 
         // Assert: migration should be done without error
         $this->assertTrue($result->isFullyProcessed());
+    }
+
+    public function testFormMigrationWithDuplicateFormNames(): void
+    {
+        global $DB;
+
+        // Arrange: create two formcreator forms with the exact same name, entity
+        // and category. This reproduces a real-world scenario where users had
+        // duplicated form names in formcreator.
+        $duplicate_name = 'Duplicate form name test';
+        $this->createSimpleFormcreatorForm(
+            name: $duplicate_name,
+            questions: [
+                ['name' => 'Question in first form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => Uuid::uuid4(),
+            ]
+        );
+        $this->createSimpleFormcreatorForm(
+            name: $duplicate_name,
+            questions: [
+                ['name' => 'Question in second form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => Uuid::uuid4(),
+            ]
+        );
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Assert: both forms must have been migrated as distinct GLPI forms.
+        $migrated_forms = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => Form::getTable(),
+            'WHERE'  => ['name' => $duplicate_name],
+        ]);
+        $this->assertEquals(
+            2,
+            $migrated_forms->count(),
+            'Two distinct forms should have been created, one per formcreator form'
+        );
     }
 
     public function testFormMigrationActorsWithEmptyDefaultValue(): void

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -4157,6 +4157,82 @@ final class FormMigrationTest extends DbTestCase
         );
     }
 
+    public function testFormMigrationSubstituteUuidIsDeterministicAcrossReplays(): void
+    {
+        global $DB;
+
+        // Arrange: a formcreator form with no UUID, forcing a substitute one to be generated.
+        $this->createSimpleFormcreatorForm(
+            name: 'Form without uuid replayed',
+            questions: [
+                ['name' => 'Question', 'fieldtype' => 'text'],
+            ],
+        );
+
+        // Act: run the migration twice, as a real replay of the console command would.
+        $first_migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($first_migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($first_migration, 'processMigration'));
+
+        $second_migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($second_migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($second_migration, 'processMigration'));
+
+        // Assert: the replay reconciled with the form created on the first run instead of duplicating it.
+        $migrated_forms = $DB->request([
+            'SELECT' => ['id', 'uuid'],
+            'FROM'   => Form::getTable(),
+            'WHERE'  => ['name' => 'Form without uuid replayed'],
+        ]);
+        $this->assertEquals(
+            1,
+            $migrated_forms->count(),
+            'The substitute UUID must be the same on both runs, so the replay must not create a duplicate'
+        );
+    }
+
+    public function testFormMigrationReconcilesFormsMigratedBeforeUuidReconciliation(): void
+    {
+        global $DB;
+
+        // Arrange: a formcreator form with a UUID, as if Formcreator was upgraded after a first migration.
+        $source_uuid = (string) Uuid::uuid4();
+        $this->createSimpleFormcreatorForm(
+            name: 'Form migrated before uuid reconciliation',
+            questions: [
+                ['name' => 'Question', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => $source_uuid,
+            ]
+        );
+
+        // Arrange: a GLPI form matching it by name/entity/category, but with an unrelated UUID,
+        // as produced by a migration run before reconciliation switched from name to uuid.
+        $legacy_form = $this->createItem(Form::class, [
+            'name'        => 'Form migrated before uuid reconciliation',
+            'entities_id' => 0,
+            'uuid'        => (string) Uuid::uuid4(),
+        ]);
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Assert: the pre-existing form was adopted, not duplicated, and its uuid was upgraded.
+        $migrated_forms = $DB->request([
+            'SELECT' => ['id', 'uuid'],
+            'FROM'   => Form::getTable(),
+            'WHERE'  => ['name' => 'Form migrated before uuid reconciliation'],
+        ]);
+        $this->assertEquals(1, $migrated_forms->count());
+
+        $migrated_form = $migrated_forms->current();
+        $this->assertEquals($legacy_form->getID(), $migrated_form['id']);
+        $this->assertEquals($source_uuid, $migrated_form['uuid']);
+    }
+
     public function testFormMigrationActorsWithEmptyDefaultValue(): void
     {
         global $DB;

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -4111,6 +4111,52 @@ final class FormMigrationTest extends DbTestCase
         );
     }
 
+    public function testFormMigrationWithCollidingFormUuids(): void
+    {
+        global $DB;
+
+        // Arrange: create two formcreator forms sharing the exact same UUID.
+        // Formcreator has no unique constraint on this column, so this can
+        // happen with real-world data (e.g. forms duplicated by a buggy tool).
+        $shared_uuid = (string) Uuid::uuid4();
+        $this->createSimpleFormcreatorForm(
+            name: 'Form with colliding uuid 1',
+            questions: [
+                ['name' => 'Question in first form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => $shared_uuid,
+            ]
+        );
+        $this->createSimpleFormcreatorForm(
+            name: 'Form with colliding uuid 2',
+            questions: [
+                ['name' => 'Question in second form', 'fieldtype' => 'text'],
+            ],
+            properties: [
+                'uuid' => $shared_uuid,
+            ]
+        );
+
+        // Act: execute migration
+        $migration = new FormMigration($DB, FormAccessControlManager::getInstance());
+        $this->setPrivateProperty($migration, 'result', new PluginMigrationResult());
+        $this->assertTrue($this->callPrivateMethod($migration, 'processMigration'));
+
+        // Assert: both forms must have been migrated as distinct GLPI forms,
+        // despite sharing the same source UUID.
+        $migrated_forms = $DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => Form::getTable(),
+            'WHERE'  => ['name' => ['Form with colliding uuid 1', 'Form with colliding uuid 2']],
+        ]);
+        $this->assertEquals(
+            2,
+            $migrated_forms->count(),
+            'Two distinct forms should have been created, one per formcreator form, despite the UUID collision'
+        );
+    }
+
     public function testFormMigrationActorsWithEmptyDefaultValue(): void
     {
         global $DB;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45786, see #23751
- When migrating a Formcreator plugin whose forms table contains several forms sharing the same name, entity and category, the migration merged them into a single GLPI form instead of creating one per source form, duplicating that form's sections and questions.
- Form reconciliation during migration now relies on Formcreator's stable `uuid` identifier instead of a combination of name, entity and category, so each source form is migrated as a distinct form.
- Forms already migrated by a previous run (before this fix) are still reconciled once via the legacy name-based criteria, then upgraded to the `uuid` key.
- Formcreator has no unique constraint on its `uuid` column: an empty or duplicate value now gets a deterministic substitute UUID, so replaying the migration stays stable.

## Screenshots (if appropriate):


