### PR TITLE
Fix `tools` dir lint

### DIFF
--- a/tools/src/Command/AbstractCommand.php
+++ b/tools/src/Command/AbstractCommand.php
@@ -104,7 +104,6 @@ abstract class AbstractCommand extends Command
 
     /**
      * Declare whether the command supports --plugin.
-     * @return bool
      */
     protected function isPluginOptionAvailable(): bool
     {
@@ -113,7 +112,6 @@ abstract class AbstractCommand extends Command
 
     /**
      * Declare the command supporting plugin and require it to be set.
-     * @return bool
      */
     protected function isRequiringPluginOption(): bool
     {

--- a/tools/src/Command/AbstractCommand.php
+++ b/tools/src/Command/AbstractCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Command;
 
+use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -45,6 +45,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Safe\file_get_contents;
+
 /**
  * Icon fonts expose their glyph through a CSS `::before { content: "\eXXX" }` rule. The accessible
  * name computation includes pseudo-element content, so a decorative icon placed inside an element
@@ -156,9 +158,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         $failed_files = [];
 
         foreach ($this->getFilesToParse($directories) as $filename) {
-            if (($contents = file_get_contents($filename)) === false) {
-                throw new \RuntimeException(sprintf('Unable to read file "%s".', $filename));
-            }
+            $contents = file_get_contents($filename);
 
             $icons = $this->findIconsToReport($contents);
             if ($icons === []) {

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -39,6 +39,7 @@ use Override;
 use RecursiveCallbackFilterIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Safe\Exceptions\FilesystemException;
 use SplFileInfo;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,6 +47,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Safe\file_get_contents;
+use function Safe\file_put_contents;
 use function Safe\preg_match;
 use function Safe\preg_match_all;
 use function Safe\preg_replace;
@@ -198,8 +200,12 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
             }
 
             $updated = $this->addAriaHidden($contents, $icons);
-            if ($updated !== $contents && file_put_contents($filename, $updated) === false) {
-                $failed_files[] = $relative_path;
+            if ($updated !== $contents) {
+                try {
+                    file_put_contents($filename, $updated);
+                } catch (FilesystemException) {
+                    $failed_files[] = $relative_path;
+                }
             }
         }
 

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -47,6 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function Safe\file_get_contents;
 use function Safe\preg_match;
+use function Safe\preg_match_all;
 use function Safe\preg_replace;
 
 /**
@@ -442,7 +443,8 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
         $window_start = max(0, $before - 2000);
         $window = substr($contents, $window_start, $before - $window_start);
 
-        if (preg_match_all('/<' . $tag_name . '\b(?<attrs>[^>]*)>/i', $window, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === 0) {
+        preg_match_all('/<' . $tag_name . '\b(?<attrs>[^>]*)>/i', $window, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        if (empty($matches)) {
             return null;
         }
 

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -321,7 +321,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
     /**
      * Print full review summary
      *
-     * @param list<string> $shown_categories
+     * @param list<string>                $shown_categories
      * @param array<string, list<string>> $review
      */
     private function reportReviewSummary(array $shown_categories, array $review): void

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -47,6 +47,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function Safe\file_get_contents;
 use function Safe\preg_match;
+use function Safe\preg_replace;
 
 /**
  * Icon fonts expose their glyph through a CSS `::before { content: "\eXXX" }` rule. The accessible
@@ -307,7 +308,7 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
      */
     private function flatten(string $tag): string
     {
-        return trim((string) preg_replace('/\s+/', ' ', $tag));
+        return trim(preg_replace('/\s+/', ' ', $tag));
     }
 
     /**

--- a/tools/src/Command/CheckDecorativeIconsCommand.php
+++ b/tools/src/Command/CheckDecorativeIconsCommand.php
@@ -46,6 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Safe\file_get_contents;
+use function Safe\preg_match;
 
 /**
  * Icon fonts expose their glyph through a CSS `::before { content: "\eXXX" }` rule. The accessible
@@ -457,7 +458,8 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
 
     private function hasIconClass(string $attrs): bool
     {
-        if (preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) !== 1) {
+        preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches);
+        if (!isset($matches['value'])) {
             return false;
         }
 
@@ -479,8 +481,9 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
             return 'interactive';
         }
 
+        preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches);
         if (
-            preg_match('/\bclass\s*=\s*(?<quote>["\'])(?<value>.*?)\g{quote}/is', $attrs, $matches) === 1
+            isset($matches['value'])
             && preg_match('/\b(?:btn|pointer|cursor-pointer)\b/', $matches['value']) === 1
         ) {
             return 'styled-as-control';
@@ -513,7 +516,8 @@ final class CheckDecorativeIconsCommand extends AbstractCommand
             $tag = $icon['tag'];
             // Reuse the quoting style already used in the tag: the markup often lives inside a PHP
             // or JS string literal, and the wrong quote would break it.
-            $quote = preg_match('/=\s*(?<quote>["\'])/', $tag, $matches) === 1 ? $matches['quote'] : '"';
+            preg_match('/=\s*(?<quote>["\'])/', $tag, $matches);
+            $quote = $matches['quote'] ?? '"';
 
             // Insert right after the last attribute, i.e. before the closing `>` and the `/` of a
             // self closing tag.

--- a/tools/src/Command/GenerateAPISnapshotCommand.php
+++ b/tools/src/Command/GenerateAPISnapshotCommand.php
@@ -112,11 +112,11 @@ class GenerateAPISnapshotCommand extends AbstractCommand
 
             $paths = $oapi->generatePathSnapshot();
             file_put_contents($PATHS_FILE, json_encode($paths, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-            unset($path_item, $paths);
+            unset($paths);
 
             $schema_components = $oapi->generateComponentsSnapshot();
             file_put_contents($COMPONENTS_FILE, json_encode(['schemas' => $schema_components], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-            unset($component_schema, $schema_components);
+            unset($schema_components);
         }
 
         return 0;

--- a/tools/src/Command/GenerateAPISnapshotCommand.php
+++ b/tools/src/Command/GenerateAPISnapshotCommand.php
@@ -38,6 +38,7 @@ use Glpi\Api\HL\OpenAPIGenerator;
 use Glpi\Api\HL\Router;
 use Glpi\Console\AbstractCommand;
 use Glpi\Console\Exception\EarlyExitException;
+use Safe\Exceptions\FilesystemException;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,6 +46,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use function Safe\file_put_contents;
+use function Safe\mkdir;
 
 class GenerateAPISnapshotCommand extends AbstractCommand
 {
@@ -93,8 +95,19 @@ class GenerateAPISnapshotCommand extends AbstractCommand
             $SNAPSHOT_DIR = GLPI_ROOT . "/tests/fixtures/hlapi/snapshots/{$version}";
             $PATHS_FILE = $SNAPSHOT_DIR . '/paths.json';
             $COMPONENTS_FILE = $SNAPSHOT_DIR . '/components.json';
-            if (!is_dir($SNAPSHOT_DIR) && !mkdir($SNAPSHOT_DIR, 0o755, true) && !is_dir($SNAPSHOT_DIR)) {
-                throw new \RuntimeException(sprintf('Directory "%s" was missing and not able to be created', $SNAPSHOT_DIR));
+            if (!is_dir($SNAPSHOT_DIR)) {
+                try {
+                    mkdir($SNAPSHOT_DIR, 0o755, true);
+                } catch (FilesystemException $e) {
+                    // Tolerate a concurrent process having created the directory in between.
+                    if (!is_dir($SNAPSHOT_DIR)) {
+                        throw new \RuntimeException(
+                            sprintf('Directory "%s" was missing and not able to be created', $SNAPSHOT_DIR),
+                            $e->getCode(),
+                            $e
+                        );
+                    }
+                }
             }
 
             $paths = $oapi->generatePathSnapshot();

--- a/tools/src/Command/GenerateAPISnapshotCommand.php
+++ b/tools/src/Command/GenerateAPISnapshotCommand.php
@@ -44,6 +44,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
+use function Safe\file_put_contents;
+
 class GenerateAPISnapshotCommand extends AbstractCommand
 {
     protected function configure()

--- a/tools/src/Command/GenerateHooksDocumentationCommand.php
+++ b/tools/src/Command/GenerateHooksDocumentationCommand.php
@@ -40,6 +40,9 @@ use ReflectionClass;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Safe\preg_replace;
+use function Safe\preg_replace_callback;
+
 final class GenerateHooksDocumentationCommand extends AbstractCommand
 {
     protected bool $requires_db = false;

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -45,6 +45,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Safe\file_get_contents;
+
 final class LicenceHeadersCheckCommand extends AbstractCommand
 {
     /**

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -45,8 +45,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function Safe\file;
 use function Safe\file_get_contents;
+use function Safe\file_put_contents;
+use function Safe\preg_grep;
 use function Safe\preg_match;
+use function Safe\realpath;
 
 final class LicenceHeadersCheckCommand extends AbstractCommand
 {

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -35,6 +35,7 @@
 
 namespace Glpi\Tools\Command;
 
+use Override;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
 use RecursiveIterator;

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -59,7 +59,6 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Header lines.
      *
-     * @var array|null
      */
     private ?array $header_lines = null;
 
@@ -382,12 +381,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
      * Get licence header lines.
      *
      * @param string|null $header_file_path
-     * @param string $line_prefix
-     * @param string $prepend_line
-     * @param string $append_line
-     * @param array  $extra_tagged_data
      *
-     * @return array
      */
     private function getLicenceHeaderLines(
         string $header_file_path,
@@ -419,9 +413,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Return files to parse.
      *
-     * @param string $directory
      *
-     * @return array
      */
     private function getFilesToParse(string $directory): array
     {
@@ -493,9 +485,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Indicates if a line can/should be located before licence header.
      *
-     * @param string $line
      *
-     * @return bool
      */
     private function shouldLineBeLocatedBeforeHeader(string $line): bool
     {
@@ -526,11 +516,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Strip empty top/bottom lines from an array.
      *
-     * @param array $lines
-     * @param bool $strip_top_lines
-     * @param bool $strip_bottom_lines
      *
-     * @return array
      */
     private function stripEmptyLines(array $lines, bool $strip_top_lines, bool $strip_bottom_lines): array
     {
@@ -566,10 +552,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Extract tagged data from header lines.
      *
-     * @param array $lines
-     * @param string|null $line_prefix
      *
-     * @return array
      */
     private function extractTaggedData(array $lines, ?string $line_prefix = null): array
     {
@@ -598,11 +581,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Append tagged data to header lines.
      *
-     * @param array $lines
-     * @param array $data_to_append
-     * @param string|null $line_prefix
      *
-     * @return array
      */
     private function appendTaggedData(array $lines, array $data_to_append, ?string $line_prefix = null): array
     {
@@ -654,9 +633,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Get regex pattern used to detect/extract tagged data.
      *
-     * @param string $line_prefix
      *
-     * @return string
      */
     private function getTagPattern(?string $line_prefix = null): string
     {
@@ -672,9 +649,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Unduplicate copyright/copyleft tags values.
      *
-     * @param array $values
      *
-     * @return array
      */
     private function unduplicateCopyTag(array $values): array
     {
@@ -752,9 +727,7 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
     /**
      * Get files exclusion pattern. All files matching this pattern will be excluded from checks.
      *
-     * @param string $directory
      *
-     * @return string
      */
     protected function getExclusionPattern(string $directory): ?string
     {

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -39,6 +39,7 @@ use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
 use RecursiveIterator;
 use RecursiveIteratorIterator;
+use Safe\Exceptions\FilesystemException;
 use SplFileInfo;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -150,8 +151,10 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
                 $this->io->text('<comment>' . sprintf('Processing "%s".', $filename) . '</comment>');
             }
 
-            if (($file_lines = file($filename)) === false) {
-                throw new \Exception(sprintf('Unable to read file "%s".', $filename));
+            try {
+                $file_lines = file($filename);
+            } catch (FilesystemException $e) {
+                throw new \Exception(sprintf('Unable to read file "%s".', $filename), $e->getCode(), $e);
             }
 
             $header_start_pattern   = null;
@@ -393,10 +396,11 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
         array $extra_tagged_data = []
     ): array {
         if ($this->header_lines === null) {
-            if (($lines = file($header_file_path)) === false) {
-                throw new \Exception('Unable to read header file.');
+            try {
+                $this->header_lines = file($header_file_path);
+            } catch (FilesystemException $e) {
+                throw new \Exception('Unable to read header file.', $e->getCode(), $e);
             }
-            $this->header_lines = $lines;
         }
 
         $lines = [];

--- a/tools/src/Command/LicenceHeadersCheckCommand.php
+++ b/tools/src/Command/LicenceHeadersCheckCommand.php
@@ -46,6 +46,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function Safe\file_get_contents;
+use function Safe\preg_match;
 
 final class LicenceHeadersCheckCommand extends AbstractCommand
 {
@@ -569,8 +570,9 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
         $tag_pattern = $this->getTagPattern($line_prefix);
 
         foreach ($lines as $line) {
-            $tag = null;
-            if (preg_match($tag_pattern, $line, $tag)) {
+            $tag = [];
+            preg_match($tag_pattern, $line, $tag);
+            if (isset($tag['name'], $tag['value'])) {
                 $tag_name = $tag['name'];
                 $tag_value = $tag['value'];
 
@@ -678,7 +680,8 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
 
         foreach ($values as $value) {
             $dates_matches = [];
-            if (preg_match($copy_dates_pattern, $value, $dates_matches) !== 1) {
+            preg_match($copy_dates_pattern, $value, $dates_matches);
+            if (!isset($dates_matches['starting_date'])) {
                 continue;
             }
 
@@ -716,6 +719,9 @@ final class LicenceHeadersCheckCommand extends AbstractCommand
             foreach ($similar_values as $similar_value) {
                 $similar_dates_matches = [];
                 preg_match($copy_dates_pattern, $similar_value, $similar_dates_matches);
+                if (!isset($similar_dates_matches['starting_date'])) {
+                    continue;
+                }
                 if ($similar_dates_matches['starting_date'] < $starting_date) {
                     $starting_date = $similar_dates_matches['starting_date'];
                 } elseif ($similar_dates_matches['starting_date'] > $ending_date) {

--- a/tools/src/Command/LocalesCompileCommand.php
+++ b/tools/src/Command/LocalesCompileCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Command;
 
+use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/tools/src/Command/LocalesCompileCommand.php
+++ b/tools/src/Command/LocalesCompileCommand.php
@@ -41,6 +41,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
+use function Safe\glob;
 use function Safe\preg_replace;
 
 final class LocalesCompileCommand extends AbstractCommand

--- a/tools/src/Command/LocalesCompileCommand.php
+++ b/tools/src/Command/LocalesCompileCommand.php
@@ -53,6 +53,7 @@ final class LocalesCompileCommand extends AbstractCommand
         return true;
     }
 
+    #[Override]
     protected function configure(): void
     {
         parent::configure();
@@ -94,7 +95,7 @@ final class LocalesCompileCommand extends AbstractCommand
         }
 
         $files = glob($locales_dir . '/*.po');
-        if (empty($files)) {
+        if ($files === []) {
             $this->io->error("No .po files found in $locales_dir");
             return false;
         }

--- a/tools/src/Command/LocalesCompileCommand.php
+++ b/tools/src/Command/LocalesCompileCommand.php
@@ -41,6 +41,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
+use function Safe\preg_replace;
+
 final class LocalesCompileCommand extends AbstractCommand
 {
     #[Override]

--- a/tools/src/Command/LocalesExtractCommand.php
+++ b/tools/src/Command/LocalesExtractCommand.php
@@ -52,6 +52,8 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 use Twig\TwigTest;
 
+use function Safe\preg_match;
+
 final class LocalesExtractCommand extends AbstractCommand
 {
     #[Override]

--- a/tools/src/Command/LocalesExtractCommand.php
+++ b/tools/src/Command/LocalesExtractCommand.php
@@ -37,6 +37,7 @@ namespace Glpi\Tools\Command;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
 use RecursiveIteratorIterator;
+use Safe\Exceptions\FilesystemException;
 use SplFileInfo;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -126,18 +127,28 @@ final class LocalesExtractCommand extends AbstractCommand
 
         $potfile = $working_dir . '/locales/' . strtolower($name) . '.pot';
 
-        if (!is_dir($working_dir . '/locales') && !mkdir($working_dir . '/locales')) {
-            $this->io->error(sprintf('Unable to create the `%s/locales` directory.', $working_dir));
-            return Command::FAILURE;
+        if (!is_dir($working_dir . '/locales')) {
+            try {
+                mkdir($working_dir . '/locales');
+            } catch (FilesystemException) {
+                $this->io->error(sprintf('Unable to create the `%s/locales` directory.', $working_dir));
+                return Command::FAILURE;
+            }
         }
 
         // Clean existing POT file
-        if (file_exists($potfile) && (!unlink($potfile))) {
-            $this->io->error(sprintf('Unable to override the `%s` file.', $potfile));
-            return Command::FAILURE;
+        if (file_exists($potfile)) {
+            try {
+                unlink($potfile);
+            } catch (FilesystemException) {
+                $this->io->error(sprintf('Unable to override the `%s` file.', $potfile));
+                return Command::FAILURE;
+            }
         }
 
-        if (!touch($potfile)) {
+        try {
+            touch($potfile);
+        } catch (FilesystemException) {
             $this->io->error(sprintf('Unable to create the `%s` file.', $potfile));
             return Command::FAILURE;
         }
@@ -146,7 +157,9 @@ final class LocalesExtractCommand extends AbstractCommand
         if (is_dir($working_dir . '/templates')) {
             $this->io->section('Processing Twig templates...');
             $temp_twig_dir = sys_get_temp_dir() . '/glpi-locales-' . uniqid();
-            if (!mkdir($temp_twig_dir . '/templates', 0o777, true)) {
+            try {
+                mkdir($temp_twig_dir . '/templates', 0o777, true);
+            } catch (FilesystemException) {
                 $this->io->error(sprintf('Unable to create the `%s/templates` dir.', $temp_twig_dir));
                 return Command::FAILURE;
             }
@@ -163,10 +176,10 @@ final class LocalesExtractCommand extends AbstractCommand
             $twig_files = $this->getFiles($temp_twig_dir, 'twig');
             if (count($twig_files) > 0) {
                 // Write files list to usage in xgettext via -f
-                if (
-                    ($list_file = tempnam(sys_get_temp_dir(), 'twigfiles')) === false
-                    || file_put_contents($list_file, implode("\n", $twig_files)) === false
-                ) {
+                try {
+                    $list_file = tempnam(sys_get_temp_dir(), 'twigfiles');
+                    file_put_contents($list_file, implode("\n", $twig_files));
+                } catch (FilesystemException) {
                     $this->io->error('Unable to create the Twig files list file.');
                     return Command::FAILURE;
                 }
@@ -200,10 +213,10 @@ final class LocalesExtractCommand extends AbstractCommand
         $php_files = $this->getFiles($working_dir, 'php', $exclude_regex);
         if (count($php_files) > 0) {
             // Write files list to usage in xgettext via -f
-            if (
-                ($list_file = tempnam(sys_get_temp_dir(), 'phpfiles')) === false
-                || file_put_contents($list_file, implode("\n", $php_files)) === false
-            ) {
+            try {
+                $list_file = tempnam(sys_get_temp_dir(), 'phpfiles');
+                file_put_contents($list_file, implode("\n", $php_files));
+            } catch (FilesystemException) {
                 $this->io->error('Unable to create the PHP files list file.');
                 return Command::FAILURE;
             }
@@ -238,10 +251,10 @@ final class LocalesExtractCommand extends AbstractCommand
         $js_files = array_filter($js_files, fn($f) => !str_ends_with($f, '.min.js'));
 
         if (count($js_files) > 0) {
-            if (
-                ($list_file = tempnam(sys_get_temp_dir(), 'jsfiles')) === false
-                || file_put_contents($list_file, implode("\n", $js_files)) === false
-            ) {
+            try {
+                $list_file = tempnam(sys_get_temp_dir(), 'jsfiles');
+                file_put_contents($list_file, implode("\n", $js_files));
+            } catch (FilesystemException) {
                 $this->io->error('Unable to create the JS files list file.');
                 return Command::FAILURE;
             }

--- a/tools/src/Command/LocalesExtractCommand.php
+++ b/tools/src/Command/LocalesExtractCommand.php
@@ -52,8 +52,15 @@ use Twig\TwigFilter;
 use Twig\TwigFunction;
 use Twig\TwigTest;
 
+use function Safe\file_put_contents;
+use function Safe\ini_set;
+use function Safe\mkdir;
 use function Safe\preg_match;
 use function Safe\preg_replace;
+use function Safe\realpath;
+use function Safe\tempnam;
+use function Safe\touch;
+use function Safe\unlink;
 
 final class LocalesExtractCommand extends AbstractCommand
 {

--- a/tools/src/Command/LocalesExtractCommand.php
+++ b/tools/src/Command/LocalesExtractCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Command;
 
+use Override;
 use RecursiveDirectoryIterator;
 use RecursiveFilterIterator;
 use RecursiveIteratorIterator;

--- a/tools/src/Command/LocalesExtractCommand.php
+++ b/tools/src/Command/LocalesExtractCommand.php
@@ -53,6 +53,7 @@ use Twig\TwigFunction;
 use Twig\TwigTest;
 
 use function Safe\preg_match;
+use function Safe\preg_replace;
 
 final class LocalesExtractCommand extends AbstractCommand
 {

--- a/tools/src/Plugin/Command/PluginReleaseCommand.php
+++ b/tools/src/Plugin/Command/PluginReleaseCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Plugin\Command;
 
+use Override;
 use Safe\Exceptions\FilesystemException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/tools/src/Plugin/Command/PluginReleaseCommand.php
+++ b/tools/src/Plugin/Command/PluginReleaseCommand.php
@@ -43,7 +43,11 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 
+use function Safe\file;
+use function Safe\getcwd;
+use function Safe\mkdir;
 use function Safe\preg_match;
+use function Safe\unlink;
 
 final class PluginReleaseCommand extends AbstractPluginCommand
 {
@@ -102,7 +106,7 @@ final class PluginReleaseCommand extends AbstractPluginCommand
         // Resolve relative paths based on plugin directory
         $fs = new Filesystem();
         if (!$fs->isAbsolutePath($dest)) {
-            $dest = \getcwd() . '/' . $dest;
+            $dest = getcwd() . '/' . $dest;
         }
 
         // Ensure parent directory exists

--- a/tools/src/Plugin/Command/PluginReleaseCommand.php
+++ b/tools/src/Plugin/Command/PluginReleaseCommand.php
@@ -55,7 +55,6 @@ final class PluginReleaseCommand extends AbstractPluginCommand
 {
     private string $dist_dir;
     private string $plugin_name = '';
-    private string $commit = '';
 
     private const BANNED_FILES = [
         '.git*',

--- a/tools/src/Plugin/Command/PluginReleaseCommand.php
+++ b/tools/src/Plugin/Command/PluginReleaseCommand.php
@@ -34,6 +34,7 @@
 
 namespace Glpi\Tools\Plugin\Command;
 
+use Safe\Exceptions\FilesystemException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -111,9 +112,13 @@ final class PluginReleaseCommand extends AbstractPluginCommand
 
         // Ensure parent directory exists
         $this->dist_dir = dirname($dest);
-        if (!is_dir($this->dist_dir) && !mkdir($this->dist_dir, 0o777, true)) {
-            $this->io->error(sprintf('Unable to create the `%s` directory.', $this->dist_dir));
-            return Command::FAILURE;
+        if (!is_dir($this->dist_dir)) {
+            try {
+                mkdir($this->dist_dir, 0o777, true);
+            } catch (FilesystemException) {
+                $this->io->error(sprintf('Unable to create the `%s` directory.', $this->dist_dir));
+                return Command::FAILURE;
+            }
         }
 
         if (!$input->getOption('force') && file_exists($dest)) {
@@ -140,7 +145,9 @@ final class PluginReleaseCommand extends AbstractPluginCommand
         if (is_dir($src_dir)) {
             $fs->remove($src_dir);
         }
-        if (!mkdir($src_subdir, 0o777, true)) {
+        try {
+            mkdir($src_subdir, 0o777, true);
+        } catch (FilesystemException) {
             $this->io->error(sprintf('Unable to create the `%s` directory.', $src_subdir));
             return Command::FAILURE;
         }

--- a/tools/src/Plugin/Command/PluginReleaseCommand.php
+++ b/tools/src/Plugin/Command/PluginReleaseCommand.php
@@ -43,6 +43,8 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Process;
 
+use function Safe\preg_match;
+
 final class PluginReleaseCommand extends AbstractPluginCommand
 {
     private string $dist_dir;


### PR DESCRIPTION
While adding some command description, I found important problems in `tools/src` directory.
I fixed some of them.
Some typing alerts of phpstan are still here. They deserve to be fixed later,  I won't spend too much time with this task.


