### PR TITLE
Fix global peripheral availability in asset connections

### DIFF
--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -311,7 +311,7 @@ final class Asset_PeripheralAsset extends CommonDBRelation
         foreach ($CFG_GLPI['directconnect_types'] as $itemtype) {
             if ($itemtype::canView()) {
                 $iterator = self::getPeripheralAssets($asset, $itemtype);
-                $usediterator = self::getUsedPeripherals($itemtype);
+                $usediterator = self::getUnavailablePeripherals($asset, $itemtype);
 
                 foreach ($iterator as $data) {
                     $data['assoc_itemtype'] = $itemtype;
@@ -998,13 +998,14 @@ TWIG, $twig_params);
     }
 
     /**
-     * Returns used peripherals.
+     * Returns peripherals that cannot be connected to the given asset.
      *
+     * @param CommonDBTM               $asset    Main asset.
      * @param class-string<CommonDBTM> $itemtype Itemtype of the peripherals to retrieve.
      *
      * @return DBmysqlIterator
-    */
-    private static function getUsedPeripherals(string $itemtype): DBmysqlIterator
+     */
+    private static function getUnavailablePeripherals(CommonDBTM $asset, string $itemtype): DBmysqlIterator
     {
         global $DB;
 
@@ -1027,7 +1028,14 @@ TWIG, $twig_params);
                 ],
             ],
             'WHERE' => [
-                self::getTable() . '.is_deleted'     => 0,
+                self::getTable() . '.is_deleted' => 0,
+                'OR' => [
+                    $peripheral::getTable() . '.is_global' => 0,
+                    [
+                        self::getTable() . '.itemtype_asset' => $asset::class,
+                        self::getTable() . '.items_id_asset' => $asset->getID(),
+                    ],
+                ],
             ] + getEntitiesRestrictCriteria($peripheral::getTable()),
             'ORDER' => $peripheral::getTable() . '.' . $peripheral::getNameField(),
         ]);

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -42,7 +42,6 @@ use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use Monitor;
 use Peripheral;
-use ReflectionMethod;
 use Toolbox;
 
 class Asset_PeripheralAssetTest extends DbTestCase
@@ -178,8 +177,12 @@ class Asset_PeripheralAssetTest extends DbTestCase
             ]);
         }
 
-        $method = new ReflectionMethod(Asset_PeripheralAsset::class, 'getUnavailablePeripherals');
-        $unavailable = iterator_to_array($method->invoke(null, $computer_2, Peripheral::class));
+        $unavailable = iterator_to_array($this->callPrivateMethod(
+            new Asset_PeripheralAsset(),
+            'getUnavailablePeripherals',
+            $computer_2,
+            Peripheral::class
+        ));
         $unavailable_ids = array_column($unavailable, 'id');
 
         $this->assertNotContains($global_on_other_computer->getID(), $unavailable_ids);

--- a/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
+++ b/tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units\Glpi\Asset;
 
+use Computer;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasPeripheralAssetsCapacity;
@@ -41,6 +42,7 @@ use Glpi\Features\Clonable;
 use Glpi\Tests\DbTestCase;
 use Monitor;
 use Peripheral;
+use ReflectionMethod;
 use Toolbox;
 
 class Asset_PeripheralAssetTest extends DbTestCase
@@ -100,7 +102,7 @@ class Asset_PeripheralAssetTest extends DbTestCase
     public function testDeletePeripheralDoesNotCallCleanRelationData(): void
     {
         $computer = $this->createItem(
-            \Computer::class,
+            Computer::class,
             [
                 'name'   => 'Le PC',
                 'serial' => 'qqzder45',
@@ -132,6 +134,56 @@ class Asset_PeripheralAssetTest extends DbTestCase
 
         $this->assertTrue($_SESSION['MESSAGE_AFTER_REDIRECT'] === []);
         $this->assertFalse((new Asset_PeripheralAsset())->getFromDB($relation->getID()));
+    }
 
+    public function testUnavailablePeripheralsForAsset(): void
+    {
+        $this->login();
+
+        $entity_id = $this->getTestRootEntity(true);
+        $computer_1 = $this->createItem(Computer::class, [
+            'name' => 'Computer 1',
+            'entities_id' => $entity_id,
+        ]);
+        $computer_2 = $this->createItem(Computer::class, [
+            'name' => 'Computer 2',
+            'entities_id' => $entity_id,
+        ]);
+        $global_on_other_computer = $this->createItem(Peripheral::class, [
+            'name' => 'Global peripheral on other computer',
+            'entities_id' => $entity_id,
+            'is_global' => 1,
+        ]);
+        $global_on_current_computer = $this->createItem(Peripheral::class, [
+            'name' => 'Global peripheral on current computer',
+            'entities_id' => $entity_id,
+            'is_global' => 1,
+        ]);
+        $non_global_on_other_computer = $this->createItem(Peripheral::class, [
+            'name' => 'Non-global peripheral on other computer',
+            'entities_id' => $entity_id,
+            'is_global' => 0,
+        ]);
+
+        foreach ([
+            [$computer_1, $global_on_other_computer],
+            [$computer_1, $non_global_on_other_computer],
+            [$computer_2, $global_on_current_computer],
+        ] as [$computer, $peripheral]) {
+            $this->createItem(Asset_PeripheralAsset::class, [
+                'itemtype_asset' => Computer::class,
+                'items_id_asset' => $computer->getID(),
+                'itemtype_peripheral' => Peripheral::class,
+                'items_id_peripheral' => $peripheral->getID(),
+            ]);
+        }
+
+        $method = new ReflectionMethod(Asset_PeripheralAsset::class, 'getUnavailablePeripherals');
+        $unavailable = iterator_to_array($method->invoke(null, $computer_2, Peripheral::class));
+        $unavailable_ids = array_column($unavailable, 'id');
+
+        $this->assertNotContains($global_on_other_computer->getID(), $unavailable_ids);
+        $this->assertContains($global_on_current_computer->getID(), $unavailable_ids);
+        $this->assertContains($non_global_on_other_computer->getID(), $unavailable_ids);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective.

## Description

Fixes https://github.com/glpi-project/glpi/issues/25134.

Globally managed peripherals can be connected to multiple assets, but the asset-side connection form excluded every peripheral that already had any connection. As a result, a global peripheral disappeared from the dropdown after its first connection and could only be connected to additional assets from the peripheral form.

This change keeps a global peripheral available when it is connected only to another asset, while still excluding:

- non-global peripherals that already have a connection;
- peripherals that are already connected to the current asset.

A functional regression test covers all three cases.

## Tests

- `vendor/bin/phpunit tests/functional/Glpi/Asset/Asset_PeripheralAssetTest.php` — 5 tests, 228 assertions
- PHP-CS-Fixer check on both changed files
- PHP syntax checks on both changed files

The checks were run against `11.0/bugfixes` in an isolated Docker volume.

## AI disclosure

This pull request was developed with assistance from OpenAI Codex. The issue analysis, implementation, and tests were reviewed and validated by the submitter.
