### PR TITLE
Apply patch

### DIFF
--- a/src/Glpi/Console/Patch/ApplyCommand.php
+++ b/src/Glpi/Console/Patch/ApplyCommand.php
@@ -183,7 +183,7 @@ final class ApplyCommand extends AbstractCommand
         /** @var string $raw_input */
         $raw_input = $input->getArgument('input');
 
-        $plugin_name = $input->getOption('plugin')??'';
+        $plugin_name = $input->getOption('plugin') ?? '';
         $dry_run     = (bool) $input->getOption('dry-run');
         $revert      = (bool) $input->getOption('revert');
 

--- a/src/Glpi/Console/Patch/ApplyCommand.php
+++ b/src/Glpi/Console/Patch/ApplyCommand.php
@@ -183,17 +183,9 @@ final class ApplyCommand extends AbstractCommand
         /** @var string $raw_input */
         $raw_input = $input->getArgument('input');
 
-        $plugin_name = '';
-        if ($input->hasOption('plugin')) {
-            $plugin_name = $input->getOption('plugin');
-            if ($plugin_name === null || $plugin_name === '') {
-                $io->error('The plugin folder name is missing.');
-                return Command::FAILURE;
-            }
-        }
-
-        $dry_run = (bool) $input->hasOption('dry-run');
-        $revert  = (bool) $input->hasOption('revert');
+        $plugin_name = $input->getOption('plugin')??'';
+        $dry_run     = (bool) $input->getOption('dry-run');
+        $revert      = (bool) $input->getOption('revert');
 
         // ------------------------------------------------------------------
         // Banner
@@ -212,7 +204,7 @@ final class ApplyCommand extends AbstractCommand
         $plugin_dir = '';
         if ($plugin_name !== '') {
             $marketplace_plugin_dir = GLPI_ROOT . '/marketplace/' . $plugin_name;
-            $plugins_plugin_dir = GLPI_ROOT . '/plugin/' . $plugin_name;
+            $plugins_plugin_dir = GLPI_ROOT . '/plugins/' . $plugin_name;
 
             $is_installed_in_marketplace = is_dir($marketplace_plugin_dir);
             $is_installed_in_plugins = is_dir($plugins_plugin_dir);
@@ -324,7 +316,9 @@ final class ApplyCommand extends AbstractCommand
             }
         } else {
             $io->success(
-                'Dry-run complete. Re-run without --dry-run to apply the changes.'
+                $revert
+                    ? 'Dry-run complete. Re-run without --dry-run to revert the changes.'
+                    : 'Dry-run complete. Re-run without --dry-run to apply the changes.'
             );
         }
 

--- a/src/Glpi/Console/Patch/ApplyCommand.php
+++ b/src/Glpi/Console/Patch/ApplyCommand.php
@@ -1,0 +1,529 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Console\Patch;
+
+use Exception;
+use Glpi\Console\AbstractCommand;
+use Glpi\Console\Build\CompileScssCommand;
+use Glpi\Console\Cache\ClearCommand;
+use Glpi\Patch\ApplyStatus;
+use Glpi\Patch\DiffFetcher;
+use Glpi\Patch\FileApplyResult;
+use Glpi\Patch\PatchApplier;
+use Glpi\Patch\PathRewriter;
+use Override;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function Safe\unlink;
+
+/**
+ * Applies a GLPI (or plugin) pull request patch directly to the filesystem.
+ *
+ * Usage examples
+ * --------------
+ *   # Apply a GLPI core fix from a GitHub PR URL
+ *   bin/console patch:apply https://github.com/glpi-project/glpi/pull/1234
+ *
+ *   # Apply a local diff file
+ *   bin/console patch:apply /tmp/my-fix.diff
+ *
+ *   # Apply a plugin patch
+ *   bin/console patch:apply https://github.com/glpi-network/approvalbymail/pull/56 --plugin=approvalbymail
+ *
+ *   # Test without writing anything
+ *   bin/console patch:apply https://github.com/glpi-project/glpi/pull/1234 --dry-run
+ *
+ * How it works
+ * ------------
+ * The command downloads (or reads) a unified diff, then applies it directly
+ * using pure PHP.  No external tools (git, patch, filterdiff …) are needed.
+ * GLPI-specific path remapping is done automatically:
+ *   - js/* and lib/* → public/js/* and public/lib/*
+ *   - tests/* is always skipped (not deployed in production)
+ *   - .vue source files are skipped by default (require a front-end rebuild)
+ *
+ * After applying, the command tells you if you also need to:
+ *   - Clear the server cache  (cache:clear)
+ *   - Recompile SCSS          (build:compile_scss)
+ *   - Clear your browser cache
+ */
+final class ApplyCommand extends AbstractCommand
+{
+    protected $requires_db           = false;
+    protected $requires_db_up_to_date = false;
+
+    #[Override]
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->setName('patch:apply');
+        $this->setDescription(
+            'Build and apply a patch to the core or a plugin using a github pull request url or a diff file.'
+        );
+
+        $this->setHelp(<<<'HELP'
+            The <info>patch:apply</info> command downloads a pull request diff from GitHub (or reads
+            a local .diff file) and applies it directly to the core or a plugin.
+
+            Before applying the patch, it does all the following modifications to the raw diff content
+            to adapt it to production GLPI installations:
+            - Remaps paths for asset folders: js/, css/ and lib/ → public/js/, public/css and public/lib/
+            - Skips any file under tests/, tools/, phpunit/, and CHANGELOG.md
+
+            If the patch contains .vue files, the command is aborted. This is because .vue files require a front-end rebuild.
+            If the patch contains .js files, the command will automatically delete the corresponding .min.js files.
+            If the patch contains .css files, the command will automatically recompile the SCSS files after applying the patch.
+            If the patch contains changes to templates/, the command will automatically clear the cache after applying the patch.
+
+            Usage examples:
+
+            <info>bin/console patch:apply <PR URL> </info>
+            <info>bin/console patch:apply <DIFF URL> </info>
+
+            Or use a local diff file:
+
+            <info>bin/console patch:apply <file path> </info>
+
+            You can also target a plugin:
+
+            <info>bin/console patch:apply <PR URL> --plugin=<plugin name> </info>
+
+            Use <comment>--dry-run</comment> to see what would happen without writing anything:
+
+            <info>bin/console patch:apply <PR URL> --dry-run</info>
+
+            Use <comment>--revert</comment> to reverse a previously applied patch:
+
+            <info>bin/console patch:apply <PR URL> --revert</info>
+
+            Both options can be combined to simulate a revert without writing anything:
+
+            <info>bin/console patch:apply <PR URL> --revert --dry-run</info>
+        HELP);
+
+        $this->addArgument(
+            'input',
+            InputArgument::REQUIRED,
+            implode("\n", [
+                'Where to get the patch from. Accepted formats:',
+                '  - GitHub PR URL  : https://github.com/glpi-project/glpi/pull/1234',
+                '  - Diff file URL  : https://patch-diff.githubusercontent.com/glpi-project/glpi/pull/1234.diff',
+                '  - Local file     : /path/to/my-fix.diff',
+            ])
+        );
+
+        $this->addOption(
+            'plugin',
+            'p',
+            InputOption::VALUE_REQUIRED,
+            'Name of the plugin to patch (directory name under plugins/ or marketplace/).'
+            . ' Leave empty to patch GLPI core.'
+        );
+
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Simulate the patch: show what would be changed without writing any file.'
+        );
+
+        $this->addOption(
+            'revert',
+            'r',
+            InputOption::VALUE_NONE,
+            'Revert the patch instead of applying it: removes added lines and restores removed lines.'
+        );
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var string $raw_input */
+        $raw_input = $input->getArgument('input');
+
+        $plugin_name = '';
+        if ($input->hasOption('plugin')) {
+            $plugin_name = $input->getOption('plugin');
+            if ($plugin_name === null || $plugin_name === '') {
+                $io->error('The plugin folder name is missing.');
+                return Command::FAILURE;
+            }
+        }
+
+        $dry_run = (bool) $input->hasOption('dry-run');
+        $revert  = (bool) $input->hasOption('revert');
+
+        // ------------------------------------------------------------------
+        // Banner
+        // ------------------------------------------------------------------
+        if ($dry_run && $revert) {
+            $io->note('DRY-RUN + REVERT mode is active - simulating patch revert without writing any files.');
+        } elseif ($dry_run) {
+            $io->note('DRY-RUN mode is active - no files will be changed.');
+        } elseif ($revert) {
+            $io->note('REVERT mode is active - the patch will be reversed.');
+        }
+
+        // ------------------------------------------------------------------
+        // Find and Validate plugin directory when --plugin is used
+        // ------------------------------------------------------------------
+        $plugin_dir = '';
+        if ($plugin_name !== '') {
+            $marketplace_plugin_dir = GLPI_ROOT . '/marketplace/' . $plugin_name;
+            $plugins_plugin_dir = GLPI_ROOT . '/plugin/' . $plugin_name;
+
+            $is_installed_in_marketplace = is_dir($marketplace_plugin_dir);
+            $is_installed_in_plugins = is_dir($plugins_plugin_dir);
+
+            if (!$is_installed_in_marketplace && !$is_installed_in_plugins) {
+                $io->error([
+                    "Plugin directory not found in either plugins/ or marketplace/.",
+                    'Please make sure the plugin folder exists in one of these directories.',
+                ]);
+                return Command::FAILURE;
+            }
+
+            if ($is_installed_in_marketplace && $is_installed_in_plugins) {
+                $io->error([
+                    "Plugin exists in both plugins/ and marketplace/.",
+                    'Please make sure the plugin is installed in only one of these directories.',
+                ]);
+                return Command::FAILURE;
+            }
+
+            //set the plugin directory for path rewriting
+            $plugin_dir = $is_installed_in_marketplace
+                          ? $marketplace_plugin_dir
+                          : $plugins_plugin_dir;
+        }
+
+        // ------------------------------------------------------------------
+        // Fetch the diff
+        // ------------------------------------------------------------------
+        $io->text('Fetching patch…');
+
+        try {
+            $diff_content = (new DiffFetcher())->fetch($raw_input);
+        } catch (RuntimeException $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        if (trim($diff_content) === '') {
+            $io->error('The patch is empty. Nothing to apply.');
+            return Command::FAILURE;
+        }
+
+        // ------------------------------------------------------------------
+        // Determine the source description for user messages
+        // ------------------------------------------------------------------
+        $source_label = $this->buildSourceLabel($raw_input);
+        if ($plugin_name !== '') {
+            $source_label .= " (plugin: $plugin_name)";
+        }
+        $io->text("Source: $source_label");
+
+        // ------------------------------------------------------------------
+        // Apply
+        // ------------------------------------------------------------------
+        $rewriter = new PathRewriter($plugin_dir !== '' ? $plugin_dir : GLPI_ROOT);
+        $applier  = new PatchApplier($rewriter);
+
+        try {
+            $results = $applier->apply($diff_content, $dry_run, false, $revert);
+        } catch (RuntimeException $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        if ($results === []) {
+            $io->warning('No file changes were found in this patch.');
+            return Command::SUCCESS;
+        }
+
+        // ------------------------------------------------------------------
+        // Display results table
+        // ------------------------------------------------------------------
+        $this->renderResultsTable($output, $results);
+
+        // ------------------------------------------------------------------
+        // Display Summary counts
+        // ------------------------------------------------------------------
+        $this->renderSummaryCounts($output, $results);
+
+        // ------------------------------------------------------------------
+        // Conflicts: show details and fail if any
+        // ------------------------------------------------------------------
+        $conflicts = array_filter($results, fn(FileApplyResult $r) => $r->status === ApplyStatus::Conflict);
+        if ($conflicts !== []) {
+            $io->section('Conflict details');
+            foreach ($conflicts as $result) {
+                $io->error([
+                    $result->display_path,
+                    $result->message,
+                ]);
+            }
+            return Command::FAILURE;
+        }
+
+        // ------------------------------------------------------------------
+        // Performe Post-apply actions
+        // ------------------------------------------------------------------
+        if (!$dry_run) {
+            $post_actions_result = $this->performePostApplyActions($results, $io, $input, $output);
+            if ($post_actions_result === true) {
+                $io->text('Please clear your browser cache.');
+                $io->success($revert ? 'Patch reverted successfully!' : 'Patch applied successfully!');
+            } else {
+                $io->warning(
+                    ($revert ? 'Patch reverted' : 'Patch applied')
+                    . ', but some post-apply actions could not be performed automatically. Please check the messages above.'
+                );
+            }
+        } else {
+            $io->success(
+                'Dry-run complete. Re-run without --dry-run to apply the changes.'
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Determines and performs necessary actions after applying the patch.
+     * Actions include:
+     *  - Deleting .min.js files corresponding to changed .js files in public/
+     *  - Recompiling SCSS if any .css or .scss file in public/ was changed
+     *  - Clearing cache if any file under templates/ was changed
+     *
+     * @param FileApplyResult[] $results The results of applying the patch, used to determine necessary post-actions.
+     * @return bool True if all post-actions were performed successfully, false if any action failed
+     */
+    private function performePostApplyActions(
+        array $results,
+        SymfonyStyle $io,
+        InputInterface $input,
+        OutputInterface $output
+    ): bool {
+        $changed_files = array_filter(
+            $results,
+            fn(FileApplyResult $r) => in_array($r->status, [ApplyStatus::Applied, ApplyStatus::Reverted, ApplyStatus::Created, ApplyStatus::Deleted], true)
+        );
+
+        if (count($changed_files) === 0) {
+            return true;
+        }
+
+        $paths = array_column($changed_files, 'display_path');
+        $recompile_css = false;
+        $clear_cache = false;
+        $error_count = 0;
+        foreach ($paths as $path) {
+            if (str_contains($path, 'public/')) {
+
+                // .js files in public/ → delete the corresponding .min.js file
+                if (
+                    str_ends_with($path, '.js')
+                    && !str_ends_with($path, '.min.js')
+                ) {
+                    $min = str_replace('.js', '.min.js', $path);
+
+                    //delete the minified file if it exists
+                    if (file_exists($min)) {
+                        try {
+                            unlink($min);
+                        } catch (Exception $e) {
+                            $io->warning("Could not delete minified file: $min. Please check permissions.");
+                            $error_count++;
+                        }
+                    }
+                }
+                // if it's a .css file in public/, we need to recompile the SCSS files
+                elseif (str_ends_with($path, '.css') || str_ends_with($path, '.scss')) {
+                    $recompile_css = true;
+                }
+            } elseif (str_contains($path, 'templates/')) {
+                $clear_cache = true;
+            }
+        }
+
+        if ($clear_cache) {
+            try {
+                (new ClearCommand())->execute($input, $output);
+            } catch (Exception $e) {
+                $io->warning("Patch applied, but failed to clear cache automatically: " . $e->getMessage());
+                $error_count++;
+            }
+        }
+        if ($recompile_css) {
+            try {
+                (new CompileScssCommand())->execute($input, $output);
+            } catch (Exception $e) {
+                $io->warning("Patch applied, but failed to recompile SCSS automatically: " . $e->getMessage());
+                $error_count++;
+            }
+        }
+
+        return $error_count === 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Output helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a short human-readable label describing where the patch came from.
+     */
+    private function buildSourceLabel(string $input): string
+    {
+        $parsed = (new DiffFetcher())->parseGitHubPrUrl($input);
+        if ($parsed !== null) {
+            [$owner, $repo, $pr_num] = $parsed;
+            return "GitHub PR #$pr_num ($owner/$repo)";
+        }
+
+        if (file_exists($input)) {
+            return 'Local file: ' . basename($input);
+        }
+
+        return $input;
+    }
+
+    /**
+     * Renders a table with one row per changed file.
+     *
+     * @param FileApplyResult[] $results
+     */
+    private function renderResultsTable(OutputInterface $output, array $results): void
+    {
+        $table = new Table($output);
+        $table->setHeaders(['File', 'Status', 'Details']);
+        $table->setColumnMaxWidth(0, 60);
+        $table->setColumnMaxWidth(2, 55);
+
+        // Sort results so conflicts appear first, then changes, then skipped
+        $display_order = [
+            ApplyStatus::Conflict->name       => 0,
+            ApplyStatus::Applied->name        => 1,
+            ApplyStatus::Reverted->name       => 1,
+            ApplyStatus::Created->name        => 1,
+            ApplyStatus::Deleted->name        => 1,
+            ApplyStatus::DryRun->name         => 2,
+            ApplyStatus::AlreadyApplied->name => 3,
+            ApplyStatus::Skipped->name        => 4,
+        ];
+        usort($results, static fn(FileApplyResult $a, FileApplyResult $b): int => ($display_order[$a->status->name] ?? 9) <=> ($display_order[$b->status->name] ?? 9));
+
+        $rows = [];
+        foreach ($results as $result) {
+            $rows[] = [
+                $result->display_path,
+                $this->formatStatus($result->status),
+                $result->message,
+            ];
+        }
+
+        $table->setRows($rows);
+        $output->writeln('');
+        $table->render();
+    }
+
+    private function formatStatus(ApplyStatus $status): string
+    {
+        return match ($status) {
+            ApplyStatus::Applied        => '<info>APPLIED</info>',
+            ApplyStatus::Reverted       => '<info>REVERTED</info>',
+            ApplyStatus::Created        => '<info>CREATED</info>',
+            ApplyStatus::Deleted        => '<info>DELETED</info>',
+            ApplyStatus::AlreadyApplied => '<comment>ALREADY APPLIED</comment>',
+            ApplyStatus::DryRun         => '<comment>DRY-RUN</comment>',
+            ApplyStatus::Skipped        => 'SKIPPED',
+            ApplyStatus::Conflict       => '<error>CONFLICT</error>',
+        };
+    }
+
+    /**
+     * Renders a summary of how many files were applied, reverted, created, deleted, skipped, etc.
+     *
+     * @param FileApplyResult[] $results The results of applying the patch, used to count the outcomes.
+     */
+    private function renderSummaryCounts(OutputInterface $output, array $results): void
+    {
+        $counts = [];
+        foreach ($results as $result) {
+            $key = $result->status->name;
+            $counts[$key] = ($counts[$key] ?? 0) + 1;
+        }
+
+        $summary_parts = [];
+        if (($counts[ApplyStatus::Applied->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<info>%d applied</info>', $counts[ApplyStatus::Applied->name]);
+        }
+        if (($counts[ApplyStatus::Reverted->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<info>%d reverted</info>', $counts[ApplyStatus::Reverted->name]);
+        }
+        if (($counts[ApplyStatus::Created->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<info>%d created</info>', $counts[ApplyStatus::Created->name]);
+        }
+        if (($counts[ApplyStatus::Deleted->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<info>%d deleted</info>', $counts[ApplyStatus::Deleted->name]);
+        }
+        if (($counts[ApplyStatus::DryRun->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<comment>%d would be changed (dry-run)</comment>', $counts[ApplyStatus::DryRun->name]);
+        }
+        if (($counts[ApplyStatus::AlreadyApplied->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<comment>%d already applied</comment>', $counts[ApplyStatus::AlreadyApplied->name]);
+        }
+        if (($counts[ApplyStatus::Skipped->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('%d skipped', $counts[ApplyStatus::Skipped->name]);
+        }
+        if (($counts[ApplyStatus::Conflict->name] ?? 0) > 0) {
+            $summary_parts[] = sprintf('<error>%d conflict(s)</error>', $counts[ApplyStatus::Conflict->name]);
+        }
+
+        $output->writeln('');
+        $output->writeln('Summary: ' . implode(', ', $summary_parts));
+    }
+}

--- a/src/Glpi/Console/Patch/ApplyCommand.php
+++ b/src/Glpi/Console/Patch/ApplyCommand.php
@@ -183,7 +183,13 @@ final class ApplyCommand extends AbstractCommand
         /** @var string $raw_input */
         $raw_input = $input->getArgument('input');
 
-        $plugin_name = $input->getOption('plugin') ?? '';
+        $plugin_name = $input->getOption('plugin');
+        if($plugin_name !== null && $plugin_name === "") { //the option is present but empty
+            $io->error('The --plugin can\'t have an empty value.');
+            return Command::FAILURE;
+        }
+        $plugin_name ??= ''; //the option is not present, set to empty string for easier handling later
+
         $dry_run     = (bool) $input->getOption('dry-run');
         $revert      = (bool) $input->getOption('revert');
 
@@ -434,7 +440,7 @@ final class ApplyCommand extends AbstractCommand
     {
         $table = new Table($output);
         $table->setHeaders(['File', 'Status', 'Details']);
-        $table->setColumnMaxWidth(0, 60);
+        $table->setColumnMaxWidth(0, 70);
         $table->setColumnMaxWidth(2, 55);
 
         // Sort results so conflicts appear first, then changes, then skipped

--- a/src/Glpi/Console/Patch/ApplyCommand.php
+++ b/src/Glpi/Console/Patch/ApplyCommand.php
@@ -36,8 +36,6 @@ namespace Glpi\Console\Patch;
 
 use Exception;
 use Glpi\Console\AbstractCommand;
-use Glpi\Console\Build\CompileScssCommand;
-use Glpi\Console\Cache\ClearCommand;
 use Glpi\Patch\ApplyStatus;
 use Glpi\Patch\DiffFetcher;
 use Glpi\Patch\FileApplyResult;
@@ -47,6 +45,7 @@ use Override;
 use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -312,7 +311,7 @@ final class ApplyCommand extends AbstractCommand
         if (!$dry_run) {
             $post_actions_result = $this->performePostApplyActions($results, $io, $input, $output);
             if ($post_actions_result === true) {
-                $io->text('Please clear your browser cache.');
+                $io->text("\nPlease clear your browser cache.");
                 $io->success($revert ? 'Patch reverted successfully!' : 'Patch applied successfully!');
             } else {
                 $io->warning(
@@ -391,7 +390,8 @@ final class ApplyCommand extends AbstractCommand
 
         if ($clear_cache) {
             try {
-                (new ClearCommand())->execute($input, $output);
+                $io->text("\nClearing cache…");
+                $this->getApplication()->find('cache:clear')->run(new ArrayInput([]), $output);
             } catch (Exception $e) {
                 $io->warning("Patch applied, but failed to clear cache automatically: " . $e->getMessage());
                 $error_count++;
@@ -399,7 +399,8 @@ final class ApplyCommand extends AbstractCommand
         }
         if ($recompile_css) {
             try {
-                (new CompileScssCommand())->execute($input, $output);
+                $io->text("\nCompiling SCSS…");
+                $this->getApplication()->find('build:compile_scss')->run(new ArrayInput([]), $output);
             } catch (Exception $e) {
                 $io->warning("Patch applied, but failed to recompile SCSS automatically: " . $e->getMessage());
                 $error_count++;

--- a/src/Glpi/Patch/ApplyStatus.php
+++ b/src/Glpi/Patch/ApplyStatus.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Patch;
+
+enum ApplyStatus
+{
+    /** Changes were applied successfully. */
+    case Applied;
+
+    /** All changes were already present in the file — nothing to do. */
+    case AlreadyApplied;
+
+    /** File was created (new file in the patch). */
+    case Created;
+
+    /** File was deleted (removed file in the patch). */
+    case Deleted;
+
+    /** File was skipped intentionally (test file, .vue source, etc.). */
+    case Skipped;
+
+    /** Changes were successfully reverted (inverse of Applied). */
+    case Reverted;
+
+    /**
+     * The patch context does not match the file content —
+     * the patch is outdated, the file was already modified differently,
+     * or this is not the right target.
+     */
+    case Conflict;
+
+    /** Dry-run mode: the change would have been applied but nothing was written. */
+    case DryRun;
+}

--- a/src/Glpi/Patch/DiffFetcher.php
+++ b/src/Glpi/Patch/DiffFetcher.php
@@ -91,6 +91,10 @@ final class DiffFetcher
 
     private function fetchFromUrl(string $url): string
     {
+        if($this->isDiffUrl($url)) {
+            return $this->download($url);
+        }
+
         // Transform a GitHub PR page URL to the raw diff endpoint
         $parsed = $this->parseGitHubPrUrl($url);
         if ($parsed !== null) {
@@ -99,8 +103,12 @@ final class DiffFetcher
             return $this->download($diff_url);
         }
 
-        // Treat as a direct URL to a .diff file
-        return $this->download($url);
+        throw new RuntimeException("The provided URL does not appear to be a valid GitHub PR URL or a direct diff URL: $url");
+    }
+
+    private function isDiffUrl(string $url): bool
+    {
+        return preg_match('#patch-diff\.githubusercontent\.com/raw/[^/]+/[^/]+/pull/\d+\.diff#', $url) === 1;
     }
 
     private function fetchFromFile(string $path): string

--- a/src/Glpi/Patch/DiffFetcher.php
+++ b/src/Glpi/Patch/DiffFetcher.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Patch;
+
+use Exception;
+use RuntimeException;
+
+use function Safe\file_get_contents;
+use function Safe\parse_url;
+use function Safe\preg_match;
+
+final class DiffFetcher
+{
+    /**
+     * URL template for GitHub's raw diff endpoint.
+     * Arguments: owner, repo, pull-request number.
+     */
+    private const GITHUB_DIFF_URL = 'https://patch-diff.githubusercontent.com/raw/%s/%s/pull/%d.diff';
+
+    /**
+     * Fetches the diff content from a GitHub PR URL or a local diff/patch file.
+     *
+     * Accepted input formats:
+     *   - https://github.com/owner/repo/pull/123   (GitHub PR page URL)
+     *   - https://patch-diff.githubusercontent.com/raw/owner/repo/pull/123.diff  (Direct diff URL)
+     *   - /absolute/path/to/file.diff              (local file)
+     *   - relative/path/to/file.patch              (local file)
+     *
+     * @throws RuntimeException When the source cannot be read.
+     */
+    public function fetch(string $input): string
+    {
+        if ($this->isUrl($input)) {
+            return $this->fetchFromUrl($input);
+        }
+
+        return $this->fetchFromFile($input);
+    }
+
+    /**
+     * Tries to extract the GitHub owner, repository, and PR number from a URL.
+     *
+     * @return array{0: string, 1: string, 2: int}|null  [owner, repo, pr_num] or null.
+     */
+    public function parseGitHubPrUrl(string $url): ?array
+    {
+        $m = [];
+        if (preg_match('#github\.com/([^/]+)/([^/]+)/pull/(\d+)#', $url, $m) === 1) {
+            return count($m) === 4 ? [$m[1], $m[2], (int) $m[3]] : null;
+        }
+
+        return null;
+    }
+
+    private function isUrl(string $input): bool
+    {
+        return in_array(parse_url($input, PHP_URL_SCHEME), ['http', 'https'], true);
+    }
+
+    private function fetchFromUrl(string $url): string
+    {
+        // Transform a GitHub PR page URL to the raw diff endpoint
+        $parsed = $this->parseGitHubPrUrl($url);
+        if ($parsed !== null) {
+            [$owner, $repo, $pr_num] = $parsed;
+            $diff_url = sprintf(self::GITHUB_DIFF_URL, $owner, $repo, $pr_num);
+            return $this->download($diff_url);
+        }
+
+        // Treat as a direct URL to a .diff file
+        return $this->download($url);
+    }
+
+    private function fetchFromFile(string $path): string
+    {
+        if (!file_exists($path)) {
+            throw new RuntimeException(
+                "Diff file not found: $path\n"
+                . "Make sure the path is correct and the file exists."
+            );
+        }
+
+        if (!is_readable($path)) {
+            throw new RuntimeException(
+                "Cannot read diff file: $path\n"
+                . "Check that the file permissions allow reading."
+            );
+        }
+
+        try {
+            $content = file_get_contents($path);
+            return $content;
+        } catch (Exception $e) {
+            throw new RuntimeException("The diff file could not be read: $path\n" . $e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    private function download(string $url): string
+    {
+        try {
+            $content = file_get_contents($url);
+            return $content;
+        } catch (Exception $e) {
+            throw new RuntimeException("Failed to download the diff from: $url\n"
+            . "Please check that the PR number is correct.", $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Glpi/Patch/DiffFetcher.php
+++ b/src/Glpi/Patch/DiffFetcher.php
@@ -142,7 +142,7 @@ final class DiffFetcher
             return $content;
         } catch (Exception $e) {
             throw new RuntimeException("Failed to download the diff from: $url\n"
-            . "Please check that the PR number is correct.", $e->getCode(), $e);
+            . "Please check that the PR number is correct and that the repository is public.", $e->getCode(), $e);
         }
     }
 }

--- a/src/Glpi/Patch/FileApplyResult.php
+++ b/src/Glpi/Patch/FileApplyResult.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Patch;
+
+/**
+ * The outcome of trying to apply one file's changes from a patch.
+ */
+final readonly class FileApplyResult
+{
+    /**
+     * @param string      $display_path  Clean path shown to the user (no a/ or b/ prefix).
+     * @param ApplyStatus $status        Outcome of the apply attempt.
+     * @param string      $message       Human-readable explanation for the outcome.
+     */
+    public function __construct(
+        public string $display_path,
+        public ApplyStatus $status,
+        public string $message,
+    ) {}
+}

--- a/src/Glpi/Patch/FileApplyResult.php
+++ b/src/Glpi/Patch/FileApplyResult.php
@@ -37,7 +37,7 @@ namespace Glpi\Patch;
 /**
  * The outcome of trying to apply one file's changes from a patch.
  */
-final readonly class FileApplyResult
+final class FileApplyResult
 {
     /**
      * @param string      $display_path  Clean path shown to the user (no a/ or b/ prefix).

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -1,0 +1,551 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Patch;
+
+use Exception;
+use SebastianBergmann\Diff\Chunk;
+use SebastianBergmann\Diff\Diff;
+use SebastianBergmann\Diff\Parser;
+
+use function Safe\file_get_contents;
+use function Safe\file_put_contents;
+use function Safe\mkdir;
+use function Safe\unlink;
+
+final class PatchApplier
+{
+    /**
+     * Number of lines to search above and below the expected hunk position
+     * when the file has been slightly changed since the patch was generated.
+     */
+    private const FUZZ_LINES = 3;
+
+    public function __construct(
+        private PathRewriter $rewriter,
+    ) {}
+
+    /**
+     * Applies a raw unified diff string to the filesystem.
+     *
+     * @param  string $diff_content  Raw unified diff (e.g. downloaded from GitHub).
+     * @param  bool   $dry_run       When true nothing is written; results show
+     *                               what WOULD happen.
+     * @return FileApplyResult[]
+     */
+    public function apply(string $diff_content, bool $dry_run = false, bool $force_vue = false, bool $revert = false): array
+    {
+        $diffs = (new Parser())->parse($diff_content);
+
+        //check if the patch contains .vue files, if yes, throw an exception if $force_vue is not set to true.
+        if (!$force_vue) {
+            foreach ($diffs as $diff) {
+                if (str_ends_with($diff->to(), '.vue') || str_ends_with($diff->from(), '.vue')) {
+                    throw new \RuntimeException('This patch contains changes to .vue files, which are not meant to be applied. Stopping the patch application.');
+                }
+            }
+        }
+
+        $results = [];
+        foreach ($diffs as $diff) {
+            $results[] = $this->applyFileDiff($diff, $dry_run, $revert);
+        }
+
+        return $results;
+    }
+
+    private function applyFileDiff(Diff $diff, bool $dry_run, bool $revert): FileApplyResult
+    {
+        $from = $diff->from();
+        $to   = $diff->to();
+
+        $is_new_file     = $this->rewriter->isDevNull($from);
+        $is_deleted_file = $this->rewriter->isDevNull($to);
+
+        // Canonical display path (no a/ / b/ prefix)
+        $display = $this->rewriter->displayPath($is_deleted_file ? $from : $to);
+
+        // Resolve filesystem target
+        $target = $this->rewriter->resolve($is_new_file ? $to : $from);
+
+        if ($target === null) {
+            return new FileApplyResult($display, ApplyStatus::Skipped, 'Skipped');
+        }
+
+        if ($revert) {
+            if ($is_new_file) {
+                // Patch created this file → revert by deleting it
+                return $this->applyDeletedFile($display, $target, $dry_run);
+            }
+            if ($is_deleted_file) {
+                // Patch deleted this file → revert by recreating it with original content
+                return $this->applyRevertDeletedFile($diff, $display, $target, $dry_run);
+            }
+            return $this->applyModifiedFile($diff, $display, $target, $dry_run, true);
+        }
+
+        if ($is_new_file) {
+            return $this->applyNewFile($diff, $display, $target, $dry_run);
+        }
+
+        if ($is_deleted_file) {
+            return $this->applyDeletedFile($display, $target, $dry_run);
+        }
+
+        return $this->applyModifiedFile($diff, $display, $target, $dry_run);
+    }
+
+    private function applyNewFile(Diff $diff, string $display, string $target, bool $dry_run): FileApplyResult
+    {
+        $new_lines = [];
+        foreach ($diff->chunks() as $chunk) {
+            foreach ($chunk->lines() as $line) {
+                if ($line->isAdded()) {
+                    $new_lines[] = $line->content();
+                }
+            }
+        }
+
+        $new_content = implode("\n", $new_lines) . "\n";
+
+        if (file_exists($target)) {
+            try {
+                $existing = file_get_contents($target);
+            } catch (Exception $e) {
+                return new FileApplyResult(
+                    $display,
+                    ApplyStatus::Conflict,
+                    "A file already exists at this location but it cannot be read: $target - check permissions.\n"
+                    . $e->getMessage()
+                );
+            }
+
+            if (
+                $existing === $new_content
+                || rtrim((string) $existing, "\r\n") === rtrim($new_content, "\r\n")
+            ) {
+                return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already created with the same content');
+            }
+
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                'A file already exists at this location but its content differs from the patch. '
+                . 'It may have been created by a different change. Please review it manually.'
+            );
+        }
+
+        if ($dry_run) {
+            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would create this new file');
+        }
+
+        $dir = dirname($target);
+        if (!is_dir($dir)) {
+            try {
+                mkdir($dir, 0o755, true);
+            } catch (Exception $e) {
+                return new FileApplyResult(
+                    $display,
+                    ApplyStatus::Conflict,
+                    "Could not create directory: $dir - check permissions."
+                );
+            }
+        }
+
+        try {
+            file_put_contents($target, $new_content);
+        } catch (Exception $e) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "Could not write to: $target - check permissions."
+            );
+        }
+
+        return new FileApplyResult($display, ApplyStatus::Created, 'New file created successfully');
+    }
+
+    private function applyDeletedFile(string $display, string $target, bool $dry_run): FileApplyResult
+    {
+        if (!file_exists($target)) {
+            return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already deleted');
+        }
+
+        if ($dry_run) {
+            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would delete this file');
+        }
+
+        try {
+            unlink($target);
+        } catch (Exception $e) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "Could not delete: $target - check permissions."
+            );
+        }
+
+        return new FileApplyResult($display, ApplyStatus::Deleted, 'File deleted successfully');
+    }
+
+    private function applyModifiedFile(Diff $diff, string $display, string $target, bool $dry_run, bool $revert = false): FileApplyResult
+    {
+        if (!file_exists($target)) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                'File not found on disk.'
+            );
+        }
+
+        if (!is_readable($target)) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "File is not readable: $target - check permissions."
+            );
+        }
+
+        try {
+            $original_content = file_get_contents($target);
+        } catch (Exception $e) {
+            return new FileApplyResult($display, ApplyStatus::Conflict, "Cannot read file: $target\n" . $e->getMessage());
+        }
+
+        // Detect line-ending style so we can preserve it after rewriting
+        $eol = str_contains($original_content, "\r\n") ? "\r\n" : "\n";
+
+        // Normalize to LF internally for uniform processing
+        $normalized = str_replace("\r\n", "\n", $original_content);
+        $lines = explode("\n", $normalized);
+        if (end($lines) === '') {
+            array_pop($lines); // Remove trailing empty element from final newline
+        }
+
+        // Track cumulative line-shift caused by applied hunks
+        $offset              = 0;
+        $applied_count       = 0;
+        $already_applied_count = 0;
+
+        foreach ($diff->chunks() as $chunk) {
+            [$old_lines, $new_lines] = $revert ? $this->buildOldNewRevert($chunk) : $this->buildOldNew($chunk);
+
+            // Expected start position in the current (shifted) $lines array (0-based)
+            // $chunk->start() - 1 because diff hunks are 1-based while the array is 0-based
+            $expected_pos = max(0, $chunk->start() - 1 + $offset);
+
+            // only new lines are added = pure insertion
+            if ($old_lines === []) {
+                if (!$dry_run) {
+                    array_splice($lines, $expected_pos, 0, $new_lines);
+                }
+                $offset += count($new_lines);
+                $applied_count++;
+                continue;
+            }
+
+            // Normal case: look for old lines near expected position
+            $found_old = $this->findSequence($lines, $old_lines, $expected_pos);
+
+            if ($found_old !== null) {
+                if (!$dry_run) {
+                    array_splice($lines, $found_old, count($old_lines), $new_lines);
+                }
+                $offset += count($new_lines) - count($old_lines);
+                $applied_count++;
+                continue;
+            }
+
+            // Old lines not found: check if new lines are already there
+            if ($new_lines !== []) {
+                $found_new = $this->findSequence($lines, $new_lines, $expected_pos);
+                if ($found_new !== null) {
+                    // Already applied — adjust offset so later hunks stay aligned
+                    $offset += count($new_lines) - count($old_lines);
+                    $already_applied_count++;
+                    continue;
+                }
+            }
+
+            // Neither found: genuine conflict
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                sprintf(
+                    'The patch does not match the file content near line %d. '
+                    . 'This usually means the patch is based on a different version of the file, '
+                    . 'or another change was applied in between. Manual intervention is required.',
+                    $chunk->start()
+                )
+            );
+        }
+
+        // All hunks accounted for - decide overall result
+        if ($applied_count === 0 && $already_applied_count > 0) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::AlreadyApplied,
+                $revert ? 'All changes were already reverted in this file' : 'All changes were already present in this file'
+            );
+        }
+
+        //check that the number of applied hunks is consistent with the diff content (sanity check)
+        $total_hunks = count($diff->chunks());
+        if ($applied_count + $already_applied_count !== $total_hunks) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "Unexpected error: only $applied_count out of $total_hunks hunks were applied, and $already_applied_count were already applied. Please review the file manually."
+            );
+        }
+
+        if ($dry_run) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::DryRun,
+                $revert ? 'Would successfully revert changes in this file' : 'Would successfully apply changes to this file'
+            );
+        }
+
+        // Reconstruct file content preserving original EOL and trailing newline
+        $new_content = implode($eol, $lines);
+        if (str_ends_with($original_content, "\n") || str_ends_with($original_content, "\r\n")) {
+            $new_content .= $eol;
+        }
+
+        try {
+            file_put_contents($target, $new_content);
+        } catch (Exception $e) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "Cannot write to file: $target - check permissions."
+            );
+        }
+
+        return new FileApplyResult(
+            $display,
+            $revert ? ApplyStatus::Reverted : ApplyStatus::Applied,
+            $revert ? 'Changes reverted successfully' : 'Changes applied successfully'
+        );
+    }
+
+    /**
+     * Recreates a file that was deleted by the patch (used when reverting).
+     * The original content is reconstructed from the removed lines in the diff.
+     */
+    private function applyRevertDeletedFile(Diff $diff, string $display, string $target, bool $dry_run): FileApplyResult
+    {
+        $old_lines = [];
+        foreach ($diff->chunks() as $chunk) {
+            foreach ($chunk->lines() as $line) {
+                $content = $line->content();
+                if (str_starts_with($content, '\\ ')) {
+                    continue;
+                }
+                if ($line->isRemoved() || $line->isUnchanged()) {
+                    $old_lines[] = $content;
+                }
+            }
+        }
+
+        $old_content = implode("\n", $old_lines) . "\n";
+
+        if (file_exists($target)) {
+            try {
+                $existing = file_get_contents($target);
+            } catch (Exception $e) {
+                return new FileApplyResult(
+                    $display,
+                    ApplyStatus::Conflict,
+                    "A file already exists at this location but it cannot be read: $target - check permissions.\n"
+                    . $e->getMessage()
+                );
+            }
+
+            if (
+                $existing === $old_content
+                || rtrim((string) $existing, "\r\n") === rtrim($old_content, "\r\n")
+            ) {
+                return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already restored with its original content');
+            }
+
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                'A file already exists at this location but its content differs from the expected original. Manual intervention is required.'
+            );
+        }
+
+        if ($dry_run) {
+            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would restore this deleted file');
+        }
+
+        $dir = dirname($target);
+        if (!is_dir($dir)) {
+            try {
+                mkdir($dir, 0o755, true);
+            } catch (Exception $e) {
+                return new FileApplyResult(
+                    $display,
+                    ApplyStatus::Conflict,
+                    "Could not create directory: $dir - check permissions."
+                );
+            }
+        }
+
+        try {
+            file_put_contents($target, $old_content);
+        } catch (Exception $e) {
+            return new FileApplyResult(
+                $display,
+                ApplyStatus::Conflict,
+                "Could not write to: $target - check permissions."
+            );
+        }
+
+        return new FileApplyResult($display, ApplyStatus::Created, 'File restored successfully');
+    }
+
+    /**
+     * Separates a hunk's lines into the "old" sequence (what must be found in
+     * the file) and the "new" sequence (what replaces it).
+     *
+     * Unified diff semantics:
+     *   UNCHANGED (+context)  → appears in both old and new
+     *   REMOVED               → appears only in old
+     *   ADDED                 → appears only in new
+     *
+     * @return array{0: string[], 1: string[]}  [$old_lines, $new_lines]
+     */
+    private function buildOldNew(Chunk $chunk): array
+    {
+        $old = [];
+        $new = [];
+
+        foreach ($chunk->lines() as $line) {
+            $content = $line->content();
+
+            // Skip the "\ No newline at end of file" indicator that git diff adds
+            if (str_starts_with($content, '\\ ')) {
+                continue;
+            }
+
+            if ($line->isUnchanged()) {
+                $old[] = $content;
+                $new[] = $content;
+            } elseif ($line->isRemoved()) {
+                $old[] = $content;
+            } elseif ($line->isAdded()) {
+                $new[] = $content;
+            }
+        }
+
+        return [$old, $new];
+    }
+
+    /**
+     * Returns the hunk's line sequences in reverse order for revert operations:
+     * the "new" sequence becomes what to search for, and the "old" sequence
+     * becomes what to replace with.
+     *
+     * @return array{0: string[], 1: string[]}  [$old_lines, $new_lines]
+     */
+    private function buildOldNewRevert(Chunk $chunk): array
+    {
+        [$old, $new] = $this->buildOldNew($chunk);
+        return [$new, $old];
+    }
+
+    /**
+     * Searches for $needle as a contiguous subsequence of $haystack,
+     * starting within [$expected_pos - FUZZ, $expected_pos + FUZZ].
+     *
+     * Trailing whitespace is ignored when comparing individual lines,
+     * which improves tolerance for minor editor differences.
+     *
+     * @param string[] $haystack
+     * @param string[] $needle
+     * @return int|null  0-based index of the match in $haystack, or null.
+     */
+    private function findSequence(array $haystack, array $needle, int $expected_pos): ?int
+    {
+        if ($needle === []) {
+            return $expected_pos;
+        }
+
+        $needle_len   = count($needle);
+        $haystack_len = count($haystack);
+
+        if ($needle_len > $haystack_len) {
+            return null;
+        }
+
+        $from = max(0, $expected_pos - self::FUZZ_LINES);
+        $to   = min($haystack_len - $needle_len, $expected_pos + self::FUZZ_LINES);
+
+        if ($to < $from) {
+            return null;
+        }
+
+        for ($i = $from; $i <= $to; $i++) {
+            if ($this->linesMatchAt($haystack, $needle, $i)) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true if every line of $needle matches $haystack starting at $pos.
+     *
+     * @param string[] $haystack
+     * @param string[] $needle
+     */
+    private function linesMatchAt(array $haystack, array $needle, int $pos): bool
+    {
+        foreach ($needle as $j => $expected_line) {
+            if (!array_key_exists($pos + $j, $haystack)) {
+                return false;
+            }
+
+            if (rtrim($haystack[$pos + $j]) !== rtrim($expected_line)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -129,15 +129,20 @@ final class PatchApplier
     private function applyNewFile(Diff $diff, string $target, bool $dry_run): FileApplyResult
     {
         $new_lines = [];
+        $has_trailing_newline = true;
         foreach ($diff->chunks() as $chunk) {
             foreach ($chunk->lines() as $line) {
+                if (str_starts_with($line->content(), '\\ ')) {
+                    $has_trailing_newline = false;
+                    continue;
+                }
                 if ($line->isAdded()) {
                     $new_lines[] = $line->content();
                 }
             }
         }
 
-        $new_content = implode("\n", $new_lines) . "\n";
+        $new_content = implode("\n", $new_lines) . ($has_trailing_newline ? "\n" : "");
 
         if (file_exists($target)) {
             try {
@@ -369,11 +374,13 @@ final class PatchApplier
     private function applyRevertDeletedFile(Diff $diff, string $target, bool $dry_run): FileApplyResult
     {
         $old_lines = [];
+        $has_trailing_newline = true;
         foreach ($diff->chunks() as $chunk) {
             foreach ($chunk->lines() as $line) {
                 $content = $line->content();
                 if (str_starts_with($content, '\\ ')) {
-                    continue;
+                    $has_trailing_newline = false;
+                    continue; // Skip the "\ No newline at end of file" indicator
                 }
                 if ($line->isRemoved() || $line->isUnchanged()) {
                     $old_lines[] = $content;
@@ -381,7 +388,7 @@ final class PatchApplier
             }
         }
 
-        $old_content = implode("\n", $old_lines) . "\n";
+        $old_content = implode("\n", $old_lines) . ($has_trailing_newline ? "\n" : "");
 
         if (file_exists($target)) {
             try {

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -93,6 +93,14 @@ final class PatchApplier
         $is_new_file     = $this->rewriter->isDevNull($from);
         $is_deleted_file = $this->rewriter->isDevNull($to);
 
+        if (!$is_new_file && !$is_deleted_file) {
+            $resolved_from = $this->rewriter->resolve($from);
+            $resolved_to   = $this->rewriter->resolve($to);
+            if($resolved_from['path'] !== $resolved_to['path']) {
+                return $this->applyRenamedFile($diff, $resolved_from, $resolved_to, $dry_run, $revert);
+            }
+        }
+
         // Resolve filesystem target
         $resolved_target = $this->rewriter->resolve($is_new_file ? $to : $from);
         $target = $resolved_target['path'];
@@ -439,6 +447,129 @@ final class PatchApplier
         }
 
         return new FileApplyResult($target, ApplyStatus::Created, 'File restored successfully');
+    }
+
+    /**
+     * Handles a rename or move diff entry.
+     *
+     * Four cases based on skip status:
+     *   - both skipped          → skip entirely
+     *   - destination skipped   → only delete the source
+     *   - source skipped        → only create the destination (source kept intact)
+     *   - neither skipped       → apply modifications, write destination, delete source
+     */
+    private function applyRenamedFile(Diff $diff, array $resolved_from, array $resolved_to, bool $dry_run, bool $revert): FileApplyResult
+    {
+        $source_path    = $revert ? $resolved_to['path']     : $resolved_from['path'];
+        $dest_path      = $revert ? $resolved_from['path']   : $resolved_to['path'];
+        $source_skipped = $revert ? $resolved_to['skiped']   : $resolved_from['skiped'];
+        $dest_skipped   = $revert ? $resolved_from['skiped'] : $resolved_to['skiped'];
+
+        if ($source_skipped && $dest_skipped) {
+            return new FileApplyResult("from " . $source_path . "\nto " . $dest_path, ApplyStatus::Skipped, 'Skipped');
+        }
+
+        if ($dest_skipped) {
+            // $to is skipped: only delete the source, don't create the destination
+            return $this->applyDeletedFile($source_path, $dry_run);
+        }
+
+        // Destination is not skipped: we must create/write it.
+        // Source may be skipped; if not, we also delete it after writing.
+
+        if (!file_exists($source_path)) {
+            return new FileApplyResult($source_path, ApplyStatus::Conflict, 'Source file not found on disk.');
+        }
+
+        if (!is_readable($source_path)) {
+            return new FileApplyResult(
+                $source_path,
+                ApplyStatus::Conflict,
+                "Source file is not readable: $source_path - check permissions."
+            );
+        }
+
+        try {
+            $original_content = file_get_contents($source_path);
+        } catch (Exception $e) {
+            return new FileApplyResult(
+                $source_path,
+                ApplyStatus::Conflict,
+                "Cannot read source file: $source_path\n" . $e->getMessage()
+            );
+        }
+
+        $target_file_already_exists = file_exists($dest_path);
+
+        if ($dry_run) {
+            //if the target file soesn't already exist,
+            //simulate the dry run on the source file (same base)
+            if (!$target_file_already_exists) {
+                $result = $this->applyModifiedFile($diff, $source_path, $dry_run, $revert);
+            }
+            else{
+                $result = $this->applyModifiedFile($diff, $dest_path, $dry_run, $revert);
+            }
+        } else {
+            if (!$target_file_already_exists) {
+                try{
+                    $dir = dirname($dest_path);
+                    if(!is_dir($dir)) {
+                        mkdir(dirname($dest_path), 0o755, true);
+                    }
+                    file_put_contents($dest_path, $original_content);
+                } catch (Exception $e) {
+                    return new FileApplyResult(
+                        $dest_path,
+                        ApplyStatus::Conflict,
+                        "Could not create destination file: $dest_path - check permissions."
+                    );
+                }
+            }
+            $result = $this->applyModifiedFile($diff, $dest_path, $dry_run, $revert);
+        }
+
+        if(
+            !in_array(
+                $result->status,
+                [
+                    ApplyStatus::Applied,
+                    ApplyStatus::AlreadyApplied,
+                    ApplyStatus::Reverted,
+                    ApplyStatus::DryRun
+                ],
+                true
+            )
+        ) {
+            $result->display_path = "From " . $source_path . "\nTo " . $dest_path;
+            return $result; // If we failed to apply modifications to the destination, don't delete the source
+        }
+
+        if (!$source_skipped && !$dry_run && file_exists($source_path)) {
+            try {
+                unlink($source_path);
+            } catch (Exception $e) {
+                return new FileApplyResult(
+                    "From " . $source_path . "\nTo " . $dest_path,
+                    ApplyStatus::Conflict,
+                    "Destination file was created successfully, but the source file could not be deleted - check permissions.\n"
+                );
+            }
+        }
+
+        if ($dry_run) {
+            return new FileApplyResult(
+                "From " . $source_path . "\nTo " . $dest_path,
+                ApplyStatus::DryRun,
+                $revert ? 'Would successfully revert this rename' : 'Would successfully apply this rename'
+            );
+        }
+
+        return new FileApplyResult(
+            "From " . $source_path . "\nTo " . $dest_path,
+            $revert ? ApplyStatus::Reverted : ApplyStatus::Applied,
+            $revert ? 'Rename reverted successfully' : 'File renamed successfully'
+        );
     }
 
     /**

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -93,14 +93,13 @@ final class PatchApplier
         $is_new_file     = $this->rewriter->isDevNull($from);
         $is_deleted_file = $this->rewriter->isDevNull($to);
 
-        // Canonical display path (no a/ / b/ prefix)
-        $display = $this->rewriter->displayPath($is_deleted_file ? $from : $to);
-
         // Resolve filesystem target
-        $target = $this->rewriter->resolve($is_new_file ? $to : $from);
+        $resolved_target = $this->rewriter->resolve($is_new_file ? $to : $from);
+        $target = $resolved_target['path'];
+        $skiped = $resolved_target['skiped'];
 
-        if ($target === null) {
-            return new FileApplyResult($display, ApplyStatus::Skipped, 'Skipped');
+        if ($skiped) {
+            return new FileApplyResult($target, ApplyStatus::Skipped, 'Skipped');
         }
 
         if ($revert) {

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -116,7 +116,7 @@ final class PatchApplier
         }
 
         if ($is_new_file) {
-            return $this->applyNewFile($diff, $display, $target, $dry_run);
+            return $this->applyNewFile($diff, $target, $dry_run);
         }
 
         if ($is_deleted_file) {
@@ -126,7 +126,7 @@ final class PatchApplier
         return $this->applyModifiedFile($diff, $target, $dry_run, $revert);
     }
 
-    private function applyNewFile(Diff $diff, string $display, string $target, bool $dry_run): FileApplyResult
+    private function applyNewFile(Diff $diff, string $target, bool $dry_run): FileApplyResult
     {
         $new_lines = [];
         foreach ($diff->chunks() as $chunk) {
@@ -144,7 +144,7 @@ final class PatchApplier
                 $existing = file_get_contents($target);
             } catch (Exception $e) {
                 return new FileApplyResult(
-                    $display,
+                    $target,
                     ApplyStatus::Conflict,
                     "A file already exists at this location but it cannot be read: $target - check permissions.\n"
                     . $e->getMessage()
@@ -155,11 +155,11 @@ final class PatchApplier
                 $existing === $new_content
                 || rtrim((string) $existing, "\r\n") === rtrim($new_content, "\r\n")
             ) {
-                return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already created with the same content');
+                return new FileApplyResult($target, ApplyStatus::AlreadyApplied, 'File was already created with the same content');
             }
 
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 'A file already exists at this location but its content differs from the patch. '
                 . 'It may have been created by a different change. Please review it manually.'
@@ -167,7 +167,7 @@ final class PatchApplier
         }
 
         if ($dry_run) {
-            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would create this new file');
+            return new FileApplyResult($target, ApplyStatus::DryRun, 'Would create this new file');
         }
 
         $dir = dirname($target);
@@ -176,7 +176,7 @@ final class PatchApplier
                 mkdir($dir, 0o755, true);
             } catch (Exception $e) {
                 return new FileApplyResult(
-                    $display,
+                    $target,
                     ApplyStatus::Conflict,
                     "Could not create directory: $dir - check permissions."
                 );
@@ -187,13 +187,13 @@ final class PatchApplier
             file_put_contents($target, $new_content);
         } catch (Exception $e) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "Could not write to: $target - check permissions."
             );
         }
 
-        return new FileApplyResult($display, ApplyStatus::Created, 'New file created successfully');
+        return new FileApplyResult($target, ApplyStatus::Created, 'New file created successfully');
     }
 
     private function applyDeletedFile(string $target, bool $dry_run): FileApplyResult

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -283,9 +283,7 @@ final class PatchApplier
 
             // only new lines are added = pure insertion
             if ($old_lines === []) {
-                if (!$dry_run) {
-                    array_splice($lines, $expected_pos, 0, $new_lines);
-                }
+                array_splice($lines, $expected_pos, 0, $new_lines);
                 $offset += count($new_lines);
                 $applied_count++;
                 continue;
@@ -295,9 +293,7 @@ final class PatchApplier
             $found_old = $this->findSequence($lines, $old_lines, $expected_pos);
 
             if ($found_old !== null) {
-                if (!$dry_run) {
-                    array_splice($lines, $found_old, count($old_lines), $new_lines);
-                }
+                array_splice($lines, $found_old, count($old_lines), $new_lines);
                 $offset += count($new_lines) - count($old_lines);
                 $applied_count++;
                 continue;

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -455,6 +455,12 @@ final class PatchApplier
         $old = [];
         $new = [];
 
+        // Use the @@ header counts as hard caps — sebastian/diff may absorb
+        // metadata lines (e.g. "deleted file mode") from the next file in a
+        // multi-file diff into the last chunk's line list.
+        $max_old = $chunk->startRange();
+        $max_new = $chunk->endRange();
+
         foreach ($chunk->lines() as $line) {
             $content = $line->content();
 
@@ -463,13 +469,24 @@ final class PatchApplier
                 continue;
             }
 
+            $count_old = count($old);
+            $count_new = count($new);
+
             if ($line->isUnchanged()) {
-                $old[] = $content;
-                $new[] = $content;
+                if ($count_old < $max_old) {
+                    $old[] = $content;
+                }
+                if ($count_new < $max_new) {
+                    $new[] = $content;
+                }
             } elseif ($line->isRemoved()) {
-                $old[] = $content;
+                if ($count_old < $max_old) {
+                    $old[] = $content;
+                }
             } elseif ($line->isAdded()) {
-                $new[] = $content;
+                if ($count_new < $max_new) {
+                    $new[] = $content;
+                }
             }
         }
 

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -106,13 +106,13 @@ final class PatchApplier
         if ($revert) {
             if ($is_new_file) {
                 // Patch created this file → revert by deleting it
-                return $this->applyDeletedFile($display, $target, $dry_run);
+                return $this->applyDeletedFile($target, $dry_run);
             }
             if ($is_deleted_file) {
                 // Patch deleted this file → revert by recreating it with original content
-                return $this->applyRevertDeletedFile($diff, $display, $target, $dry_run);
+                return $this->applyRevertDeletedFile($diff, $target, $dry_run);
             }
-            return $this->applyModifiedFile($diff, $display, $target, $dry_run, true);
+            return $this->applyModifiedFile($diff, $target, $dry_run, $revert);
         }
 
         if ($is_new_file) {
@@ -120,10 +120,10 @@ final class PatchApplier
         }
 
         if ($is_deleted_file) {
-            return $this->applyDeletedFile($display, $target, $dry_run);
+            return $this->applyDeletedFile($target, $dry_run);
         }
 
-        return $this->applyModifiedFile($diff, $display, $target, $dry_run);
+        return $this->applyModifiedFile($diff, $target, $dry_run, $revert);
     }
 
     private function applyNewFile(Diff $diff, string $display, string $target, bool $dry_run): FileApplyResult
@@ -196,34 +196,34 @@ final class PatchApplier
         return new FileApplyResult($display, ApplyStatus::Created, 'New file created successfully');
     }
 
-    private function applyDeletedFile(string $display, string $target, bool $dry_run): FileApplyResult
+    private function applyDeletedFile(string $target, bool $dry_run): FileApplyResult
     {
         if (!file_exists($target)) {
-            return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already deleted');
+            return new FileApplyResult($target, ApplyStatus::AlreadyApplied, 'File was already deleted');
         }
 
         if ($dry_run) {
-            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would delete this file');
+            return new FileApplyResult($target, ApplyStatus::DryRun, 'Would delete this file');
         }
 
         try {
             unlink($target);
         } catch (Exception $e) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "Could not delete: $target - check permissions."
             );
         }
 
-        return new FileApplyResult($display, ApplyStatus::Deleted, 'File deleted successfully');
+        return new FileApplyResult($target, ApplyStatus::Deleted, 'File deleted successfully');
     }
 
-    private function applyModifiedFile(Diff $diff, string $display, string $target, bool $dry_run, bool $revert = false): FileApplyResult
+    private function applyModifiedFile(Diff $diff, string $target, bool $dry_run, bool $revert = false): FileApplyResult
     {
         if (!file_exists($target)) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 'File not found on disk.'
             );
@@ -231,7 +231,7 @@ final class PatchApplier
 
         if (!is_readable($target)) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "File is not readable: $target - check permissions."
             );
@@ -240,7 +240,7 @@ final class PatchApplier
         try {
             $original_content = file_get_contents($target);
         } catch (Exception $e) {
-            return new FileApplyResult($display, ApplyStatus::Conflict, "Cannot read file: $target\n" . $e->getMessage());
+            return new FileApplyResult($target, ApplyStatus::Conflict, "Cannot read file: $target\n" . $e->getMessage());
         }
 
         // Detect line-ending style so we can preserve it after rewriting
@@ -261,9 +261,10 @@ final class PatchApplier
         foreach ($diff->chunks() as $chunk) {
             [$old_lines, $new_lines] = $revert ? $this->buildOldNewRevert($chunk) : $this->buildOldNew($chunk);
 
-            // Expected start position in the current (shifted) $lines array (0-based)
-            // $chunk->start() - 1 because diff hunks are 1-based while the array is 0-based
-            $expected_pos = max(0, $chunk->start() - 1 + $offset);
+            // Expected start position in the current (shifted) $lines array (0-based).
+            // In normal mode, start() is the old-file line number (1-based).
+            // In revert mode, end() is the new-file line number (1-based).
+            $expected_pos = max(0, ($revert ? $chunk->end() : $chunk->start()) - 1 + $offset);
 
             // only new lines are added = pure insertion
             if ($old_lines === []) {
@@ -300,7 +301,7 @@ final class PatchApplier
 
             // Neither found: genuine conflict
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 sprintf(
                     'The patch does not match the file content near line %d. '
@@ -314,7 +315,7 @@ final class PatchApplier
         // All hunks accounted for - decide overall result
         if ($applied_count === 0 && $already_applied_count > 0) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::AlreadyApplied,
                 $revert ? 'All changes were already reverted in this file' : 'All changes were already present in this file'
             );
@@ -324,7 +325,7 @@ final class PatchApplier
         $total_hunks = count($diff->chunks());
         if ($applied_count + $already_applied_count !== $total_hunks) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "Unexpected error: only $applied_count out of $total_hunks hunks were applied, and $already_applied_count were already applied. Please review the file manually."
             );
@@ -332,7 +333,7 @@ final class PatchApplier
 
         if ($dry_run) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::DryRun,
                 $revert ? 'Would successfully revert changes in this file' : 'Would successfully apply changes to this file'
             );
@@ -348,14 +349,14 @@ final class PatchApplier
             file_put_contents($target, $new_content);
         } catch (Exception $e) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "Cannot write to file: $target - check permissions."
             );
         }
 
         return new FileApplyResult(
-            $display,
+            $target,
             $revert ? ApplyStatus::Reverted : ApplyStatus::Applied,
             $revert ? 'Changes reverted successfully' : 'Changes applied successfully'
         );
@@ -365,7 +366,7 @@ final class PatchApplier
      * Recreates a file that was deleted by the patch (used when reverting).
      * The original content is reconstructed from the removed lines in the diff.
      */
-    private function applyRevertDeletedFile(Diff $diff, string $display, string $target, bool $dry_run): FileApplyResult
+    private function applyRevertDeletedFile(Diff $diff, string $target, bool $dry_run): FileApplyResult
     {
         $old_lines = [];
         foreach ($diff->chunks() as $chunk) {
@@ -387,7 +388,7 @@ final class PatchApplier
                 $existing = file_get_contents($target);
             } catch (Exception $e) {
                 return new FileApplyResult(
-                    $display,
+                    $target,
                     ApplyStatus::Conflict,
                     "A file already exists at this location but it cannot be read: $target - check permissions.\n"
                     . $e->getMessage()
@@ -398,18 +399,18 @@ final class PatchApplier
                 $existing === $old_content
                 || rtrim((string) $existing, "\r\n") === rtrim($old_content, "\r\n")
             ) {
-                return new FileApplyResult($display, ApplyStatus::AlreadyApplied, 'File was already restored with its original content');
+                return new FileApplyResult($target, ApplyStatus::AlreadyApplied, 'File was already restored with its original content');
             }
 
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 'A file already exists at this location but its content differs from the expected original. Manual intervention is required.'
             );
         }
 
         if ($dry_run) {
-            return new FileApplyResult($display, ApplyStatus::DryRun, 'Would restore this deleted file');
+            return new FileApplyResult($target, ApplyStatus::DryRun, 'Would restore this deleted file');
         }
 
         $dir = dirname($target);
@@ -418,7 +419,7 @@ final class PatchApplier
                 mkdir($dir, 0o755, true);
             } catch (Exception $e) {
                 return new FileApplyResult(
-                    $display,
+                    $target,
                     ApplyStatus::Conflict,
                     "Could not create directory: $dir - check permissions."
                 );
@@ -429,13 +430,13 @@ final class PatchApplier
             file_put_contents($target, $old_content);
         } catch (Exception $e) {
             return new FileApplyResult(
-                $display,
+                $target,
                 ApplyStatus::Conflict,
                 "Could not write to: $target - check permissions."
             );
         }
 
-        return new FileApplyResult($display, ApplyStatus::Created, 'File restored successfully');
+        return new FileApplyResult($target, ApplyStatus::Created, 'File restored successfully');
     }
 
     /**

--- a/src/Glpi/Patch/PatchApplier.php
+++ b/src/Glpi/Patch/PatchApplier.php
@@ -270,6 +270,17 @@ final class PatchApplier
             // In revert mode, end() is the new-file line number (1-based).
             $expected_pos = max(0, ($revert ? $chunk->end() : $chunk->start()) - 1 + $offset);
 
+            // Check if new lines are already present (patch already applied).
+            if ($new_lines !== []) {
+                $found_new = $this->findSequence($lines, $new_lines, $expected_pos);
+                if ($found_new !== null) {
+                    // Already applied — adjust offset so later hunks stay aligned
+                    $offset += count($new_lines) - count($old_lines);
+                    $already_applied_count++;
+                    continue;
+                }
+            }
+
             // only new lines are added = pure insertion
             if ($old_lines === []) {
                 if (!$dry_run) {
@@ -280,7 +291,7 @@ final class PatchApplier
                 continue;
             }
 
-            // Normal case: look for old lines near expected position
+            // old lines are present and new lines aren't added yet : look for old lines to apply the change
             $found_old = $this->findSequence($lines, $old_lines, $expected_pos);
 
             if ($found_old !== null) {
@@ -290,17 +301,6 @@ final class PatchApplier
                 $offset += count($new_lines) - count($old_lines);
                 $applied_count++;
                 continue;
-            }
-
-            // Old lines not found: check if new lines are already there
-            if ($new_lines !== []) {
-                $found_new = $this->findSequence($lines, $new_lines, $expected_pos);
-                if ($found_new !== null) {
-                    // Already applied — adjust offset so later hunks stay aligned
-                    $offset += count($new_lines) - count($old_lines);
-                    $already_applied_count++;
-                    continue;
-                }
             }
 
             // Neither found: genuine conflict

--- a/src/Glpi/Patch/PathRewriter.php
+++ b/src/Glpi/Patch/PathRewriter.php
@@ -41,7 +41,7 @@ final class PathRewriter
     /**
      * Files that must be skipped when applying the patch.
      */
-    private const SKIPED_FILES = ['tests/', 'tools/', 'phpunit/', 'CHANGELOG.md'];
+    private const SKIPED_FILES = ['tests/', 'tools/', 'phpunit/', 'CHANGELOG.md', '/dev/null'];
 
     /**
      * Folders that live under public/ in a production GLPI installation.
@@ -61,30 +61,34 @@ final class PathRewriter
      * Adds the absolute workdir path of the current object to the begining of a raw diff path.
      *
      * @param  string $diff_path  Path as it appears in the diff (e.g. "a/src/Foo.php").
-     * @return string|null        Absolute path, or null when the file must be skipped.
+     * @return array<string, mixed>  {skiped: bool, path: string}  skiped=true if the file should be skipped, path is the resolved absolute path to the file.
      */
-    public function resolve(string $diff_path): ?string
+    public function resolve(string $diff_path): array
     {
         $path = $this->stripPrefix($diff_path);
-
-        if ($path === '/dev/null') {
-            return null;
-        }
-
         foreach (self::SKIPED_FILES as $skip) {
             if (str_starts_with($path, $skip)) {
-                return null;
+                return [
+                    'skiped' => true,
+                    'path'   => $this->work_dir . '/' . $path,
+                ];
             }
         }
 
         // GLPI core: remap assets folders to the public/ subfolder
         foreach (self::PUBLIC_REMAPPED_FOLDERS as $folder) {
             if (str_starts_with($path, $folder)) {
-                return $this->work_dir . '/public/' . $path;
+                return [
+                    'skiped'   => false,
+                    'path'     => $this->work_dir . '/public/' . $path
+                ];
             }
         }
 
-        return $this->work_dir . '/' . $path;
+        return [
+            'skiped' => false,
+            'path'   => $this->work_dir . '/' . $path,
+        ];
     }
 
     /**

--- a/src/Glpi/Patch/PathRewriter.php
+++ b/src/Glpi/Patch/PathRewriter.php
@@ -42,6 +42,8 @@ final class PathRewriter
      * Files that must be skipped when applying the patch.
      */
     private const SKIPED_FILES = ['tests/', 'tools/', 'phpunit/', 'CHANGELOG.md', '/dev/null'];
+    private const ALLOWED_FILES = ['src/', 'ajax/', 'bin/', 'css/', 'dependency_injection/', 'front', 'inc', 'install', 'js', 'lib', 'public', 'ressources', 'templates'];
+
 
     /**
      * Folders that live under public/ in a production GLPI installation.
@@ -49,6 +51,14 @@ final class PathRewriter
      * prefixed with "public/".
      */
     private const PUBLIC_REMAPPED_FOLDERS = ['js/', 'lib/', 'css/'];
+
+    // local = indiquer le changement de traductions
+    // *.vue = arrêt du patch et msg d'erreur
+    // css et scss = des fichiers min
+    // scss = recompiler les css
+    // tests unitaires pour vérifier
+    // constant('GLPI_PLUGINS_DIRECTORIES') / constant('GLPI_MARKETPLACE_DIRECTORIES')
+    // libs à vérifier : ptlis/diff-parser xdiff alto/code-diff bsdiff
 
     /**
      * @param string $work_dir   Absolute path to the directory where the patch is being applied.

--- a/src/Glpi/Patch/PathRewriter.php
+++ b/src/Glpi/Patch/PathRewriter.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Patch;
+
+use function Safe\preg_replace;
+
+final class PathRewriter
+{
+    /**
+     * Files that must be skipped when applying the patch.
+     */
+    private const SKIPED_FILES = ['tests/', 'tools/', 'phpunit/', 'CHANGELOG.md'];
+
+    /**
+     * Folders that live under public/ in a production GLPI installation.
+     * In the repository they are at the root, but in production they are
+     * prefixed with "public/".
+     */
+    private const PUBLIC_REMAPPED_FOLDERS = ['js/', 'lib/', 'css/'];
+
+    /**
+     * @param string $work_dir   Absolute path to the directory where the patch is being applied.
+     */
+    public function __construct(
+        private readonly string $work_dir,
+    ) {}
+
+    /**
+     * Adds the absolute workdir path of the current object to the begining of a raw diff path.
+     *
+     * @param  string $diff_path  Path as it appears in the diff (e.g. "a/src/Foo.php").
+     * @return string|null        Absolute path, or null when the file must be skipped.
+     */
+    public function resolve(string $diff_path): ?string
+    {
+        $path = $this->stripPrefix($diff_path);
+
+        if ($path === '/dev/null') {
+            return null;
+        }
+
+        foreach (self::SKIPED_FILES as $skip) {
+            if (str_starts_with($path, $skip)) {
+                return null;
+            }
+        }
+
+        // GLPI core: remap assets folders to the public/ subfolder
+        foreach (self::PUBLIC_REMAPPED_FOLDERS as $folder) {
+            if (str_starts_with($path, $folder)) {
+                return $this->work_dir . '/public/' . $path;
+            }
+        }
+
+        return $this->work_dir . '/' . $path;
+    }
+
+    /**
+     * Returns true when the given diff path represents /dev/null
+     * (used for new-file and deleted-file entries in git diffs).
+     */
+    public function isDevNull(string $diff_path): bool
+    {
+        return $this->stripPrefix($diff_path) === '/dev/null';
+    }
+
+    /**
+     * Returns a clean, human-readable path for display (strips a/ / b/ prefix).
+     */
+    public function displayPath(string $diff_path): string
+    {
+        return $this->stripPrefix($diff_path);
+    }
+
+    /**
+     * Strips the "a/" or "b/" prefix that git adds to diff paths.
+     */
+    private function stripPrefix(string $diff_path): string
+    {
+        return (string) preg_replace('#^[ab]/#', '', $diff_path);
+    }
+}


### PR DESCRIPTION
## Description

### This PR is not yet complete, and its idea has been discussed but has not yet been confirmed as accepted.

The idea is to introduce a new `bin/console patch:apply` command that would allow users to apply a patch to the core or a plugin using a PR URL, a diff URL, or a diff file.

Before applying the patch, the command would clean the raw diff by making the following modifications to adapt it to production GLPI installations:

- Remap paths for asset folders: `js/`, `css/`, and `lib/` → `public/js/`, `public/css/`, and `public/lib/`.
- Skip any files under `tests/`, `tools/`, and `phpunit/`, as well as `CHANGELOG.md`.
- Abort if the patch contains `.vue` files, as these files require a front-end rebuild.
- If the patch contains `.js` files, automatically delete the corresponding `.min.js files`.
- If the patch contains `.css` files, automatically recompile the `SCSS` files after applying the patch.
- If the patch contains changes to `templates/`, automatically clear the cache after applying the patch.

The current implementation of this PR will most likely be rejected because the new command relies on parts of GLPI to patch the code that it may itself be using. This could lead to unexpected results.

Two possible refactoring approaches have been identified:

- Make the current code completely independent from GLPI by moving it to independent scripts under the bin/ directory. This approach would require using external libraries and/or PHP extensions, such as `sebastian/diff` (https://github.com/sebastianbergmann/diff), which is already used by GLPI, and the `xdiff` PHP extension (https://www.php.net/manual/en/book.xdiff.php).
- Turn the `glpi-patch-builder` tool (https://github.com/glpi-network-internals/glpi-patch-builder/tree/main) into a Composer package, add it to GLPI, and introduce a new `bin/console` command that would only generate a cleaned diff and indicate the steps that need to be performed after applying the patch, without actually applying it. The user would then have to apply the cleaned diff manually using the standard `patch` command and perform the additional steps indicated by the command.





