### PR TITLE
fix custom assets in my devices dropdown

### DIFF
--- a/src/Glpi/Asset/AssetDefinitionManager.php
+++ b/src/Glpi/Asset/AssetDefinitionManager.php
@@ -196,6 +196,11 @@ final class AssetDefinitionManager extends AbstractDefinitionManager
             'state_types',
             'ticket_types',
             'unicity_types',
+            // keys derived from assignable_types which need manually updated
+            'linkuser_types',
+            'linkgroup_types',
+            'linkuser_tech_types',
+            'linkgroup_tech_types',
         ];
         foreach ($config_keys as $config_key) {
             if (!in_array($asset_class_name, $CFG_GLPI[$config_key], true)) {

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -3191,7 +3191,7 @@ HTML;
 
         // Check dropdown results
         $results = Dropdown::getDropdownMyDevices([
-            'entity_restrict' => $_SESSION["glpiactiveentities"]
+            'entity_restrict' => $_SESSION["glpiactiveentities"],
         ], false)['results'];
         $has_match = false;
         foreach ($results as $result) {

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -3180,10 +3180,13 @@ HTML;
         $this->login();
 
         $custom_asset = getItemByTypeName('Glpi\\CustomAsset\\Test01Asset', 'TestA');
-        $this->assertTrue($custom_asset->update([
-            'id' => $custom_asset->getID(),
-            'users_id' => Session::getLoginUserID(),
-        ]));
+        $custom_asset = $this->updateItem(
+            'Glpi\\CustomAsset\\Test01Asset',
+            $custom_asset->getID(),
+            [
+                'users_id' => Session::getLoginUserID(),
+            ]
+        );
 
         // Ensure user has permission to see the asset and has permission to link that type of custom asset to tickets
         $_SESSION["glpiactiveprofile"]["asset_test01"] = 3871;

--- a/tests/functional/DropdownTest.php
+++ b/tests/functional/DropdownTest.php
@@ -3174,4 +3174,35 @@ HTML;
         $this->assertContains($computer_with_contact_id, $ids);
         $this->assertNotContains($other_computer_id, $ids);
     }
+
+    public function testGetDropdownMyDevicesCustomAsset(): void
+    {
+        $this->login();
+
+        $custom_asset = getItemByTypeName('Glpi\\CustomAsset\\Test01Asset', 'TestA');
+        $this->assertTrue($custom_asset->update([
+            'id' => $custom_asset->getID(),
+            'users_id' => Session::getLoginUserID(),
+        ]));
+
+        // Ensure user has permission to see the asset and has permission to link that type of custom asset to tickets
+        $_SESSION["glpiactiveprofile"]["asset_test01"] = 3871;
+        $_SESSION["glpiactiveprofile"]["helpdesk_item_type"][] = 'Glpi\\CustomAsset\\Test01Asset';
+
+        // Check dropdown results
+        $results = Dropdown::getDropdownMyDevices([
+            'entity_restrict' => $_SESSION["glpiactiveentities"]
+        ], false)['results'];
+        $has_match = false;
+        foreach ($results as $result) {
+            if ($result['text'] === 'My Test01') {
+                foreach ($result['children'] as $child_result) {
+                    if ($child_result['text'] === 'TestA') {
+                        $has_match = true;
+                    }
+                }
+            }
+        }
+        $this->assertTrue($has_match);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

fixes #25067

Custom assets were not being added to the `CFG_GLPI` arrays that were derived from `assignable_types` which caused them to be excluded from the My Devices dropdown.