### PR TITLE
fix: restore type field permission check on notification form

### DIFF
--- a/templates/pages/setup/notification/notification.html.twig
+++ b/templates/pages/setup/notification/notification.html.twig
@@ -39,9 +39,7 @@
     {{ fields.dropdownYesNo('is_active', item.fields['is_active'], __('Active')) }}
     {{ fields.dropdownYesNo('allow_response', item.fields['allow_response'], __('Allow response')) }}
 
-    {% if not has_profile_right('config', constant('UPDATE')) %}
-        {{ fields.htmlField('', item.fields['itemtype']|e, _n('Type', 'Types', 1)) }}
-    {% elseif call('Config::canUpdate') and item.getEntityID == 0 %}
+    {% if call('Config::canUpdate') and item.getEntityID == 0 %}
         {{ fields.dropdownItemTypes('itemtype', item.fields['itemtype'], _n('Type', 'Types', 1), {
             types: config('notificationtemplates_types'),
             rand: rand

--- a/tests/functional/NotificationTest.php
+++ b/tests/functional/NotificationTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units;
 
+use Config;
 use Contract;
 use Glpi\DBAL\QueryExpression;
 use Glpi\Tests\DbTestCase;
@@ -987,5 +988,24 @@ HTML,
             sort($expected_queue);
             $this->assertEquals($expected_queue, $emails);
         }
+    }
+
+    public function testShowFormItemtypeFieldIsEditableWithoutConfigRight(): void
+    {
+        $this->login();
+        $this->removeRightFromProfile('Super-Admin', Config::$rightname, UPDATE);
+
+        $notification = new Notification();
+        $this->assertTrue($notification->getFromDB(1));
+
+        // Act
+        ob_start();
+        $notification->showForm(1);
+        $output = ob_get_clean();
+
+        $this->assertMatchesRegularExpression(
+            '/<select[^>]*id=\'dropdown_itemtype\d+\'/',
+            $output
+        );
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] This change requires a documentation update.

## Description

- It fixes !45861
- The notification type (`itemtype`) field on the notification form  was  entirely absent for any user lacking the `config` `UPDATE` right, even when that user has full `notification` management rights and is only trying to pick between ordinary item types (e.g. `Ticket`, `Change`) that have nothing to do with the general configuration.

### Fix 

Restore permission check that was done in `Notification::showForm()`  before #15375  which used the `config` `UPDATE` right combined with the entity being the root entity to decide which itemtype list to expose — the full list, or a list
excluding the entity-sensitive types (`CronTask`, `DBConnection`, `User`) — never to make the field entirely absent.


