### PR TITLE
Fix: avoid blank page on SMTP OAuth send failure

### DIFF
--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -397,11 +397,17 @@ class NotificationEventMailing extends NotificationEventAbstract
                 if (!empty($current->fields['messageid'])) {
                     $mmail->MessageID = "<" . $current->fields['messageid'] . ">";
                 }
+
+                $sent = $mmail->Send();
             } catch (\Throwable $e) {
+                // Catches PHPMailer setup errors, but also exceptions thrown by
+                // Send() itself (e.g. SMTP OAuth token refresh failures), which
+                // PHPMailer does not catch as they are not its own Exception type.
                 self::handleFailedSend($current, $e->getMessage());
+                continue;
             }
 
-            if (!$mmail->Send()) {
+            if (!$sent) {
                 self::handleFailedSend($current, $mmail->ErrorInfo);
             } else {
                 //TRANS to be written in logs %1$s is the to email / %2$s is the subject of the mail

--- a/src/NotificationEventMailing.php
+++ b/src/NotificationEventMailing.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\Application\ErrorHandler;
 use Glpi\Toolbox\Sanitizer;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -400,9 +401,8 @@ class NotificationEventMailing extends NotificationEventAbstract
 
                 $sent = $mmail->Send();
             } catch (\Throwable $e) {
-                // Catches PHPMailer setup errors, but also exceptions thrown by
-                // Send() itself (e.g. SMTP OAuth token refresh failures), which
-                // PHPMailer does not catch as they are not its own Exception type.
+                // handleFailedSend() below only keeps the exception message, log the full trace here.
+                ErrorHandler::getInstance()->handleException($e, true);
                 self::handleFailedSend($current, $e->getMessage());
                 continue;
             }

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -119,20 +119,25 @@ class NotificationMailing implements NotificationInterface
         $mmail->Subject = "[GLPI] " . __('Mail test');
         $mmail->Body    = $text;
 
+        $error = null;
         try {
             // Send() can throw on failures that PHPMailer itself does not catch,
             // e.g. SMTP OAuth token refresh errors thrown by the OAuth provider.
             $sent = $mmail->Send();
+            if (!$sent) {
+                $error = $mmail->ErrorInfo;
+            }
         } catch (\Throwable $e) {
             $sent = false;
+            $error = $e->getMessage();
         }
 
         if (!$sent) {
-            Session::addMessageAfterRedirect(
-                __('Failed to send test email to administrator'),
-                false,
-                ERROR
-            );
+            $message = __('Failed to send test email to administrator');
+            if (!empty($error)) {
+                $message .= "<br/>" . $error;
+            }
+            Session::addMessageAfterRedirect($message, false, ERROR);
             GLPINetwork::addErrorMessageAfterRedirect();
             return false;
         } else {

--- a/src/NotificationMailing.php
+++ b/src/NotificationMailing.php
@@ -119,7 +119,15 @@ class NotificationMailing implements NotificationInterface
         $mmail->Subject = "[GLPI] " . __('Mail test');
         $mmail->Body    = $text;
 
-        if (!$mmail->Send()) {
+        try {
+            // Send() can throw on failures that PHPMailer itself does not catch,
+            // e.g. SMTP OAuth token refresh errors thrown by the OAuth provider.
+            $sent = $mmail->Send();
+        } catch (\Throwable $e) {
+            $sent = false;
+        }
+
+        if (!$sent) {
             Session::addMessageAfterRedirect(
                 __('Failed to send test email to administrator'),
                 false,

--- a/src/User.php
+++ b/src/User.php
@@ -5789,7 +5789,7 @@ HTML;
         } catch (\Glpi\Exception\PasswordTooWeakException $e) {
             // Force display on error
             foreach ($e->getMessages() as $message) {
-                Session::addMessageAfteRredirect($message, false, ERROR);
+                Session::addMessageAfterRedirect($message, false, ERROR);
             }
         }
 
@@ -5815,7 +5815,7 @@ HTML;
             Session::addMessageAfterRedirect($e->getMessage(), false, ERROR);
             return;
         }
-        Session::addMessageAfteRredirect(__('If the given email address corresponds to one and only one GLPI user, you will receive an email containing the information required to reset your password. Please contact your administrator if you do not receive an email.'));
+        Session::addMessageAfterRedirect(__('If the given email address corresponds to one and only one GLPI user, you will receive an email containing the information required to reset your password. Please contact your administrator if you do not receive an email.'));
 
         TemplateRenderer::getInstance()->display('password_form.html.twig', [
             'title'         => __('Forgotten password?'),


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45787
- Sending a notification email could crash with an unhandled exception when the mailer's `Send()` call itself fails outside of PHPMailer's own error handling (for example when an SMTP OAuth token refresh is rejected by the provider), resulting in a blank page instead of a proper error message.
- The failure is now caught and reported the same way as any other send failure, both for queued notifications and for the "send a test email" action.

## Screenshots (if appropriate):
