### PR TITLE
Fix SQL error in Supplier Items tab for device components

### DIFF
--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -455,16 +455,19 @@ class Supplier extends CommonDBTM
             $linkfield = 'consumableitems_id';
         }
 
-        if ($itemtype === Item_DeviceControl::class) {
-            $criteria['INNER JOIN']['glpi_devicecontrols'] = [
+        if (is_a($itemtype, Item_Devices::class, true) && !$item->isField($itemtype::getNameField())) {
+            $devicetype  = $itemtype::getDeviceType();
+            $devicetable = getTableForItemType($devicetype);
+
+            $criteria['INNER JOIN'][$devicetable] = [
                 'ON' => [
-                    'glpi_items_devicecontrols'   => 'devicecontrols_id',
-                    'glpi_devicecontrols'         => 'id',
+                    $itemtable   => $itemtype::$items_id_2,
+                    $devicetable => 'id',
                 ],
             ];
 
-            $linktype = 'DeviceControl';
-            $linkfield = 'devicecontrols_id';
+            $linktype  = $devicetype;
+            $linkfield = $itemtype::$items_id_2;
         }
 
         $linktable = getTableForItemType($linktype);

--- a/tests/functional/SupplierTest.php
+++ b/tests/functional/SupplierTest.php
@@ -39,10 +39,19 @@ use CartridgeItem;
 use Computer;
 use Consumable;
 use ConsumableItem;
+use DeviceControl;
+use DeviceDrive;
+use DeviceGraphicCard;
+use DeviceNetworkCard;
 use DeviceSimcard;
 use Glpi\Tests\DbTestCase;
 use Infocom;
+use Item_DeviceControl;
+use Item_DeviceDrive;
+use Item_DeviceGraphicCard;
+use Item_DeviceNetworkCard;
 use Item_DeviceSimcard;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Supplier;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -227,5 +236,95 @@ class SupplierTest extends DbTestCase
                 "Missing link to search results for infocom type {$current_itemtype}",
             );
         }
+    }
+
+    public static function deviceComponentProvider(): iterable
+    {
+        yield [
+            'itemtype'      => Item_DeviceDrive::class,
+            'devicetype'    => DeviceDrive::class,
+            'device_fkfield' => 'devicedrives_id',
+        ];
+        yield [
+            'itemtype'      => Item_DeviceGraphicCard::class,
+            'devicetype'    => DeviceGraphicCard::class,
+            'device_fkfield' => 'devicegraphiccards_id',
+        ];
+        yield [
+            'itemtype'      => Item_DeviceNetworkCard::class,
+            'devicetype'    => DeviceNetworkCard::class,
+            'device_fkfield' => 'devicenetworkcards_id',
+        ];
+        yield [
+            'itemtype'      => Item_DeviceControl::class,
+            'devicetype'    => DeviceControl::class,
+            'device_fkfield' => 'devicecontrols_id',
+        ];
+    }
+
+    /**
+     * Non-regression test for https://github.com/glpi-project/glpi/issues/25170
+     *
+     * A Supplier can be linked to a device component (e.g. a hard drive or
+     * graphic card) directly through that component's own "Financial &
+     * Administrative Information" tab. This creates a `glpi_infocoms` row
+     * whose `itemtype` is the `Item_Device*` link class, which is not part
+     * of `$CFG_GLPI['infocom_types']`. Supplier::showInfocoms() must still
+     * be able to display such rows without a SQL error.
+     */
+    #[DataProvider('deviceComponentProvider')]
+    public function testShowInfocomsForDeviceComponents(string $itemtype, string $devicetype, string $device_fkfield): void
+    {
+        $this->login();
+
+        $entities_id = $this->getTestRootEntity(true);
+
+        $supplier = $this->createItem(Supplier::class, [
+            'name'        => $this->getUniqueString(),
+            'entities_id' => $entities_id,
+        ]);
+
+        $computer = getItemByTypeName(Computer::class, '_test_pc01', true);
+
+        $device = $this->createItem($devicetype, [
+            'designation' => $this->getUniqueString(),
+            'entities_id' => $entities_id,
+        ]);
+
+        $item_device = $this->createItem($itemtype, [
+            'itemtype'      => Computer::class,
+            'items_id'      => $computer,
+            $device_fkfield => $device->getID(),
+            'entities_id'   => $entities_id,
+            'serial'        => "{$itemtype}-serial",
+            'otherserial'   => "{$itemtype}-otherserial",
+        ]);
+
+        $this->createItem(Infocom::class, [
+            'entities_id'  => $entities_id,
+            'suppliers_id' => $supplier->getID(),
+            'itemtype'     => $itemtype,
+            'items_id'     => $item_device->getID(),
+        ]);
+
+        ob_start();
+        $supplier->showInfocoms();
+        $out = ob_get_clean();
+
+        $crawler = new Crawler($out);
+        $rows = $crawler->filter('table tbody tr');
+        $this->assertGreaterThan(0, $rows->count(), "No row rendered for {$itemtype}");
+
+        $found = false;
+        foreach ($rows as $row) {
+            $cells = (new Crawler($row))->filter('td');
+            $name_cell = trim($cells->getNode(2)->textContent);
+            if (str_contains($name_cell, $device->fields['designation'])) {
+                $found = true;
+                $this->assertStringContainsString("{$itemtype}-serial", trim($cells->getNode(3)->textContent));
+                $this->assertStringContainsString("{$itemtype}-otherserial", trim($cells->getNode(4)->textContent));
+            }
+        }
+        $this->assertTrue($found, "Missing row for {$itemtype} device '{$device->fields['designation']}'");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #25170.

Setting a Supplier on a device component (hard drive, graphic card, network card, ...) via that component's own **Financial & Administrative Information** tab, then opening the Supplier's **Items** tab, threw:

```
RuntimeException: MySQL query error: Unknown column 'name' in 'SELECT' (1054)
```

`Supplier::getInfocomsForItemtype()` assumed the linked itemtype's `getNameField()` column always exists on its own table. That's false for `Item_Devices` link classes (`Item_DeviceDrive`, `Item_DeviceGraphicCard`, `Item_DeviceNetworkCard`, ...): their display name (`designation`) lives on the associated master `Device*` table, not on the `glpi_items_device*` link table. The code already had a special case for exactly this problem, but hard-coded to `Item_DeviceControl` only.

## Change

Generalized the existing `Item_DeviceControl` special case in `Supplier::getInfocomsForItemtype()` to any  `Item_Devices` subclass whose own table doesn't have the expected name column: it joins the master device table and points the name/entity-restriction/ORDER BY at it, exactly as the `Item_DeviceControl` case already did. Verified
against schema + source for all 18 core `Item_Devices` subclasses: no exceptions. `Item_DeviceSimcard` (which overrides `getNameField()` to `serial`, a column it does have) is correctly unaffected.

## Test plan

- [x] Added `testShowInfocomsForDeviceComponents` in
      `tests/functional/SupplierTest.php`, covering
      `Item_DeviceDrive`, `Item_DeviceGraphicCard`,
      `Item_DeviceNetworkCard` (named in the issue) and
      `Item_DeviceControl` (pre-existing case, regression guard).
- [x] Confirmed the new test fails with the exact reported
      `RuntimeException` /SQL error when the fix is reverted, and passes
      with it applied.
- [x] Existing `testShowInfocoms()` still passes unchanged.

## AI disclosure

Portions of this change (investigation, implementation, and tests) were
produced with AI assistance, reviewed and verified by me before submission