### PR TITLE
feature(Forms): add tags resolving a specific property of the selected answer in a 'GLPI Object' question

### DIFF
--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -36,7 +36,10 @@ namespace Glpi\Form\Migration;
 
 use Glpi\Form\Question;
 use Glpi\Form\Tag\AnswerTagProvider;
+use Glpi\Form\Tag\ItemPropertyTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
+use Glpi\Form\Tag\Tag;
+use Glpi\Search\SearchOption;
 
 use function Safe\preg_match_all;
 
@@ -45,6 +48,32 @@ use function Safe\preg_match_all;
  */
 trait TagConversionTrait
 {
+    /**
+     * Maps Formcreator property names to database fields
+     */
+    private const FORMCREATOR_FIELD_MAP = [
+        '*' => [
+            'name'        => 'name',
+            'comment'     => 'comment',
+        ],
+        \User::class => [
+            'login'       => 'name',
+            'firstname'   => 'firstname',
+            'realname'    => 'realname',
+            'phone'       => 'phone',
+            'phone2'      => 'phone2',
+            'mobile'      => 'mobile',
+            'email'       => 'emails',
+            'emails'      => 'emails',
+        ],
+        \Computer::class => [
+            'serial'      => 'serial',
+            'otherserial' => 'otherserial',
+            'contact'     => 'contact',
+            'contact_num' => 'contact_num',
+        ],
+    ];
+
     /**
      * Convert legacy tags in the format ##question_ID## or ##answer_ID## to new tag format
      *
@@ -59,8 +88,39 @@ trait TagConversionTrait
             return $content;
         }
 
-        preg_match_all('/##(question_\d+|answer_\d+)##/', $content, $tags);
+        preg_match_all('/##(question_\d+|answer_\d+(?:\.\w+)?)##/', $content, $tags);
         foreach ($tags[1] as $tag) {
+
+            if (str_contains($tag, '.')) {
+                [$answer_part, $property_name] = explode('.', $tag, 2);
+                $item_id = (int) explode('_', $answer_part)[1];
+
+                $target = $migration->getMappedItemTarget('PluginFormcreatorQuestion', $item_id);
+                if (empty($target)) {
+                    continue;
+                }
+                $question_id = $target['items_id'];
+                $question = Question::getById($question_id);
+                if (!$question) {
+                    continue;
+                }
+
+                // Resolve the FormCreator property name to a search option ID
+                $search_option_id = self::resolveFormcreatorPropertyToSearchOptionId($question, $property_name);
+                if ($search_option_id === null) {
+                    continue;
+                }
+
+                $provider = new ItemPropertyTagProvider();
+                $new_tag = new Tag(
+                    label: sprintf(__('Answer: %1$s › %2$s'), $question->fields['name'], '...'),
+                    value: $question_id . ':' . $search_option_id,
+                    provider: $provider,
+                );
+                $content = str_replace("##$tag##", $new_tag->html, $content);
+                continue;
+            }
+
             $type = explode('_', $tag)[0];
             $item_id = (int) explode('_', $tag)[1];
 
@@ -96,4 +156,51 @@ trait TagConversionTrait
 
         return $content;
     }
+
+    /**
+     * Resolves a Formcreator property name to the corresponding search option ID for a given question.
+     *
+     * @param Question $question The question object
+     * @param string $property_name The property name to resolve
+     * @return int|null The corresponding search option ID, or null if not found
+     */
+    private static function resolveFormcreatorPropertyToSearchOptionId(
+        Question $question,
+        string $property_name
+    ): ?int {
+        $itemtype = (new ($question->fields['type'])())->getDefaultValueItemtype($question);
+        if ($itemtype === null) {
+            return null;
+        }
+
+        $key = strtolower($property_name);
+        $field_name = self::FORMCREATOR_FIELD_MAP[$itemtype][$key]
+            ?? self::FORMCREATOR_FIELD_MAP['*'][$key]
+            ?? null;
+
+        if ($field_name === null) {
+            // Log a warning about the unknown property
+            trigger_error(
+                sprintf('Formcreator migration: unknown property "%s" for %s', $property_name, $itemtype),
+                E_USER_WARNING
+            );
+            return null;
+        }
+
+        // Handle special case for user emails
+        if ($field_name === 'emails') {
+            return ItemPropertyTagProvider::USER_EMAILS_PSEUDO_ID;
+        }
+
+        // Find the search option ID corresponding to the field name
+        $options = SearchOption::getOptionsForItemtype($itemtype);
+        foreach ($options as $id => $option) {
+            if (is_int($id) && ($option['field'] ?? null) === $field_name) {
+                return $id;
+            }
+        }
+
+        return null;
+    }
+
 }

--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -35,6 +35,7 @@
 namespace Glpi\Form\Migration;
 
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\ItemPropertyTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
@@ -168,6 +169,10 @@ trait TagConversionTrait
         Question $question,
         string $property_name
     ): ?int {
+        if(!is_a($question->fields['type'], QuestionTypeItem::class, true)) {
+            return null;
+        }
+
         $itemtype = (new ($question->fields['type'])())->getDefaultValueItemtype($question);
         if ($itemtype === null) {
             return null;

--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -115,6 +115,14 @@ trait TagConversionTrait
                 $provider = new ItemPropertyTagProvider();
                 $new_tag = $provider->getTagFromRawValue($question_id . ':' . $search_option_id);
                 if ($new_tag === null) {
+                    $migration->addMessageToResult(
+                        MessageType::Warning,
+                        sprintf(
+                            __('Formcreator migration: cannot convert legacy tag "%s" tag of question "%s".'),
+                            $tag,
+                            $question->fields['name']
+                        )
+                    );
                     continue;
                 }
 
@@ -160,6 +168,7 @@ trait TagConversionTrait
 
     /**
      * Resolves a Formcreator property name to the corresponding search option ID for a given question.
+     * If the resolving fails, a warning message describing the failure is added to the migration result object.
      *
      * @param Question $question The question object
      * @param string $property_name The property name to resolve
@@ -221,9 +230,9 @@ trait TagConversionTrait
         }
 
         // Find the search option ID corresponding to the field name
-        $options = SearchOption::getOptionsForItemtype($itemtype);
+        $options = SearchOption::getOptionsForItemtype($itemtype, true, false);
         foreach ($options as $id => $option) {
-            if (is_int($id) && ($option['field'] ?? null) === $field_name) {
+            if (is_int($id) && ($option['field'] ?? null) === $field_name && ($option['table'] ?? null) === $itemtype::getTable()) {
                 return $id;
             }
         }

--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -169,12 +169,12 @@ trait TagConversionTrait
         Question $question,
         string $property_name
     ): ?int {
-        if(!is_a($question->fields['type'], QuestionTypeItem::class, true)) {
+        if (!is_a($question->fields['type'], QuestionTypeItem::class, true)) {
             return null;
         }
 
         $itemtype = (new ($question->fields['type'])())->getDefaultValueItemtype($question);
-        if ($itemtype === null) {
+        if ($itemtype === null || !is_a($itemtype, \CommonDBTM::class, true)) {
             return null;
         }
 

--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -39,6 +39,7 @@ use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\ItemPropertyTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
+use Glpi\Message\MessageType;
 use Glpi\Search\SearchOption;
 
 use function Safe\preg_match_all;
@@ -106,7 +107,7 @@ trait TagConversionTrait
                 }
 
                 // Resolve the FormCreator property name to a search option ID
-                $search_option_id = self::resolveFormcreatorPropertyToSearchOptionId($question, $property_name);
+                $search_option_id = self::resolveFormcreatorPropertyToSearchOptionId($question, $property_name, $migration);
                 if ($search_option_id === null) {
                     continue;
                 }
@@ -162,18 +163,38 @@ trait TagConversionTrait
      *
      * @param Question $question The question object
      * @param string $property_name The property name to resolve
+     * @param FormMigration $migration Migration object for ID mapping
      * @return int|null The corresponding search option ID, or null if not found
      */
     private static function resolveFormcreatorPropertyToSearchOptionId(
         Question $question,
-        string $property_name
+        string $property_name,
+        FormMigration $migration
     ): ?int {
         if (!is_a($question->fields['type'], QuestionTypeItem::class, true)) {
+            $migration->addMessageToResult(
+                MessageType::Warning,
+                sprintf(
+                    __('Formcreator migration: cannot convert the property "%s" tag of question "%s" because it\'s '
+                        . 'not an Item question.'),
+                    $property_name,
+                    $question->fields['name'],
+                )
+            );
             return null;
         }
 
         $itemtype = (new ($question->fields['type'])())->getDefaultValueItemtype($question);
         if ($itemtype === null || !is_a($itemtype, \CommonDBTM::class, true)) {
+            $migration->addMessageToResult(
+                MessageType::Warning,
+                sprintf(
+                    __('Formcreator migration: cannot convert the property "%s" tag of question "%s" because the Itemtype of '
+                    . 'the question is not a valid CommonDBTM.'),
+                    $property_name,
+                    $question->fields['name'],
+                )
+            );
             return null;
         }
 
@@ -183,10 +204,13 @@ trait TagConversionTrait
             ?? null;
 
         if ($field_name === null) {
-            // Log a warning about the unknown property
-            trigger_error(
-                sprintf('Formcreator migration: unknown property "%s" for %s', $property_name, $itemtype),
-                E_USER_WARNING
+            $migration->addMessageToResult(
+                MessageType::Warning,
+                sprintf(
+                    __('Formcreator migration: unknown property "%s" for %s'),
+                    $property_name,
+                    $itemtype
+                )
             );
             return null;
         }
@@ -204,6 +228,14 @@ trait TagConversionTrait
             }
         }
 
+        $migration->addMessageToResult(
+            MessageType::Warning,
+            sprintf(
+                __('Formcreator migration: cannot convert the property "%s" tag of question "%s"'),
+                $property_name,
+                $question->fields['name']
+            )
+        );
         return null;
     }
 

--- a/src/Glpi/Form/Migration/TagConversionTrait.php
+++ b/src/Glpi/Form/Migration/TagConversionTrait.php
@@ -39,7 +39,6 @@ use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\ItemPropertyTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
-use Glpi\Form\Tag\Tag;
 use Glpi\Search\SearchOption;
 
 use function Safe\preg_match_all;
@@ -113,11 +112,11 @@ trait TagConversionTrait
                 }
 
                 $provider = new ItemPropertyTagProvider();
-                $new_tag = new Tag(
-                    label: sprintf(__('Answer: %1$s › %2$s'), $question->fields['name'], '...'),
-                    value: $question_id . ':' . $search_option_id,
-                    provider: $provider,
-                );
+                $new_tag = $provider->getTagFromRawValue($question_id . ':' . $search_option_id);
+                if ($new_tag === null) {
+                    continue;
+                }
+
                 $content = str_replace("##$tag##", $new_tag->html, $content);
                 continue;
             }

--- a/src/Glpi/Form/Tag/CompositeTagValueInterface.php
+++ b/src/Glpi/Form/Tag/CompositeTagValueInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Tag;
+
+interface CompositeTagValueInterface
+{
+    /**
+     * Extracts the ID to be remapped from the composite value.
+     * Ex : "5:1" → "5"
+     *
+     * @param string $value The composite value
+     * @return string The ID to be remapped
+     */
+    public function extractItemIdFromValue(string $value): string;
+
+    /**
+     * Rebuilds the composite value with a new ID.
+     * Ex : ("5:1", "10") → "10:1"
+     *
+     * @param string $value The composite value
+     * @param string $new_id The new ID to replace the old one
+     * @return string The rebuilt composite value
+     */
+    public function rebuildValueWithMappedId(string $value, string $new_id): string;
+}

--- a/src/Glpi/Form/Tag/CompositeTagValueInterface.php
+++ b/src/Glpi/Form/Tag/CompositeTagValueInterface.php
@@ -34,7 +34,7 @@
 
 namespace Glpi\Form\Tag;
 
-interface CompositeTagValueInterface
+interface CompositeTagValueInterface extends TagWithIdValueInterface
 {
     /**
      * Extracts the ID to be remapped from the composite value.

--- a/src/Glpi/Form/Tag/FormTagsManager.php
+++ b/src/Glpi/Form/Tag/FormTagsManager.php
@@ -140,6 +140,7 @@ final class FormTagsManager
             new CommentTitleTagProvider(),
             new CommentDescriptionTagProvider(),
             new FullFormTagProvider(),
+            new ItemPropertyTagProvider(),
         ]);
     }
 
@@ -147,6 +148,7 @@ final class FormTagsManager
         string $subject,
         MapperInterface $mapper
     ): string {
+
         foreach ($this->getTagProviders() as $tag_provider) {
             if (!$tag_provider instanceof TagWithIdValueInterface) {
                 // This tag value do not reference and ID, we can skip it
@@ -154,6 +156,23 @@ final class FormTagsManager
             }
             $provider_class = preg_quote($tag_provider::class);
             $mapped_class = $tag_provider->getItemtype();
+
+            if ($tag_provider instanceof CompositeTagValueInterface) {
+                $subject = preg_replace_callback(
+                    "/data-form-tag-value=\"([^\"]+)\" "
+                    . "data-form-tag-provider=\"$provider_class\"/",
+                    fn($match) => preg_replace(
+                        "/value=\"([^\"]+)/",
+                        "value=\"" . $tag_provider->rebuildValueWithMappedId(
+                            $match[1],
+                            (string) $mapper->getItemId($mapped_class, $tag_provider->extractItemIdFromValue($match[1]))
+                        ),
+                        $match[0]
+                    ),
+                    $subject,
+                );
+                continue;
+            }
 
             $subject = preg_replace_callback(
                 // Look for the value + provider properties

--- a/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
+++ b/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Tag;
+
+use CommonDBTM;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Form;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Search\SearchOption;
+use Override;
+
+final class ItemPropertyTagProvider implements TagProviderInterface, TagWithIdValueInterface, CompositeTagValueInterface
+{
+    public const SEPARATOR = ':';
+    public const USER_EMAILS_PSEUDO_ID = -1;
+
+    #[Override]
+    public function getTagColor(): string
+    {
+        return "cyan";
+    }
+
+    #[Override]
+    public function getItemtype(): string
+    {
+        return Question::class;
+    }
+
+    #[Override]
+    public function getTags(Form $form): array
+    {
+        $tags = [];
+        foreach ($form->getQuestions() as $question) {
+            if (!$this->isItemQuestion($question)) {
+                continue;
+            }
+            foreach ($this->getPropertiesForQuestion($question) as $option_id => $option_label) {
+                $tags[] = new Tag(
+                    label: sprintf(__('Answer: %1$s › %2$s'), $question->fields['name'], $option_label),
+                    value: $question->getId() . self::SEPARATOR . $option_id,
+                    provider: $this,
+                );
+            }
+        }
+        return $tags;
+    }
+
+    #[Override]
+    public function getTagFromRawValue(string $value): ?Tag
+    {
+        [$question_id, $option_id] = $this->parseValue($value);
+        $question = Question::getById($question_id);
+        if (!$question || !$this->isItemQuestion($question)) {
+            return null;
+        }
+        $properties = $this->getPropertiesForQuestion($question);
+        if (!isset($properties[$option_id])) {
+            return null;
+        }
+        return new Tag(
+            label: sprintf(__('Answer: %1$s › %2$s'), $question->fields['name'], $properties[$option_id]),
+            value: $value,
+            provider: $this,
+        );
+    }
+
+    #[Override]
+    public function getTagContentForValue(string $value, AnswersSet $answers_set): string
+    {
+        [$question_id, $option_id] = $this->parseValue($value);
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($answer === null) {
+            return '';
+        }
+
+        $raw = $answer->getRawAnswer();
+        if (!is_array($raw) || empty($raw['itemtype']) || empty($raw['items_ids'])) {
+            return '';
+        }
+
+        if (!is_array($raw['items_ids'])) {
+            $raw['items_ids'] = [$raw['items_ids']];
+        }
+
+        $itemtype = $raw['itemtype'];
+        $field_vlaues = [];
+        foreach ($raw['items_ids'] as $item_id) {
+            $item = $itemtype::getById((int) $item_id);
+            if (!$item) {
+                return '';
+            }
+            $field_vlaues[] = $this->resolveProperty($item, $itemtype, $option_id);
+        }
+
+        return implode(', ', $field_vlaues);
+    }
+
+    #[Override]
+    public function extractItemIdFromValue(string $value): string
+    {
+        return (string) $this->parseValue($value)[0];
+    }
+
+    #[Override]
+    public function rebuildValueWithMappedId(string $value, string $new_id): string
+    {
+        $parts = $this->parseValue($value);
+        return $new_id . self::SEPARATOR . $parts[1];
+    }
+
+    // --- private helpers ---
+
+    private function isItemQuestion(Question $question): bool
+    {
+        $type = $question->fields['type'];
+        return is_a($type, QuestionTypeItem::class, true);
+    }
+
+    /**
+     * Return available properties for a question.
+     * Only simple properties are returned,(main table, scalar field) and documented special cases (ex: User emails).
+     *
+     * @return array<int, string>  [search_option_id => translated label]
+     */
+    private function getPropertiesForQuestion(Question $question): array
+    {
+        if (!is_a($question->fields['type'], QuestionTypeItem::class, true)) {
+            return [];
+        }
+
+        $itemtype = (new ($question->fields['type'])())->getDefaultValueItemtype($question);
+        if ($itemtype === null || !class_exists($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {
+            return [];
+        }
+
+        $options = SearchOption::getOptionsForItemtype($itemtype);
+        $properties = [];
+
+        foreach ($options as $id => $option) {
+            if (!is_int($id) || $id === 0) {
+                continue;
+            }
+            // keep only options of the main table, with a scalar field.
+            if (
+                !isset($option['table'], $option['field'], $option['name'])
+                || $option['table'] !== $itemtype::getTable()
+                || isset($option['nosearch'])
+                || isset($option['nodisplay'])
+                || str_contains($option['field'], '.')
+            ) {
+                continue;
+            }
+
+            $allowed_types = [
+                'string', 'text', 'longtext',
+                'integer', 'number', 'decimal', 'float',
+                'bool', 'itemlink',
+                'date', 'datetime',
+                'email', 'ip', 'mac', 'weblink',
+                'right',
+            ];
+            if (isset($option['datatype']) && !in_array($option['datatype'], $allowed_types, true)) {
+                continue;
+            }
+            $properties[$id] = $option['name'];
+        }
+
+        if (is_a($itemtype, \User::class, true)) {
+            $properties[self::USER_EMAILS_PSEUDO_ID] = __('Email addresses');
+        }
+
+        return $properties;
+    }
+
+    private function resolveProperty(CommonDBTM $item, string $itemtype, int $option_id): string
+    {
+        // special case for user emails, as they are not a real property.
+        if ($item instanceof \User && $option_id === self::USER_EMAILS_PSEUDO_ID) {
+            return implode(', ', \UserEmail::getAllForUser($item->getID()));
+        }
+
+        if (!is_a($itemtype, CommonDBTM::class, true)) {
+            return '';
+        }
+
+        $options = SearchOption::getOptionsForItemtype($itemtype);
+        $option = $options[$option_id] ?? null;
+        if ($option === null) {
+            return '';
+        }
+
+        $field = $option['field'];
+        $value = $item->fields[$field] ?? null;
+
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        // Convert the value to a readable string based on its datatype
+        $datatype = $option['datatype'] ?? 'string';
+        return match ($datatype) {
+            'bool'     => $value ? __('Yes') : __('No'),
+            'datetime' => \Html::convDateTime($value) ?? (string) $value,
+            'date'     => \Html::convDate($value) ?? (string) $value,
+            default    => (string) $value,
+        };
+    }
+
+    /** @return array{0: int, 1: int} */
+    private function parseValue(string $value): array
+    {
+        $parts = explode(self::SEPARATOR, $value, 2);
+        return [(int) ($parts[0] ?? 0), (int) ($parts[1] ?? 0)];
+    }
+}

--- a/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
+++ b/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
@@ -117,13 +117,21 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
         }
 
         $itemtype = $raw['itemtype'];
+        if (!is_string($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {
+            return '';
+        }
+
         $field_values = [];
         foreach ($raw['items_ids'] as $item_id) {
             $item = $itemtype::getById((int) $item_id);
             if (!$item) {
                 continue;
             }
-            $field_values[] = $this->resolveProperty($item, $itemtype, $option_id);
+            $value = $this->resolveProperty($item, $itemtype, $option_id);
+            if ($value === '') {
+                continue;
+            }
+            $field_values[] = $value;
         }
 
         return implode(', ', $field_values);
@@ -183,7 +191,7 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
             return [];
         }
 
-        $options = SearchOption::getOptionsForItemtype($itemtype);
+        $options = SearchOption::getOptionsForItemtype($itemtype, true, false);
         $allowed_types = $this->getAllowedDataTypes();
         $properties = [];
 
@@ -226,7 +234,7 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
             return '';
         }
 
-        $options = SearchOption::getOptionsForItemtype($itemtype);
+        $options = SearchOption::getOptionsForItemtype($itemtype, true, false);
         $option = $options[$option_id] ?? null;
         if ($option === null) {
             return '';

--- a/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
+++ b/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
@@ -117,16 +117,16 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
         }
 
         $itemtype = $raw['itemtype'];
-        $field_vlaues = [];
+        $field_values = [];
         foreach ($raw['items_ids'] as $item_id) {
             $item = $itemtype::getById((int) $item_id);
             if (!$item) {
                 continue;
             }
-            $field_vlaues[] = $this->resolveProperty($item, $itemtype, $option_id);
+            $field_values[] = $this->resolveProperty($item, $itemtype, $option_id);
         }
 
-        return implode(', ', $field_vlaues);
+        return implode(', ', $field_values);
     }
 
     #[Override]

--- a/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
+++ b/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
@@ -42,7 +42,7 @@ use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Search\SearchOption;
 use Override;
 
-final class ItemPropertyTagProvider implements TagProviderInterface, TagWithIdValueInterface, CompositeTagValueInterface
+final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTagValueInterface
 {
     public const SEPARATOR = ':';
     public const USER_EMAILS_PSEUDO_ID = -1;
@@ -121,7 +121,7 @@ final class ItemPropertyTagProvider implements TagProviderInterface, TagWithIdVa
         foreach ($raw['items_ids'] as $item_id) {
             $item = $itemtype::getById((int) $item_id);
             if (!$item) {
-                return '';
+                continue;
             }
             $field_vlaues[] = $this->resolveProperty($item, $itemtype, $option_id);
         }

--- a/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
+++ b/src/Glpi/Form/Tag/ItemPropertyTagProvider.php
@@ -142,6 +142,22 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
         return $new_id . self::SEPARATOR . $parts[1];
     }
 
+    /**
+     * Returns the list of allowed data types for item properties that can be used in tags.
+     *
+     * @return array<int, string> */
+    public function getAllowedDataTypes(): array
+    {
+        return [
+            'string', 'text', 'longtext',
+            'integer', 'number', 'decimal', 'float',
+            'bool', 'itemlink',
+            'date', 'datetime',
+            'email', 'ip', 'mac', 'weblink',
+            'right',
+        ];
+    }
+
     // --- private helpers ---
 
     private function isItemQuestion(Question $question): bool
@@ -168,6 +184,7 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
         }
 
         $options = SearchOption::getOptionsForItemtype($itemtype);
+        $allowed_types = $this->getAllowedDataTypes();
         $properties = [];
 
         foreach ($options as $id => $option) {
@@ -185,14 +202,6 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
                 continue;
             }
 
-            $allowed_types = [
-                'string', 'text', 'longtext',
-                'integer', 'number', 'decimal', 'float',
-                'bool', 'itemlink',
-                'date', 'datetime',
-                'email', 'ip', 'mac', 'weblink',
-                'right',
-            ];
             if (isset($option['datatype']) && !in_array($option['datatype'], $allowed_types, true)) {
                 continue;
             }
@@ -220,6 +229,11 @@ final class ItemPropertyTagProvider implements TagProviderInterface, CompositeTa
         $options = SearchOption::getOptionsForItemtype($itemtype);
         $option = $options[$option_id] ?? null;
         if ($option === null) {
+            return '';
+        }
+
+        $allowed_types = $this->getAllowedDataTypes();
+        if (isset($option['datatype']) && !in_array($option['datatype'], $allowed_types, true)) {
             return '';
         }
 

--- a/src/Glpi/Migration/AbstractPluginMigration.php
+++ b/src/Glpi/Migration/AbstractPluginMigration.php
@@ -709,6 +709,14 @@ abstract class AbstractPluginMigration
     }
 
     /**
+     * Add a message to the result object.
+     */
+    final public function addMessageToResult(MessageType $type, string $message): void
+    {
+        $this->result->addMessage($type, $message);
+    }
+
+    /**
      * Add the session messages from the session to the result object.
      * Transfered messages will be removed from the session, to prevent output duplicates.
      */

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -96,7 +96,6 @@ use Group;
 use ITILCategory;
 use Location;
 use LogicException;
-use Monolog\Logger;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1231,12 +1230,11 @@ final class FormMigrationTest extends DbTestCase
             'rawContent'                => 'Unknown: ##answer_9997.unknown##',
             'expectedPatternForTitle'   => '/^Unknown: ##answer_9997.unknown##$/',
             'expectedPatternForContent' => '/^Unknown: ##answer_9997.unknown##$/',
-            'emptyLogs'                 => true,  // expect a log entry for this case, but we don't want to fail the test in GLPITestCase::tearDown()
         ];
     }
 
     #[DataProvider('provideFormMigrationTagConversion')]
-    public function testFormMigrationTagConversion(string $rawContent, string $expectedPatternForTitle, string $expectedPatternForContent, bool $emptyLogs = false): void
+    public function testFormMigrationTagConversion(string $rawContent, string $expectedPatternForTitle, string $expectedPatternForContent): void
     {
         global $DB;
 
@@ -1341,12 +1339,6 @@ final class FormMigrationTest extends DbTestCase
             $expectedPatternForContent,
             $content_config->getValue()
         );
-
-        if ($emptyLogs) {
-            /** @var Logger $PHPLOGGER */
-            global $PHPLOGGER;
-            $PHPLOGGER->reset();
-        }
     }
 
     public function testFormMigrationWithRadioQuestion(): void

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -1182,13 +1182,35 @@ final class FormMigrationTest extends DbTestCase
         yield 'FULLFORM placeholder' => [
             'rawContent'                => '##FULLFORM##',
             'expectedPatternForTitle'   => '/##FULLFORM##/',
-            'expectedPatternForContent' => '/<p><b>1\) <span[^>]*>#Question: Question for tag tests 1<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 1<\/span><br><b>2\) <span[^>]*>#Question: Question for tag tests 2<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 2<\/span><br><\/p>/',
+            'expectedPatternForContent' => '/<p>'
+                                                . '<b>1\) <span[^>]*>#Question: Question for tag tests 1<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 1<\/span><br>'
+                                                . '<b>2\) <span[^>]*>#Question: Question for tag tests 2<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 2<\/span><br>'
+                                                . '<b>3\) <span[^>]*>#Question: Question for tag tests 3<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 3<\/span><br>'
+                                            . '<\/p>/',
         ];
 
         yield 'No tags' => [
             'rawContent'                => 'Plain text without any tags',
             'expectedPatternForTitle' => '/^Plain text without any tags$/',
             'expectedPatternForContent' => '/^Plain text without any tags$/',
+        ];
+
+        yield 'Property tag on a non "GLPI Object" question is left untouched' => [
+            'rawContent'                => 'NonItem: ##answer_9998.serial##',
+            'expectedPatternForTitle'   => '/^NonItem: ##answer_9998\.serial##$/',
+            'expectedPatternForContent' => '/^NonItem: ##answer_9998\.serial##$/',
+        ];
+
+        yield 'Property tag on a "GLPI Object" question (simple field)' => [
+            'rawContent'                => 'Serial: ##answer_9996.serial##',
+            'expectedPatternForTitle'   => '/Serial: <span[^>]*>#Answer: Question for tag tests 3 › Serial number<\/span>/',
+            'expectedPatternForContent' => '/Serial: <span[^>]*>#Answer: Question for tag tests 3 › Serial number<\/span>/',
+        ];
+
+        yield 'Property tag on a "GLPI Object" question (generic field)' => [
+            'rawContent'                => 'Name: ##answer_9996.name##',
+            'expectedPatternForTitle'   => '/Name: <span[^>]*>#Answer: Question for tag tests 3 › Name<\/span>/',
+            'expectedPatternForContent' => '/Name: <span[^>]*>#Answer: Question for tag tests 3 › Name<\/span>/',
         ];
     }
 
@@ -1233,6 +1255,20 @@ final class FormMigrationTest extends DbTestCase
                 'plugin_formcreator_sections_id' => $section_id,
                 'name'                           => 'Question for tag tests 2',
                 'row'                            => 1,
+            ]
+        ));
+
+        // A "GLPI Object" question (fieldtype "glpiselect"), migrated into a
+        // `QuestionTypeItem` question so that its properties can be resolved.
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'id'                             => 9996,                         // Fixed ID to match our test tags
+                'plugin_formcreator_sections_id' => $section_id,
+                'name'                           => 'Question for tag tests 3',
+                'fieldtype'                      => 'glpiselect',
+                'itemtype'                       => 'Computer',
+                'row'                            => 2,
             ]
         ));
 

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -96,6 +96,7 @@ use Group;
 use ITILCategory;
 use Location;
 use LogicException;
+use Monolog\Logger;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -1186,6 +1187,7 @@ final class FormMigrationTest extends DbTestCase
                                                 . '<b>1\) <span[^>]*>#Question: Question for tag tests 1<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 1<\/span><br>'
                                                 . '<b>2\) <span[^>]*>#Question: Question for tag tests 2<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 2<\/span><br>'
                                                 . '<b>3\) <span[^>]*>#Question: Question for tag tests 3<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 3<\/span><br>'
+                                                . '<b>4\) <span[^>]*>#Question: Question for tag tests 4<\/span><\/b>: <span[^>]*>#Answer: Question for tag tests 4<\/span><br>'
                                             . '<\/p>/',
         ];
 
@@ -1212,10 +1214,29 @@ final class FormMigrationTest extends DbTestCase
             'expectedPatternForTitle'   => '/Name: <span[^>]*>#Answer: Question for tag tests 3 › Name<\/span>/',
             'expectedPatternForContent' => '/Name: <span[^>]*>#Answer: Question for tag tests 3 › Name<\/span>/',
         ];
+
+        yield 'Property tag on a User question (simple field)' => [
+            'rawContent'                => 'Email: ##answer_9997.login##',
+            'expectedPatternForTitle'   => '/Email: <span[^>]*>#Answer: Question for tag tests 4 › Login<\/span>/',
+            'expectedPatternForContent' => '/Email: <span[^>]*>#Answer: Question for tag tests 4 › Login<\/span>/',
+        ];
+
+        yield 'Email tag on a User question' => [
+            'rawContent'                => 'Email: ##answer_9997.email##',
+            'expectedPatternForTitle'   => '/Email: <span[^>]*>#Answer: Question for tag tests 4 › Email addresses<\/span>/',
+            'expectedPatternForContent' => '/Email: <span[^>]*>#Answer: Question for tag tests 4 › Email addresses<\/span>/',
+        ];
+
+        yield 'Unknown property tag tag on a User question' => [
+            'rawContent'                => 'Unknown: ##answer_9997.unknown##',
+            'expectedPatternForTitle'   => '/^Unknown: ##answer_9997.unknown##$/',
+            'expectedPatternForContent' => '/^Unknown: ##answer_9997.unknown##$/',
+            'emptyLogs'                 => true,  // expect a log entry for this case, but we don't want to fail the test in GLPITestCase::tearDown()
+        ];
     }
 
     #[DataProvider('provideFormMigrationTagConversion')]
-    public function testFormMigrationTagConversion(string $rawContent, string $expectedPatternForTitle, string $expectedPatternForContent): void
+    public function testFormMigrationTagConversion(string $rawContent, string $expectedPatternForTitle, string $expectedPatternForContent, bool $emptyLogs = false): void
     {
         global $DB;
 
@@ -1258,7 +1279,7 @@ final class FormMigrationTest extends DbTestCase
             ]
         ));
 
-        // A "GLPI Object" question (fieldtype "glpiselect"), migrated into a
+        // "GLPI Object" questions (fieldtype "glpiselect"), migrated into a
         // `QuestionTypeItem` question so that its properties can be resolved.
         $this->assertTrue($DB->insert(
             'glpi_plugin_formcreator_questions',
@@ -1269,6 +1290,18 @@ final class FormMigrationTest extends DbTestCase
                 'fieldtype'                      => 'glpiselect',
                 'itemtype'                       => 'Computer',
                 'row'                            => 2,
+            ]
+        ));
+
+        $this->assertTrue($DB->insert(
+            'glpi_plugin_formcreator_questions',
+            [
+                'id'                             => 9997,                         // Fixed ID to match our test tags
+                'plugin_formcreator_sections_id' => $section_id,
+                'name'                           => 'Question for tag tests 4',
+                'fieldtype'                      => 'glpiselect',
+                'itemtype'                       => 'User',
+                'row'                            => 3,
             ]
         ));
 
@@ -1308,6 +1341,12 @@ final class FormMigrationTest extends DbTestCase
             $expectedPatternForContent,
             $content_config->getValue()
         );
+
+        if ($emptyLogs) {
+            /** @var Logger $PHPLOGGER */
+            global $PHPLOGGER;
+            $PHPLOGGER->reset();
+        }
     }
 
     public function testFormMigrationWithRadioQuestion(): void

--- a/tests/functional/Glpi/Form/Tag/FormTagsManagerTest.php
+++ b/tests/functional/Glpi/Form/Tag/FormTagsManagerTest.php
@@ -34,8 +34,12 @@
 
 namespace tests\units\Glpi\Form\Tag;
 
+use Computer;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Form;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Form\Tag\AnswerTagProvider;
 use Glpi\Form\Tag\CommentDescriptionTagProvider;
@@ -43,12 +47,18 @@ use Glpi\Form\Tag\CommentTitleTagProvider;
 use Glpi\Form\Tag\FormTagProvider;
 use Glpi\Form\Tag\FormTagsManager;
 use Glpi\Form\Tag\FullFormTagProvider;
+use Glpi\Form\Tag\ItemPropertyTagProvider;
 use Glpi\Form\Tag\QuestionTagProvider;
 use Glpi\Form\Tag\SectionTagProvider;
 use Glpi\Form\Tag\Tag;
 use Glpi\Tests\DbTestCase;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use Glpi\Toolbox\MapperInterface;
+use LogicException;
+
+use function Safe\json_encode;
+use function Safe\preg_match;
 
 final class FormTagsManagerTest extends DbTestCase
 {
@@ -289,6 +299,63 @@ final class FormTagsManagerTest extends DbTestCase
         // Assert: the tag label was updated
         $this->assertStringNotContainsString("My form name", $new_html);
         $this->assertStringContainsString("My new form name", $new_html);
+    }
+
+    public function testReplaceIdsInTagsRemapsCompositeTagValue(): void
+    {
+        // Arrange: a form with an item question, and the tag referencing one
+        // of its properties.
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: 'Asset',
+                type: QuestionTypeItem::class,
+                extra_data: json_encode(
+                    (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                ),
+            )
+        );
+        $question_id = $this->getQuestionId($form, 'Asset');
+
+        $tags = (new ItemPropertyTagProvider())->getTags($form);
+        $this->assertNotEmpty($tags);
+        $tag = $tags[0];
+
+        [$original_question_id, $option_id] = explode(ItemPropertyTagProvider::SEPARATOR, $this->extractTagValue($tag->html), 2);
+        $this->assertEquals($question_id, (int) $original_question_id);
+
+        // Act: replace ids using a mapper that maps the question to a new id.
+        $new_question_id = $question_id + 1000;
+        $mapper = new class ($question_id, $new_question_id) implements MapperInterface {
+            public function __construct(
+                private int $old_id,
+                private int $new_id,
+            ) {}
+
+            public function addMappedItem(string $itemtype, string|int $key, int $id): void
+            {
+                // Not needed for this test.
+            }
+
+            public function getItemId(string $itemtype, string|int $key): int
+            {
+                if ($itemtype === Question::class && (int) $key === $this->old_id) {
+                    return $this->new_id;
+                }
+                throw new LogicException("Unexpected mapper lookup: $itemtype::$key");
+            }
+        };
+        $new_html = (new FormTagsManager())->replaceIdsInTags($tag->html, $mapper);
+
+        // Assert: the question id was remapped, the option id was preserved.
+        [$new_value_question_id, $new_value_option_id] = explode(':', $this->extractTagValue($new_html), 2);
+        $this->assertEquals($new_question_id, (int) $new_value_question_id);
+        $this->assertEquals($option_id, $new_value_option_id);
+    }
+
+    private function extractTagValue(string $html): string
+    {
+        preg_match('/data-form-tag-value="([^"]+)"/', $html, $matches);
+        return $matches[1] ?? '';
     }
 
     private function createAndGetFormWithFirstAndLastNameQuestions(): Form

--- a/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
@@ -123,7 +123,7 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         // Every exposed property must belong to the main itemtype table,
         // not to a joined table (ex: manufacturer name, location name, ...),
         // and must be an allowed data type (ex: no password, no image, ...).
-        $options = SearchOption::getOptionsForItemtype($item_type);
+        $options = SearchOption::getOptionsForItemtype($item_type, true, false);
         foreach ($tags as $tag) {
             $this->assertInstanceOf(Tag::class, $tag);
 
@@ -314,7 +314,7 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         // Test with blacklisted properties
         $allowed_types = $item_property_tag_provider->getAllowedDataTypes();
         $black_listed_search_options = array_filter(
-            SearchOption::getOptionsForItemtype(User::class),
+            SearchOption::getOptionsForItemtype(User::class, true, false),
             fn($option) => isset($option['datatype']) && !in_array($option['datatype'], $allowed_types, true)
         );
 
@@ -360,7 +360,7 @@ final class ItemPropertyTagProviderTest extends DbTestCase
 
     private function getSearchOptionId(string $itemtype, string $field): int
     {
-        foreach (SearchOption::getOptionsForItemtype($itemtype) as $id => $option) {
+        foreach (SearchOption::getOptionsForItemtype($itemtype, true, false) as $id => $option) {
             if (
                 is_int($id)
                 && ($option['field'] ?? null) === $field

--- a/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
@@ -114,11 +114,15 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         );
         $question_id = $this->getQuestionId($form, 'Q1');
 
-        $tags = (new ItemPropertyTagProvider())->getTags($form);
+        $item_property_tag_provider = new ItemPropertyTagProvider();
+        $tags = $item_property_tag_provider->getTags($form);
         $this->assertNotEmpty($tags);
 
+        $allowed_type = $item_property_tag_provider->getAllowedDataTypes();
+
         // Every exposed property must belong to the main itemtype table,
-        // not to a joined table (ex: manufacturer name, location name, ...).
+        // not to a joined table (ex: manufacturer name, location name, ...),
+        // and must be an allowed data type (ex: no password, no image, ...).
         $options = SearchOption::getOptionsForItemtype($item_type);
         foreach ($tags as $tag) {
             $this->assertInstanceOf(Tag::class, $tag);
@@ -133,6 +137,7 @@ final class ItemPropertyTagProviderTest extends DbTestCase
             } else {
                 $this->assertArrayHasKey($option_id, $options);
                 $this->assertSame($item_type::getTable(), $options[$option_id]['table']);
+                $this->assertContains($options[$option_id]['datatype'] ?? 'string', $allowed_type);
             }
         }
 
@@ -161,7 +166,6 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         $tag = $item_property_tag_provider->getTagFromRawValue('not-a-value');
         $this->assertNull($tag);
 
-
         $form = $this->createForm(
             (new FormBuilder())->addQuestion('Comments', QuestionTypeShortText::class)
         );
@@ -169,12 +173,10 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:1");
         $this->assertNull($tag);
 
-        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        [, $question_id] = $this->createFormWithQuestion(Computer::class, 'Asset');
         $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:999999");
         $this->assertNull($tag);
 
-
-        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
         $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
         $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:$serial_option_id");
 
@@ -182,12 +184,12 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         $this->assertEquals("$question_id:$serial_option_id", $this->getTagValue($tag));
     }
 
-    public function testGetTagContentForValue(): void
+    public function testGetTagContentForValueWithSimpleQuestion(): void
     {
         $item_property_tag_provider = new ItemPropertyTagProvider();
 
         // Test with empty answer -> empty
-        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        [$form, $question_id] = $this->createFormWithQuestion(Computer::class, 'Asset');
         $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
         $this->assertEquals(
             '',
@@ -207,7 +209,6 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         );
 
         // Test with valid tag value and answer
-        [$form, $question_id] = $this->createFormWithComputerQuestion('Asset');
         $computer = $this->createItem(Computer::class, [
             'name'        => 'My computer',
             'serial'      => 'SN-1234',
@@ -229,6 +230,11 @@ final class ItemPropertyTagProviderTest extends DbTestCase
                 $answers
             )
         );
+    }
+
+    public function testGetTagContentForValueWithMultipleItemsAnswer(): void
+    {
+        $item_property_tag_provider = new ItemPropertyTagProvider();
 
         // Test with a multiple items answer
         $form = $this->createForm(
@@ -271,24 +277,23 @@ final class ItemPropertyTagProviderTest extends DbTestCase
                 $answers
             )
         );
+    }
 
+    public function testGetTagContentForValueWithSpecialProperties(): void
+    {
+        $item_property_tag_provider = new ItemPropertyTagProvider();
 
         // Test with the special "email addresses" pseudo-property
-        $form = $this->createForm(
-            (new FormBuilder())->addQuestion(
-                name: 'Requester asset',
-                type: QuestionTypeItem::class,
-                extra_data: json_encode(
-                    (new QuestionTypeItemExtraDataConfig(itemtype: User::class))->jsonSerialize()
-                ),
-            )
-        );
-        $question_id = $this->getQuestionId($form, 'Requester asset');
+        [$form, $question_id] = $this->createFormWithQuestion(User::class, 'Requester asset');
 
         $user = $this->createItem(User::class, ['name' => 'tag_provider_test_user']);
         $this->createItem(UserEmail::class, [
             'users_id' => $user->getID(),
             'email'    => 'primary@example.org',
+        ]);
+        $this->createItem(UserEmail::class, [
+            'users_id' => $user->getID(),
+            'email'    => 'secondary@example.org',
         ]);
 
         $answers = AnswersHandler::getInstance()->saveAnswers($form, [
@@ -299,12 +304,29 @@ final class ItemPropertyTagProviderTest extends DbTestCase
         ], 0);
 
         $this->assertEquals(
-            'primary@example.org',
+            'primary@example.org, secondary@example.org',
             $item_property_tag_provider->getTagContentForValue(
                 "$question_id:" . ItemPropertyTagProvider::USER_EMAILS_PSEUDO_ID,
                 $answers
             )
         );
+
+        // Test with blacklisted properties
+        $allowed_types = $item_property_tag_provider->getAllowedDataTypes();
+        $black_listed_search_options = array_filter(
+            SearchOption::getOptionsForItemtype(User::class),
+            fn($option) => isset($option['datatype']) && !in_array($option['datatype'], $allowed_types, true)
+        );
+
+        foreach ($black_listed_search_options as $id => $option) {
+            $this->assertEquals(
+                '',
+                $item_property_tag_provider->getTagContentForValue(
+                    "$question_id:$id",
+                    $answers
+                )
+            );
+        }
     }
 
     public function testExtractItemIdFromValue(): void
@@ -321,14 +343,14 @@ final class ItemPropertyTagProviderTest extends DbTestCase
     }
 
     /** @return array{0: Form, 1: int} */
-    private function createFormWithComputerQuestion(string $question_name): array
+    private function createFormWithQuestion(string $answer_itemtype, string $question_name): array
     {
         $form = $this->createForm(
             (new FormBuilder())->addQuestion(
                 name: $question_name,
                 type: QuestionTypeItem::class,
                 extra_data: json_encode(
-                    (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                    (new QuestionTypeItemExtraDataConfig(itemtype: $answer_itemtype))->jsonSerialize()
                 ),
             )
         );

--- a/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
+++ b/tests/functional/Glpi/Form/Tag/ItemPropertyTagProviderTest.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\Tag;
+
+use Computer;
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Form;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeItemExtraDataConfig;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Form\Tag\ItemPropertyTagProvider;
+use Glpi\Form\Tag\Tag;
+use Glpi\Search\SearchOption;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use Location;
+use PHPUnit\Framework\Attributes\DataProvider;
+use User;
+use UserEmail;
+
+use function Safe\json_encode;
+
+final class ItemPropertyTagProviderTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    public function testGetTagsForEmptyForm(): void
+    {
+        $form = $this->createForm(new FormBuilder());
+        $this->assertEquals([], (new ItemPropertyTagProvider())->getTags($form));
+    }
+
+    public function testGetTagsSkipsQuestionsThatAreNotItemQuestions(): void
+    {
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion('Comments', QuestionTypeShortText::class)
+        );
+
+        $this->assertEquals([], (new ItemPropertyTagProvider())->getTags($form));
+    }
+
+    public static function getTagsForItemQuestionReturnsScalarFieldsProvider(): array
+    {
+        return [
+            [
+                'question_type' => QuestionTypeItem::class,
+                'extra_data' => json_encode(
+                    (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                ),
+                'item_type' => Computer::class,
+            ],
+            [
+                'question_type' => QuestionTypeItemDropdown::class,
+                'extra_data' => json_encode(
+                    (new QuestionTypeItemDropdownExtraDataConfig(itemtype: Location::class))->jsonSerialize()
+                ),
+                'item_type' => Location::class,
+            ],
+            [
+                'question_type' => QuestionTypeItem::class,
+                'extra_data' => json_encode(
+                    (new QuestionTypeItemExtraDataConfig(itemtype: User::class))->jsonSerialize()
+                ),
+                'item_type' => User::class,
+            ],
+        ];
+    }
+
+    #[DataProvider('getTagsForItemQuestionReturnsScalarFieldsProvider')]
+    public function testGetTagsForItemQuestionReturnsScalarFields(string $question_type, string $extra_data, string $item_type): void
+    {
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: 'Q1',
+                type: $question_type,
+                extra_data: $extra_data,
+            )
+        );
+        $question_id = $this->getQuestionId($form, 'Q1');
+
+        $tags = (new ItemPropertyTagProvider())->getTags($form);
+        $this->assertNotEmpty($tags);
+
+        // Every exposed property must belong to the main itemtype table,
+        // not to a joined table (ex: manufacturer name, location name, ...).
+        $options = SearchOption::getOptionsForItemtype($item_type);
+        foreach ($tags as $tag) {
+            $this->assertInstanceOf(Tag::class, $tag);
+
+            [$tag_question_id, $option_id] = array_map('intval', explode(':', $this->getTagValue($tag), 2));
+            $this->assertSame($question_id, $tag_question_id);
+
+            // Special case for the "email addresses" pseudo-property for User itemtype
+            if ($option_id === ItemPropertyTagProvider::USER_EMAILS_PSEUDO_ID) {
+                $this->assertSame(User::class, $item_type);
+                continue;
+            } else {
+                $this->assertArrayHasKey($option_id, $options);
+                $this->assertSame($item_type::getTable(), $options[$option_id]['table']);
+            }
+        }
+
+        // Test a well known scalar property.
+        $name_option_id = $this->getSearchOptionId($item_type, 'name');
+        $this->assertNotNull($this->findTagByValue($tags, "$question_id:$name_option_id"));
+
+        // Check email tag for User itemtype
+        if (is_a($item_type, User::class, true)) {
+            $emails_tag = $this->findTagByValue($tags, $question_id . ':' . ItemPropertyTagProvider::USER_EMAILS_PSEUDO_ID);
+
+            $this->assertNotNull($emails_tag);
+            $this->assertEquals(
+                sprintf('Answer: %s › %s', 'Q1', 'Email addresses'),
+                $emails_tag->label,
+            );
+        }
+    }
+
+    public function testGetTagFromRawValue(): void
+    {
+        $item_property_tag_provider = new ItemPropertyTagProvider();
+        $tag = $item_property_tag_provider->getTagFromRawValue('999999:1');
+        $this->assertNull($tag);
+
+        $tag = $item_property_tag_provider->getTagFromRawValue('not-a-value');
+        $this->assertNull($tag);
+
+
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion('Comments', QuestionTypeShortText::class)
+        );
+        $question_id = $this->getQuestionId($form, 'Comments');
+        $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:1");
+        $this->assertNull($tag);
+
+        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:999999");
+        $this->assertNull($tag);
+
+
+        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
+        $tag = $item_property_tag_provider->getTagFromRawValue("$question_id:$serial_option_id");
+
+        $this->assertInstanceOf(Tag::class, $tag);
+        $this->assertEquals("$question_id:$serial_option_id", $this->getTagValue($tag));
+    }
+
+    public function testGetTagContentForValue(): void
+    {
+        $item_property_tag_provider = new ItemPropertyTagProvider();
+
+        // Test with empty answer -> empty
+        [, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
+        $this->assertEquals(
+            '',
+            $item_property_tag_provider->getTagContentForValue(
+                "$question_id:$serial_option_id",
+                $this->getEmptyAnswerSet()
+            )
+        );
+
+        // Test with unvalid tag value -> empty
+        $this->assertEquals(
+            '',
+            $item_property_tag_provider->getTagContentForValue(
+                'not-a-value',
+                $this->getEmptyAnswerSet()
+            )
+        );
+
+        // Test with valid tag value and answer
+        [$form, $question_id] = $this->createFormWithComputerQuestion('Asset');
+        $computer = $this->createItem(Computer::class, [
+            'name'        => 'My computer',
+            'serial'      => 'SN-1234',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $answers = AnswersHandler::getInstance()->saveAnswers($form, [
+            $question_id => [
+                'itemtype'  => Computer::class,
+                'items_ids' => [$computer->getID()],
+            ],
+        ], 0);
+
+        $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
+        $this->assertEquals(
+            'SN-1234',
+            $item_property_tag_provider->getTagContentForValue(
+                "$question_id:$serial_option_id",
+                $answers
+            )
+        );
+
+        // Test with a multiple items answer
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: 'Assets',
+                type: QuestionTypeItem::class,
+                extra_data: json_encode(
+                    (new QuestionTypeItemExtraDataConfig(
+                        itemtype: Computer::class,
+                        is_multiple_items: true,
+                    ))->jsonSerialize()
+                ),
+            )
+        );
+        $question_id = $this->getQuestionId($form, 'Assets');
+
+        $first_computer = $this->createItem(Computer::class, [
+            'name'        => 'First computer',
+            'serial'      => 'SN-FIRST',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $second_computer = $this->createItem(Computer::class, [
+            'name'        => 'Second computer',
+            'serial'      => 'SN-SECOND',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        $answers = AnswersHandler::getInstance()->saveAnswers($form, [
+            $question_id => [
+                'itemtype'  => Computer::class,
+                'items_ids' => [$first_computer->getID(), $second_computer->getID()],
+            ],
+        ], 0);
+
+        $serial_option_id = $this->getSearchOptionId(Computer::class, 'serial');
+        $this->assertEquals(
+            'SN-FIRST, SN-SECOND',
+            $item_property_tag_provider->getTagContentForValue(
+                "$question_id:$serial_option_id",
+                $answers
+            )
+        );
+
+
+        // Test with the special "email addresses" pseudo-property
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: 'Requester asset',
+                type: QuestionTypeItem::class,
+                extra_data: json_encode(
+                    (new QuestionTypeItemExtraDataConfig(itemtype: User::class))->jsonSerialize()
+                ),
+            )
+        );
+        $question_id = $this->getQuestionId($form, 'Requester asset');
+
+        $user = $this->createItem(User::class, ['name' => 'tag_provider_test_user']);
+        $this->createItem(UserEmail::class, [
+            'users_id' => $user->getID(),
+            'email'    => 'primary@example.org',
+        ]);
+
+        $answers = AnswersHandler::getInstance()->saveAnswers($form, [
+            $question_id => [
+                'itemtype'  => User::class,
+                'items_ids' => [$user->getID()],
+            ],
+        ], 0);
+
+        $this->assertEquals(
+            'primary@example.org',
+            $item_property_tag_provider->getTagContentForValue(
+                "$question_id:" . ItemPropertyTagProvider::USER_EMAILS_PSEUDO_ID,
+                $answers
+            )
+        );
+    }
+
+    public function testExtractItemIdFromValue(): void
+    {
+        $this->assertEquals('42', (new ItemPropertyTagProvider())->extractItemIdFromValue('42:7'));
+    }
+
+    public function testRebuildValueWithMappedId(): void
+    {
+        $this->assertEquals(
+            '99:7',
+            (new ItemPropertyTagProvider())->rebuildValueWithMappedId('42:7', '99'),
+        );
+    }
+
+    /** @return array{0: Form, 1: int} */
+    private function createFormWithComputerQuestion(string $question_name): array
+    {
+        $form = $this->createForm(
+            (new FormBuilder())->addQuestion(
+                name: $question_name,
+                type: QuestionTypeItem::class,
+                extra_data: json_encode(
+                    (new QuestionTypeItemExtraDataConfig(itemtype: Computer::class))->jsonSerialize()
+                ),
+            )
+        );
+
+        return [$form, $this->getQuestionId($form, $question_name)];
+    }
+
+    private function getSearchOptionId(string $itemtype, string $field): int
+    {
+        foreach (SearchOption::getOptionsForItemtype($itemtype) as $id => $option) {
+            if (
+                is_int($id)
+                && ($option['field'] ?? null) === $field
+                && ($option['table'] ?? null) === $itemtype::getTable()
+            ) {
+                return $id;
+            }
+        }
+
+        $this->fail("No search option found for field '$field' on '$itemtype'");
+    }
+
+    private function findTagByValue(array $tags, string $value): ?Tag
+    {
+        foreach ($tags as $tag) {
+            if ($this->getTagValue($tag) === $value) {
+                return $tag;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * `Tag::$value` is not exposed as a public property, it is only used to
+     * build the tag's HTML representation. Extract it back from there.
+     */
+    private function getTagValue(Tag $tag): string
+    {
+        preg_match('/data-form-tag-value="([^"]+)"/', $tag->html, $matches);
+        return $matches[1] ?? '';
+    }
+
+    private function getEmptyAnswerSet(): AnswersSet
+    {
+        $answers = new AnswersSet();
+        $answers->fields['answers'] = json_encode([]);
+        return $answers;
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] This change requires a documentation update.

## Description

- It fixes !45452 by implementing the specifications made for !43864.
- It Allows GLPI 11 form designers to insert tags into the ticket fields (title, content, etc.) that resolve to a specific property of the selected GLPI object in a “GLPI Object” (`QuestionTypeItem`) or “Dropdown” (`QuestionTypeItemDropdown`) question.
- Two small changes were made compared to the specifications : 
  - In the specifications, `ItemPropertyTagProvider::getTagContentForValue()` used the `item_id` key to retrieve the ID of the selected answer from the `AnswerSet`. This was incorrect because `AnswerSet::getRawAnswer()` returns the IDs using an `items_ids` key (to handle cases where multiple elements are selected). The implementation now iterates over this array and builds a string containing the values of all items whose IDs are present in the array.
  - In the specifications, `ItemPropertyTagProvider::getPropertiesForQuestion()` had a whitelist of allowed `datatypes` that did not contain the `itemlink` datatype. This was intended to eliminate properties coming from a table other than the one associated with the selected item type. However, some search options belonging to the item type's table use this datatype (for example, the `name` property of `User`). Filtering properties coming from another table is already handled earlier in the same function, so adding the `itemlink` datatype to the whitelist is safe. I therefore added it.

### Behavior 

In the form editor, for each `QuestionTypeItem` or `QuestionTypeItemDropdown` question, the tag selector (GLPI.RichText.FormTags component) now offers additional entries in the following format :
`# Answer: {question name} › {property}`

Example for a “Select a user” question of type `User`:

```
- # Answer: Select a user › Login
- # Answer: Select a user › First Name
- # Answer: Select a user › Email Addresses
```




