### PR TITLE
Ldap improvements

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -1174,7 +1174,7 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Access to an undefined property object\\:\\:\\$fields\\.$#',
 	'identifier' => 'property.notFound',
-	'count' => 17,
+	'count' => 16,
 	'path' => __DIR__ . '/src/AuthLDAP.php',
 ];
 $ignoreErrors[] = [

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1760,6 +1760,7 @@ TWIG, $twig_params);
      * @param array    $user_infos    user information
      * @param array    $ldap_users    ldap users
      * @param object   $config_ldap   ldap configuration
+     * @param array<string, array<string, mixed>>|null $ldap_users_by_dn LDAP users indexed by DN
      *
      * @return bool
      */
@@ -1771,7 +1772,8 @@ TWIG, $twig_params);
         &$limitexceeded,
         &$user_infos,
         &$ldap_users,
-        $config_ldap
+        $config_ldap,
+        &$ldap_users_by_dn = null
     ) {
 
         // If paged results cannot be used (PHP < 5.4)
@@ -1894,6 +1896,9 @@ TWIG, $twig_params);
                             $ldap_users[$uid] = '';
                         }
                         $user_infos[$uid]["name"] = $info[$ligne][$login_field][0];
+                        if ($ldap_users_by_dn !== null) {
+                            $ldap_users_by_dn[$info[$ligne]['dn']] ??= $user_infos[$uid];
+                        }
                     }
                 }
             }
@@ -1942,9 +1947,10 @@ TWIG, $twig_params);
             //}
         }
 
-        $ldap_users    = [];
-        $user_infos    = [];
-        $limitexceeded = false;
+        $ldap_users       = [];
+        $ldap_users_by_dn = [];
+        $user_infos       = [];
+        $limitexceeded    = false;
 
         // we prevent some delay...
         if (!$res) {
@@ -1989,7 +1995,8 @@ TWIG, $twig_params);
                 $limitexceeded,
                 $user_infos,
                 $ldap_users,
-                $config_ldap
+                $config_ldap,
+                $ldap_users_by_dn
             );
             if (!$result) {
                 return false;
@@ -2023,7 +2030,7 @@ TWIG, $twig_params);
             } else {
                 //Ldap synchronisation : look if the user exists in the directory
                 //and compares the modifications dates (ldap and glpi db)
-                $userfound = self::dnExistsInLdap($user_infos, $user['user_dn']);
+                $userfound = $ldap_users_by_dn[$user['user_dn']] ?? false;
                 if (!empty($ldap_users[$user[$field_for_db]]) || $userfound) {
                     // userfound seems that user dn is present in GLPI DB but do not correspond to an GLPI user
                     // -> renaming case

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1887,14 +1887,7 @@ TWIG, $twig_params);
                         $ldap_users[$uid] = $uid;
                     } else {
                         //If ldap synchronisation
-                        if (isset($info[$ligne]['modifytimestamp'])) {
-                            $ldap_users[$uid] = self::ldapStamp2UnixStamp(
-                                $info[$ligne]['modifytimestamp'][0],
-                                $config_ldap->fields['time_offset']
-                            );
-                        } else {
-                            $ldap_users[$uid] = '';
-                        }
+                        $ldap_users[$uid] = $user_infos[$uid]["timestamp"];
                         $user_infos[$uid]["name"] = $info[$ligne][$login_field][0];
                         if ($ldap_users_by_dn !== null) {
                             $ldap_users_by_dn[$info[$ligne]['dn']] ??= $user_infos[$uid];

--- a/src/AuthLDAP.php
+++ b/src/AuthLDAP.php
@@ -1760,7 +1760,8 @@ TWIG, $twig_params);
      * @param array    $user_infos    user information
      * @param array    $ldap_users    ldap users
      * @param object   $config_ldap   ldap configuration
-     * @param array<string, array<string, mixed>>|null $ldap_users_by_dn LDAP users indexed by DN
+     * @param array<mixed>|null $ldap_users_by_dn LDAP users indexed by DN
+     * @param-out array<mixed>|null $ldap_users_by_dn
      *
      * @return bool
      */

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -3054,7 +3054,7 @@ class AuthLdapTest extends DbTestCase
             $ldap->connect(),
             ['basedn' => $ldap->fields['basedn'], 'mode' => AuthLDAP::ACTION_SYNCHRONIZE],
             '(uid=ecuador0)',
-            ['uid'],
+            ['uid', 'modifyTimestamp'],
             $limitexceeded,
             $user_infos,
             $ldap_users,
@@ -3066,6 +3066,7 @@ class AuthLdapTest extends DbTestCase
             'ecuador0',
             $ldap_users_by_dn['uid=ecuador0,ou=people,ou=R&D,dc=glpi,dc=org']['name'] ?? null
         );
+        $this->assertSame($user_infos['ecuador0']['timestamp'], $ldap_users['ecuador0']);
     }
 
     public static function searchForUsersErrorsProvider(): iterable

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -1012,7 +1012,7 @@ class AuthLdapTest extends DbTestCase
         yield [
             'group_dn'            => 'cn=glpi2-group2,ou=groups,ou=\#1-test,ou=ldap2,dc=glpi,dc=org',
             'user_uid'            => 'specialchar1',
-            // openladap replaces `\#` by `\23` (23 is the ascii code for #)
+            // OpenLDAP replaces `\#` by `\23` (23 is the ascii code for #)
             'expected_group_dn'   => 'cn=glpi2-group2,ou=groups,ou=\231-test,ou=ldap2,dc=glpi,dc=org',
             'expected_group_name' => 'glpi2-group2',
         ];

--- a/tests/LDAP/AuthLdapTest.php
+++ b/tests/LDAP/AuthLdapTest.php
@@ -3043,6 +3043,31 @@ class AuthLdapTest extends DbTestCase
         );
     }
 
+    #[RequiresPhpExtension('ldap')]
+    public function testSearchForUsersIndexesUsersByDn(): void
+    {
+        $ldap = $this->ldap;
+        $limitexceeded = false;
+        $user_infos = $ldap_users = $ldap_users_by_dn = [];
+
+        AuthLDAP::searchForUsers(
+            $ldap->connect(),
+            ['basedn' => $ldap->fields['basedn'], 'mode' => AuthLDAP::ACTION_SYNCHRONIZE],
+            '(uid=ecuador0)',
+            ['uid'],
+            $limitexceeded,
+            $user_infos,
+            $ldap_users,
+            $ldap,
+            $ldap_users_by_dn
+        );
+
+        $this->assertSame(
+            'ecuador0',
+            $ldap_users_by_dn['uid=ecuador0,ou=people,ou=R&D,dc=glpi,dc=org']['name'] ?? null
+        );
+    }
+
     public static function searchForUsersErrorsProvider(): iterable
     {
         // error messages should be identical whether pagesize support is enabled or not

--- a/tests/LDAP/README.ldap
+++ b/tests/LDAP/README.ldap
@@ -1,6 +1,6 @@
 tests/LDAP/ldif provides :
 - 3 branches, to simulate 3 different directories
-- users stored in using 2 different objectclasses : person & inetOrgPerson
+- users stored using 2 different objectclasses : person & inetOrgPerson
 - groups : groupOfNames & posixGroup
 - a lot of users in order to test ldap sizelimit
 


### PR DESCRIPTION


- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.


## Description

- It fixes #25166
- Lookup users by "dn" instead of fullscan
- Reuse timestamp instead of calculation throught ldapStamp2UnixStamp

I wrote benchmarks localy. It looked something like this ->

| Scenario | Linear scan | DN index |
|---|---:|---:|
| Existing DN | 88.21 s | 23.93 ms |
| Missing DN | 200.42 s | 27.01 ms |


