### PR TITLE
Feat: add export button to the debug toolbar

### DIFF
--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -323,21 +323,13 @@
         };
 
         const json_string = JSON.stringify(payload, null, 2);
-        let blob, filename;
-        if (typeof CompressionStream !== 'undefined') {
-            const compressed_stream = new Blob([json_string]).stream().pipeThrough(new CompressionStream('gzip'));
-            blob = await new Response(compressed_stream).blob();
-            filename = `glpi-debug-${Date.now()}.json.gz`;
-        } else {
-            // Fallback for browsers without the Compression Streams API
-            blob = new Blob([json_string], {type: 'application/json'});
-            filename = `glpi-debug-${Date.now()}.json`;
-        }
+        const compressed_stream = new Blob([json_string]).stream().pipeThrough(new CompressionStream('gzip'));
+        const blob = await new Response(compressed_stream).blob();
 
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-        link.download = filename;
+        link.download = `glpi-debug-${Date.now()}.json.gz`;
         link.click();
         URL.revokeObjectURL(url);
     }

--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -68,8 +68,9 @@
             refreshButton: (button) => {
                 const server_perf = props.initial_request.server_performance;
                 const memory_usage = +(server_perf.memory_usage / 1024 / 1024).toFixed(2);
+                const initial_execution_time = +server_perf.execution_time;
                 const total_execution_time = getTotalServerExecutionTime();
-                const server_performance_button_label = `${_.escape(total_execution_time)} <span class="text-muted"> ms using </span> ${_.escape(memory_usage)} <span class="text-muted"> MiB </span>`;
+                const server_performance_button_label = `${_.escape(initial_execution_time)}<span class="text-muted"> ms initial, </span>${_.escape(total_execution_time)}<span class="text-muted"> ms total using </span>${_.escape(memory_usage)}<span class="text-muted"> MiB </span>`;
                 button.find('.debug-text').html(server_performance_button_label);
             }
         },
@@ -281,7 +282,7 @@
         }));
     }
 
-    function exportDebugData() {
+    async function exportDebugData() {
         const requests = [
             {
                 url: window.location.href,
@@ -321,11 +322,22 @@
             requests: requests,
         };
 
-        const blob = new Blob([JSON.stringify(payload, null, 2)], {type: 'application/json'});
+        const json_string = JSON.stringify(payload, null, 2);
+        let blob, filename;
+        if (typeof CompressionStream !== 'undefined') {
+            const compressed_stream = new Blob([json_string]).stream().pipeThrough(new CompressionStream('gzip'));
+            blob = await new Response(compressed_stream).blob();
+            filename = `glpi-debug-${Date.now()}.json.gz`;
+        } else {
+            // Fallback for browsers without the Compression Streams API
+            blob = new Blob([json_string], {type: 'application/json'});
+            filename = `glpi-debug-${Date.now()}.json`;
+        }
+
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-        link.download = `glpi-debug-${Date.now()}.json`;
+        link.download = filename;
         link.click();
         URL.revokeObjectURL(url);
     }

--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -68,7 +68,8 @@
             refreshButton: (button) => {
                 const server_perf = props.initial_request.server_performance;
                 const memory_usage = +(server_perf.memory_usage / 1024 / 1024).toFixed(2);
-                const server_performance_button_label = `${_.escape(server_perf.execution_time)} <span class="text-muted"> ms using </span> ${_.escape(memory_usage)} <span class="text-muted"> MiB </span>`;
+                const total_execution_time = getTotalServerExecutionTime();
+                const server_performance_button_label = `${_.escape(total_execution_time)} <span class="text-muted"> ms using </span> ${_.escape(memory_usage)} <span class="text-muted"> MiB </span>`;
                 button.find('.debug-text').html(server_performance_button_label);
             }
         },
@@ -240,6 +241,95 @@
         return widgets.filter((widget) => widget.main_widget);
     }
 
+    function getTotalServerExecutionTime() {
+        let total = +props.initial_request.server_performance.execution_time;
+        ajax_requests.value.forEach((request) => {
+            if (request.profile !== undefined && request.profile !== null) {
+                total += +request.profile.server_performance.execution_time;
+            }
+        });
+        return total;
+    }
+
+    function getSQLTime(queries) {
+        if (!queries) {
+            return null;
+        }
+        return +queries.reduce((total, query) => total + query.time, 0).toFixed(2);
+    }
+
+    function getSQLQueriesDetail(queries) {
+        if (!queries) {
+            return [];
+        }
+        return queries.map((query) => ({
+            query: query.query,
+            time_ms: +query.time.toFixed(2),
+            rows: query.rows,
+        })).sort((a, b) => b.time_ms - a.time_ms);
+    }
+
+    function getProfilerSections(profile) {
+        if (!profile?.profiler) {
+            return [];
+        }
+        return profile.profiler.map((section) => ({
+            category: section.category,
+            name: section.name,
+            parent_id: section.parent_id,
+            duration_ms: +(section.end - section.start).toFixed(2),
+        }));
+    }
+
+    function exportDebugData() {
+        const requests = [
+            {
+                url: window.location.href,
+                type: 'GET',
+                status: 200,
+                duration_ms: +props.initial_request.server_performance.execution_time,
+                server_execution_time_ms: +props.initial_request.server_performance.execution_time,
+                sql_query_count: props.initial_request.sql.queries.length,
+                sql_time_ms: getSQLTime(props.initial_request.sql.queries),
+                sql_queries: getSQLQueriesDetail(props.initial_request.sql.queries),
+                profiler: getProfilerSections(props.initial_request),
+                start_offset_ms: 0,
+                end_offset_ms: +props.initial_request.server_performance.execution_time,
+            },
+            ...ajax_requests.value.map((request) => ({
+                url: request.url,
+                type: request.type,
+                status: request.status,
+                duration_ms: request.time ?? null,
+                server_execution_time_ms: request.profile?.server_performance?.execution_time !== undefined
+                    ? +request.profile.server_performance.execution_time
+                    : null,
+                sql_query_count: request.profile?.sql?.queries?.length ?? null,
+                sql_time_ms: getSQLTime(request.profile?.sql?.queries),
+                sql_queries: getSQLQueriesDetail(request.profile?.sql?.queries),
+                profiler: getProfilerSections(request.profile),
+                start_offset_ms: +(request.start - performance.timeOrigin).toFixed(2),
+                end_offset_ms: request.time !== undefined ? +(request.start - performance.timeOrigin + request.time).toFixed(2) : null,
+            })),
+        ];
+        requests.sort((a, b) => (b.duration_ms ?? 0) - (a.duration_ms ?? 0));
+
+        const payload = {
+            page_url: window.location.href,
+            exported_at: new Date().toISOString(),
+            total_execution_time_ms: getTotalServerExecutionTime(),
+            requests: requests,
+        };
+
+        const blob = new Blob([JSON.stringify(payload, null, 2)], {type: 'application/json'});
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `glpi-debug-${Date.now()}.json`;
+        link.click();
+        URL.revokeObjectURL(url);
+    }
+
     function getCombinedSQLData() {
         const sql_data = {
             total_requests: 0,
@@ -358,6 +448,9 @@
                 </ul>
                 <div class="debug-toolbar-controls">
                     <div class="debug-toolbar-control">
+                        <button type="button" class="btn btn-icon border-0 p-1" title="Export debug data" @click="exportDebugData">
+                            <i class="ti ti-download"></i>
+                        </button>
                         <button type="button" class="btn btn-icon border-0 p-1" name="toggle_content_area" @click="show_content_area = !show_content_area"
                                 title="Toggle debug content area">
                             <i :class="show_content_area ? 'ti ti-square-arrow-up' : 'ti ti-square-arrow-down'"></i>

--- a/tests/cypress/e2e/DebugMode/debug_bar.cy.js
+++ b/tests/cypress/e2e/DebugMode/debug_bar.cy.js
@@ -65,7 +65,7 @@ describe("Debug Bar", () => {
         cy.get('#debug-toolbar-applet').should('exist').within(() => {
             cy.get('.debug-toolbar-widget[data-glpi-debug-widget-id="server_performance"]')
                 .should('exist')
-                .invoke('text').should('match', /\d+\s+ms\s+using\s+[\d.]+\s+MiB/);
+                .invoke('text').should('match', /\d+\s+ms\s+initial,\s+\d+\s+ms\s+total\s+using\s+[\d.]+\s+MiB/);
             cy.get('.debug-toolbar-widget[data-glpi-debug-widget-id="server_performance"]').click();
             cy.get('#debug-toolbar-expanded-content').should('be.visible').within(() => {
                 cy.get('.datagrid-title').contains('Initial Execution Time').next().invoke('text').should('match', /\d+\s+ms/);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- It fixes #N/A
- When debug mode is enabled, the debug toolbar now has an export button that downloads a JSON file with the page's total execution time and, for each request (initial page and AJAX), its duration, SQL queries, and timing breakdown.
- This gives support a single file a client can send when reporting slowness, with enough detail to identify what is slow without needing further back and forth.

## Screenshots (if appropriate):

<img width="199" height="68" alt="image" src="https://github.com/user-attachments/assets/ab4c9c40-4276-4264-8ac5-69dcae728e63" />
