### PR TITLE
fix (KB) transfer document to another entity

### DIFF
--- a/ajax/dropdownRubDocument.php
+++ b/ajax/dropdownRubDocument.php
@@ -69,8 +69,15 @@ if (isset($_POST["rubdoc"])) {
         throw new \RuntimeException('Invalid name provided!');
     }
 
-    if (!isset($_POST['entity']) || $_POST['entity'] === '') {
+    if (!isset($_POST['entity']) || $_POST['entity'] === '' || $_POST['entity'] === []) {
         $_POST['entity'] = $_SESSION['glpiactive_entity'];
+    }
+
+    // $entity may be a single entity id or a list of entity ids
+    if (is_array($_POST['entity'])) {
+        $entity = array_values(array_map('intval', $_POST['entity']));
+    } else {
+        $entity = (int) $_POST['entity'];
     }
 
     Dropdown::show(
@@ -79,7 +86,7 @@ if (isset($_POST["rubdoc"])) {
             'name'      => $_POST['myname'],
             'used'      => $used,
             'width'     => '50%',
-            'entity'    => intval($_POST['entity']),
+            'entity'    => $entity,
             'rand'      => intval($_POST['rand']),
             'condition' => ['glpi_documents.documentcategories_id' => (int) $_POST["rubdoc"]],
             'value'     => (int) ($_POST['value'] ?? -1),

--- a/phpunit/functional/TransferTest.php
+++ b/phpunit/functional/TransferTest.php
@@ -821,4 +821,74 @@ class TransferTest extends DbTestCase
             'entities_id' => $fentity,
         ])), 1);
     }
+
+    public function testAddTransferListResolvesRelationToEntityOwner(): void
+    {
+        $this->login();
+
+        $entity_id = (int) getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $document = $this->createItem(\Document::class, [
+            'name'        => 'Test document linked to FAQ',
+            'entities_id' => $entity_id,
+        ]);
+
+        $kb_item = $this->createItem(\KnowbaseItem::class, [
+            'name'        => 'Test FAQ article',
+            'answer'      => 'Test answer content',
+            'is_faq'      => 1,
+        ]);
+
+        $this->createItem(\Entity_KnowbaseItem::class, [
+            'knowbaseitems_id' => $kb_item->getID(),
+            'entities_id'      => $entity_id,
+            'is_recursive'     => 0,
+        ]);
+
+        $doc_item = $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $kb_item->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+
+        // Verify the action is registered under document_item
+        $actions = (new \Document_Item())->getSpecificMassiveActions();
+        $this->assertArrayNotHasKey(
+            \MassiveAction::class . \MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list',
+            $actions
+        );
+        $this->assertArrayHasKey(
+            \Document_Item::class . \MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list',
+            $actions
+        );
+
+        // Verify adds the doc to the transfer list
+        unset($_SESSION['glpitransfer_list']);
+
+        \Document_Item::processMassiveActionsForOneItemtype(
+            $this->createMassiveActionMock('add_transfer_list'),
+            new \Document_Item(),
+            [$doc_item->getID()]
+        );
+
+        $this->assertArrayNotHasKey(\Document_Item::class, $_SESSION['glpitransfer_list'] ?? []);
+        $this->assertArrayHasKey(\Document::class, $_SESSION['glpitransfer_list'] ?? []);
+        $this->assertArrayHasKey(
+            $document->getID(),
+            $_SESSION['glpitransfer_list'][\Document::class]
+        );
+
+        unset($_SESSION['glpitransfer_list']);
+    }
+
+    private function createMassiveActionMock(string $action): \MassiveAction
+    {
+        $ma = $this->getMockBuilder(\MassiveAction::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAction', 'itemDone', 'setRedirect'])
+            ->getMock();
+        $ma->method('getAction')->willReturn($action);
+        return $ma;
+    }
 }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -967,6 +967,64 @@ class Document_Item extends CommonDBRelation
     }
 
     /**
+     * @param CommonDBTM|null $checkitem
+     * @return array<string, string>
+     */
+    public function getSpecificMassiveActions($checkitem = null): array
+    {
+        $actions = parent::getSpecificMassiveActions($checkitem);
+
+        $generic_key = MassiveAction::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list';
+        if (isset($actions[$generic_key])) {
+            $label = $actions[$generic_key];
+            unset($actions[$generic_key]);
+            $actions[self::class . MassiveAction::CLASS_ACTION_SEPARATOR . 'add_transfer_list'] = $label;
+        }
+
+        return $actions;
+    }
+
+    /**
+     * @param MassiveAction $ma
+     * @param CommonDBTM $item
+     * @param array<int> $ids
+     */
+    public static function processMassiveActionsForOneItemtype(
+        MassiveAction $ma,
+        CommonDBTM $item,
+        array $ids
+    ): void {
+        global $CFG_GLPI;
+
+        if ($ma->getAction() !== 'add_transfer_list') {
+            parent::processMassiveActionsForOneItemtype($ma, $item, $ids);
+            return;
+        }
+
+        if (!isset($_SESSION['glpitransfer_list'])) {
+            $_SESSION['glpitransfer_list'] = [];
+        }
+
+        // Remove any residual Document_Item entries to avoid errors in transfer list
+        unset($_SESSION['glpitransfer_list'][Document_Item::class]);
+        if (!isset($_SESSION['glpitransfer_list'][Document::class])) {
+            $_SESSION['glpitransfer_list'][Document::class] = [];
+        }
+
+        foreach ($ids as $id) {
+            if (!$item->getFromDB($id)) {
+                $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_KO);
+                continue;
+            }
+            $doc_id = (int) $item->fields['documents_id'];
+            $_SESSION['glpitransfer_list'][Document::class][$doc_id] = $doc_id;
+            $ma->itemDone($item->getType(), $id, MassiveAction::ACTION_OK);
+        }
+
+        $ma->setRedirect($CFG_GLPI['root_doc'] . '/front/transfer.action.php');
+    }
+
+    /**
      * Get items for an itemtype
      *
      * @since 9.3.1

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -994,6 +994,7 @@ class Document_Item extends CommonDBRelation
         CommonDBTM $item,
         array $ids
     ): void {
+        /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
         if ($ma->getAction() !== 'add_transfer_list') {


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45817
- Here is a brief description of what this PR does

Bug 1
In a KB article within the root entity, GLPI sends the list of authorized entities to filter documents. Since the root entity is recursive, it sends an array of IDs.

The code did this:

‘entity’ => intval($_POST[‘entity’])

intval() on an array in PHP always returns 1 (or 0). Result: GLPI searched for documents from entity number 1 instead of all entities. Documents from the root entity did not appear in the dropdown.


Bug 2 

Massive action transfer

The problem: a document attached to a KB article is not a Document directly; it is a  Document_Item  relationship. GLPI added this relationship to the transfer list, not the document itself.

The fix intercepts the “add to transfer” action for Document_Item relationships and replaces the entry with the actual Document (via the documents_id field of the relationship).

