### PR TITLE
Add QueryValue - Accept any query element in QueryFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The present file will list all changes made to the project; according to the
 - `Glpi\DBAL\QueryValue`, to designate a scalar value used in a statement. It renders as a `?` placeholder and carries the value to bind for it, instead of the value being inlined into the SQL. Not to be confused with `QueryParam`, which renders as `?` but binds nothing.
 
 #### Changes
+- `QueryFunction` methods now accept any `QueryElementInterface` where they used to accept only a `string` or a `QueryExpression`
 - `Session::haveRight()` now only returns a boolean
 - All `CommonGLPI`, `CommonDBTM` parameters now have a native PHP type
 - `KnowbaseItem_Comment` is now final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The present file will list all changes made to the project; according to the
 #### Added
 - `Glpi\DBAL\QueryElementInterface`, implemented by every SQL building block that may carry bound values (`QueryExpression`, `QueryIdentifier`, `QueryValue`, `AbstractQuery`). It exposes `getValue()` for the SQL fragment and `getParams()` for the values to bind for its `?` placeholders; both must always be used together.
 - `Glpi\DBAL\QueryIdentifier`, to designate a database identifier (table or field name) that has to be quoted, instead of relying on a bare string.
+- `Glpi\DBAL\QueryValue`, to designate a scalar value used in a statement. It renders as a `?` placeholder and carries the value to bind for it, instead of the value being inlined into the SQL. Not to be confused with `QueryParam`, which renders as `?` but binds nothing.
 
 #### Changes
 - `Session::haveRight()` now only returns a boolean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The present file will list all changes made to the project; according to the
 - Type declarations for some `CronTask` methods have been added.
 
 #### Added
+- `Glpi\DBAL\QueryElementInterface`, implemented by every SQL building block that may carry bound values (`QueryExpression`, `QueryIdentifier`, `QueryValue`, `AbstractQuery`). It exposes `getValue()` for the SQL fragment and `getParams()` for the values to bind for its `?` placeholders; both must always be used together.
+- `Glpi\DBAL\QueryIdentifier`, to designate a database identifier (table or field name) that has to be quoted, instead of relying on a bare string.
 
 #### Changes
 - `Session::haveRight()` now only returns a boolean

--- a/ajax/dropdownConnectNetworkPort.php
+++ b/ajax/dropdownConnectNetworkPort.php
@@ -38,6 +38,7 @@
  */
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 
 global $DB;
 
@@ -103,7 +104,7 @@ if (
                     'glpi_networkports_networkports' => 'networkports_id_1',
                     'glpi_networkports'              => 'id', [
                         'OR'  => [
-                            'glpi_networkports_networkports.networkports_id_2' => new QueryExpression($DB::quoteName('glpi_networkports.id')),
+                            'glpi_networkports_networkports.networkports_id_2' => new QueryIdentifier('glpi_networkports.id'),
                         ],
                     ],
                 ],

--- a/ajax/selectUnaffectedOrNewItem_Device.php
+++ b/ajax/selectUnaffectedOrNewItem_Device.php
@@ -40,6 +40,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Exception\Http\BadRequestHttpException;
 
 global $DB;
@@ -69,7 +70,7 @@ if (
         $keys = array_keys($specificities);
         $name_field = QueryFunction::concat_ws(
             separator: new QueryExpression($DB::quoteValue(' - ')),
-            params: array_map(static fn($k) => QueryFunction::ifnull($k, new QueryExpression($DB::quoteValue(''))), $keys),
+            params: array_map(static fn($k) => QueryFunction::ifnull(new QueryIdentifier($k), new QueryExpression($DB::quoteValue(''))), $keys),
             alias: 'name'
         );
         $label_pattern = implode(' - ', array_map(

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -36,6 +36,7 @@
 use Glpi\Api\HL\Router;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Error\ErrorHandler;
 use Glpi\Event;
 use Glpi\Plugin\Hooks;
@@ -452,13 +453,13 @@ class Auth extends CommonGLPI
                     'id',
                     'password',
                     QueryFunction::dateAdd(
-                        date: 'password_last_update',
+                        date: new QueryIdentifier('password_last_update'),
                         interval: $pass_expiration_delay,
                         interval_unit: 'DAY',
                         alias: 'password_expiration_date'
                     ),
                     QueryFunction::dateAdd(
-                        date: 'password_last_update',
+                        date: new QueryIdentifier('password_last_update'),
                         interval: $pass_expiration_delay + $lock_delay,
                         interval_unit: 'DAY',
                         alias: 'lock_date'

--- a/src/BarcodeManager.php
+++ b/src/BarcodeManager.php
@@ -37,6 +37,7 @@ use Com\Tecnick\Barcode\Barcode;
 use Com\Tecnick\Barcode\Model;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 class BarcodeManager
 {
@@ -93,7 +94,7 @@ class BarcodeManager
                 'datatype'      => 'string',
                 'computation'   => QueryFunction::concat([
                     new QueryExpression('?', null, [$url_prefix]),
-                    'TABLE.id',
+                    new QueryIdentifier('TABLE.id'),
                 ]),
             ],
         ];

--- a/src/Budget.php
+++ b/src/Budget.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Features\Clonable;
@@ -396,7 +397,7 @@ class Budget extends CommonDropdown
                                       + " . $DB::quoteName("$cost_table.cost_material")),
                     alias: 'value'
                 ),
-                default => QueryFunction::sum(expression: "{$cost_table}.cost", alias: 'value'),
+                default => QueryFunction::sum(expression: new QueryIdentifier("{$cost_table}.cost"), alias: 'value'),
             };
             $criteria['SELECT'][] = $item->maybeDeleted() ? "$item_table.is_deleted" : '0 AS is_deleted';
 
@@ -488,7 +489,7 @@ class Budget extends CommonDropdown
 
             $criteria = [
                 'SELECT' => [
-                    QueryFunction::count("{$item_table}.id", true, 'cpt'),
+                    QueryFunction::count(new QueryIdentifier("{$item_table}.id"), true, 'cpt'),
                 ],
                 'FROM' => $cost_table,
                 'INNER JOIN' => [

--- a/src/CalendarSegment.php
+++ b/src/CalendarSegment.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * CalendarSegment Class
@@ -166,8 +167,8 @@ class CalendarSegment extends CommonDBChild
         $iterator = $DB->request([
             'SELECT' => [
                 QueryFunction::timediff(
-                    expression1: QueryFunction::least([new QueryExpression($DB::quoteValue($end_time)), 'end']),
-                    expression2: QueryFunction::greatest(['begin', new QueryExpression($DB::quoteValue($begin_time))]),
+                    expression1: QueryFunction::least([new QueryExpression($DB::quoteValue($end_time)), new QueryIdentifier('end')]),
+                    expression2: QueryFunction::greatest([new QueryIdentifier('begin'), new QueryExpression($DB::quoteValue($begin_time))]),
                     alias: 'TDIFF'
                 ),
             ],
@@ -220,12 +221,12 @@ class CalendarSegment extends CommonDBChild
         if (!$negative_delay) {
             // For positive delay: calculate time from begin_time to end of segment
             $SELECT[] = QueryFunction::timediff(
-                expression1: 'end',
-                expression2: QueryFunction::greatest(['begin', new QueryExpression($DB::quoteValue($begin_time))]),
+                expression1: new QueryIdentifier('end'),
+                expression2: QueryFunction::greatest([new QueryIdentifier('begin'), new QueryExpression($DB::quoteValue($begin_time))]),
                 alias: 'TDIFF'
             );
             $SELECT[] = QueryFunction::greatest(
-                params: ['begin', new QueryExpression($DB::quoteValue($begin_time))],
+                params: [new QueryIdentifier('begin'), new QueryExpression($DB::quoteValue($begin_time))],
                 alias: 'BEGIN'
             );
             $WHERE['end'] = ['>', $begin_time];
@@ -239,12 +240,12 @@ class CalendarSegment extends CommonDBChild
             // For negative delay: calculate time from begin of segment to begin_time
             // This gives us the available time to go backwards in this segment
             $SELECT[] = QueryFunction::timediff(
-                expression1: QueryFunction::least(['end', new QueryExpression($DB::quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode))]),
-                expression2: 'begin',
+                expression1: QueryFunction::least([new QueryIdentifier('end'), new QueryExpression($DB::quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode))]),
+                expression2: new QueryIdentifier('begin'),
                 alias: 'TDIFF'
             );
             $SELECT[] = QueryFunction::least(
-                params: ['end', new QueryExpression($DB::quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode))],
+                params: [new QueryIdentifier('end'), new QueryExpression($DB::quoteValue($adjusted_time_for_comparaison_in_negative_delay_mode))],
                 alias: 'END'
             );
             $WHERE['begin'] = ['<', $adjusted_time_for_comparaison_in_negative_delay_mode];

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
 use Glpi\Features\Clonable;
@@ -759,7 +760,7 @@ class Certificate extends CommonDBTM implements AssignableItemInterface, StateIn
                         ],
                         [
                             'RAW' => [
-                                'DATEDIFF(' . DBmysql::quoteName('glpi_certificates.date_expiration') . ', CURDATE())' => ['<', $before],
+                                'DATEDIFF(' . new QueryIdentifier('glpi_certificates.date_expiration') . ', CURDATE())' => ['<', $before],
                             ],
                         ],
                         'glpi_certificates.entities_id' => $entity,

--- a/src/Change.php
+++ b/src/Change.php
@@ -36,7 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\ContentTemplates\Parameters\ChangeParameters;
 use Glpi\ContentTemplates\Parameters\CommonITILObjectParameters;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\RichText\RichText;
 use Glpi\Search\DefaultSearchRequestInterface;
 
@@ -250,7 +250,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_changes', 'glpi_changes_users'],
                             [
-                                'glpi_changes_users.changes_id'  => new QueryExpression(DBmysql::quoteName('glpi_changes.id')),
+                                'glpi_changes_users.changes_id'  => new QueryIdentifier('glpi_changes.id'),
                                 'glpi_changes_users.users_id'    => $item->getID(),
                                 'glpi_changes_users.type'        => CommonITILActor::REQUESTER,
                                 'glpi_changes.is_deleted'        => 0,
@@ -265,7 +265,7 @@ class Change extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_changes', 'glpi_changes_groups'],
                             [
-                                'glpi_changes_groups.changes_id' => new QueryExpression(DBmysql::quoteName('glpi_changes.id')),
+                                'glpi_changes_groups.changes_id' => new QueryIdentifier('glpi_changes.id'),
                                 'glpi_changes_groups.groups_id'  => $item->getID(),
                                 'glpi_changes_groups.type'       => CommonITILActor::REQUESTER,
                                 'glpi_changes.is_deleted'        => 0,

--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QueryParam;
 use Glpi\Debug\Profiler;
 use Glpi\Event;
@@ -6141,7 +6142,7 @@ class CommonDBTM extends CommonGLPI
 
         return [
             'RAW' => [
-                (string) QueryFunction::lower("$table.$name_field") => ['LIKE', "%$filter%"],
+                (string) QueryFunction::lower(new QueryIdentifier("$table.$name_field")) => ['LIKE', "%$filter%"],
             ],
         ];
     }

--- a/src/CommonDevice.php
+++ b/src/CommonDevice.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * CommonDevice Class
@@ -262,7 +263,7 @@ abstract class CommonDevice extends CommonDropdown
                 'SELECT'    => [
                     'itemtype',
                     QueryFunction::groupConcat(
-                        expression: 'items_id',
+                        expression: new QueryIdentifier('items_id'),
                         distinct: true,
                         alias: 'ids'
                     ),

--- a/src/CommonITILCost.php
+++ b/src/CommonITILCost.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * CommonITILCost Class
@@ -226,8 +227,8 @@ abstract class CommonITILCost extends CommonDBChild
                 '(' . QueryFunction::sum(
                     expression: new QueryExpression($DB::quoteName('TABLE.actiontime') . ' * ' . $DB::quoteName('TABLE.cost_time') . ' / '
                         . HOUR_TIMESTAMP . ' + ' . $DB::quoteName('TABLE.cost_fixed') . ' + ' . $DB::quoteName('TABLE.cost_material'))
-                ) . ' / ' . QueryFunction::count('TABLE.id') . ') * '
-                    . QueryFunction::count(expression: 'TABLE.id', distinct: true)
+                ) . ' / ' . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                    . QueryFunction::count(expression: new QueryIdentifier('TABLE.id'), distinct: true)
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
@@ -248,8 +249,8 @@ abstract class CommonITILCost extends CommonDBChild
                 '(' . QueryFunction::sum(
                     expression: new QueryExpression($DB::quoteName('TABLE.actiontime') . ' * ' . $DB::quoteName('TABLE.cost_time') . ' / '
                         . HOUR_TIMESTAMP)
-                ) . ' / ' . QueryFunction::count('TABLE.id') . ') * '
-                    . QueryFunction::count(expression: 'TABLE.id', distinct: true)
+                ) . ' / ' . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                    . QueryFunction::count(expression: new QueryIdentifier('TABLE.id'), distinct: true)
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
@@ -282,9 +283,9 @@ abstract class CommonITILCost extends CommonDBChild
             ],
             'computation'        => new QueryExpression(
                 '(' . QueryFunction::sum(
-                    expression: 'TABLE.cost_fixed'
-                ) . ' / ' . QueryFunction::count('TABLE.id') . ') * '
-                    . QueryFunction::count(expression: 'TABLE.id', distinct: true)
+                    expression: new QueryIdentifier('TABLE.cost_fixed')
+                ) . ' / ' . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                    . QueryFunction::count(expression: new QueryIdentifier('TABLE.id'), distinct: true)
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
@@ -303,9 +304,9 @@ abstract class CommonITILCost extends CommonDBChild
             ],
             'computation'        => new QueryExpression(
                 '(' . QueryFunction::sum(
-                    expression: 'TABLE.cost_material'
-                ) . ' / ' . QueryFunction::count('TABLE.id') . ') * '
-                    . QueryFunction::count(expression: 'TABLE.id', distinct: true)
+                    expression: new QueryIdentifier('TABLE.cost_material')
+                ) . ' / ' . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                    . QueryFunction::count(expression: new QueryIdentifier('TABLE.id'), distinct: true)
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -37,6 +37,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\ContentTemplates\Parameters\CommonITILObjectParameters;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Event;
@@ -1600,7 +1601,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         return countElementsInTable(
             [$itemtable, $linktable],
             [
-                "$linktable.$itemfk"    => new QueryExpression(DBmysql::quoteName("$itemtable.id")),
+                "$linktable.$itemfk"    => new QueryIdentifier("$itemtable.id"),
                 "$linktable.$field"     => $id,
                 "$linktable.type"       => $role,
                 "$itemtable.is_deleted" => 0,
@@ -1795,7 +1796,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         'NOT' => [$this->getTable() . '.solvedate' => null],
                         new QueryExpression(
                             QueryFunction::dateAdd(
-                                date: static::getTable() . '.solvedate',
+                                date: new QueryIdentifier(static::getTable() . '.solvedate'),
                                 interval: $days,
                                 interval_unit: 'DAY'
                             ) . ' > ' . QueryFunction::now()
@@ -4711,7 +4712,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'SELECT' => 'id',
             'FROM'   => ITILSolution::getTable(),
             'WHERE'  => [
-                ITILSolution::getTable() . '.items_id' => new QueryExpression($DB::quoteName('REFTABLE.id')),
+                ITILSolution::getTable() . '.items_id' => new QueryIdentifier('REFTABLE.id'),
                 ITILSolution::getTable() . '.itemtype' => static::class,
             ],
             'ORDER'  => ITILSolution::getTable() . '.id DESC',
@@ -4747,7 +4748,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             'joinparams'         => [
                 'jointype'           => 'itemtype_item',
             ],
-            'computation'        => QueryFunction::max('TABLE.date_creation'),
+            'computation'        => QueryFunction::max(new QueryIdentifier('TABLE.date_creation')),
             'nometa'             => true, // cannot GROUP_CONCAT a MAX
         ];
 
@@ -5153,7 +5154,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                             [
                                 'AND' => [
                                     'NOT' => ["$table.takeintoaccountdate" => null],
-                                    "$table.takeintoaccountdate" => ['>', new QueryExpression($DB::quoteName("{$table}.{$type}"))],
+                                    "$table.takeintoaccountdate" => ['>', new QueryIdentifier("{$table}.{$type}")],
                                 ],
                             ],
                             [
@@ -5162,8 +5163,8 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                                     "$table.takeintoaccount_delay_stat" => ['>',
                                         QueryFunction::timestampdiff(
                                             unit: 'SECOND',
-                                            expression1: "$table.date",
-                                            expression2: "{$table}.{$type}"
+                                            expression1: new QueryIdentifier("$table.date"),
+                                            expression2: new QueryIdentifier("{$table}.{$type}")
                                         ),
                                     ],
                                 ],
@@ -5186,7 +5187,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                         'NOT' => ["{$table}.{$type}" => null],
                         "$table.status" => ['<>', self::WAITING],
                         'OR' => [
-                            "$table.solvedate" => ['>', new QueryExpression($DB::quoteName("$table.$type"))],
+                            "$table.solvedate" => ['>', new QueryIdentifier("$table.$type")],
                             'AND' => [
                                 "$table.solvedate" => null,
                                 "$table.$type" => ['<', QueryFunction::now()],
@@ -10938,14 +10939,14 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
                     "$table.closedate"            => ['>', $max_closedate],
                     new QueryExpression(
                         QueryFunction::dateAdd(
-                            date: "$table.closedate",
+                            date: new QueryIdentifier("$table.closedate"),
                             interval: $delay,
                             interval_unit: 'DAY'
                         ) . ' <= ' . QueryFunction::now()
                     ),
                     new QueryExpression(
                         QueryFunction::dateAdd(
-                            date: "glpi_entities.max_closedate$config_suffix",
+                            date: new QueryIdentifier("glpi_entities.max_closedate$config_suffix"),
                             interval: $duration,
                             interval_unit: 'DAY'
                         ) . ' <= ' . QueryFunction::now()

--- a/src/CommonITILSatisfaction.php
+++ b/src/CommonITILSatisfaction.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 use function Safe\preg_replace;
 use function Safe\strtotime;
@@ -481,7 +482,7 @@ abstract class CommonITILSatisfaction extends CommonDBTM
             'computation'        => QueryFunction::if(
                 condition: new QueryExpression("EXISTS (SELECT 1 FROM $subquery WHERE durations.entity_id = $parent_table.entities_id AND durations.inquest_duration > 0)"),
                 true_expression: QueryFunction::dateAdd(
-                    date: "$table.date_begin",
+                    date: new QueryIdentifier("$table.date_begin"),
                     interval: new QueryExpression("(SELECT durations.inquest_duration FROM $subquery WHERE durations.entity_id = $parent_table.entities_id)"),
                     interval_unit: 'DAY',
                 ),

--- a/src/CommonITILTask.php
+++ b/src/CommonITILTask.php
@@ -38,6 +38,7 @@ use Glpi\CalDAV\Contracts\CalDAVCompatibleItemInterface;
 use Glpi\CalDAV\Traits\VobjectConverterTrait;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\ParentStatus;
 use Glpi\Features\PlanningEvent;
@@ -1265,7 +1266,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                 'jointype'           => 'child',
                 'condition'          => $task_condition,
             ],
-            'computation'        => QueryFunction::max('TABLE.date'),
+            'computation'        => QueryFunction::max(new QueryIdentifier('TABLE.date')),
             'nometa'             => true, // cannot GROUP_CONCAT a MAX
             'usehaving'          => true,
         ];
@@ -1422,8 +1423,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             // begin date is task date minus duration
             // and end date is task date
             $bdate = QueryFunction::dateSub(
-                date: $item::getTable() . '.date',
-                interval: new QueryExpression($DB::quoteName($item::getTable() . '.actiontime')),
+                date: new QueryIdentifier($item::getTable() . '.date'),
+                interval: new QueryIdentifier($item::getTable() . '.actiontime'),
                 interval_unit: 'SECOND'
             );
             $SELECT[] = new QueryExpression($bdate, 'notp_date');

--- a/src/Contract.php
+++ b/src/Contract.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Features\Clonable;
 use Glpi\Features\StateInterface;
 
@@ -354,9 +355,9 @@ class Contract extends CommonDBTM implements StateInterface
             'datatype'           => 'decimal',
             'massiveaction'      => false,
             'joinparams'         => $joinparamscost,
-            'computation'        => '(' . QueryFunction::sum('TABLE.cost') . ' / '
-                . QueryFunction::count('TABLE.id') . ') * '
-                . QueryFunction::count('TABLE.id', distinct: true),
+            'computation'        => '(' . QueryFunction::sum(new QueryIdentifier('TABLE.cost')) . ' / '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id'), distinct: true),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 
@@ -778,9 +779,9 @@ class Contract extends CommonDBTM implements StateInterface
             'joinparams'         => [
                 'jointype'           => 'child',
             ],
-            'computation'        => '(' . QueryFunction::sum('TABLE.cost') . ' / '
-                . QueryFunction::count('TABLE.id') . ') * '
-                . QueryFunction::count('TABLE.id', distinct: true),
+            'computation'        => '(' . QueryFunction::sum(new QueryIdentifier('TABLE.cost')) . ' / '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id'), distinct: true),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 
@@ -874,8 +875,8 @@ class Contract extends CommonDBTM implements StateInterface
         }
 
         $end_date = QueryFunction::dateAdd(
-            date: 'begin_date',
-            interval: new QueryExpression($DB::quoteName('duration')),
+            date: new QueryIdentifier('begin_date'),
+            interval: new QueryIdentifier('duration'),
             interval_unit: 'MONTH'
         );
 
@@ -923,7 +924,7 @@ class Contract extends CommonDBTM implements StateInterface
         $contract30 = $result['cpt'];
 
         $notice_date = QueryFunction::dateAdd(
-            date: 'begin_date',
+            date: new QueryIdentifier('begin_date'),
             interval: new QueryExpression($DB::quoteName('duration') . ' - ' . $DB::quoteName('notice')),
             interval_unit: 'MONTH'
         );
@@ -1107,8 +1108,8 @@ class Contract extends CommonDBTM implements StateInterface
         $contract_messages = [];
 
         $end_date = QueryFunction::dateAdd(
-            date: 'glpi_contracts.begin_date',
-            interval: new QueryExpression($DB::quoteName('glpi_contracts.duration')),
+            date: new QueryIdentifier('glpi_contracts.begin_date'),
+            interval: new QueryIdentifier('glpi_contracts.duration'),
             interval_unit: 'MONTH'
         );
 
@@ -1118,7 +1119,7 @@ class Contract extends CommonDBTM implements StateInterface
         );
 
         $notice_date = QueryFunction::dateAdd(
-            date: 'glpi_contracts.begin_date',
+            date: new QueryIdentifier('glpi_contracts.begin_date'),
             interval: new QueryExpression($DB::quoteName('glpi_contracts.duration') . ' - ' . $DB::quoteName('glpi_contracts.notice')),
             interval_unit: 'MONTH'
         );
@@ -1153,7 +1154,7 @@ class Contract extends CommonDBTM implements StateInterface
                 'WHERE'     => [
                     [
                         'RAW' => [
-                            DBmysql::quoteName('glpi_contracts.alert') . ' & ' . 2 ** Alert::NOTICE => ['>', 0],
+                            new QueryIdentifier('glpi_contracts.alert') . ' & ' . 2 ** Alert::NOTICE => ['>', 0],
                         ],
                     ],
                     'glpi_alerts.date'           => null,
@@ -1191,7 +1192,7 @@ class Contract extends CommonDBTM implements StateInterface
                 'WHERE'     => [
                     [
                         'RAW' => [
-                            DBmysql::quoteName('glpi_contracts.alert') . ' & ' . 2 ** Alert::END => ['>', 0],
+                            new QueryIdentifier('glpi_contracts.alert') . ' & ' . 2 ** Alert::END => ['>', 0],
                         ],
                     ],
                     'glpi_alerts.date'           => null,
@@ -1671,8 +1672,8 @@ class Contract extends CommonDBTM implements StateInterface
                 new QueryExpression(
                     QueryFunction::dateDiff(
                         expression1: QueryFunction::dateAdd(
-                            date: 'glpi_contracts.begin_date',
-                            interval: new QueryExpression($DB::quoteName('glpi_contracts.duration')),
+                            date: new QueryIdentifier('glpi_contracts.begin_date'),
+                            interval: new QueryIdentifier('glpi_contracts.duration'),
                             interval_unit: 'MONTH'
                         ),
                         expression2: QueryFunction::curDate()

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Error\ErrorHandler;
 use Glpi\Event;
 use Glpi\Security\SessionTracker;
@@ -578,13 +579,13 @@ class CronTask extends CommonDBTM
             // Build query for next_run and allowed hour
             $WHERE[] = ['OR' => [
                 ['AND' => [
-                    ['hourmin'   => ['<', new QueryExpression($DB::quoteName('hourmax'))]],
+                    ['hourmin'   => ['<', new QueryIdentifier('hourmax')]],
                     'hourmin'   => ['<=', $hour_criteria],
                     'hourmax'   => ['>', $hour_criteria],
                 ],
                 ],
                 ['AND' => [
-                    'hourmin'   => ['>', new QueryExpression($DB::quoteName('hourmax'))],
+                    'hourmin'   => ['>', new QueryIdentifier('hourmax')],
                     'OR'        => [
                         'hourmin'   => ['<=', $hour_criteria],
                         'hourmax'   => ['>', $hour_criteria],
@@ -596,7 +597,7 @@ class CronTask extends CommonDBTM
             $WHERE[] = [
                 'OR' => [
                     'lastrun'   => null,
-                    new QueryExpression(QueryFunction::ifnull(QueryFunction::unixTimestamp('next_run'), new QueryExpression('0')) . ' <= ' . QueryFunction::unixTimestamp()),
+                    new QueryExpression(QueryFunction::ifnull(QueryFunction::unixTimestamp(new QueryIdentifier('next_run')), new QueryExpression('0')) . ' <= ' . QueryFunction::unixTimestamp()),
                 ],
             ];
         }
@@ -606,7 +607,7 @@ class CronTask extends CommonDBTM
                 '*',
                 QueryFunction::locate(
                     substring: 'Plugin',
-                    expression: $DB::quoteName('itemtype'),
+                    expression: new QueryIdentifier('itemtype'),
                     alias: 'ISPLUGIN'
                 ),
             ],
@@ -615,7 +616,7 @@ class CronTask extends CommonDBTM
             // Core task before plugins
             'ORDER'  => [
                 'ISPLUGIN',
-                QueryFunction::unixTimestamp('next_run'),
+                QueryFunction::unixTimestamp(new QueryIdentifier('next_run')),
             ],
         ]);
 
@@ -1926,9 +1927,9 @@ TWIG, ['msg' => __('Last run list')]);
             'WHERE'  => [
                 'state'  => self::STATE_RUNNING,
                 'OR'     => [
-                    new QueryExpression(QueryFunction::unixTimestamp('lastrun') . ' + 2 * '
+                    new QueryExpression(QueryFunction::unixTimestamp(new QueryIdentifier('lastrun')) . ' + 2 * '
                         . $DB::quoteName('frequency') . ' < ' . QueryFunction::unixTimestamp()),
-                    new QueryExpression(QueryFunction::unixTimestamp('lastrun') . ' + 2 * '
+                    new QueryExpression(QueryFunction::unixTimestamp(new QueryIdentifier('lastrun')) . ' + 2 * '
                         . HOUR_TIMESTAMP . ' < ' . QueryFunction::unixTimestamp()),
                 ],
             ],

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -37,6 +37,7 @@ use Glpi\DBAL\Parts\BasePart;
 use Glpi\DBAL\Parts\Delete;
 use Glpi\DBAL\Parts\Insert;
 use Glpi\DBAL\Parts\Update;
+use Glpi\DBAL\QueryElementInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryParam;
 use Glpi\DBAL\QuerySubQuery;
@@ -1224,7 +1225,7 @@ class DBmysql
      *
      * @since 9.3
      *
-     * @param string|QueryExpression $name
+     * @param string|QueryElementInterface $name
      *
      * @return string
      *
@@ -1233,7 +1234,7 @@ class DBmysql
     public static function quoteName($name)
     {
         // handle verbatim names
-        if ($name instanceof QueryExpression) {
+        if ($name instanceof QueryElementInterface) {
             return $name->getValue();
         }
 
@@ -1279,8 +1280,8 @@ class DBmysql
      */
     public static function quoteValue($value)
     {
-        if ($value instanceof QueryParam || $value instanceof QueryExpression) {
-            //no quote for query parameters nor expressions
+        if ($value instanceof QueryParam || $value instanceof QueryElementInterface) {
+            //no quote for query parameters nor query elements
             $value = $value->getValue();
         } elseif ($value === null || $value === 'NULL' || $value === 'null') {
             $value = 'NULL';
@@ -1320,7 +1321,7 @@ class DBmysql
             $values = [];
             foreach ($params as $key => $value) {
                 $fields[] = static::quoteName($key);
-                if ($value instanceof QueryExpression) {
+                if ($value instanceof QueryElementInterface) {
                     $parameters[] = $value->getValue();
                     $values = array_merge($values, $value->getParams());
                     unset($params[$key]);
@@ -1421,7 +1422,7 @@ class DBmysql
         foreach ($params as $field => $value) {
             if ($value instanceof QueryParam) {
                 $query .= self::quoteName($field) . " = " . $value->getValue() . ", ";
-            } elseif ($value instanceof QueryExpression) {
+            } elseif ($value instanceof QueryElementInterface) {
                 $qvalues = $value->getParams();
                 $query .= self::quoteName($field) . " = " . $value->getValue() . ", ";
                 $set_values = array_merge($set_values, $qvalues);

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -33,6 +33,7 @@
  * ---------------------------------------------------------------------
  */
 
+use Glpi\DBAL\QueryElementInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryParam;
 use Glpi\DBAL\QuerySubQuery;
@@ -315,7 +316,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 $query = $table;
                 $table = $query->getQuery();
                 $this->values = array_merge($this->values, $query->getParams());
-            } elseif ($table instanceof QueryExpression) {
+            } elseif ($table instanceof QueryElementInterface) {
                 $query = $table;
                 $table = $query->getValue();
                 $this->values = array_merge($this->values, $query->getParams());
@@ -379,7 +380,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
     /**
      * Handle "ORDER BY" SQL clause
      *
-     * @param string|QueryExpression|array<int, string|QueryExpression> $clause Clause parameters
+     * @param string|QueryElementInterface|array<int, string|QueryElementInterface> $clause Clause parameters
      *
      * @return string
      */
@@ -413,7 +414,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 $cleanorderby[] = DBmysql::quoteName($name)
                     . (in_array($direction, ['ASC', 'DESC']) ? ' ' . $direction : '');
 
-            } elseif ($o instanceof QueryExpression) {
+            } elseif ($o instanceof QueryElementInterface) {
                 $cleanorderby[] = $o->getValue();
                 $this->values = array_merge($this->values, $o->getParams());
             } else {
@@ -448,12 +449,12 @@ class DBmysqlIterator implements SeekableIterator, Countable
     /**
      * Handle fields
      *
-     * @param int|string                                    $t Table name or function
-     * @param string[]|string|QueryExpression|AbstractQuery $f Field(s) name(s)
+     * @param int|string                            $t Table name or function
+     * @param string[]|string|QueryElementInterface $f Field(s) name(s)
      *
      * @return string
      */
-    private function handleFields(int|string $t, array|string|QueryExpression|AbstractQuery $f): string
+    private function handleFields(int|string $t, array|string|QueryElementInterface $f): string
     {
         if (is_numeric($t)) {
             if (is_array($f)) {
@@ -463,7 +464,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
             if ($f instanceof AbstractQuery) {
                 $this->values = array_merge($this->values, $f->getParams());
                 return $f->getQuery();
-            } elseif ($f instanceof QueryExpression) {
+            } elseif ($f instanceof QueryElementInterface) {
                 $this->values = array_merge($this->values, $f->getParams());
                 return $f->getValue();
             } else {
@@ -581,12 +582,9 @@ class DBmysqlIterator implements SeekableIterator, Countable
             }
             if (is_numeric($name)) {
                 // no key and direct expression
-                if ($value instanceof QueryExpression) {
+                if ($value instanceof QueryElementInterface) {
                     $this->values = array_merge($this->values, $value->getParams());
                     $ret .= $value->getValue();
-                } elseif ($value instanceof QuerySubQuery) {
-                    $this->values = array_merge($this->values, $value->getParams());
-                    $ret .= $value->getQuery();
                 } else {
                     // No Key case => recurse.
                     $ret .= "(" . $this->analyseCrit($value) . ")";
@@ -661,7 +659,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
      *
      * @param mixed $value The value to handle. This may be:
      *                      - an instance of AbstractQuery
-     *                      - a QueryExpression
+     *                      - a QueryExpression, a QueryIdentifier or any other query element
      *                      - a value quoted as a name in the db engine
      *                      - a QueryParam
      *                      - a value or an array of values
@@ -674,7 +672,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
             case $value instanceof AbstractQuery:
                 $this->values = array_merge($this->values, $value->getParams());
                 return $value->getQuery();
-            case $value instanceof QueryExpression:
+            case $value instanceof QueryElementInterface:
                 $this->values = array_merge($this->values, $value->getParams());
                 return $value->getValue();
             case $value instanceof QueryParam:
@@ -774,19 +772,19 @@ class DBmysqlIterator implements SeekableIterator, Countable
             if (count($values) == 2) {
                 $t1 = $keys[0];
                 $f1 = $values[$t1];
-                $left_value = $f1 instanceof QuerySubQuery || $f1 instanceof QueryExpression
+                $left_value = $f1 instanceof QueryElementInterface
                     ? (string) $f1
                     : (is_numeric($t1) ? DBmysql::quoteName($f1) : DBmysql::quoteName($t1) . '.' . DBmysql::quoteName($f1));
-                if ($f1 instanceof QuerySubQuery || $f1 instanceof QueryExpression) {
+                if ($f1 instanceof QueryElementInterface) {
                     $this->values = array_merge($this->values, $f1->getParams());
                 }
 
                 $t2 = $keys[1];
                 $f2 = $values[$t2];
-                $right_value = $f2 instanceof QuerySubQuery || $f2 instanceof QueryExpression
+                $right_value = $f2 instanceof QueryElementInterface
                     ? (string) $f2
                     : (is_numeric($t2) ? DBmysql::quoteName($f2) : DBmysql::quoteName($t2) . '.' . DBmysql::quoteName($f2));
-                if ($f2 instanceof QuerySubQuery || $f2 instanceof QueryExpression) {
+                if ($f2 instanceof QueryElementInterface) {
                     $this->values = array_merge($this->values, $f2->getParams());
                 }
 
@@ -813,7 +811,7 @@ class DBmysqlIterator implements SeekableIterator, Countable
                 }
                 return $fkey;
             }
-        } elseif ($values instanceof QueryExpression) {
+        } elseif ($values instanceof QueryElementInterface) {
             $this->values = array_merge($this->values, $values->getParams());
             return $values->getValue();
         }

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -353,14 +353,12 @@ class DBmysqlIterator implements SeekableIterator, Countable
         // GROUP BY field list
         if (is_array($groupby)) {
             if (count($groupby)) {
-                $groupby = array_map([DBmysql::class, 'quoteName'], $groupby);
-                $this->sql .= ' GROUP BY ' . implode(", ", $groupby);
+                $this->sql .= ' GROUP BY ' . implode(", ", $this->handleGroupByFields($groupby));
             } else {
                 throw new LogicException("Missing group by field.");
             }
         } elseif ($groupby) {
-            $groupby = DBmysql::quoteName($groupby);
-            $this->sql .= " GROUP BY $groupby";
+            $this->sql .= " GROUP BY " . implode(", ", $this->handleGroupByFields([$groupby]));
         }
 
         // HAVING criteria list
@@ -375,6 +373,27 @@ class DBmysqlIterator implements SeekableIterator, Countable
 
         //LIMIT & OFFSET
         $this->sql .= $this->handleLimits($limit, $start);
+    }
+
+    /**
+     * Handle "GROUP BY" fields
+     *
+     * @param array<int, string|QueryElementInterface> $fields
+     *
+     * @return array<int, string>
+     */
+    private function handleGroupByFields(array $fields): array
+    {
+        $groupby = [];
+        foreach ($fields as $field) {
+            if ($field instanceof QueryElementInterface) {
+                $this->values = array_merge($this->values, $field->getParams());
+                $groupby[] = $field->getValue();
+            } else {
+                $groupby[] = DBmysql::quoteName($field);
+            }
+        }
+        return $groupby;
     }
 
     /**

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -36,6 +36,7 @@
 use Glpi\Application\Environment;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Exception\Database\QueryException;
@@ -1940,7 +1941,7 @@ final class DbUtils
             $criteria = [
                 'SELECT' => [
                     QueryFunction::cast(
-                        expression: QueryFunction::substring('code', $pos, $len),
+                        expression: QueryFunction::substring(new QueryIdentifier('code'), $pos, $len),
                         type: 'UNSIGNED',
                         alias: 'no'
                     ),
@@ -1952,7 +1953,7 @@ final class DbUtils
             $criteria = [
                 'SELECT' => [
                     QueryFunction::cast(
-                        expression: QueryFunction::substring($field, $pos, $len),
+                        expression: QueryFunction::substring(new QueryIdentifier($field), $pos, $len),
                         type: 'UNSIGNED',
                         alias: 'no'
                     ),

--- a/src/DeviceHardDrive.php
+++ b/src/DeviceHardDrive.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /// Class DeviceHardDrive
 class DeviceHardDrive extends CommonDevice
@@ -282,9 +283,9 @@ class DeviceHardDrive extends CommonDevice
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
             'computation'        => '('
-                . QueryFunction::sum('TABLE.capacity') . ' / '
-                . QueryFunction::count('TABLE.id') . ') * '
-                . QueryFunction::count(expression: 'TABLE.id', distinct: true),
+                . QueryFunction::sum(new QueryIdentifier('TABLE.capacity')) . ' / '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                . QueryFunction::count(expression: new QueryIdentifier('TABLE.id'), distinct: true),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /// Class DeviceMemory
 class DeviceMemory extends CommonDevice
@@ -250,9 +251,9 @@ class DeviceMemory extends CommonDevice
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
             'computation'        => '('
-                . QueryFunction::sum('TABLE.size') . '/'
-                . QueryFunction::count('TABLE.id') . ') * '
-                . QueryFunction::count('TABLE.id', true),
+                . QueryFunction::sum(new QueryIdentifier('TABLE.size')) . '/'
+                . QueryFunction::count(new QueryIdentifier('TABLE.id')) . ') * '
+                . QueryFunction::count(new QueryIdentifier('TABLE.id'), true),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 

--- a/src/DeviceProcessor.php
+++ b/src/DeviceProcessor.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /// Class DeviceProcessor
 class DeviceProcessor extends CommonDevice
@@ -249,8 +250,8 @@ class DeviceProcessor extends CommonDevice
             'datatype'           => 'number',
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
-            'computation'        => QueryFunction::sum('TABLE.nbcores') . ' * ' . QueryFunction::count(
-                expression: 'TABLE.id',
+            'computation'        => QueryFunction::sum(new QueryIdentifier('TABLE.nbcores')) . ' * ' . QueryFunction::count(
+                expression: new QueryIdentifier('TABLE.id'),
                 distinct: true
             ) . ' / ' . QueryFunction::count(new QueryExpression('*')),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
@@ -266,8 +267,8 @@ class DeviceProcessor extends CommonDevice
             'datatype'           => 'number',
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
-            'computation'        => QueryFunction::sum('TABLE.nbthreads') . ' * ' . QueryFunction::count(
-                expression: 'TABLE.id',
+            'computation'        => QueryFunction::sum(new QueryIdentifier('TABLE.nbthreads')) . ' * ' . QueryFunction::count(
+                expression: new QueryIdentifier('TABLE.id'),
                 distinct: true
             ) . ' / ' . QueryFunction::count(new QueryExpression('*')),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
@@ -284,7 +285,7 @@ class DeviceProcessor extends CommonDevice
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
             'computation'        => QueryFunction::count(
-                expression: 'TABLE.id',
+                expression: new QueryIdentifier('TABLE.id'),
                 distinct: true
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
@@ -302,8 +303,8 @@ class DeviceProcessor extends CommonDevice
             'width'              => 100,
             'massiveaction'      => false,
             'joinparams'         => $main_joinparams,
-            'computation'        => QueryFunction::sum('TABLE.frequency') . ' / ' . QueryFunction::count(
-                expression: 'TABLE.id',
+            'computation'        => QueryFunction::sum(new QueryIdentifier('TABLE.frequency')) . ' / ' . QueryFunction::count(
+                expression: new QueryIdentifier('TABLE.id'),
             ),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];

--- a/src/Domain_Item.php
+++ b/src/Domain_Item.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 class Domain_Item extends CommonDBRelation
 {
@@ -399,7 +400,7 @@ TWIG, $twig_params);
                 'glpi_domains.name AS assocName',
                 'glpi_domains.*',
                 QueryFunction::groupConcat(
-                    expression: Group_Item::getTable() . '.groups_id',
+                    expression: new QueryIdentifier(Group_Item::getTable() . '.groups_id'),
                     separator: ',',
                     alias: 'groups_id_tech',
                 ),

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -38,6 +38,7 @@ use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Dropdown\DropdownDefinitionManager;
 use Glpi\Features\AssignableItem;
 use Glpi\Form\Category;
@@ -3514,9 +3515,9 @@ HTML;
                             "$table.entities_id",
                             QueryFunction::concat(
                                 params: [
-                                    QueryFunction::ifnull('name', new QueryExpression($DB::quoteValue(''))),
+                                    QueryFunction::ifnull(new QueryIdentifier('name'), new QueryExpression($DB::quoteValue(''))),
                                     new QueryExpression($DB::quoteValue(' ')),
-                                    QueryFunction::ifnull('firstname', new QueryExpression($DB::quoteValue(''))),
+                                    QueryFunction::ifnull(new QueryIdentifier('firstname'), new QueryExpression($DB::quoteValue(''))),
                                 ],
                                 alias: $field
                             ),
@@ -3532,7 +3533,7 @@ HTML;
                         'SELECT' => [
                             "$table.*",
                             QueryFunction::concat(
-                                params: ['glpi_softwares.name', new QueryExpression($DB::quoteValue(' - ')), 'glpi_softwarelicenses.name'],
+                                params: [new QueryIdentifier('glpi_softwares.name'), new QueryExpression($DB::quoteValue(' - ')), new QueryIdentifier('glpi_softwarelicenses.name')],
                                 alias: $field
                             ),
                         ],

--- a/src/Glpi/Api/API.php
+++ b/src/Glpi/Api/API.php
@@ -57,6 +57,7 @@ use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Config\ConfigContainer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Exception\ForgetPasswordException;
 use Glpi\Exception\PasswordTooWeakException;
 use Glpi\Search\Provider\SQLProvider;
@@ -3033,9 +3034,9 @@ TWIG, ['md' => (new MarkdownRenderer())->render($documentation)]);
                         // append network name
                         $concat_expr = QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                'ipadr.id',
+                                new QueryIdentifier('ipadr.id'),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                'ipadr.name',
+                                new QueryIdentifier('ipadr.name'),
                             ]),
                             separator: Search::LONGSEP,
                             alias: 'ipadresses'

--- a/src/Glpi/Api/HL/Controller/CustomAssetController.php
+++ b/src/Glpi/Api/HL/Controller/CustomAssetController.php
@@ -44,6 +44,7 @@ use Glpi\Asset\Asset;
 use Glpi\Asset\AssetDefinitionManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Http\JSONResponse;
 use Glpi\Http\Request;
 use Glpi\Http\Response;
@@ -200,7 +201,7 @@ final class CustomAssetController extends AbstractController
                     'computation' =>  QueryFunction::coalesce([
                         QueryFunction::jsonUnquote(
                             expression: QueryFunction::jsonExtract([
-                                '_.custom_fields',
+                                new QueryIdentifier('_.custom_fields'),
                                 new QueryExpression($DB::quoteValue('$."' . $field->fields['id'] . '"')),
                             ])
                         ),

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -43,6 +43,7 @@ use Glpi\Api\HL\Schemas;
 use Glpi\Api\HL\Search;
 use Glpi\Api\HL\Search\SearchContext;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
 use GraphQL\Deferred;
@@ -443,7 +444,7 @@ class DefaultResolvers
                 'FROM' => $subquery_criteria,
             ];
         }
-        $count_select = [QueryFunction::count("$table_alias.id", true, 'count')];
+        $count_select = [QueryFunction::count(new QueryIdentifier("$table_alias.id"), true, 'count')];
         $count_criteria['SELECT'] = $count_select;
         return $count_criteria;
     }

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -53,6 +53,7 @@ use Glpi\Api\HL\Search\SearchContext;
 use Glpi\Application\Environment;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Debug\Profiler;
@@ -228,7 +229,7 @@ final class Search
 
 
                                     $parent_keys[] = QueryFunction::ifnull(
-                                        expression: $primary_key,
+                                        expression: new QueryIdentifier($primary_key),
                                         value: new QueryExpression('0x0')
                                     );
                                     $current_join_parent = $current_join_def['join_parent'] ?? null;
@@ -236,16 +237,16 @@ final class Search
                                 }
                                 $parent_keys = array_reverse($parent_keys);
                                 $expression = QueryFunction::groupConcat(
-                                    expression: QueryFunction::concat([...$parent_keys, QueryFunction::ifnull($sql_field, new QueryExpression('0x0'))]),
+                                    expression: QueryFunction::concat([...$parent_keys, QueryFunction::ifnull(new QueryIdentifier($sql_field), new QueryExpression('0x0'))]),
                                     separator: new QueryExpression(chr(0x1D)),
                                 );
                             } else {
                                 // Probably a nested property
-                                $expression = QueryFunction::ifnull($sql_field, new QueryExpression('0x0'));
+                                $expression = QueryFunction::ifnull(new QueryIdentifier($sql_field), new QueryExpression('0x0'));
                                 $expression = QueryFunction::groupConcat($expression, new QueryExpression(chr(0x1D)), $distinct_groups);
                             }
                         } else {
-                            $expression = QueryFunction::ifnull($sql_field, new QueryExpression('0x0'));
+                            $expression = QueryFunction::ifnull(new QueryIdentifier($sql_field), new QueryExpression('0x0'));
                             $expression = QueryFunction::groupConcat($expression, new QueryExpression(chr(0x1D)), $distinct_groups);
                         }
                     }
@@ -703,9 +704,9 @@ final class Search
                     ];
                 }
                 if ($this->context->isUnionSearchMode()) {
-                    $count_select = [QueryFunction::count(QueryFunction::concat(['_itemtype', new QueryExpression('0x1E'), "$table_alias.id",]), true, 'count')];
+                    $count_select = [QueryFunction::count(QueryFunction::concat([new QueryIdentifier('_itemtype'), new QueryExpression('0x1E'), new QueryIdentifier("$table_alias.id"),]), true, 'count')];
                 } else {
-                    $count_select = [QueryFunction::count("$table_alias.id", true, 'count')];
+                    $count_select = [QueryFunction::count(new QueryIdentifier("$table_alias.id"), true, 'count')];
                 }
                 $criteria['SELECT'] = $count_select;
             }

--- a/src/Glpi/Api/HL/Search/RecordSet.php
+++ b/src/Glpi/Api/HL/Search/RecordSet.php
@@ -40,6 +40,7 @@ use Glpi\Api\HL\Doc as Doc;
 use Glpi\Api\HL\Search;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Debug\Profiler;
 use Glpi\Toolbox\ArrayPathAccessor;
 use Session;
@@ -180,8 +181,8 @@ final class RecordSet
             if (!$is_computed && isset($trans_alias)) {
                 // Try to use the translated value, but fall back to the default value if there is no translation
                 $criteria['SELECT'][] = QueryFunction::ifnull(
-                    expression: "{$trans_alias}.value",
-                    value: $sql_field,
+                    expression: new QueryIdentifier("{$trans_alias}.value"),
+                    value: new QueryIdentifier($sql_field),
                     alias: $alias
                 );
             } else {

--- a/src/Glpi/Asset/Asset_PeripheralAsset.php
+++ b/src/Glpi/Asset/Asset_PeripheralAsset.php
@@ -43,6 +43,7 @@ use Dropdown;
 use Entity;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Html;
 use LogicException;
 use MassiveAction;
@@ -744,7 +745,7 @@ TWIG, $twig_params);
                 'SELECT' => [
                     'itemtype_peripheral',
                     QueryFunction::groupConcat(
-                        expression: 'items_id_peripheral',
+                        expression: new QueryIdentifier('items_id_peripheral'),
                         distinct: true,
                         alias: 'ids'
                     ),
@@ -779,7 +780,7 @@ TWIG, $twig_params);
                 'SELECT' => [
                     'itemtype_peripheral',
                     QueryFunction::groupConcat(
-                        expression: 'items_id_peripheral',
+                        expression: new QueryIdentifier('items_id_peripheral'),
                         distinct: true,
                         alias: 'ids'
                     ),

--- a/src/Glpi/Asset/CustomFieldDefinition.php
+++ b/src/Glpi/Asset/CustomFieldDefinition.php
@@ -41,6 +41,7 @@ use Glpi\Asset\CustomFieldType\RawType;
 use Glpi\Asset\CustomFieldType\TypeInterface;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Locale\LanguageRegistry;
 use InvalidArgumentException;
 use RuntimeException;
@@ -122,7 +123,7 @@ final class CustomFieldDefinition extends CommonDBChild
 
         $DB->update('glpi_assets_assets', [
             'custom_fields' => QueryFunction::jsonRemove([
-                'custom_fields',
+                new QueryIdentifier('custom_fields'),
                 new QueryExpression($DB::quoteValue('$."' . $this->fields['id'] . '"')),
             ]),
         ], [

--- a/src/Glpi/Asset/CustomFieldType/AbstractType.php
+++ b/src/Glpi/Asset/CustomFieldType/AbstractType.php
@@ -39,6 +39,7 @@ use Glpi\Asset\CustomFieldOption\BooleanOption;
 use Glpi\Asset\CustomFieldOption\ProfileRestrictOption;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 abstract class AbstractType implements TypeInterface
 {
@@ -125,7 +126,7 @@ abstract class AbstractType implements TypeInterface
             'computation' => QueryFunction::coalesce([
                 QueryFunction::jsonUnquote(
                     expression: QueryFunction::jsonExtract([
-                        'glpi_assets_assets.custom_fields',
+                        new QueryIdentifier('glpi_assets_assets.custom_fields'),
                         new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                     ])
                 ),

--- a/src/Glpi/Asset/CustomFieldType/BooleanType.php
+++ b/src/Glpi/Asset/CustomFieldType/BooleanType.php
@@ -38,6 +38,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\CustomFieldOption\BooleanOption;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use InvalidArgumentException;
 
 class BooleanType extends AbstractType
@@ -87,7 +88,7 @@ TWIG, $twig_params);
         $opt['computation'] = new QueryExpression(QueryFunction::coalesce([
             QueryFunction::jsonUnquote(
                 expression: QueryFunction::jsonExtract([
-                    'glpi_assets_assets.custom_fields',
+                    new QueryIdentifier('glpi_assets_assets.custom_fields'),
                     new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                 ])
             ),

--- a/src/Glpi/Asset/CustomFieldType/DropdownType.php
+++ b/src/Glpi/Asset/CustomFieldType/DropdownType.php
@@ -39,6 +39,7 @@ use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\CustomFieldOption\BooleanOption;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 class DropdownType extends AbstractType
 {
@@ -146,7 +147,7 @@ TWIG, $twig_params);
                 new QueryExpression(
                     'NEWTABLE.' . $DB::quoteName('id') . ' = ' . QueryFunction::jsonUnquote(
                         expression: QueryFunction::jsonExtract([
-                            'REFTABLE.custom_fields',
+                            new QueryIdentifier('REFTABLE.custom_fields'),
                             new QueryExpression($DB::quoteValue('$."' . $this->custom_field->fields['id'] . '"')),
                         ])
                     )
@@ -155,8 +156,8 @@ TWIG, $twig_params);
         } else {
             $opt['joinparams']['condition'] = [
                 QueryFunction::jsonContains(
-                    'REFTABLE.custom_fields',
-                    'NEWTABLE.id',
+                    new QueryIdentifier('REFTABLE.custom_fields'),
+                    new QueryIdentifier('NEWTABLE.id'),
                     '$."' . $this->custom_field->fields['id'] . '"'
                 ),
             ];

--- a/src/Glpi/Console/Task/UnlockCommand.php
+++ b/src/Glpi/Console/Task/UnlockCommand.php
@@ -39,6 +39,7 @@ use CronTask;
 use Glpi\Console\AbstractCommand;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Event;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -106,7 +107,7 @@ class UnlockCommand extends AbstractCommand
                 'SELECT' => [
                     'id',
                     QueryFunction::concat(
-                        params: ['itemtype', new QueryExpression($this->getDb()::quoteValue('::')), 'name'],
+                        params: [new QueryIdentifier('itemtype'), new QueryExpression($this->getDb()::quoteValue('::')), new QueryIdentifier('name')],
                         alias: 'task'
                     ),
                 ],
@@ -114,7 +115,7 @@ class UnlockCommand extends AbstractCommand
                 'WHERE'  => [
                     'state' => CronTask::STATE_RUNNING,
                     new QueryExpression(
-                        QueryFunction::unixTimestamp('lastrun') . " + $delay"
+                        QueryFunction::unixTimestamp(new QueryIdentifier('lastrun')) . " + $delay"
                         . " < "
                         . QueryFunction::unixTimestamp()
                     ),

--- a/src/Glpi/DBAL/QueryElementInterface.php
+++ b/src/Glpi/DBAL/QueryElementInterface.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,74 +32,42 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\DBAL\QueryElementInterface;
+namespace Glpi\DBAL;
+
+use Stringable;
 
 /**
- *  Sub query class
- **/
-abstract class AbstractQuery implements QueryElementInterface
+ * Common contract for the SQL building blocks that may carry bound parameters.
+ *
+ * Implementations render themselves to a SQL fragment through {@see self::getValue()} and
+ * expose the values to bind for the `?` placeholders that fragment contains through
+ * {@see self::getParams()}.
+ *
+ * Both methods must always be used together: rendering a fragment without collecting its
+ * parameters silently drops them, which shifts the positional binding of the whole statement.
+ */
+interface QueryElementInterface extends Stringable
 {
-    protected ?string $alias = null;
-    /** @var array<int, mixed> */
-    protected array $params = [];
-
     /**
-     * Create a query
-     *
-     * @param string $alias Alias for the whole subquery
-     */
-    public function __construct($alias = null)
-    {
-        $this->alias = $alias;
-    }
-
-    /**
-     * Get alias
-     *
-     * @return string|null
-     */
-    public function getAlias()
-    {
-        return $this->alias;
-    }
-
-    /**
-     *
-     * Get SQL query
+     * SQL fragment.
      *
      * @return string
      *
      * @psalm-taint-escape sql
      */
-    abstract public function getQuery();
+    public function getValue(): string;
 
     /**
+     * Values to bind, in the order their placeholders appear in {@see self::getValue()}.
+     *
+     * @return array<int, mixed>
+     */
+    public function getParams(): array;
+
+    /**
+     * SQL fragment, so that the element can be interpolated in a larger one.
+     *
      * @psalm-taint-escape sql
      */
-    public function getValue(): string
-    {
-        return $this->getQuery();
-    }
-
-    public function __toString(): string
-    {
-        return $this->getQuery();
-    }
-
-    /**
-    * @return array<int, mixed>
-    */
-    public function getParams(): array
-    {
-        return $this->params;
-    }
-
-    /**
-     * @param array<int, mixed> $params
-     */
-    public function setParams(array $params): static
-    {
-        $this->params = $params;
-        return $this;
-    }
+    public function __toString(): string;
 }

--- a/src/Glpi/DBAL/QueryExpression.php
+++ b/src/Glpi/DBAL/QueryExpression.php
@@ -39,7 +39,7 @@ use RuntimeException;
 /**
  *  Query expression class
  **/
-class QueryExpression
+class QueryExpression implements QueryElementInterface
 {
     private string $expression;
 
@@ -51,18 +51,18 @@ class QueryExpression
     /**
      * Create a query expression
      *
-     * @param string|QueryExpression $expression The query expression
+     * @param string|QueryElementInterface $expression The query expression
      * @param ?string $alias     The query expression alias
      * @param array<int, mixed> $values    The query expression values
      */
-    public function __construct(string|QueryExpression $expression, ?string $alias = null, array $values = [])
+    public function __construct(string|QueryElementInterface $expression, ?string $alias = null, array $values = [])
     {
         if ($expression === '') {
             throw new RuntimeException('Cannot build an empty expression');
         }
         $this->alias = $alias;
 
-        if ($expression instanceof QueryExpression) {
+        if ($expression instanceof QueryElementInterface) {
             $this->expression = $expression->getValue();
             $values = array_merge($expression->getParams(), $values);
         } else {
@@ -78,7 +78,7 @@ class QueryExpression
      *
      * @psalm-taint-escape sql
      */
-    public function getValue()
+    public function getValue(): string
     {
         global $DB;
         $sql = $this->expression;
@@ -88,7 +88,7 @@ class QueryExpression
         return $sql;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getValue();
     }

--- a/src/Glpi/DBAL/QueryFunction.php
+++ b/src/Glpi/DBAL/QueryFunction.php
@@ -34,7 +34,7 @@
 
 namespace Glpi\DBAL;
 
-use AbstractQuery;
+use DBmysql;
 use DBmysqlIterator;
 
 use function Safe\preg_match;
@@ -43,45 +43,136 @@ use function Safe\preg_replace;
 /**
  *  Query function class
  *
- * If a parameter takes a string or a QueryExpression, a string is an unquoted identifier while a QueryExpression is used for everything else.
- * Generic 'params' array parameters follow the same rules for their elements.
+ * Arguments that designate a database identifier should be given as a {@see QueryIdentifier};
+ * passing a bare string is still supported and behaves the same way.
+ * Any other {@see QueryElementInterface} ({@see QueryExpression}, {@see QueryValue}, sub-queries)
+ * is rendered through its `getValue()`, and the values it binds are collected automatically.
+ * Generic 'params' array parameters follow the same rules for their elements; `null` elements are ignored.
  * All aliases passed to the functions are automatically quoted as identifiers.
- * @method static QueryExpression avg(string|QueryExpression $expression, ?string $alias = null) Build an 'AVG' SQL function call
- * @method static QueryExpression bitAnd(string|QueryExpression $expression, ?string $alias = null) Build a 'BIT_AND' SQL function call
- * @method static QueryExpression bitCount(string|QueryExpression $expression, ?string $alias = null) Build a 'BIT_COUNT' SQL function call
- * @method static QueryExpression bitOr(string|QueryExpression $expression, ?string $alias = null) Build a 'BIT_OR' SQL function call
- * @method static QueryExpression bitXor(string|QueryExpression $expression, ?string $alias = null) Build a 'BIT_XOR' SQL function call
+ * @method static QueryExpression avg(QueryElementInterface|string $expression, ?string $alias = null) Build an 'AVG' SQL function call
+ * @method static QueryExpression bitAnd(QueryElementInterface|string $expression, ?string $alias = null) Build a 'BIT_AND' SQL function call
+ * @method static QueryExpression bitCount(QueryElementInterface|string $expression, ?string $alias = null) Build a 'BIT_COUNT' SQL function call
+ * @method static QueryExpression bitOr(QueryElementInterface|string $expression, ?string $alias = null) Build a 'BIT_OR' SQL function call
+ * @method static QueryExpression bitXor(QueryElementInterface|string $expression, ?string $alias = null) Build a 'BIT_XOR' SQL function call
  * @method static QueryExpression coalesce(array<int|string, mixed> $params, ?string $alias = null) Build a 'COALESCE' function call
  * @method static QueryExpression concat(array<int|string, mixed> $params, ?string $alias = null) Build a 'CONCAT' SQL function call
- * @method static QueryExpression floor(string|QueryExpression $expression, ?string $alias = null) Build a 'FLOOR' function call
+ * @method static QueryExpression floor(QueryElementInterface|string $expression, ?string $alias = null) Build a 'FLOOR' function call
  * @method static QueryExpression greatest(array<int|string, mixed> $params, ?string $alias = null) Build a 'GREATEST' function call
- * @method static QueryExpression inet6Aton(string|QueryExpression $expression, ?string $alias = null) Build an 'INET6_ATON' function call
+ * @method static QueryExpression inet6Aton(QueryElementInterface|string $expression, ?string $alias = null) Build an 'INET6_ATON' function call
  * @method static QueryExpression jsonExtract(array<int|string, mixed> $params, ?string $alias = null) Build a 'JSON_EXTRACT' function call
- * @method static QueryExpression jsonUnquote(string|QueryExpression $expression, ?string $alias = null) Build a 'JSON_UNQUOTE' function call
+ * @method static QueryExpression jsonUnquote(QueryElementInterface|string $expression, ?string $alias = null) Build a 'JSON_UNQUOTE' function call
  * @method static QueryExpression jsonRemove(array<int|string, mixed> $params, ?string $alias = null) Build a 'JSON_REMOVE' function call
  * @method static QueryExpression least(array<int|string, mixed> $params, ?string $alias = null) Build a 'LEAST' function call
- * @method static QueryExpression lower(string|QueryExpression $expression, ?string $alias = null) Build a 'LOWER' SQL function call
- * @method static QueryExpression max(string|QueryExpression $expression, ?string $alias = null) Build a 'MAX' SQL function call
- * @method static QueryExpression min(string|QueryExpression $expression, ?string $alias = null) Build a 'MIN' SQL function call
- * @method static QueryExpression upper(string|QueryExpression $expression, ?string $alias = null) Build a 'UPPER' SQL function call
- * @method static QueryExpression year(string|QueryExpression $expression, ?string $alias = null) Build a 'YEAR' SQL function call
+ * @method static QueryExpression lower(QueryElementInterface|string $expression, ?string $alias = null) Build a 'LOWER' SQL function call
+ * @method static QueryExpression max(QueryElementInterface|string $expression, ?string $alias = null) Build a 'MAX' SQL function call
+ * @method static QueryExpression min(QueryElementInterface|string $expression, ?string $alias = null) Build a 'MIN' SQL function call
+ * @method static QueryExpression upper(QueryElementInterface|string $expression, ?string $alias = null) Build an 'UPPER' SQL function call
+ * @method static QueryExpression year(QueryElementInterface|string $expression, ?string $alias = null) Build a 'YEAR' SQL function call
  **/
 class QueryFunction
 {
     /**
+     * Render a single function argument to its SQL fragment, collecting the values it binds.
+     *
+     * @param mixed $arg Argument to render. `null` is skipped, a {@see QueryElementInterface} is
+     *                   rendered through its `getValue()`, anything else is a bare identifier.
+     * @param array<int, mixed> $params Values to bind passed by reference
+     * @return string|null SQL fragment, or `null` when the argument has to be skipped
+     */
+    private static function renderArg(mixed $arg, array &$params): ?string
+    {
+        if ($arg === null) {
+            return null;
+        }
+
+        if ($arg instanceof QueryElementInterface) {
+            $params = array_merge($params, $arg->getParams());
+            return $arg->getValue();
+        }
+
+        //TODO: deprecate 13.0.0. Passing raw string is still possible but should be removed in a future version
+        //Toolbox::deprecate('Passing a bare string as a function argument is deprecated, use any QueryElementInterface instead', '13.0.0');
+        return DBmysql::quoteName($arg);
+    }
+
+    /**
+     * Render a list of function arguments, collecting the values they bind.
+     *
+     * @param array<int|string, mixed> $args
+     * @param array<int, mixed> $params Values to bind passed by reference
+     * @return array<int, string> SQL fragments, `null` arguments removed
+     */
+    private static function renderArgs(array $args, array &$params): array
+    {
+        $rendered = [];
+        foreach ($args as $arg) {
+            $sql = self::renderArg($arg, $params);
+            if ($sql !== null) {
+                $rendered[] = $sql;
+            }
+        }
+        return $rendered;
+    }
+
+    /**
      * Format the given data as a SQL function call.
      * The alias should not be quoted. It will be done in the returned QueryExpression when its value is evaluated.
      * @param string $func_name SQL function name
-     * @param array<int, string|QueryExpression|null> $func_args Array of quoted identifiers or QueryExpressions
-     * @param array<int, mixed> $params Array of statement values
+     * @param array<int|string, mixed> $func_args Function arguments
      * @param string|null $alias Unquoted alias
      * @return QueryExpression
      */
-    private static function getExpression(string $func_name, array $func_args, array $params, ?string $alias = null): QueryExpression
+    private static function getExpression(string $func_name, array $func_args, ?string $alias = null): QueryExpression
     {
+        $params = [];
+        $rendered = self::renderArgs($func_args, $params);
+        return new QueryExpression($func_name . '(' . implode(', ', $rendered) . ')', $alias, $params);
+    }
+
+    /**
+     * Build an aggregate SQL function call that supports the DISTINCT keyword.
+     * @param string $func_name SQL function name
+     * @param QueryElementInterface|string $expression Expression to aggregate
+     * @param bool $distinct Whether to add the DISTINCT keyword
+     * @param string|null $alias Function result alias (will be automatically quoted)
+     * @return QueryExpression
+     */
+    private static function getAggregateExpression(string $func_name, QueryElementInterface|string $expression, bool $distinct, ?string $alias): QueryExpression
+    {
+        $params = [];
+        $exp = $func_name . '(' . ($distinct ? 'DISTINCT ' : '') . self::renderArg($expression, $params) . ')';
+        return new QueryExpression($exp, $alias, $params);
+    }
+
+    /**
+     * Build a DATE_ADD or DATE_SUB SQL function call.
+     * @param string $func_name SQL function name
+     * @param QueryElementInterface|string $date Date to apply the interval to
+     * @param QueryElementInterface|int|string $interval Interval. A bare string is a literal value, not an identifier.
+     * @param string $interval_unit Interval unit. The SQL engine requires a literal here, so it cannot be parameterized.
+     * @param string|null $alias Function result alias (will be automatically quoted)
+     * @return QueryExpression
+     */
+    private static function getDateIntervalExpression(
+        string $func_name,
+        QueryElementInterface|string $date,
+        QueryElementInterface|int|string $interval,
+        string $interval_unit,
+        ?string $alias
+    ): QueryExpression {
         global $DB;
-        $func_args = array_map(static fn($p) => $p instanceof QueryExpression || $p === null ? $p : $DB::quoteName($p), $func_args);
-        return new QueryExpression($func_name . '(' . implode(', ', $func_args) . ')', $alias, $params);
+
+        $params = [];
+        $date_sql = self::renderArg($date, $params);
+        if ($interval instanceof QueryElementInterface) {
+            $interval_sql = self::renderArg($interval, $params);
+        } else {
+            // a bare string interval is a literal value (e.g. '5-1'), not an identifier
+            $interval_sql = is_string($interval) ? $DB::quoteValue($interval) : (string) $interval;
+        }
+
+        $exp = sprintf('%s(%s, INTERVAL %s %s)', $func_name, $date_sql, $interval_sql, strtoupper($interval_unit));
+        return new QueryExpression($exp, $alias, $params);
     }
 
     /**
@@ -99,13 +190,6 @@ class QueryFunction
             $params = [$params];
         }
 
-        $values = [];
-        foreach ($params as $param) {
-            if ($param instanceof QueryExpression || $param instanceof AbstractQuery) {
-                $values = array_merge($values, $param->getParams());
-            }
-        }
-
         // Map camelCase function names to SQL function names
         $func_name = match (true) {
             // if the name is in camelCase, convert camelCase to snake_case
@@ -114,7 +198,7 @@ class QueryFunction
             default => $name,
         };
         $func_name = strtoupper($func_name);
-        return self::getExpression($func_name, $params, $values, $args[1] ?? null);
+        return self::getExpression($func_name, $params, $args[1] ?? null);
     }
 
     /**
@@ -127,198 +211,133 @@ class QueryFunction
      */
     public static function dateAdd(QueryElementInterface|string $date, QueryElementInterface|int|string $interval, string $interval_unit, ?string $alias = null): QueryExpression
     {
-        global $DB;
-        $date = $date instanceof QueryElementInterface ? $date : $DB::quoteName($date);
-        $interval = is_string($interval) ? $DB::quoteValue($interval) : $interval;
-        $exp = sprintf('DATE_ADD(%s, INTERVAL %s %s)', $date, $interval, strtoupper($interval_unit));
-        return new QueryExpression($exp, $alias);
+        return self::getDateIntervalExpression('DATE_ADD', $date, $interval, $interval_unit, $alias);
     }
 
     /**
      * Build an DATE_SUB SQL function call
-     * @param QueryElementInterface|string $date Date to add interval to
-     * @param QueryElementInterface|int|string $interval Interval to add. A bare string is a literal value, not an identifier.
+     * @param QueryElementInterface|string $date Date to subtract interval from
+     * @param QueryElementInterface|int|string $interval Interval to subtract. A bare string is a literal value, not an identifier.
      * @param string $interval_unit Interval unit
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
     public static function dateSub(QueryElementInterface|string $date, QueryElementInterface|int|string $interval, string $interval_unit, ?string $alias = null): QueryExpression
     {
-        global $DB;
-        $date = $date instanceof QueryElementInterface ? $date : $DB::quoteName($date);
-        $interval = is_string($interval) ? $DB::quoteValue($interval) : $interval;
-        $exp = sprintf('DATE_SUB(%s, INTERVAL %s %s)', $date, $interval, strtoupper($interval_unit));
-        return new QueryExpression($exp, $alias);
+        return self::getDateIntervalExpression('DATE_SUB', $date, $interval, $interval_unit, $alias);
     }
 
     /**
      * Build an IF SQL function call
-     * @param string|QueryExpression|array<int|string, mixed> $condition Condition to test
-     * @param string|QueryExpression $true_expression Expression to return if condition is true
-     * @param string|QueryExpression $false_expression Expression to return if condition is false
+     * @param QueryElementInterface|string|array<int|string, mixed> $condition Condition to test
+     * @param QueryElementInterface|string $true_expression Expression to return if condition is true
+     * @param QueryElementInterface|string $false_expression Expression to return if condition is false
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function if(string|QueryExpression|array $condition, string|QueryExpression $true_expression, string|QueryExpression $false_expression, ?string $alias = null): QueryExpression
+    public static function if(QueryElementInterface|string|array $condition, QueryElementInterface|string $true_expression, QueryElementInterface|string $false_expression, ?string $alias = null): QueryExpression
     {
-        $values = [];
         if (is_array($condition)) {
             $iterator = new DBmysqlIterator(null);
             $condition = new QueryExpression($iterator->analyseCrit($condition), values: $iterator->getValues());
-            $values = $iterator->getValues();
-        } elseif ($condition instanceof QueryExpression) {
-            $values = array_merge($values, $condition->getParams());
         }
-        if ($true_expression instanceof QueryExpression) {
-            $values = array_merge($values, $true_expression->getParams());
-        }
-        if ($false_expression instanceof QueryExpression) {
-            $values = array_merge($values, $false_expression->getParams());
-        }
-        return self::getExpression('IF', [$condition, $true_expression, $false_expression], $values, $alias);
+        return self::getExpression('IF', [$condition, $true_expression, $false_expression], $alias);
     }
 
     /**
      * Build an IFNULL SQL function call
-     * @param string|QueryExpression $expression Expression to check
-     * @param string|QueryExpression $value Value to return if expression is null
+     * @param QueryElementInterface|string $expression Expression to check
+     * @param QueryElementInterface|string $value Value to return if expression is null
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function ifnull(string|QueryExpression $expression, string|QueryExpression $value, ?string $alias = null): QueryExpression
+    public static function ifnull(QueryElementInterface|string $expression, QueryElementInterface|string $value, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        if ($value instanceof QueryExpression) {
-            $values = array_merge($values, $value->getParams());
-        }
-        return self::getExpression('IFNULL', [$expression, $value], $values, $alias);
+        return self::getExpression('IFNULL', [$expression, $value], $alias);
     }
 
     /**
      * Build a GROUP_CONCAT SQL function call
-     * @param string|QueryExpression $expression Expression to group
-     * @param string|null $separator Separator to use (will be automatically quoted as a value)
-     * @param bool $distinct Use DISTINCT or not
-     * @param string|array<int, string|QueryExpression>|null $order_by Order by clause
+     * @param QueryElementInterface|string $expression Expression to concatenate
+     * @param string|null $separator Separator to use. The SQL engine requires a literal here, so it cannot be parameterized.
+     * @param bool $distinct Whether to add the DISTINCT keyword
+     * @param QueryElementInterface|array<int, QueryElementInterface|string>|string|null $order_by Order by clause
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function groupConcat(string|QueryExpression $expression, ?string $separator = null, bool $distinct = false, array|string|null $order_by = null, ?string $alias = null): QueryExpression
+    public static function groupConcat(QueryElementInterface|string $expression, ?string $separator = null, bool $distinct = false, QueryElementInterface|array|string|null $order_by = null, ?string $alias = null): QueryExpression
     {
         global $DB;
 
-        $expression = $expression instanceof QueryExpression ? $expression : $DB::quoteName($expression);
+        $params = [];
         $exp = 'GROUP_CONCAT(';
         if ($distinct) {
             $exp .= 'DISTINCT ';
         }
-        $exp .= $expression;
+        $exp .= self::renderArg($expression, $params);
         if ($order_by) {
-            $exp .= (new DBmysqlIterator(null))->handleOrderClause($order_by);
+            $iterator = new DBmysqlIterator(null);
+            $exp .= $iterator->handleOrderClause($order_by);
+            $params = array_merge($params, $iterator->getValues());
         }
         if (!empty($separator)) {
             $exp .= ' SEPARATOR ' . $DB::quoteValue($separator);
         }
         $exp .= ')';
 
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return new QueryExpression($exp, $alias, $values);
+        return new QueryExpression($exp, $alias, $params);
     }
 
     /**
      * Build a SUM SQL function call
-     * @param string|QueryExpression $expression Expression to sum
-     * @param bool $distinct Use DISTINCT or not
+     * @param QueryElementInterface|string $expression Expression to sum
+     * @param bool $distinct Whether to add the DISTINCT keyword
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function sum(string|QueryExpression $expression, bool $distinct = false, ?string $alias = null): QueryExpression
+    public static function sum(QueryElementInterface|string $expression, bool $distinct = false, ?string $alias = null): QueryExpression
     {
-        global $DB;
-
-        $expression = $expression instanceof QueryExpression ? $expression : $DB::quoteName($expression);
-        $exp = 'SUM(';
-        if ($distinct) {
-            $exp .= 'DISTINCT ';
-        }
-        $exp .= $expression . ')';
-
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return new QueryExpression($exp, $alias, $values);
+        return self::getAggregateExpression('SUM', $expression, $distinct, $alias);
     }
 
     /**
      * Build a COUNT SQL function call
-     * @param string|QueryExpression $expression Expression to count
-     * @param bool $distinct Use DISTINCT or not
+     * @param QueryElementInterface|string $expression Expression to count
+     * @param bool $distinct Whether to add the DISTINCT keyword
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function count(string|QueryExpression $expression, bool $distinct = false, ?string $alias = null): QueryExpression
+    public static function count(QueryElementInterface|string $expression, bool $distinct = false, ?string $alias = null): QueryExpression
     {
-        global $DB;
-
-        $expression = $expression instanceof QueryExpression ? $expression : $DB::quoteName($expression);
-        $exp = 'COUNT(';
-        if ($distinct) {
-            $exp .= 'DISTINCT ';
-        }
-        $exp .= $expression . ')';
-
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return new QueryExpression($exp, $alias, $values);
+        return self::getAggregateExpression('COUNT', $expression, $distinct, $alias);
     }
 
     /**
      * Build a CAST SQL function call
-     * @param string|QueryExpression $expression Expression to cast
-     * @param string $type Type to cast to
+     * @param QueryElementInterface|string $expression Expression to cast
+     * @param string $type Type to cast to. The SQL engine requires a literal here, so it cannot be parameterized.
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function cast(string|QueryExpression $expression, string $type, ?string $alias = null): QueryExpression
+    public static function cast(QueryElementInterface|string $expression, string $type, ?string $alias = null): QueryExpression
     {
-        global $DB;
-
-        $expression = $expression instanceof QueryExpression ? $expression : $DB::quoteName($expression);
-
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return new QueryExpression('CAST(' . $expression . ' AS ' . $type . ')', $alias, $values);
+        $params = [];
+        $expression_sql = self::renderArg($expression, $params);
+        return new QueryExpression('CAST(' . $expression_sql . ' AS ' . $type . ')', $alias, $params);
     }
 
     /**
      * Build a CONVERT SQL function call
-     * @param string|QueryExpression $expression Expression to convert
-     * @param string $transcoding Transcoding to use
+     * @param QueryElementInterface|string $expression Expression to convert
+     * @param string $transcoding Transcoding to use. The SQL engine requires a literal here, so it cannot be parameterized.
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function convert(string|QueryExpression $expression, string $transcoding, ?string $alias = null): QueryExpression
+    public static function convert(QueryElementInterface|string $expression, string $transcoding, ?string $alias = null): QueryExpression
     {
-        global $DB;
-        $expression = $expression instanceof QueryExpression ? $expression : $DB::quoteName($expression);
-
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return new QueryExpression('CONVERT(' . $expression . ' USING ' . $transcoding . ')', $alias, $values);
-
+        $params = [];
+        $expression_sql = self::renderArg($expression, $params);
+        return new QueryExpression('CONVERT(' . $expression_sql . ' USING ' . $transcoding . ')', $alias, $params);
     }
 
     /**
@@ -343,258 +362,176 @@ class QueryFunction
 
     /**
      * Build a REPLACE SQL function call
-     * @param string|QueryExpression $expression Expression to search in
-     * @param string|QueryExpression $search String to search
-     * @param string|QueryExpression $replace String to replace
+     * @param QueryElementInterface|string $expression Expression to search in
+     * @param QueryElementInterface|string $search String to search
+     * @param QueryElementInterface|string $replace String to replace
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function replace(string|QueryExpression $expression, string|QueryExpression $search, string|QueryExpression $replace, ?string $alias = null): QueryExpression
+    public static function replace(QueryElementInterface|string $expression, QueryElementInterface|string $search, QueryElementInterface|string $replace, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        if ($search instanceof QueryExpression) {
-            $values = array_merge($values, $search->getParams());
-        }
-        if ($replace instanceof QueryExpression) {
-            $values = array_merge($values, $replace->getParams());
-        }
-        return self::getExpression('REPLACE', [$expression, $search, $replace], $values, $alias);
+        return self::getExpression('REPLACE', [$expression, $search, $replace], $alias);
     }
 
     /**
      * Build a FROM_UNIXTIME SQL function call
-     * @param string|QueryExpression $expression Expression to convert
-     * @param string|QueryExpression|null $format Function result alias
+     * @param QueryElementInterface|string $expression Expression to convert
+     * @param QueryElementInterface|string|null $format Format to use
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function fromUnixtime(string|QueryExpression $expression, string|QueryExpression|null $format = null, ?string $alias = null): QueryExpression
+    public static function fromUnixtime(QueryElementInterface|string $expression, QueryElementInterface|string|null $format = null, ?string $alias = null): QueryExpression
     {
-        $params = [$expression];
-        $values = [];
-        if ($format !== null) {
-            $params[] = $format;
-        }
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        if ($format instanceof QueryExpression) {
-            $values = array_merge($values, $format->getParams());
-        }
-        return self::getExpression('FROM_UNIXTIME', $params, $values, $alias);
+        return self::getExpression('FROM_UNIXTIME', [$expression, $format], $alias);
     }
 
     /**
      * Build a DATE_FORMAT SQL function call
-     * @param string|QueryExpression $expression Expression to format
+     * @param QueryElementInterface|string $expression Expression to format
      * @param string $format Format to use (Automatically quoted as a value)
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function dateFormat(string|QueryExpression $expression, string $format, ?string $alias = null): QueryExpression
+    public static function dateFormat(QueryElementInterface|string $expression, string $format, ?string $alias = null): QueryExpression
     {
         global $DB;
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        $format = new QueryExpression($DB::quoteValue($format));
-        return self::getExpression('DATE_FORMAT', [$expression, $format], $values, $alias);
+        return self::getExpression('DATE_FORMAT', [$expression, new QueryExpression($DB::quoteValue($format))], $alias);
     }
 
     /**
      * Build a LPAD SQL function call
-     * @param string|QueryExpression $expression Expression to pad
+     * @param QueryElementInterface|string $expression Expression to pad
      * @param int $length Length to pad to
      * @param string $pad_string String to pad with (Automatically quoted as a value)
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function lpad(string|QueryExpression $expression, int $length, string $pad_string, ?string $alias = null): QueryExpression
+    public static function lpad(QueryElementInterface|string $expression, int $length, string $pad_string, ?string $alias = null): QueryExpression
     {
         global $DB;
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        $length = new QueryExpression((string) $length);
-        $values = array_merge($values, $length->getParams());
-        $pad_string = new QueryExpression($DB::quoteValue($pad_string));
-        $values = array_merge($values, $pad_string->getParams());
-        return self::getExpression('LPAD', [$expression, $length, $pad_string], $values, $alias);
+        return self::getExpression('LPAD', [
+            $expression,
+            new QueryExpression((string) $length),
+            new QueryExpression($DB::quoteValue($pad_string)),
+        ], $alias);
     }
 
     /**
      * Build a SUBSTRING SQL function call
-     * @param string|QueryExpression $expression Expression
+     * @param QueryElementInterface|string $expression Expression
      * @param int $start Start position
      * @param int $length Length
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function substring(string|QueryExpression $expression, int $start, int $length, ?string $alias = null): QueryExpression
+    public static function substring(QueryElementInterface|string $expression, int $start, int $length, ?string $alias = null): QueryExpression
     {
-        $start_expr = new QueryExpression((string) $start);
-        $length_expr = new QueryExpression((string) $length);
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        $values = array_merge($values, $start_expr->getParams(), $length_expr->getParams());
         return self::getExpression('SUBSTRING', [
-            $expression, $start_expr, $length_expr,
-        ], $values, $alias);
+            $expression,
+            new QueryExpression((string) $start),
+            new QueryExpression((string) $length),
+        ], $alias);
     }
 
     /**
-     * Buidl a ROUND SQL function call
-     * @param string|QueryExpression $expression Expression to round
+     * Build a ROUND SQL function call
+     * @param QueryElementInterface|string $expression Expression to round
      * @param int $precision Precision to round to
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function round(string|QueryExpression $expression, int $precision = 0, ?string $alias = null): QueryExpression
+    public static function round(QueryElementInterface|string $expression, int $precision = 0, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        $precision = new QueryExpression((string) $precision);
-        $values = array_merge($values, $precision->getParams());
-        return self::getExpression('ROUND', [$expression, $precision], $values, $alias);
+        return self::getExpression('ROUND', [$expression, new QueryExpression((string) $precision)], $alias);
     }
 
     /**
      * Build a NULLIF SQL function call
-     * @param string|QueryExpression $expression Expression to check
-     * @param string|QueryExpression $value Value to check against
+     * @param QueryElementInterface|string $expression Expression to check
+     * @param QueryElementInterface|string $value Value to check against
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function nullif(string|QueryExpression $expression, string|QueryExpression $value, ?string $alias = null): QueryExpression
+    public static function nullif(QueryElementInterface|string $expression, QueryElementInterface|string $value, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        if ($value instanceof QueryExpression) {
-            $values = array_merge($values, $value->getParams());
-        }
-        return self::getExpression('NULLIF', [$expression, $value], $values, $alias);
+        return self::getExpression('NULLIF', [$expression, $value], $alias);
     }
 
     /**
      * Build a TIMESTAMPDIFF SQL function call
-     * @param string $unit Unit to use
-     * @param string|QueryExpression $expression1 Expression to compare
-     * @param string|QueryExpression $expression2 Expression to compare
+     * @param string $unit Unit to use. The SQL engine requires a literal here, so it cannot be parameterized.
+     * @param QueryElementInterface|string $expression1 Expression to compare
+     * @param QueryElementInterface|string $expression2 Expression to compare
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function timestampdiff(string $unit, string|QueryExpression $expression1, string|QueryExpression $expression2, ?string $alias = null): QueryExpression
+    public static function timestampdiff(string $unit, QueryElementInterface|string $expression1, QueryElementInterface|string $expression2, ?string $alias = null): QueryExpression
     {
-        $unit_expr = new QueryExpression($unit);
-        $values = $unit_expr->getParams();
-        if ($expression1 instanceof QueryExpression) {
-            $values = array_merge($values, $expression1->getParams());
-        }
-        if ($expression2 instanceof QueryExpression) {
-            $values = array_merge($values, $expression2->getParams());
-        }
-        return self::getExpression('TIMESTAMPDIFF', [$unit_expr, $expression1, $expression2], $values, $alias);
+        return self::getExpression('TIMESTAMPDIFF', [new QueryExpression($unit), $expression1, $expression2], $alias);
     }
 
     /**
      * Build a DATEDIFF SQL function call
-     * @param string|QueryExpression $expression1 Expression to compare
-     * @param string|QueryExpression $expression2 Expression to compare
+     * @param QueryElementInterface|string $expression1 Expression to compare
+     * @param QueryElementInterface|string $expression2 Expression to compare
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function datediff(string|QueryExpression $expression1, string|QueryExpression $expression2, ?string $alias = null): QueryExpression
+    public static function datediff(QueryElementInterface|string $expression1, QueryElementInterface|string $expression2, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression1 instanceof QueryExpression) {
-            $values = array_merge($values, $expression1->getParams());
-        }
-        if ($expression2 instanceof QueryExpression) {
-            $values = array_merge($values, $expression2->getParams());
-        }
-        return self::getExpression('DATEDIFF', [$expression1, $expression2], $values, $alias);
+        return self::getExpression('DATEDIFF', [$expression1, $expression2], $alias);
     }
 
     /**
      * Build a TIMEDIFF SQL function call
-     * @param string|QueryExpression $expression1 Expression to compare
-     * @param string|QueryExpression $expression2 Expression to compare
+     * @param QueryElementInterface|string $expression1 Expression to compare
+     * @param QueryElementInterface|string $expression2 Expression to compare
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function timediff(string|QueryExpression $expression1, string|QueryExpression $expression2, ?string $alias = null): QueryExpression
+    public static function timediff(QueryElementInterface|string $expression1, QueryElementInterface|string $expression2, ?string $alias = null): QueryExpression
     {
-        $values = [];
-        if ($expression1 instanceof QueryExpression) {
-            $values = array_merge($values, $expression1->getParams());
-        }
-        if ($expression2 instanceof QueryExpression) {
-            $values = array_merge($values, $expression2->getParams());
-        }
-        return self::getExpression('TIMEDIFF', [$expression1, $expression2], $values, $alias);
+        return self::getExpression('TIMEDIFF', [$expression1, $expression2], $alias);
     }
 
     /**
      * Build a UNIX_TIMSTAMP SQL function call
-     * @param string|QueryExpression|null $expression Expression to convert. If null, the current timestamp will be used (NOW() implied at the DB level).
+     * @param QueryElementInterface|string|null $expression Expression to convert. If null, the current timestamp will be used (NOW() implied at the DB level).
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function unixTimestamp(string|QueryExpression|null $expression = null, ?string $alias = null): QueryExpression
+    public static function unixTimestamp(QueryElementInterface|string|null $expression = null, ?string $alias = null): QueryExpression
     {
-        $params = [];
-        $values = [];
-        if ($expression !== null) {
-            $params = [$expression];
-            if ($expression instanceof QueryExpression) {
-                $values = array_merge($values, $expression->getParams());
-            }
-        }
-        return self::getExpression('UNIX_TIMESTAMP', $params, $values, $alias);
+        return self::getExpression('UNIX_TIMESTAMP', [$expression], $alias);
     }
 
     /**
      * Build a LOCATE SQL function call
-     * @param string|QueryExpression $substring String to search for. Treated like a value if it's a string.
-     * @param string|QueryExpression $expression Expression to search in
+     * @param QueryElementInterface|string $substring String to search for. Treated like a value if it's a string.
+     * @param QueryElementInterface|string $expression Expression to search in
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function locate(string|QueryExpression $substring, string|QueryExpression $expression, ?string $alias = null): QueryExpression
+    public static function locate(QueryElementInterface|string $substring, QueryElementInterface|string $expression, ?string $alias = null): QueryExpression
     {
         global $DB;
         $substring = is_string($substring) ? new QueryExpression($DB::quoteValue($substring)) : $substring;
-        $values = $substring->getParams();
-        if ($expression instanceof QueryExpression) {
-            $values = array_merge($values, $expression->getParams());
-        }
-        return self::getExpression('LOCATE', [$substring, $expression], $values, $alias);
+        return self::getExpression('LOCATE', [$substring, $expression], $alias);
     }
 
     /**
      * Build a CONCAT_WS SQL function call
-     * @param string|QueryExpression $separator Separator to use. Treated like a value if it's a string.
-     * @param array<int, string|QueryExpression|null> $params Array of expressions to concatenate. String values will be treated as identifiers, null values will be ignored.
+     * @param QueryElementInterface|string $separator Separator to use. String values are treated as identifiers; use a QueryValue for a literal.
+     * @param array<int, mixed> $params Array of expressions to concatenate. String values will be treated as identifiers, null values will be ignored.
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function concat_ws(string|QueryExpression $separator, array $params, ?string $alias = null): QueryExpression
+    public static function concat_ws(QueryElementInterface|string $separator, array $params, ?string $alias = null): QueryExpression
     {
-        global $DB;
-        $params = array_map(static fn($p) => $p instanceof QueryExpression || $p === null ? $p : $DB::quoteName($p), $params);
-        $separator = $separator instanceof QueryExpression ? $separator : $DB::quoteName($separator);
-        return new QueryExpression('CONCAT_WS(' . $separator . ', ' . implode(', ', $params) . ')', $alias);
+        $values = [];
+        $separator_sql = self::renderArg($separator, $values);
+        $rendered = self::renderArgs($params, $values);
+        return new QueryExpression('CONCAT_WS(' . $separator_sql . ', ' . implode(', ', $rendered) . ')', $alias, $values);
     }
 
     /**
@@ -602,8 +539,8 @@ class QueryFunction
      *
      * Searches for a value within a JSON document.
      *
-     * @param string|QueryExpression $target JSON field or expression to search in.
-     * @param string|QueryExpression $candidate Value to search for. String values will be treated as field identifiers.
+     * @param QueryElementInterface|string $target JSON field or expression to search in.
+     * @param QueryElementInterface|string $candidate Value to search for. String values will be treated as field identifiers.
      * @param string $path JSON path expression (e.g., '$' for root, '$.fieldname' for nested).
      * @param string|null $alias Function result alias.
      * @return QueryExpression
@@ -611,43 +548,30 @@ class QueryFunction
      * @example
      * // Search for a scalar value
      * QueryFunction::jsonContains(
-     *     'users_id_guests',
-     *     new QueryExpression($DB::quoteValue(4)),
+     *     new QueryIdentifier('users_id_guests'),
+     *     new QueryValue(4),
      *     '$'
      * )
      *
      * @example
      * // Search using a column reference
      * QueryFunction::jsonContains(
-     *     'REFTABLE.custom_fields',
-     *     'NEWTABLE.id',
+     *     new QueryIdentifier('REFTABLE.custom_fields'),
+     *     new QueryIdentifier('NEWTABLE.id'),
      *     '$.field_id'
      * )
      */
-    public static function jsonContains(string|QueryExpression $target, string|QueryExpression $candidate, string $path, ?string $alias = null): QueryExpression
+    public static function jsonContains(QueryElementInterface|string $target, QueryElementInterface|string $candidate, string $path, ?string $alias = null): QueryExpression
     {
         global $DB;
-
-        $values = [];
-        if (is_string($target)) {
-            $target = new QueryExpression($DB::quoteName($target));
-        }
-
-        if (is_string($candidate)) {
-            $candidate = new QueryExpression($DB::quoteName($candidate));
-        }
-
-        $path = new QueryExpression($DB::quoteValue($path));
-        $values = array_merge($values, $target->getParams(), $candidate->getParams());
 
         return self::getExpression(
             'JSON_CONTAINS',
             [
                 $target,
-                $DB->getVersionAndServer()['server'] === 'MariaDB' ? $candidate : QueryFunction::cast($candidate, 'JSON'),
-                $path,
+                $DB->getVersionAndServer()['server'] === 'MariaDB' ? $candidate : self::cast($candidate, 'JSON'),
+                new QueryExpression($DB::quoteValue($path)),
             ],
-            $values,
             $alias
         );
     }

--- a/src/Glpi/DBAL/QueryFunction.php
+++ b/src/Glpi/DBAL/QueryFunction.php
@@ -119,16 +119,16 @@ class QueryFunction
 
     /**
      * Build an DATE_ADD SQL function call
-     * @param string|QueryExpression $date Date to add interval to
-     * @param int|string|QueryExpression $interval Interval to add
+     * @param QueryElementInterface|string $date Date to add interval to
+     * @param QueryElementInterface|int|string $interval Interval to add. A bare string is a literal value, not an identifier.
      * @param string $interval_unit Interval unit
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function dateAdd(string|QueryExpression $date, int|string|QueryExpression $interval, string $interval_unit, ?string $alias = null): QueryExpression
+    public static function dateAdd(QueryElementInterface|string $date, QueryElementInterface|int|string $interval, string $interval_unit, ?string $alias = null): QueryExpression
     {
         global $DB;
-        $date = $date instanceof QueryExpression ? $date : $DB::quoteName($date);
+        $date = $date instanceof QueryElementInterface ? $date : $DB::quoteName($date);
         $interval = is_string($interval) ? $DB::quoteValue($interval) : $interval;
         $exp = sprintf('DATE_ADD(%s, INTERVAL %s %s)', $date, $interval, strtoupper($interval_unit));
         return new QueryExpression($exp, $alias);
@@ -136,16 +136,16 @@ class QueryFunction
 
     /**
      * Build an DATE_SUB SQL function call
-     * @param string|QueryExpression $date Date to add interval to
-     * @param int|string|QueryExpression $interval Interval to add
+     * @param QueryElementInterface|string $date Date to add interval to
+     * @param QueryElementInterface|int|string $interval Interval to add. A bare string is a literal value, not an identifier.
      * @param string $interval_unit Interval unit
      * @param string|null $alias Function result alias (will be automatically quoted)
      * @return QueryExpression
      */
-    public static function dateSub(string|QueryExpression $date, int|string|QueryExpression $interval, string $interval_unit, ?string $alias = null): QueryExpression
+    public static function dateSub(QueryElementInterface|string $date, QueryElementInterface|int|string $interval, string $interval_unit, ?string $alias = null): QueryExpression
     {
         global $DB;
-        $date = $date instanceof QueryExpression ? $date : $DB::quoteName($date);
+        $date = $date instanceof QueryElementInterface ? $date : $DB::quoteName($date);
         $interval = is_string($interval) ? $DB::quoteValue($interval) : $interval;
         $exp = sprintf('DATE_SUB(%s, INTERVAL %s %s)', $date, $interval, strtoupper($interval_unit));
         return new QueryExpression($exp, $alias);

--- a/src/Glpi/DBAL/QueryIdentifier.php
+++ b/src/Glpi/DBAL/QueryIdentifier.php
@@ -8,7 +8,6 @@
  * http://glpi-project.org
  *
  * @copyright 2015-2026 Teclib' and contributors.
- * @copyright 2003-2014 by the INDEPNET Development Team.
  * @licence   https://www.gnu.org/licenses/gpl-3.0.html
  *
  * ---------------------------------------------------------------------
@@ -33,74 +32,49 @@
  * ---------------------------------------------------------------------
  */
 
-use Glpi\DBAL\QueryElementInterface;
+namespace Glpi\DBAL;
+
+use DBmysql;
+use Glpi\Exception\Database\QueryException;
 
 /**
- *  Sub query class
- **/
-abstract class AbstractQuery implements QueryElementInterface
+ * A database identifier (table or field name) that has to be quoted.
+ */
+final class QueryIdentifier implements QueryElementInterface
 {
-    protected ?string $alias = null;
-    /** @var array<int, mixed> */
-    protected array $params = [];
-
     /**
-     * Create a query
-     *
-     * @param string $alias Alias for the whole subquery
+     * @param string  $name  Identifier to quote. May be qualified (`table.field`), the `*`
+     *                       wildcard, or already quoted.
+     * @param ?string $alias Alias, quoted along with the identifier.
      */
-    public function __construct($alias = null)
-    {
-        $this->alias = $alias;
+    public function __construct(
+        private readonly string $name,
+        private readonly ?string $alias = null,
+    ) {
+        if ($name === '') {
+            throw new QueryException('Cannot build an empty identifier');
+        }
+        if ($alias === '') {
+            throw new QueryException('Cannot build an empty alias');
+        }
     }
 
-    /**
-     * Get alias
-     *
-     * @return string|null
-     */
-    public function getAlias()
-    {
-        return $this->alias;
-    }
-
-    /**
-     *
-     * Get SQL query
-     *
-     * @return string
-     *
-     * @psalm-taint-escape sql
-     */
-    abstract public function getQuery();
-
-    /**
-     * @psalm-taint-escape sql
-     */
     public function getValue(): string
     {
-        return $this->getQuery();
+        $sql = DBmysql::quoteName($this->name);
+        if ($this->alias !== null) {
+            $sql .= ' AS ' . DBmysql::quoteName($this->alias);
+        }
+        return $sql;
+    }
+
+    public function getParams(): array
+    {
+        return [];
     }
 
     public function __toString(): string
     {
-        return $this->getQuery();
-    }
-
-    /**
-    * @return array<int, mixed>
-    */
-    public function getParams(): array
-    {
-        return $this->params;
-    }
-
-    /**
-     * @param array<int, mixed> $params
-     */
-    public function setParams(array $params): static
-    {
-        $this->params = $params;
-        return $this;
+        return $this->getValue();
     }
 }

--- a/src/Glpi/DBAL/QueryValue.php
+++ b/src/Glpi/DBAL/QueryValue.php
@@ -37,20 +37,13 @@ namespace Glpi\DBAL;
 use Glpi\Exception\Database\QueryException;
 
 /**
- * A scalar value used in a statement.
+ * A database scalar value used in a statement.
  *
  * Renders as a `?` placeholder and carries the value to bind for it, so the value travels with
  * the SQL fragment instead of being inlined into it:
  * ```php
  * QueryFunction::dateAdd(new QueryIdentifier('date_creation'), new QueryValue(3), 'DAY')
  * ```
- *
- * Not to be confused with {@see QueryParam}, which also renders as `?` but binds *nothing*: it
- * marks the placeholders of a statement that is prepared once and executed many times.
- *
- * Note that the SQL engine does not accept a placeholder everywhere. `GROUP_CONCAT(... SEPARATOR
- * 'x')`, `CAST(x AS TYPE)` and `CONVERT(x USING charset)` require a literal, so those positions
- * cannot take a `QueryValue`.
  */
 final class QueryValue implements QueryElementInterface
 {

--- a/src/Glpi/DBAL/QueryValue.php
+++ b/src/Glpi/DBAL/QueryValue.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\DBAL;
+
+use Glpi\Exception\Database\QueryException;
+
+/**
+ * A scalar value used in a statement.
+ *
+ * Renders as a `?` placeholder and carries the value to bind for it, so the value travels with
+ * the SQL fragment instead of being inlined into it:
+ * ```php
+ * QueryFunction::dateAdd(new QueryIdentifier('date_creation'), new QueryValue(3), 'DAY')
+ * ```
+ *
+ * Not to be confused with {@see QueryParam}, which also renders as `?` but binds *nothing*: it
+ * marks the placeholders of a statement that is prepared once and executed many times.
+ *
+ * Note that the SQL engine does not accept a placeholder everywhere. `GROUP_CONCAT(... SEPARATOR
+ * 'x')`, `CAST(x AS TYPE)` and `CONVERT(x USING charset)` require a literal, so those positions
+ * cannot take a `QueryValue`.
+ */
+final class QueryValue implements QueryElementInterface
+{
+    /**
+     * @param scalar|null $value Value to bind.
+     */
+    public function __construct(private readonly mixed $value)
+    {
+        if ($value !== null && !is_scalar($value)) {
+            throw new QueryException(
+                sprintf('A query value must be a scalar, %s given', get_debug_type($value))
+            );
+        }
+    }
+
+    public function getValue(): string
+    {
+        return '?';
+    }
+
+    public function getParams(): array
+    {
+        return [$this->value];
+    }
+
+    public function __toString(): string
+    {
+        return $this->getValue();
+    }
+}

--- a/src/Glpi/Dashboard/Provider.php
+++ b/src/Glpi/Dashboard/Provider.php
@@ -52,6 +52,7 @@ use Glpi\Dashboard\Filters\{
 };
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
 use Glpi\Search\Input\QueryBuilder;
@@ -583,7 +584,7 @@ class Provider
         $query_criteria = [
             'COUNT' => 'cpt',
             'SELECT'    => [
-                QueryFunction::concat(["{$userTable}.{$first}", new QueryExpression($DB::quoteValue(' ')), "{$userTable}.{$second}"], 'username'),
+                QueryFunction::concat([new QueryIdentifier("{$userTable}.{$first}"), new QueryExpression($DB::quoteValue(' ')), new QueryIdentifier("{$userTable}.{$second}")], 'username'),
                 "$userTable.name",
                 $slaState,
             ],
@@ -1456,7 +1457,7 @@ class Provider
             [
                 'SELECT' => [
                     'COUNT DISTINCT' => "$t_table.id as nb_tickets",
-                    QueryFunction::dateFormat('date', '%Y-%m', 'ticket_month'),
+                    QueryFunction::dateFormat(new QueryIdentifier('date'), '%Y-%m', 'ticket_month'),
                 ],
                 'FROM'    => $t_table,
                 'WHERE'    => [
@@ -1744,7 +1745,7 @@ class Provider
         $criteria = [
             'SELECT'   => [
                 QueryFunction::fromUnixtime(
-                    expression: QueryFunction::unixTimestamp("{$t_table}_distinct.date"),
+                    expression: QueryFunction::unixTimestamp(new QueryIdentifier("{$t_table}_distinct.date")),
                     format: new QueryExpression($DB::quoteValue('%Y-%m')),
                     alias: 'period'
                 ),
@@ -2045,11 +2046,11 @@ class Provider
         $criteria = array_merge_recursive(
             [
                 'SELECT' => [
-                    QueryFunction::dateFormat('date', '%Y-%m', 'period'),
-                    QueryFunction::avg('takeintoaccount_delay_stat', 'avg_takeintoaccount_delay_stat'),
-                    QueryFunction::avg('waiting_duration', 'avg_waiting_duration'),
-                    QueryFunction::avg('solve_delay_stat', 'avg_solve_delay_stat'),
-                    QueryFunction::avg('close_delay_stat', 'close_delay_stat'),
+                    QueryFunction::dateFormat(new QueryIdentifier('date'), '%Y-%m', 'period'),
+                    QueryFunction::avg(new QueryIdentifier('takeintoaccount_delay_stat'), 'avg_takeintoaccount_delay_stat'),
+                    QueryFunction::avg(new QueryIdentifier('waiting_duration'), 'avg_waiting_duration'),
+                    QueryFunction::avg(new QueryIdentifier('solve_delay_stat'), 'avg_solve_delay_stat'),
+                    QueryFunction::avg(new QueryIdentifier('close_delay_stat'), 'close_delay_stat'),
                 ],
                 'FROM' => $t_table,
                 'WHERE' => [

--- a/src/Glpi/Features/PlanningEvent.php
+++ b/src/Glpi/Features/PlanningEvent.php
@@ -43,6 +43,7 @@ use Entity;
 use ExtraVisibilityCriteria;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\RichText\RichText;
 use Glpi\Toolbox\ArrayNormalizer;
 use Group_User;
@@ -486,7 +487,7 @@ trait PlanningEvent
                     'OR' => [
                         "$table.users_id" => $who,
                         QueryFunction::jsonContains(
-                            "$table.users_id_guests",
+                            new QueryIdentifier("$table.users_id_guests"),
                             new QueryExpression($DB::quoteValue((int) $who)),
                             '$'
                         ),

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -68,6 +68,7 @@ use Glpi\DBAL\Parts\Select;
 use Glpi\DBAL\Parts\Where;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Debug\Profiler;
 use Glpi\Features\AssignableItemInterface;
@@ -278,7 +279,7 @@ final class SQLProvider implements SearchProviderInterface
 
         $tocompute      = "$table$addtable.$field";
         $tocomputeid    = "$table$addtable.id";
-        $tocomputetrans = QueryFunction::ifnull("{$table}{$addtable}_trans_{$field}.value", new QueryExpression($DB::quoteValue(Search::NULLVALUE)));
+        $tocomputetrans = QueryFunction::ifnull(new QueryIdentifier("{$table}{$addtable}_trans_{$field}.value"), new QueryExpression($DB::quoteValue(Search::NULLVALUE)));
 
         $ADDITONALFIELDS = [];
         if (
@@ -297,11 +298,11 @@ final class SQLProvider implements SearchProviderInterface
                         expression: QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
                                 QueryFunction::ifnull(
-                                    expression: $additionalfield_field,
+                                    expression: new QueryIdentifier($additionalfield_field),
                                     value: new QueryExpression($DB::quoteValue(Search::NULLVALUE))
                                 ),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                $tocomputeid,
+                                new QueryIdentifier($tocomputeid),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -335,9 +336,9 @@ final class SQLProvider implements SearchProviderInterface
                             $ticket_user_table = $before_join['table'] . "_" . Search::computeComplexJoinID($before_join['joinparams']) . $addmeta;
                             $addaltemail = QueryFunction::groupConcat(
                                 expression: QueryFunction::concat([
-                                    "{$ticket_user_table}.users_id",
+                                    new QueryIdentifier("{$ticket_user_table}.users_id"),
                                     new QueryExpression($DB::quoteValue(' ')),
-                                    "{$ticket_user_table}.alternative_email",
+                                    new QueryIdentifier("{$ticket_user_table}.alternative_email"),
                                 ]),
                                 separator: Search::LONGSEP,
                                 distinct: true,
@@ -346,7 +347,7 @@ final class SQLProvider implements SearchProviderInterface
                         }
                         $SELECT = [
                             QueryFunction::groupConcat(
-                                expression: "{$table}{$addtable}.id",
+                                expression: new QueryIdentifier("{$table}{$addtable}.id"),
                                 separator: Search::LONGSEP,
                                 distinct: true,
                                 alias: $NAME
@@ -371,12 +372,12 @@ final class SQLProvider implements SearchProviderInterface
                 $_table_add_table = $table . ($meta ? $addtable2 : $addtable);
                 $SELECT = [
                     QueryFunction::floor(
-                        expression: new QueryExpression(QueryFunction::sum("{$_table_add_table}.{$field}") . ' * '
-                            . QueryFunction::count("{$_table_add_table}.id", true) . ' / '
-                            . QueryFunction::count("{$_table_add_table}.id")),
+                        expression: new QueryExpression(QueryFunction::sum(new QueryIdentifier("{$_table_add_table}.{$field}")) . ' * '
+                            . QueryFunction::count(new QueryIdentifier("{$_table_add_table}.id"), true) . ' / '
+                            . QueryFunction::count(new QueryIdentifier("{$_table_add_table}.id"))),
                         alias: $NAME
                     ),
-                    QueryFunction::min("{$_table_add_table}.{$field}", "{$NAME}_min"),
+                    QueryFunction::min(new QueryIdentifier("{$_table_add_table}.{$field}"), "{$NAME}_min"),
                 ];
                 return array_merge($SELECT, $ADDITONALFIELDS);
 
@@ -389,13 +390,13 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                "{$table}{$addtable}.{$field}",
+                                new QueryIdentifier("{$table}{$addtable}.{$field}"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.entities_id",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.entities_id"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.is_recursive",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.is_recursive"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.is_dynamic",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.is_dynamic"),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -415,13 +416,13 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                "{$table}{$addtable}.completename",
+                                new QueryIdentifier("{$table}{$addtable}.completename"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.profiles_id",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.profiles_id"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.is_recursive",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.is_recursive"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "glpi_profiles_users{$addtable2}.is_dynamic",
+                                new QueryIdentifier("glpi_profiles_users{$addtable2}.is_dynamic"),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -437,11 +438,11 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                "glpi_softwares.name",
+                                new QueryIdentifier("glpi_softwares.name"),
                                 new QueryExpression($DB::quoteValue(" - ")),
-                                "{$table}{$addtable2}.{$field}",
+                                new QueryIdentifier("{$table}{$addtable2}.{$field}"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "{$table}{$addtable2}.id",
+                                new QueryIdentifier("{$table}{$addtable2}.id"),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -458,11 +459,11 @@ final class SQLProvider implements SearchProviderInterface
                 $SELECT = [
                     QueryFunction::groupConcat(
                         expression: QueryFunction::concat([
-                            "{$_table}.name",
+                            new QueryIdentifier("{$_table}.name"),
                             new QueryExpression($DB::quoteValue(" - ")),
-                            "{$_table_add_table}.{$field}",
+                            new QueryIdentifier("{$_table_add_table}.{$field}"),
                             new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                            "{$_table_add_table}.id",
+                            new QueryIdentifier("{$_table_add_table}.id"),
                         ]),
                         separator: Search::LONGSEP,
                         distinct: true,
@@ -476,13 +477,13 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                "glpi_softwares.name",
+                                new QueryIdentifier("glpi_softwares.name"),
                                 new QueryExpression($DB::quoteValue(" - ")),
-                                "glpi_softwareversions{$addtable}.name",
+                                new QueryIdentifier("glpi_softwareversions{$addtable}.name"),
                                 new QueryExpression($DB::quoteValue(" - ")),
-                                "{$table}{$addtable2}.{$field}",
+                                new QueryIdentifier("{$table}{$addtable2}.{$field}"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "{$table}{$addtable2}.id",
+                                new QueryIdentifier("{$table}{$addtable2}.id"),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -494,11 +495,11 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                "glpi_softwareversions.name",
+                                new QueryIdentifier("glpi_softwareversions.name"),
                                 new QueryExpression($DB::quoteValue(" - ")),
-                                "{$table}{$addtable}.{$field}",
+                                new QueryIdentifier("{$table}{$addtable}.{$field}"),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                "{$table}{$addtable}.id",
+                                new QueryIdentifier("{$table}{$addtable}.id"),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -533,9 +534,9 @@ final class SQLProvider implements SearchProviderInterface
                     $SELECT = [
                         QueryFunction::groupConcat(
                             expression: QueryFunction::concat([
-                                QueryFunction::ifnull($tocompute, new QueryExpression($DB::quoteValue(Search::NULLVALUE))),
+                                QueryFunction::ifnull(new QueryIdentifier($tocompute), new QueryExpression($DB::quoteValue(Search::NULLVALUE))),
                                 new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                $tocomputeid,
+                                new QueryIdentifier($tocomputeid),
                             ]),
                             separator: Search::LONGSEP,
                             distinct: true,
@@ -583,7 +584,7 @@ final class SQLProvider implements SearchProviderInterface
                     }
                     return array_merge([
                         QueryFunction::count(
-                            expression: "$table$addtable.$field",
+                            expression: new QueryIdentifier("$table$addtable.$field"),
                             distinct: true,
                             alias: $NAME
                         ),
@@ -600,7 +601,7 @@ final class SQLProvider implements SearchProviderInterface
                         return array_merge([
                             QueryFunction::groupConcat(
                                 expression: QueryFunction::dateAdd(
-                                    date: "{$table}{$addtable}.{$opt['datafields'][1]}",
+                                    date: new QueryIdentifier("{$table}{$addtable}.{$opt['datafields'][1]}"),
                                     interval: new QueryExpression($DB::quoteName("{$table}{$addtable}.{$opt['datafields'][2]}") . $add_minus),
                                     interval_unit: $interval
                                 ),
@@ -612,7 +613,7 @@ final class SQLProvider implements SearchProviderInterface
                     }
                     return array_merge([
                         QueryFunction::dateAdd(
-                            date: "{$table}{$addtable}.{$opt['datafields'][1]}",
+                            date: new QueryIdentifier("{$table}{$addtable}.{$opt['datafields'][1]}"),
                             interval: new QueryExpression($DB::quoteName("{$table}{$addtable}.{$opt['datafields'][2]}") . $add_minus),
                             interval_unit: $interval,
                             alias: $NAME
@@ -627,7 +628,7 @@ final class SQLProvider implements SearchProviderInterface
                                 expression: QueryFunction::concat([
                                     QueryFunction::ifnull($tocomputetrans, new QueryExpression($DB::quoteValue(Search::NULLVALUE))),
                                     new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                    $tocomputeid,
+                                    new QueryIdentifier($tocomputeid),
                                 ]),
                                 separator: Search::LONGSEP,
                                 distinct: true,
@@ -640,7 +641,7 @@ final class SQLProvider implements SearchProviderInterface
                                 expression: QueryFunction::concat([
                                     $tocompute,
                                     new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                                    "{$table}{$addtable}.id",
+                                    new QueryIdentifier("{$table}{$addtable}.id"),
                                 ])->setParams($tocompute->getParams()),
                                 separator: Search::LONGSEP,
                                 distinct: true,
@@ -677,7 +678,7 @@ final class SQLProvider implements SearchProviderInterface
                     expression: QueryFunction::concat([
                         QueryFunction::ifnull($tocomputetrans, new QueryExpression($DB::quoteValue(Search::NULLVALUE))),
                         new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                        $tocomputeid,
+                        new QueryIdentifier($tocomputeid),
                     ]),
                     separator: $DB::quoteValue(Search::LONGSEP),
                     distinct: true,
@@ -690,7 +691,7 @@ final class SQLProvider implements SearchProviderInterface
                     expression: QueryFunction::concat([
                         QueryFunction::ifnull($tocompute, new QueryExpression($DB::quoteValue(Search::NULLVALUE))),
                         new QueryExpression($DB::quoteValue(Search::SHORTSEP)),
-                        $tocomputeid,
+                        new QueryIdentifier($tocomputeid),
                     ]),
                     separator: Search::LONGSEP,
                     distinct: true,
@@ -1931,7 +1932,7 @@ final class SQLProvider implements SearchProviderInterface
                         // FIXME Maybe address the existing fixme instead of bypassing it when the field is computed (uses a function)
                         // FIXME `CONVERT` operation should not be necessary if we only allow legitimate date/time chars
                         $default_charset = DBConnection::getDefaultCharset();
-                        $date_computation = QueryFunction::convert($date_computation, $default_charset);
+                        $date_computation = QueryFunction::convert(new QueryIdentifier($date_computation), $default_charset);
                     }
                     $search_unit = $opt['searchunit'] ?? 'MONTH';
                     if ($opt["datatype"] === "date_delay") {
@@ -1941,7 +1942,7 @@ final class SQLProvider implements SearchProviderInterface
                             $add_minus = '-' . $DB::quoteName($table . '.' . $opt["datafields"][3]);
                         }
                         $date_computation = QueryFunction::dateAdd(
-                            date: "$table." . $opt["datafields"][1],
+                            date: new QueryIdentifier("$table." . $opt["datafields"][1]),
                             interval: new QueryExpression($DB::quoteName("$table." . $opt["datafields"][2]) . $add_minus),
                             interval_unit: $delay_unit
                         );
@@ -4487,7 +4488,7 @@ final class SQLProvider implements SearchProviderInterface
                         );
                     }
                     $criterion = QueryFunction::dateAdd(
-                        date: "{$table}{$addtable}.{$searchopt[$ID]['datafields'][1]}",
+                        date: new QueryIdentifier("{$table}{$addtable}.{$searchopt[$ID]['datafields'][1]}"),
                         interval: new QueryExpression($DB::quoteName("{$table}{$addtable}.{$searchopt[$ID]['datafields'][2]}") . " $add_minus"),
                         interval_unit: $interval,
                     ) . " $order";

--- a/src/Glpi/Security/SessionTracker.php
+++ b/src/Glpi/Security/SessionTracker.php
@@ -41,6 +41,7 @@ use Glpi\Application\Environment;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Debug\Profiler;
 use Glpi\Error\ErrorHandler;
@@ -305,7 +306,7 @@ final class SessionTracker
                     [$start_ip, $end_ip] = IPUtilities::cidrToRange($ip);
                     $ip_criteria[] = [
                         'RAW' => [
-                            (string) QueryFunction::inet6Aton('ip_address') => [
+                            (string) QueryFunction::inet6Aton(new QueryIdentifier('ip_address')) => [
                                 'BETWEEN',
                                 new QueryExpression(
                                     QueryFunction::inet6Aton(new QueryExpression($DB::quoteValue($start_ip)))
@@ -432,10 +433,10 @@ final class SessionTracker
                 'glpi_users_sessionhistories.id',
                 new QueryExpression('glpi_users_sessionhistories.users_id', 'user_identifier'),
                 'glpi_users_sessionhistories.login_session_uid',
-                QueryFunction::ifnull('glpi_users_sessions.ip_address', 'glpi_users_sessionhistories.ip_address', 'ip_address'),
-                QueryFunction::ifnull('glpi_users_sessions.user_agent', 'glpi_users_sessionhistories.user_agent', 'user_agent'),
+                QueryFunction::ifnull(new QueryIdentifier('glpi_users_sessions.ip_address'), new QueryIdentifier('glpi_users_sessionhistories.ip_address'), 'ip_address'),
+                QueryFunction::ifnull(new QueryIdentifier('glpi_users_sessions.user_agent'), new QueryIdentifier('glpi_users_sessionhistories.user_agent'), 'user_agent'),
                 'glpi_users_sessionhistories.auth_type',
-                QueryFunction::ifnull('glpi_users_sessions.created_at', 'glpi_users_sessionhistories.logged_in_at', 'logged_in_at'),
+                QueryFunction::ifnull(new QueryIdentifier('glpi_users_sessions.created_at'), new QueryIdentifier('glpi_users_sessionhistories.logged_in_at'), 'logged_in_at'),
                 'glpi_users_sessions.last_activity_at',
                 'glpi_users_sessionhistories.logged_out_at',
                 'glpi_users_sessionhistories.logout_reason',
@@ -480,7 +481,7 @@ final class SessionTracker
                 new QueryExpression('NULL', 'user_agent'),
                 new QueryExpression('NULL', 'auth_type'),
                 QueryFunction::dateSub(
-                    date: 'glpi_oauth_access_tokens.date_expiration',
+                    date: new QueryIdentifier('glpi_oauth_access_tokens.date_expiration'),
                     interval: $access_token_lifetime_seconds,
                     interval_unit: 'SECOND',
                     alias: 'logged_in_at',

--- a/src/IPNetwork.php
+++ b/src/IPNetwork.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /// Class IPNetwork : Represent an IPv4 or an IPv6 network.
 /// It fully use IPAddress and IPNetmask to check validity and change representation from binary
@@ -721,7 +722,7 @@ class IPNetwork extends CommonImplicitTreeDropdown
         // the last should be 0.0.0.0/0.0.0.0 of x.y.z.a/255.255.255.255 regarding the interested
         // element)
         for ($i = $startIndex; $i < 4; ++$i) {
-            $ORDER[] = new QueryExpression(QueryFunction::bitCount($netmaskDB[$i]) . " $ORDER_ORIENTATION");
+            $ORDER[] = new QueryExpression(QueryFunction::bitCount(new QueryIdentifier($netmaskDB[$i])) . " $ORDER_ORIENTATION");
         }
 
         if (!empty($condition["where"])) {

--- a/src/ITILFollowup.php
+++ b/src/ITILFollowup.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\ParentStatus;
 
@@ -804,7 +805,7 @@ class ITILFollowup extends CommonDBChild
                 'jointype'           => 'itemtype_item',
                 'condition'          => $followup_condition,
             ],
-            'computation'        => QueryFunction::max('TABLE.date'),
+            'computation'        => QueryFunction::max(new QueryIdentifier('TABLE.date')),
             'nometa'             => true, // cannot GROUP_CONCAT a MAX
         ];
 

--- a/src/Infocom.php
+++ b/src/Infocom.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Exception\Http\NotFoundHttpException;
 use Safe\DateTime;
 
@@ -687,7 +688,7 @@ class Infocom extends CommonDBChild
                     'NOT'                      => ["$table.warranty_date" => null],
                     new QueryExpression(QueryFunction::dateDiff(
                         expression1: QueryFunction::dateAdd(
-                            date: 'glpi_infocoms.warranty_date',
+                            date: new QueryIdentifier('glpi_infocoms.warranty_date'),
                             interval: new QueryExpression($DB::quoteName('glpi_infocoms.warranty_duration')),
                             interval_unit: 'MONTH'
                         ),

--- a/src/ItemVirtualMachine.php
+++ b/src/ItemVirtualMachine.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Exception\TooManyResultsException;
 
 use function Safe\preg_match;
@@ -191,7 +192,7 @@ class ItemVirtualMachine extends CommonDBChild
                 self::getTable(),
                 [
                     'RAW' => [
-                        (string) QueryFunction::lower('uuid') => self::getUUIDRestrictCriteria($asset->fields['uuid']),
+                        (string) QueryFunction::lower(new QueryIdentifier('uuid')) => self::getUUIDRestrictCriteria($asset->fields['uuid']),
                     ],
                 ]
             );
@@ -416,7 +417,7 @@ class ItemVirtualMachine extends CommonDBChild
             'FROM'   => $itemtype::getTable(),
             'WHERE'  => [
                 'RAW' => [
-                    (string) QueryFunction::lower('uuid')  => self::getUUIDRestrictCriteria($fields['uuid']),
+                    (string) QueryFunction::lower(new QueryIdentifier('uuid'))  => self::getUUIDRestrictCriteria($fields['uuid']),
                 ],
             ],
         ]);

--- a/src/Item_Disk.php
+++ b/src/Item_Disk.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * Disk Class
@@ -447,7 +448,7 @@ TWIG, $twig_params);
             'width'              => 2,
             // NULLIF -> avoid divizion by zero by replacing it by null (division by null return null without warning)
             'computation'        => QueryFunction::lpad(
-                expression: QueryFunction::round(new QueryExpression('100*TABLE.freesize/' . QueryFunction::nullif('TABLE.totalsize', new QueryExpression('0')))),
+                expression: QueryFunction::round(new QueryExpression('100*TABLE.freesize/' . QueryFunction::nullif(new QueryIdentifier('TABLE.totalsize'), new QueryExpression('0')))),
                 length: 3,
                 pad_string: '0'
             ),

--- a/src/Item_SoftwareVersion.php
+++ b/src/Item_SoftwareVersion.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QueryUnion;
 
 class Item_SoftwareVersion extends CommonDBRelation
@@ -1293,7 +1294,7 @@ class Item_SoftwareVersion extends CommonDBRelation
                         [
                             'AND' => [
                                 'glpi_softwarelicenses.softwareversions_id_use' => 0,
-                                'glpi_softwarelicenses.softwareversions_id_buy' => new QueryExpression(DBmysql::quoteName('glpi_softwareversions.id')),
+                                'glpi_softwarelicenses.softwareversions_id_buy' => new QueryIdentifier('glpi_softwareversions.id'),
                             ],
                         ],
                     ],

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Event;
 use Glpi\Features\Clonable;
@@ -2052,10 +2053,10 @@ TWIG, $twig_params);
             'SELECT' => [
                 'glpi_knowbaseitems.*',
                 new QueryExpression(
-                    QueryFunction::count('glpi_knowbaseitems_users.id') . ' + '
-                    . QueryFunction::count('glpi_groups_knowbaseitems.id') . ' + '
-                    . QueryFunction::count('glpi_knowbaseitems_profiles.id') . ' + '
-                    . QueryFunction::count('glpi_entities_knowbaseitems.id') . ' AS '
+                    QueryFunction::count(new QueryIdentifier('glpi_knowbaseitems_users.id')) . ' + '
+                    . QueryFunction::count(new QueryIdentifier('glpi_groups_knowbaseitems.id')) . ' + '
+                    . QueryFunction::count(new QueryIdentifier('glpi_knowbaseitems_profiles.id')) . ' + '
+                    . QueryFunction::count(new QueryIdentifier('glpi_entities_knowbaseitems.id')) . ' AS '
                     . $DB::quoteName('visibility_count')
                 ),
             ],

--- a/src/Link.php
+++ b/src/Link.php
@@ -35,7 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\ContentTemplates\TemplateManager;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Features\AssignableItem;
 use Glpi\Toolbox\URL;
 
@@ -104,7 +104,7 @@ class Link extends CommonDBTM
                 $nb = countElementsInTable(
                     ['glpi_links_itemtypes','glpi_links'],
                     [
-                        'glpi_links_itemtypes.links_id'  => new QueryExpression(DBmysql::quoteName('glpi_links.id')),
+                        'glpi_links_itemtypes.links_id'  => new QueryIdentifier('glpi_links.id'),
                         'glpi_links_itemtypes.itemtype'  => $item::class,
                     ] + $entity_criteria
                 );

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -35,7 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Plugin\Hooks;
@@ -151,7 +151,7 @@ TWIG;
                             'OR' => [
                                 [
                                     $lockedfield_table . '.itemtype'  => $lockable_itemtype,
-                                    $lockedfield_table . '.items_id'  => new QueryExpression($DB::quoteName($lockable_itemtype_table . '.id')),
+                                $lockedfield_table . '.items_id'  => new QueryIdentifier($lockable_itemtype_table . '.id'),
                                 ], [
                                     $lockedfield_table . '.itemtype'  => $lockable_itemtype,
                                     $lockedfield_table . '.is_global' => 1,

--- a/src/ManualLink.php
+++ b/src/ManualLink.php
@@ -34,7 +34,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * @since 10.0.0
@@ -78,7 +78,7 @@ class ManualLink extends CommonDBChild
                 $count += countElementsInTable(
                     ['glpi_links_itemtypes', 'glpi_links'],
                     [
-                        'glpi_links_itemtypes.links_id'  => new QueryExpression(DBmysql::quoteName('glpi_links.id')),
+                        'glpi_links_itemtypes.links_id'  => new QueryIdentifier('glpi_links.id'),
                         'glpi_links_itemtypes.itemtype'  => $item::class,
                     ] + getEntitiesRestrictCriteria('glpi_links', '', '', false)
                 );

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -36,6 +36,7 @@
 use Glpi\DBAL\Parts\BasePart;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Message\MessageType;
 use Glpi\Progress\AbstractProgressIndicator;
 
@@ -892,7 +893,7 @@ class Migration
                 foreach ($iterator as $data) {
                     $max_rank = $this->db->request([
                         'SELECT' => [
-                            QueryFunction::max('rank', 'max_rank'),
+                            QueryFunction::max(new QueryIdentifier('rank'), 'max_rank'),
                         ],
                         'FROM'   => 'glpi_displaypreferences',
                         'WHERE'  => [
@@ -1670,7 +1671,7 @@ class Migration
                                     'old' => 'itemtype',
                                     [
                                         'AND' => [
-                                            'new.users_id' => new QueryExpression($this->db::quoteName('old.users_id')),
+                                            'new.users_id' => new QueryIdentifier('old.users_id'),
                                             'new.itemtype' => $itemtype,
                                             'new.num' => $new_search_opt,
                                             'old.num' => $old_search_opt,

--- a/src/NetworkEquipment.php
+++ b/src/NetworkEquipment.php
@@ -34,6 +34,7 @@
  */
 
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
@@ -213,7 +214,7 @@ class NetworkEquipment extends CommonDBTM implements AssignableItemInterface, DC
                 'SELECT'       => [
                     'itemtype',
                     QueryFunction::groupConcat(
-                        expression: 'items_id',
+                        expression: new QueryIdentifier('items_id'),
                         distinct: true,
                         alias: 'ids'
                     ),

--- a/src/NotificationAjax.php
+++ b/src/NotificationAjax.php
@@ -35,6 +35,7 @@
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  *  NotificationAjax
@@ -129,7 +130,7 @@ class NotificationAjax implements NotificationInterface
                     'recipient'    => Session::getLoginUserID(),
                     'mode'         => Notification_NotificationTemplate::MODE_AJAX,
                     new QueryExpression(
-                        QueryFunction::unixTimestamp('send_time') . ' + ' . $secs
+                        QueryFunction::unixTimestamp(new QueryIdentifier('send_time')) . ' + ' . $secs
                             . ' > ' . QueryFunction::unixTimestamp()
                     ),
                 ],

--- a/src/PlanningRecall.php
+++ b/src/PlanningRecall.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 use function Safe\strtotime;
 
@@ -263,7 +264,7 @@ class PlanningRecall extends CommonDBChild
             [
                 'when'   => QueryFunction::dateSub(
                     date: new QueryExpression($DB::quoteValue($begin)),
-                    interval: new QueryExpression($DB::quoteName('before_time')),
+                    interval: new QueryIdentifier('before_time'),
                     interval_unit: 'SECOND'
                 ),
             ],

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\AssignableItem;
 use Glpi\Features\AssignableItemInterface;
@@ -194,7 +195,7 @@ class Printer extends CommonDBTM implements AssignableItemInterface, StateInterf
                 'SELECT'       => [
                     'itemtype',
                     QueryFunction::groupConcat(
-                        expression: 'items_id',
+                        expression: new QueryIdentifier('items_id'),
                         distinct: true,
                         alias: 'ids'
                     ),

--- a/src/Problem.php
+++ b/src/Problem.php
@@ -36,7 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\ContentTemplates\Parameters\CommonITILObjectParameters;
 use Glpi\ContentTemplates\Parameters\ProblemParameters;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\RichText\RichText;
 use Glpi\Search\DefaultSearchRequestInterface;
 
@@ -182,7 +182,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_problems', 'glpi_problems_users'],
                             [
-                                'glpi_problems_users.problems_id'  => new QueryExpression(DBmysql::quoteName('glpi_problems.id')),
+                                'glpi_problems_users.problems_id'  => new QueryIdentifier('glpi_problems.id'),
                                 'glpi_problems_users.users_id'    => $item->getID(),
                                 'glpi_problems_users.type'        => CommonITILActor::REQUESTER,
                                 'glpi_problems.is_deleted'        => 0,
@@ -197,7 +197,7 @@ class Problem extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_problems', 'glpi_groups_problems'],
                             [
-                                'glpi_groups_problems.problems_id' => new QueryExpression(DBmysql::quoteName('glpi_problems.id')),
+                                'glpi_groups_problems.problems_id' => new QueryIdentifier('glpi_problems.id'),
                                 'glpi_groups_problems.groups_id'  => $item->getID(),
                                 'glpi_groups_problems.type'       => CommonITILActor::REQUESTER,
                                 'glpi_problems.is_deleted'        => 0,

--- a/src/Project.php
+++ b/src/Project.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\DBAL\QueryUnion;
 use Glpi\Features\Clonable;
@@ -748,7 +749,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInter
             'joinparams'         => [
                 'jointype'           => 'child',
                 'specific_itemtype'  => 'ProjectCost',
-                'condition'          => ['NEWTABLE.projects_id' => new QueryExpression($DB::quoteName('REFTABLE.id'))],
+                'condition'          => ['NEWTABLE.projects_id' => new QueryIdentifier('REFTABLE.id')],
                 'beforejoin'         => [
                     'table'        => static::getTable(),
                     'joinparams'   => [
@@ -756,7 +757,7 @@ class Project extends CommonDBTM implements ExtraVisibilityCriteria, KanbanInter
                     ],
                 ],
             ],
-            'computation'        => QueryFunction::sum('TABLE.cost'),
+            'computation'        => QueryFunction::sum(new QueryIdentifier('TABLE.cost')),
             'nometa'             => true, // cannot GROUP_CONCAT a SUM
         ];
 
@@ -2529,7 +2530,7 @@ TWIG, $twig_params);
         $iterator = $DB->request([
             'SELECT' => [
                 QueryFunction::cast(
-                    expression: QueryFunction::avg('percent_done'),
+                    expression: QueryFunction::avg(new QueryIdentifier('percent_done')),
                     type: 'UNSIGNED',
                     alias: 'percent_done'
                 ),

--- a/src/ProjectTask.php
+++ b/src/ProjectTask.php
@@ -38,6 +38,7 @@ use Glpi\CalDAV\Contracts\CalDAVCompatibleItemInterface;
 use Glpi\CalDAV\Traits\VobjectConverterTrait;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Features\CloneMapper;
 use Glpi\Features\PlanningEvent;
@@ -962,7 +963,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $iterator = $DB->request([
             'SELECT'    => [
                 QueryFunction::sum(
-                    expression: 'glpi_tickets.actiontime',
+                    expression: new QueryIdentifier('glpi_tickets.actiontime'),
                     alias: 'duration'
                 ),
             ],
@@ -1027,7 +1028,7 @@ class ProjectTask extends CommonDBChild implements CalDAVCompatibleItemInterface
         $iterator = $DB->request([
             'SELECT'    => [
                 QueryFunction::sum(
-                    expression: 'planned_duration',
+                    expression: new QueryIdentifier('planned_duration'),
                     alias: 'duration'
                 ),
             ],
@@ -2085,13 +2086,13 @@ TWIG, $twig_params);
         if (isset($options['not_planned'])) {
             //not planned case
             $bdate = QueryFunction::dateSub(
-                date: $ttask_table . '.date_creation',
-                interval: new QueryExpression($DB::quoteName($ttask_table . '.planned_duration')),
+                date: new QueryIdentifier($ttask_table . '.date_creation'),
+                interval: new QueryIdentifier($ttask_table . '.planned_duration'),
                 interval_unit: 'SECOND',
             );
             $edate = QueryFunction::dateAdd(
-                date: $ttask_table . '.date_creation',
-                interval: new QueryExpression($DB::quoteName($ttask_table . '.planned_duration')),
+                date: new QueryIdentifier($ttask_table . '.date_creation'),
+                interval: new QueryIdentifier($ttask_table . '.planned_duration'),
                 interval_unit: 'SECOND',
             );
             $SELECT[] = new QueryExpression($bdate, 'notp_date');
@@ -2319,7 +2320,7 @@ TWIG, $twig_params);
         $iterator = $DB->request([
             'SELECT' => [
                 QueryFunction::cast(
-                    expression: QueryFunction::avg('percent_done'),
+                    expression: QueryFunction::avg(new QueryIdentifier('percent_done')),
                     type: 'UNSIGNED',
                     alias: 'percent_done'
                 ),

--- a/src/ProjectTask_Ticket.php
+++ b/src/ProjectTask_Ticket.php
@@ -35,6 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 
 /**
  * ProjectTask_Ticket Class
@@ -130,7 +131,7 @@ class ProjectTask_Ticket extends CommonDBRelation
         $iterator = $DB->request([
             'SELECT'    => [
                 QueryFunction::sum(
-                    expression: 'glpi_tickets.actiontime',
+                    expression: new QueryIdentifier('glpi_tickets.actiontime'),
                     alias: 'duration'
                 ),
             ],

--- a/src/QueuedNotification.php
+++ b/src/QueuedNotification.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\RichText\RichText;
 
 use function Safe\preg_match;
@@ -678,7 +679,7 @@ class QueuedNotification extends CommonDBTM
                 self::getTable(),
                 [
                     'is_deleted'   => 1,
-                    new QueryExpression(QueryFunction::unixTimestamp('send_time') . ' < ' . $DB::quoteValue($send_time)),
+                    new QueryExpression(QueryFunction::unixTimestamp(new QueryIdentifier('send_time')) . ' < ' . $DB::quoteValue($send_time)),
                 ]
             );
             $vol = $DB->getAffectedRows();
@@ -714,7 +715,7 @@ class QueuedNotification extends CommonDBTM
                     'is_deleted'   => 0,
                     'mode'         => Notification_NotificationTemplate::MODE_AJAX,
                     new QueryExpression(
-                        QueryFunction::unixTimestamp('send_time') . ' + ' . $secs
+                        QueryFunction::unixTimestamp(new QueryIdentifier('send_time')) . ' + ' . $secs
                             . ' < ' . QueryFunction::unixTimestamp()
                     ),
                 ]

--- a/src/QueuedWebhook.php
+++ b/src/QueuedWebhook.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Toolbox\HttpClient;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
@@ -652,7 +653,7 @@ JS);
                 $queued_table,
                 [
                     'OR' => [
-                        new QueryExpression(QueryFunction::unixTimestamp('send_time') . ' < ' . $DB::quoteValue($send_time)),
+                        new QueryExpression(QueryFunction::unixTimestamp(new QueryIdentifier('send_time')) . ' < ' . $DB::quoteValue($send_time)),
                         new QueryExpression($DB::quoteName($queued_table . '.sent_try') . ' >= ' . $DB::quoteName($webhook_table . '.sent_try')),
                     ],
                 ],

--- a/src/Report.php
+++ b/src/Report.php
@@ -38,6 +38,7 @@ use Glpi\Asset\Asset_PeripheralAsset;
 use Glpi\Dashboard\Widget;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Socket;
 
 use function Safe\mktime;
@@ -490,7 +491,7 @@ TWIG, ['title' => $report['title'], 'counts' => $counts]);
                 'PORT_1.mac AS mac_1',
                 'PORT_1.logical_number AS logical_1',
                 QueryFunction::groupConcat(
-                    expression: 'ADDR_1.name',
+                    expression: new QueryIdentifier('ADDR_1.name'),
                     separator: ', ',
                     alias: 'ip_1'
                 ),
@@ -500,7 +501,7 @@ TWIG, ['title' => $report['title'], 'counts' => $counts]);
                 'PORT_2.name AS port_2',
                 'PORT_2.mac AS mac_2',
                 QueryFunction::groupConcat(
-                    expression: 'ADDR_2.name',
+                    expression: new QueryIdentifier('ADDR_2.name'),
                     separator: ', ',
                     alias: 'ip_2'
                 ),
@@ -534,7 +535,7 @@ TWIG, ['title' => $report['title'], 'counts' => $counts]);
                         'LINK'   => 'networkports_id_1',
                         'PORT_1' => 'id', [
                             'OR'     => [
-                                'LINK.networkports_id_2'   => new QueryExpression($DB::quoteName('PORT_1.id')),
+                                'LINK.networkports_id_2'   => new QueryIdentifier('PORT_1.id'),
                             ],
                         ],
                     ],
@@ -544,8 +545,8 @@ TWIG, ['title' => $report['title'], 'counts' => $counts]);
                         'PORT_2' => 'id',
                         QueryFunction::if(
                             condition: new QueryExpression($DB::quoteName("LINK.networkports_id_1") . ' = ' . $DB::quoteName("PORT_1.id")),
-                            true_expression: "LINK.networkports_id_2",
-                            false_expression: "LINK.networkports_id_1"
+                            true_expression: new QueryIdentifier("LINK.networkports_id_2"),
+                            false_expression: new QueryIdentifier("LINK.networkports_id_1")
                         ),
                     ],
                 ],
@@ -1017,8 +1018,8 @@ TWIG, $twig_params);
 
             $ors = [];
             foreach ($years as $val2) {
-                $ors[] = new QueryExpression(QueryFunction::year('glpi_infocoms.buy_date') . " = " . $DB->quote($val2));
-                $ors[] = new QueryExpression(QueryFunction::year('glpi_contracts.begin_date') . " = " . $DB->quote($val2));
+                $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_infocoms.buy_date')) . " = " . $DB->quote($val2));
+                $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_contracts.begin_date')) . " = " . $DB->quote($val2));
             }
             if (count($ors)) {
                 $criteria['WHERE'][] = [
@@ -1246,9 +1247,9 @@ TWIG, $twig_params);
                 if (isset($_POST["year"][0]) && ($_POST["year"][0] != 0)) {
                     $ors = [];
                     foreach ($_POST["year"] as $val2) {
-                        $ors[] = new QueryExpression(QueryFunction::year('glpi_contracts.begin_date') . ' = ' . $DB->quote($val2));
+                        $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_contracts.begin_date')) . ' = ' . $DB->quote($val2));
                         if ($itemtype === SoftwareLicense::class) {
-                            $ors[] = new QueryExpression(QueryFunction::year('glpi_infocoms.buy_date') . ' = ' . $DB->quote($val2));
+                            $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_infocoms.buy_date')) . ' = ' . $DB->quote($val2));
                         }
                     }
                     if (count($ors)) {
@@ -1291,8 +1292,8 @@ TWIG, $twig_params);
 
                 $ors = [];
                 foreach ($years as $val2) {
-                    $ors[] = new QueryExpression(QueryFunction::year('glpi_infocoms.buy_date') . ' = ' . $DB::quoteValue($val2));
-                    $ors[] = new QueryExpression(QueryFunction::year('glpi_contracts.begin_date') . ' = ' . $DB::quoteValue($val2));
+                    $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_infocoms.buy_date')) . ' = ' . $DB::quoteValue($val2));
+                    $ors[] = new QueryExpression(QueryFunction::year(new QueryIdentifier('glpi_contracts.begin_date')) . ' = ' . $DB::quoteValue($val2));
                 }
                 if (count($ors)) {
                     $criteria['WHERE'][] = ['OR' => $ors];

--- a/src/ReservationItem.php
+++ b/src/ReservationItem.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\RichText\RichText;
 
 /**
@@ -758,7 +759,7 @@ TWIG, $twig_params);
                 'WHERE'     => [
                     'glpi_reservationitems.entities_id' => $entity,
                     new QueryExpression(
-                        QueryFunction::unixTimestamp('glpi_reservations.end') . ' - ' . $secs
+                        QueryFunction::unixTimestamp(new QueryIdentifier('glpi_reservations.end')) . ' - ' . $secs
                             . ' < ' . QueryFunction::unixTimestamp()
                     ),
                     'glpi_reservations.begin'  => ['<', QueryFunction::now()],

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -35,7 +35,7 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Asset\AssetDefinitionManager;
-use Glpi\DBAL\QueryExpression;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Features\Clonable;
 use Glpi\Plugin\Hooks;
 
@@ -2982,7 +2982,7 @@ TWIG, $twig_params);
                 static::getTable(),
             ],
             'WHERE'  => [
-                getTableForItemType($this->ruleactionclass) . "." . $this->rules_id_field   => new QueryExpression(DBmysql::quoteName(static::getTable() . '.id')),
+                getTableForItemType($this->ruleactionclass) . "." . $this->rules_id_field   => new QueryIdentifier(static::getTable() . '.id'),
                 static::getTable() . '.sub_type'                                           => static::class,
 
             ],
@@ -3285,7 +3285,7 @@ TWIG, ['label' => $this->getTitle()]);
                             $nb = countElementsInTable(
                                 ['glpi_rules', 'glpi_ruleactions'],
                                 [
-                                    'glpi_ruleactions.rules_id'   => new QueryExpression(DBmysql::quoteName('glpi_rules.id')),
+                                    'glpi_ruleactions.rules_id'   => new QueryIdentifier('glpi_rules.id'),
                                     'glpi_rules.sub_type'         => $types,
                                     'glpi_ruleactions.field'      => 'entities_id',
                                     'glpi_ruleactions.value'      => $item->getID(),

--- a/src/SavedSearch_Alert.php
+++ b/src/SavedSearch_Alert.php
@@ -35,8 +35,8 @@
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Config\ConfigContainer;
-use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Error\ErrorHandler;
 use Glpi\Plugin\Hooks;
 
@@ -336,7 +336,7 @@ class SavedSearch_Alert extends CommonDBChild
                         'glpi_alerts.date' => ['<',
                             QueryFunction::dateSub(
                                 date: QueryFunction::now(),
-                                interval: new QueryExpression($DB::quoteName('glpi_savedsearches_alerts.frequency')),
+                                interval: new QueryIdentifier('glpi_savedsearches_alerts.frequency'),
                                 interval_unit: 'SECOND'
                             ),
                         ],

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Kernel\Kernel;
 use Glpi\Plugin\Hooks;
 use Glpi\Search\Output\Csv;
@@ -1227,17 +1228,17 @@ class Stat extends CommonGLPI
         }
 
         $date_unix = QueryFunction::fromUnixtime(
-            expression: QueryFunction::unixTimestamp("$table.date"),
+            expression: QueryFunction::unixTimestamp(new QueryIdentifier("$table.date")),
             format: new QueryExpression($DB::quoteValue('%Y-%m')),
             alias: 'date_unix'
         );
         $solvedate_unix = QueryFunction::fromUnixtime(
-            expression: QueryFunction::unixTimestamp("$table.solvedate"),
+            expression: QueryFunction::unixTimestamp(new QueryIdentifier("$table.solvedate")),
             format: new QueryExpression($DB::quoteValue('%Y-%m')),
             alias: 'date_unix'
         );
         $closedate_unix = QueryFunction::fromUnixtime(
-            expression: QueryFunction::unixTimestamp("$table.closedate"),
+            expression: QueryFunction::unixTimestamp(new QueryIdentifier("$table.closedate")),
             format: new QueryExpression($DB::quoteValue('%Y-%m')),
             alias: 'date_unix'
         );

--- a/src/Supplier.php
+++ b/src/Supplier.php
@@ -36,6 +36,7 @@
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\Features\AssetImage;
 use Glpi\Features\Clonable;
 use Glpi\Toolbox\URL;
@@ -295,7 +296,7 @@ class Supplier extends CommonDBTM
             'forcegroupby'       => true,
             'datatype'           => 'itemlink',
             'massiveaction'      => false,
-            'computation'        => QueryFunction::concat(["TABLE.{$name1}", new QueryExpression($DB::quoteValue(' ')), "TABLE.{$name2}"]),
+            'computation'        => QueryFunction::concat([new QueryIdentifier("TABLE.{$name1}"), new QueryExpression($DB::quoteValue(' ')), new QueryIdentifier("TABLE.{$name2}")]),
             'computationgroupby' => true,
             'joinparams'         => [
                 'beforejoin'         => [

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -40,6 +40,7 @@ use Glpi\ContentTemplates\ParametersPreset;
 use Glpi\ContentTemplates\TemplateManager;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Event;
 use Glpi\RichText\RichText;
@@ -719,7 +720,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_tickets', 'glpi_tickets_users'],
                             [
-                                'glpi_tickets_users.tickets_id'  => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
+                                'glpi_tickets_users.tickets_id'  => new QueryIdentifier('glpi_tickets.id'),
                                 'glpi_tickets_users.users_id'    => $item->getID(),
                                 'glpi_tickets_users.type'        => CommonITILActor::REQUESTER,
                                 'glpi_tickets.is_deleted'        => 0,
@@ -732,7 +733,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_tickets', 'glpi_suppliers_tickets'],
                             [
-                                'glpi_suppliers_tickets.tickets_id'    => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
+                                'glpi_suppliers_tickets.tickets_id'    => new QueryIdentifier('glpi_tickets.id'),
                                 'glpi_suppliers_tickets.suppliers_id'  => $item->getID(),
                                 'glpi_tickets.is_deleted'              => 0,
                             ] + getEntitiesRestrictCriteria(self::getTable())
@@ -765,7 +766,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                         $nb = countElementsInTable(
                             ['glpi_tickets', 'glpi_groups_tickets'],
                             [
-                                'glpi_groups_tickets.tickets_id' => new QueryExpression(DBmysql::quoteName('glpi_tickets.id')),
+                                'glpi_groups_tickets.tickets_id' => new QueryIdentifier('glpi_tickets.id'),
                                 'glpi_groups_tickets.groups_id'  => $item->getID(),
                                 'glpi_groups_tickets.type'       => CommonITILActor::REQUESTER,
                                 'glpi_tickets.is_deleted'        => 0,
@@ -1891,7 +1892,7 @@ class Ticket extends CommonITILObject implements DefaultSearchRequestInterface
                 ),
                 new QueryExpression(
                     QueryFunction::dateAdd(
-                        date: static::getTable() . '.solvedate',
+                        date: new QueryIdentifier(static::getTable() . '.solvedate'),
                         interval: $days,
                         interval_unit: 'DAY'
                     ) . ' > ' . QueryFunction::now()
@@ -2544,15 +2545,15 @@ JAVASCRIPT;
                 expression: QueryFunction::least([
                     QueryFunction::if(
                         condition: ['TABLE.takeintoaccount_delay_stat' => ['<=', 0]],
-                        true_expression: QueryFunction::coalesce(['TABLE.time_to_own', $max_date]),
+                        true_expression: QueryFunction::coalesce([new QueryIdentifier('TABLE.time_to_own'), $max_date]),
                         false_expression: $max_date
                     ),
                     QueryFunction::coalesce([
-                        new QueryExpression((new QuerySubQuery(['FROM' => Item_Ola::getTable(), 'SELECT' => QueryFunction::min('due_time')]))->getQuery()), $max_date,
+                        new QueryExpression((new QuerySubQuery(['FROM' => Item_Ola::getTable(), 'SELECT' => QueryFunction::min(new QueryIdentifier('due_time'))]))->getQuery()), $max_date,
                     ]),
                     QueryFunction::if(
                         condition: ['TABLE.solvedate' => null],
-                        true_expression: QueryFunction::coalesce(['TABLE.time_to_resolve', $max_date]),
+                        true_expression: QueryFunction::coalesce([new QueryIdentifier('TABLE.time_to_resolve'), $max_date]),
                         false_expression: $max_date
                     ),
                 ]),
@@ -3902,7 +3903,7 @@ JAVASCRIPT;
                     'SELECT' => 'last_solution.id',
                     'FROM'   => 'glpi_itilsolutions AS last_solution',
                     'WHERE'  => [
-                        'last_solution.items_id'   => new QueryExpression($DB->quoteName('glpi_tickets.id')),
+                        'last_solution.items_id'   => new QueryIdentifier('glpi_tickets.id'),
                         'last_solution.itemtype'   => self::class,
                     ],
                     'ORDER'  => 'last_solution.id DESC',
@@ -3997,8 +3998,8 @@ JAVASCRIPT;
                                 new QueryExpression(
                                     QueryFunction::dateDiff(
                                         expression1: QueryFunction::dateAdd(
-                                            date: 'glpi_ticketsatisfactions.date_begin',
-                                            interval: new QueryExpression($DB::quoteName('glpi_entities.inquest_duration')),
+                                            date: new QueryIdentifier('glpi_ticketsatisfactions.date_begin'),
+                                            interval: new QueryIdentifier('glpi_entities.inquest_duration'),
                                             interval_unit: 'DAY'
                                         ),
                                         expression2: QueryFunction::curDate()
@@ -5114,7 +5115,7 @@ JAVASCRIPT;
                         // no calendar, remove all days
                         $criteria['WHERE'][] = new QueryExpression(
                             QueryFunction::dateAdd(
-                                date: 'solvedate',
+                                date: new QueryIdentifier('solvedate'),
                                 interval: $delay,
                                 interval_unit: 'DAY'
                             ) . ' < ' . QueryFunction::now()
@@ -5176,7 +5177,7 @@ JAVASCRIPT;
                     'closedate'    => null,
                     new QueryExpression(
                         QueryFunction::dateAdd(
-                            date: 'date',
+                            date: new QueryIdentifier('date'),
                             interval: $value,
                             interval_unit: 'DAY'
                         ) . ' < ' . QueryFunction::now()
@@ -5252,7 +5253,7 @@ JAVASCRIPT;
                     // remove all days
                     $criteria['WHERE'][] = new QueryExpression(
                         QueryFunction::dateAdd(
-                            date: 'closedate',
+                            date: new QueryIdentifier('closedate'),
                             interval: $delay,
                             interval_unit: 'DAY'
                         ) . ' < ' . QueryFunction::now()

--- a/src/User.php
+++ b/src/User.php
@@ -38,6 +38,7 @@ use Glpi\Dashboard\Dashboard;
 use Glpi\Dashboard\Filter;
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Exception\ForgetPasswordException;
 use Glpi\Exception\PasswordTooWeakException;
@@ -4376,8 +4377,8 @@ HTML;
             if (((string) $search) !== '') {
                 $txt_search = Search::makeTextSearchValue($search);
 
-                $firstname_field = self::getTableField('firstname');
-                $realname_field = self::getTableField('realname');
+                $firstname_field = new QueryIdentifier(self::getTableField('firstname'));
+                $realname_field = new QueryIdentifier(self::getTableField('realname'));
                 $fields = $_SESSION["glpinames_format"] == self::FIRSTNAME_BEFORE
                 ? [$firstname_field, new QueryExpression($DB::quoteValue(' ')), $realname_field]
                 : [$realname_field, new QueryExpression($DB::quoteValue(' ')), $firstname_field];
@@ -6451,7 +6452,7 @@ HTML;
                 'authtype'   => Auth::DB_GLPI,
                 new QueryExpression(
                     QueryFunction::now() . ' > ' . QueryFunction::dateAdd(
-                        date: 'password_last_update',
+                        date: new QueryIdentifier('password_last_update'),
                         interval: $expiration_delay + $lock_delay,
                         interval_unit: 'DAY'
                     )
@@ -6584,14 +6585,14 @@ HTML;
         $filter_no_spaces = str_replace(" ", "", $filter);
         $concat_names_first_last = QueryFunction::lower(
             QueryFunction::replace(
-                expression: QueryFunction::concat(["$table.firstname", "$table.realname"]),
+                expression: QueryFunction::concat([new QueryIdentifier("$table.firstname"), new QueryIdentifier("$table.realname")]),
                 search: new QueryExpression($DB::quoteValue(' ')),
                 replace: new QueryExpression($DB::quoteValue(''))
             )
         );
         $concat_names_last_first = QueryFunction::lower(
             QueryFunction::replace(
-                expression: QueryFunction::concat(["$table.realname", "$table.firstname"]),
+                expression: QueryFunction::concat([new QueryIdentifier("$table.realname"), new QueryIdentifier("$table.firstname")]),
                 search: new QueryExpression($DB::quoteValue(' ')),
                 replace: new QueryExpression($DB::quoteValue(''))
             )
@@ -6599,7 +6600,7 @@ HTML;
 
         return [
             'OR' => [
-                new QueryExpression(QueryFunction::lower("$table.name") . ' LIKE ' . $DB::quoteValue("%$filter%")),
+                new QueryExpression(QueryFunction::lower(new QueryIdentifier("$table.name")) . ' LIKE ' . $DB::quoteValue("%$filter%")),
                 new QueryExpression($concat_names_first_last . ' LIKE ' . $DB::quoteValue("%$filter_no_spaces%")),
                 new QueryExpression($concat_names_last_first . ' LIKE ' . $DB::quoteValue("%$filter_no_spaces%")),
             ],
@@ -6621,10 +6622,10 @@ HTML;
 
         $table  = self::getTable();
 
-        $first  = DBmysql::quoteName("$table.$first");
-        $second = DBmysql::quoteName("$table.$second");
-        $alias  = DBmysql::quoteName($alias);
-        $name   = DBmysql::quoteName($table . '.' . self::getNameField());
+        $first  = new QueryIdentifier("$table.$first");
+        $second = new QueryIdentifier("$table.$second");
+        $alias  = new QueryIdentifier($alias);
+        $name   = new QueryIdentifier($table . '.' . self::getNameField());
 
         return new QueryExpression("CASE
             WHEN $first <> '' AND $second <> '' THEN CONCAT($first, ' ', $second)
@@ -6959,7 +6960,7 @@ HTML;
             'WHERE'  => [
                 new QueryExpression(
                     QueryFunction::now() . ' < ' . QueryFunction::dateAdd(
-                        date: 'password_forget_token_date',
+                        date: new QueryIdentifier('password_forget_token_date'),
                         interval: $CFG_GLPI['password_init_token_delay'],
                         interval_unit: 'SECOND'
                     )

--- a/tests/functional/DBmysqlIteratorTest.php
+++ b/tests/functional/DBmysqlIteratorTest.php
@@ -916,6 +916,29 @@ class DBmysqlIteratorTest extends DbTestCase
 
         $it = $this->it->execute(['FROM' => 'foo', 'GROUP' => ['id', 'name']]);
         $this->assertSame('SELECT * FROM `foo` GROUP BY `id`, `name`', $it->getSql());
+
+        // the values bound by a grouped expression must be collected too, otherwise the
+        // statement ends up with more placeholders than values
+        $it = $this->it->execute([
+            'FROM'    => 'foo',
+            'GROUPBY' => [new QueryExpression('CASE WHEN `bar` = ? THEN 1 END', values: [42])],
+        ]);
+        $this->assertSame('SELECT * FROM `foo` GROUP BY CASE WHEN `bar` = ? THEN 1 END', $it->getSql());
+        $this->assertEquals([42], $it->getValues());
+
+        $it = $this->it->execute([
+            'FROM'    => 'foo',
+            'GROUPBY' => ['id', new QueryExpression('CASE WHEN `bar` = ? THEN 1 END', values: [42])],
+        ]);
+        $this->assertSame('SELECT * FROM `foo` GROUP BY `id`, CASE WHEN `bar` = ? THEN 1 END', $it->getSql());
+        $this->assertEquals([42], $it->getValues());
+
+        $it = $this->it->execute([
+            'FROM'    => 'foo',
+            'GROUPBY' => new QueryExpression('CASE WHEN `bar` = ? THEN 1 END', values: [7]),
+        ]);
+        $this->assertSame('SELECT * FROM `foo` GROUP BY CASE WHEN `bar` = ? THEN 1 END', $it->getSql());
+        $this->assertEquals([7], $it->getValues());
     }
 
     public function testNoFieldGroup()

--- a/tests/functional/Glpi/DBAL/QueryExpressionTest.php
+++ b/tests/functional/Glpi/DBAL/QueryExpressionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\DBAL;
+
+use Glpi\DBAL\QueryElementInterface;
+use Glpi\DBAL\QueryExpression;
+use Glpi\Tests\GLPITestCase;
+use RuntimeException;
+
+class QueryExpressionTest extends GLPITestCase
+{
+    public function testASimpleExpressionBindsNothing(): void
+    {
+        $expression = new QueryExpression('1 = 1');
+
+        $this->assertSame('1 = 1', $expression->getValue());
+        $this->assertSame('1 = 1', (string) $expression);
+        $this->assertSame([], $expression->getParams());
+    }
+
+    public function testTheAliasIsQuoted(): void
+    {
+        $this->assertSame('1 = 1 AS `my_alias`', (string) new QueryExpression('1 = 1', 'my_alias'));
+    }
+
+    public function testValuesAreCarriedAlong(): void
+    {
+        $expression = new QueryExpression('a = ? AND b = ?', values: [1, 'two']);
+
+        $this->assertSame('a = ? AND b = ?', (string) $expression);
+        $this->assertSame([1, 'two'], $expression->getParams());
+    }
+
+    public function testWrappingAnExpressionMergesItsParams(): void
+    {
+        $inner = new QueryExpression('a = ?', values: [1]);
+        $outer = new QueryExpression($inner, null, [2]);
+
+        $this->assertSame('a = ?', (string) $outer);
+        // the wrapped expression's own values come first, then the ones given to the wrapper
+        $this->assertSame([1, 2], $outer->getParams());
+    }
+
+    public function testAnEmptyExpressionIsRejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot build an empty expression');
+        new QueryExpression('');
+    }
+
+    public function testItIsAQueryElement(): void
+    {
+        $this->assertInstanceOf(QueryElementInterface::class, new QueryExpression('1'));
+    }
+
+    /**
+     * `Domain::getEntitiesCriteria()` clones a shared expression and rebinds each copy, so
+     * `setParams()` has to stay a mutator and `clone` has to yield an independent object.
+     */
+    public function testAClonedExpressionCanBeRebound(): void
+    {
+        $expression = new QueryExpression('DATEDIFF(CURDATE(), `date_expiration`) > ?');
+
+        $delay = (clone $expression)->setParams([7]);
+        $zero  = (clone $expression)->setParams([0]);
+
+        $this->assertSame([7], $delay->getParams());
+        $this->assertSame([0], $zero->getParams());
+        $this->assertSame([], $expression->getParams());
+        $this->assertSame((string) $expression, (string) $delay);
+    }
+}

--- a/tests/functional/Glpi/DBAL/QueryFunctionTest.php
+++ b/tests/functional/Glpi/DBAL/QueryFunctionTest.php
@@ -36,6 +36,8 @@ namespace tests\units\Glpi\DBAL;
 
 use Glpi\DBAL\QueryExpression;
 use Glpi\DBAL\QueryFunction;
+use Glpi\DBAL\QueryIdentifier;
+use Glpi\DBAL\QueryValue;
 use Glpi\Tests\GLPITestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -765,6 +767,182 @@ class QueryFunctionTest extends GLPITestCase
         $this->assertSame(
             $expected,
             (string) QueryFunction::locate($substring, $expression, $alias)
+        );
+    }
+
+    /**
+     * Values bound by an argument must survive the concatenation performed to build the call.
+     *
+     * These used to get dropped: the argument was cast to a string through `__toString()`, which
+     * renders the SQL only, so the statement ended up with more `?` placeholders than bound
+     * values, shifting the positional binding of everything that followed.
+     */
+    public static function parameterPropagationProvider(): iterable
+    {
+        $sub = static fn(int $value): QueryExpression => new QueryExpression('(SELECT x FROM t WHERE y = ?)', values: [$value]);
+
+        yield 'dateAdd interval' => [
+            static fn() => QueryFunction::dateAdd(new QueryIdentifier('date_creation'), $sub(42), 'SECOND'),
+            'DATE_ADD(`date_creation`, INTERVAL (SELECT x FROM t WHERE y = ?) SECOND)',
+            [42],
+        ];
+        yield 'dateAdd date' => [
+            static fn() => QueryFunction::dateAdd($sub(42), 3, 'DAY'),
+            'DATE_ADD((SELECT x FROM t WHERE y = ?), INTERVAL 3 DAY)',
+            [42],
+        ];
+        yield 'dateSub interval' => [
+            static fn() => QueryFunction::dateSub(new QueryIdentifier('date_creation'), $sub(42), 'SECOND'),
+            'DATE_SUB(`date_creation`, INTERVAL (SELECT x FROM t WHERE y = ?) SECOND)',
+            [42],
+        ];
+        yield 'concat_ws separator and elements' => [
+            static fn() => QueryFunction::concat_ws($sub(1), [$sub(2), new QueryIdentifier('a.b'), $sub(3)]),
+            'CONCAT_WS((SELECT x FROM t WHERE y = ?), (SELECT x FROM t WHERE y = ?), `a`.`b`, (SELECT x FROM t WHERE y = ?))',
+            [1, 2, 3],
+        ];
+        yield 'groupConcat order by' => [
+            static fn() => QueryFunction::groupConcat(
+                new QueryIdentifier('a.x'),
+                ',',
+                false,
+                new QueryExpression('CASE WHEN z = ? END', values: [9])
+            ),
+            "GROUP_CONCAT(`a`.`x` ORDER BY CASE WHEN z = ? END SEPARATOR ',')",
+            [9],
+        ];
+        yield 'groupConcat order by inside an array' => [
+            static fn() => QueryFunction::groupConcat(
+                new QueryIdentifier('a.x'),
+                null,
+                false,
+                ['a.y', new QueryExpression('CASE WHEN z = ? END', values: [9])]
+            ),
+            'GROUP_CONCAT(`a`.`x` ORDER BY `a`.`y`, CASE WHEN z = ? END)',
+            [9],
+        ];
+        yield 'if' => [
+            static fn() => QueryFunction::if($sub(1), $sub(2), $sub(3)),
+            'IF((SELECT x FROM t WHERE y = ?), (SELECT x FROM t WHERE y = ?), (SELECT x FROM t WHERE y = ?))',
+            [1, 2, 3],
+        ];
+        yield 'if with array criteria' => [
+            static fn() => QueryFunction::if(['a.x' => 5], new QueryExpression("'yes'"), new QueryExpression("'no'")),
+            "IF(`a`.`x` = ?, 'yes', 'no')",
+            [5],
+        ];
+        yield 'cast' => [
+            static fn() => QueryFunction::cast($sub(1), 'CHAR'),
+            'CAST((SELECT x FROM t WHERE y = ?) AS CHAR)',
+            [1],
+        ];
+        yield 'convert' => [
+            static fn() => QueryFunction::convert($sub(1), 'utf8mb4'),
+            'CONVERT((SELECT x FROM t WHERE y = ?) USING utf8mb4)',
+            [1],
+        ];
+        yield 'sum distinct' => [
+            static fn() => QueryFunction::sum($sub(1), true),
+            'SUM(DISTINCT (SELECT x FROM t WHERE y = ?))',
+            [1],
+        ];
+        yield 'magic call with an array' => [
+            static fn() => QueryFunction::concat([$sub(1), $sub(2)]),
+            'CONCAT((SELECT x FROM t WHERE y = ?), (SELECT x FROM t WHERE y = ?))',
+            [1, 2],
+        ];
+        yield 'nested calls' => [
+            static fn() => QueryFunction::ifnull(QueryFunction::cast($sub(1), 'CHAR'), $sub(2)),
+            'IFNULL(CAST((SELECT x FROM t WHERE y = ?) AS CHAR), (SELECT x FROM t WHERE y = ?))',
+            [1, 2],
+        ];
+    }
+
+    /**
+     * @param callable(): QueryExpression $build
+     * @param array<int, mixed> $expected_params
+     */
+    #[DataProvider('parameterPropagationProvider')]
+    public function testParametersArePropagated(callable $build, string $expected_sql, array $expected_params): void
+    {
+        $result = $build();
+
+        $this->assertSame($expected_sql, (string) $result);
+        $this->assertSame($expected_params, $result->getParams());
+        // a mismatch here is what silently shifts the binding of the whole statement
+        $this->assertSame(substr_count($expected_sql, '?'), count($result->getParams()));
+    }
+
+    /**
+     * Parameters are positional, so they must be collected in the order the SQL is assembled.
+     */
+    public function testParametersKeepTheEmissionOrder(): void
+    {
+        $result = QueryFunction::concat([
+            new QueryValue('first'),
+            new QueryValue('second'),
+            new QueryValue('third'),
+        ]);
+
+        $this->assertSame('CONCAT(?, ?, ?)', (string) $result);
+        $this->assertSame(['first', 'second', 'third'], $result->getParams());
+    }
+
+    public static function queryValueProvider(): iterable
+    {
+        yield 'aggregate' => [static fn() => QueryFunction::sum(new QueryValue(5)), 'SUM(?)', [5]];
+        yield 'ifnull' => [
+            static fn() => QueryFunction::ifnull(new QueryIdentifier('a.x'), new QueryValue('fallback')),
+            'IFNULL(`a`.`x`, ?)',
+            ['fallback'],
+        ];
+        yield 'cast' => [static fn() => QueryFunction::cast(new QueryValue(7), 'CHAR'), 'CAST(? AS CHAR)', [7]];
+        yield 'date interval' => [
+            static fn() => QueryFunction::dateAdd(new QueryIdentifier('a.d'), new QueryValue(3), 'DAY'),
+            'DATE_ADD(`a`.`d`, INTERVAL ? DAY)',
+            [3],
+        ];
+        yield 'concat_ws' => [
+            static fn() => QueryFunction::concat_ws(new QueryValue('-'), [new QueryValue('a'), new QueryIdentifier('b.c')]),
+            'CONCAT_WS(?, ?, `b`.`c`)',
+            ['-', 'a'],
+        ];
+    }
+
+    /**
+     * @param callable(): QueryExpression $build
+     * @param array<int, mixed> $expected_params
+     */
+    #[DataProvider('queryValueProvider')]
+    public function testAQueryValueIsBoundInsteadOfInlined(callable $build, string $expected_sql, array $expected_params): void
+    {
+        $result = $build();
+
+        $this->assertSame($expected_sql, (string) $result);
+        $this->assertSame($expected_params, $result->getParams());
+    }
+
+    public function testNullArgumentsAreIgnored(): void
+    {
+        $this->assertSame('UNIX_TIMESTAMP()', (string) QueryFunction::unixTimestamp());
+        $this->assertSame(
+            'CONCAT_WS(?, `a`.`b`)',
+            (string) QueryFunction::concat_ws(new QueryValue('-'), [new QueryIdentifier('a.b'), null])
+        );
+    }
+
+    /**
+     * A bare string identifier keeps working; it is only the less explicit form.
+     */
+    public function testABareStringIsStillTreatedAsAnIdentifier(): void
+    {
+        $bare = QueryFunction::sum('glpi_computers.id');
+
+        $this->assertSame('SUM(`glpi_computers`.`id`)', (string) $bare);
+        $this->assertSame([], $bare->getParams());
+        $this->assertSame(
+            (string) QueryFunction::sum(new QueryIdentifier('glpi_computers.id')),
+            (string) $bare
         );
     }
 }

--- a/tests/functional/Glpi/DBAL/QueryIdentifierTest.php
+++ b/tests/functional/Glpi/DBAL/QueryIdentifierTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\DBAL;
+
+use Glpi\DBAL\QueryIdentifier;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+
+class QueryIdentifierTest extends GLPITestCase
+{
+    public static function identifierProvider(): iterable
+    {
+        yield 'simple name' => ['name', null, '`name`'];
+        yield 'qualified name' => ['glpi_computers.name', null, '`glpi_computers`.`name`'];
+        yield 'wildcard' => ['*', null, '*'];
+        yield 'qualified wildcard' => ['glpi_computers.*', null, '`glpi_computers`.*'];
+        yield 'already quoted' => ['`name`', null, '`name`'];
+        yield 'backtick is escaped' => ['na`me', null, '`na``me`'];
+        yield 'with alias' => ['glpi_computers.name', 'computer_name', '`glpi_computers`.`name` AS `computer_name`'];
+    }
+
+    #[DataProvider('identifierProvider')]
+    public function testGetValue(string $name, ?string $alias, string $expected): void
+    {
+        $this->assertSame($expected, (new QueryIdentifier($name, $alias))->getValue());
+    }
+
+    #[DataProvider('identifierProvider')]
+    public function testToString(string $name, ?string $alias, string $expected): void
+    {
+        $this->assertSame($expected, (string) new QueryIdentifier($name, $alias));
+    }
+
+    public function testAnIdentifierBindsNoValue(): void
+    {
+        $this->assertSame([], (new QueryIdentifier('glpi_computers.name'))->getParams());
+    }
+
+    public function testAnEmptyNameIsRejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot build an empty identifier');
+        new QueryIdentifier('');
+    }
+
+    public function testAnEmptyAliasIsRejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot build an empty alias');
+        new QueryIdentifier('name', '');
+    }
+}

--- a/tests/functional/Glpi/DBAL/QueryValueTest.php
+++ b/tests/functional/Glpi/DBAL/QueryValueTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\DBAL;
+
+use Glpi\DBAL\QueryParam;
+use Glpi\DBAL\QueryValue;
+use Glpi\Exception\Database\QueryException;
+use Glpi\Tests\GLPITestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class QueryValueTest extends GLPITestCase
+{
+    public static function valueProvider(): iterable
+    {
+        yield 'string' => ['a string'];
+        yield 'empty string' => [''];
+        yield 'int' => [42];
+        yield 'zero' => [0];
+        yield 'float' => [4.2];
+        yield 'true' => [true];
+        yield 'false' => [false];
+        yield 'null' => [null];
+    }
+
+    #[DataProvider('valueProvider')]
+    public function testAValueRendersAsAPlaceholderAndBindsItself(mixed $value): void
+    {
+        $query_value = new QueryValue($value);
+
+        $this->assertSame('?', $query_value->getValue());
+        $this->assertSame('?', (string) $query_value);
+        $this->assertSame([$value], $query_value->getParams());
+    }
+
+    public static function invalidValueProvider(): iterable
+    {
+        yield 'array' => [['a', 'b'], 'array'];
+        yield 'object' => [new QueryParam(), 'Glpi\DBAL\QueryParam'];
+    }
+
+    #[DataProvider('invalidValueProvider')]
+    public function testANonScalarValueIsRejected(mixed $value, string $type): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage(sprintf('A query value must be a scalar, %s given', $type));
+        new QueryValue($value);
+    }
+
+    /**
+     * Both render as `?`, but a QueryValue binds its value whereas a QueryParam binds nothing:
+     * they are not interchangeable.
+     */
+    public function testAQueryValueIsNotAQueryParam(): void
+    {
+        $this->assertSame((new QueryParam())->getValue(), (new QueryValue('foo'))->getValue());
+        $this->assertSame(['foo'], (new QueryValue('foo'))->getParams());
+        $this->assertFalse(method_exists(QueryParam::class, 'getParams'));
+    }
+}


### PR DESCRIPTION
QueryFunction methods now accepts any query element (it was limited to `QueryExpression|string`).

Some "helpers" methods have been added to simplify few parts (parameters management, aggregate and date interval expressions).

Requires: https://github.com/glpi-project/glpi/pull/25206 - which commits are currently included.