### PR TITLE
Fix - Avoid array-to-string warnings on multi-value massive action fields

### DIFF
--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1571,7 +1571,9 @@ class MassiveAction
                                 ) {
                                     $related_item = null;
                                     // Case 1: The modified field is a foreign key (ex : locations_id)
-                                    if (isForeignKeyField($field_name)) {
+                                    // Multi-value fields (e.g. a "multiple" dropdown) submit an array
+                                    // as $field_value, which is not a valid single foreign key value.
+                                    if (isForeignKeyField($field_name) && !is_array($field_value)) {
                                         // Attempt to load the related object using its ID (from the input value)
                                         if ($item2->getFromDB($field_value)) {
                                             $related_item = $item2;

--- a/src/MassiveAction.php
+++ b/src/MassiveAction.php
@@ -1571,11 +1571,11 @@ class MassiveAction
                                 ) {
                                     $related_item = null;
                                     // Case 1: The modified field is a foreign key (ex : locations_id)
-                                    // Multi-value fields (e.g. a "multiple" dropdown) submit an array
-                                    // as $field_value, which is not a valid single foreign key value.
-                                    if (isForeignKeyField($field_name) && !is_array($field_value)) {
+                                    if (isForeignKeyField($field_name)) {
+                                        // Multi-value fields (e.g. a "multiple" dropdown) submit an array
+                                        // as $field_value, which is not a valid single foreign key value.
                                         // Attempt to load the related object using its ID (from the input value)
-                                        if ($item2->getFromDB($field_value)) {
+                                        if (!is_array($field_value) && $item2->getFromDB($field_value)) {
                                             $related_item = $item2;
                                         }
                                         // Case 2: The field is not a foreign key, but the target class supports connexity (relations)

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1799,4 +1799,62 @@ class MassiveActionTest extends DbTestCase
             $target_itemtype::getForeignKeyField() => $target->getID(),
         ]));
     }
+
+    /**
+     * Multi-value fields (e.g. a plugin's "multiple" dropdown) submit an
+     * array as their value. A field matching the foreign-key naming pattern
+     * (isForeignKeyField(), e.g. "locations_id") must not be treated as a
+     * single scalar foreign key in that case, or PHP emits
+     * "Array to string conversion" warnings (which fail the test, as
+     * GLPITestCase asserts there are no unexpected log entries).
+     */
+    public function testProcessMassiveActionsForOneItemtypeDoesNotWarnOnArrayValueForForeignKeyNamedField(): void
+    {
+        $ticket = new Ticket();
+        $id = $ticket->add([
+            'name'        => 'test',
+            'content'     => 'test',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->assertGreaterThan(0, $id);
+        $ticket->getFromDB($id);
+
+        $location = new Location();
+        $location_id = $location->add([
+            'name'        => 'test',
+            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
+        ]);
+        $this->assertGreaterThan(0, $location_id);
+
+        $location_so_id = null;
+        foreach (SearchOption::getOptionsForItemtype($ticket->getType()) as $so_id => $so) {
+            if (($so['table'] ?? null) === Location::getTable() && ($so['linkfield'] ?? null) === 'locations_id') {
+                $location_so_id = $so_id;
+                break;
+            }
+        }
+        $this->assertNotNull($location_so_id);
+
+        // Deny update rights so processing stops before reaching update():
+        // this isolates the code path under test (the entity-validation
+        // branch, where the warnings originated) from the actual field
+        // write, which is not what is being tested here.
+        $old_right = $_SESSION['glpiactiveprofile'][Ticket::$rightname] ?? 0;
+        $_SESSION['glpiactiveprofile'][Ticket::$rightname] = 0;
+
+        $this->processMassiveActionsForOneItemtype(
+            'update',
+            $ticket,
+            [$ticket->fields['id']],
+            [
+                'locations_id'   => [$location_id], // array, as a "multiple" field would submit
+                'search_options' => [$ticket->getType() => $location_so_id],
+                'field'          => 'locations_id',
+            ],
+            0,
+            1,
+        );
+
+        $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $old_right;
+    }
 }

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1810,21 +1810,22 @@ class MassiveActionTest extends DbTestCase
      */
     public function testProcessMassiveActionsForOneItemtypeDoesNotWarnOnArrayValueForForeignKeyNamedField(): void
     {
-        $ticket = new Ticket();
-        $id = $ticket->add([
-            'name'        => 'test',
-            'content'     => 'test',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-        ]);
-        $this->assertGreaterThan(0, $id);
-        $ticket->getFromDB($id);
+        $ticket = $this->createItem(
+            Ticket::class,
+            [
+                'name'        => 'test',
+                'content'     => 'test',
+                'entities_id' => $this->getTestRootEntity(true),
+            ]
+        );
 
-        $location = new Location();
-        $location_id = $location->add([
-            'name'        => 'test',
-            'entities_id' => getItemByTypeName('Entity', '_test_root_entity', true),
-        ]);
-        $this->assertGreaterThan(0, $location_id);
+        $location_id = $this->createItem(
+            Location::class,
+            [
+                'name'        => 'test',
+                'entities_id' => $this->getTestRootEntity(true),
+            ]
+        );
 
         $location_so_id = null;
         foreach (SearchOption::getOptionsForItemtype($ticket->getType()) as $so_id => $so) {

--- a/tests/functional/MassiveActionTest.php
+++ b/tests/functional/MassiveActionTest.php
@@ -1825,7 +1825,7 @@ class MassiveActionTest extends DbTestCase
                 'name'        => 'test',
                 'entities_id' => $this->getTestRootEntity(true),
             ]
-        );
+        )->getID();
 
         $location_so_id = null;
         foreach (SearchOption::getOptionsForItemtype($ticket->getType()) as $so_id => $so) {
@@ -1843,19 +1843,21 @@ class MassiveActionTest extends DbTestCase
         $old_right = $_SESSION['glpiactiveprofile'][Ticket::$rightname] ?? 0;
         $_SESSION['glpiactiveprofile'][Ticket::$rightname] = 0;
 
-        $this->processMassiveActionsForOneItemtype(
-            'update',
-            $ticket,
-            [$ticket->fields['id']],
-            [
-                'locations_id'   => [$location_id], // array, as a "multiple" field would submit
-                'search_options' => [$ticket->getType() => $location_so_id],
-                'field'          => 'locations_id',
-            ],
-            0,
-            1,
-        );
-
-        $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $old_right;
+        try {
+            $this->processMassiveActionsForOneItemtype(
+                'update',
+                $ticket,
+                [$ticket->fields['id']],
+                [
+                    'locations_id'   => [$location_id], // array, as a "multiple" field would submit
+                    'search_options' => [$ticket->getType() => $location_so_id],
+                    'field'          => 'locations_id',
+                ],
+                0,
+                1,
+            );
+        } finally {
+            $_SESSION['glpiactiveprofile'][Ticket::$rightname] = $old_right;
+        }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45865
- Here is a brief description of what this PR does

Massive-updating a multi-value field (e.g. a "multiple" dropdown provided by a plugin) logged `Array to string conversion` warnings and could misbehave, because the code assumed a field named like a foreign key (`isForeignKeyField()`) always holds a single scalar value.

`isForeignKeyField($field_name)` matches on naming convention only, so it also matches multi-value fields whose submitted value is an **array** (e.g. `plugin_fields_xxxdropdowns_id`). The code then called `CommonDBTM::getFromDB($field_value)` with that array, which internally calls `Toolbox::cleanInteger()` on it, triggering both warnings.

### Fix

Skip the foreign-key entity-validation branch when `$field_value` is an array, it was never meaningful for multi-value fields anyway.

### Test plan

- Added `testProcessMassiveActionsForOneItemtypeDoesNotWarnOnArrayValueForForeignKeyNamedField` in `tests/functional/MassiveActionTest.php`, reproducing the exact warnings with an array value on a foreign-key-named field.
- Confirmed the test fails without the fix (reproduces both warnings) and passes with it.