### PR TITLE
Fix: incorrect articles listed as linked to a document

### DIFF
--- a/phpunit/functional/Document_ItemTest.php
+++ b/phpunit/functional/Document_ItemTest.php
@@ -224,4 +224,55 @@ class Document_ItemTest extends DbTestCase
             $ticket->fields['date_mod'],
         );
     }
+
+    public function testGetTypeItemsForKnowbaseItemDoesNotLeakUnrelatedArticles()
+    {
+        $this->login();
+
+        $document = $this->createItem(\Document::class, [
+            'name' => __FUNCTION__,
+        ]);
+
+        $linked_kb = $this->createItem(\KnowbaseItem::class, [
+            'name'   => __FUNCTION__ . ' linked',
+            'answer' => 'linked',
+            'is_faq' => 0,
+        ]);
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $linked_kb->getID(),
+        ]);
+
+        // Visible to the "tech" user but linked to another document, not this one
+        $other_document = $this->createItem(\Document::class, [
+            'name' => __FUNCTION__ . ' other',
+        ]);
+        $unrelated_kb = $this->createItem(\KnowbaseItem::class, [
+            'name'   => __FUNCTION__ . ' unrelated',
+            'answer' => 'unrelated',
+            'is_faq' => 0,
+        ]);
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $other_document->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $unrelated_kb->getID(),
+        ]);
+
+        $tech_user = getItemByTypeName('User', 'tech', true);
+        $this->createItems('KnowbaseItem_User', [
+            ['knowbaseitems_id' => $linked_kb->getID(), 'users_id' => $tech_user],
+            ['knowbaseitems_id' => $unrelated_kb->getID(), 'users_id' => $tech_user],
+        ]);
+
+        // "tech" is not a KB admin, so visibility is checked through the OR
+        // criteria merged in Document_Item::getTypeItemsQueryParams()
+        $this->login('tech', 'tech');
+
+        $iterator = \Document_Item::getTypeItems($document->getID(), \KnowbaseItem::class);
+        $ids = array_column(iterator_to_array($iterator), 'id');
+
+        $this->assertContains($linked_kb->getID(), $ids);
+        $this->assertNotContains($unrelated_kb->getID(), $ids);
+    }
 }

--- a/src/Document_Item.php
+++ b/src/Document_Item.php
@@ -1005,7 +1005,22 @@ class Document_Item extends CommonDBRelation
                 ];
             }
 
-            $params = array_merge_recursive($params, $kb_params);
+            // Use a subquery to check visibility instead of merging LEFT JOINs
+            // into the main query, which would multiply rows when a KB article
+            // has multiple visibility targets (profiles, users, groups, entities).
+            $subquery_criteria = [
+                'SELECT' => ['glpi_knowbaseitems.id'],
+                'FROM'   => 'glpi_knowbaseitems',
+            ];
+            if (isset($kb_params['LEFT JOIN'])) {
+                $subquery_criteria['LEFT JOIN'] = $kb_params['LEFT JOIN'];
+            }
+            if (isset($kb_params['WHERE'])) {
+                $subquery_criteria['WHERE'] = $kb_params['WHERE'];
+            }
+            $params['WHERE'][] = [
+                'glpi_knowbaseitems.id' => new QuerySubQuery($subquery_criteria),
+            ];
         }
 
         return $params;


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- fixes !45873
- On the "Associated items" tab of a document, the knowledge base articles count and list were wrong for users who do not have the knowledge base administration right: articles that have no actual link to the document could appear in the list, and the displayed count did not match the real number of linked articles.
- Backport of the fix already present on `main`: #23599

## Screenshots (if appropriate):
