### PR TITLE
Fix gettext warning about strings embedding URLs

### DIFF
--- a/src/Glpi/System/Requirement/DbTimezones.php
+++ b/src/Glpi/System/Requirement/DbTimezones.php
@@ -65,7 +65,7 @@ class DbTimezones extends AbstractRequirement
 
         if (count($available_timezones) === 0) {
             $this->validated = false;
-            $this->validation_messages[] = __('Timezones seems not loaded, see https://glpi-install.readthedocs.io/en/latest/timezones.html.');
+            $this->validation_messages[] = sprintf(__('Timezones seems not loaded, see %1$s'), 'https://glpi-install.readthedocs.io/en/latest/timezones.html.');
             return;
         }
 


### PR DESCRIPTION
Fixes the following gettext warning on locales extraction: 
```
./src/Glpi/System/Requirement/DbTimezones.php:68: AVERTISSEMENT : Message contains an embedded URL.  Better move it out of the translatable string, see https://www.gnu.org/software/gettext/manual/html_node/No-embedded-URLs.html
```