### PR TITLE
Add/dashboard report tickets by category and entity

### DIFF
--- a/src/Glpi/Dashboard/Grid.php
+++ b/src/Glpi/Dashboard/Grid.php
@@ -1542,6 +1542,15 @@ HTML;
                 'filters'    => Filter::getAppliableFilters(Ticket::getTable()),
             ];
 
+            $cards["ticket_by_category_and_entity"] = [
+                'widgettype' => ['hBars', 'stackedHBars'],
+                'itemtype'   => "\\Ticket",
+                'group'      => __('Assistance'),
+                'label'      => __("Number of tickets by category and entity"),
+                'provider'   => "Glpi\\Dashboard\\Provider::ticketsByCategoryAndEntity",
+                'filters'    => Filter::getAppliableFilters(Ticket::getTable()),
+            ];
+
             $cards["ticket_times"] = [
                 'widgettype' => ['lines', 'areas', 'bars', 'stackedbars'],
                 'itemtype'   => "\\Ticket",

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1199,7 +1199,9 @@ class Provider
         $criteria = array_merge_recursive(
             [
                 'SELECT'    => [
+                    "$entity_table.id AS entity_id",
                     "$entity_table.completename AS entity_name",
+                    "$category_table.id AS category_id",
                     "$category_table.completename AS category_name",
                     'COUNT DISTINCT' => "$ticket_table.id AS cpt",
                 ],
@@ -1230,27 +1232,26 @@ class Provider
         $iterator = $DB->request($criteria);
         Profiler::getInstance()->stop(__METHOD__ . ' build SQL criteria');
 
-        $matrix     = [];
-        $categories = [];
+        $matrix         = [];
+        $entity_names   = [];
+        $category_names = [];
         foreach ($iterator as $result) {
-            $entity_name   = $result['entity_name'] ?? __('Root entity');
-            $category_name = $result['category_name'] ?? __('None');
+            $entity_id   = $result['entity_id'] ?? 0;
+            $category_id = $result['category_id'] ?? 0;
 
-            $matrix[$entity_name][$category_name] = (int) $result['cpt'];
-            $categories[$category_name]           = true;
+            $entity_names[$entity_id]         = $result['entity_name'] ?? __('Root entity');
+            $category_names[$category_id]     = $result['category_name'] ?? __('None');
+            $matrix[$entity_id][$category_id] = (int) $result['cpt'];
         }
 
-        $entities   = array_keys($matrix);
-        $categories = array_keys($categories);
-
         $data = [
-            'labels' => $entities,
+            'labels' => array_values($entity_names),
             'series' => [],
         ];
-        foreach ($categories as $category_name) {
+        foreach ($category_names as $category_id => $category_name) {
             $series_data = [];
-            foreach ($entities as $entity_name) {
-                $series_data[] = $matrix[$entity_name][$category_name] ?? 0;
+            foreach (array_keys($entity_names) as $entity_id) {
+                $series_data[] = $matrix[$entity_id][$category_id] ?? 0;
             }
             $data['series'][] = [
                 'name' => $category_name,

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1200,9 +1200,7 @@ class Provider
             [
                 'SELECT'    => [
                     "$entity_table.completename AS entity_name",
-                    "$entity_table.id AS entity_id",
                     "$category_table.completename AS category_name",
-                    "$category_table.id AS category_id",
                     'COUNT DISTINCT' => "$ticket_table.id AS cpt",
                 ],
                 'FROM'      => $ticket_table,

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -1176,6 +1176,102 @@ class Provider
     }
 
     /**
+     * Count number of tickets grouped by their category and their entity
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    public static function ticketsByCategoryAndEntity(array $params = []): array
+    {
+        $DB = DBConnection::getReadConnection();
+
+        $default_params = [
+            'label'         => "",
+            'icon'          => Ticket::getIcon(),
+            'apply_filters' => [],
+        ];
+        $params = array_merge($default_params, $params);
+
+        $ticket_table   = Ticket::getTable();
+        $entity_table   = \Entity::getTable();
+        $category_table = \ITILCategory::getTable();
+
+        Profiler::getInstance()->start(__METHOD__ . ' build SQL criteria');
+        $criteria = array_merge_recursive(
+            [
+                'SELECT'    => [
+                    "$entity_table.completename AS entity_name",
+                    "$entity_table.id AS entity_id",
+                    "$category_table.completename AS category_name",
+                    "$category_table.id AS category_id",
+                    'COUNT DISTINCT' => "$ticket_table.id AS cpt",
+                ],
+                'FROM'      => $ticket_table,
+                'LEFT JOIN' => [
+                    $entity_table => [
+                        'ON' => [
+                            $ticket_table => 'entities_id',
+                            $entity_table => 'id',
+                        ],
+                    ],
+                    $category_table => [
+                        'ON' => [
+                            $ticket_table   => 'itilcategories_id',
+                            $category_table => 'id',
+                        ],
+                    ],
+                ],
+                'WHERE'     => [
+                    "$ticket_table.is_deleted" => 0,
+                ] + getEntitiesRestrictCriteria($ticket_table),
+                'GROUPBY'   => ["$entity_table.id", "$category_table.id"],
+                'ORDERBY'   => ["$entity_table.completename", "$category_table.completename"],
+            ],
+            Ticket::getCriteriaFromProfile(),
+            self::getFiltersCriteria($ticket_table, $params['apply_filters'])
+        );
+        $iterator = $DB->request($criteria);
+        Profiler::getInstance()->stop(__METHOD__ . ' build SQL criteria');
+
+        $matrix     = [];
+        $categories = [];
+        foreach ($iterator as $result) {
+            $entity_name   = $result['entity_name'] ?? __('Root entity');
+            $category_name = $result['category_name'] ?? __('None');
+
+            $matrix[$entity_name][$category_name] = (int) $result['cpt'];
+            $categories[$category_name]           = true;
+        }
+
+        $entities   = array_keys($matrix);
+        $categories = array_keys($categories);
+
+        $data = [
+            'labels' => $entities,
+            'series' => [],
+        ];
+        foreach ($categories as $category_name) {
+            $series_data = [];
+            foreach ($entities as $entity_name) {
+                $series_data[] = $matrix[$entity_name][$category_name] ?? 0;
+            }
+            $data['series'][] = [
+                'name' => $category_name,
+                'data' => $series_data,
+            ];
+        }
+
+        if (count($data['labels']) === 0) {
+            $data['nodata'] = true;
+        }
+
+        return [
+            'data'  => $data,
+            'label' => $params['label'],
+            'icon'  => $params['icon'],
+        ];
+    }
+
+    /**
      * Get a list of article for an compatible item (with date,name,text fields)
      *
      * @param CommonDBTM $item the itemtype to list

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -1068,4 +1068,60 @@ class ProviderTest extends DbTestCase
 
         $this->assertGreaterThan(0, $nb_items);
     }
+
+    public function testTicketsByCategoryAndEntity()
+    {
+        $this->login();
+        $entity_id = $this->getTestRootEntity(true);
+
+        $category1 = $this->createItem(\ITILCategory::class, [
+            'name' => 'test dashboard category 1 for tickets by category and entity',
+        ]);
+        $category2 = $this->createItem(\ITILCategory::class, [
+            'name' => 'test dashboard category 2 for tickets by category and entity',
+        ]);
+
+        $this->createItem(\Ticket::class, [
+            'name'             => 'test dashboard ticket cat1 a',
+            'content'          => 'blablabla',
+            'entities_id'      => $entity_id,
+            'itilcategories_id' => $category1->getID(),
+        ]);
+        $this->createItem(\Ticket::class, [
+            'name'             => 'test dashboard ticket cat1 b',
+            'content'          => 'blablabla',
+            'entities_id'      => $entity_id,
+            'itilcategories_id' => $category1->getID(),
+        ]);
+        $this->createItem(\Ticket::class, [
+            'name'             => 'test dashboard ticket cat2',
+            'content'          => 'blablabla',
+            'entities_id'      => $entity_id,
+            'itilcategories_id' => $category2->getID(),
+        ]);
+
+        $result = Provider::ticketsByCategoryAndEntity();
+        $this->assertArrayHasKey('data', $result);
+        $this->assertArrayHasKey('label', $result);
+        $this->assertArrayHasKey('icon', $result);
+
+        $this->assertArrayHasKey('labels', $result['data']);
+        $this->assertArrayHasKey('series', $result['data']);
+
+        $entity = new \Entity();
+        $this->assertTrue($entity->getFromDB($entity_id));
+        $entity_index = array_search($entity->fields['completename'], $result['data']['labels'], true);
+        $this->assertNotFalse($entity_index, 'entity must appear in the report labels');
+
+        $series_by_name = [];
+        foreach ($result['data']['series'] as $serie) {
+            $series_by_name[$serie['name']] = $serie['data'];
+        }
+
+        $this->assertArrayHasKey($category1->fields['name'], $series_by_name);
+        $this->assertArrayHasKey($category2->fields['name'], $series_by_name);
+
+        $this->assertSame(2, $series_by_name[$category1->fields['name']][$entity_index], '2 tickets expected for category 1');
+        $this->assertSame(1, $series_by_name[$category2->fields['name']][$entity_index], '1 ticket expected for category 2');
+    }
 }

--- a/tests/functional/Glpi/Dashboard/ProviderTest.php
+++ b/tests/functional/Glpi/Dashboard/ProviderTest.php
@@ -1099,6 +1099,12 @@ class ProviderTest extends DbTestCase
             'entities_id'      => $entity_id,
             'itilcategories_id' => $category2->getID(),
         ]);
+        $this->createItem(\Ticket::class, [
+            'name'              => 'test dashboard ticket no category',
+            'content'           => 'blablabla',
+            'entities_id'       => $entity_id,
+            'itilcategories_id' => 0,
+        ]);
 
         $result = Provider::ticketsByCategoryAndEntity();
         $this->assertArrayHasKey('data', $result);
@@ -1118,10 +1124,11 @@ class ProviderTest extends DbTestCase
             $series_by_name[$serie['name']] = $serie['data'];
         }
 
-        $this->assertArrayHasKey($category1->fields['name'], $series_by_name);
-        $this->assertArrayHasKey($category2->fields['name'], $series_by_name);
-
-        $this->assertSame(2, $series_by_name[$category1->fields['name']][$entity_index], '2 tickets expected for category 1');
-        $this->assertSame(1, $series_by_name[$category2->fields['name']][$entity_index], '1 ticket expected for category 2');
+        $this->assertArrayHasKey($category1->fields['completename'], $series_by_name);
+        $this->assertArrayHasKey($category2->fields['completename'], $series_by_name);
+        $this->assertArrayHasKey(__('None'), $series_by_name, 'a "None" series is expected for the uncategorized ticket');
+        $this->assertSame(2, $series_by_name[$category1->fields['completename']][$entity_index], '2 tickets expected for category 1');
+        $this->assertSame(1, $series_by_name[$category2->fields['completename']][$entity_index], '1 ticket expected for category 2');
+        $this->assertGreaterThanOrEqual(1, $series_by_name[__('None')][$entity_index], 'at least 1 uncategorized ticket expected');
     }
 }


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/glpi-project/Professional-Services/issues/83
- Add a new dashboard card titled “Number of tickets by category and entity”, migrated from the mreporting plugin

plugins/mreporting/inc/helpdesk.class.php
reportHgbarTicketNumberByCatAndEntity l.98

## Screenshots (if appropriate):

<img width="700" height="312" alt="image" src="https://github.com/user-attachments/assets/d199f352-cff7-484a-91ae-6225af787b57" />

