### PR TITLE
webhooks use real parent item schema for body content

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -640,17 +640,10 @@ class Webhook extends CommonDBTM implements FilterableInterface
         } else {
             return;
         }
-        $parent_schema = self::getParentItemSchema($itemtype);
-        // filter properties in parent schema by the resolved parent itemtype (checks the x-parent-itemtype property)
-        foreach ($parent_schema['properties'] as $property_name => $property_data) {
-            if (in_array($parent_itemtype, $property_data['x-parent-itemtype'] ?? [], true)) {
-                $parent_schema['properties'][$property_name] = $property_data;
-            } else {
-                unset($parent_schema['properties'][$property_name]);
-            }
+        $parent_schema = self::getAPISchemaBySupportedItemtype($parent_itemtype);
+        if ($parent_schema === null) {
+            throw new LogicException("Parent itemtype $parent_itemtype does not have a valid API schema");
         }
-        $parent_schema['x-itemtype'] = $parent_itemtype;
-        unset($parent_schema['x-subtypes']);
         $parent_result = ResourceAccessor::getOneBySchema($parent_schema, [
             'itemtype' => $parent_itemtype,
             'id' => $parent_id,

--- a/tests/functional/WebhookTest.php
+++ b/tests/functional/WebhookTest.php
@@ -34,6 +34,7 @@
 
 namespace tests\units;
 
+use Change;
 use Glpi\Api\HL\Controller\AbstractController;
 use Glpi\Search\CriteriaFilter;
 use Glpi\Tests\DbTestCase;
@@ -592,5 +593,69 @@ JSON;
             static fn(string $msg) => stripos($msg, 'webhook') !== false
         );
         $this->assertEmpty($webhook_errors);
+    }
+
+    public function testParentItemResolvedProperly(): void
+    {
+        $entity_id = $this->getTestRootEntity(only_id: true);
+        $this->login();
+
+        // Create webhook for new followups
+        $webhook = $this->createItem(Webhook::class, [
+            'name'                => 'Test webhook',
+            'entities_id'         => $entity_id,
+            'url'                 => 'http://localhost',
+            'itemtype'            => ITILFollowup::class,
+            'event'               => 'new',
+            'is_active'           => 1,
+            'use_default_payload' => 1,
+        ]);
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'Test ticket',
+            'entities_id' => $entity_id,
+            '_actors' => [
+                'observer' => [
+                    [
+                        'itemtype' => User::class,
+                        'items_id' => 2,
+                    ],
+                ],
+            ],
+        ]);
+
+        $change = $this->createItem(Change::class, [
+            'name' => 'Test change',
+            'entities_id' => $entity_id,
+            '_actors' => [
+                'observer' => [
+                    [
+                        'itemtype' => User::class,
+                        'items_id' => 3,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->createItem(ITILFollowup::class, [
+            'items_id' => $ticket->getID(),
+            'itemtype' => Ticket::class,
+            'content'  => 'Test followup for ticket',
+        ]);
+
+        $this->createItem(ITILFollowup::class, [
+            'items_id' => $change->getID(),
+            'itemtype' => Change::class,
+            'content'  => 'Test followup for change',
+        ]);
+
+        $webhooks = array_values(getAllDataFromTable(QueuedWebhook::getTable(), ['webhooks_id' => $webhook->getID()]));
+        $this->assertCount(2, $webhooks);
+        $team_1 = json_decode($webhooks[0]['body'], true)['parent_item']['team'][0];
+        $team_2 = json_decode($webhooks[1]['body'], true)['parent_item']['team'][0];
+        $this->assertSame('glpi', $team_1['name']);
+        $this->assertSame('observer', $team_1['role']);
+        $this->assertSame('post-only', $team_2['name']);
+        $this->assertSame('observer', $team_2['role']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

fixes #25016

Use the real, resolve parent itemtype's schema instead of using the merged schema that is only useful for generating the Monaco suggestions.

