### PR TITLE
API : Pin webhooks to a specific API version

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/webhooks.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/webhooks.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+use Glpi\Api\HL\Router;
+
+/**
+ * @var Migration $migration
+ */
+
+// Existing webhooks were built against the v2 payloads. Without this, they would silently
+// switch to the next major version as soon as it becomes the router default.
+$migration->addField('glpi_webhooks', 'pinned_version', 'string', [
+    'update' => "'2'",
+]);
+
+// array_map: PHP turns numeric array keys into integers, and the column holds a string.
+$deprecated_majors = array_map(
+    'strval',
+    array_keys(
+        array_filter(
+            Router::getAPIMajorVersions(),
+            static fn(array $info): bool => $info['deprecated']
+        )
+    )
+);
+
+if ($deprecated_majors !== []) {
+    $deprecated_count = countElementsInTable('glpi_webhooks', ['pinned_version' => $deprecated_majors]);
+    if ($deprecated_count > 0) {
+        $migration->addWarningMessage(
+            sprintf(
+                __('%d webhooks are pinned to a deprecated API version. Update them to a supported version.'),
+                $deprecated_count
+            )
+        );
+    }
+}

--- a/install/migrations/update_11.0.x_to_12.0.0/webhooks.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/webhooks.php
@@ -32,8 +32,6 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\Api\HL\Router;
-
 /**
  * @var Migration $migration
  */
@@ -43,26 +41,3 @@ use Glpi\Api\HL\Router;
 $migration->addField('glpi_webhooks', 'pinned_version', 'string', [
     'update' => "'2'",
 ]);
-
-// array_map: PHP turns numeric array keys into integers, and the column holds a string.
-$deprecated_majors = array_map(
-    'strval',
-    array_keys(
-        array_filter(
-            Router::getAPIMajorVersions(),
-            static fn(array $info): bool => $info['deprecated']
-        )
-    )
-);
-
-if ($deprecated_majors !== []) {
-    $deprecated_count = countElementsInTable('glpi_webhooks', ['pinned_version' => $deprecated_majors]);
-    if ($deprecated_count > 0) {
-        $migration->addWarningMessage(
-            sprintf(
-                __('%d webhooks are pinned to a deprecated API version. Update them to a supported version.'),
-                $deprecated_count
-            )
-        );
-    }
-}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10190,6 +10190,7 @@ CREATE TABLE `glpi_webhooks` (
   `oauth_url` varchar(255) DEFAULT NULL,
   `clientid` varchar(255) DEFAULT NULL,
   `clientsecret` varchar(255) DEFAULT NULL,
+  `pinned_version` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -10186,6 +10186,7 @@ CREATE TABLE `glpi_webhooks` (
   `oauth_url` varchar(255) DEFAULT NULL,
   `clientid` varchar(255) DEFAULT NULL,
   `clientsecret` varchar(255) DEFAULT NULL,
+  `pinned_version` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `name` (`name`),
   KEY `is_active` (`is_active`),

--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -194,6 +194,29 @@ EOT;
     }
 
     /**
+     * Get the distinct major API versions and whether each of them is deprecated.
+     *
+     * A major version is only considered deprecated once all of its minor versions are.
+     *
+     * @return array<int|string, array{deprecated: bool}> Indexed by major version, sorted ascending.
+     */
+    final public static function getAPIMajorVersions(): array
+    {
+        $majors = [];
+        foreach (static::getAPIVersions() as $version) {
+            $major = $version['api_version'];
+            if (!array_key_exists($major, $majors)) {
+                $majors[$major] = ['deprecated' => true];
+            }
+            $majors[$major]['deprecated'] = $majors[$major]['deprecated'] && ($version['deprecated'] ?? false);
+        }
+        // PHP normalizes numeric string keys to int, so this closure may receive either type.
+        uksort($majors, static fn(int|string $a, int|string $b): int => version_compare((string) $a, (string) $b));
+
+        return $majors;
+    }
+
+    /**
      * Normalize the requested API version based on the available versions.
      *
      * If only a major version is specified, the latest minor version will be used.

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -203,6 +203,15 @@ class Webhook extends CommonDBTM implements FilterableInterface
             'datatype'           => 'dropdown',
         ];
 
+        $tab[] = [
+            'id'                 => '8',
+            'table'              => self::getTable(),
+            'field'              => 'pinned_version',
+            'name'               => __('API version'),
+            'massiveaction'      => false, // must be one of the pinnable versions, not free text
+            'datatype'           => 'string',
+        ];
+
         return $tab;
     }
 
@@ -362,16 +371,21 @@ class Webhook extends CommonDBTM implements FilterableInterface
     }
 
     /**
+     * @param string|null $api_version The API version to resolve the schemas against, defaults to {@see Router::API_VERSION}
      * @return array<class-string<AbstractController>, array{
      *     main: array<class-string<CommonDBTM>, array{name: string}>,
      *     subtypes?: array<class-string<CommonDBTM>, array{name: string, parent: class-string<CommonDBTM>}|array{}>
      * }>
      */
-    public static function getAPIItemtypeData(): array
+    public static function getAPIItemtypeData(?string $api_version = null): array
     {
-        static $supported = null;
+        // Normalized so that a bare major (e.g. '2') and its resolved full version (e.g. '2.4.0') share the same cache entry.
+        $api_version = Router::normalizeAPIVersion($api_version ?? Router::API_VERSION);
+        // Memoized per version: a single cache slot would return the first requested version's
+        // schemas for every other version once the schemas actually differ between majors.
+        static $supported_by_version = [];
 
-        if ($supported === null || Environment::get()->shouldExpectResourcesToChange()) {
+        if (!isset($supported_by_version[$api_version]) || Environment::get()->shouldExpectResourcesToChange()) {
             $supported = [
                 AssetController::class => [
                     'main' => AssetController::getAssetTypes(),
@@ -432,8 +446,10 @@ class Webhook extends CommonDBTM implements FilterableInterface
              * @phpstan-var class-string<AbstractController> $controller
              */
             foreach ($supported as $controller => $categories) {
-                // TODO Allow pinning webhooks to specific API versions
-                $schemas = $controller::getKnownSchemas(Router::API_VERSION);
+                // Schemas absent from this version are already dropped by getKnownSchemas(), which
+                // makes the 'main' category below version-aware: an itemtype whose schema does not
+                // exist for $api_version keeps no entry.
+                $schemas = $controller::getKnownSchemas($api_version);
                 foreach ($categories as $category => $itemtypes) {
                     if ($category === 'main') {
                         foreach ($itemtypes as $i => $supported_itemtype) {
@@ -446,15 +462,19 @@ class Webhook extends CommonDBTM implements FilterableInterface
                             unset($supported[$controller][$category][$i]);
                         }
                     } elseif ($controller === ITILController::class) {
+                        // TODO Unlike 'main' above, subtypes are named from a static match and are
+                        // never checked against $schemas, so they stay listed for every API version.
                         foreach (array_keys($itemtypes) as $supported_itemtype) {
                             $supported[$controller][$category][$supported_itemtype]['name'] = $controller::getFriendlyNameForSubtype($supported_itemtype);
                         }
                     }
                 }
             }
+
+            $supported_by_version[$api_version] = $supported;
         }
 
-        return $supported;
+        return $supported_by_version[$api_version];
     }
 
     /**
@@ -509,12 +529,74 @@ class Webhook extends CommonDBTM implements FilterableInterface
         return $sub_item;
     }
 
+    /**
+     * Get the API major versions a webhook can be pinned to.
+     *
+     * Only major versions are offered: the router resolves them to their latest minor version,
+     * which is not supposed to introduce breaking changes for a webhook consumer.
+     * v1 is excluded as it is routed to the legacy API and would not resolve any webhook path.
+     *
+     * @return array<int|string, string> Major version => label to display.
+     */
+    public static function getPinnableAPIVersions(): array
+    {
+        $pinnable = [];
+        foreach (Router::getAPIMajorVersions() as $version => $info) {
+            // Array keys of numeric strings are normalized to int by PHP, so compare as strings.
+            if ((string) $version === '1') {
+                continue;
+            }
+            $pinnable[$version] = $info['deprecated']
+                ? sprintf(__('%s (deprecated)'), $version)
+                : (string) $version;
+        }
+
+        return $pinnable;
+    }
+
+    /**
+     * Get the API version this webhook requests, as a `GLPI-API-Version` header value.
+     *
+     * An empty or unknown stored value falls back to the oldest pinnable major version rather
+     * than to the latest one: a webhook created outside of {@see self::prepareInputForAdd()},
+     * by a plugin or a direct SQL insert, must not silently jump to a newer major version.
+     *
+     * @return string
+     */
+    public function getPinnedAPIVersion(): string
+    {
+        $pinnable = self::getPinnableAPIVersions();
+        $pinned = (string) ($this->fields['pinned_version'] ?? '');
+
+        // array_key_exists() normalizes $pinned the same way PHP normalized the array keys,
+        // unlike in_array() on array_keys($pinnable) which would compare a string to integers.
+        if (array_key_exists($pinned, $pinnable)) {
+            return $pinned;
+        }
+
+        $oldest = array_key_first($pinnable);
+
+        return $oldest !== null ? (string) $oldest : explode('.', Router::API_VERSION)[0];
+    }
+
+    /**
+     * Whether the API version this webhook is pinned to is deprecated.
+     *
+     * @return bool
+     */
+    public function isPinnedAPIVersionDeprecated(): bool
+    {
+        return Router::getAPIMajorVersions()[$this->getPinnedAPIVersion()]['deprecated'] ?? false;
+    }
+
     private function getAPIResponse(string $path): array
     {
         $router = Router::getInstance();
         $router->registerAuthMiddleware(new InternalAuthMiddleware());
         $path = rtrim($path, '/');
-        $request = new Request('GET', $path);
+        // Without this header the router falls back to its latest version, so the payload would
+        // change under the consumer's feet as soon as a new major version ships.
+        $request = new Request('GET', $path, ['GLPI-API-Version' => $this->getPinnedAPIVersion()]);
         $response = Session::callAsSystem(static fn() => $router->handleRequest($request));
         if ($response->getStatusCode() === 200) {
             $body = (string) $response->getBody();
@@ -578,11 +660,13 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     /**
      * @param string $itemtype The itemtype to get the parent item schema for.
+     * @param string|null $api_version The API version whose schema should be used, defaults to {@see Router::API_VERSION}.
      * @return array
      */
-    private static function getParentItemSchema(string $itemtype): array
+    private static function getParentItemSchema(string $itemtype, ?string $api_version = null): array
     {
-        $supported = self::getAPIItemtypeData();
+        $api_version ??= Router::API_VERSION;
+        $supported = self::getAPIItemtypeData($api_version);
         $parent_itemtypes = [];
         foreach ($supported as $controller => $categories) {
             if (isset($categories['subtypes']) && array_key_exists($itemtype, $categories['subtypes'])) {
@@ -597,7 +681,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
         if (count($parent_itemtypes) === 1) {
             $parent_itemtype = array_key_first($parent_itemtypes);
-            return self::getAPISchemaBySupportedItemtype($parent_itemtype);
+            return self::getAPISchemaBySupportedItemtype($parent_itemtype, $api_version);
         }
         $schema = [
             'type' => 'object',
@@ -605,7 +689,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
             'properties' => [],
         ];
         foreach ($parent_itemtypes as $parent_itemtype => $parent_itemtype_data) {
-            $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype);
+            $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype, $api_version);
             $schema['x-subtypes'][] = [
                 'itemtype' => $parent_itemtype,
                 'schema_name' => $parent_itemtype_data['name'],
@@ -640,7 +724,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         } else {
             return;
         }
-        $parent_schema = self::getParentItemSchema($itemtype);
+        $parent_schema = self::getParentItemSchema($itemtype, $this->getPinnedAPIVersion());
         // filter properties in parent schema by the resolved parent itemtype (checks the x-parent-itemtype property)
         foreach ($parent_schema['properties'] as $property_name => $property_data) {
             if (in_array($parent_itemtype, $property_data['x-parent-itemtype'] ?? [], true)) {
@@ -681,7 +765,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
     {
         $itemtype = $item::class;
         $id = $item->getID();
-        $itemtypes = self::getAPIItemtypeData();
+        $itemtypes = self::getAPIItemtypeData($this->getPinnedAPIVersion());
 
         $controller = null;
         $api_name = null;
@@ -778,7 +862,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook.html.twig', [
             'item' => $this,
-            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype']),
+            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion()),
         ]);
 
         return true;
@@ -867,12 +951,12 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     private function showCustomHeaders(): void
     {
-        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
+        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype'], $this->getPinnedAPIVersion());
         $item_fields = Doc\Schema::flattenProperties($schema['properties'], 'item.');
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook_headers.html.twig', [
             'item' => $this,
             'item_fields' => $item_fields,
-            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype']),
+            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion()),
             'params' => [
                 'candel' => false,
                 'formfooter' => false,
@@ -933,13 +1017,15 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     /**
      * @param class-string<CommonDBTM> $itemtype The itemtype to get the schema for
+     * @param string|null $api_version The API version to resolve the schema against, defaults to {@see Router::API_VERSION}
      * @return array|null
      */
-    public static function getAPISchemaBySupportedItemtype(string $itemtype): ?array
+    public static function getAPISchemaBySupportedItemtype(string $itemtype, ?string $api_version = null): ?array
     {
+        $api_version ??= Router::API_VERSION;
         $controller_class = null;
         $schema_name = null;
-        $supported = self::getAPIItemtypeData();
+        $supported = self::getAPIItemtypeData($api_version);
 
         foreach ($supported as $controller => $categories) {
             if (array_key_exists($itemtype, $categories['main'])) {
@@ -968,21 +1054,22 @@ class Webhook extends CommonDBTM implements FilterableInterface
             echo __s('This itemtype is not supported by the API. Maybe a plugin is missing/disabled?');
             return null;
         }
-        // TODO Allow pinning webhooks to specific API versions
-        return $controller_class::getKnownSchemas(Router::API_VERSION)[$schema_name] ?? null;
+        // Properties outside their x-version-introduced/x-version-removed window are already
+        // dropped by getKnownSchemas(), so the returned schema matches the requested version.
+        return $controller_class::getKnownSchemas($api_version)[$schema_name] ?? null;
     }
 
-    public static function getMonacoSuggestions(?string $itemtype): array
+    public static function getMonacoSuggestions(?string $itemtype, ?string $api_version = null): array
     {
         if (empty($itemtype)) {
             return [];
         }
-        $schema = self::getAPISchemaBySupportedItemtype($itemtype);
+        $schema = self::getAPISchemaBySupportedItemtype($itemtype, $api_version);
         if (is_null($schema)) {
             return [];
         }
         $props = Doc\Schema::flattenProperties($schema['properties'], 'item.');
-        $parent_schema = self::getParentItemSchema($itemtype);
+        $parent_schema = self::getParentItemSchema($itemtype, $api_version);
         $parent_props = $parent_schema !== [] ? Doc\Schema::flattenProperties($parent_schema['properties'], 'parent_item.') : [];
 
         $response_schema = [
@@ -1024,8 +1111,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     private function showPayloadEditor(): void
     {
-        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
-        $response_schema = self::getMonacoSuggestions($this->fields['itemtype']);
+        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype'], $this->getPinnedAPIVersion());
+        $response_schema = self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion());
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/payload_editor.html.twig', [
             'item' => $this,
@@ -1288,7 +1375,39 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     public function prepareInputForAdd($input)
     {
-        return $this->handleInput($input);
+        $input = $this->handleInput($input);
+        if ($input === false) {
+            return false;
+        }
+
+        if (empty($input['pinned_version'])) {
+            $default_pinned_version = self::getDefaultPinnedAPIVersion();
+            if ($default_pinned_version !== null) {
+                $input['pinned_version'] = $default_pinned_version;
+            }
+        }
+
+        return $input;
+    }
+
+    /**
+     * Get the API major version a new webhook should be pinned to when none is specified.
+     *
+     * Shared by {@see self::prepareInputForAdd()} (actual insert) and {@see self::post_getEmpty()}
+     * (form pre-selection) so the two never disagree on what a webhook created without an explicit
+     * `pinned_version` ends up pinned to.
+     *
+     * @return string|null Null if no major version is pinnable at all.
+     */
+    private static function getDefaultPinnedAPIVersion(): ?string
+    {
+        $pinnable = array_keys(self::getPinnableAPIVersions());
+        if ($pinnable === []) {
+            return null;
+        }
+
+        // Cast: PHP turns numeric array keys into integers, and the column holds a string.
+        return (string) end($pinnable);
     }
 
     public function prepareInputForUpdate($input)
@@ -1366,6 +1485,13 @@ class Webhook extends CommonDBTM implements FilterableInterface
     public function post_getEmpty()
     {
         $this->fields['is_cra_challenge_valid'] = 0;
+
+        // Match prepareInputForAdd()'s default so the form does not preselect a different
+        // version than the one that will actually be saved.
+        $default_pinned_version = self::getDefaultPinnedAPIVersion();
+        if ($default_pinned_version !== null) {
+            $this->fields['pinned_version'] = $default_pinned_version;
+        }
     }
 
     public static function getMenuContent()

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -203,6 +203,15 @@ class Webhook extends CommonDBTM implements FilterableInterface
             'datatype'           => 'dropdown',
         ];
 
+        $tab[] = [
+            'id'                 => '8',
+            'table'              => self::getTable(),
+            'field'              => 'pinned_version',
+            'name'               => __('API version'),
+            'massiveaction'      => false, // must be one of the pinnable versions, not free text
+            'datatype'           => 'string',
+        ];
+
         return $tab;
     }
 
@@ -362,16 +371,21 @@ class Webhook extends CommonDBTM implements FilterableInterface
     }
 
     /**
+     * @param string|null $api_version The API version to resolve the schemas against, defaults to {@see Router::API_VERSION}
      * @return array<class-string<AbstractController>, array{
      *     main: array<class-string<CommonDBTM>, array{name: string}>,
      *     subtypes?: array<class-string<CommonDBTM>, array{name: string, parent: class-string<CommonDBTM>}|array{}>
      * }>
      */
-    public static function getAPIItemtypeData(): array
+    public static function getAPIItemtypeData(?string $api_version = null): array
     {
-        static $supported = null;
+        // Normalized so that a bare major (e.g. '2') and its resolved full version (e.g. '2.4.0') share the same cache entry.
+        $api_version = Router::normalizeAPIVersion($api_version ?? Router::API_VERSION);
+        // Memoized per version: a single cache slot would return the first requested version's
+        // schemas for every other version once the schemas actually differ between majors.
+        static $supported_by_version = [];
 
-        if ($supported === null || Environment::get()->shouldExpectResourcesToChange()) {
+        if (!isset($supported_by_version[$api_version]) || Environment::get()->shouldExpectResourcesToChange()) {
             $supported = [
                 AssetController::class => [
                     'main' => AssetController::getAssetTypes(),
@@ -432,8 +446,10 @@ class Webhook extends CommonDBTM implements FilterableInterface
              * @phpstan-var class-string<AbstractController> $controller
              */
             foreach ($supported as $controller => $categories) {
-                // TODO Allow pinning webhooks to specific API versions
-                $schemas = $controller::getKnownSchemas(Router::API_VERSION);
+                // Schemas absent from this version are already dropped by getKnownSchemas(), which
+                // makes the 'main' category below version-aware: an itemtype whose schema does not
+                // exist for $api_version keeps no entry.
+                $schemas = $controller::getKnownSchemas($api_version);
                 foreach ($categories as $category => $itemtypes) {
                     if ($category === 'main') {
                         foreach ($itemtypes as $i => $supported_itemtype) {
@@ -446,15 +462,19 @@ class Webhook extends CommonDBTM implements FilterableInterface
                             unset($supported[$controller][$category][$i]);
                         }
                     } elseif ($controller === ITILController::class) {
+                        // TODO Unlike 'main' above, subtypes are named from a static match and are
+                        // never checked against $schemas, so they stay listed for every API version.
                         foreach (array_keys($itemtypes) as $supported_itemtype) {
                             $supported[$controller][$category][$supported_itemtype]['name'] = $controller::getFriendlyNameForSubtype($supported_itemtype);
                         }
                     }
                 }
             }
+
+            $supported_by_version[$api_version] = $supported;
         }
 
-        return $supported;
+        return $supported_by_version[$api_version];
     }
 
     /**
@@ -509,12 +529,74 @@ class Webhook extends CommonDBTM implements FilterableInterface
         return $sub_item;
     }
 
+    /**
+     * Get the API major versions a webhook can be pinned to.
+     *
+     * Only major versions are offered: the router resolves them to their latest minor version,
+     * which is not supposed to introduce breaking changes for a webhook consumer.
+     * v1 is excluded as it is routed to the legacy API and would not resolve any webhook path.
+     *
+     * @return array<int|string, string> Major version => label to display.
+     */
+    public static function getPinnableAPIVersions(): array
+    {
+        $pinnable = [];
+        foreach (Router::getAPIMajorVersions() as $version => $info) {
+            // Array keys of numeric strings are normalized to int by PHP, so compare as strings.
+            if ((string) $version === '1') {
+                continue;
+            }
+            $pinnable[$version] = $info['deprecated']
+                ? sprintf(__('%s (deprecated)'), $version)
+                : (string) $version;
+        }
+
+        return $pinnable;
+    }
+
+    /**
+     * Get the API version this webhook requests, as a `GLPI-API-Version` header value.
+     *
+     * An empty or unknown stored value falls back to the oldest pinnable major version rather
+     * than to the latest one: a webhook created outside of {@see self::prepareInputForAdd()},
+     * by a plugin or a direct SQL insert, must not silently jump to a newer major version.
+     *
+     * @return string
+     */
+    public function getPinnedAPIVersion(): string
+    {
+        $pinnable = self::getPinnableAPIVersions();
+        $pinned = (string) ($this->fields['pinned_version'] ?? '');
+
+        // array_key_exists() normalizes $pinned the same way PHP normalized the array keys,
+        // unlike in_array() on array_keys($pinnable) which would compare a string to integers.
+        if (array_key_exists($pinned, $pinnable)) {
+            return $pinned;
+        }
+
+        $oldest = array_key_first($pinnable);
+
+        return $oldest !== null ? (string) $oldest : explode('.', Router::API_VERSION)[0];
+    }
+
+    /**
+     * Whether the API version this webhook is pinned to is deprecated.
+     *
+     * @return bool
+     */
+    public function isPinnedAPIVersionDeprecated(): bool
+    {
+        return Router::getAPIMajorVersions()[$this->getPinnedAPIVersion()]['deprecated'] ?? false;
+    }
+
     private function getAPIResponse(string $path): array
     {
         $router = Router::getInstance();
         $router->registerAuthMiddleware(new InternalAuthMiddleware());
         $path = rtrim($path, '/');
-        $request = new Request('GET', $path);
+        // Without this header the router falls back to its latest version, so the payload would
+        // change under the consumer's feet as soon as a new major version ships.
+        $request = new Request('GET', $path, ['GLPI-API-Version' => $this->getPinnedAPIVersion()]);
         $response = Session::callAsSystem(static fn() => $router->handleRequest($request));
         if ($response->getStatusCode() === 200) {
             $body = (string) $response->getBody();
@@ -578,11 +660,13 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     /**
      * @param string $itemtype The itemtype to get the parent item schema for.
+     * @param string|null $api_version The API version whose schema should be used, defaults to {@see Router::API_VERSION}.
      * @return array
      */
-    private static function getParentItemSchema(string $itemtype): array
+    private static function getParentItemSchema(string $itemtype, ?string $api_version = null): array
     {
-        $supported = self::getAPIItemtypeData();
+        $api_version ??= Router::API_VERSION;
+        $supported = self::getAPIItemtypeData($api_version);
         $parent_itemtypes = [];
         foreach ($supported as $controller => $categories) {
             if (isset($categories['subtypes']) && array_key_exists($itemtype, $categories['subtypes'])) {
@@ -597,7 +681,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
         if (count($parent_itemtypes) === 1) {
             $parent_itemtype = array_key_first($parent_itemtypes);
-            return self::getAPISchemaBySupportedItemtype($parent_itemtype);
+            return self::getAPISchemaBySupportedItemtype($parent_itemtype, $api_version);
         }
         $schema = [
             'type' => 'object',
@@ -605,7 +689,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
             'properties' => [],
         ];
         foreach ($parent_itemtypes as $parent_itemtype => $parent_itemtype_data) {
-            $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype);
+            $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype, $api_version);
             $schema['x-subtypes'][] = [
                 'itemtype' => $parent_itemtype,
                 'schema_name' => $parent_itemtype_data['name'],
@@ -640,7 +724,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
         } else {
             return;
         }
-        $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype);
+        $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype, $this->getPinnedAPIVersion());
         if ($parent_schema === null) {
             throw new LogicException("Parent itemtype $parent_itemtype does not have a valid API schema");
         }
@@ -674,7 +758,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
     {
         $itemtype = $item::class;
         $id = $item->getID();
-        $itemtypes = self::getAPIItemtypeData();
+        $itemtypes = self::getAPIItemtypeData($this->getPinnedAPIVersion());
 
         $controller = null;
         $api_name = null;
@@ -771,7 +855,7 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook.html.twig', [
             'item' => $this,
-            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype']),
+            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion()),
         ]);
 
         return true;
@@ -860,12 +944,12 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     private function showCustomHeaders(): void
     {
-        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
+        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype'], $this->getPinnedAPIVersion());
         $item_fields = Doc\Schema::flattenProperties($schema['properties'], 'item.');
         TemplateRenderer::getInstance()->display('pages/setup/webhook/webhook_headers.html.twig', [
             'item' => $this,
             'item_fields' => $item_fields,
-            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype']),
+            'response_schema' => self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion()),
             'params' => [
                 'candel' => false,
                 'formfooter' => false,
@@ -926,13 +1010,15 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     /**
      * @param class-string<CommonDBTM> $itemtype The itemtype to get the schema for
+     * @param string|null $api_version The API version to resolve the schema against, defaults to {@see Router::API_VERSION}
      * @return array|null
      */
-    public static function getAPISchemaBySupportedItemtype(string $itemtype): ?array
+    public static function getAPISchemaBySupportedItemtype(string $itemtype, ?string $api_version = null): ?array
     {
+        $api_version ??= Router::API_VERSION;
         $controller_class = null;
         $schema_name = null;
-        $supported = self::getAPIItemtypeData();
+        $supported = self::getAPIItemtypeData($api_version);
 
         foreach ($supported as $controller => $categories) {
             if (array_key_exists($itemtype, $categories['main'])) {
@@ -961,21 +1047,22 @@ class Webhook extends CommonDBTM implements FilterableInterface
             echo __s('This itemtype is not supported by the API. Maybe a plugin is missing/disabled?');
             return null;
         }
-        // TODO Allow pinning webhooks to specific API versions
-        return $controller_class::getKnownSchemas(Router::API_VERSION)[$schema_name] ?? null;
+        // Properties outside their x-version-introduced/x-version-removed window are already
+        // dropped by getKnownSchemas(), so the returned schema matches the requested version.
+        return $controller_class::getKnownSchemas($api_version)[$schema_name] ?? null;
     }
 
-    public static function getMonacoSuggestions(?string $itemtype): array
+    public static function getMonacoSuggestions(?string $itemtype, ?string $api_version = null): array
     {
         if (empty($itemtype)) {
             return [];
         }
-        $schema = self::getAPISchemaBySupportedItemtype($itemtype);
+        $schema = self::getAPISchemaBySupportedItemtype($itemtype, $api_version);
         if (is_null($schema)) {
             return [];
         }
         $props = Doc\Schema::flattenProperties($schema['properties'], 'item.');
-        $parent_schema = self::getParentItemSchema($itemtype);
+        $parent_schema = self::getParentItemSchema($itemtype, $api_version);
         $parent_props = $parent_schema !== [] ? Doc\Schema::flattenProperties($parent_schema['properties'], 'parent_item.') : [];
 
         $response_schema = [
@@ -1017,8 +1104,8 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     private function showPayloadEditor(): void
     {
-        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype']);
-        $response_schema = self::getMonacoSuggestions($this->fields['itemtype']);
+        $schema = self::getAPISchemaBySupportedItemtype($this->fields['itemtype'], $this->getPinnedAPIVersion());
+        $response_schema = self::getMonacoSuggestions($this->fields['itemtype'], $this->getPinnedAPIVersion());
 
         TemplateRenderer::getInstance()->display('pages/setup/webhook/payload_editor.html.twig', [
             'item' => $this,
@@ -1281,7 +1368,39 @@ class Webhook extends CommonDBTM implements FilterableInterface
 
     public function prepareInputForAdd($input)
     {
-        return $this->handleInput($input);
+        $input = $this->handleInput($input);
+        if ($input === false) {
+            return false;
+        }
+
+        if (empty($input['pinned_version'])) {
+            $default_pinned_version = self::getDefaultPinnedAPIVersion();
+            if ($default_pinned_version !== null) {
+                $input['pinned_version'] = $default_pinned_version;
+            }
+        }
+
+        return $input;
+    }
+
+    /**
+     * Get the API major version a new webhook should be pinned to when none is specified.
+     *
+     * Shared by {@see self::prepareInputForAdd()} (actual insert) and {@see self::post_getEmpty()}
+     * (form pre-selection) so the two never disagree on what a webhook created without an explicit
+     * `pinned_version` ends up pinned to.
+     *
+     * @return string|null Null if no major version is pinnable at all.
+     */
+    private static function getDefaultPinnedAPIVersion(): ?string
+    {
+        $pinnable = array_keys(self::getPinnableAPIVersions());
+        if ($pinnable === []) {
+            return null;
+        }
+
+        // Cast: PHP turns numeric array keys into integers, and the column holds a string.
+        return (string) end($pinnable);
     }
 
     public function prepareInputForUpdate($input)
@@ -1359,6 +1478,13 @@ class Webhook extends CommonDBTM implements FilterableInterface
     public function post_getEmpty()
     {
         $this->fields['is_cra_challenge_valid'] = 0;
+
+        // Match prepareInputForAdd()'s default so the form does not preselect a different
+        // version than the one that will actually be saved.
+        $default_pinned_version = self::getDefaultPinnedAPIVersion();
+        if ($default_pinned_version !== null) {
+            $this->fields['pinned_version'] = $default_pinned_version;
+        }
     }
 
     public static function getMenuContent()

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -40,6 +40,22 @@
     {{ fields.dropdownField('WebhookCategory', 'webhookcategories_id', item.fields['webhookcategories_id'], 'WebhookCategory'|itemtype_name) }}
 
     {{ fields.dropdownArrayField(
+        'pinned_version',
+        item.fields['pinned_version'],
+        item.getPinnableAPIVersions(),
+        __('API version'),
+        field_options|merge({
+            helper: __('The payload is built using this version of the API. Existing integrations keep working as long as the webhook stays on the version they were built for.'),
+        })
+    ) }}
+
+    {% if not item.isNewItem() and item.isPinnedAPIVersionDeprecated() %}
+        <twig:Alert:Warning
+            :title="__('This webhook is pinned to a deprecated API version. Move it to a supported version before it is removed.')"
+        />
+    {% endif %}
+
+    {{ fields.dropdownArrayField(
         'itemtype',
         item.fields['itemtype'],
         item.getItemtypesDropdownValues(),

--- a/templates/pages/setup/webhook/webhook.html.twig
+++ b/templates/pages/setup/webhook/webhook.html.twig
@@ -51,7 +51,7 @@
 
     {% if not item.isNewItem() and item.isPinnedAPIVersionDeprecated() %}
         <twig:Alert:Warning
-            :title="__('This webhook is pinned to a deprecated API version. Move it to a supported version before it is removed.')"
+            :heading="__('This webhook is pinned to a deprecated API version. Move it to a supported version before it is removed.')"
         />
     {% endif %}
 

--- a/tests/e2e/pages/GlpiPage.ts
+++ b/tests/e2e/pages/GlpiPage.ts
@@ -299,11 +299,16 @@ export class GlpiPage
      * Select2's container is the span right after the select.
      * The interactive element is the combobox inside the container.
      */
-    public getDropdownByLabel(label: string, base?: Locator): Locator
-    {
+    public getDropdownByLabel(
+        label: string,
+        base?: Locator,
+        exact: boolean = true,
+    ): Locator {
+        // Fields carrying a help tooltip render it inside the <label>, so their accessible name
+        // is not the label text alone: pass exact = false to match on the label text only.
         // eslint-disable-next-line playwright/no-raw-locators
         return (base ?? this.page)
-            .getByLabel(label, {exact: true})
+            .getByLabel(label, {exact: exact})
             .locator('+ span')
             .getByRole('combobox')
         ;

--- a/tests/e2e/pages/WebhookPage.ts
+++ b/tests/e2e/pages/WebhookPage.ts
@@ -1,0 +1,56 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { Page } from "@playwright/test";
+import { GlpiPage } from "./GlpiPage";
+
+export class WebhookPage extends GlpiPage
+{
+    public constructor(page: Page)
+    {
+        super(page);
+    }
+
+    public async goto(id: number, tab?: string): Promise<void>
+    {
+        let url = `/front/webhook.form.php?id=${id}`;
+        if (tab) {
+            url += `&forcetab=${tab}`;
+        }
+        await this.page.goto(url);
+    }
+
+    public async gotoNew(): Promise<void>
+    {
+        await this.page.goto('/front/webhook.form.php');
+    }
+}

--- a/tests/e2e/specs/Setup/webhook.spec.ts
+++ b/tests/e2e/specs/Setup/webhook.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { Profiles } from '../../utils/Profiles';
+import { WebhookPage } from '../../pages/WebhookPage';
+
+/**
+ * A webhook pins the API major version its payload is built against. A new webhook must start on
+ * the highest offered major, so that a webhook created through the form and one created
+ * programmatically never end up on different versions. The form default and the programmatic
+ * default live in two different places (post_getEmpty() and prepareInputForAdd()), are each
+ * correct in isolation, and can only disagree once rendered together, which no unit test sees.
+ *
+ * What this test can and cannot catch today, verified by mutation: with a single pinnable major,
+ * the dropdown holds one option, so an empty pre-selection and a correct one render identically.
+ * Removing the form default does NOT fail this test yet, and neither would reversing the order the
+ * versions are offered in. Both become detectable as soon as a second major ships, which is
+ * exactly when they would start to matter.
+ *
+ * What it does catch now: the field disappearing from the creation form, v1 leaking into the
+ * offered versions, and the chosen version not surviving a save.
+ */
+test('A new webhook is pinned to the highest offered API version', async ({ page, profile }) => {
+    await profile.set(Profiles.SuperAdmin);
+
+    const webhook_page = new WebhookPage(page);
+    await webhook_page.gotoNew();
+
+    await page.getByRole('textbox', { name: 'Name' }).fill('Pinned version default');
+    await webhook_page.doSetDropdownValue(
+        webhook_page.getDropdownByLabel('Itemtype'),
+        'Ticket'
+    );
+
+    // The label carries a help tooltip, so it is matched on its text rather than exactly.
+    const version_dropdown = webhook_page.getDropdownByLabel('API version', undefined, false);
+
+    // Read the offered versions from the dropdown itself rather than hardcoding one, so this test
+    // keeps its meaning once a new major version ships.
+    const offered = await webhook_page.getDropdownOptions(version_dropdown);
+    const majors = offered.map((option) => parseInt(option ?? '', 10)).filter(Number.isInteger);
+    expect(majors.length).toBeGreaterThan(0);
+
+    // v1 is routed to the legacy API and would resolve no webhook path, so it is never offered.
+    expect(majors).not.toContain(1);
+
+    // Deliberately computed, not taken as the last entry: this also catches a reversal of the
+    // order the versions are offered in.
+    const highest_major = Math.max(...majors).toString();
+    await expect(version_dropdown).toContainText(highest_major);
+
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    // The saved webhook keeps the version the form showed before saving.
+    await expect(
+        webhook_page.getDropdownByLabel('API version', undefined, false)
+    ).toContainText(highest_major);
+});

--- a/tests/functional/Glpi/Api/HL/RouterTest.php
+++ b/tests/functional/Glpi/Api/HL/RouterTest.php
@@ -249,6 +249,43 @@ class RouterTest extends GLPITestCase
         $this->assertEquals('50.2.0', TestRouter::normalizeAPIVersion('50.2'));
     }
 
+    public function testGetAPIMajorVersions()
+    {
+        $majors = Router::getAPIMajorVersions();
+        // Numeric string keys are normalized to int by PHP, hence the array_map().
+        $declared = array_map('strval', array_keys($majors));
+
+        // Asserted as invariants rather than as an exact list: shipping a new major is precisely
+        // what this whole feature prepares for, and must not turn this test red.
+
+        // Deduplicated: the real router declares several 2.x minor versions.
+        $this->assertCount(count(array_unique($declared)), $declared);
+
+        // Sorted ascending, which is what makes "oldest" and "latest" meaningful to the callers.
+        $sorted = $declared;
+        usort($sorted, static fn(string $a, string $b): int => version_compare($a, $b));
+        $this->assertSame($sorted, $declared);
+
+        // Major 2 still has non deprecated minor versions (2.3, 2.4).
+        $this->assertArrayHasKey('2', $majors);
+        $this->assertFalse($majors['2']['deprecated']);
+        $this->assertArrayHasKey('1', $majors);
+        $this->assertFalse($majors['1']['deprecated']);
+    }
+
+    public function testGetAPIMajorVersionsDeprecatedMajor()
+    {
+        $majors = FullyDeprecatedMajorRouter::getAPIMajorVersions();
+
+        // Major 60 only has deprecated minor versions, so the major itself is deprecated.
+        $this->assertTrue($majors['60']['deprecated']);
+        // Major 61 has one non deprecated minor version.
+        $this->assertFalse($majors['61']['deprecated']);
+        // Sorted by ascending version, not by declaration order.
+        // Numeric string keys are normalized to int by PHP, hence the array_map().
+        $this->assertSame(['1', '2', '60', '61'], array_map('strval', array_keys($majors)));
+    }
+
     public function testRoutingByVersion()
     {
         $router = TestRouter::getInstance();
@@ -432,5 +469,38 @@ class TestController extends AbstractController
     public function testVersion510(RequestInterface $request): Response
     {
         return new Response(200, [], __FUNCTION__);
+    }
+}
+
+// @codingStandardsIgnoreStart
+class FullyDeprecatedMajorRouter extends Router
+{
+    // @codingStandardsIgnoreEnd
+    public static function getAPIVersions(): array
+    {
+        global $CFG_GLPI;
+
+        $versions = parent::getAPIVersions();
+
+        // Declared out of order on purpose to check the sorting.
+        $versions[] = [
+            'api_version' => '61',
+            'version' => '61.0.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v61',
+        ];
+        $versions[] = [
+            'api_version' => '60',
+            'version' => '60.0.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v60',
+            'deprecated' => true,
+        ];
+        $versions[] = [
+            'api_version' => '60',
+            'version' => '60.1.0',
+            'endpoint' => $CFG_GLPI['url_base'] . '/api.php/v60.1',
+            'deprecated' => true,
+        ];
+
+        return $versions;
     }
 }

--- a/tests/functional/WebhookTest.php
+++ b/tests/functional/WebhookTest.php
@@ -36,6 +36,7 @@ namespace tests\units;
 
 use Change;
 use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Api\HL\Router;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Tests\DbTestCase;
 use ITILFollowup;
@@ -270,6 +271,39 @@ JSON;
                 }
             }
         }
+    }
+
+    /**
+     * The schema resolution methods accept an API version so that the v3 work does not have to
+     * change their signatures. The filtering itself is not implemented yet, so passing a version
+     * must not change what they return today.
+     *
+     * The per-version memoization of getAPIItemtypeData() is deliberately not covered: under
+     * PHPUnit, Environment::shouldExpectResourcesToChange() is always true, so the static cache
+     * is bypassed on every call and its keying cannot be observed from a test.
+     */
+    public function testSchemaResolutionAcceptsAnAPIVersion()
+    {
+        $this->login();
+
+        $default = Webhook::getAPIItemtypeData();
+        $explicit = Webhook::getAPIItemtypeData(Router::API_VERSION);
+        $this->assertSame($default, $explicit);
+
+        $schema_default = Webhook::getAPISchemaBySupportedItemtype(\Computer::class);
+        $schema_explicit = Webhook::getAPISchemaBySupportedItemtype(\Computer::class, Router::API_VERSION);
+        // Schemas embed closures (rights checks) that are fresh instances on every call, so the
+        // exposed property names are compared rather than the raw structures.
+        $this->assertNotEmpty($schema_default['properties']);
+        $this->assertSame(
+            array_keys($schema_default['properties']),
+            array_keys($schema_explicit['properties'])
+        );
+
+        $suggestions_default = Webhook::getMonacoSuggestions(\Computer::class);
+        $suggestions_explicit = Webhook::getMonacoSuggestions(\Computer::class, Router::API_VERSION);
+        $this->assertNotEmpty($suggestions_default);
+        $this->assertSame($suggestions_default, $suggestions_explicit);
     }
 
     public function testGetAPIPath()
@@ -659,5 +693,143 @@ JSON;
         $this->assertSame('observer', $team_1['role']);
         $this->assertSame('post-only', $team_2['name']);
         $this->assertSame('observer', $team_2['role']);
+    }
+
+    public function testGetPinnableAPIVersions()
+    {
+        $pinnable = Webhook::getPinnableAPIVersions();
+
+        // v1 is routed to the legacy API and would never resolve a webhook path.
+        $this->assertArrayNotHasKey('1', $pinnable);
+        $this->assertArrayHasKey('2', $pinnable);
+        // Major 2 is not fully deprecated, so its label is the bare version.
+        $this->assertSame('2', $pinnable['2']);
+    }
+
+    public function testGetPinnedAPIVersion()
+    {
+        $this->login();
+        $webhook = new Webhook();
+
+        // Explicit value is kept.
+        $webhook->fields['pinned_version'] = '2';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Empty value falls back to the oldest pinnable major, not to the latest one.
+        $webhook->fields['pinned_version'] = '';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Unknown value falls back too, otherwise normalizeAPIVersion() would silently
+        // resolve it to the latest version, which is the bug being fixed.
+        $webhook->fields['pinned_version'] = '99';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Missing key behaves like an empty value.
+        unset($webhook->fields['pinned_version']);
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+    }
+
+    public function testIsPinnedAPIVersionDeprecated()
+    {
+        $webhook = new Webhook();
+        $webhook->fields['pinned_version'] = '2';
+        $this->assertFalse($webhook->isPinnedAPIVersionDeprecated());
+    }
+
+    public function testNewWebhookIsPinnedToLatestMajorVersion()
+    {
+        $this->login();
+        $pinnable = array_keys(Webhook::getPinnableAPIVersions());
+        // Cast: array keys are integers, the stored field is a string.
+        $latest_major = (string) end($pinnable);
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned version default',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+        ]);
+
+        $this->assertSame($latest_major, $webhook->fields['pinned_version']);
+    }
+
+    public function testExplicitPinnedVersionIsKeptOnCreation()
+    {
+        $this->login();
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned version explicit',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'pinned_version' => '2',
+        ]);
+
+        $this->assertSame('2', $webhook->fields['pinned_version']);
+    }
+
+    /**
+     * The no-op this whole change relies on: an existing webhook, pinned to the major it was
+     * built against, still asks the router for the version it was already getting.
+     * The day this fails is the day pinning starts changing an existing payload, which is
+     * exactly the moment a conscious decision is required rather than a silent drift.
+     */
+    public function testPinnedMajorResolvesToRouterCurrentVersion()
+    {
+        $this->login();
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned to v2',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'pinned_version' => '2',
+        ]);
+
+        $this->assertSame(Router::API_VERSION, Router::normalizeAPIVersion($webhook->getPinnedAPIVersion()));
+    }
+
+    /**
+     * A webhook whose stored version is missing falls back to the oldest pinnable major, so it
+     * must produce the very same payload as one pinned to it explicitly. This also proves that
+     * setting the version header does not break the internal routing.
+     */
+    public function testFallbackVersionProducesSamePayloadAsExplicitPin()
+    {
+        $this->login();
+        $users_id = \Session::getLoginUserID();
+
+        $common_input = [
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 1,
+        ];
+
+        /** @var Webhook $pinned */
+        $pinned = $this->createItem(Webhook::class, $common_input + [
+            'name' => 'Pinned to v2',
+            'pinned_version' => '2',
+        ]);
+
+        /** @var Webhook $unpinned */
+        $unpinned = $this->createItem(Webhook::class, $common_input + ['name' => 'Unpinned']);
+        // Simulate a webhook inserted without going through prepareInputForAdd().
+        $unpinned->fields['pinned_version'] = '';
+
+        $path = '/Administration/User/' . $users_id;
+        $pinned_body = $pinned->getResultForPath($path, 'new', User::class, $users_id);
+        $unpinned_body = $unpinned->getResultForPath($path, 'new', User::class, $users_id);
+
+        $this->assertNotNull($pinned_body);
+        $this->assertSame($pinned_body, $unpinned_body);
     }
 }

--- a/tests/functional/WebhookTest.php
+++ b/tests/functional/WebhookTest.php
@@ -35,6 +35,7 @@
 namespace tests\units;
 
 use Glpi\Api\HL\Controller\AbstractController;
+use Glpi\Api\HL\Router;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Tests\DbTestCase;
 use ITILFollowup;
@@ -269,6 +270,39 @@ JSON;
                 }
             }
         }
+    }
+
+    /**
+     * The schema resolution methods accept an API version so that the v3 work does not have to
+     * change their signatures. The filtering itself is not implemented yet, so passing a version
+     * must not change what they return today.
+     *
+     * The per-version memoization of getAPIItemtypeData() is deliberately not covered: under
+     * PHPUnit, Environment::shouldExpectResourcesToChange() is always true, so the static cache
+     * is bypassed on every call and its keying cannot be observed from a test.
+     */
+    public function testSchemaResolutionAcceptsAnAPIVersion()
+    {
+        $this->login();
+
+        $default = Webhook::getAPIItemtypeData();
+        $explicit = Webhook::getAPIItemtypeData(Router::API_VERSION);
+        $this->assertSame($default, $explicit);
+
+        $schema_default = Webhook::getAPISchemaBySupportedItemtype(\Computer::class);
+        $schema_explicit = Webhook::getAPISchemaBySupportedItemtype(\Computer::class, Router::API_VERSION);
+        // Schemas embed closures (rights checks) that are fresh instances on every call, so the
+        // exposed property names are compared rather than the raw structures.
+        $this->assertNotEmpty($schema_default['properties']);
+        $this->assertSame(
+            array_keys($schema_default['properties']),
+            array_keys($schema_explicit['properties'])
+        );
+
+        $suggestions_default = Webhook::getMonacoSuggestions(\Computer::class);
+        $suggestions_explicit = Webhook::getMonacoSuggestions(\Computer::class, Router::API_VERSION);
+        $this->assertNotEmpty($suggestions_default);
+        $this->assertSame($suggestions_default, $suggestions_explicit);
     }
 
     public function testGetAPIPath()
@@ -594,5 +628,143 @@ JSON;
             static fn(string $msg) => stripos($msg, 'webhook') !== false
         );
         $this->assertEmpty($webhook_errors);
+    }
+
+    public function testGetPinnableAPIVersions()
+    {
+        $pinnable = Webhook::getPinnableAPIVersions();
+
+        // v1 is routed to the legacy API and would never resolve a webhook path.
+        $this->assertArrayNotHasKey('1', $pinnable);
+        $this->assertArrayHasKey('2', $pinnable);
+        // Major 2 is not fully deprecated, so its label is the bare version.
+        $this->assertSame('2', $pinnable['2']);
+    }
+
+    public function testGetPinnedAPIVersion()
+    {
+        $this->login();
+        $webhook = new Webhook();
+
+        // Explicit value is kept.
+        $webhook->fields['pinned_version'] = '2';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Empty value falls back to the oldest pinnable major, not to the latest one.
+        $webhook->fields['pinned_version'] = '';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Unknown value falls back too, otherwise normalizeAPIVersion() would silently
+        // resolve it to the latest version, which is the bug being fixed.
+        $webhook->fields['pinned_version'] = '99';
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+
+        // Missing key behaves like an empty value.
+        unset($webhook->fields['pinned_version']);
+        $this->assertSame('2', $webhook->getPinnedAPIVersion());
+    }
+
+    public function testIsPinnedAPIVersionDeprecated()
+    {
+        $webhook = new Webhook();
+        $webhook->fields['pinned_version'] = '2';
+        $this->assertFalse($webhook->isPinnedAPIVersionDeprecated());
+    }
+
+    public function testNewWebhookIsPinnedToLatestMajorVersion()
+    {
+        $this->login();
+        $pinnable = array_keys(Webhook::getPinnableAPIVersions());
+        // Cast: array keys are integers, the stored field is a string.
+        $latest_major = (string) end($pinnable);
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned version default',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+        ]);
+
+        $this->assertSame($latest_major, $webhook->fields['pinned_version']);
+    }
+
+    public function testExplicitPinnedVersionIsKeptOnCreation()
+    {
+        $this->login();
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned version explicit',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'pinned_version' => '2',
+        ]);
+
+        $this->assertSame('2', $webhook->fields['pinned_version']);
+    }
+
+    /**
+     * The no-op this whole change relies on: an existing webhook, pinned to the major it was
+     * built against, still asks the router for the version it was already getting.
+     * The day this fails is the day pinning starts changing an existing payload, which is
+     * exactly the moment a conscious decision is required rather than a silent drift.
+     */
+    public function testPinnedMajorResolvesToRouterCurrentVersion()
+    {
+        $this->login();
+
+        /** @var Webhook $webhook */
+        $webhook = $this->createItem(Webhook::class, [
+            'name' => 'Pinned to v2',
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'pinned_version' => '2',
+        ]);
+
+        $this->assertSame(Router::API_VERSION, Router::normalizeAPIVersion($webhook->getPinnedAPIVersion()));
+    }
+
+    /**
+     * A webhook whose stored version is missing falls back to the oldest pinnable major, so it
+     * must produce the very same payload as one pinned to it explicitly. This also proves that
+     * setting the version header does not break the internal routing.
+     */
+    public function testFallbackVersionProducesSamePayloadAsExplicitPin()
+    {
+        $this->login();
+        $users_id = \Session::getLoginUserID();
+
+        $common_input = [
+            'entities_id' => $_SESSION['glpiactive_entity'],
+            'url' => 'http://localhost',
+            'itemtype' => User::class,
+            'event' => 'new',
+            'is_active' => 1,
+            'use_default_payload' => 1,
+        ];
+
+        /** @var Webhook $pinned */
+        $pinned = $this->createItem(Webhook::class, $common_input + [
+            'name' => 'Pinned to v2',
+            'pinned_version' => '2',
+        ]);
+
+        /** @var Webhook $unpinned */
+        $unpinned = $this->createItem(Webhook::class, $common_input + ['name' => 'Unpinned']);
+        // Simulate a webhook inserted without going through prepareInputForAdd().
+        $unpinned->fields['pinned_version'] = '';
+
+        $path = '/Administration/User/' . $users_id;
+        $pinned_body = $pinned->getResultForPath($path, 'new', User::class, $users_id);
+        $unpinned_body = $unpinned->getResultForPath($path, 'new', User::class, $users_id);
+
+        $this->assertNotNull($pinned_body);
+        $this->assertSame($pinned_body, $unpinned_body);
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.


## Description

- It fixes https://github.com/glpi-project/glpi/issues/24970
- Here is a brief description of what this PR does : 

Webhooks build their payload by calling the HL API internally, and that internal request never carried a version header, so the router always fell back to `Router::API_VERSION`. That is harmless while v2 is the only major, but the day v3 becomes the default, every existing webhook would start sending v3 payloads without anyone having changed anything on their side.

Each webhook now stores the API major version its payload is built against:

* a `pinned_version` column and a dropdown on the webhook form
* `Webhook::getAPIResponse()` sends it as the `GLPI-API-Version` header
* a migration pins existing webhooks to "2", new ones default to the highest available major
* deprecated majors are flagged in the dropdown, with a warning on the form

Only majors can be pinned, the router already resolves them to their latest minor. v1 is excluded since it is routed to the legacy API and would resolve no webhook path.

Nothing changes today: "2" resolves to 2.4.0, which is already the router default, so payloads are identical before and after. The dropdown holds a single entry until v3 ships.

Left out on purpose : the itemtype list still offers ITIL subtypes whatever the pinned version, since they are named from a static map instead of the schemas, and the Monaco suggestions endpoint does not carry the version yet. Both belong with the v3 work.


## Screenshot : 

<img width="1293" height="696" alt="image" src="https://github.com/user-attachments/assets/32da41ff-d60b-4b6e-89eb-0f968b8f09ba" />



