### PR TITLE
Add home article for the knowledge base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The present file will list all changes made to the project; according to the
 - Remember me support for multiple devices at the same time.
 - `Setup > Data and Privacy` menu item to centralize all data policies and privacy related settings.
 - New automatic action "purgesessionhistory" to automate deleting old login history data based on a retention period set in `Setup > Data and Privacy`.
-- A root article, base of the knowledge base tree, is now created on installation and on upgrade. Its id is stored in the `root_knowbaseitems_id` configuration.
+- A root article, base of the knowledge base tree, is now created on installation and on upgrade. Its id is stored in the `root_knowbaseitems_id` configuration. It can be edited like any other article but it cannot be deleted.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The present file will list all changes made to the project; according to the
 - CSRF protection is now handled via browser-native `Sec-Fetch-Site`/`Origin` header validation instead of per-request tokens. All `_glpi_csrf_token` hidden form fields and `X-Glpi-Csrf-Token` AJAX headers must be removed from plugins. See API changes below for the full list of removed methods and helpers.
 - The `KnowbaseItemCategory` itemtype and the `knowbasecategory` right have been removed. Knowledge base categories are now regular articles; hierarchy is expressed by linking child articles to parent articles.
 - Generic tree-browse (`TreeBrowse`) support for the knowledge base. The KB aside provides browsing.
+- The `Search` and `Browse` tabs of the knowledge base article list. The list is now a plain search page.
 
 ### API changes
 - Type declarations for some `CronTask` methods have been added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The present file will list all changes made to the project; according to the
 - Remember me support for multiple devices at the same time.
 - `Setup > Data and Privacy` menu item to centralize all data policies and privacy related settings.
 - New automatic action "purgesessionhistory" to automate deleting old login history data based on a retention period set in `Setup > Data and Privacy`.
-- A root article, base of the knowledge base tree, is now created on installation and on upgrade. Its id is stored in the `root_knowbaseitems_id` configuration. It can be edited like any other article but it cannot be deleted.
+- A root article, base of the knowledge base tree, is now created on installation and on upgrade. Its id is stored in the `root_knowbaseitems_id` configuration. It can be edited like any other article but it cannot be deleted. **On upgrade, articles that have no parent (including the ones created from the former categories) become children of it.**
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The present file will list all changes made to the project; according to the
 - Remember me support for multiple devices at the same time.
 - `Setup > Data and Privacy` menu item to centralize all data policies and privacy related settings.
 - New automatic action "purgesessionhistory" to automate deleting old login history data based on a retention period set in `Setup > Data and Privacy`.
+- A root article, base of the knowledge base tree, is now created on installation and on upgrade. Its id is stored in the `root_knowbaseitems_id` configuration.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The present file will list all changes made to the project; according to the
   If your monitoring relies on parsing this string, make sure it can handle the new format.
 - New `errored` property for the cronttask (automatic actions) service in the status checker to indicate the names of the errored actions requiring manual intervention.
 - "Logs purge" tab moved from `Setup > General` to `Setup > Data and Privacy` and renamed to "Historical logs".
-- Knowledge base article visibility now inherits down the tree: a user who can access an article, or any of its ancestors, can view it. **On upgrade, existing categories become invisible until access is granted to them** (which then cascades to their contents).
+- Knowledge base article visibility now inherits down the tree: a user who can access an article, or any of its ancestors, can view it. **On upgrade, existing categories become invisible until access is granted to them** (which then cascades to their contents). The root article is an exception: it is readable by anyone who can read the knowledge base, and it never grants access to its descendants.
 
 ### Deprecated
 

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -37,8 +37,6 @@ require_once(__DIR__ . '/_check_webserver_config.php');
 
 use Glpi\Exception\Http\AccessDeniedHttpException;
 
-global $CFG_GLPI;
-
 if (!Session::haveRightsOr(KnowbaseItem::$rightname, [READ, KnowbaseItem::READFAQ])) {
     throw new AccessDeniedHttpException();
 }
@@ -55,26 +53,6 @@ if (isset($_GET["id"])) {
 
 Html::header(KnowbaseItem::getTypeName(1), '', "tools", "knowbaseitem");
 
-// Search a solution
-if (
-    !isset($_GET["contains"])
-    && isset($_GET["item_itemtype"])
-    && isset($_GET["item_items_id"])
-) {
-    if (in_array($_GET["item_itemtype"], $CFG_GLPI['kb_types']) && $item = getItemForItemtype($_GET["item_itemtype"])) {
-        if ($item->can($_GET["item_items_id"], READ)) {
-            $_GET["contains"] = $item->fields['name'];
-        }
-    }
-}
-
-// Manage forcetab : non standard system (file name <> class name)
-if (isset($_GET['forcetab'])) {
-    Session::setActiveTab('Knowbase', $_GET['forcetab']);
-    unset($_GET['forcetab']);
-}
-
-$kb = new Knowbase();
-$kb->display($_GET);
+Search::show(KnowbaseItem::class);
 
 Html::footer();

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -43,8 +43,12 @@ if (!Session::haveRightsOr(KnowbaseItem::$rightname, [READ, KnowbaseItem::READFA
 
 // Entering the knowledge base without any parameter means opening its root
 // article.
-if ($_GET === []) {
-    Html::redirect(KnowbaseItem::getFormURLWithID(KnowbaseItem::getRootId()));
+if ($_GET === [] && KnowbaseItem::hasRoot()) {
+    $root_id = KnowbaseItem::getRootId();
+    $root    = new KnowbaseItem();
+    if ($root->getFromDB($root_id) && $root->can($root_id, READ)) {
+        Html::redirect(KnowbaseItem::getFormURLWithID($root_id));
+    }
 }
 
 if (isset($_GET["id"])) {

--- a/front/knowbaseitem.php
+++ b/front/knowbaseitem.php
@@ -42,6 +42,13 @@ global $CFG_GLPI;
 if (!Session::haveRightsOr(KnowbaseItem::$rightname, [READ, KnowbaseItem::READFAQ])) {
     throw new AccessDeniedHttpException();
 }
+
+// Entering the knowledge base without any parameter means opening its root
+// article.
+if ($_GET === []) {
+    Html::redirect(KnowbaseItem::getFormURLWithID(KnowbaseItem::getRootId()));
+}
+
 if (isset($_GET["id"])) {
     Html::redirect(KnowbaseItem::getFormURLWithID($_GET["id"]));
 }

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -74,6 +74,9 @@ $empty_data_builder = new class {
     public const USER_NORMAL          = 5;
     public const USER_SYSTEM          = 6;
 
+    /** @var int Root knowledge base article ID (the base of the KB tree) */
+    public const KB_ROOT_ARTICLE      = 1;
+
     /** @var int Value indicating no rights */
     public const RIGHT_NONE           = 0;
 
@@ -419,6 +422,7 @@ $empty_data_builder = new class {
             'glpi_11_assets_migration' => 0,
             'must_unsanitize_db_data' => 0,
             'login_history_retention_days' => 90,
+            'root_knowbaseitems_id' => self::KB_ROOT_ARTICLE,
         ];
 
         $tables['glpi_configs'] = [];
@@ -2724,6 +2728,23 @@ $empty_data_builder = new class {
             [
                 'id' => 8,
                 'name' => 'PCI-X',
+            ],
+        ];
+
+        // The root article, base of the knowledge base tree. Its id is stored in
+        // the `root_knowbaseitems_id` configuration.
+        // Existing installations get theirs from the 12.0.0 migration.
+        $tables['glpi_knowbaseitems'] = [
+            [
+                'id' => self::KB_ROOT_ARTICLE,
+                'entities_id' => 0,
+                'is_recursive' => 1,
+                'name' => __('Home'),
+                'answer' => '',
+                'is_faq' => 0,
+                'users_id' => 0,
+                'date_creation' => date('Y-m-d H:i:s'),
+                'date_mod' => date('Y-m-d H:i:s'),
             ],
         ];
 

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2742,7 +2742,7 @@ $empty_data_builder = new class {
                 'name' => __('Home'),
                 'answer' => '',
                 'is_faq' => 0,
-                'users_id' => 0,
+                'users_id' => self::USER_SYSTEM,
                 'date_creation' => date('Y-m-d H:i:s'),
                 'date_mod' => date('Y-m-d H:i:s'),
             ],

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
@@ -32,6 +32,8 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QuerySubQuery;
+
 /**
  * @var DBmysql $DB
  * @var Migration $migration
@@ -43,7 +45,21 @@
 //
 // This file must run *after* `knowbaseitemcategory_to_article.php` (it does,
 // files are included in alphabetical order) so that the articles created from
-// the former categories are known when the tree is later reparented.
+// the former categories are attached to the root article too.
+$kb_links_table = 'glpi_knowbaseitems_knowbaseitems';
+
+// Drop the links that reference an article that no longer exists as a safety.
+$kb_existing_articles = new QuerySubQuery([
+    'SELECT' => 'id',
+    'FROM'   => 'glpi_knowbaseitems',
+]);
+$DB->delete($kb_links_table, [
+    'OR' => [
+        'knowbaseitems_id'        => ['NOT IN', $kb_existing_articles],
+        'knowbaseitems_id_parent' => ['NOT IN', $kb_existing_articles],
+    ],
+]);
+
 $root_config = $DB->request([
     'SELECT' => 'value',
     'FROM'   => 'glpi_configs',
@@ -86,4 +102,25 @@ if ($root_id === 0 || countElementsInTable('glpi_knowbaseitems', ['id' => $root_
             'name'    => 'root_knowbaseitems_id',
         ]
     );
+}
+
+// Attach every other top-level article, i.e. every article that has no parent,
+// to the root article so the knowledge base is a single tree.
+$migration->displayMessage("Attach top-level knowledge base articles to the root article");
+
+foreach ($DB->request([
+    'SELECT' => 'id',
+    'FROM'   => 'glpi_knowbaseitems',
+    'WHERE'  => [
+        ['NOT' => ['id' => $root_id]],
+        'id' => ['NOT IN', new QuerySubQuery([
+            'SELECT' => 'knowbaseitems_id',
+            'FROM'   => $kb_links_table,
+        ])],
+    ],
+]) as $article) {
+    $DB->insert($kb_links_table, [
+        'knowbaseitems_id'        => (int) $article['id'],
+        'knowbaseitems_id_parent' => $root_id,
+    ]);
 }

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
@@ -71,6 +71,16 @@ $root_config = $DB->request([
 
 $root_id = (int) ($root_config['value'] ?? 0);
 
+$system_user_config = $DB->request([
+    'SELECT' => 'value',
+    'FROM'   => 'glpi_configs',
+    'WHERE'  => [
+        'context' => 'core',
+        'name'    => 'system_user',
+    ],
+])->current();
+$system_user_id = (int) ($system_user_config['value'] ?? 0);
+
 // Also recreate the article when the configuration points to an article that no
 // longer exists (interrupted migration, manual database surgery, ...), as the
 // whole feature relies on this id being valid.
@@ -84,7 +94,7 @@ if ($root_id === 0 || countElementsInTable('glpi_knowbaseitems', ['id' => $root_
         'name'          => __('Home'),
         'answer'        => '',
         'is_faq'        => 0,
-        'users_id'      => 0,
+        'users_id'      => $system_user_id,
         'date_creation' => $now,
         'date_mod'      => $now,
     ]);

--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitems_root_article.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * @var DBmysql $DB
+ * @var Migration $migration
+ */
+
+// The root article is the base of the knowledge base tree: it can never be
+// deleted and its id is kept in the `root_knowbaseitems_id` configuration.
+// Fresh installations get theirs from `install/empty_data.php`.
+//
+// This file must run *after* `knowbaseitemcategory_to_article.php` (it does,
+// files are included in alphabetical order) so that the articles created from
+// the former categories are known when the tree is later reparented.
+$root_config = $DB->request([
+    'SELECT' => 'value',
+    'FROM'   => 'glpi_configs',
+    'WHERE'  => [
+        'context' => 'core',
+        'name'    => 'root_knowbaseitems_id',
+    ],
+])->current();
+
+$root_id = (int) ($root_config['value'] ?? 0);
+
+// Also recreate the article when the configuration points to an article that no
+// longer exists (interrupted migration, manual database surgery, ...), as the
+// whole feature relies on this id being valid.
+if ($root_id === 0 || countElementsInTable('glpi_knowbaseitems', ['id' => $root_id]) === 0) {
+    $migration->displayMessage("Create the knowledge base root article");
+
+    $now = date('Y-m-d H:i:s');
+    $DB->insert('glpi_knowbaseitems', [
+        'entities_id'   => 0,
+        'is_recursive'  => 1,
+        'name'          => __('Home'),
+        'answer'        => '',
+        'is_faq'        => 0,
+        'users_id'      => 0,
+        'date_creation' => $now,
+        'date_mod'      => $now,
+    ]);
+    $root_id = (int) $DB->insertId();
+
+    // Not `$migration->addConfig()`: that one only inserts missing keys, while
+    // we may also have to fix a key pointing to a missing article.
+    $DB->updateOrInsert(
+        'glpi_configs',
+        [
+            'value' => $root_id,
+        ],
+        [
+            'context' => 'core',
+            'name'    => 'root_knowbaseitems_id',
+        ]
+    );
+}

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -685,9 +685,7 @@ export class GlpiKnowbaseAsideController
             return;
         }
 
-        const selector = `[data-glpi-kb-article-id="${CSS.escape(id)}"] `
-            + `[data-glpi-kb-actions-menu]:not([data-glpi-kb-actions-loaded])`;
-        if (this.#aside.querySelector(selector) === null) {
+        if (this.#findEmptyMenus(id).length === 0) {
             return; // Nothing left to populate for this id.
         }
 
@@ -700,10 +698,26 @@ export class GlpiKnowbaseAsideController
             return;
         }
 
-        for (const menu of this.#aside.querySelectorAll(selector)) {
+        for (const menu of this.#findEmptyMenus(id)) {
             menu.innerHTML = html;
             menu.setAttribute('data-glpi-kb-actions-loaded', '');
         }
+    }
+
+    /**
+     * @param {number} id
+     * @returns {HTMLElement[]}
+     */
+    #findEmptyMenus(id)
+    {
+        const menus = this.#aside.querySelectorAll(
+            `[data-glpi-kb-article-id="${CSS.escape(id)}"] `
+            + `[data-glpi-kb-actions-menu]:not([data-glpi-kb-actions-loaded])`,
+        );
+
+        return Array.from(menus).filter(
+            (menu) => menu.closest('[data-glpi-kb-article-id]')?.dataset.glpiKbArticleId === String(id),
+        );
     }
 
     /**
@@ -909,6 +923,7 @@ export class GlpiKnowbaseAsideController
                     const clone = source.cloneNode(true);
                     clone.classList.add('mb-2');
                     clone.removeAttribute('data-glpi-kb-search-hidden');
+                    this.#flattenClonedFavorite(clone);
                     // The source row's dots menu is still open (the user just
                     // clicked a toggle inside it); close it in the clone.
                     this.#resetClonedDropdown(clone);
@@ -924,6 +939,36 @@ export class GlpiKnowbaseAsideController
         }
 
         this.#refreshFavoritesVisibility(favorites);
+    }
+
+    /**
+     * @param {HTMLElement} clone
+     */
+    #flattenClonedFavorite(clone)
+    {
+        for (const children of clone.querySelectorAll(':scope > ul')) {
+            children.remove();
+        }
+
+        for (const affordance of clone.querySelectorAll(
+            '[data-glpi-kb-aside-category-toggle], [data-glpi-kb-aside-category-add]',
+        )) {
+            affordance.remove();
+        }
+
+        clone.classList.remove('node');
+        clone.removeAttribute('data-glpi-kb-aside-category');
+        clone.removeAttribute('data-glpi-kb-aside-category-collapsed');
+        // Node rows are groups labelled by their title; a flat entry is a plain
+        // list item again.
+        clone.removeAttribute('role');
+        clone.removeAttribute('aria-label');
+
+        const line = clone.querySelector(':scope > .article-line');
+        if (line) {
+            line.removeAttribute('data-glpi-kb-aside-category-header');
+            line.classList.remove('mb-2');
+        }
     }
 
     /**

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -160,6 +160,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
     public function canViewItem(): bool
     {
+        // The root article is the entry point of the knowledge base: everyone
+        // allowed to read the knowledge base can view it, it has no visibility
+        // rules of its own. FAQ-only readers are not concerned: the root article
+        // is not part of the FAQ, see `getVisibilityCriteriaFAQ()`.
+        if ($this->isRoot()) {
+            return Session::haveRight(self::$rightname, READ);
+        }
+
         if ($this->fields['users_id'] === Session::getLoginUserID()) {
             return true;
         }
@@ -867,9 +875,18 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         // Inherited visibility: an article is also visible if any of its
         // ancestors is directly visible. Build the inherited term from the
         // direct terms BEFORE appending it (it must not contain itself).
-        $inherited = self::getInheritedVisibilityCondition($direct_or);
+        $criteria = array_merge($direct_or, [self::getInheritedVisibilityCondition($direct_or)]);
 
-        return ['OR' => array_merge($direct_or, [$inherited])];
+        // The root article is the entry point of the knowledge base: everyone
+        // allowed to read the knowledge base sees it, it has no visibility rules
+        // of its own. Appended after the inherited term on purpose, see
+        // `getInheritedVisibilityCondition()` for why it must not seed it.
+        $root_id = self::getConfiguredRootId();
+        if ($root_id > 0) {
+            $criteria[] = [self::getTableField('id') => $root_id];
+        }
+
+        return ['OR' => $criteria];
     }
 
     /**
@@ -887,11 +904,23 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         global $DB;
 
         // Seed: ids of directly-visible articles (self-contained subquery).
+        $seed_where = ['OR' => $direct_or];
+
+        // The root article is the ancestor of every article: were it part of the
+        // seed, the whole knowledge base would inherit its visibility.
+        $root_id = self::getConfiguredRootId();
+        if ($root_id > 0) {
+            $seed_where = [
+                $seed_where,
+                ['NOT' => [self::getTableField('id') => $root_id]],
+            ];
+        }
+
         $seed = new QuerySubQuery([
             'SELECT'    => self::getTableField('id'),
             'FROM'      => self::getTable(),
             'LEFT JOIN' => self::getVisibilityCriteriaCommonJoin(true),
-            'WHERE'     => ['OR' => $direct_or],
+            'WHERE'     => $seed_where,
         ]);
 
         // GLPI's iterator emits `?` placeholders and keeps the bound values

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -3155,7 +3155,8 @@ TWIG, $twig_params);
 
     public static function getAdditionalMenuLinks(): array
     {
-        return ['all_articles' => self::getSearchURL(false)];
+        // Dummy parameter to prevent redirection to the root article.
+        return ['all_articles' => self::getSearchURL(false) . '?list=1'];
     }
 
     /** @return Article[] */

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -161,11 +161,12 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
     public function canViewItem(): bool
     {
         // The root article is the entry point of the knowledge base: everyone
-        // allowed to read the knowledge base can view it, it has no visibility
-        // rules of its own. FAQ-only readers are not concerned: the root article
-        // is not part of the FAQ, see `getVisibilityCriteriaFAQ()`.
+        // allowed to read the knowledge base, administrators included, can view
+        // it, it has no visibility rules of its own. FAQ-only readers are not
+        // concerned: the root article is not part of the FAQ, see
+        // `getVisibilityCriteriaFAQ()` and `prepareInputForUpdate()`.
         if ($this->isRoot()) {
-            return Session::haveRight(self::$rightname, READ);
+            return Session::haveRightsOr(self::$rightname, [READ, self::KNOWBASEADMIN]);
         }
 
         if ($this->fields['users_id'] === Session::getLoginUserID()) {
@@ -249,6 +250,17 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         }
 
         return $root_id;
+    }
+
+    /**
+     * Whether the knowledge base has a root article, see `getRootId()`.
+     *
+     * Only a corrupted installation has none; callers that can do without it
+     * must use this method instead of catching `getRootId()` exception.
+     */
+    public static function hasRoot(): bool
+    {
+        return self::getConfiguredRootId() > 0;
     }
 
     /**
@@ -491,15 +503,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
         // Handle parent articles. Articles created without a parent are attached
         // to the root article, so the knowledge base always is a single tree.
-        $root_id = self::getConfiguredRootId();
-        if (
-            empty($this->input['_parents'])
-            && !$this->isRoot()
-            && $root_id > 0
-            && self::getById($root_id) !== false
-        ) {
-            $this->input['_parents'] = [$root_id];
-        }
+        $this->setRootAsDefaultParent(on_creation: true);
         $this->update1NTableData(KnowbaseItem_KnowbaseItem::class, "_parents");
 
         NotificationEvent::raiseEvent('new', $this);
@@ -665,6 +669,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
     public function cleanDBonPurge()
     {
+        // Collect the children that this purge would leave outside the tree
+        // before their links to the purged article are removed below.
+        $orphaned_children = $this->getChildrenWithoutOtherParent();
+
         $this->deleteChildrenAndRelationsFromDb(
             [
                 Entity_KnowbaseItem::class,
@@ -685,6 +693,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             ['knowbaseitems_id_parent' => $this->fields['id']]
         );
 
+        // Attach the children that just lost their only parent back to the root
+        // article, so the knowledge base always is a single tree.
+        self::attachToRootArticle($orphaned_children);
+
         // KnowbaseItem_Comment does not extends CommonDBConnexity
         $kbic = new KnowbaseItem_Comment();
         $kbic->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
@@ -692,6 +704,62 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         // KnowbaseItem_Revision does not extends CommonDBConnexity
         $kbir = new KnowbaseItem_Revision();
         $kbir->deleteByCriteria(['knowbaseitems_id' => $this->fields['id']]);
+    }
+
+    /**
+     * Ids of the children of the loaded article that have no other parent, and
+     * would thus be left outside the knowledge base tree if the article is
+     * removed from it.
+     *
+     * @return int[]
+     */
+    private function getChildrenWithoutOtherParent(): array
+    {
+        $relation = new KnowbaseItem_KnowbaseItem();
+
+        $children_ids = array_map('intval', array_column(
+            $relation->find(['knowbaseitems_id_parent' => $this->fields['id']]),
+            'knowbaseitems_id'
+        ));
+        if ($children_ids === []) {
+            return [];
+        }
+
+        $parents_count = array_count_values(array_map('intval', array_column(
+            $relation->find(['knowbaseitems_id' => $children_ids]),
+            'knowbaseitems_id'
+        )));
+
+        return array_values(array_filter(
+            $children_ids,
+            static fn(int $child_id): bool => ($parents_count[$child_id] ?? 0) <= 1,
+        ));
+    }
+
+    /**
+     * Attach the given articles to the root article, ignoring the ones that
+     * can not have a parent.
+     *
+     * @param int[] $article_ids
+     */
+    private static function attachToRootArticle(array $article_ids): void
+    {
+        if ($article_ids === [] || !self::hasRoot()) {
+            return;
+        }
+
+        $root_id  = self::getRootId();
+        $relation = new KnowbaseItem_KnowbaseItem();
+        foreach ($article_ids as $article_id) {
+            if ($article_id === $root_id) {
+                continue;
+            }
+
+            $relation->add([
+                'knowbaseitems_id'        => $article_id,
+                'knowbaseitems_id_parent' => $root_id,
+            ]);
+        }
     }
 
     /**
@@ -1088,6 +1156,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             $input["name"] = __('New item');
         }
 
+        // The root article is the entry point of the knowledge base, not a
+        // piece of content to publish. Listing it in the FAQ or in the service
+        // catalog would offer it to readers that are not allowed to open it,
+        // down to anonymous users on a public FAQ, see `canViewItem()`.
+        if ($this->isRoot()) {
+            unset($input['is_faq'], $input['show_in_service_catalog']);
+        }
+
         return $this->prepareIllustrationInput($input);
     }
 
@@ -1113,6 +1189,50 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         return $input;
     }
 
+    /**
+     * Make sure the `_parents` input never leaves the article outside the
+     * knowledge base tree: an article that would end up without any parent is
+     * attached to the root article instead.
+     *
+     * @param bool $on_creation Whether the article is being created, in which
+     *                          case an input that does not mention the parents
+     *                          at all must be defaulted too.
+     */
+    private function setRootAsDefaultParent(bool $on_creation): void
+    {
+        // The root article is the only one allowed to have no parent.
+        if (!is_array($this->input) || $this->isRoot()) {
+            return;
+        }
+
+        $parents = $this->input['_parents'] ?? null;
+
+        // See `update1NTableData()`: an input that does not target the parents
+        // at all must be left alone, unless the article has no parent yet.
+        $targets_parents = $parents !== null
+            || (bool) ($this->input['__parents_defined'] ?? false);
+        if (!$targets_parents && !$on_creation) {
+            return;
+        }
+
+        // Only an emptied input needs a default.
+        if (!empty($parents)) {
+            return;
+        }
+
+        // Guard against an installation that has no root article: a link to a
+        // missing article would be worse than no link at all.
+        if (!self::hasRoot()) {
+            return;
+        }
+        $root_id = self::getRootId();
+        if (countElementsInTable(self::getTable(), ['id' => $root_id]) === 0) {
+            return;
+        }
+
+        $this->input['_parents'] = [$root_id];
+    }
+
     public function post_updateItem($history = true)
     {
         // Handle rich-text images and uploaded documents
@@ -1124,7 +1244,10 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             ]
         );
 
-        // Update parent articles
+        // Update parent articles. An article whose parents are all removed is
+        // attached back to the root article, so the knowledge base always is a
+        // single tree.
+        $this->setRootAsDefaultParent(on_creation: false);
         $this->update1NTableData(KnowbaseItem_KnowbaseItem::class, '_parents');
         NotificationEvent::raiseEvent('update', $this);
     }
@@ -1518,20 +1641,20 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 );
             }
 
-            $actions[] = new EditorAction(
-                label: __("Service catalog"),
-                icon: "ti ti-library",
-                type: EditorActionType::OPEN_MODAL,
-                params: [
-                    'id'    => $this->fields['id'],
-                    'key'   => 'SidePanel/service-catalog',
-                    'title' => __("Service catalog"),
-                    'icon'  => 'ti ti-library',
-                ],
-            );
-
-            // Neither of the two actions below applies to the root article.
+            // None of the actions below applies to the root article.
             if (!$this->isRoot()) {
+                $actions[] = new EditorAction(
+                    label: __("Service catalog"),
+                    icon: "ti ti-library",
+                    type: EditorActionType::OPEN_MODAL,
+                    params: [
+                        'id'    => $this->fields['id'],
+                        'key'   => 'SidePanel/service-catalog',
+                        'title' => __("Service catalog"),
+                        'icon'  => 'ti ti-library',
+                    ],
+                );
+
                 $label = __('Permissions');
                 $icon  = "ti ti-lock";
                 $actions[] = new EditorAction(
@@ -1593,7 +1716,8 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 ],
             );
         }
-        if ($this->can($this->fields['id'], UPDATE)) {
+        // The root article is not part of the FAQ, see `prepareInputForUpdate()`.
+        if (!$this->isRoot() && $this->can($this->fields['id'], UPDATE)) {
             $toggles[] = new EditorAction(
                 label: __("Add to FAQ"),
                 icon: "ti ti-bookmark",

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -489,7 +489,17 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
             $kb_item_item->add($params);
         }
 
-        // Handle parent articles
+        // Handle parent articles. Articles created without a parent are attached
+        // to the root article, so the knowledge base always is a single tree.
+        $root_id = self::getConfiguredRootId();
+        if (
+            empty($this->input['_parents'])
+            && !$this->isRoot()
+            && $root_id > 0
+            && self::getById($root_id) !== false
+        ) {
+            $this->input['_parents'] = [$root_id];
+        }
         $this->update1NTableData(KnowbaseItem_KnowbaseItem::class, "_parents");
 
         NotificationEvent::raiseEvent('new', $this);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -185,6 +185,13 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
     public function canUpdateItem(): bool
     {
+        // The root article is the entry point of the knowledge base: everyone
+        // allowed to update the knowledge base can edit it, it has no visibility
+        // rules of its own (see `canViewItem()`).
+        if ($this->isRoot()) {
+            return Session::haveRightsOr(self::$rightname, [UPDATE, self::KNOWBASEADMIN]);
+        }
+
         // Personal knowbase or visibility and write access
         return (Session::haveRight(self::$rightname, self::KNOWBASEADMIN)
               || (Session::getCurrentInterface() === "central"
@@ -1507,29 +1514,32 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 ],
             );
 
-            $label = __('Permissions');
-            $icon  = "ti ti-lock";
-            $actions[] = new EditorAction(
-                label: $label,
-                icon: $icon,
-                type: EditorActionType::OPEN_MODAL,
-                params: [
-                    'id'    => $this->fields['id'],
-                    'key'   => 'SidePanel/targets',
-                    'title' => $label,
-                    'icon'  => $icon,
-                ],
-            );
-            $actions[] = new EditorAction(
-                label: __('Schedule visibility'),
-                icon: 'ti ti-calendar-clock',
-                type: EditorActionType::OPEN_MODAL,
-                params: [
-                    'id'    => $this->fields['id'],
-                    'key'   => 'SidePanel/schedule-visibility',
-                    'title' => __('Schedule visibility'),
-                ],
-            );
+            // Neither of the two actions below applies to the root article.
+            if (!$this->isRoot()) {
+                $label = __('Permissions');
+                $icon  = "ti ti-lock";
+                $actions[] = new EditorAction(
+                    label: $label,
+                    icon: $icon,
+                    type: EditorActionType::OPEN_MODAL,
+                    params: [
+                        'id'    => $this->fields['id'],
+                        'key'   => 'SidePanel/targets',
+                        'title' => $label,
+                        'icon'  => $icon,
+                    ],
+                );
+                $actions[] = new EditorAction(
+                    label: __('Schedule visibility'),
+                    icon: 'ti ti-calendar-clock',
+                    type: EditorActionType::OPEN_MODAL,
+                    params: [
+                        'id'    => $this->fields['id'],
+                        'key'   => 'SidePanel/schedule-visibility',
+                        'title' => __('Schedule visibility'),
+                    ],
+                );
+            }
         }
 
         // Include base actions that are available for articles in the aside

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -187,6 +187,26 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                   && $this->haveVisibilityAccess()));
     }
 
+    public function canDeleteItem(): bool
+    {
+        // The root article is the base of the knowledge base tree, it must
+        // always exist.
+        if ($this->isRoot()) {
+            return false;
+        }
+
+        return parent::canDeleteItem();
+    }
+
+    public function canPurgeItem(): bool
+    {
+        if ($this->isRoot()) {
+            return false;
+        }
+
+        return parent::canPurgeItem();
+    }
+
     /**
      * Check if current user can comment on KB entries
      *
@@ -208,14 +228,35 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
      */
     public static function getRootId(): int
     {
-        global $CFG_GLPI;
-
-        $root_id = (int) ($CFG_GLPI['root_knowbaseitems_id'] ?? 0);
+        $root_id = self::getConfiguredRootId();
         if ($root_id <= 0) {
             throw new RuntimeException('The knowledge base root article is not defined.');
         }
 
         return $root_id;
+    }
+
+    /**
+     * Whether the loaded article is the root article, see `getRootId()`.
+     */
+    public function isRoot(): bool
+    {
+        $id = (int) ($this->fields['id'] ?? 0);
+
+        // Compared to the raw configuration value instead of `getRootId()`: this
+        // method is called from rights checks, which must not fail on an
+        // installation that has no root article (no article is the root then).
+        return $id > 0 && $id === self::getConfiguredRootId();
+    }
+
+    /**
+     * Configured id of the root article, 0 if there is none.
+     */
+    private static function getConfiguredRootId(): int
+    {
+        global $CFG_GLPI;
+
+        return (int) ($CFG_GLPI['root_knowbaseitems_id'] ?? 0);
     }
 
     public static function getSearchURL($full = true)
@@ -572,6 +613,23 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
 
         // Load parent articles
         $this->load1NTableData(KnowbaseItem_KnowbaseItem::class, '_parents');
+    }
+
+    public function pre_deleteItem()
+    {
+        // Last line of defense: `canDeleteItem()` and `canPurgeItem()` already
+        // forbid the action, but this hook is the single gate that every deletion
+        // goes through, including the code paths that do not check rights.
+        if ($this->isRoot()) {
+            Session::addMessageAfterRedirect(
+                msg: __s('The root article of the knowledge base cannot be deleted.'),
+                message_type: ERROR,
+            );
+
+            return false;
+        }
+
+        return parent::pre_deleteItem();
     }
 
     public function cleanDBonPurge()

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -197,6 +197,27 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
         return $this->can($this->getID(), READ) && Session::haveRight(self::$rightname, self::COMMENTS);
     }
 
+    /**
+     * Id of the root article, which is the base of the knowledge base tree.
+     *
+     * The root article is created by the installation process, see
+     * `install/empty_data.php` and the 12.0.0 migration.
+     *
+     * @throws RuntimeException if the configuration value is missing, which can
+     *                          only happen on a corrupted installation.
+     */
+    public static function getRootId(): int
+    {
+        global $CFG_GLPI;
+
+        $root_id = (int) ($CFG_GLPI['root_knowbaseitems_id'] ?? 0);
+        if ($root_id <= 0) {
+            throw new RuntimeException('The knowledge base root article is not defined.');
+        }
+
+        return $root_id;
+    }
+
     public static function getSearchURL($full = true)
     {
         global $CFG_GLPI;

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -256,8 +256,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
      */
     public function isRoot(): bool
     {
-        $id = (int) ($this->fields['id'] ?? 0);
+        return self::isRootId((int) ($this->fields['id'] ?? 0));
+    }
 
+    /**
+     * Whether the given article id is the root article's one, see `getRootId()`.
+     */
+    public static function isRootId(int $id): bool
+    {
         // Compared to the raw configuration value instead of `getRootId()`: this
         // method is called from rights checks, which must not fail on an
         // installation that has no root article (no article is the root then).

--- a/src/KnowbaseItem_KnowbaseItem.php
+++ b/src/KnowbaseItem_KnowbaseItem.php
@@ -86,6 +86,17 @@ final class KnowbaseItem_KnowbaseItem extends CommonDBRelation
             return false;
         }
 
+        // The root article is the base of the knowledge base tree, it cannot be
+        // moved under another article.
+        if (KnowbaseItem::isRootId($child_id)) {
+            Session::addMessageAfterRedirect(
+                __s('The root article of the knowledge base cannot have a parent.'),
+                false,
+                ERROR,
+            );
+            return false;
+        }
+
         // Reject if $child is an ancestor of $parent
         if (self::isAncestor($child_id, $parent_id)) {
             Session::addMessageAfterRedirect(

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -209,30 +209,7 @@
     class="card-body"
     data-glpi-kb-aside-tree
     data-testid="aside-tree"
-    {% if can_create %}
-        {#- The tree container doubles as the "node" for the root-level "+"
-         # affordance below, reusing the same collapsible-node DOM contract as
-         # any other article (see AsideController.js `#openCreateInput`,
-         # which walks up to the closest `[data-glpi-kb-aside-category]` and
-         # looks for its direct child `<ul>`). -#}
-        data-glpi-kb-aside-category
-    {% endif %}
 >
-    {% if can_create %}
-        <div class="d-flex align-items-center mb-2" data-glpi-kb-aside-category-header>
-            {% set add_href = path('/front/knowbaseitem.form.php') %}
-            <a
-                href="{{ add_href }}"
-                class="d-flex align-items-center p-1 text-secondary pe-none"
-                data-glpi-kb-aside-category-add
-                aria-label="{{ __('Create a root article') }}"
-                title="{{ __('Create a root article') }}"
-            >
-                <i class="ti ti-plus" aria-hidden="true"></i>
-                <span class="ms-1">{{ __('Create a root article') }}</span>
-            </a>
-        </div>
-    {% endif %}
     <ul class="kb-tree ps-0">
         {% for article in tree.getArticles %}
             {{ macros.render_article(article, can_create, show_actions) }}

--- a/tests/cypress/e2e/search/toolbar.cy.js
+++ b/tests/cypress/e2e/search/toolbar.cy.js
@@ -76,7 +76,7 @@ for (const [i, settings] of settings_presets.entries()) {
         it(`can toggle unpublished items`, () => {
             // Go to the a search page that support the "unpublished" feature,
             // should be toggled off by default.
-            cy.visit('/front/knowbaseitem.php?forcetab=Knowbase$2');
+            cy.visit('/front/knowbaseitem.php?list=1');
             cy.findByTestId('unpublished-on').should('be.visible');
             cy.findByTestId('unpublished-off').should('not.exist');
 

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -545,8 +545,7 @@ export class KnowbaseItemPage extends GlpiPage
     }
 
     /**
-     * The root-level container of the aside article tree. Doubles as the
-     * "node" for the root "+" affordance (see `aside.html.twig`).
+     * The root-level container of the aside article tree.
      */
     public get asideTree(): Locator
     {
@@ -561,19 +560,6 @@ export class KnowbaseItemPage extends GlpiPage
     {
         // eslint-disable-next-line playwright/no-raw-locators -- using scope
         return this.asideTree.locator(':scope > [data-glpi-kb-aside-category-header]');
-    }
-
-    /**
-     * The "+" link that creates a root-level article (no parent).
-     */
-    public get asideRootCreateLink(): Locator
-    {
-        return this.page.getByRole('link', { name: 'Create a root article' });
-    }
-
-    public get asideRootCreateInput(): Locator
-    {
-        return this.asideTree.getByPlaceholder('New article...');
     }
 
     public get asideSearchInput(): Locator

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -208,13 +208,19 @@ export class KnowbaseItemPage extends GlpiPage
         return this.favoritesSection.locator(`[data-glpi-kb-article-id="${id}"]`);
     }
 
+    public getAsideTreeArticleLine(id: number): Locator
+    {
+        // eslint-disable-next-line playwright/no-raw-locators -- using scope
+        return this.getAsideTreeArticleRow(id).locator(':scope > .article-line');
+    }
+
     /**
      * The illustration slot (`<use>` element for a native icon) of an article
      * row in the aside tree.
      */
     public getAsideTreeArticleIllustration(id: number): Locator
     {
-        return this.getAsideTreeArticleRow(id)
+        return this.getAsideTreeArticleLine(id)
             .getByTestId('kb-illustration')
             .getByTestId('illustration-use')
         ;
@@ -237,7 +243,7 @@ export class KnowbaseItemPage extends GlpiPage
      */
     public getAsideArticleAddChildTrigger(id: number): Locator
     {
-        return this.getAsideTreeArticleRow(id).getByTitle('Create a child article').first();
+        return this.getAsideTreeArticleLine(id).getByTitle('Create a child article');
     }
 
     /**
@@ -245,7 +251,7 @@ export class KnowbaseItemPage extends GlpiPage
      */
     public getAsideArticleMenuTrigger(id: number): Locator
     {
-        return this.getAsideTreeArticleRow(id).getByRole('button', { name: 'More actions' });
+        return this.getAsideTreeArticleLine(id).getByRole('button', { name: 'More actions' });
     }
 
     /**
@@ -253,11 +259,10 @@ export class KnowbaseItemPage extends GlpiPage
      */
     public async doOpenAsideArticleMenu(id: number): Promise<void>
     {
-        const row = this.getAsideTreeArticleRow(id);
-        await row.hover();
+        await this.getAsideTreeArticleLine(id).hover();
         await this.getAsideArticleMenuTrigger(id).click();
         // The aside menu content is lazy-loaded; wait until it is rendered.
-        await expect(row.getByRole('button', { name: 'Add to favorites' })).toBeVisible();
+        await expect(this.getAsideArticleAction(id, 'Add to favorites')).toBeVisible();
     }
 
     /**
@@ -265,7 +270,7 @@ export class KnowbaseItemPage extends GlpiPage
      */
     public getAsideArticleAction(id: number, name: string): Locator
     {
-        return this.getAsideTreeArticleRow(id).getByRole('button', { name });
+        return this.getAsideTreeArticleLine(id).getByRole('button', { name });
     }
 
     public async doToggleAsideFavorite(id: number): Promise<void>

--- a/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
+++ b/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
@@ -86,53 +86,6 @@ test('the aside "+" opens an inline input under a parent article; an empty submi
     await expect(kb.getAsideCategoryCreateInput(parent_name)).toBeHidden();
 });
 
-test('using the root-level "+" creates an article without a parent', async ({ page, profile, api }) => {
-    await profile.set(Profiles.SuperAdmin);
-    const kb = new KnowbaseItemPage(page);
-
-    const unique = randomUUID().slice(0, 8);
-    const article_title = `E2E Root Article ${unique}`;
-
-    const seed_id = await api.createItem('KnowbaseItem', {
-        name: `Seed ${unique}`,
-        answer: 'Seed content',
-        entities_id: getWorkerEntityId(),
-    });
-
-    await kb.goto(seed_id);
-
-    // The "+" click is intercepted by AsideController (a dynamically
-    // imported module), instead of being a plain <a href> navigation. Wait
-    // for the controller to finish initializing before clicking it, using
-    // the same readiness signal doSearchAside() relies on, otherwise the
-    // click can race the module load and fall through to the browser's
-    // default navigation.
-    await expect(kb.asideSearchInput).not.toHaveClass(/pe-none/);
-
-    await kb.asideRootHeader.hover();
-    await expect(kb.asideRootCreateLink).toBeVisible();
-    await kb.asideRootCreateLink.click();
-
-    // No navigation: the "+" now opens an inline input instead of a full page,
-    // so we are still on the seed article's page.
-    await expect(page).toHaveURL(new RegExp(`id=${seed_id}\\b`));
-    const inline_input = kb.asideRootCreateInput;
-    await expect(inline_input).toBeFocused();
-    await inline_input.fill(article_title);
-    await inline_input.press('Enter');
-
-    await expect(page).toHaveURL(/knowbaseitem\.form\.php\?id=\d+/);
-    await expect(page.getByTestId('subject')).toHaveText(article_title);
-
-    // The new article is visible at the root of the tree, and marked current.
-    // (Its <li> has `role="group"` since article creation is allowed here,
-    // overriding the implicit "listitem" role — locate it by id instead.)
-    const new_id = Number(new URL(page.url()).searchParams.get('id'));
-    const article_row = kb.getAsideTreeArticleRow(new_id);
-    await expect(article_row).toBeVisible();
-    await expect(article_row).toHaveAttribute('aria-current', 'page');
-});
-
 test('hovering a child article does not reveal its parent\'s add-article link', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);

--- a/tests/e2e/specs/Knowbase/delete.spec.ts
+++ b/tests/e2e/specs/Knowbase/delete.spec.ts
@@ -58,8 +58,9 @@ test('Can delete an article', async ({ page, profile, api }) => {
     await expect(confirm_button).toBeVisible();
     await confirm_button.click();
 
-    // Should be redirected to knowbase list
-    await expect(page).toHaveURL(/\/front\/knowbaseitem\.php/);
+    // Sent back to the entry point of the knowledge base, which opens the root
+    // article now that the deleted one is gone.
+    await expect(page).toHaveURL(/\/front\/knowbaseitem\.form\.php\?id=\d+/);
     await expect(page.getByText('Item successfully deleted.')).toBeVisible();
 
     // Article should no longer exist

--- a/tests/e2e/specs/Knowbase/entry_point.spec.ts
+++ b/tests/e2e/specs/Knowbase/entry_point.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { KnowbaseItemPage } from '../../pages/KnowbaseItemPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test('entering the knowledge base opens the root article', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    await page.goto('/front/knowbaseitem.php');
+
+    // Redirected to an article, and it is the one at the root of the tree: the
+    // aside marks it as current and it is not nested under another row.
+    await expect(page).toHaveURL(/knowbaseitem\.form\.php\?id=\d+/);
+    const root_id = Number(new URL(page.url()).searchParams.get('id'));
+    const root_row = kb.getAsideTreeArticleRow(root_id);
+    await expect(root_row).toHaveAttribute('aria-current', 'page');
+    await expect(kb.asideTree.locator(`:scope > ul > [data-glpi-kb-article-id="${root_id}"]`)).toBeVisible();
+});
+
+test('the "All articles" button reaches the article list, not the root article', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const unique = randomUUID().slice(0, 8);
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Entry Point ${unique}`,
+        answer: 'My answer',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await kb.goto(article_id);
+    await page.getByRole('button', { name: 'All articles' }).click();
+
+    // Still on the list: the button carries the parameter that skips the
+    // redirect, so no article is rendered.
+    await expect(page).toHaveURL(/knowbaseitem\.php\?/);
+    await expect(page.getByTestId('kb-article')).toHaveCount(0);
+});
+
+test('a search request is not redirected to the root article', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    // What the search form posts back to this page. It cannot carry the "All
+    // articles" parameter: browsers drop the query string of a GET form action.
+    await page.goto(
+        '/front/knowbaseitem.php?itemtype=KnowbaseItem'
+        + '&criteria[0][link]=AND&criteria[0][field]=1'
+        + '&criteria[0][searchtype]=contains&criteria[0][value]=',
+    );
+
+    await expect(page).toHaveURL(/knowbaseitem\.php\?/);
+    await expect(page.getByTestId('kb-article')).toHaveCount(0);
+});

--- a/tests/e2e/specs/Knowbase/entry_point.spec.ts
+++ b/tests/e2e/specs/Knowbase/entry_point.spec.ts
@@ -63,7 +63,9 @@ test('the "All articles" button reaches the article list, not the root article',
     });
 
     await kb.goto(article_id);
-    await page.getByRole('button', { name: 'All articles' }).click();
+    // The context links of the breadcrumb bar are button-styled links, see the
+    // `action_link` macro of `layout/parts/context_links.html.twig`.
+    await page.getByRole('link', { name: 'All articles' }).click();
 
     // Still on the list: the button carries the parameter that skips the
     // redirect, and the page is a standard search page.

--- a/tests/e2e/specs/Knowbase/entry_point.spec.ts
+++ b/tests/e2e/specs/Knowbase/entry_point.spec.ts
@@ -66,8 +66,9 @@ test('the "All articles" button reaches the article list, not the root article',
     await page.getByRole('button', { name: 'All articles' }).click();
 
     // Still on the list: the button carries the parameter that skips the
-    // redirect, so no article is rendered.
+    // redirect, and the page is a standard search page.
     await expect(page).toHaveURL(/knowbaseitem\.php\?/);
+    await expect(page.getByTestId('search-page')).toBeVisible();
     await expect(page.getByTestId('kb-article')).toHaveCount(0);
 });
 
@@ -83,5 +84,6 @@ test('a search request is not redirected to the root article', async ({ page, pr
     );
 
     await expect(page).toHaveURL(/knowbaseitem\.php\?/);
+    await expect(page.getByTestId('search-page')).toBeVisible();
     await expect(page.getByTestId('kb-article')).toHaveCount(0);
 });

--- a/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
@@ -34,6 +34,7 @@ import { expect, test } from "../../fixtures/glpi_fixture";
 import { KnowbaseItemPage } from "../../pages/KnowbaseItemPage";
 import { Profiles } from "../../utils/Profiles";
 import { getUniqueName } from "../../utils/Random";
+import { getWorkerEntityId } from "../../utils/WorkerEntities";
 
 test('Can add and remove a favorite from the aside dots menu', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
@@ -71,6 +72,47 @@ test('Can add and remove a favorite from the aside dots menu', async ({ page, pr
     await kb.doToggleAsideFavorite(target_id);
     await expect(favorite_checkbox).not.toBeChecked();
     await expect(kb.getFavoriteArticle(target_name)).toBeHidden();
+});
+
+test('A nested article dots menu acts on that article, not on its parent', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const viewed_id = await api.knowbase.createArticle({
+        name: getUniqueName(`Aside nested viewed`),
+        answer: "My answer",
+    });
+    const parent_name = getUniqueName(`Aside nested parent`);
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        answer: 'Parent content',
+        entities_id: getWorkerEntityId(),
+    });
+    const child_name = getUniqueName(`Aside nested child`);
+    const child_id = await api.createItem('KnowbaseItem', {
+        name: child_name,
+        answer: 'Child content',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    await kb.goto(viewed_id);
+    await kb.waitForAsideReady();
+
+    // Load parent menu actions.
+    const parent_actions = page.waitForResponse(
+        (response) => response.url().includes(`/Knowbase/${parent_id}/AsideActions`),
+    );
+    await kb.getAsideArticleTitleLink(parent_name).hover();
+    await parent_actions;
+
+    // Favorite the child from its own menu.
+    await kb.doOpenAsideArticleMenu(child_id);
+    await kb.doToggleAsideFavorite(child_id);
+
+    // The child is favorited, the parent is untouched.
+    await expect(kb.getFavoriteArticle(child_name)).toBeVisible();
+    await expect(kb.getFavoriteArticle(parent_name)).toBeHidden();
 });
 
 test('Can toggle FAQ status from the aside dots menu', async ({ page, profile, api }) => {

--- a/tests/e2e/specs/Knowbase/kb-favorites.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-favorites.spec.ts
@@ -97,3 +97,50 @@ test('Can toggle favorites from true to false', async ({ page, profile, api }) =
     await expect(favorite_toggle_after_reload.getByRole('checkbox')).not.toBeChecked();
     await expect(kb.getFavoriteArticle(name)).toBeHidden();
 });
+
+test('The favorites area stays a flat list when favoriting an article with children', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const unique = randomUUID().slice(0, 8);
+    const parent_name = `Favorite parent ${unique}`;
+    const child_name = `Favorite child ${unique}`;
+
+    const viewed_id = await api.createItem('KnowbaseItem', {
+        name: `Favorite viewed ${unique}`,
+        entities_id: getWorkerEntityId(),
+        answer: "My answer",
+    });
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        entities_id: getWorkerEntityId(),
+        answer: "Parent content",
+    });
+    await api.createItem('KnowbaseItem', {
+        name: child_name,
+        entities_id: getWorkerEntityId(),
+        answer: "Child content",
+        _parents: [parent_id],
+    });
+
+    await kb.goto(viewed_id);
+    await kb.waitForAsideReady();
+
+    // Favorite another article than the current one, so the entry is built from
+    // its tree row instead of the current article's dedicated one.
+    await kb.doOpenAsideArticleMenu(parent_id);
+    await kb.doToggleAsideFavorite(parent_id);
+
+    // The favorites area lists the article alone: no children, and none of the
+    // tree affordances (the collapse toggle is a button labelled by the title).
+    await expect(kb.getFavoriteArticle(parent_name)).toBeVisible();
+    await expect(kb.getFavoriteArticle(child_name)).toBeHidden();
+    await expect(
+        kb.favoritesSection.getByRole('button', { name: parent_name, exact: true }),
+    ).toHaveCount(0);
+
+    // The server-rendered version agrees.
+    await page.reload();
+    await expect(kb.getFavoriteArticle(parent_name)).toBeVisible();
+    await expect(kb.getFavoriteArticle(child_name)).toBeHidden();
+});

--- a/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
@@ -38,7 +38,6 @@ use Budget;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use KnowbaseItem;
-use KnowbaseItem_KnowbaseItem;
 use KnowbaseItemTranslation;
 use Project;
 use Ticket;
@@ -194,23 +193,22 @@ class KnowbaseControllerTest extends HLAPITestCase
         $this->loginWeb();
 
         $entity = $this->getTestRootEntity(true);
+
+        // Chained at creation time: adding the links afterwards would leave each
+        // article with a second parent, the root article every parentless
+        // creation is attached to.
         $articles = [];
+        $parent_id = 0;
         foreach (['root', 'middle', 'leaf'] as $name) {
             $articles[$name] = $this->createItem(KnowbaseItem::class, [
                 'name' => '_kbcategory_' . $name,
                 'answer' => $name,
                 'entities_id' => $entity,
                 'is_recursive' => 1,
+                '_parents' => $parent_id > 0 ? [$parent_id] : [],
             ]);
+            $parent_id = $articles[$name]->getID();
         }
-        $this->createItem(KnowbaseItem_KnowbaseItem::class, [
-            'knowbaseitems_id' => $articles['middle']->getID(),
-            'knowbaseitems_id_parent' => $articles['root']->getID(),
-        ]);
-        $this->createItem(KnowbaseItem_KnowbaseItem::class, [
-            'knowbaseitems_id' => $articles['leaf']->getID(),
-            'knowbaseitems_id_parent' => $articles['middle']->getID(),
-        ]);
 
         $this->login();
 
@@ -226,15 +224,17 @@ class KnowbaseControllerTest extends HLAPITestCase
                     $this->assertArrayHasKey($articles['root']->getID(), $categories);
                     $this->assertArrayHasKey($articles['middle']->getID(), $categories);
 
+                    // Every article hangs under the root article, which is thus
+                    // the first level of the deprecated category tree.
                     $root = $categories[$articles['root']->getID()];
-                    $this->assertEquals('_kbcategory_root', $root['completename']);
-                    $this->assertEquals(1, $root['level']);
-                    $this->assertNull($root['parent']);
+                    $this->assertEquals('Home > _kbcategory_root', $root['completename']);
+                    $this->assertEquals(2, $root['level']);
+                    $this->assertEquals(KnowbaseItem::getRootId(), $root['parent']['id']);
                     $this->assertEquals('', $root['comment']);
 
                     $middle = $categories[$articles['middle']->getID()];
-                    $this->assertEquals('_kbcategory_root > _kbcategory_middle', $middle['completename']);
-                    $this->assertEquals(2, $middle['level']);
+                    $this->assertEquals('Home > _kbcategory_root > _kbcategory_middle', $middle['completename']);
+                    $this->assertEquals(3, $middle['level']);
                     $this->assertEquals($articles['root']->getID(), $middle['parent']['id']);
                     $this->assertEquals('_kbcategory_root', $middle['parent']['name']);
                 });
@@ -245,8 +245,8 @@ class KnowbaseControllerTest extends HLAPITestCase
                 ->isOK()
                 ->jsonContent(function ($content) use ($articles) {
                     $this->assertEquals('_kbcategory_middle', $content['name']);
-                    $this->assertEquals('_kbcategory_root > _kbcategory_middle', $content['completename']);
-                    $this->assertEquals(2, $content['level']);
+                    $this->assertEquals('Home > _kbcategory_root > _kbcategory_middle', $content['completename']);
+                    $this->assertEquals(3, $content['level']);
                     $this->assertEquals($articles['root']->getID(), $content['parent']['id']);
                 });
         });

--- a/tests/functional/Glpi/ContentTemplates/Parameters/TicketParametersTest.php
+++ b/tests/functional/Glpi/ContentTemplates/Parameters/TicketParametersTest.php
@@ -313,7 +313,7 @@ class TicketParametersTest extends AbstractParametersTest
                         'id' => getItemByTypeName(\KnowbaseItem::class, '_knowbaseitem01', true),
                         'name' => '_knowbaseitem01',
                         'answer' => "Answer for Knowledge base entry _knowbaseitem01 apple juice turnover",
-                        'link' => "<a href=\"/front/knowbaseitem.form.php?id=1\" data-bs-toggle=\"tooltip\" data-bs-placement=\"bottom\" title=\"_knowbaseitem01\">_knowbaseitem01</a>",
+                        'link' => "<a href=\"/front/knowbaseitem.form.php?id=" . getItemByTypeName(\KnowbaseItem::class, '_knowbaseitem01', true) . "\" data-bs-toggle=\"tooltip\" data-bs-placement=\"bottom\" title=\"_knowbaseitem01\">_knowbaseitem01</a>",
                     ],
                 ],
                 'assets'        => [],

--- a/tests/functional/Glpi/Controller/Knowbase/CreateArticleControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/CreateArticleControllerTest.php
@@ -95,7 +95,7 @@ final class CreateArticleControllerTest extends DbTestCase
         $this->assertSame(0, (int) $item->fields['is_recursive']);
     }
 
-    public function testCreatesRootArticleWhenNoParentGiven(): void
+    public function testCreatesArticleUnderRootWhenNoParentGiven(): void
     {
         $this->login();
 
@@ -104,10 +104,10 @@ final class CreateArticleControllerTest extends DbTestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $data = json_decode($response->getContent(), true);
-        $links = (new \KnowbaseItem_KnowbaseItem())->find([
-            'knowbaseitems_id' => $data['id'],
-        ]);
-        $this->assertCount(0, $links);
+        $this->assertSame(
+            [KnowbaseItem::getRootId()],
+            $this->getParentIds((int) $data['id']),
+        );
     }
 
     public function testEmptyNameReturns400(): void
@@ -139,10 +139,25 @@ final class CreateArticleControllerTest extends DbTestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $data = json_decode($response->getContent(), true);
+
+        // The unreadable parent is dropped, so the article falls back to the
+        // root article like any other parentless creation.
+        $this->assertSame(
+            [KnowbaseItem::getRootId()],
+            $this->getParentIds((int) $data['id']),
+        );
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getParentIds(int $article_id): array
+    {
         $links = (new \KnowbaseItem_KnowbaseItem())->find([
-            'knowbaseitems_id' => $data['id'],
+            'knowbaseitems_id' => $article_id,
         ]);
-        $this->assertCount(0, $links);
+
+        return array_map('intval', array_column($links, 'knowbaseitems_id_parent'));
     }
 
     public function testUserWithoutCreateRightIsDenied(): void

--- a/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
@@ -67,10 +67,11 @@ final class BuilderTest extends DbTestCase
 
         $tree = (new Builder())->buildTree();
 
-        // Root level: the two fixture articles, "Animals", "Plants" and "Root article"
-        // (order follows insertion/id order, not the order they were requested above).
+        // Root level: the two fixture articles, "Animals", "Plants", "Root article"
+        // and the installation's root article (ordered by name, not by the order
+        // they were requested above).
         $this->assertEquals(
-            ['_knowbaseitem01', '_knowbaseitem02', 'Animals', 'Plants', 'Root article'],
+            ['_knowbaseitem01', '_knowbaseitem02', 'Animals', 'Home', 'Plants', 'Root article'],
             array_column($tree->getArticles(), 'title'),
         );
 

--- a/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
@@ -34,7 +34,9 @@
 
 namespace tests\unit\Glpi\Knowbase\Aside;
 
+use Glpi\Knowbase\Aside\Article;
 use Glpi\Knowbase\Aside\Builder;
+use Glpi\Knowbase\Aside\Tree;
 use Glpi\Tests\DbTestCase;
 use KnowbaseItem;
 use KnowbaseItem_User;
@@ -46,7 +48,8 @@ final class BuilderTest extends DbTestCase
      * Builds a multi-level tree via `_parents` and asserts its recursive
      * structure:
      *
-     *  Root articles : _knowbaseitem01, _knowbaseitem02 (fixtures), "Root article"
+     *  Home (root)   : _knowbaseitem01, _knowbaseitem02 (fixtures), "Top level
+     *                  article", "Animals", "Plants"
      *  Animals       : "Cat article", "Dog article"
      *    └─ Birds    : "Eagle article"
      *  Plants        : "Rose article"
@@ -59,7 +62,7 @@ final class BuilderTest extends DbTestCase
         $birds   = $this->makeArticle('Birds', $animals->getID());
         $plants  = $this->makeArticle('Plants');
 
-        $this->makeArticle('Root article');
+        $this->makeArticle('Top level article');
         $this->makeArticle('Cat article', $animals->getID());
         $this->makeArticle('Dog article', $animals->getID());
         $this->makeArticle('Eagle article', $birds->getID());
@@ -67,15 +70,15 @@ final class BuilderTest extends DbTestCase
 
         $tree = (new Builder())->buildTree();
 
-        // Root level: the two fixture articles, "Animals", "Plants", "Root article"
-        // and the installation's root article (ordered by name, not by the order
-        // they were requested above).
-        $this->assertEquals(
-            ['_knowbaseitem01', '_knowbaseitem02', 'Animals', 'Home', 'Plants', 'Root article'],
-            array_column($tree->getArticles(), 'title'),
-        );
+        // The tree has a single root, the installation's root article, and every
+        // other article hangs under it.
+        $this->assertEquals(['Home'], array_column($tree->getArticles(), 'title'));
 
-        $by_title = array_column($tree->getArticles(), null, 'title');
+        $by_title = $this->getTopLevelArticles($tree);
+        $this->assertEqualsCanonicalizing(
+            ['_knowbaseitem01', '_knowbaseitem02', 'Animals', 'Plants', 'Top level article'],
+            array_keys($by_title),
+        );
 
         // Animals has three direct children: Birds (a nested article), Cat, Dog.
         $animals_node = $by_title['Animals'];
@@ -97,7 +100,7 @@ final class BuilderTest extends DbTestCase
         $this->assertEquals(['Rose article'], array_column($plants_node->getChildren(), 'title'));
 
         // Leaves have no children.
-        $this->assertFalse($by_title['Root article']->hasChildren());
+        $this->assertFalse($by_title['Top level article']->hasChildren());
         $cat_node = array_column($animals_node->getChildren(), null, 'title')['Cat article'];
         $this->assertFalse($cat_node->hasChildren());
     }
@@ -116,7 +119,7 @@ final class BuilderTest extends DbTestCase
         }
     }
 
-    public function testCurrentIdMarksMatchingRootArticle(): void
+    public function testCurrentIdMarksMatchingTopLevelArticle(): void
     {
         $this->login();
 
@@ -125,7 +128,7 @@ final class BuilderTest extends DbTestCase
 
         $tree = (new Builder($target->getID()))->buildTree();
 
-        $by_title = array_column($tree->getArticles(), null, 'title');
+        $by_title = $this->getTopLevelArticles($tree);
         $this->assertFalse($by_title['Other article']->is_current);
         $this->assertTrue($by_title['Target article']->is_current);
     }
@@ -135,13 +138,13 @@ final class BuilderTest extends DbTestCase
         $this->login();
 
         $parent = $this->makeArticle('Animals');
-        $this->makeArticle('Root article');
+        $this->makeArticle('Top level article');
         $nested = $this->makeArticle('Nested article', $parent->getID());
 
         $tree = (new Builder($nested->getID()))->buildTree();
 
-        $by_title = array_column($tree->getArticles(), null, 'title');
-        $this->assertFalse($by_title['Root article']->is_current);
+        $by_title = $this->getTopLevelArticles($tree);
+        $this->assertFalse($by_title['Top level article']->is_current);
 
         $animals_node = $by_title['Animals'];
         $nested_by_title = array_column($animals_node->getChildren(), null, 'title');
@@ -161,7 +164,7 @@ final class BuilderTest extends DbTestCase
 
         $tree = (new Builder())->buildTree();
 
-        $by_title = array_column($tree->getArticles(), null, 'title');
+        $by_title = $this->getTopLevelArticles($tree);
         $this->assertSame('antivirus', $by_title['With illustration']->illustration);
         $this->assertSame('', $by_title['Without illustration']->illustration);
     }
@@ -221,7 +224,7 @@ final class BuilderTest extends DbTestCase
         $this->makeArticle('Shared child ' . __FUNCTION__, [$parent1->getID(), $parent2->getID()]);
 
         $tree = (new Builder())->buildTree();
-        $by_title = array_column($tree->getArticles(), null, 'title');
+        $by_title = $this->getTopLevelArticles($tree);
 
         $this->assertEquals(
             ['Shared child ' . __FUNCTION__],
@@ -231,6 +234,24 @@ final class BuilderTest extends DbTestCase
             ['Shared child ' . __FUNCTION__],
             array_column($by_title['Parent two ' . __FUNCTION__]->getChildren(), 'title'),
         );
+    }
+
+    /**
+     * The articles of the top level, i.e. the children of the root article every
+     * article hangs under, keyed by title.
+     *
+     * @return array<string, Article>
+     */
+    private function getTopLevelArticles(Tree $tree): array
+    {
+        $root_id = KnowbaseItem::getRootId();
+        foreach ($tree->getArticles() as $article) {
+            if ($article->id === $root_id) {
+                return array_column($article->getChildren(), null, 'title');
+            }
+        }
+
+        $this->fail('The root article is missing from the tree');
     }
 
     /**

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -41,6 +41,7 @@ use KnowbaseItem;
 use KnowbaseItem_User;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
 use Session;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -801,12 +802,19 @@ HTML,
         // Check that the request is valid
         $iterator = $DB->request($criteria);
 
+        // Exclude the root article, which is created by the installation process
+        // and thus matches any parentless search.
+        $rows = array_filter(
+            iterator_to_array($iterator),
+            static fn(array $row): bool => (int) $row['id'] !== KnowbaseItem::getRootId(),
+        );
+
         //count KnowBaseItem found
-        $this->assertEquals($count, $iterator->numrows());
+        $this->assertCount($count, $rows);
 
         // check order if needed
         if ($sort != null) {
-            $names = array_column(iterator_to_array($iterator), 'name');
+            $names = array_column($rows, 'name');
             $this->assertEquals($sort, $names);
         }
     }
@@ -2437,5 +2445,31 @@ HTML,
             "data-parent-id='" . $parent->getID() . "'",
             $output
         );
+    }
+
+    public function testRootArticleExists(): void
+    {
+        // The root article is created by the installation process, thus the
+        // configured id must always point to an existing article.
+        $root_id = KnowbaseItem::getRootId();
+        $this->assertGreaterThan(0, $root_id);
+
+        $root = KnowbaseItem::getById($root_id);
+        $this->assertInstanceOf(KnowbaseItem::class, $root);
+
+        // It must be readable from any entity.
+        $this->assertEquals(0, $root->fields['entities_id']);
+        $this->assertEquals(1, $root->fields['is_recursive']);
+    }
+
+    public function testGetRootIdFailIfNotConfigured(): void
+    {
+        global $CFG_GLPI;
+
+        $CFG_GLPI['root_knowbaseitems_id'] = 0;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The knowledge base root article is not defined.');
+        KnowbaseItem::getRootId();
     }
 }

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -48,6 +48,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Session;
 use Symfony\Component\DomCrawler\Crawler;
+use User;
 
 use function Safe\file_get_contents;
 use function Safe\file_put_contents;
@@ -1467,7 +1468,7 @@ HTML,
                 '_visibility' => [
                     'entities_id' => -1,
                     'is_recursive' => 1,
-                    '_type' => \User::class,
+                    '_type' => User::class,
                     'users_id' => $tech_user,
                 ],
             ],
@@ -1481,7 +1482,7 @@ HTML,
                 '_visibility' => [
                     'entities_id' => -1,
                     'is_recursive' => 1,
-                    '_type' => \User::class,
+                    '_type' => User::class,
                     'users_id' => $normal_user,
                 ],
             ],
@@ -2128,7 +2129,7 @@ HTML,
             'ticket'    => 0,
         ]);
 
-        $user = $this->createItem(\User::class, [
+        $user = $this->createItem(User::class, [
             'name'         => __FUNCTION__,
             'password'     => 'testpassword',
             'password2'    => 'testpassword',
@@ -2444,6 +2445,32 @@ HTML,
         // It must be readable from any entity.
         $this->assertEquals(0, $root->fields['entities_id']);
         $this->assertEquals(1, $root->fields['is_recursive']);
+    }
+
+    public function testAllArticlesMenuLinkSkipsTheRootArticleRedirect(): void
+    {
+        // A bare `front/knowbaseitem.php` redirects to the root article, so the
+        // link to the article list has to carry a parameter.
+        $link = KnowbaseItem::getAdditionalMenuLinks()['all_articles'];
+
+        $this->assertStringStartsWith(KnowbaseItem::getSearchURL(false) . '?', $link);
+        $this->assertNotEmpty(parse_url($link, PHP_URL_QUERY));
+    }
+
+    public function testRootArticleIsAuthoredByTheSystemUser(): void
+    {
+        global $CFG_GLPI;
+
+        $this->login();
+
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+
+        // Created in the background: credited to the system user, else the
+        // history and the last update info would report a deleted user.
+        $this->assertSame((int) $CFG_GLPI['system_user'], (int) $root->fields['users_id']);
+        $this->assertInstanceOf(User::class, User::getById((int) $root->fields['users_id']));
+        $this->assertNotEquals(__('Deleted user'), $root->getLastUpdateInfo()->getAuthorName());
     }
 
     public function testRootArticleCannotBeDeleted(): void

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -35,6 +35,8 @@
 namespace test\units;
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\Knowbase\EditorAction;
+use Glpi\Knowbase\EditorActionType;
 use Glpi\Tests\DbTestCase;
 use InvalidArgumentException;
 use KnowbaseItem;
@@ -2460,6 +2462,84 @@ HTML,
         // It must be readable from any entity.
         $this->assertEquals(0, $root->fields['entities_id']);
         $this->assertEquals(1, $root->fields['is_recursive']);
+    }
+
+    public function testRootArticleCannotBeDeleted(): void
+    {
+        // The root article belongs to the root entity: work from there, else the
+        // entity check of `canDeleteItem()`/`canPurgeItem()` would be the one
+        // refusing the action.
+        $this->login();
+        $this->setEntity(0, true);
+
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+        $this->assertTrue($root->checkEntity());
+
+        // Sanity check: the current user is allowed to delete a regular article
+        // of the same entity.
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Article ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertTrue($other->can($other->getID(), DELETE));
+        $this->assertTrue($other->can($other->getID(), PURGE));
+
+        // Rights checks, on which every UI and API deletion path relies, refuse
+        // the action for the root article.
+        $this->assertFalse($root->canDeleteItem());
+        $this->assertFalse($root->canPurgeItem());
+        $this->assertFalse($root->can($root->getID(), DELETE));
+        $this->assertFalse($root->can($root->getID(), PURGE));
+
+        // The deletion itself is refused too, even when rights are not checked.
+        $this->assertFalse($root->delete(['id' => $root->getID()]));
+        $this->hasSessionMessages(ERROR, ['The root article of the knowledge base cannot be deleted.']);
+        $this->assertFalse($root->delete(['id' => $root->getID()], true));
+        $this->hasSessionMessages(ERROR, ['The root article of the knowledge base cannot be deleted.']);
+
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+    }
+
+    public function testRootArticleDeleteActionIsNotOffered(): void
+    {
+        $this->login();
+        $this->setEntity(0, true);
+
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+        $this->assertNotContains(
+            EditorActionType::DELETE_ARTICLE,
+            $this->getAsideActionTypes($root),
+        );
+
+        // Sanity check: the action is offered for a regular article.
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Article ' . __FUNCTION__,
+            'answer'       => '',
+            'entities_id'  => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertContains(
+            EditorActionType::DELETE_ARTICLE,
+            $this->getAsideActionTypes($other),
+        );
+    }
+
+    /**
+     * @return EditorActionType[]
+     */
+    private function getAsideActionTypes(KnowbaseItem $article): array
+    {
+        return array_map(
+            static fn(EditorAction $action): EditorActionType => $action->type,
+            array_filter(
+                $article->getAsideActions(),
+                static fn(object $action): bool => $action instanceof EditorAction,
+            ),
+        );
     }
 
     public function testGetRootIdFailIfNotConfigured(): void

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -1901,12 +1901,12 @@ HTML,
             '_parents' => '',
             '__parents_defined' => 1,
         ]);
-        $this->assertEquals(
-            0,
-            countElementsInTable(
-                KnowbaseItem_KnowbaseItem::getTable(),
-                ['knowbaseitems_id' => $kbi->getID()]
-            )
+        // The chosen parent is gone. The article joins the root article rather
+        // than being left outside the tree, see
+        // `testArticleUpdatedWithoutAnyParentIsAttachedToTheRoot()`.
+        $this->assertSame(
+            [KnowbaseItem::getRootId()],
+            $this->getParentIds($kbi->getID())
         );
     }
 
@@ -2579,6 +2579,89 @@ HTML,
         $this->assertContains($root_id, $this->getVisibleArticleIds());
     }
 
+    public function testRootArticleIsReadableByKnowledgeBaseAdmins(): void
+    {
+        $this->login();
+
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Article ' . __FUNCTION__,
+            'answer'   => '',
+            // Authored by someone else, else the author shortcut would answer
+            // instead of the rights check.
+            'users_id' => getItemByTypeName('User', 'tech', true),
+        ]);
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+
+        // Knowledge base administrators bypass every visibility rule. The root
+        // article has none, so it must not be the single article they are
+        // refused, as `canUpdateItem()` already lets them edit it.
+        $_SESSION['glpiactiveprofile']['knowbase'] = KnowbaseItem::KNOWBASEADMIN;
+        $this->assertFalse(Session::haveRight('knowbase', READ));
+
+        $this->assertTrue($other->canViewItem());
+        $this->assertTrue($root->canViewItem());
+    }
+
+    public function testRootArticleIsNotPublishable(): void
+    {
+        $this->login();
+
+        $root_id = KnowbaseItem::getRootId();
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB($root_id));
+        $this->assertEquals(0, $root->fields['is_faq']);
+        $this->assertEquals(0, $root->fields['show_in_service_catalog']);
+
+        // The root article is the entry point of the knowledge base, not a piece
+        // of content. FAQ readers are not even allowed to open it, see
+        // `testRootArticleIsNotPartOfTheFaq()`, so publishing it would list it
+        // for users that can only get an error out of it, down to anonymous ones
+        // on a public FAQ.
+        $this->assertTrue($root->update([
+            'id'                      => $root_id,
+            'is_faq'                  => 1,
+            'show_in_service_catalog' => 1,
+        ]));
+        $this->assertTrue($root->getFromDB($root_id));
+        $this->assertEquals(0, $root->fields['is_faq']);
+        $this->assertEquals(0, $root->fields['show_in_service_catalog']);
+
+        // The action that would set the FAQ flag is not offered either, see
+        // `testRootArticleHasNoVisibilityRelatedActions()` for the service
+        // catalog one.
+        $this->assertNotContains('Add to FAQ', $this->getAsideActionLabels($root));
+
+        // Sanity check: a regular article can be published.
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Article ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $this->assertContains('Add to FAQ', $this->getAsideActionLabels($other));
+        $this->assertTrue($other->update([
+            'id'                      => $other->getID(),
+            'is_faq'                  => 1,
+            'show_in_service_catalog' => 1,
+        ]));
+        $this->assertTrue($other->getFromDB($other->getID()));
+        $this->assertEquals(1, $other->fields['is_faq']);
+        $this->assertEquals(1, $other->fields['show_in_service_catalog']);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAsideActionLabels(KnowbaseItem $article): array
+    {
+        return array_map(
+            static fn(EditorAction $action): string => $action->label,
+            array_filter(
+                $article->getAsideActions(),
+                static fn(object $action): bool => $action instanceof EditorAction,
+            ),
+        );
+    }
+
     public function testArticleCreatedWithoutParentIsAttachedToTheRoot(): void
     {
         $this->login();
@@ -2610,6 +2693,70 @@ HTML,
             ],
         ]);
         $this->assertSame([$root_id], array_map('intval', array_column($parentless, 'id')));
+    }
+
+    public function testArticleUpdatedWithoutAnyParentIsAttachedToTheRoot(): void
+    {
+        $this->login();
+        $root_id = KnowbaseItem::getRootId();
+
+        $parent = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Parent ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $child = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Child ' . __FUNCTION__,
+            'answer'   => '',
+            '_parents' => [$parent->getID()],
+        ]);
+        $this->assertSame([$parent->getID()], $this->getParentIds($child->getID()));
+
+        // An update that does not target the parents leaves them alone.
+        $this->updateItem(KnowbaseItem::class, $child->getID(), [
+            'name' => 'Renamed ' . __FUNCTION__,
+        ]);
+        $this->assertSame([$parent->getID()], $this->getParentIds($child->getID()));
+
+        // Removing every parent would turn the article into a second root: it
+        // is attached back to the root article instead.
+        $this->updateItem(KnowbaseItem::class, $child->getID(), [
+            '__parents_defined' => 1,
+        ]);
+        $this->assertSame([$root_id], $this->getParentIds($child->getID()));
+    }
+
+    public function testPurgingAnArticleAttachesItsOrphanedChildrenToTheRoot(): void
+    {
+        $this->login();
+        $root_id = KnowbaseItem::getRootId();
+
+        $parent = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Parent ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $other_parent = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Other parent ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $only_child = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Only child ' . __FUNCTION__,
+            'answer'   => '',
+            '_parents' => [$parent->getID()],
+        ]);
+        $shared_child = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Shared child ' . __FUNCTION__,
+            'answer'   => '',
+            '_parents' => [$parent->getID(), $other_parent->getID()],
+        ]);
+
+        $this->assertTrue($parent->delete(['id' => $parent->getID()], true));
+
+        // The child that just lost its only parent is kept in the tree, under
+        // the root article, instead of becoming a second root.
+        $this->assertSame([$root_id], $this->getParentIds($only_child->getID()));
+
+        // The one that still has a parent is left alone.
+        $this->assertSame([$other_parent->getID()], $this->getParentIds($shared_child->getID()));
     }
 
     /**
@@ -2648,15 +2795,17 @@ HTML,
         $labels = $this->getEditorActionLabels($root);
 
         // Visibility rules have no effect on the root article, and scheduling it
-        // out of sight would leave the article tree headless.
+        // out of sight would leave the article tree headless. Publishing it to
+        // the service catalog would expose the entry point of the knowledge base
+        // as a piece of content, see `testRootArticleIsNotPublishable()`.
         $this->assertNotContains('Permissions', $labels);
         $this->assertNotContains('Schedule visibility', $labels);
+        $this->assertNotContains('Service catalog', $labels);
 
         // The other actions of the same block are untouched.
-        $this->assertContains('Service catalog', $labels);
         $this->assertContains('History', $labels);
 
-        // Sanity check: a regular article offers both.
+        // Sanity check: a regular article offers all three.
         $other = $this->createItem(KnowbaseItem::class, [
             'name'   => 'Article ' . __FUNCTION__,
             'answer' => '',
@@ -2664,6 +2813,7 @@ HTML,
         $labels = $this->getEditorActionLabels($other);
         $this->assertContains('Permissions', $labels);
         $this->assertContains('Schedule visibility', $labels);
+        $this->assertContains('Service catalog', $labels);
     }
 
     /**
@@ -2786,6 +2936,18 @@ HTML,
             'intval',
             array_column(iterator_to_array($DB->request($criteria)), 'id'),
         );
+    }
+
+    public function testHasRoot(): void
+    {
+        global $CFG_GLPI;
+
+        $this->assertTrue(KnowbaseItem::hasRoot());
+
+        // Only a corrupted installation has no root article. The pages that can
+        // do without one must be able to tell without catching an exception.
+        $CFG_GLPI['root_knowbaseitems_id'] = 0;
+        $this->assertFalse(KnowbaseItem::hasRoot());
     }
 
     public function testGetRootIdFailIfNotConfigured(): void

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -35,11 +35,13 @@
 namespace test\units;
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QuerySubQuery;
 use Glpi\Knowbase\EditorAction;
 use Glpi\Knowbase\EditorActionType;
 use Glpi\Tests\DbTestCase;
 use InvalidArgumentException;
 use KnowbaseItem;
+use KnowbaseItem_KnowbaseItem;
 use KnowbaseItem_User;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -570,7 +572,6 @@ HTML,
         return [
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+macintosh",
                     //Find rows that contain the word 'macintosh'
@@ -581,7 +582,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+apple",
                     //Find rows that contain the word 'apple'
@@ -592,7 +592,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "apple macintosh",
                     //Find rows that contain at least one of the two words.
@@ -603,7 +602,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "base entry _knowbaseitem02",
                     //Find rows that contain at least one of the three words.
@@ -614,7 +612,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "apple",
                     //Find rows that contain at least 'apple'
@@ -625,7 +622,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "macintosh",
                     //Find rows that contain at least 'macintosh'
@@ -636,7 +632,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "Knowledge",
                     //Find rows that contain at least 'macintosh'
@@ -647,7 +642,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+juice +macintosh",
                     //Find rows that contain both words.
@@ -658,7 +652,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+apple -macintosh",
                     //Find rows that contain the word “apple” but not “macintosh”.
@@ -669,7 +662,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+apple ~macintosh",
                     //Find rows that contain the word “apple”, but if the row also contains the word “macintosh”, rate it lower than if row does not.
@@ -680,7 +672,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+apple macintosh",
                     //Find rows that contain the word “apple”, but rank rows higher if they also contain “macintosh”.
@@ -691,7 +682,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "+apple +(>macintosh <juice)",
                     //Find rows that contain the words “apple” and "juice", or “apple” and "macintosh" (in any order), but rank “apple macintosh" higher than “apple juice".
@@ -702,7 +692,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "Know*",
                     //Find rows that contain "Know" such as "Knowledge"
@@ -713,7 +702,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => "turn*",
                     //Find rows that contain "turn" such as "turnover"
@@ -724,7 +712,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => '"macintosh strudel"',
                     //Find rows that contain the exact phrase “macintosh strudel”
@@ -735,7 +722,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => '"base entry _knowbaseitem02"',
                     //Find rows that contain the exact phrase “base entry _knowbaseitem02”
@@ -746,7 +732,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => ' ',
                     // Make sure no errors are triggered when sending this specific request
@@ -757,7 +742,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => '      ',
                     // Make sure no errors are triggered when sending this specific request
@@ -768,7 +752,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => '*',
                     // Make sure no errors are triggered when sending this specific request
@@ -779,7 +762,6 @@ HTML,
             ],
             [
                 'params' => [
-                    'knowbaseitems_id_parent' => 0,
                     'faq' => false,
                     'contains' => '%',
                     // Make sure no errors are triggered when sending this specific request
@@ -874,7 +856,7 @@ HTML,
 
         // Expect the KB item to have the first parent
         $iterator = $DB->request([
-            'FROM' => \KnowbaseItem_KnowbaseItem::getTable(),
+            'FROM' => KnowbaseItem_KnowbaseItem::getTable(),
             'WHERE' => [
                 'knowbaseitems_id' => $kbitems_id1,
             ],
@@ -892,7 +874,7 @@ HTML,
 
         // Expect the KB item to have both parents
         $iterator = $DB->request([
-            'FROM' => \KnowbaseItem_KnowbaseItem::getTable(),
+            'FROM' => KnowbaseItem_KnowbaseItem::getTable(),
             'WHERE' => [
                 'knowbaseitems_id' => $kbitems_id2,
             ],
@@ -1909,7 +1891,7 @@ HTML,
         $this->assertEquals(
             1,
             countElementsInTable(
-                \KnowbaseItem_KnowbaseItem::getTable(),
+                KnowbaseItem_KnowbaseItem::getTable(),
                 ['knowbaseitems_id' => $kbi->getID()]
             )
         );
@@ -1921,7 +1903,7 @@ HTML,
         $this->assertEquals(
             0,
             countElementsInTable(
-                \KnowbaseItem_KnowbaseItem::getTable(),
+                KnowbaseItem_KnowbaseItem::getTable(),
                 ['knowbaseitems_id' => $kbi->getID()]
             )
         );
@@ -2406,7 +2388,7 @@ HTML,
         // The child (visible) is listed, but the unviewable parent must not leak.
         $this->assertStringContainsString('Leaf child ' . __FUNCTION__, $output);
         $this->assertStringNotContainsString('Secret parent ' . __FUNCTION__, $output);
-        $this->assertStringNotContainsString('kb-parent', $output);
+        $this->assertStringNotContainsString("data-parent-id='" . $parent_id . "'", $output);
     }
 
     /**
@@ -2568,6 +2550,51 @@ HTML,
         $this->assertTrue($root->canViewItem());
         $this->assertTrue($root->can($root_id, READ));
         $this->assertContains($root_id, $this->getVisibleArticleIds());
+    }
+
+    public function testArticleCreatedWithoutParentIsAttachedToTheRoot(): void
+    {
+        $this->login();
+        $root_id = KnowbaseItem::getRootId();
+
+        // No parent given: the article joins the tree under the root article,
+        // so it does not become a second root.
+        $orphan = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Orphan ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $this->assertSame([$root_id], $this->getParentIds($orphan->getID()));
+
+        // An explicit parent is left alone.
+        $child = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Child ' . __FUNCTION__,
+            'answer'   => '',
+            '_parents' => [$orphan->getID()],
+        ]);
+        $this->assertSame([$orphan->getID()], $this->getParentIds($child->getID()));
+
+        // The root article is the only one left without a parent.
+        $parentless = (new KnowbaseItem())->find([
+            'NOT' => [
+                'id' => new QuerySubQuery([
+                    'SELECT' => 'knowbaseitems_id',
+                    'FROM'   => KnowbaseItem_KnowbaseItem::getTable(),
+                ]),
+            ],
+        ]);
+        $this->assertSame([$root_id], array_map('intval', array_column($parentless, 'id')));
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getParentIds(int $article_id): array
+    {
+        $links = (new KnowbaseItem_KnowbaseItem())->find([
+            'knowbaseitems_id' => $article_id,
+        ]);
+
+        return array_map('intval', array_column($links, 'knowbaseitems_id_parent'));
     }
 
     public function testRootArticleIsEditableWithoutVisibilityRules(): void

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -2570,6 +2570,64 @@ HTML,
         $this->assertContains($root_id, $this->getVisibleArticleIds());
     }
 
+    public function testRootArticleIsEditableWithoutVisibilityRules(): void
+    {
+        // A profile that can update the knowledge base but is not a KB admin.
+        $this->login('tech', 'tech');
+        $this->assertFalse(Session::haveRight('knowbase', KnowbaseItem::KNOWBASEADMIN));
+        $this->assertTrue(Session::haveRight('knowbase', UPDATE));
+
+        $root_id = KnowbaseItem::getRootId();
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB($root_id));
+
+        $this->assertTrue($root->canUpdateItem());
+        $this->assertTrue($root->can($root_id, UPDATE));
+    }
+
+    public function testRootArticleHasNoVisibilityRelatedActions(): void
+    {
+        $this->login();
+
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+        $labels = $this->getEditorActionLabels($root);
+
+        // Visibility rules have no effect on the root article, and scheduling it
+        // out of sight would leave the article tree headless.
+        $this->assertNotContains('Permissions', $labels);
+        $this->assertNotContains('Schedule visibility', $labels);
+
+        // The other actions of the same block are untouched.
+        $this->assertContains('Service catalog', $labels);
+        $this->assertContains('History', $labels);
+
+        // Sanity check: a regular article offers both.
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Article ' . __FUNCTION__,
+            'answer' => '',
+        ]);
+        $labels = $this->getEditorActionLabels($other);
+        $this->assertContains('Permissions', $labels);
+        $this->assertContains('Schedule visibility', $labels);
+    }
+
+    /**
+     * Labels of the actions offered by the article editor's dots menu.
+     *
+     * @return string[]
+     */
+    private function getEditorActionLabels(KnowbaseItem $article): array
+    {
+        return array_map(
+            static fn(EditorAction $action): string => $action->label,
+            array_filter(
+                $this->callPrivateMethod($article, 'getEditorActions'),
+                static fn(object $action): bool => $action instanceof EditorAction,
+            ),
+        );
+    }
+
     public function testRootArticleIsNotPartOfTheFaq(): void
     {
         // A self-service user, allowed to read the FAQ but not the knowledge base.

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -2542,6 +2542,140 @@ HTML,
         );
     }
 
+    public function testRootArticleIsReadableWithoutVisibilityRules(): void
+    {
+        // A profile that can read the knowledge base but is not a KB admin, as
+        // admins bypass every visibility check.
+        $this->login('tech', 'tech');
+        $this->assertFalse(Session::haveRight('knowbase', KnowbaseItem::KNOWBASEADMIN));
+
+        $root_id = KnowbaseItem::getRootId();
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB($root_id));
+
+        // Premise: the root article has no visibility rule whatsoever.
+        $visibility_tables = [
+            'glpi_entities_knowbaseitems',
+            'glpi_groups_knowbaseitems',
+            'glpi_knowbaseitems_profiles',
+            'glpi_knowbaseitems_users',
+        ];
+        foreach ($visibility_tables as $table) {
+            $this->assertEquals(0, countElementsInTable($table, ['knowbaseitems_id' => $root_id]));
+        }
+
+        // It is readable anyway, and listed among the visible articles.
+        $this->assertTrue($root->canViewItem());
+        $this->assertTrue($root->can($root_id, READ));
+        $this->assertContains($root_id, $this->getVisibleArticleIds());
+    }
+
+    public function testRootArticleIsNotPartOfTheFaq(): void
+    {
+        // A self-service user, allowed to read the FAQ but not the knowledge base.
+        $this->login('post-only', 'postonly');
+        $this->assertFalse(Session::haveRight('knowbase', READ));
+
+        $root = new KnowbaseItem();
+        $this->assertTrue($root->getFromDB(KnowbaseItem::getRootId()));
+
+        // The root article is the entry point of the knowledge base, not a FAQ
+        // article: it must not show up in the FAQ nor in the service catalog.
+        $this->assertFalse($root->canViewItem());
+        $this->assertNotContains(KnowbaseItem::getRootId(), $this->getVisibleArticleIds());
+    }
+
+    public function testRootArticleDoesNotMakeItsChildrenVisible(): void
+    {
+        $glpi_user = getItemByTypeName('User', 'glpi', true);
+        $this->login();
+        $root_id = KnowbaseItem::getRootId();
+
+        // Three articles authored by someone else and without any visibility rule
+        // of their own: only inheritance can make them visible.
+        $child_of_root = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Child of root ' . __FUNCTION__,
+            'answer'   => '',
+            'users_id' => $glpi_user,
+            '_parents' => [$root_id],
+        ]);
+        $visible_parent = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Visible parent ' . __FUNCTION__,
+            'answer'   => '',
+            'users_id' => $glpi_user,
+            '_parents' => [$root_id],
+        ]);
+        $child_of_visible = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Child of visible parent ' . __FUNCTION__,
+            'answer'   => '',
+            'users_id' => $glpi_user,
+            '_parents' => [$visible_parent->getID()],
+        ]);
+
+        $this->login('tech', 'tech');
+        (new KnowbaseItem_User())->add([
+            'knowbaseitems_id' => $visible_parent->getID(),
+            'users_id'         => Session::getLoginUserID(),
+        ]);
+
+        $visible = $this->getVisibleArticleIds();
+        $this->assertContains($root_id, $visible);
+
+        // Inheriting from a regular ancestor still works...
+        $this->assertContains($child_of_visible->getID(), $visible);
+
+        // ... but the root article, being the ancestor of everything, never
+        // grants access to its descendants.
+        $this->assertNotContains($child_of_root->getID(), $visible);
+        $this->assertFalse((new KnowbaseItem())->can($child_of_root->getID(), READ));
+    }
+
+    public function testVisibilityRulesSetOnTheRootArticleDoNotCascade(): void
+    {
+        $glpi_user = getItemByTypeName('User', 'glpi', true);
+        $this->login();
+        $root_id = KnowbaseItem::getRootId();
+
+        $child_of_root = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Child of root ' . __FUNCTION__,
+            'answer'   => '',
+            'users_id' => $glpi_user,
+            '_parents' => [$root_id],
+        ]);
+
+        // An administrator may add visibility rules to the root article like to
+        // any other one. Doing so must not open the whole knowledge base.
+        $this->login('tech', 'tech');
+        (new KnowbaseItem_User())->add([
+            'knowbaseitems_id' => $root_id,
+            'users_id'         => Session::getLoginUserID(),
+        ]);
+
+        $visible = $this->getVisibleArticleIds();
+        $this->assertContains($root_id, $visible);
+        $this->assertNotContains($child_of_root->getID(), $visible);
+    }
+
+    /**
+     * Ids of the articles the current user is allowed to see.
+     *
+     * @return int[]
+     */
+    private function getVisibleArticleIds(): array
+    {
+        global $DB;
+
+        $criteria = array_merge(KnowbaseItem::getVisibilityCriteria(false), [
+            'SELECT' => KnowbaseItem::getTableField('id'),
+            'FROM'   => KnowbaseItem::getTable(),
+        ]);
+
+        return array_map(
+            'intval',
+            array_column(iterator_to_array($DB->request($criteria)), 'id'),
+        );
+    }
+
     public function testGetRootIdFailIfNotConfigured(): void
     {
         global $CFG_GLPI;

--- a/tests/functional/KnowbaseItem_KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItem_KnowbaseItemTest.php
@@ -124,6 +124,25 @@ final class KnowbaseItem_KnowbaseItemTest extends DbTestCase
             'with_message' => "An article cannot be its own parent.",
         ];
 
+        // The root article is the base of the tree
+        yield "The root article cannot be given a parent" => [
+            'tree' => $tree,
+            'input' => [
+                'knowbaseitems_id' => KnowbaseItem::getRootId(),
+                'knowbaseitems_id_parent' => "Article A",
+            ],
+            'expected' => false,
+            'with_message' => "The root article of the knowledge base cannot have a parent.",
+        ];
+        yield "The root article can be a parent" => [
+            'tree' => $tree,
+            'input' => [
+                'knowbaseitems_id' => "Article A",
+                'knowbaseitems_id_parent' => KnowbaseItem::getRootId(),
+            ],
+            'expected' => true,
+        ];
+
         // Cyclic graph prevention
         yield "Can't link to direct parent" => [
             'tree' => $tree,
@@ -230,6 +249,17 @@ final class KnowbaseItem_KnowbaseItemTest extends DbTestCase
             ],
             'expected' => false,
             'with_message' => "An article cannot be its own parent.",
+        ];
+
+        // The root article is the base of the tree
+        yield "An existing link cannot be moved onto the root article" => [
+            'tree' => $tree,
+            'input' => [
+                'id' => 'Article A > Article A1',
+                'knowbaseitems_id' => KnowbaseItem::getRootId(),
+            ],
+            'expected' => false,
+            'with_message' => "The root article of the knowledge base cannot have a parent.",
         ];
 
         // Cyclic graph prevention

--- a/tests/functional/KnowbaseItem_KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItem_KnowbaseItemTest.php
@@ -134,10 +134,12 @@ final class KnowbaseItem_KnowbaseItemTest extends DbTestCase
             'expected' => false,
             'with_message' => "The root article of the knowledge base cannot have a parent.",
         ];
+        // "Article A" already hangs under the root article, "Article A1" does
+        // not: an article may have several parents.
         yield "The root article can be a parent" => [
             'tree' => $tree,
             'input' => [
-                'knowbaseitems_id' => "Article A",
+                'knowbaseitems_id' => "Article A1",
                 'knowbaseitems_id_parent' => KnowbaseItem::getRootId(),
             ],
             'expected' => true,
@@ -304,17 +306,14 @@ final class KnowbaseItem_KnowbaseItemTest extends DbTestCase
     private function createTree(array $tree, int $parent_id = 0): void
     {
         foreach ($tree as $name => $children) {
+            // The parent is set at creation time: articles created without one
+            // are attached to the root article, which would leave every node of
+            // the tree with a second parent.
             $article = $this->createItem(KnowbaseItem::class, [
                 'name' => $name,
                 'answer' => '',
+                '_parents' => $parent_id > 0 ? [$parent_id] : [],
             ]);
-
-            if ($parent_id > 0) {
-                $this->createItem(KnowbaseItem_KnowbaseItem::class, [
-                    'knowbaseitems_id'        => $article->getID(),
-                    'knowbaseitems_id_parent' => $parent_id,
-                ]);
-            }
 
             $this->createTree($children, $article->getID());
         }


### PR DESCRIPTION
The KB now has a "Home" article serving as the root of its tree.
It it created during installation/update and can't be deleted.