### PR TITLE
fix: show filled default star for current user savesearch

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -869,7 +869,7 @@
       }
    }
 
-   .fa {
+   .fa, .ti {
       &.bookmark_record, &.reset-search {
          font-size: 1.5em;
          color: #ccc !important;

--- a/src/SavedSearch_User.php
+++ b/src/SavedSearch_User.php
@@ -54,7 +54,7 @@ class SavedSearch_User extends CommonDBRelation
                 if (!empty($values[$field])) {
                     return "<span class='ti ti-star-filled bookmark_default'><span class='sr-only'>" . __s('Yes') . "</span></span>";
                 } else {
-                    return "<span class='ti ti-star-filled bookmark_record'><span class='sr-only'>" . __s('No') . "</span></span>";
+                    return "<span class='ti ti-star bookmark_record'><span class='sr-only'>" . __s('No') . "</span></span>";
                 }
         }
         return parent::getSpecificValueToDisplay($field, $values, $options);


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- In the list of savesearch, the “Default” star appeared filled in on every row. It is now filled in (and gold) only when the search is set as the default for the logged-in user; otherwise, it is empty.

## Screenshots (if appropriate):
<img width="1451" height="261" alt="image" src="https://github.com/user-attachments/assets/3ccce751-3123-4846-be0f-ae1da276ec1b" />


