### PR TITLE
Fix valid KB comments being refused due to empty()

### DIFF
--- a/src/Glpi/Controller/Knowbase/AddCommentController.php
+++ b/src/Glpi/Controller/Knowbase/AddCommentController.php
@@ -70,7 +70,7 @@ final class AddCommentController extends AbstractController
 
         // Parse content
         $content = $data['content'] ?? '';
-        if (empty($content)) {
+        if ($content === "") {
             throw new BadRequestHttpException();
         }
 


### PR DESCRIPTION
A valid comment like "0" would be refused due to the nature of the `empty()` method which refuse a lot of "falsy" values.
