### PR TITLE
Add missing max value for monitor size input

### DIFF
--- a/src/Glpi/Api/HL/Controller/AssetController.php
+++ b/src/Glpi/Api/HL/Controller/AssetController.php
@@ -749,7 +749,14 @@ final class AssetController extends AbstractController
                     'readOnly' => true,
                 ],
                 'autoupdatesystem' => $autoupdatesystem_property,
-                'size' => ['type' => Doc\Schema::TYPE_NUMBER, 'format' => Doc\Schema::FORMAT_NUMBER_FLOAT, 'minimum' => 0, 'x-version-introduced' => '2.3.0'],
+                'size' => [
+                    'type' => Doc\Schema::TYPE_NUMBER,
+                    'format' => Doc\Schema::FORMAT_NUMBER_FLOAT,
+                    'minimum' => 0,
+                    'maximum' => 999.99,
+                    'multipleOf' => 0.01,
+                    'x-version-introduced' => '2.3.0',
+                ],
                 'has_microphone' => [
                     'x-version-introduced' => '2.3.0',
                     'x-field' => 'have_micro',

--- a/templates/generic_show_form.html.twig
+++ b/templates/generic_show_form.html.twig
@@ -430,6 +430,7 @@
                                   __('Size'),
                                   specific_field_options|merge({
                                       'min': 0,
+                                      'max': 999.99,
                                       'step': 0.01
                                   }),
                               ) }}

--- a/tests/fixtures/hlapi/snapshots/2.3.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/2.3.0/components.json
@@ -12328,7 +12328,9 @@
                 "size": {
                     "type": "number",
                     "format": "float",
-                    "minimum": 0
+                    "minimum": 0,
+                    "maximum": 999.99,
+                    "multipleOf": 0.01
                 },
                 "has_microphone": {
                     "type": "boolean",


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #25171

Fixes client-side validation of Monitor size field by adding max value.
Also fixes HLAPI schema to add max and step information in the OpenAPI schema which would cause the API to return a clean validation error rather than letting it get to the point of triggering a SQL exception.