### PR TITLE
Fix: menu dropdowns cannot be expanded on mobile when sidebar is folded

### DIFF
--- a/templates/layout/parts/menu.html.twig
+++ b/templates/layout/parts/menu.html.twig
@@ -133,7 +133,11 @@ $(function() {
 
       // opening a sub menu close others
       menuDropdown.addEventListener('show.bs.dropdown', function (event) {
-          if ($('body').hasClass('navbar-collapsed')) {
+          // The CSS-only "flyout on hover" replacement for Bootstrap's dropdown only
+          // exists at the `lg` breakpoint and up (see _global-menu.scss, min-width:992px).
+          // Below that, the sidebar is an off-canvas mobile menu: dropdowns must stay
+          // Bootstrap-driven or they can never be opened (glpi-project/glpi#23124).
+          if ($('body').hasClass('navbar-collapsed') && window.matchMedia('(min-width: 992px)').matches) {
               // Dropdown submenus will be shown with CSS, and shouldn't be handled by Bootstrap
               event.preventDefault();
               event.stopPropagation();


### PR DESCRIPTION
The show.bs.dropdown handler blocks Bootstrap's native dropdown toggle whenever body has the navbar-collapsed class (fold_menu preference), assuming the CSS-only hover flyout will take over. That CSS is scoped to min-width:992px (_global-menu.scss), so below that breakpoint the dropdown is blocked with no fallback and can never be opened.

Gate the guard to the same breakpoint the CSS uses, so mobile keeps native Bootstrap dropdown behavior regardless of the user's desktop fold preference.

Fixes #23124

<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #23124

Sidebar dropdown categories (e.g. Assets, Administration) could not be expanded on mobile viewports.

`templates/layout/parts/menu.html.twig` blocks Bootstrap's native `show.bs.dropdown` event whenever `<body>` has the `navbar-collapsed` class (the `fold_menu` user preference), assuming a CSS-only `:hover` flyout will take over instead. That CSS rule only exists at `min-width: 992px` (`css/includes/components/_global-menu.scss`), and touch devices have no `:hover` anyway — so below that breakpoint, any user whose `fold_menu` preference is truthy gets their sidebar dropdowns permanently blocked with no fallback.

Reproduced on a clean 11.0.4 / 11.0.8 install: set `fold_menu = 1` (or `NULL`) for a user, open the sidebar on a mobile viewport, tap any category with sub-items — nothing opens. With `fold_menu = 0` it works normally.

**Fix**: gate the existing `navbar-collapsed` check to the same breakpoint the SCSS already uses, so it only applies where the CSS fallback it depends on actually exists. Desktop behavior (fold/unfold, hover flyouts) is unchanged; below `lg`, Bootstrap's native dropdown toggle is left alone.

## Screenshots (if appropriate):

N/A — behavioral/JS fix, no visual change on desktop; on mobile the dropdown now opens as expected.


