### PR TITLE
Add unit-aware values for device components

### DIFF
--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -236,6 +236,41 @@ abstract class CommonDevice extends CommonDropdown
         ];
     }
 
+    /**
+     * Convert a value entered with an alternate display unit to the unit used
+     * by the database. Fields without alternate-unit metadata are untouched.
+     */
+    protected function prepareUnitAwareInput(array $input): array
+    {
+        $values = $input['_unit_value'] ?? [];
+        $units  = $input['_unit'] ?? [];
+
+        if (is_array($values) && is_array($units)) {
+            foreach ($this->getAdditionalFields() as $field) {
+                $name    = $field['name'] ?? null;
+                $factors = $field['unit_factors'] ?? null;
+                if (
+                    $name === null
+                    || !is_array($factors)
+                    || !array_key_exists($name, $values)
+                    || !array_key_exists($name, $units)
+                    || !array_key_exists($units[$name], $factors)
+                ) {
+                    continue;
+                }
+
+                $value = str_replace(',', '.', trim((string) $values[$name]));
+                if (is_numeric($value) && (float) $value >= 0) {
+                    $input[$name] = (int) round((float) $value * (float) $factors[$units[$name]]);
+                }
+            }
+        }
+
+        unset($input['_unit_value'], $input['_unit']);
+
+        return $input;
+    }
+
     public function canUnrecurs()
     {
         global $DB;

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -239,6 +239,10 @@ abstract class CommonDevice extends CommonDropdown
     /**
      * Convert a value entered with an alternate display unit to the unit used
      * by the database. Fields without alternate-unit metadata are untouched.
+     *
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
      */
     protected function prepareUnitAwareInput(array $input): array
     {

--- a/src/DeviceGraphicCard.php
+++ b/src/DeviceGraphicCard.php
@@ -55,10 +55,14 @@ class DeviceGraphicCard extends CommonDevice
                 ],
                 [
                     'name'  => 'memory_default',
-                    'label' => __('Memory by default'),
+                    'label' => sprintf(__('%1$s (%2$s)'), __('Memory by default'), _x('size', 'MiB')),
                     'type'  => 'integer',
-                    'min'  => 0,
-                    'unit'  => __('Mio'),
+                    'min'   => 0,
+                    'unit_factors' => [
+                        _x('size', 'MiB') => 1,
+                        _x('size', 'GiB') => 1024,
+                        _x('size', 'TiB') => 1024 ** 2,
+                    ],
                 ],
                 [
                     'name'  => 'interfacetypes_id',
@@ -126,6 +130,7 @@ class DeviceGraphicCard extends CommonDevice
      **/
     public function prepareInputForAddOrUpdate($input)
     {
+        $input = $this->prepareUnitAwareInput($input);
         foreach (['memory_default'] as $field) {
             if (isset($input[$field]) && !is_numeric($input[$field])) {
                 $input[$field] = 0;

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -52,10 +52,14 @@ class DeviceHardDrive extends CommonDevice
             [
                 [
                     'name'  => 'capacity_default',
-                    'label' => __('Capacity by default'),
+                    'label' => sprintf(__('%1$s (%2$s)'), __('Capacity by default'), _x('size', 'MiB')),
                     'type'  => 'integer',
                     'min'   => 0,
-                    'unit'  => __('Mio'),
+                    'unit_factors' => [
+                        _x('size', 'MiB') => 1,
+                        _x('size', 'GiB') => 1024,
+                        _x('size', 'TiB') => 1024 ** 2,
+                    ],
                 ],
                 [
                     'name'  => 'rpm',
@@ -66,7 +70,12 @@ class DeviceHardDrive extends CommonDevice
                     'name'  => 'cache',
                     'label' => __('Cache'),
                     'type'  => 'integer',
-                    'unit'  => __('Mio'),
+                    'min'   => 0,
+                    'unit_factors' => [
+                        _x('size', 'MiB') => 1,
+                        _x('size', 'GiB') => 1024,
+                        _x('size', 'TiB') => 1024 ** 2,
+                    ],
                 ],
                 [
                     'name'  => 'deviceharddrivemodels_id',
@@ -150,6 +159,7 @@ class DeviceHardDrive extends CommonDevice
      **/
     public function prepareInputForAddOrUpdate($input)
     {
+        $input = $this->prepareUnitAwareInput($input);
         foreach (['capacity_default'] as $field) {
             if (isset($input[$field]) && !is_numeric($input[$field])) {
                 $input[$field] = 0;

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -52,17 +52,24 @@ class DeviceMemory extends CommonDevice
             [
                 [
                     'name'  => 'size_default',
-                    'label' => __('Size by default'),
+                    'label' => sprintf(__('%1$s (%2$s)'), __('Size by default'), _x('size', 'MiB')),
                     'type'  => 'integer',
                     'min'   => 0,
-                    'unit'  => __('Mio'),
+                    'unit_factors' => [
+                        _x('size', 'MiB') => 1,
+                        _x('size', 'GiB') => 1024,
+                        _x('size', 'TiB') => 1024 ** 2,
+                    ],
                 ],
                 [
                     'name'  => 'frequence',
                     'label' => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
                     'type'  => 'integer',
                     'min'   => 0,
-                    'unit'  => __('MHz'),
+                    'unit_factors' => [
+                        __('MHz') => 1,
+                        __('GHz') => 1000,
+                    ],
                 ],
                 [
                     'name'  => 'devicememorytypes_id',
@@ -125,6 +132,7 @@ class DeviceMemory extends CommonDevice
      **/
     public function prepareInputForAddOrUpdate($input)
     {
+        $input = $this->prepareUnitAwareInput($input);
         foreach (['size_default'] as $field) {
             if (isset($input[$field]) && !is_numeric($input[$field])) {
                 $input[$field] = 0;

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -56,14 +56,20 @@ class DeviceProcessor extends CommonDevice
                     'label' => sprintf(__('%1$s (%2$s)'), __('Frequency by default'), __('MHz')),
                     'type'  => 'integer',
                     'min'   => 0,
-                    'unit'  => __('MHz'),
+                    'unit_factors' => [
+                        __('MHz') => 1,
+                        __('GHz') => 1000,
+                    ],
                 ],
                 [
                     'name'  => 'frequence',
                     'label' => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
                     'type'  => 'integer',
                     'min'   => 0,
-                    'unit'  => __('MHz'),
+                    'unit_factors' => [
+                        __('MHz') => 1,
+                        __('GHz') => 1000,
+                    ],
                 ],
                 [
                     'name'  => 'nbcores_default',
@@ -141,6 +147,7 @@ class DeviceProcessor extends CommonDevice
      **/
     public function prepareInputForAddOrUpdate($input)
     {
+        $input = $this->prepareUnitAwareInput($input);
         foreach (
             ['frequence', 'frequency_default', 'nbcores_default',
                 'nbthreads_default',

--- a/src/Item_DeviceHardDrive.php
+++ b/src/Item_DeviceHardDrive.php
@@ -48,11 +48,13 @@ class Item_DeviceHardDrive extends Item_Devices
 
         return [
             'capacity' => [
-                'long name'  => sprintf(__('%1$s (%2$s)'), __('Capacity'), __('Mio')),
-                'short name' => __('Capacity'),
-                'size'       => 10,
-                'id'         => 20,
-                'datatype'   => 'integer',
+                'long name'    => sprintf(__('%1$s (%2$s)'), __('Capacity'), __('Mio')),
+                'short name'   => __('Capacity'),
+                'display_name' => __('Capacity'),
+                'display_unit' => 'binary_size',
+                'size'         => 10,
+                'id'           => 20,
+                'datatype'     => 'integer',
             ],
             'serial'   => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),

--- a/src/Item_DeviceMemory.php
+++ b/src/Item_DeviceMemory.php
@@ -54,11 +54,13 @@ class Item_DeviceMemory extends Item_Devices
 
         return [
             'size'   => [
-                'long name'  => sprintf(__('%1$s (%2$s)'), __('Size'), __('Mio')),
-                'short name' => __('Size'),
-                'size'       => 10,
-                'id'         => 20,
-                'datatype'   => 'integer',
+                'long name'    => sprintf(__('%1$s (%2$s)'), __('Size'), __('Mio')),
+                'short name'   => __('Size'),
+                'display_name' => __('Size'),
+                'display_unit' => 'binary_size',
+                'size'         => 10,
+                'id'           => 20,
+                'datatype'     => 'integer',
             ],
             'serial' => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),

--- a/src/Item_DeviceProcessor.php
+++ b/src/Item_DeviceProcessor.php
@@ -49,11 +49,13 @@ class Item_DeviceProcessor extends Item_Devices
 
         return [
             'frequency' => [
-                'long name'  => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
-                'short name' => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
-                'size'       => 10,
-                'id'         => 20,
-                'datatype'   => 'integer',
+                'long name'    => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
+                'short name'   => sprintf(__('%1$s (%2$s)'), __('Frequency'), __('MHz')),
+                'display_name' => __('Frequency'),
+                'display_unit' => 'frequency',
+                'size'         => 10,
+                'id'           => 20,
+                'datatype'     => 'integer',
             ],
             'serial'    => parent::getSpecificities('serial'),
             'otherserial' => parent::getSpecificities('otherserial'),

--- a/src/Item_Devices.php
+++ b/src/Item_Devices.php
@@ -436,6 +436,52 @@ class Item_Devices extends CommonDBRelation implements StateInterface
 
 
     /**
+     * Format a specificity value for display without changing its stored unit.
+     *
+     * @param int|float|string $value      Value in the unit used by the database
+     * @param array            $attributes Specificity attributes
+     * @phpstan-param array{display_unit?: string, ...} $attributes
+     */
+    public static function formatSpecificityValue($value, array $attributes): string
+    {
+        $display_unit = $attributes['display_unit'] ?? null;
+
+        if ($display_unit === 'binary_size') {
+            $units = [
+                _x('size', 'MiB'),
+                _x('size', 'GiB'),
+                _x('size', 'TiB'),
+                _x('size', 'PiB'),
+                _x('size', 'EiB'),
+            ];
+            $base = 1024;
+        } elseif ($display_unit === 'frequency') {
+            $units = [
+                __('MHz'),
+                __('GHz'),
+                __('THz'),
+            ];
+            $base = 1000;
+        } else {
+            return (string) $value;
+        }
+
+        $formatted_value = (float) $value;
+        $unit = $units[0];
+        foreach ($units as $index => $current_unit) {
+            $unit = $current_unit;
+            if (abs($formatted_value) < $base || !isset($units[$index + 1])) {
+                break;
+            }
+            $formatted_value /= $base;
+        }
+
+        //TRANS: %1$s is a number and %2$s is its unit
+        return sprintf(__('%1$s %2$s'), round($formatted_value, 2), $unit);
+    }
+
+
+    /**
      * Get the items on which this Item_Device can be attached. For instance, a computer can have
      * any kind of device. Conversely, a soundcard does not concern a NetworkEquipment
      * A configuration entry is automatically checked in $CFG_GLPI (must be the name of
@@ -977,14 +1023,15 @@ class Item_Devices extends CommonDBRelation implements StateInterface
             ? $table_group->addHeader('firmware', _sn('Firmware', 'Firmware', 1), $common_column)
             : null;
 
+        $specificities       = static::getSpecificities();
         $specificity_columns = [];
         $link_column         = $table_group->addHeader('spec_link', '', $specific_column);
         $spec_column         = $link_column;
 
-        foreach (static::getSpecificities() as $field => $attributs) {
+        foreach ($specificities as $field => $attributs) {
             $spec_column                 = $table_group->addHeader(
                 'spec_' . $field,
-                htmlescape($attributs['long name']),
+                htmlescape($attributs['display_name'] ?? $attributs['long name']),
                 $specific_column,
                 $spec_column
             );
@@ -1140,7 +1187,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                 "<a href='" . htmlescape($this->getLinkURL()) . "'>$mode</a>"
             );
 
-            foreach (static::getSpecificities() as $field => $attributs) {
+            foreach ($specificities as $field => $attributs) {
                 $content = '';
 
                 if (!empty($link[$field])) {
@@ -1181,7 +1228,7 @@ class Item_Devices extends CommonDBRelation implements StateInterface
                                 break;
 
                             default:
-                                $content = htmlescape($link[$field]);
+                                $content = htmlescape(static::formatSpecificityValue($link[$field], $attributs));
                         }
                     }
                 }

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -205,6 +205,135 @@
     {{ _self.field(name, field, label, options) }}
 {% endmacro %}
 
+{% macro unitNumberField(name, value, label = '', units = {}, options = {}) %}
+    {% set rand = random() %}
+    {% set canonical_id = (name ~ '_canonical_' ~ rand)|safe_dom_id %}
+    {% set toggle_id = (name ~ '_unit_toggle_' ~ rand)|safe_dom_id %}
+    {% set alternate_id = (name ~ '_alternate_' ~ rand)|safe_dom_id %}
+    {% set unit_id = (name ~ '_unit_' ~ rand)|safe_dom_id %}
+
+    {% set field %}
+        {% import 'components/form/basic_inputs_macros.html.twig' as _inputs %}
+        <div class="input-group" data-glpi-unit-number-field data-units="{{ units|json_encode|e('html_attr') }}">
+            {{ _inputs.number(name, value, options|merge({
+                'id': canonical_id,
+                'input_addclass': (options.input_addclass ?? '') ~ ' rounded-end-0',
+                'additional_attributes': (options.additional_attributes ?? {})|merge({
+                    'data-glpi-canonical-input': ''
+                })
+            })) }}
+            <input type="text"
+                   class="form-control d-none"
+                   id="{{ alternate_id }}"
+                   name="_unit_value[{{ name }}]"
+                   inputmode="decimal"
+                   autocomplete="off"
+                   data-glpi-alternate-input
+                   disabled>
+            <select class="form-select flex-grow-0 w-auto d-none"
+                    id="{{ unit_id }}"
+                    name="_unit[{{ name }}]"
+                    data-glpi-unit-select
+                    disabled>
+                {% for unit, factor in units %}
+                    <option value="{{ unit }}">{{ unit }}</option>
+                {% endfor %}
+            </select>
+            <label class="input-group-text gap-2 text-nowrap" for="{{ toggle_id }}">
+                <input class="form-check-input mt-0" type="checkbox" id="{{ toggle_id }}">
+                <span>{{ __('Use another unit') }}</span>
+            </label>
+        </div>
+        <script>
+            (() => {
+                const root = document.getElementById('{{ toggle_id|e('js') }}').closest('[data-glpi-unit-number-field]');
+                const canonical = root.querySelector('[data-glpi-canonical-input]');
+                const alternate = document.getElementById('{{ alternate_id|e('js') }}');
+                const unit = document.getElementById('{{ unit_id|e('js') }}');
+                const toggle = document.getElementById('{{ toggle_id|e('js') }}');
+                const units = JSON.parse(root.dataset.units);
+                const storageKey = 'glpi.unit-number-field.{{ name|e('js') }}';
+
+                const getStoredUnit = () => {
+                    try {
+                        return window.localStorage.getItem(storageKey);
+                    } catch (e) {
+                        return null;
+                    }
+                };
+                const storeUnit = (value) => {
+                    try {
+                        if (value === null) {
+                            window.localStorage.removeItem(storageKey);
+                        } else {
+                            window.localStorage.setItem(storageKey, value);
+                        }
+                    } catch (e) {
+                        // Local storage may be unavailable in hardened browsers.
+                    }
+                };
+
+                const formatValue = (number) => Number(number.toFixed(6)).toString();
+                const updateCanonical = () => {
+                    const number = Number(alternate.value.replace(',', '.'));
+                    const factor = Number(units[unit.value]);
+                    if (Number.isFinite(number) && number >= 0 && Number.isFinite(factor)) {
+                        canonical.value = Math.round(number * factor).toString();
+                    }
+                };
+                const updateAlternate = (selectBestUnit = false) => {
+                    const number = Number(canonical.value);
+                    if (!Number.isFinite(number)) {
+                        return;
+                    }
+                    if (selectBestUnit) {
+                        const availableUnits = Object.entries(units);
+                        const bestUnit = availableUnits.reduce((best, current) => {
+                            return number / Number(current[1]) >= 1 ? current : best;
+                        }, availableUnits[0]);
+                        unit.value = bestUnit[0];
+                    }
+                    alternate.value = formatValue(number / Number(units[unit.value]));
+                };
+                const setAlternateMode = (enabled) => {
+                    canonical.classList.toggle('d-none', enabled);
+                    alternate.classList.toggle('d-none', !enabled);
+                    unit.classList.toggle('d-none', !enabled);
+                    alternate.disabled = !enabled;
+                    unit.disabled = !enabled;
+                };
+
+                toggle.addEventListener('change', () => {
+                    if (toggle.checked) {
+                        updateAlternate(true);
+                        storeUnit(unit.value);
+                    } else {
+                        updateCanonical();
+                        storeUnit(null);
+                    }
+                    setAlternateMode(toggle.checked);
+                });
+                canonical.addEventListener('input', () => updateAlternate());
+                alternate.addEventListener('input', updateCanonical);
+                unit.addEventListener('change', () => {
+                    updateAlternate();
+                    storeUnit(unit.value);
+                });
+
+                const storedUnit = getStoredUnit();
+                if (storedUnit !== null && Object.prototype.hasOwnProperty.call(units, storedUnit)) {
+                    unit.value = storedUnit;
+                    toggle.checked = true;
+                    updateAlternate();
+                    setAlternateMode(true);
+                }
+            })();
+        </script>
+    {% endset %}
+
+    {{ _self.field(name, field, label, options) }}
+{% endmacro %}
+
 
 {% macro readOnlyField(name, value, label = '', options = {}) %}
    {% set options = options|merge({'readonly': true}) %}

--- a/templates/components/form/fields_macros.html.twig
+++ b/templates/components/form/fields_macros.html.twig
@@ -273,15 +273,30 @@
                     }
                 };
 
-                const formatValue = (number) => Number(number.toFixed(6)).toString();
+                const formatCompactValue = (number) => Number(number.toFixed(2)).toString();
+                const formatFullValue = (number) => number.toString();
+                const syncFullValue = () => {
+                    const number = Number(canonical.value);
+                    const factor = Number(units[unit.value]);
+                    if (!Number.isFinite(number) || !Number.isFinite(factor)) {
+                        return null;
+                    }
+
+                    const fullValue = formatFullValue(number / factor);
+                    alternate.dataset.fullValue = fullValue;
+                    alternate.title = fullValue;
+
+                    return fullValue;
+                };
                 const updateCanonical = () => {
                     const number = Number(alternate.value.replace(',', '.'));
                     const factor = Number(units[unit.value]);
                     if (Number.isFinite(number) && number >= 0 && Number.isFinite(factor)) {
                         canonical.value = Math.round(number * factor).toString();
+                        syncFullValue();
                     }
                 };
-                const updateAlternate = (selectBestUnit = false) => {
+                const updateAlternate = (selectBestUnit = false, compact = true) => {
                     const number = Number(canonical.value);
                     if (!Number.isFinite(number)) {
                         return;
@@ -293,7 +308,12 @@
                         }, availableUnits[0]);
                         unit.value = bestUnit[0];
                     }
-                    alternate.value = formatValue(number / Number(units[unit.value]));
+                    const fullValue = syncFullValue();
+                    if (fullValue !== null) {
+                        alternate.value = compact
+                            ? formatCompactValue(Number(fullValue))
+                            : fullValue;
+                    }
                 };
                 const setAlternateMode = (enabled) => {
                     canonical.classList.toggle('d-none', enabled);
@@ -315,9 +335,22 @@
                 });
                 canonical.addEventListener('input', () => updateAlternate());
                 alternate.addEventListener('input', updateCanonical);
+                alternate.addEventListener('focus', () => updateAlternate(false, false));
+                alternate.addEventListener('blur', () => {
+                    updateCanonical();
+                    updateAlternate();
+                });
                 unit.addEventListener('change', () => {
                     updateAlternate();
                     storeUnit(unit.value);
+                });
+                root.closest('form')?.addEventListener('submit', () => {
+                    if (toggle.checked) {
+                        const fullValue = syncFullValue();
+                        if (fullValue !== null) {
+                            alternate.value = fullValue;
+                        }
+                    }
                 });
 
                 const storedUnit = getStoredUnit();

--- a/templates/dropdown_form.html.twig
+++ b/templates/dropdown_form.html.twig
@@ -152,7 +152,17 @@
                     {% endif %}
 
                     {% set fields_params = fields_params|merge({'type': 'number'}) %}
-                    {{ fields.numberField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
+                    {% if field['unit_factors'] is defined %}
+                        {{ fields.unitNumberField(
+                            field['name'],
+                            item.fields[field['name']],
+                            field['label'],
+                            field['unit_factors'],
+                            fields_params
+                        ) }}
+                    {% else %}
+                        {{ fields.numberField(field['name'], item.fields[field['name']], field['label'], fields_params) }}
+                    {% endif %}
                 {% elseif type == 'timestamp' %}
                     {% set fields_params = {'value': item.fields[field['name']]} %}
                     {% if field['min'] is defined %}

--- a/tests/functional/DeviceHardDriveTest.php
+++ b/tests/functional/DeviceHardDriveTest.php
@@ -109,4 +109,38 @@ class DeviceHardDriveTest extends DbTestCase
         ];
         $this->assertTrue($obj->delete($in));
     }
+
+    public function testAddCapacityUsingAlternateUnit(): void
+    {
+        $this->login();
+        $obj = new \DeviceHardDrive();
+
+        $id = $obj->add([
+            'designation' => __METHOD__,
+            'capacity_default' => 0,
+            '_unit_value' => ['capacity_default' => '1,79'],
+            '_unit' => ['capacity_default' => 'TiB'],
+        ]);
+
+        $this->assertGreaterThan(0, $id);
+        $this->assertTrue($obj->getFromDB($id));
+        $this->assertSame(1876951, $obj->getField('capacity_default'));
+    }
+
+    public function testInvalidAlternateUnitFallsBackToCanonicalValue(): void
+    {
+        $this->login();
+        $obj = new \DeviceHardDrive();
+
+        $id = $obj->add([
+            'designation' => __METHOD__,
+            'capacity_default' => 2048,
+            '_unit_value' => ['capacity_default' => '2'],
+            '_unit' => ['capacity_default' => 'invalid'],
+        ]);
+
+        $this->assertGreaterThan(0, $id);
+        $this->assertTrue($obj->getFromDB($id));
+        $this->assertSame(2048, $obj->getField('capacity_default'));
+    }
 }

--- a/tests/functional/Item_DevicesTest.php
+++ b/tests/functional/Item_DevicesTest.php
@@ -212,4 +212,65 @@ class Item_DevicesTest extends DbTestCase
 
         $this->assertFalse($item_firmware->getFromDB($item_firmware_id));
     }
+
+    public static function specificityValueProvider(): iterable
+    {
+        yield 'value without an adaptive unit' => [
+            'value' => 1234,
+            'attributes' => [],
+            'expected' => '1234',
+        ];
+
+        yield 'memory below one GiB' => [
+            'value' => 512,
+            'attributes' => ['display_unit' => 'binary_size'],
+            'expected' => '512 MiB',
+        ];
+
+        yield 'memory at the GiB boundary' => [
+            'value' => 1024,
+            'attributes' => ['display_unit' => 'binary_size'],
+            'expected' => '1 GiB',
+        ];
+
+        yield 'disk capacity in TiB' => [
+            'value' => 1_876_951,
+            'attributes' => ['display_unit' => 'binary_size'],
+            'expected' => '1.79 TiB',
+        ];
+
+        yield 'frequency below one GHz' => [
+            'value' => 800,
+            'attributes' => ['display_unit' => 'frequency'],
+            'expected' => '800 MHz',
+        ];
+
+        yield 'frequency in GHz' => [
+            'value' => 2300,
+            'attributes' => ['display_unit' => 'frequency'],
+            'expected' => '2.3 GHz',
+        ];
+    }
+
+    #[DataProvider('specificityValueProvider')]
+    public function testFormatSpecificityValue(int|float|string $value, array $attributes, string $expected): void
+    {
+        $this->assertSame($expected, Item_Devices::formatSpecificityValue($value, $attributes));
+    }
+
+    public function testAdaptiveDisplayUnitsAreConfigured(): void
+    {
+        $this->assertSame(
+            'binary_size',
+            \Item_DeviceHardDrive::getSpecificities()['capacity']['display_unit']
+        );
+        $this->assertSame(
+            'binary_size',
+            \Item_DeviceMemory::getSpecificities()['size']['display_unit']
+        );
+        $this->assertSame(
+            'frequency',
+            \Item_DeviceProcessor::getSpecificities()['frequency']['display_unit']
+        );
+    }
 }


### PR DESCRIPTION
## Motivation

Component capacities and frequencies are currently stored and entered using fixed base units such as MiB and MHz. This is reliable for inventory data, but increasingly inconvenient for users working with GiB/TiB disk capacities, GPU memory, RAM, and GHz CPU frequencies.

This draft explores a backward-compatible way to improve both display and data entry without changing the database schema or the canonical values used by inventory.

## Proposed behavior

- Keep canonical values in their existing units (MiB or MHz).
- Display component values using a suitable binary size/frequency unit.
- Keep the existing input as the default.
- Let users opt into another unit with a checkbox and selector.
- Convert alternate input back to the canonical unit on submit.
- Remember the selected mode and unit locally for subsequent edits.
- Show a compact value with two decimal places while retaining the exact value for editing, tooltip display, and form submission.

The implementation currently covers:

- hard-drive capacity and cache;
- memory capacity and frequency;
- graphics-card memory;
- processor frequency;
- component values displayed in computer component tables.

## Screenshots

Canonical MiB input:

![Hard-drive capacity using the canonical MiB input](https://raw.githubusercontent.com/mykolaq/glpi/be9ebd6bb23fbe7e5bda98d57977cc6be89ede74/docs/screenshots/pr-25137/unit-aware-hard-drive-mib.png)

Optional alternate-unit input:

![Hard-drive capacity using the alternate GiB input](https://raw.githubusercontent.com/mykolaq/glpi/be9ebd6bb23fbe7e5bda98d57977cc6be89ede74/docs/screenshots/pr-25137/unit-aware-hard-drive-gib.png)

## Related discussions

- #11290 reports the same components-page usability problem: capacities and frequencies are displayed only in MB/MHz rather than user-friendly GB/GHz units.
- #4882 requested adaptive Mio/Gio/Tio display for hard-drive sizes in computer search results.
- #821 is an earlier discussion about MiB-only capacity input and display becoming outdated as device sizes increased.

These issues are included as prior context; this draft does not claim to close every workflow discussed in them.

## Compatibility

There is no database migration. Existing API, inventory, and stored values remain in MiB/MHz. Static forms without unit metadata continue to use the existing number input.

## Testing

- Added functional coverage for adaptive component values and unit conversion.
- Twig syntax validated.
- PHPStan validated for the changed common device input path.
- Manually tested in a Docker GLPI instance, including MiB/GiB/TiB switching, persistence after Save, and preservation of the exact canonical MiB value.

## Feedback requested

This is intentionally opened as a draft. I would appreciate maintainer feedback on the overall direction before polishing it further:

- Is an opt-in alternate-unit input appropriate for core GLPI?
- Should the preference remain browser-local, or should it be a GLPI user preference?
- Are there other component fields or bulk-edit forms that should be handled in the same change?
- Is the two-decimal compact display plus exact value on focus/hover a suitable UX?
- Would you prefer this to be split into separate display and input PRs?

## AI usage

OpenAI Codex was used to assist with codebase exploration, implementation and test drafting, code review, manual testing, and preparation of the pull request description. The resulting changes were reviewed by the contributor and the feature was manually tested on a GLPI installation.
