### PR TITLE
Fix console command descriptions

### DIFF
--- a/tools/src/Command/CheckTwigTemplatesSyntaxCommand.php
+++ b/tools/src/Command/CheckTwigTemplatesSyntaxCommand.php
@@ -45,7 +45,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Twig\Error\Error;
 use Twig\TwigFunction;
-use function \Safe\realpath;
+
+use function Safe\realpath;
 
 final class CheckTwigTemplatesSyntaxCommand extends Command
 {

--- a/tools/src/Command/CheckTwigTemplatesSyntaxCommand.php
+++ b/tools/src/Command/CheckTwigTemplatesSyntaxCommand.php
@@ -45,6 +45,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Twig\Error\Error;
 use Twig\TwigFunction;
+use function \Safe\realpath;
 
 final class CheckTwigTemplatesSyntaxCommand extends Command
 {
@@ -59,7 +60,8 @@ final class CheckTwigTemplatesSyntaxCommand extends Command
     {
         parent::configure();
 
-        $this->setName('tools:check_twig_templates_syntax');
+        $this->setName('tools:check_twig_templates_syntax')
+             ->setDescription('Check twig templates syntax is valid');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/tools/src/Command/GenerateIllustrationTranslationFileCommand.php
+++ b/tools/src/Command/GenerateIllustrationTranslationFileCommand.php
@@ -40,7 +40,8 @@ use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use function \Safe\file_put_contents;
+
+use function Safe\file_put_contents;
 
 final class GenerateIllustrationTranslationFileCommand extends Command
 {

--- a/tools/src/Command/GenerateIllustrationTranslationFileCommand.php
+++ b/tools/src/Command/GenerateIllustrationTranslationFileCommand.php
@@ -35,9 +35,12 @@
 namespace Glpi\Tools\Command;
 
 use Glpi\UI\IllustrationManager;
+use Override;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function \Safe\file_put_contents;
 
 final class GenerateIllustrationTranslationFileCommand extends Command
 {
@@ -49,6 +52,8 @@ final class GenerateIllustrationTranslationFileCommand extends Command
         parent::configure();
 
         $this->setName('tools:generate_illustration_translations');
+        $this->setDescription('Generate a files Illustrations tags and title. It\'s required for translations generation - tools:locales:extract');
+        $this->setHidden();
     }
 
     #[Override]


### PR DESCRIPTION
*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Add description
- Set generate_illustration command hidden
- fix missing imports

---

By the way, phpstan and other php tools don't parse `tools/src` (I'll work on that).

