### PR TITLE
Fix: skip reloading parent item on timeline render

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -2372,12 +2372,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot access property \\$fields on CommonITILTask\\|false\\.$#',
-	'identifier' => 'property.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot access property \\$fields on ITILCategory\\|false\\.$#',
 	'identifier' => 'property.nonObject',
 	'count' => 2,
@@ -2385,18 +2379,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method add\\(\\) on ITIL_ValidationStep\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method canUpdateItem\\(\\) on CommonITILTask\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call method canViewItem\\(\\) on CommonITILTask\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
@@ -2438,20 +2420,8 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method post_getFromDB\\(\\) on CommonITILTask\\|false\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method update\\(\\) on ITIL_ValidationStep\\|null\\.$#',
 	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/CommonITILObject.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Cannot call static method getType\\(\\) on CommonITILTask\\|false\\.$#',
-	'identifier' => 'staticMethod.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/CommonITILObject.php',
 ];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -7777,7 +7777,9 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
 
             foreach ($tasks as $tasks_id => $task_row) {
                 // Safer to use a clean object to load our data
+                /** @var CommonITILTask $tltask */
                 $tltask = getItemForItemtype($taskClass);
+                $tltask->setParentItem($this);
                 $tltask->fields = $task_row;
                 $tltask->post_getFromDB();
 
@@ -7858,11 +7860,14 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                 // Safer to use a clean object to load our data
                 /** @var CommonITILValidation $validation */
                 $validation = getItemForItemtype($validation_class);
+                $validation->setParentItem($this);
                 $validation->fields = $validation_row;
                 $validation->post_getFromDB();
 
-                $canedit = $validation_obj->can($validations_id, UPDATE);
-                $cananswer = $validation_obj->canAnswer()
+                // Use $validation (already loaded with this row's data) instead of $validation_obj,
+                // so that can() does not reload it from the DB.
+                $canedit = $validation->can($validations_id, UPDATE);
+                $cananswer = $validation->canAnswer()
                     && $validation_row['status'] == CommonITILValidation::WAITING
                     && !$this->isSolved(true);
                 $user = new User();

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -61,10 +61,58 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
 
     public static $rightname = 'task';
 
+    private ?CommonITILObject $item = null;
+
     /** @return class-string<CommonITILObject> */
     public static function getItilObjectItemType()
     {
         return str_replace('Task', '', static::class);
+    }
+
+    /**
+     * Set the parent ITIL object, to avoid reloading it from the DB when it
+     * is already available (e.g. when building the ticket/change/problem timeline).
+     *
+     * @param CommonITILObject $parent Parent item
+     *
+     * @return void
+     */
+    final public function setParentItem(CommonITILObject $parent): void
+    {
+        $this->item = $parent;
+    }
+
+    /**
+     * Check if $this->item already contains the correct parent item and thus
+     * help us to avoid reloading it for no reason.
+     *
+     * @phpstan-assert-if-true !null $this->item
+     *
+     * @return bool
+     */
+    protected function isParentAlreadyLoaded(): bool
+    {
+        // If current item fields are not loaded, we can't know what its parent should be
+        if (!isset($this->fields[static::getItilObjectItemType()::getForeignKeyField()])) {
+            return false;
+        }
+
+        // Fail if no item is loaded in $this->item
+        if ($this->item === null) {
+            return false;
+        }
+
+        // Fail if loaded item's type doesn't match our expected parent itemtype
+        if ($this->item->getType() !== static::getItilObjectItemType()) {
+            return false;
+        }
+
+        // Fail if loaded item's id is not what we expect
+        if ($this->item->getID() !== $this->fields[$this->item::getForeignKeyField()]) {
+            return false;
+        }
+
+        return true;
     }
 
     public static function getItilObjectItemInstance(): CommonITILObject
@@ -186,6 +234,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             return false;
         }
 
+        if ($this->isParentAlreadyLoaded()) {
+            return $this->item->canAddTasks();
+        }
+
         $item = static::getItilObjectItemInstance();
         if ($item->getFromDB($this->fields[$item::getForeignKeyField()])) {
             return $item->canAddTasks();
@@ -205,9 +257,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             return false;
         }
 
-        $item = static::getItilObjectItemInstance();
+        $parent_loaded = $this->isParentAlreadyLoaded();
+        $item = $parent_loaded ? $this->item : static::getItilObjectItemInstance();
         if (
-            $item->getFromDB($this->fields[$item::getForeignKeyField()])
+            ($parent_loaded || $item->getFromDB($this->fields[$item::getForeignKeyField()]))
             && in_array($item->fields['status'], $item->getClosedStatusArray())
         ) {
             return false;
@@ -235,9 +288,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function canPurgeItem(): bool
     {
-        $item = static::getItilObjectItemInstance();
+        $parent_loaded = $this->isParentAlreadyLoaded();
+        $item = $parent_loaded ? $this->item : static::getItilObjectItemInstance();
         if (
-            $item->getFromDB($this->fields[$item::getForeignKeyField()])
+            ($parent_loaded || $item->getFromDB($this->fields[$item::getForeignKeyField()]))
             && in_array($item->fields['status'], $item->getClosedStatusArray())
         ) {
             return false;
@@ -255,6 +309,10 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function getItem()
     {
+        if ($this->isParentAlreadyLoaded()) {
+            return $this->item;
+        }
+
         $item = static::getItilObjectItemInstance();
         if ($item->getFromDB($this->fields[$item::getForeignKeyField()])) {
             return $item;
@@ -269,8 +327,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
      **/
     public function canReadITILItem()
     {
-        $item = static::getItilObjectItemInstance();
-        if (!$item->can($this->getField($item->getForeignKeyField()), READ)) {
+        $item = $this->isParentAlreadyLoaded() ? $this->item : static::getItilObjectItemInstance();
+        if (!$item->can($this->getField($item::getForeignKeyField()), READ)) {
             return false;
         }
         return true;

--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -51,6 +51,8 @@ abstract class CommonITILValidation extends CommonDBChild
     // From CommonDBTM
     public $auto_message_on_action    = false;
 
+    protected ?CommonITILObject $item = null;
+
     public static $log_history_add    = Log::HISTORY_LOG_SIMPLE_MESSAGE;
     public static $log_history_update = Log::HISTORY_LOG_SIMPLE_MESSAGE;
     public static $log_history_delete = Log::HISTORY_LOG_SIMPLE_MESSAGE;
@@ -86,6 +88,38 @@ abstract class CommonITILValidation extends CommonDBChild
         }
 
         return new $class();
+    }
+
+    /**
+     * Set the parent ITIL object, to avoid reloading it from the DB when it
+     * is already available (e.g. when building the ticket/change/problem timeline).
+     *
+     * @param CommonITILObject $parent Parent item
+     *
+     * @return void
+     */
+    final public function setParentItem(CommonITILObject $parent): void
+    {
+        $this->item = $parent;
+    }
+
+    /**
+     * Check if $this->item already contains the correct parent item and thus
+     * help us to avoid reloading it for no reason.
+     *
+     * @phpstan-assert-if-true !null $this->item
+     *
+     * @return bool
+     */
+    protected function isParentAlreadyLoaded(): bool
+    {
+        if (!isset($this->fields[static::$items_id])) {
+            return false;
+        }
+
+        return $this->item !== null
+            && $this->item->getType() === static::getItilObjectItemType()
+            && $this->item->getID() === $this->fields[static::$items_id];
     }
 
     /**

--- a/src/ITILSolution.php
+++ b/src/ITILSolution.php
@@ -109,6 +109,10 @@ class ITILSolution extends CommonDBChild
 
     public function canCreateItem(): bool
     {
+        if ($this->isParentAlreadyLoaded()) {
+            return $this->item->canSolve();
+        }
+
         $item = getItemForItemtype($this->fields['itemtype']);
 
         if (!($item instanceof CommonITILObject)) {
@@ -117,6 +121,25 @@ class ITILSolution extends CommonDBChild
 
         $item->getFromDB($this->fields['items_id']);
         return $item->canSolve();
+    }
+
+    /**
+     * Check if $this->item already contains the correct parent item, to avoid
+     * reloading it for no reason.
+     *
+     * @phpstan-assert-if-true !null $this->item
+     *
+     * @return bool
+     */
+    private function isParentAlreadyLoaded(): bool
+    {
+        if (!isset($this->fields['itemtype'], $this->fields['items_id'])) {
+            return false;
+        }
+
+        return $this->item !== null
+            && $this->item->getType() === $this->fields['itemtype']
+            && $this->item->getID() === $this->fields['items_id'];
     }
 
     public function canEdit($ID): bool
@@ -128,11 +151,7 @@ class ITILSolution extends CommonDBChild
     {
         // Bandaid to avoid loading parent item if not needed
         // TODO: replace by proper lazy loading
-        if (
-            $this->item == null // No item loaded
-            || $this->item->getType() !== $this->fields['itemtype'] // Another item is loaded
-            || $this->item->getID() !== $this->fields['items_id']   // Another item is loaded
-        ) {
+        if (!$this->isParentAlreadyLoaded()) {
             $item = getItemForItemtype($this->fields['itemtype']);
             if ($item instanceof CommonITILObject) {
                 $this->item = $item;

--- a/src/TicketValidation.php
+++ b/src/TicketValidation.php
@@ -74,8 +74,9 @@ class TicketValidation extends CommonITILValidation
     {
 
         if ($this->canChildItem('canViewItem', 'canView')) {
-            $ticket = new Ticket();
-            if ($ticket->getFromDB($this->fields['tickets_id'])) {
+            $parent_loaded = $this->isParentAlreadyLoaded();
+            $ticket = $parent_loaded ? $this->item : new Ticket();
+            if ($parent_loaded || $ticket->getFromDB($this->fields['tickets_id'])) {
                 // No validation for closed tickets
                 if (in_array($ticket->fields['status'], $ticket->getClosedStatusArray())) {
                     return false;

--- a/tests/src/CommonITILTaskTestCase.php
+++ b/tests/src/CommonITILTaskTestCase.php
@@ -36,7 +36,7 @@ namespace Glpi\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 
-use function Safe\ob_end_clean;
+use function Safe\ob_get_clean;
 use function Safe\ob_start;
 
 abstract class CommonITILTaskTestCase extends DbTestCase
@@ -463,7 +463,7 @@ abstract class CommonITILTaskTestCase extends DbTestCase
         $task = new $task_class();
         ob_start();
         $task->showMassiveActionAddTaskForm();
-        $output = ob_end_clean();
+        $output = ob_get_clean();
 
         // Assert: make sure the template was renderer without fatal errors
         $this->assertNotEmpty($output);

--- a/tests/src/CommonITILTaskTestCase.php
+++ b/tests/src/CommonITILTaskTestCase.php
@@ -36,6 +36,9 @@ namespace Glpi\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function Safe\ob_end_clean;
+use function Safe\ob_start;
+
 abstract class CommonITILTaskTestCase extends DbTestCase
 {
     /** @return class-string<\CommonITILTask> */
@@ -375,6 +378,79 @@ abstract class CommonITILTaskTestCase extends DbTestCase
         $this->login();
         $this->assertTrue($my_task->canUpdateItem());
         $this->assertFalse($tech_task->canUpdateItem());
+    }
+
+    /**
+     * Data provider for testIsParentAlreadyLoaded
+     *
+     * @return iterable
+     */
+    protected function testIsParentAlreadyLoadedProvider(): iterable
+    {
+        $this->login();
+        $entity = getItemByTypeName(\Entity::class, '_test_root_entity', true);
+
+        $task_class = static::getTaskClass();
+        $itil_class = $task_class::getItilObjectItemType();
+
+        // Obviously false, no data was loaded
+        $task = new $task_class();
+        yield [$task, false];
+
+        // Create two ITIL items of the expected type and a task
+        $parent_1 = $this->createItem($itil_class, [
+            'entities_id' => $entity,
+            'name'        => 'Test item 1',
+            'content'     => '',
+        ]);
+        $parent_2 = $this->createItem($itil_class, [
+            'entities_id' => $entity,
+            'name'        => 'Test item 2',
+            'content'     => '',
+        ]);
+        // Create an ITIL item of a different type, to test the itemtype check.
+        // Avoid Ticket when possible, its plugin hooks are noisy in tests.
+        $other_itil_class = $itil_class === \Problem::class ? \Change::class : \Problem::class;
+        $parent_3 = $this->createItem($other_itil_class, [
+            'entities_id' => $entity,
+            'name'        => 'Test item 3',
+            'content'     => '',
+        ]);
+
+        $itil_fkey = getForeignKeyFieldForItemType($itil_class);
+        $task = $this->createItem($task_class, [
+            $itil_fkey => $parent_1->getID(),
+            'content'  => 'Test task',
+        ]);
+
+        // Correct parent
+        $task->setParentItem($parent_1);
+        yield [$task, true];
+
+        // Invalid parent (wrong id)
+        $task->setParentItem($parent_2);
+        yield [$task, false];
+
+        // Invalid parent (wrong itemtype)
+        $task->setParentItem($parent_3);
+        yield [$task, false];
+    }
+
+    /**
+     * Tests for the isParentAlreadyLoaded method
+     *
+     * @return void
+     */
+    public function testIsParentAlreadyLoaded(): void
+    {
+        $provider = $this->testIsParentAlreadyLoadedProvider();
+        foreach ($provider as $row) {
+            [$task, $is_parent_loaded] = $row;
+            $this->assertEquals(
+                $is_parent_loaded,
+                $this->callPrivateMethod($task, 'isParentAlreadyLoaded')
+            );
+        }
     }
 
     public function testShowMassiveActionAddTaskForm(): void


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45836
- Opening a ticket, change or problem with many followups, tasks, solutions or approval requests triggered redundant database queries to reload the parent item on every permission check.
- This fix reuses the already loaded parent item instead of reloading it, reducing server response time when displaying items with a large history.

## Screenshots (if appropriate):
