### PR TITLE
Fix KB "+" button reacting to middle clicks

### DIFF
--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -294,31 +294,25 @@ export class GlpiKnowbaseAsideController
 
     #initCreateArticle()
     {
-        // The links are rendered with pe-none so a click cannot fall through to
-        // their plain href before the listener below exists.
-        for (const add_link of this.#aside.querySelectorAll('[data-glpi-kb-aside-category-add]')) {
-            add_link.classList.remove('pe-none');
-        }
-
         this.#aside.addEventListener('click', (e) => {
-            const add_link = e.target.closest('[data-glpi-kb-aside-category-add]');
-            if (!add_link) {
+            const add_button = e.target.closest('[data-glpi-kb-aside-category-add]');
+            if (!add_button) {
                 return;
             }
             e.preventDefault();
-            this.#openCreateInput(add_link);
+            this.#openCreateInput(add_button);
         });
     }
 
     /**
-     * @param {HTMLElement} add_link
+     * @param {HTMLElement} add_button
      */
-    #openCreateInput(add_link)
+    #openCreateInput(add_button)
     {
-        const header = add_link.closest('[data-glpi-kb-aside-category-header]');
+        const header = add_button.closest('[data-glpi-kb-aside-category-header]');
         const node = header.closest('[data-glpi-kb-aside-category]');
         const list = node.querySelector(':scope > ul');
-        const parent_id = Number(new URL(add_link.href).searchParams.get('knowbaseitems_id_parent')) || 0;
+        const parent_id = Number(add_button.dataset.glpiKbAsideCategoryAdd) || 0;
 
         // The list is hidden while the node is collapsed, so the input below
         // would be inserted into a `display: none` subtree: invisible, and

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -81,17 +81,15 @@
                 <span data-glpi-kb-article-title>{{ article.title }}</span>
             </a>
             {% if can_create %}
-                {% set add_href = path('/front/knowbaseitem.form.php', {knowbaseitems_id_parent: article.id}) %}
-                {% set add_title = __('Create a child article') %}
-                <a
-                    href="{{ add_href }}"
-                    class="d-flex align-items-center ms-2 p-1 text-secondary pe-none"
-                    data-glpi-kb-aside-category-add
+                <button
+                    type="button"
+                    class="d-flex align-items-center ms-2 p-1 text-secondary border-0 bg-transparent"
+                    data-glpi-kb-aside-category-add="{{ article.id }}"
                     aria-label="{{ __('Create an article under %s')|format(article.title) }}"
-                    title="{{ add_title }}"
+                    title="{{ __('Create a child article') }}"
                 >
                     <i class="ti ti-plus" aria-hidden="true"></i>
-                </a>
+                </button>
             {% endif %}
             {% if show_actions %}
                 {{ actions_menu.render_actions_menu_lazy() }}

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -86,7 +86,7 @@
                     class="d-flex align-items-center ms-2 p-1 text-secondary border-0 bg-transparent"
                     data-glpi-kb-aside-category-add="{{ article.id }}"
                     aria-label="{{ __('Create an article under %s')|format(article.title) }}"
-                    title="{{ __('Create a child article') }}"
+                    title="{{ __('Create a child article under %s')|format(article.title) }}"
                 >
                     <i class="ti ti-plus" aria-hidden="true"></i>
                 </button>

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -502,14 +502,14 @@ export class KnowbaseItemPage extends GlpiPage
     }
 
     /**
-     * The "+" link that creates a child article under the given (parent)
+     * The "+" button that creates a child article under the given (parent)
      * article's aside tree node. Hidden until the node's header is hovered
      * or focused (see `_kb.scss`), hence exposed separately from
      * `getAsideCategoryArticle()`.
      */
-    public getAsideCategoryAddLink(title: string): Locator
+    public getAsideCategoryAddButton(title: string): Locator
     {
-        return this.getAsideCategory(title).getByRole('link', {
+        return this.getAsideCategory(title).getByRole('button', {
             name: new RegExp(`Create an article under ${title}`, 'i'),
         });
     }

--- a/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
+++ b/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
@@ -57,18 +57,16 @@ test('the aside "+" opens an inline input under a parent article; an empty submi
 
     await kb.goto(parent_id);
 
-    // The "+" click is intercepted by AsideController (a dynamically
-    // imported module), instead of being a plain <a href> navigation. Wait
-    // for the controller to finish initializing before clicking it, using
-    // the same readiness signal doSearchAside() relies on, otherwise the
-    // click can race the module load and fall through to the browser's
-    // default navigation.
+    // The "+" is handled by AsideController (a dynamically imported module).
+    // Wait for the controller to finish initializing before clicking it, using
+    // the same readiness signal doSearchAside() relies on, otherwise the click
+    // can race the module load and do nothing.
     await expect(kb.asideSearchInput).not.toHaveClass(/pe-none/);
 
-    const add_link = kb.getAsideCategoryAddLink(parent_name);
+    const add_button = kb.getAsideCategoryAddButton(parent_name);
     await kb.getAsideArticleTitleLink(parent_name).hover();
-    await expect(add_link).toBeVisible();
-    await add_link.click();
+    await expect(add_button).toBeVisible();
+    await add_button.click();
 
     // No navigation: the "+" now opens an inline input instead of a full page.
     await expect(page).not.toHaveURL(/knowbaseitems_id_parent=/);
@@ -80,13 +78,13 @@ test('the aside "+" opens an inline input under a parent article; an empty submi
     await expect(inline_input).toBeHidden();
 
     // Re-open and blur while empty: same result.
-    await add_link.click();
+    await add_button.click();
     await expect(kb.getAsideCategoryCreateInput(parent_name)).toBeFocused();
     await page.keyboard.press('Tab');
     await expect(kb.getAsideCategoryCreateInput(parent_name)).toBeHidden();
 });
 
-test('hovering a child article does not reveal its parent\'s add-article link', async ({ page, profile, api }) => {
+test('hovering a child article does not reveal its parent\'s add-article button', async ({ page, profile, api }) => {
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
@@ -108,12 +106,12 @@ test('hovering a child article does not reveal its parent\'s add-article link', 
 
     await kb.goto(child_id);
 
-    const parent_add = kb.getAsideCategoryAddLink(parent_name);
-    const child_add = kb.getAsideCategoryAddLink(child_name);
+    const parent_add = kb.getAsideCategoryAddButton(parent_name);
+    const child_add = kb.getAsideCategoryAddButton(child_name);
 
     await kb.getAsideArticleTitleLink(child_name).hover();
 
-    // visibility:hidden removes the parent link from the a11y tree, so the
+    // visibility:hidden removes the parent button from the a11y tree, so the
     // role-based locator resolves to nothing — assert visibility, not CSS.
     await expect(child_add).toBeVisible();
     await expect(parent_add).toBeHidden();
@@ -135,17 +133,15 @@ test('typing a title and pressing Enter creates the child article and navigates 
 
     await kb.goto(parent_id);
 
-    // The "+" click is intercepted by AsideController (a dynamically imported
-    // module) instead of being a plain <a href> navigation. Wait for the
-    // controller to finish initializing before clicking it, using the same
-    // readiness signal doSearchAside() relies on, otherwise the click can
-    // race the module load and fall through to the browser's default
-    // navigation.
+    // The "+" is handled by AsideController (a dynamically imported module).
+    // Wait for the controller to finish initializing before clicking it, using
+    // the same readiness signal doSearchAside() relies on, otherwise the click
+    // can race the module load and do nothing.
     await expect(kb.asideSearchInput).not.toHaveClass(/pe-none/);
 
-    const add_link = kb.getAsideCategoryAddLink(parent_name);
+    const add_button = kb.getAsideCategoryAddButton(parent_name);
     await kb.getAsideArticleTitleLink(parent_name).hover();
-    await add_link.click();
+    await add_button.click();
 
     const inline_input = kb.getAsideCategoryCreateInput(parent_name);
     await expect(inline_input).toBeFocused();
@@ -202,9 +198,9 @@ test('the "+" on a folded article expands it, so the inline input is usable', as
 
     // The "+" must expand the node before inserting the inline input, else the
     // input lands in a hidden subtree: invisible, and impossible to focus.
-    const add_link = kb.getAsideCategoryAddLink(parent_name);
+    const add_button = kb.getAsideCategoryAddButton(parent_name);
     await kb.getAsideArticleTitleLink(parent_name).hover();
-    await add_link.click();
+    await add_button.click();
 
     await expect(parent_toggle).toHaveAttribute('aria-expanded', 'true');
     const inline_input = kb.getAsideCategoryCreateInput(parent_name);


### PR DESCRIPTION
This button was a link for some reason:

<img width="362" height="218" alt="image" src="https://github.com/user-attachments/assets/44e2e960-95e7-4c37-a046-d3668d95ab83" />

It allowed users to middle click on it and skip its handler.
I've made it a proper button to prevent that.
