### PR TITLE
fix(forms): migrate empty destination creation operator

### DIFF
--- a/src/Glpi/Form/Migration/FormMigration.php
+++ b/src/Glpi/Form/Migration/FormMigration.php
@@ -1619,8 +1619,15 @@ class FormMigration extends AbstractPluginMigration
                 $conditioning_item,
                 $target_item
             );
+
             if ($condition_entry === null) {
-                continue;
+                if ($target_item['itemtype'] !== FormDestination::class) {
+                    continue;
+                }
+
+                // If the target item is a destination, we still want to create the destination even if the condition is invalid.
+                // Some users use empty strategies without conditions to "disable" the destination.
+                $condition_entry = [];
             }
 
             if (is_a($target_item['itemtype'], FormDestination::class, true)) {

--- a/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
+++ b/tests/functional/Glpi/Form/Migration/FormMigrationTest.php
@@ -2491,8 +2491,22 @@ final class FormMigrationTest extends DbTestCase
                     'legacy_itemtype'            => $itemtype,
                     'legacy_table'               => $table,
                     'legacy_strategy'            => $key,
+                    'condition'                  => [
+                        'show_condition' => 1,
+                        'show_value'     => 'Test',
+                        'show_logic'     => 1,
+                    ],
                     'expected_creation_strategy' => $strategy,
                     'expected_conditions'        => $expected_conditions,
+                ];
+
+                yield 'Destination ' . $itemtype . ' - ' . $strategy->getLabel() . ' with no conditions' => [
+                    'legacy_itemtype'            => $itemtype,
+                    'legacy_table'               => $table,
+                    'legacy_strategy'            => $key,
+                    'condition'                  => [],
+                    'expected_creation_strategy' => $strategy,
+                    'expected_conditions'        => [],
                 ];
             }
         }
@@ -2503,6 +2517,7 @@ final class FormMigrationTest extends DbTestCase
         string $legacy_itemtype,
         string $legacy_table,
         int $legacy_strategy,
+        array $condition,
         CreationStrategy $expected_creation_strategy,
         array $expected_conditions
     ): void {
@@ -2552,14 +2567,14 @@ final class FormMigrationTest extends DbTestCase
         // Insert condition
         $this->assertTrue($DB->insert(
             'glpi_plugin_formcreator_conditions',
-            [
-                'itemtype'                        => $legacy_itemtype,
-                'items_id'                        => $destination_id,
-                'plugin_formcreator_questions_id' => $target_question_id,
-                'show_condition'                  => 1,
-                'show_value'                      => 'Test',
-                'show_logic'                      => 1,
-            ]
+            array_merge(
+                [
+                    'itemtype'                        => $legacy_itemtype,
+                    'items_id'                        => $destination_id,
+                    'plugin_formcreator_questions_id' => $target_question_id,
+                ],
+                $condition
+            )
         ));
 
         // Process migration


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !45886

Updated `processMigrationOfVisibilityConditions()` in `FormMigration.php` to ensure that destination items are created even when their conditions are empty or invalid, supporting workflows where destinations are intentionally "disabled" by users using empty strategies.