### PR TITLE
fix(search): order default lists by first visible column again

### DIFF
--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -432,6 +432,7 @@ final class SearchEngine
         $data['toview'] = SearchOption::getDefaultToView($itemtype, $params);
         if ($p['sort'] === [0]) {
             $p['sort'] = [array_values($data['toview'])[0]];
+            $data['search']['sort'] = $p['sort'];
         }
         $data['meta_toview'] = [];
         if (!$forcetoview) {


### PR DESCRIPTION
## Fix default sorting: order lists by first visible column again

Fixes #25208

### Problem

Since GLPI 11, default list views (Users, Computers, Groups, Entities, Locations, Change, Problem, …) are silently sorted by the **`id`** column instead of the first visible column when the user has not explicitly chosen a sort. The list looks "unsorted" / ordered by an invisible column.

In GLPI 10 the same lists were sorted by the first visible column by default. Clicking a column header still sorts correctly — the bug only affects the **default** case (fresh session / no stored sort).

### Root cause

In `SearchEngine::prepareDataForSearch()`:

```php
$data['search'] = $p;                                   // (1) snapshot — sort is [0] here
// ...
$data['toview'] = SearchOption::getDefaultToView($itemtype, $params);
if ($p['sort'] === [0]) {
    $p['sort'] = [array_values($data['toview'])[0]];    // (2) only $p is updated
}
```

`$data['search']` is copied before the default sort substitution, so the later `$p['sort']` assignment is never propagated back. `SQLProvider::constructSQL()` then reads `$data['search']['sort']` (still `[0]`), which never matches any element of `tocompute` in the ORDER BY loop, so the fallback `ORDER BY id` is used.

### Change

One-line synchronization of the corrected default sort back into `$data['search']`:

```php
$data['toview'] = SearchOption::getDefaultToView($itemtype, $params);
if ($p['sort'] === [0]) {
    $p['sort'] = [array_values($data['toview'])[0]];
    $data['search']['sort'] = $p['sort'];
}
```

### Verification

- Reproduced on GLPI 11.0.8 and confirmed present on `11.0/bugfixes`.
- With no explicit sort, the generated SQL is now `ORDER BY ITEM_<ItemType>_<first visible searchopt> ASC` (e.g. `ORDER BY name ASC` for Users, `ITEM_Computer_1`, `ITEM_Group_1`, `ITEM_Entity_1`, `ITEM_Location_1`, `ITEM_Change_2`, …) instead of `ORDER BY id`.
- Explicit sort behavior is unchanged.
- `php -l` clean.
