### PR TITLE
OpenAPI schema fixes blocking openapi-typescript

### DIFF
--- a/src/Glpi/Api/HL/Controller/DropdownController.php
+++ b/src/Glpi/Api/HL/Controller/DropdownController.php
@@ -2302,7 +2302,7 @@ EOT,
             'ContractType', 'ConsumableItemType', 'DomainRecordType', 'DomainType', 'LineType', 'NetworkPortType',
             'ProjectTaskType', 'ProjectType', 'LicenseType', 'SupplierType', 'HardDriveType', 'Filesystem',
             'ApplianceEnvironment', 'Network', 'DomainRelation', 'Stencil', 'CameraImageFormat', 'CameraImageResolution',
-            'CalendarCloseTime', 'CalendarTimeRange', 'Plug', 'Item_Plug', 'PhonePowerSupply',
+            'CalendarTimeRange', 'Plug', 'Item_Plug', 'PhonePowerSupply',
         ];
     }
 

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -701,6 +701,12 @@ EOT;
                 $resolved_schema = $response->getSchema()?->toArray() ?? [];
             }
             $response_media_type = $response->getMediaType();
+            if ($resolved_schema === []) {
+                $response_schemas[$response->getStatusCode()] = [
+                    'description' => $response->getDescription(),
+                ];
+                continue;
+            }
             $response_schema = [
                 'description' => $response->getDescription(),
                 'content' => [

--- a/src/Glpi/Api/HL/OpenAPIGenerator.php
+++ b/src/Glpi/Api/HL/OpenAPIGenerator.php
@@ -715,6 +715,12 @@ EOT;
                 $resolved_schema = $response->getSchema()?->toArray() ?? [];
             }
             $response_media_type = $response->getMediaType();
+            if ($resolved_schema === []) {
+                $response_schemas[$response->getStatusCode()] = [
+                    'description' => $response->getDescription(),
+                ];
+                continue;
+            }
             $response_schema = [
                 'description' => $response->getDescription(),
                 'content' => [

--- a/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.0.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {

--- a/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.1.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {

--- a/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.2.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {

--- a/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -79197,102 +79132,6 @@
             ]
         }
     },
-    "/Dropdowns/CalendarCloseTime": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
     "/Dropdowns/CalendarTimeRange": {
         "get": {
             "responses": {
@@ -87231,116 +87070,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "#/components/schemas/CameraImageResolution"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Dropdowns/CalendarCloseTime/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
                         }
                     }
                 }

--- a/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -79373,102 +79308,6 @@
             ]
         }
     },
-    "/Dropdowns/CalendarCloseTime": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
     "/Dropdowns/CalendarTimeRange": {
         "get": {
             "responses": {
@@ -88235,128 +88074,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "#/components/schemas/CameraImageResolution"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Dropdowns/CalendarCloseTime/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/If-Modified-Since"
-                },
-                {
-                    "$ref": "#/components/parameters/If-Unmodified-Since"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/If-Modified-Since"
-                },
-                {
-                    "$ref": "#/components/parameters/If-Unmodified-Since"
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
                         }
                     }
                 }

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -82065,102 +82000,6 @@
             ]
         }
     },
-    "/Dropdowns/CalendarCloseTime": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
     "/Dropdowns/CalendarTimeRange": {
         "get": {
             "responses": {
@@ -90099,116 +89938,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "#/components/schemas/CameraImageResolution"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Dropdowns/CalendarCloseTime/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
                         }
                     }
                 }

--- a/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
+++ b/tests/fixtures/hlapi/snapshots/2.4.0/paths.json
@@ -70,20 +70,7 @@
     "/{req}": {
         "get": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -107,20 +94,7 @@
         },
         "post": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
+                "200": [],
                 "201": {
                     "headers": [],
                     "content": {
@@ -164,20 +138,7 @@
         },
         "patch": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -201,20 +162,7 @@
         },
         "put": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -238,20 +186,7 @@
         },
         "delete": {
             "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                },
-                "404": {
-                    "content": {
-                        "application/json": {
-                            "schema": []
-                        }
-                    }
-                }
+                "200": []
             },
             "parameters": [
                 {
@@ -83069,102 +83004,6 @@
             ]
         }
     },
-    "/Dropdowns/CalendarCloseTime": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/CalendarCloseTime"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/filter"
-                },
-                {
-                    "$ref": "#/components/parameters/start"
-                },
-                {
-                    "$ref": "#/components/parameters/limit"
-                },
-                {
-                    "$ref": "#/components/parameters/sort"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "post": {
-            "responses": {
-                "201": {
-                    "headers": [],
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "integer",
-                                        "format": "int64",
-                                        "readOnly": true
-                                    },
-                                    "href": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
     "/Dropdowns/CalendarTimeRange": {
         "get": {
             "responses": {
@@ -91931,128 +91770,6 @@
                     "application/json": {
                         "schema": {
                             "$ref": "#/components/schemas/CameraImageResolution"
-                        }
-                    }
-                }
-            },
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "delete": {
-            "responses": [],
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        }
-    },
-    "/Dropdowns/CalendarCloseTime/{id}": {
-        "get": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "text/csv": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        },
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/If-Modified-Since"
-                },
-                {
-                    "$ref": "#/components/parameters/If-Unmodified-Since"
-                }
-            ],
-            "security": [
-                {
-                    "oauth": [
-                        "api"
-                    ]
-                }
-            ]
-        },
-        "patch": {
-            "responses": {
-                "200": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CalendarCloseTime"
-                            }
-                        }
-                    }
-                }
-            },
-            "parameters": [
-                {
-                    "name": "id",
-                    "description": "The ID of the dropdown item",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "integer",
-                        "format": "int32",
-                        "pattern": "\\d+"
-                    }
-                },
-                {
-                    "$ref": "#/components/parameters/If-Modified-Since"
-                },
-                {
-                    "$ref": "#/components/parameters/If-Unmodified-Since"
-                }
-            ],
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/CalendarCloseTime"
                         }
                     }
                 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I use `openapi-typescript` to automatically generate TypeScript types from the GLPI API schema for my project and two issues were blocking the type generation.

- CalendarCloseTime was a non-existent schema name which was adding endpoints that were broken.
- The default endpoints were adding a "content" property for an empty schema which is not valid OpenAPI syntax.