### PR TITLE
fix: display linked socket in network ports list

### DIFF
--- a/src/NetworkPort.php
+++ b/src/NetworkPort.php
@@ -958,6 +958,12 @@ class NetworkPort extends CommonDBChild
                         case 6:
                             $output .= htmlescape(Dropdown::getYesNo($port['is_deleted']));
                             break;
+                        case 9:
+                            $socket = new Socket();
+                            if ($socket->getFromDBByCrit(['networkports_id' => $port['id']])) {
+                                $output .= $socket->getLink();
+                            }
+                            break;
                         case 1:
                             if ($agg === true) {
                                 $td_class = 'aggregated';
@@ -1580,15 +1586,17 @@ class NetworkPort extends CommonDBChild
             'massiveaction'      => false,
         ];
 
-        if ($this->isField('sockets_id')) {
-            $tab[] = [
-                'id'                 => '9',
-                'table'              => 'glpi_sockets',
-                'field'              => 'name',
-                'name'               => Socket::getTypeName(1),
-                'datatype'           => 'dropdown',
-            ];
-        }
+        $tab[] = [
+            'id'                 => '9',
+            'table'              => 'glpi_sockets',
+            'field'              => 'name',
+            'name'               => Socket::getTypeName(1),
+            'datatype'           => 'dropdown',
+            'joinparams'         => [
+                'jointype'  => 'child',
+                'linkfield' => 'networkports_id',
+            ],
+        ];
 
         $tab[] = [
             'id'                 => '16',

--- a/tests/functional/NetworkPortTest.php
+++ b/tests/functional/NetworkPortTest.php
@@ -37,6 +37,7 @@ namespace tests\units;
 use Glpi\Asset\Capacity;
 use Glpi\Asset\Capacity\HasNetworkPortCapacity;
 use Glpi\Features\Clonable;
+use Glpi\Socket;
 use Glpi\Tests\DbTestCase;
 use NetworkPort;
 use NetworkPortEthernet;
@@ -457,6 +458,63 @@ class NetworkPortTest extends DbTestCase
                     $this->assertStringContainsString((string) $netport->fields[$column['field']], $result);
                 }
             }
+        }
+    }
+
+    public function testShowForItemDisplaysLinkedSocket()
+    {
+        $this->login();
+
+        $computer = getItemByTypeName('Computer', '_test_pc01');
+
+        // Add a network port with a linked socket
+        $networkport = new NetworkPort();
+        $np_id = $networkport->add([
+            'items_id'                    => $computer->getID(),
+            'itemtype'                    => 'Computer',
+            'entities_id'                 => $computer->fields['entities_id'],
+            'is_recursive'                => 0,
+            'logical_number'              => 7,
+            'mac'                         => '00:24:81:eb:c6:d7',
+            'instantiation_type'          => 'NetworkPortEthernet',
+            'name'                        => 'eth_socket',
+            'items_devicenetworkcards_id' => 0,
+            'type'                        => 'T',
+            'speed'                       => 1000,
+            '_create_children'            => true,
+        ]);
+        $this->assertGreaterThan(0, (int) $np_id);
+
+        $socket = new Socket();
+        $sockets_id = $socket->add([
+            'name'        => 'socket_1',
+            'items_id'    => '',
+            'itemtype'    => '',
+        ]);
+        $this->assertGreaterThan(0, (int) $sockets_id);
+
+        $ethernetPort = new NetworkPortEthernet();
+        $this->assertTrue($ethernetPort->getFromDBByCrit(['networkports_id' => $np_id]));
+        $this->assertTrue($ethernetPort->update([
+            'id'               => $ethernetPort->getID(),
+            'sockets_id'       => $sockets_id,
+            'networkports_id'  => $np_id,
+        ]));
+
+        // Add the socket display preference (option 9)
+        $displaypref = new \DisplayPreference();
+        $this->assertGreaterThan(0, (int) $displaypref->add([
+            'itemtype' => 'NetworkPort',
+            'users_id' => \Session::getLoginUserID(),
+            'num'      => 9,
+        ]));
+
+        foreach (['showForItem', 'displayTabContentForItem'] as $method) {
+            ob_start();
+            NetworkPort::$method($computer);
+            $result = ob_get_clean();
+            $this->assertStringContainsString(Socket::getTypeName(1), $result);
+            $this->assertStringContainsString('socket_1', $result);
         }
     }
 

--- a/tests/functional/NetworkPortTest.php
+++ b/tests/functional/NetworkPortTest.php
@@ -516,6 +516,16 @@ class NetworkPortTest extends DbTestCase
             $this->assertStringContainsString(Socket::getTypeName(1), $result);
             $this->assertStringContainsString('socket_1', $result);
         }
+
+        // Check that the search engine can filter by the linked socket (option 9).
+        // This tests the JOIN between glpi_networkports and glpi_sockets, which is
+        // the actual fix for filtering/sorting by socket.
+        $data = \Search::getDatas('NetworkPort', [
+            'criteria' => [
+                ['field' => 9, 'searchtype' => 'contains', 'value' => 'socket_1'],
+            ],
+        ], [9]);
+        $this->assertGreaterThan(0, $data['data']['totalcount']);
     }
 
     public function testCanViewItemWithoutGlobalReadRight()


### PR DESCRIPTION
Fixes #11258

## Problem

Since GLPI 10, the *Network sockets* column no longer appears in the network ports list and in the tab shown on asset pages (Computer, NetworkEquipment, Phone, ...). In 9.5 the socket of each port was visible in this list; from 10.0 onward the column vanished entirely even though ports can still be linked to a socket (the socket model moved to `glpi_sockets`, linked through `glpi_sockets.networkports_id`). I can reproduce it on a current 11.0.x instance: a port that has a socket linked shows nothing about it in the ports table, and the socket option is not even offered in the "Select default items to show" display preferences.

This is the regression reported in #11258 (closed without a fix).

## Root cause

In `NetworkPort::rawSearchOptions()` the socket search option (id 9) is declared behind this guard:

```php
if ($this->isField('sockets_id')) {
    $tab[] = [
        'id'                 => '9',
        'table'              => 'glpi_sockets',
        'field'              => 'name',
        ...
    ];
}
```

`isField()` checks the columns of `glpi_networkports`, and `glpi_networkports` has never had a `sockets_id` column. In 9.5 the equivalent option was guarded by `netpoints_id` and the socket lived on the main table; in 10 the data model moved the link to `glpi_sockets.networkports_id`, but the guard was ported over as-is and always evaluates to false. The option therefore never makes it into the list, and even when the port does have a socket attached nothing is rendered.

## Change

`src/NetworkPort.php`:

- Always add search option 9, with a proper child join on `glpi_sockets.networkports_id` (same join pattern the instantiation search options already use for sockets).
- Add a `case 9` in `NetworkPort::showPort()` so the linked socket name is rendered in the table when the column is selected. Ports without a linked socket simply show an empty cell.

`tests/functional/NetworkPortTest.php`:

- New `testShowForItemDisplaysLinkedSocket`: creates a computer, an Ethernet port, a socket, links the socket to the port, enables display preference 9, and checks that both the column header and the socket value are rendered by `showForItem()`/`displayTabContentForItem()`.

## Verification

- `php -l` clean on both files.
- Reproduced the regression on a live 11.0.8 instance (fresh port with a linked socket shows no socket information, option 9 absent from display preferences).
- With the patch applied on the same instance: the `Network socket` column is available in the display preferences picker, appears in the ports tab, and shows the linked socket. Verified through both `showForItem()` and `displayTabContentForItem()`.
- No behavior change when no socket is linked (empty cell).
