### PR TITLE
Do not clear provided begin/end dates in new planning events

### DIFF
--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -152,7 +152,8 @@ trait PlanningEvent
             $input["name"] = __('Without title');
         }
 
-        $input["begin"] = $input["end"] = "NULL";
+        $input["begin"] ??= 'NULL';
+        $input["end"] ??= "NULL";
 
         if (isset($input['plan'])) {
             if (

--- a/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/ITILControllerTest.php
@@ -744,4 +744,22 @@ class ITILControllerTest extends HLAPITestCase
             'cost_fixed' => 150,
         ]);
     }
+
+    public function testCRUDExternalEvent(): void
+    {
+        $entities_id = $this->getTestRootEntity(true);
+
+        $this->api->autoTestCRUD('/Assistance/ExternalEvent', [
+            'name' => __FUNCTION__,
+            'text' => 'test',
+            'entity' => $entities_id,
+            'user' => 2,
+            'date_begin' => date(\DateTimeInterface::RFC3339, strtotime('+1 day')),
+            'date_end' => date(\DateTimeInterface::RFC3339, strtotime('+2 days')),
+        ], [
+            'name' => __FUNCTION__ . '2',
+            'date_begin' => date(\DateTimeInterface::RFC3339, strtotime('+3 days')),
+            'date_end' => date(\DateTimeInterface::RFC3339, strtotime('+4 days')),
+        ]);
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #24651