### PR TITLE
Fix: form tiles hidden on Home when user lacks ticket creation right

### DIFF
--- a/src/Glpi/Helpdesk/Tile/FormTile.php
+++ b/src/Glpi/Helpdesk/Tile/FormTile.php
@@ -41,7 +41,6 @@ use Glpi\Form\Form;
 use Glpi\Session\SessionInfo;
 use Html;
 use Override;
-use Ticket;
 
 final class FormTile extends CommonDBChild implements TileInterface
 {
@@ -104,10 +103,6 @@ final class FormTile extends CommonDBChild implements TileInterface
     public function isAvailable(SessionInfo $session_info): bool
     {
         $form_access_manager = FormAccessControlManager::getInstance();
-
-        if (!$session_info->hasRight(Ticket::$rightname, CREATE)) {
-            return false;
-        }
 
         // Form must be active
         if (!$this->form->isActive()) {

--- a/tests/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
+++ b/tests/functional/Glpi/Helpdesk/Tile/TilesManagerTest.php
@@ -661,7 +661,7 @@ final class TilesManagerTest extends DbTestCase
         $this->assertTrue($this->tilesExist("Report an issue", $tiles));
     }
 
-    public function testFormsTilesAreHiddenIfUserCantCreateTicket(): void
+    public function testFormsTilesAreVisibleEvenIfUserCantCreateTicket(): void
     {
         // Arrange: remove the right to create ticket from self service user.
         $this->removeRightFromProfile("Self-Service", Ticket::$rightname, CREATE);
@@ -673,13 +673,14 @@ final class TilesManagerTest extends DbTestCase
             Session::getCurrentSessionInfo()
         );
 
-        // Assert: tiles related to ticket creation should not be found
+        // Assert: form tiles are only gated by their own access control
+        // policy, not by the ticket creation right.
         $this->assertTrue($this->tilesExist("Browse help articles", $tiles));
         $this->assertTrue($this->tilesExist("Make a reservation", $tiles));
         $this->assertTrue($this->tilesExist("See your tickets", $tiles));
         $this->assertTrue($this->tilesExist("Create a ticket", $tiles));
-        $this->assertFalse($this->tilesExist("Request a service", $tiles));
-        $this->assertFalse($this->tilesExist("Report an issue", $tiles));
+        $this->assertTrue($this->tilesExist("Request a service", $tiles));
+        $this->assertTrue($this->tilesExist("Report an issue", $tiles));
     }
 
     /** @param array<TileInterface> $tiles */


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45705
- Here is a brief description of what this PR does
Form tiles were gated by Ticket::CREATE regardless of what the form actually does, hiding forms unrelated to ticket creation (Problem, Change, or informational forms) and creating an inconsistency with the Service Catalog, which already relies solely on each form's own access control policy.

## Screenshots (if appropriate):


