### PR TITLE
fix(ticket): honor entity 'Enable notifications by default' for actors added via dropdown

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4992,6 +4992,7 @@ HTML;
             $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);
             $entity_restrict = Session::getMatchingActiveEntities($entity_restrict);
         }
+        $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
 
         // prevent instanciation of bad classes
         if (!is_subclass_of($post['itiltemplate_class'], ITILTemplate::class)) {
@@ -5026,7 +5027,7 @@ HTML;
                     'title'             => sprintf(__('%1$s - %2$s'), $text, $user['name']),
                     'itemtype'          => "User",
                     'items_id'          => $ID,
-                    'use_notification'  => (string) ($user['default_email'] ?? "") !== '' ? 1 : 0,
+                    'use_notification'  => ($default_use_notif && (string) ($user['default_email'] ?? "") !== '') ? 1 : 0,
                     'default_email'     => $user['default_email'],
                     'alternative_email' => '',
                 ];
@@ -5100,7 +5101,7 @@ HTML;
                         $children['items_id']          = $children['id'];
                         $children['id']                = "Supplier_" . $children['id'];
                         $children['itemtype']          = "Supplier";
-                        $children['use_notification']  = (string) ($supplier_obj->fields['email'] ?? '') !== '' ? 1 : 0;
+                        $children['use_notification']  = ($default_use_notif && (string) ($supplier_obj->fields['email'] ?? '') !== '') ? 1 : 0;
                         $children['default_email']     = $supplier_obj->fields['email'];
                         $children['alternative_email'] = '';
                     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4981,6 +4981,7 @@ HTML;
             $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);
             $entity_restrict = Session::getMatchingActiveEntities($entity_restrict);
         }
+        $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
 
         // prevent instanciation of bad classes
         if (!is_subclass_of($post['itiltemplate_class'], ITILTemplate::class)) {
@@ -5015,7 +5016,7 @@ HTML;
                     'title'             => sprintf(__('%1$s - %2$s'), $text, $user['name']),
                     'itemtype'          => "User",
                     'items_id'          => $ID,
-                    'use_notification'  => (string) ($user['default_email'] ?? "") !== '' ? 1 : 0,
+                    'use_notification'  => ($default_use_notif && (string) ($user['default_email'] ?? "") !== '') ? 1 : 0,
                     'default_email'     => $user['default_email'],
                     'alternative_email' => '',
                 ];
@@ -5089,7 +5090,7 @@ HTML;
                         $children['items_id']          = $children['id'];
                         $children['id']                = "Supplier_" . $children['id'];
                         $children['itemtype']          = "Supplier";
-                        $children['use_notification']  = (string) ($supplier_obj->fields['email'] ?? '') !== '' ? 1 : 0;
+                        $children['use_notification']  = ($default_use_notif && (string) ($supplier_obj->fields['email'] ?? '') !== '') ? 1 : 0;
                         $children['default_email']     = $supplier_obj->fields['email'];
                         $children['alternative_email'] = '';
                     }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4248,7 +4248,7 @@ HTML;
                     if (is_numeric($post['searchText'])) {
                         $orwhere['id'] = $post['searchText'];
                     }
-                    if (!empty($orwhere)) {
+                    if ($orwhere !== []) {
                         $criteria['WHERE'][] = ['OR' => $orwhere];
                     }
                 }
@@ -4377,7 +4377,7 @@ HTML;
                             if (is_numeric($post['searchText'])) {
                                 $orwhere['id'] = $post['searchText'];
                             }
-                            if (!empty($orwhere)) {
+                            if ($orwhere !== []) {
                                 $criteria['WHERE'][] = ['OR' => $orwhere];
                             }
                         }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -4992,7 +4992,12 @@ HTML;
             $entity_restrict = Toolbox::jsonDecode($post['entity_restrict']);
             $entity_restrict = Session::getMatchingActiveEntities($entity_restrict);
         }
-        $default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
+        $default_use_notif = Entity::getUsedConfig(
+            'is_notif_enable_default',
+            $post['item']['entities_id'] ?? $_SESSION['glpiactive_entity'],
+            '',
+            1
+        );
 
         // prevent instanciation of bad classes
         if (!is_subclass_of($post['itiltemplate_class'], ITILTemplate::class)) {

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -2616,6 +2616,65 @@ HTML;
         }));
     }
 
+    /**
+     * Test that `getDropdownActors` uses the `is_notif_enable_default` config of the item's entity,
+     * not the one of the session's active entity.
+     *
+     * @return void
+     */
+    public function testGetDropdownActorsUsesItemEntityNotifDefault()
+    {
+        $this->login();
+        $_SESSION['glpiactive_entity'] = 0; // root entity: different from the item's entities below
+
+        $root_id = getItemByTypeName('Entity', 'Root entity', true);
+
+        $notif_entity = $this->createItem(Entity::class, [
+            'name'                   => __FUNCTION__ . '_notif',
+            'entities_id'            => $root_id,
+            'is_notif_enable_default' => 1,
+        ]);
+        $no_notif_entity = $this->createItem(Entity::class, [
+            'name'                   => __FUNCTION__ . '_no_notif',
+            'entities_id'            => $root_id,
+            'is_notif_enable_default' => 0,
+        ]);
+
+        // A user with a default email, visible in the dropdown
+        $user = $this->createItem(User::class, [
+            'name'        => __FUNCTION__,
+            '_useremails' => [
+                -1 => 'user-default-email@example.com',
+            ],
+            '_default_email' => -1,
+        ]);
+
+        $base_post = [
+            'itemtype'           => Ticket::class,
+            'actortype'          => 'requester',
+            'returned_itemtypes' => [User::class],
+            'searchText'         => '',
+        ];
+
+        $results = Dropdown::getDropdownActors($base_post + [
+            'item'        => ['entities_id' => $notif_entity->getID()],
+            '_idor_token' => Session::getNewIDORToken(Ticket::class, $base_post),
+        ], false);
+        $this->assertNotEmpty($results['results']);
+        $user_result = array_filter($results['results'], static fn ($r) => $r['id'] === 'User_' . $user->getID());
+        $this->assertNotEmpty($user_result);
+        $this->assertSame(1, (int) reset($user_result)['use_notification']);
+
+        $results = Dropdown::getDropdownActors($base_post + [
+            'item'        => ['entities_id' => $no_notif_entity->getID()],
+            '_idor_token' => Session::getNewIDORToken(Ticket::class, $base_post),
+        ], false);
+        $this->assertNotEmpty($results['results']);
+        $user_result = array_filter($results['results'], static fn ($r) => $r['id'] === 'User_' . $user->getID());
+        $this->assertNotEmpty($user_result);
+        $this->assertSame(0, (int) reset($user_result)['use_notification']);
+    }
+
     public function testGetDeviceItemTypes()
     {
         $this->login();

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -64,6 +64,7 @@ use Phone;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Printer;
 use Profile;
+use Profile_User;
 use Project;
 use ProjectTask;
 use Session;
@@ -2647,6 +2648,12 @@ HTML;
                 -1 => 'user-default-email@example.com',
             ],
             '_default_email' => -1,
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id'     => $user->getID(),
+            'profiles_id'  => getItemByTypeName(Profile::class, 'Technician', true),
+            'entities_id'  => $root_id,
+            'is_recursive' => 1,
         ]);
 
         $base_post = [


### PR DESCRIPTION
## Fix "Enable notifications by default" for actors added via the search dropdown

Fixes #16829

### Problem

Since GLPI 10.0.0, the entity setting **"Enable notifications by default"** (`is_notif_enable_default`) is ignored when an actor is added to a ticket through the search dropdown (requester / watcher / assignee / supplier).

`Dropdown::getDropdownActors()` hardcodes the default notification state based only on whether the actor has an email address:

```php
'use_notification' => (string) ($user['default_email'] ?? "") !== '' ? 1 : 0,
```

…and the equivalent for suppliers. The front-end stores this value verbatim in the `_actors` JSON and it is saved without re-applying the entity default, so with the setting at **No** the bell still defaults to **ON** for any actor that has an email.

The only path that respects the setting is the auto-prefilled default requester, which is why this went unnoticed for a while. In GLPI 9.5 the notification defaults were correctly derived from `Entity::getUsedConfig('is_notif_enable_default', $entity, '', 1)`.

### Change

In `Dropdown::getDropdownActors()`, compute the default notification state from the entity's `is_notif_enable_default` setting, and only keep the "no email → no notify" guard:

```php
$default_use_notif = Entity::getUsedConfig('is_notif_enable_default', $_SESSION['glpiactive_entity'], '', 1);
// ...
'use_notification'  => ($default_use_notif && (string) ($user['default_email'] ?? "") !== '') ? 1 : 0,
// ...
$default_use_notif and (string) ($supplier_obj->fields['email'] ?? '') !== ''
```

These are the same expressions GLPI already uses elsewhere for this setting (e.g. `Change::getDefaultValues()`, `Problem::getDefaultValues()`).

### Verification

- Reproduced on GLPI 11.0.8 and confirmed present on `11.0/bugfixes`.
- With the entity setting at **No**, `POST /ajax/actors.php` (which calls `getDropdownActors()`) now returns `use_notification: 0` for an actor with an email address; before the change it returned `1`.
- `php -l` passes; no front-end or template changes needed; backwards compatible (an entity with the setting at **Yes**, the default, keeps the previous behaviour).
