### PR TITLE
fix datatable specific rows with massive actions disabled

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -751,7 +751,7 @@ class Group extends CommonTreeDropdown
                 $show_massive_actions = true;
             } else {
                 // This row cannot have massive actions due to lack of rights.
-                $entry['skip_ma'] = true;
+                $entry['showmassiveactions'] = false;
             }
 
             $assignees = [];

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -276,7 +276,7 @@
             <tbody>
                 {% if entries|length > 0 %}
                     {% for entry in entries %}
-                        {% set row_massiveactions = entry['showmassiveactions']|default(showmassiveactions) %}
+                        {% set row_massiveactions = entry['showmassiveactions'] is defined ? entry['showmassiveactions'] : showmassiveactions %}
                         <tr
                             class="{{ loop.last ? "border-transparent" : "" }} {{ row_class|default('') }} {{ entry['row_class']|default('') }}"
                             {% if entry['itemtype'] is defined %}
@@ -289,12 +289,14 @@
                                 aria-label="{{ entry['row_aria_label'] }}"
                             {% endif %}
                         >
-                            {% if row_massiveactions %}
+                            {% if showmassiveactions %}
                                 <td style="width: 10px">
-                                    {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}
-                                        <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
-                                               value="1" aria-label="{{ __("Select item") }}"
-                                               name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                    {% if row_massiveactions %}
+                                        {% if entry['skip_ma'] is not defined or entry['skip_ma'] == false %}
+                                            <input class="form-check-input massive_action_checkbox" type="checkbox" data-glpicore-ma-tags="common"
+                                                   value="1" aria-label="{{ __("Select item") }}"
+                                                   name="item[{{ entry['itemtype'] }}][{{ entry['id'] }}]" />
+                                        {% endif %}
                                     {% endif %}
                                 </td>
                             {% endif %}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

fixes #24993

The `|default` filter considers `false` an empty value so datatable entries that set `showmassiveactions` to false would cause the default `showmassiveactions` of the datatable to be used which would of shown the massive action checkbox.

Then, if a row didn't have massive actions when the overall table did, the row would be missing the table cell and shift everything to the left.

Finally, there was a redundant `skip_ma` property handling that did the same thing. I removed the only place in the core this was set but kept the handling in case a plugin ended up using the bad code. It can be removed in GLPI 12.