### PR TITLE
Fix: cache custom illustrations in the browser (#25102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The present file will list all changes made to the project; according to the
 ### Changed
 - Fixed searching values with multiple concurrent spaces.
 - Fixed import of exported forms containing a condition on an item dropdown with no item selected.
+- Fixed missing browser caching headers on custom illustrations, causing them to be re-fetched on every page load instead of being cached.
 
 ### Deprecated
 

--- a/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
+++ b/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
@@ -45,6 +45,17 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class CustomIllustrationController extends AbstractController
 {
+    /**
+     * Number of seconds a custom illustration response may be kept in the
+     * browser's cache before it must be revalidated with the server.
+     *
+     * Illustrations are only replaced by an explicit re-upload (see
+     * IllustrationManager::saveCustomIllustration()), so a long duration is
+     * safe here; the ETag/Last-Modified pair still lets the browser detect
+     * a change immediately if one occurs.
+     */
+    private const CACHE_MAX_AGE = 604800; // 7 days
+
     public function __construct(
         private IllustrationManager $illustration_manager
     ) {}
@@ -63,6 +74,17 @@ final class CustomIllustrationController extends AbstractController
         }
 
         // Read parameters
-        return new BinaryFileResponse($file);
+        $response = new BinaryFileResponse($file);
+        $response->setAutoEtag();
+        $response->setAutoLastModified();
+        // The route requires an authenticated session, so the response must stay
+        // "private" (per-user), but it can still be cached by the browser instead
+        // of being re-fetched on every page that displays the illustration.
+        $response->setCache([
+            'private' => true,
+            'max_age' => self::CACHE_MAX_AGE,
+        ]);
+
+        return $response;
     }
 }

--- a/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
+++ b/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\UI\Illustration;
+
+use Glpi\Controller\UI\Illustration\CustomIllustrationController;
+use Glpi\Tests\GLPITestCase;
+use Glpi\UI\IllustrationManager;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final class CustomIllustrationControllerTest extends GLPITestCase
+{
+    private IllustrationManager $manager;
+
+    private string $illustration_id;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->manager = new IllustrationManager();
+        $this->illustration_id = 'test_custom_illustration_' . uniqid() . '.svg';
+
+        // `saveCustomIllustration()` moves its source file into place, so the
+        // temporary file must be created first and then handed over to it.
+        $tmp_file = GLPI_TMP_DIR . '/' . uniqid('custom_illustration_test_') . '.svg';
+        file_put_contents($tmp_file, '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+        $this->manager->saveCustomIllustration($this->illustration_id, $tmp_file);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->manager->deleteCustomIllustrationFile($this->illustration_id);
+
+        parent::tearDown();
+    }
+
+    public function testResponseIsCacheableByTheBrowser(): void
+    {
+        $controller = new CustomIllustrationController($this->manager);
+
+        $response = $controller->__invoke($this->illustration_id);
+
+        // The bug being fixed: a bare `BinaryFileResponse` has no Cache-Control
+        // directive of its own, forcing the browser to re-fetch the illustration
+        // (with a full authenticated round-trip) on every single page load.
+        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        $this->assertTrue(
+            $response->headers->hasCacheControlDirective('private'),
+            'Response must stay private since the route requires authentication.'
+        );
+        $this->assertSame(
+            '604800',
+            $response->headers->getCacheControlDirective('max-age'),
+            'Response must be cacheable by the browser for a meaningful duration.'
+        );
+        $this->assertNotEmpty(
+            $response->getEtag(),
+            'Response must expose an ETag so the browser can revalidate cheaply.'
+        );
+        $this->assertNotNull(
+            $response->getLastModified(),
+            'Response must expose a Last-Modified date so the browser can revalidate cheaply.'
+        );
+    }
+
+    public function testUnknownIllustrationStillReturnsBadRequest(): void
+    {
+        $controller = new CustomIllustrationController($this->manager);
+
+        $this->expectException(\Glpi\Exception\Http\BadRequestHttpException::class);
+        $controller->__invoke('this_id_does_not_exist.svg');
+    }
+}


### PR DESCRIPTION
Fixes #25102

## Summary

`CustomIllustrationController` returned a bare `BinaryFileResponse` with no cache configuration. Combined with the route requiring an authenticated session, every single page load that renders a custom illustration (e.g. the Service Catalog) forced a full authenticated round-trip for the browser, instead of reusing a cached copy — even though the underlying file only changes on an explicit re-upload via `IllustrationManager::saveCustomIllustration()`.

This adds `ETag`/`Last-Modified` plus a `private`, 7-day `Cache-Control` directive to the response. It stays `private` (not a shared/public cache) since the route is authenticated, but the browser can now skip re-fetching an unchanged illustration on every page load.

## Test plan

- Added `tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php`, covering:
  - the response carries the expected `Cache-Control` (`private`, `max-age=604800`), `ETag` and `Last-Modified`;
  - an unknown illustration id still results in a `BadRequestHttpException`, unchanged from current behavior.
- Verified both changed files with `php -l` (no syntax errors) against PHP 8.2.
- I was not able to run the full GLPI test suite locally (no local PHP/MySQL/Docker environment available to me); please let CI confirm the test passes as expected.

## AI disclosure

Per CONTRIBUTING.md: I used Claude (Anthropic) as a coding assistant to investigate the root cause, implement this fix, and write the accompanying test. I reviewed and understand the change; commits are authored under my own name/email.
