### PR TITLE
Fix KB editor min height

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -398,7 +398,7 @@ body.in_modal .kb-article {
 
 // Reserve the height that the editor will take once tiptap is mounted, which
 // happens asynchronously. Prevent some height issues on chrome based browsers.
-.kb-editor-reserved {
+body.in_modal .kb-editor-reserved {
     min-height: 200px;
 }
 


### PR DESCRIPTION
A min height was added recently to help with display issues on chrome when rendering the KB in a modal (the `Save and add to the knowledge base` feature).

However, it does not look very good outside that modal, especially on empty articles:

<img width="694" height="568" alt="image" src="https://github.com/user-attachments/assets/c3c48884-6931-4c32-ab55-ace8204e263a" />

Since the height only matter for the modal, I've restricted the CSS rule scope and it fixes the issue:

<img width="632" height="328" alt="image" src="https://github.com/user-attachments/assets/47660650-3e40-4d03-ac3f-ca2900b0c1c4" />
