### PR TITLE
Display search/MA Update decimal field as number, not text

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -5087,6 +5087,15 @@ class CommonDBTM extends CommonGLPI
                     return Dropdown::showNumber($name, $options);
 
                 case "decimal":
+                    $copytooption = ['min', 'max', 'step'];
+                    foreach ($copytooption as $key) {
+                        if (isset($searchoptions[$key]) && !isset($options[$key])) {
+                            $options[$key] = $searchoptions[$key];
+                        }
+                    }
+                    $options['type'] = 'number';
+                    $options['value'] = $value;
+                    return Html::input($name, $options);
                 case "mac":
                 case "ip":
                 case "string":

--- a/src/Monitor.php
+++ b/src/Monitor.php
@@ -368,6 +368,9 @@ class Monitor extends CommonDBTM implements AssignableItemInterface, DCBreadcrum
             'field'              => 'size',
             'name'               => __('Size'),
             'datatype'           => 'decimal',
+            'min'                => 0,
+            'max'                => 999.99,
+            'step'               => 0.01,
         ];
 
         $tab[] = [


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Fixes the update massive action field and search field display for decimal search options to be a number input with the min, max and step defined in the search option rather than a text field.
- Fixes Monitor's size search option to define the min, max and step options.
