### PR TITLE
Improve KB performance by adding lazy loading when possible

### DIFF
--- a/install/migrations/update_11.0.x_to_12.0.0/knowbaseitem_folds.php
+++ b/install/migrations/update_11.0.x_to_12.0.0/knowbaseitem_folds.php
@@ -36,10 +36,10 @@
  * @var Migration $migration
  */
 
-// Per-user list of KB aside articles the user has collapsed (folded).
+// Per-user list of KB aside articles the user has unfolded.
 $migration->addField(
     'glpi_users',
-    'folded_knowbaseitems',
+    'unfolded_knowbaseitems',
     'json DEFAULT NULL',
     ['after' => 'itil_layout']
 );

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8095,7 +8095,7 @@ CREATE TABLE `glpi_users` (
   `savedsearches_pinned` text,
   `timeline_order` char(20) DEFAULT NULL,
   `itil_layout` text,
-  `folded_knowbaseitems` json,
+  `unfolded_knowbaseitems` json,
   `richtext_layout` char(20) DEFAULT NULL,
   `set_default_requester` tinyint DEFAULT NULL,
   `lock_autolock_mode` tinyint DEFAULT NULL,

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -526,6 +526,8 @@ export class GlpiKnowbaseAsideController
         const tree      = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
         const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
 
+        const request_id = ++this.#search_request_id;
+
         // Search criteria was removed, show all items again
         if (value.trim() === '') {
             this.#showAllTreeItems(tree);
@@ -534,7 +536,6 @@ export class GlpiKnowbaseAsideController
         }
 
         // Send request to backend
-        const request_id = ++this.#search_request_id;
         const current_id = this.#aside
             .querySelector('[data-glpi-kb-article-current]')?.dataset.glpiKbArticleId ?? '';
         const response = await get(

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -143,6 +143,17 @@ export class GlpiKnowbaseAsideController
     {
         node.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
 
+        // The same article can be rendered twice (original tree + search results)
+        // Update the second node data properties too if found.
+        const id = node.dataset.glpiKbArticleId;
+        for (const twin of this.#aside.querySelectorAll(
+            `[data-glpi-kb-aside-category][data-glpi-kb-article-id="${CSS.escape(id)}"]`,
+        )) {
+            if (twin !== node) {
+                twin.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
+            }
+        }
+
         // `:scope >` on the header is required: without it we would reach the
         // toggle of a nested article instead of this node's own one.
         const toggle = node.querySelector(
@@ -470,17 +481,45 @@ export class GlpiKnowbaseAsideController
 
         // Send request to backend
         const request_id = ++this.#search_request_id;
+        const current_id = this.#aside
+            .querySelector('[data-glpi-kb-article-current]')?.dataset.glpiKbArticleId ?? '';
         const response = await get(
-            `Knowbase/Aside/Search?contains=${encodeURIComponent(value)}`,
+            `Knowbase/Aside/Search?contains=${encodeURIComponent(value)}`
+            + `&current_id=${encodeURIComponent(current_id)}`,
         );
-        const matching_ids = new Set(await response.json());
+        const { ids, html } = await response.json();
         if (request_id !== this.#search_request_id) {
             return;
         }
 
         // Apply results
-        this.#filterTree(tree, matching_ids);
-        this.#filterFavorites(favorites, matching_ids);
+        this.#showTreeResults(tree, html);
+        this.#filterFavorites(favorites, new Set(ids));
+    }
+
+    /**
+     * Replace the tree with the server-rendered search results. The rendered
+     * tree is kept in place (hidden) so clearing the search restores it without
+     * a round trip.
+     *
+     * @param {HTMLElement} tree
+     * @param {string}      html
+     */
+    #showTreeResults(tree, html)
+    {
+        const rendered = tree.querySelector(':scope > ul.kb-tree');
+        rendered?.setAttribute('data-glpi-kb-search-hidden', '');
+
+        let results = tree.querySelector(':scope > [data-glpi-kb-aside-tree-results]');
+        if (!results) {
+            results = document.createElement('div');
+            results.setAttribute('data-glpi-kb-aside-tree-results', '');
+            rendered ? rendered.after(results) : tree.prepend(results);
+        }
+        results.innerHTML = html;
+
+        const no_results = tree.querySelector('[data-glpi-kb-aside-no-results]');
+        no_results.hidden = results.querySelector('[data-glpi-kb-article-id]') !== null;
     }
 
     /**
@@ -490,6 +529,8 @@ export class GlpiKnowbaseAsideController
      */
     #showAllTreeItems(tree)
     {
+        tree.querySelector(':scope > [data-glpi-kb-aside-tree-results]')?.remove();
+
         for (const el of tree.querySelectorAll('[data-glpi-kb-search-hidden]')) {
             el.removeAttribute('data-glpi-kb-search-hidden');
         }
@@ -563,62 +604,6 @@ export class GlpiKnowbaseAsideController
             favorites_el.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
             header.setAttribute('data-glpi-kb-aside-header-no-border', '');
         }
-    }
-
-    /**
-     * Filter the tree to only show articles whose IDs are in matching_ids.
-     * Articles (leaf or with children) with no visible descendant are hidden
-     * recursively.
-     *
-     * @param {HTMLElement} tree
-     * @param {Set<number>} matching_ids
-     */
-    #filterTree(tree, matching_ids)
-    {
-        let any_visible = false;
-
-        for (const article of tree.querySelectorAll(':scope > ul > [data-glpi-kb-article-id]')) {
-            if (this.#filterArticle(article, matching_ids)) {
-                any_visible = true;
-            }
-        }
-
-        // Show information message if no results are found
-        const no_results = tree.querySelector('[data-glpi-kb-aside-no-results]');
-        no_results.hidden = any_visible;
-    }
-
-    /**
-     * Recursively determines whether an article row (leaf or with children)
-     * should stay visible — either its own title/id matched the search, or
-     * one of its descendants did — and hides/shows it (and recurses into its
-     * children, if any) in place.
-     *
-     * @param {HTMLElement} article_el
-     * @param {Set<number>} matching_ids
-     * @returns {boolean} Whether this article or any of its descendants match.
-     */
-    #filterArticle(article_el, matching_ids)
-    {
-        const id = parseInt(article_el.dataset.glpiKbArticleId);
-        let visible = matching_ids.has(id);
-
-        const ul = article_el.querySelector(':scope > ul');
-        if (ul) {
-            for (const child of ul.querySelectorAll(':scope > [data-glpi-kb-article-id]')) {
-                if (this.#filterArticle(child, matching_ids)) {
-                    visible = true;
-                }
-            }
-        }
-
-        if (visible) {
-            article_el.removeAttribute('data-glpi-kb-search-hidden');
-        } else {
-            article_el.setAttribute('data-glpi-kb-search-hidden', '');
-        }
-
-        return visible;
     }
 
     /**

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -146,8 +146,9 @@ export class GlpiKnowbaseAsideController
      *
      * @param {HTMLElement} node
      * @param {boolean} collapsed
+     * @returns {Promise<void>}
      */
-    #setCollapsed(node, collapsed)
+    async #setCollapsed(node, collapsed)
     {
         node.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
 
@@ -174,7 +175,7 @@ export class GlpiKnowbaseAsideController
         this.#persistArticleFold(node.dataset.glpiKbArticleId, collapsed);
 
         if (!collapsed) {
-            this.#loadChildren(node);
+            await this.#loadChildren(node);
         }
     }
 
@@ -369,11 +370,10 @@ export class GlpiKnowbaseAsideController
     /**
      * @param {HTMLElement} add_button
      */
-    #openCreateInput(add_button)
+    async #openCreateInput(add_button)
     {
         const header = add_button.closest('[data-glpi-kb-aside-category-header]');
         const node = header.closest('[data-glpi-kb-aside-category]');
-        const list = node.querySelector(':scope > ul');
         const parent_id = Number(add_button.dataset.glpiKbAsideCategoryAdd) || 0;
 
         // The list is hidden while the node is collapsed, so the input below
@@ -383,8 +383,11 @@ export class GlpiKnowbaseAsideController
         // article: were the parent still folded on that reload, the article the
         // user just created would be hidden.
         if (node.hasAttribute('data-glpi-kb-aside-category-collapsed')) {
-            this.#setCollapsed(node, false);
+            await this.#setCollapsed(node, false);
         }
+
+        // Looked up after the expansion above, which may have refilled it.
+        const list = node.querySelector(':scope > ul');
 
         // Only one inline input at a time across the whole tree.
         const existing = this.#aside.querySelector('[data-glpi-kb-aside-create-row]');

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -646,16 +646,23 @@ export class GlpiKnowbaseAsideController
             }
         });
 
-        // Prefetch the menu content as soon as the row is hovered or focused, so
-        // it is ready by the time the user opens the kebab (no visible latency).
-        const prefetch = (e) => {
+        // Create the row's menu and prefetch its content as soon as the row is
+        // hovered or focused, so both are ready by the time the user opens the
+        // kebab (no visible latency).
+        const prepare = (e) => {
             const line = e.target.closest('.article[data-glpi-kb-article-id]');
             if (line && this.#aside.contains(line)) {
+                this.#ensureActionsMenu(line);
                 this.#populateMenus(parseInt(line.dataset.glpiKbArticleId));
             }
         };
-        this.#aside.addEventListener('mouseover', prefetch);
-        this.#aside.addEventListener('focusin', prefetch);
+        this.#aside.addEventListener('mouseover', prepare);
+        this.#aside.addEventListener('focusin', prepare);
+        // Safety net for opens that skip hover and focus (touch, synthetic
+        // clicks): the menu has to exist before Bootstrap looks it up, and the
+        // capture phase runs before its own delegated click handler.
+        this.#aside.addEventListener('pointerdown', prepare);
+        this.#aside.addEventListener('click', prepare, true);
 
         // Fallback for opens that outran the prefetch (touch, instant clicks,
         // keyboard): make sure the content is loaded when the menu opens.
@@ -665,6 +672,31 @@ export class GlpiKnowbaseAsideController
                 this.#populateMenus(parseInt(line.dataset.glpiKbArticleId));
             }
         });
+    }
+
+    /**
+     * Create an article row's kebab menu element, unless it already has one.
+     *
+     * The tree only renders the menu triggers: a large knowledge base would
+     * otherwise carry thousands of identical, never-opened menus. The menu is
+     * cloned from the template the aside renders once, see
+     * `render_actions_menu_lazy()`.
+     *
+     * @param {HTMLElement} line
+     */
+    #ensureActionsMenu(line)
+    {
+        // Scoped to the row itself: a row nests its child rows, whose own
+        // triggers must not be confused with it.
+        const dropdown = line.querySelector(':scope > .article-line > .dropdown');
+        if (!dropdown || dropdown.querySelector(':scope > [data-glpi-kb-actions-menu]')) {
+            return;
+        }
+
+        const template = this.#aside.querySelector('[data-glpi-kb-actions-menu-template]');
+        if (template) {
+            dropdown.append(template.content.cloneNode(true));
+        }
     }
 
     /**

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -58,6 +58,14 @@ export class GlpiKnowbaseAsideController
     #search_request_id = 0;
 
     /**
+     * Children requests by article id, so a branch is only fetched once even if
+     * the reader folds and unfolds it repeatedly.
+     *
+     * @type {Map<number, Promise<string>>}
+     */
+    #children_cache = new Map();
+
+    /**
      * Whether the favorites section was hidden on initial server render.
      * Used to restore the correct state after clearing the search.
      * @type {boolean}
@@ -164,6 +172,49 @@ export class GlpiKnowbaseAsideController
         toggle?.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
 
         this.#persistArticleFold(node.dataset.glpiKbArticleId, collapsed);
+
+        if (!collapsed) {
+            this.#loadChildren(node);
+        }
+    }
+
+    /**
+     * Fill in the children of a node the reader just unfolded, if the tree was
+     * rendered without them.
+     *
+     * @param {HTMLElement} node
+     */
+    async #loadChildren(node)
+    {
+        // `:scope >` is required: a nested node has a list of its own.
+        const list = node.querySelector(':scope > ul[data-glpi-kb-children-unloaded]');
+        if (!list) {
+            return;
+        }
+        // Claim it right away, so a second unfold does not fetch it again.
+        list.removeAttribute('data-glpi-kb-children-unloaded');
+
+        const id = parseInt(node.dataset.glpiKbArticleId);
+        if (!this.#children_cache.has(id)) {
+            const current_id = this.#aside
+                .querySelector('[data-glpi-kb-aside-tree] [data-glpi-kb-article-current]')
+                ?.dataset.glpiKbArticleId ?? '';
+            this.#children_cache.set(
+                id,
+                get(
+                    `Knowbase/Aside/Article/${encodeURIComponent(id)}/Children`
+                    + `?current_id=${encodeURIComponent(current_id)}`,
+                ).then((response) => response.text()),
+            );
+        }
+
+        try {
+            list.innerHTML = await this.#children_cache.get(id);
+        } catch {
+            // Drop the cached rejection and let a later unfold retry.
+            this.#children_cache.delete(id);
+            list.setAttribute('data-glpi-kb-children-unloaded', '');
+        }
     }
 
     #initToggle()

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -150,33 +150,39 @@ export class GlpiKnowbaseAsideController
      */
     async #setCollapsed(node, collapsed)
     {
-        node.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
-
-        // The same article can be rendered twice (original tree + search results)
-        // Update the second node data properties too if found.
         const id = node.dataset.glpiKbArticleId;
-        for (const twin of this.#aside.querySelectorAll(
+
+        // The same article can be rendered more than once: under each of its
+        // parents, and again in the search results while the rendered tree is
+        // kept hidden. They all share one fold state, so every copy gets the
+        // very same treatment.
+        const nodes = id ? this.#aside.querySelectorAll(
             `[data-glpi-kb-aside-category][data-glpi-kb-article-id="${CSS.escape(id)}"]`,
-        )) {
-            if (twin !== node) {
-                twin.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
+        ) : [node];
+
+        const loading = [];
+        for (const twin of nodes) {
+            twin.toggleAttribute('data-glpi-kb-aside-category-collapsed', collapsed);
+
+            // `:scope >` on the header is required: without it we would reach
+            // the toggle of a nested article instead of this node's own one.
+            const toggle = twin.querySelector(
+                ':scope > [data-glpi-kb-aside-category-header] [data-glpi-kb-aside-category-toggle]'
+            );
+            // A childless node has no toggle to update (it is still collapsible,
+            // so that a child created below lands in a visible list).
+            toggle?.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+
+            if (!collapsed) {
+                // A single fetch feeds them all: `#loadChildren()` caches the
+                // pending request per article id.
+                loading.push(this.#loadChildren(twin));
             }
         }
 
-        // `:scope >` on the header is required: without it we would reach the
-        // toggle of a nested article instead of this node's own one.
-        const toggle = node.querySelector(
-            ':scope > [data-glpi-kb-aside-category-header] [data-glpi-kb-aside-category-toggle]'
-        );
-        // A childless node has no toggle to update (it is still collapsible, so
-        // that a child created below lands in a visible list).
-        toggle?.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        this.#persistArticleFold(id, collapsed);
 
-        this.#persistArticleFold(node.dataset.glpiKbArticleId, collapsed);
-
-        if (!collapsed) {
-            await this.#loadChildren(node);
-        }
+        await Promise.all(loading);
     }
 
     /**

--- a/src/Glpi/Controller/Knowbase/AsideArticleChildrenController.php
+++ b/src/Glpi/Controller/Knowbase/AsideArticleChildrenController.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Controller\Knowbase;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Knowbase\Aside\Builder;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Renders the children of a single knowledge base article, for the aside tree.
+ *
+ * The tree is folded by default and renders a folded article without its
+ * children: rendering the whole knowledge base up front is what makes a large
+ * one expensive. This fills a branch in when the reader unfolds it.
+ */
+final class AsideArticleChildrenController extends AbstractController
+{
+    #[Route(
+        "/Knowbase/Aside/Article/{id}/Children",
+        name: "knowbase_aside_article_children",
+        requirements: [
+            'id' => '\d+',
+        ],
+        methods: 'GET',
+    )]
+    public function __invoke(int $id, Request $request): Response
+    {
+        if (!KnowbaseItem::canView()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // Visibility is applied by the builder, which returns nothing for an
+        // article the current user may not see.
+        $children = (new Builder($request->query->getInt('current_id')))->buildChildren($id);
+
+        return $this->render('pages/tools/kb/aside_children.html.twig', [
+            'children'     => $children,
+            'can_create'   => KnowbaseItem::canCreate(),
+            'show_actions' => KnowbaseItem::canShowAsideActions(),
+        ]);
+    }
+}

--- a/src/Glpi/Controller/Knowbase/AsideArticleFoldController.php
+++ b/src/Glpi/Controller/Knowbase/AsideArticleFoldController.php
@@ -72,9 +72,9 @@ final class AsideArticleFoldController extends AbstractController
             return new Response();
         }
 
-        KnowbaseItem::setFoldedForCurrentUser(
+        KnowbaseItem::setUnfoldedForCurrentUser(
             id: $id,
-            folded: (bool) $collapsed
+            unfolded: !((bool) $collapsed)
         );
 
         return new Response(); // OK

--- a/src/Glpi/Controller/Knowbase/AsideSearchController.php
+++ b/src/Glpi/Controller/Knowbase/AsideSearchController.php
@@ -34,9 +34,11 @@
 
 namespace Glpi\Controller\Knowbase;
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Knowbase\Aside\Builder;
 use KnowbaseItem;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -68,9 +70,7 @@ final class AsideSearchController extends AbstractController
         // Get article IDs that match this filter
         $criteria = KnowbaseItem::getListRequest(['contains' => $contains], 'search');
 
-        // The response is only used for membership tests, so neither the article
-        // columns (`glpi_knowbaseitems.*` includes `answer`) nor the relevance
-        // ordering are needed.
+        // Only the matching ids are needed here
         $criteria['SELECT'] = [KnowbaseItem::getTableField('id')];
         unset($criteria['ORDERBY']);
 
@@ -79,6 +79,21 @@ final class AsideSearchController extends AbstractController
             $ids[] = (int) $data['id'];
         }
 
-        return new JsonResponse($ids);
+        // Render the filtered tree
+        $tree = (new Builder($request->query->getInt('current_id')))->buildSearchTree($ids);
+
+        return new JsonResponse([
+            // Consumed by the favorites section, which filters the rows it
+            // already holds.
+            'ids'  => $ids,
+            'html' => TemplateRenderer::getInstance()->render(
+                'pages/tools/kb/aside_tree.html.twig',
+                [
+                    'tree'         => $tree,
+                    'can_create'   => KnowbaseItem::canCreate(),
+                    'show_actions' => KnowbaseItem::canShowAsideActions(),
+                ]
+            ),
+        ]);
     }
 }

--- a/src/Glpi/Controller/Knowbase/AsideSearchController.php
+++ b/src/Glpi/Controller/Knowbase/AsideSearchController.php
@@ -67,6 +67,13 @@ final class AsideSearchController extends AbstractController
 
         // Get article IDs that match this filter
         $criteria = KnowbaseItem::getListRequest(['contains' => $contains], 'search');
+
+        // The response is only used for membership tests, so neither the article
+        // columns (`glpi_knowbaseitems.*` includes `answer`) nor the relevance
+        // ordering are needed.
+        $criteria['SELECT'] = [KnowbaseItem::getTableField('id')];
+        unset($criteria['ORDERBY']);
+
         $ids = [];
         foreach ($DB->request($criteria) as $data) {
             $ids[] = (int) $data['id'];

--- a/src/Glpi/Knowbase/Aside/Article.php
+++ b/src/Glpi/Knowbase/Aside/Article.php
@@ -39,6 +39,13 @@ final class Article
     /** @var Article[] */
     private array $children = [];
 
+    /**
+     * @param bool $has_children    Whether the article has children to show,
+     *                              whether or not they are loaded.
+     * @param bool $children_loaded Whether `getChildren()` holds them. A folded
+     *                              article renders without its children, which
+     *                              the aside fetches when the reader unfolds it.
+     */
     public function __construct(
         public readonly int $id,
         public readonly string $title,
@@ -46,6 +53,8 @@ final class Article
         public readonly string $link,
         public readonly bool $is_current = false,
         public readonly bool $collapsed = false,
+        public readonly bool $has_children = false,
+        public readonly bool $children_loaded = true,
     ) {}
 
     public function addChild(self $child): void
@@ -61,6 +70,6 @@ final class Article
 
     public function hasChildren(): bool
     {
-        return $this->children !== [];
+        return $this->has_children || $this->children !== [];
     }
 }

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -59,9 +59,41 @@ final class Builder
     /** @var array<int, true> */
     private array $folded_ids_lookup_map = [];
 
+    /**
+     * Articles to render, when the tree is restricted to a subset (search).
+     * Null renders the whole tree.
+     *
+     * @var array<int, true>|null
+     */
+    private ?array $rendered_ids = null;
+
     public function __construct(private readonly int $current_id = 0) {}
 
     public function buildTree(): Tree
+    {
+        return $this->build(null);
+    }
+
+    /**
+     * Tree restricted to the given articles and to the branches leading to
+     * them, as used by the aside search.
+     *
+     * Ancestors are included so a match is never orphaned, and nothing is
+     * collapsed: a match has to be visible without the user unfolding its
+     * ancestors first. Descendants of a match are left out unless they match
+     * too, which is what the search filter it replaces did.
+     *
+     * @param int[] $matching_ids
+     */
+    public function buildSearchTree(array $matching_ids): Tree
+    {
+        return $this->build(array_fill_keys(array_map('intval', $matching_ids), true));
+    }
+
+    /**
+     * @param array<int, true>|null $matching_ids Null builds the whole tree.
+     */
+    private function build(?array $matching_ids): Tree
     {
         global $DB;
 
@@ -83,6 +115,7 @@ final class Builder
 
         // 2) Visible parent -> [visible children] adjacency, and child -> has a visible parent?
         $children_of         = [];     // parent_id => int[] child ids
+        $parents_of          = [];     // child_id => int[] parent ids
         $has_visible_parent  = [];     // child_id => true
         foreach ($DB->request(['FROM' => KnowbaseItem_KnowbaseItem::getTable()]) as $link) {
             $child  = (int) $link['knowbaseitems_id'];
@@ -91,15 +124,21 @@ final class Builder
                 continue; // one of the ends is not visible to the current user
             }
             $children_of[$parent][] = $child;
+            $parents_of[$child][] = $parent;
             $has_visible_parent[$child] = true;
         }
+
+        $this->rendered_ids = $matching_ids === null
+            ? null
+            : $this->withAncestors(array_intersect_key($matching_ids, $data), $parents_of);
 
         // 3) Roots = visible articles with no visible parent (promote-to-root).
         $tree = new Tree();
         foreach ($visible_ids as $id) {
-            if (!isset($has_visible_parent[$id])) {
-                $tree->addArticle($this->buildArticle($id, $data, $children_of, []));
+            if (isset($has_visible_parent[$id]) || !$this->isRendered($id)) {
+                continue;
             }
+            $tree->addArticle($this->buildArticle($id, $data, $children_of, []));
         }
         return $tree;
     }
@@ -118,15 +157,48 @@ final class Builder
             illustration: $row['illustration'] ?? '',
             link: KnowbaseItem::getFormURLWithID($id),
             is_current: $this->current_id > 0 && $id === $this->current_id,
-            collapsed: isset($this->folded_ids_lookup_map[$id]),
+            collapsed: $this->rendered_ids === null
+                && isset($this->folded_ids_lookup_map[$id]),
         );
         $ancestors[$id] = true;
         foreach ($children_of[$id] ?? [] as $child_id) {
-            if (isset($ancestors[$child_id])) {
-                continue; // defensive against cycles (writes forbid them)
+            if (isset($ancestors[$child_id]) || !$this->isRendered($child_id)) {
+                continue; // cycles are forbidden by writes; guard defensively
             }
             $article->addChild($this->buildArticle($child_id, $data, $children_of, $ancestors));
         }
         return $article;
+    }
+
+    private function isRendered(int $id): bool
+    {
+        return $this->rendered_ids === null || isset($this->rendered_ids[$id]);
+    }
+
+    /**
+     * The given articles plus every ancestor leading to them, so a restricted
+     * tree stays attached to its roots.
+     *
+     * @param array<int, true> $ids
+     * @param array<int, int[]> $parents_of
+     *
+     * @return array<int, true>
+     */
+    private function withAncestors(array $ids, array $parents_of): array
+    {
+        $kept = [];
+        $to_walk = array_keys($ids);
+        while ($to_walk !== []) {
+            $id = array_pop($to_walk);
+            if (isset($kept[$id])) {
+                continue;
+            }
+            $kept[$id] = true;
+            foreach ($parents_of[$id] ?? [] as $parent) {
+                $to_walk[] = $parent;
+            }
+        }
+
+        return $kept;
     }
 }

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -50,7 +50,7 @@ use KnowbaseItem_KnowbaseItem;
  */
 final class Builder
 {
-    private const array LIST_COLUMNS = [
+    public const array LIST_COLUMNS = [
         'glpi_knowbaseitems.id',
         'glpi_knowbaseitems.name',
         'glpi_knowbaseitems.illustration',

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -56,7 +56,15 @@ final class Builder
         'glpi_knowbaseitems.illustration',
     ];
 
-    /** @var array<int, true> */
+    /**
+     * Articles that render folded, as a lookup map.
+     *
+     * The knowledge base is folded by default.
+     * An article is unfolded when it is a root (the entry point of the tree),
+     * when the user unfolded it, or when it leads to the article being read.
+     *
+     * @var array<int, true>
+     */
     private array $folded_ids_lookup_map = [];
 
     /**
@@ -97,9 +105,6 @@ final class Builder
     {
         global $DB;
 
-        // Articles the current user has collapsed, restored on each render.
-        $this->folded_ids_lookup_map = array_fill_keys(KnowbaseItem::getFoldedIdsForCurrentUser(), true);
-
         // 1) All articles the current user may see (visibility applied).
         $criteria = KnowbaseItem::getListRequest([], 'browse');
         $criteria['SELECT'] = self::LIST_COLUMNS;
@@ -133,6 +138,16 @@ final class Builder
             : $this->withAncestors(array_intersect_key($matching_ids, $data), $parents_of);
 
         // 3) Roots = visible articles with no visible parent (promote-to-root).
+        $roots = [];
+        foreach ($visible_ids as $id) {
+            if (!isset($has_visible_parent[$id])) {
+                $roots[$id] = true;
+            }
+        }
+
+        // 4) Which of those articles render folded, see `$folded_ids_lookup_map`.
+        $this->folded_ids_lookup_map = $this->computeFoldedIds($visible_ids, $roots, $parents_of);
+
         $tree = new Tree();
         foreach ($visible_ids as $id) {
             if (isset($has_visible_parent[$id]) || !$this->isRendered($id)) {
@@ -168,6 +183,38 @@ final class Builder
             $article->addChild($this->buildArticle($child_id, $data, $children_of, $ancestors));
         }
         return $article;
+    }
+
+    /**
+     * Resolve the fold state of every visible article, see
+     * `$folded_ids_lookup_map`.
+     *
+     * @param int[] $visible_ids
+     * @param array<int, true> $roots
+     * @param array<int, int[]> $parents_of
+     *
+     * @return array<int, true>
+     */
+    private function computeFoldedIds(array $visible_ids, array $roots, array $parents_of): array
+    {
+        $unfolded = array_fill_keys(KnowbaseItem::getUnfoldedIdsForCurrentUser(), true);
+
+        // The branch leading to the article being read is always unfolded, so
+        // the reader can see where they are. It is not persisted: reading an
+        // article is not the same as opening a branch for good.
+        $on_current_branch = $this->current_id > 0
+            ? $this->withAncestors([$this->current_id => true], $parents_of)
+            : [];
+
+        $folded = [];
+        foreach ($visible_ids as $id) {
+            if (isset($roots[$id]) || isset($unfolded[$id]) || isset($on_current_branch[$id])) {
+                continue;
+            }
+            $folded[$id] = true;
+        }
+
+        return $folded;
     }
 
     private function isRendered(int $id): bool

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -50,6 +50,12 @@ use KnowbaseItem_KnowbaseItem;
  */
 final class Builder
 {
+    private const array LIST_COLUMNS = [
+        'glpi_knowbaseitems.id',
+        'glpi_knowbaseitems.name',
+        'glpi_knowbaseitems.illustration',
+    ];
+
     /** @var int[] */
     private array $folded_ids = [];
 
@@ -63,7 +69,9 @@ final class Builder
         $this->folded_ids = KnowbaseItem::getFoldedIdsForCurrentUser();
 
         // 1) All articles the current user may see (visibility applied).
-        $rows = $DB->request(KnowbaseItem::getListRequest([], 'browse'));
+        $criteria = KnowbaseItem::getListRequest([], 'browse');
+        $criteria['SELECT'] = self::LIST_COLUMNS;
+        $rows = $DB->request($criteria);
         $data = [];              // id => row
         foreach ($rows as $row) {
             $data[(int) $row['id']] = $row;

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -56,6 +56,18 @@ final class Builder
         'glpi_knowbaseitems.illustration',
     ];
 
+    /** @var array<int, array<string, mixed>> Visible articles, id => row */
+    private array $data = [];
+
+    /** @var array<int, int[]> parent_id => visible child ids */
+    private array $children_of = [];
+
+    /** @var array<int, int[]> child_id => visible parent ids */
+    private array $parents_of = [];
+
+    /** @var array<int, true> Visible articles with no visible parent */
+    private array $roots = [];
+
     /**
      * Articles that render folded, as a lookup map.
      *
@@ -75,11 +87,22 @@ final class Builder
      */
     private ?array $rendered_ids = null;
 
+    private bool $hierarchy_loaded = false;
+
     public function __construct(private readonly int $current_id = 0) {}
 
     public function buildTree(): Tree
     {
-        return $this->build(null);
+        $this->loadHierarchy();
+        $this->rendered_ids = null;
+        $this->folded_ids_lookup_map = $this->computeFoldedIds();
+
+        $tree = new Tree();
+        foreach (array_keys($this->roots) as $id) {
+            $tree->addArticle($this->buildArticle($id, []));
+        }
+
+        return $tree;
     }
 
     /**
@@ -87,7 +110,7 @@ final class Builder
      * them, as used by the aside search.
      *
      * Ancestors are included so a match is never orphaned, and nothing is
-     * collapsed: a match has to be visible without the user unfolding its
+     * folded: a match has to be visible without the reader unfolding its
      * ancestors first. Descendants of a match are left out unless they match
      * too, which is what the search filter it replaces did.
      *
@@ -95,93 +118,124 @@ final class Builder
      */
     public function buildSearchTree(array $matching_ids): Tree
     {
-        return $this->build(array_fill_keys(array_map('intval', $matching_ids), true));
-    }
-
-    /**
-     * @param array<int, true>|null $matching_ids Null builds the whole tree.
-     */
-    private function build(?array $matching_ids): Tree
-    {
-        global $DB;
-
-        // 1) All articles the current user may see (visibility applied).
-        $criteria = KnowbaseItem::getListRequest([], 'browse');
-        $criteria['SELECT'] = self::LIST_COLUMNS;
-        $rows = $DB->request($criteria);
-        $data = [];              // id => row
-        foreach ($rows as $row) {
-            $data[(int) $row['id']] = $row;
-        }
-        if ($data === []) {
-            return new Tree();
-        }
-        $visible_ids = array_keys($data);
-
-        // 2) Visible parent -> [visible children] adjacency, and child -> has a visible parent?
-        $children_of         = [];     // parent_id => int[] child ids
-        $parents_of          = [];     // child_id => int[] parent ids
-        $has_visible_parent  = [];     // child_id => true
-        foreach ($DB->request(['FROM' => KnowbaseItem_KnowbaseItem::getTable()]) as $link) {
-            $child  = (int) $link['knowbaseitems_id'];
-            $parent = (int) $link['knowbaseitems_id_parent'];
-            if (!isset($data[$child], $data[$parent])) {
-                continue; // one of the ends is not visible to the current user
-            }
-            $children_of[$parent][] = $child;
-            $parents_of[$child][] = $parent;
-            $has_visible_parent[$child] = true;
-        }
-
-        $this->rendered_ids = $matching_ids === null
-            ? null
-            : $this->withAncestors(array_intersect_key($matching_ids, $data), $parents_of);
-
-        // 3) Roots = visible articles with no visible parent (promote-to-root).
-        $roots = [];
-        foreach ($visible_ids as $id) {
-            if (!isset($has_visible_parent[$id])) {
-                $roots[$id] = true;
-            }
-        }
-
-        // 4) Which of those articles render folded, see `$folded_ids_lookup_map`.
-        $this->folded_ids_lookup_map = $this->computeFoldedIds($visible_ids, $roots, $parents_of);
+        $this->loadHierarchy();
+        $this->rendered_ids = $this->withAncestors(array_intersect_key(
+            array_fill_keys(array_map('intval', $matching_ids), true),
+            $this->data
+        ));
+        $this->folded_ids_lookup_map = [];
 
         $tree = new Tree();
-        foreach ($visible_ids as $id) {
-            if (isset($has_visible_parent[$id]) || !$this->isRendered($id)) {
-                continue;
+        foreach (array_keys($this->roots) as $id) {
+            if ($this->isRendered($id)) {
+                $tree->addArticle($this->buildArticle($id, []));
             }
-            $tree->addArticle($this->buildArticle($id, $data, $children_of, []));
         }
+
         return $tree;
     }
 
     /**
-     * @param array<int, array<string, mixed>> $data
-     * @param array<int,int[]> $children_of
-     * @param array<int,bool>  $ancestors  visited guard (DAG, but defensive)
+     * Children of a single article, as the aside fetches them when the reader
+     * unfolds it. Empty when the article is not visible to the current user.
+     *
+     * @return Article[]
      */
-    private function buildArticle(int $id, array $data, array $children_of, array $ancestors): Article
+    public function buildChildren(int $parent_id): array
     {
-        $row = $data[$id];
+        $this->loadHierarchy();
+        if (!isset($this->data[$parent_id])) {
+            return [];
+        }
+        $this->rendered_ids = null;
+        $this->folded_ids_lookup_map = $this->computeFoldedIds();
+
+        $children = [];
+        foreach ($this->children_of[$parent_id] ?? [] as $child_id) {
+            $children[] = $this->buildArticle($child_id, [$parent_id => true]);
+        }
+
+        return $children;
+    }
+
+    /**
+     * Load the visible articles and the hierarchy between them, once.
+     */
+    private function loadHierarchy(): void
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        if ($this->hierarchy_loaded) {
+            return;
+        }
+        $this->hierarchy_loaded = true;
+
+        // 1) All articles the current user may see (visibility applied).
+        $criteria = KnowbaseItem::getListRequest([], 'browse');
+        $criteria['SELECT'] = self::LIST_COLUMNS;
+        foreach ($DB->request($criteria) as $row) {
+            $this->data[(int) $row['id']] = $row;
+        }
+        if ($this->data === []) {
+            return;
+        }
+
+        // 2) Visible parent-> [visible children] adjacency, and the reverse.
+        $has_visible_parent = [];
+        foreach ($DB->request(['FROM' => KnowbaseItem_KnowbaseItem::getTable()]) as $link) {
+            $child  = (int) $link['knowbaseitems_id'];
+            $parent = (int) $link['knowbaseitems_id_parent'];
+            if (!isset($this->data[$child], $this->data[$parent])) {
+                continue; // one of the ends is not visible to the current user
+            }
+            $this->children_of[$parent][] = $child;
+            $this->parents_of[$child][] = $parent;
+            $has_visible_parent[$child] = true;
+        }
+
+        // 3) Roots = visible articles with no visible parent (promote-to-root).
+        foreach (array_keys($this->data) as $id) {
+            if (!isset($has_visible_parent[$id])) {
+                $this->roots[$id] = true;
+            }
+        }
+    }
+
+    /**
+     * @param array<int, true> $ancestors Visited guard (DAG, but defensive)
+     */
+    private function buildArticle(int $id, array $ancestors): Article
+    {
+        $row = $this->data[$id];
+        $folded = $this->rendered_ids === null && isset($this->folded_ids_lookup_map[$id]);
+
+        $ancestors[$id] = true;
+        $children = [];
+        foreach ($this->children_of[$id] ?? [] as $child_id) {
+            if (isset($ancestors[$child_id]) || !$this->isRendered($child_id)) {
+                continue; // cycles are forbidden by writes; guard defensively
+            }
+            $children[] = $child_id;
+        }
+
         $article = new Article(
             id: $id,
             title: $row['name'] ?? '',
             illustration: $row['illustration'] ?? '',
             link: KnowbaseItem::getFormURLWithID($id),
             is_current: $this->current_id > 0 && $id === $this->current_id,
-            collapsed: $this->rendered_ids === null
-                && isset($this->folded_ids_lookup_map[$id]),
+            collapsed: $folded,
+            has_children: $children !== [],
+            children_loaded: !$folded,
         );
-        $ancestors[$id] = true;
-        foreach ($children_of[$id] ?? [] as $child_id) {
-            if (isset($ancestors[$child_id]) || !$this->isRendered($child_id)) {
-                continue; // cycles are forbidden by writes; guard defensively
+
+        if (!$folded) {
+            foreach ($children as $child_id) {
+                $article->addChild($this->buildArticle($child_id, $ancestors));
             }
-            $article->addChild($this->buildArticle($child_id, $data, $children_of, $ancestors));
         }
+
         return $article;
     }
 
@@ -189,13 +243,9 @@ final class Builder
      * Resolve the fold state of every visible article, see
      * `$folded_ids_lookup_map`.
      *
-     * @param int[] $visible_ids
-     * @param array<int, true> $roots
-     * @param array<int, int[]> $parents_of
-     *
      * @return array<int, true>
      */
-    private function computeFoldedIds(array $visible_ids, array $roots, array $parents_of): array
+    private function computeFoldedIds(): array
     {
         $unfolded = array_fill_keys(KnowbaseItem::getUnfoldedIdsForCurrentUser(), true);
 
@@ -203,12 +253,12 @@ final class Builder
         // the reader can see where they are. It is not persisted: reading an
         // article is not the same as opening a branch for good.
         $on_current_branch = $this->current_id > 0
-            ? $this->withAncestors([$this->current_id => true], $parents_of)
+            ? $this->withAncestors([$this->current_id => true])
             : [];
 
         $folded = [];
-        foreach ($visible_ids as $id) {
-            if (isset($roots[$id]) || isset($unfolded[$id]) || isset($on_current_branch[$id])) {
+        foreach (array_keys($this->data) as $id) {
+            if (isset($this->roots[$id]) || isset($unfolded[$id]) || isset($on_current_branch[$id])) {
                 continue;
             }
             $folded[$id] = true;
@@ -227,11 +277,10 @@ final class Builder
      * tree stays attached to its roots.
      *
      * @param array<int, true> $ids
-     * @param array<int, int[]> $parents_of
      *
      * @return array<int, true>
      */
-    private function withAncestors(array $ids, array $parents_of): array
+    private function withAncestors(array $ids): array
     {
         $kept = [];
         $to_walk = array_keys($ids);
@@ -241,7 +290,7 @@ final class Builder
                 continue;
             }
             $kept[$id] = true;
-            foreach ($parents_of[$id] ?? [] as $parent) {
+            foreach ($this->parents_of[$id] ?? [] as $parent) {
                 $to_walk[] = $parent;
             }
         }

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -56,8 +56,8 @@ final class Builder
         'glpi_knowbaseitems.illustration',
     ];
 
-    /** @var int[] */
-    private array $folded_ids = [];
+    /** @var array<int, true> */
+    private array $folded_ids_lookup_map = [];
 
     public function __construct(private readonly int $current_id = 0) {}
 
@@ -66,7 +66,7 @@ final class Builder
         global $DB;
 
         // Articles the current user has collapsed, restored on each render.
-        $this->folded_ids = KnowbaseItem::getFoldedIdsForCurrentUser();
+        $this->folded_ids_lookup_map = array_fill_keys(KnowbaseItem::getFoldedIdsForCurrentUser(), true);
 
         // 1) All articles the current user may see (visibility applied).
         $criteria = KnowbaseItem::getListRequest([], 'browse');
@@ -118,7 +118,7 @@ final class Builder
             illustration: $row['illustration'] ?? '',
             link: KnowbaseItem::getFormURLWithID($id),
             is_current: $this->current_id > 0 && $id === $this->current_id,
-            collapsed: in_array($id, $this->folded_ids, true),
+            collapsed: isset($this->folded_ids_lookup_map[$id]),
         );
         $ancestors[$id] = true;
         foreach ($children_of[$id] ?? [] as $child_id) {

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -84,15 +84,12 @@ final class Builder
         // 2) Visible parent -> [visible children] adjacency, and child -> has a visible parent?
         $children_of         = [];     // parent_id => int[] child ids
         $has_visible_parent  = [];     // child_id => true
-        foreach ($DB->request([
-            'FROM'  => KnowbaseItem_KnowbaseItem::getTable(),
-            'WHERE' => [
-                'knowbaseitems_id'        => $visible_ids,
-                'knowbaseitems_id_parent' => $visible_ids,
-            ],
-        ]) as $link) {
+        foreach ($DB->request(['FROM' => KnowbaseItem_KnowbaseItem::getTable()]) as $link) {
             $child  = (int) $link['knowbaseitems_id'];
             $parent = (int) $link['knowbaseitems_id_parent'];
+            if (!isset($data[$child], $data[$parent])) {
+                continue; // one of the ends is not visible to the current user
+            }
             $children_of[$parent][] = $child;
             $has_visible_parent[$child] = true;
         }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -3415,11 +3415,15 @@ TWIG, $twig_params);
     }
 
     /**
-     * Ids of the KB aside articles the current user has collapsed (folded).
+     * Ids of the aside articles the current user has unfolded.
+     *
+     * The knowledge base is folded by default, so this holds what the user
+     * opened. Articles unfolded because they lead to the article being read are
+     * not stored, see `Glpi\Knowbase\Aside\Builder`.
      *
      * @return int[]
      */
-    public static function getFoldedIdsForCurrentUser(): array
+    public static function getUnfoldedIdsForCurrentUser(): array
     {
         $user_id = Session::getLoginUserID();
         if ($user_id === false) {
@@ -3431,15 +3435,15 @@ TWIG, $twig_params);
             return [];
         }
 
-        $ids = json_decode($user->fields['folded_knowbaseitems'] ?? '[]', true);
+        $ids = json_decode($user->fields['unfolded_knowbaseitems'] ?? '[]', true);
 
         return array_map('intval', array_values(is_array($ids) ? $ids : []));
     }
 
     /**
-     * Persist whether an aside article is collapsed (folded) for the current user.
+     * Persist whether an aside article is unfolded for the current user.
      */
-    public static function setFoldedForCurrentUser(int $id, bool $folded): void
+    public static function setUnfoldedForCurrentUser(int $id, bool $unfolded): void
     {
         $user_id = Session::getLoginUserID();
         if ($user_id === false) {
@@ -3447,16 +3451,16 @@ TWIG, $twig_params);
         }
 
         $ids = array_values(array_filter(
-            self::getFoldedIdsForCurrentUser(),
+            self::getUnfoldedIdsForCurrentUser(),
             static fn(int $existing): bool => $existing !== $id,
         ));
-        if ($folded) {
+        if ($unfolded) {
             $ids[] = $id;
         }
 
         (new User())->update([
-            'id'                   => $user_id,
-            'folded_knowbaseitems' => json_encode($ids),
+            'id'                     => $user_id,
+            'unfolded_knowbaseitems' => json_encode($ids),
         ]);
     }
 

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -3373,6 +3373,7 @@ TWIG, $twig_params);
         }
 
         $criteria = self::getListRequest([], 'browse');
+        $criteria['SELECT'] = Builder::LIST_COLUMNS;
 
         $is_favorite_condition = [
             self::getTable() . '.id' => new QuerySubQuery([

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -3475,14 +3475,6 @@ TWIG, $twig_params);
             return null;
         }
 
-        // Whether to render the per-article dots menu trigger. This is a cheap
-        // session-level check: the menu content itself (and its per-article
-        // permission gating) is lazy-loaded on demand, so we never load every
-        // tree article here just to know if any action is available.
-        $show_actions = KnowbaseItem_Favorite::canCreate()
-            || self::canUpdate()
-            || self::canPurge();
-
         return TemplateRenderer::getInstance()->render(
             'pages/tools/kb/aside.html.twig',
             [
@@ -3491,8 +3483,23 @@ TWIG, $twig_params);
                 'current_is_favorite' => $current_is_favorite,
                 'has_other_favorites' => $has_other_favorites,
                 'can_create'          => self::canCreate(),
-                'show_actions'        => $show_actions,
+                'show_actions'        => self::canShowAsideActions(),
             ]
         );
+    }
+
+    /**
+     * Whether the aside renders the per-article dots menu trigger. This is a
+     * cheap session-level check: the menu content itself (and its per-article
+     * permission gating) is lazy-loaded on demand, so we never load every tree
+     * article just to know if any action is available.
+     *
+     * Shared with `AsideSearchController`, which renders the same rows.
+     */
+    public static function canShowAsideActions(): bool
+    {
+        return KnowbaseItem_Favorite::canCreate()
+            || self::canUpdate()
+            || self::canPurge();
     }
 }

--- a/templates/pages/tools/kb/_actions_menu.html.twig
+++ b/templates/pages/tools/kb/_actions_menu.html.twig
@@ -101,10 +101,15 @@
     </div>
 {% endmacro %}
 
-{# Renders a dots menu whose items are lazy-loaded (on hover/open) by the aside
- # controller, so the tree never has to build every article's actions up-front.
- # The menu starts with a loading placeholder that gets replaced with the
- # fetched items. #}
+{# Renders the trigger of a dots menu whose items are lazy-loaded (on
+ # hover/open) by the aside controller, so the tree never has to build every
+ # article's actions up-front.
+ #
+ # The menu element itself is not rendered here: the aside controller clones it
+ # from `render_actions_menu_placeholder()` when the row is first hovered,
+ # focused or pressed. A large tree would otherwise carry thousands of
+ # identical, never-opened menus. The trigger, on the other hand, stays in the
+ # markup so it remains exposed to assistive technologies. #}
 {% macro render_actions_menu_lazy() %}
     <div class="dropdown cursor-pointer d-flex align-items-center">
         <button
@@ -118,6 +123,14 @@
         >
             <i class="fs-08x ti ti-dots-vertical " aria-hidden="true"></i>
         </button>
+    </div>
+{% endmacro %}
+
+{# The menu element cloned into a row by the aside controller, see
+ # `render_actions_menu_lazy()`. Rendered once per aside; its content is inert
+ # until cloned, and gets replaced with the fetched items. #}
+{% macro render_actions_menu_placeholder() %}
+    <template data-glpi-kb-actions-menu-template>
         <ul class="dropdown-menu" data-bs-popper="none" data-glpi-kb-actions-menu>
             <li data-glpi-kb-actions-loading>
                 <span class="dropdown-item-text text-muted d-flex align-items-center">
@@ -126,5 +139,5 @@
                 </span>
             </li>
         </ul>
-    </div>
+    </template>
 {% endmacro %}

--- a/templates/pages/tools/kb/_article_row.html.twig
+++ b/templates/pages/tools/kb/_article_row.html.twig
@@ -96,10 +96,10 @@
             {% endif %}
         </div>
         {% if is_node %}
-            <ul>
-                {% for child in article.getChildren %}
-                    {{ macros.render_article(child, can_create, show_actions) }}
-                {% endfor %}
+            {# A folded article renders without its children; the aside fetches
+             # them the first time the reader unfolds it. #}
+            <ul {{ article.hasChildren and not article.children_loaded ? 'data-glpi-kb-children-unloaded' : '' }}>
+                {{ macros.render_rows(article.getChildren, can_create, show_actions) }}
             </ul>
         {% endif %}
     </li>
@@ -112,8 +112,17 @@
 {% macro render_tree(articles, can_create = false, show_actions = false) %}
     {% import _self as macros %}
     <ul class="kb-tree ps-0">
-        {% for article in articles %}
-            {{ macros.render_article(article, can_create, show_actions) }}
-        {% endfor %}
+        {{ macros.render_rows(articles, can_create, show_actions) }}
     </ul>
+{% endmacro %}
+
+{#
+ # Renders a list of articles as bare rows, without the wrapping list. Used to
+ # fill in the children of an article that the reader just unfolded.
+ #}
+{% macro render_rows(articles, can_create = false, show_actions = false) %}
+    {% import _self as macros %}
+    {% for article in articles %}
+        {{ macros.render_article(article, can_create, show_actions) }}
+    {% endfor %}
 {% endmacro %}

--- a/templates/pages/tools/kb/_article_row.html.twig
+++ b/templates/pages/tools/kb/_article_row.html.twig
@@ -1,0 +1,119 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{#
+ # Renders a single article, recursing into its children.
+ #
+ # - `can_create`   whether to show the "+" (create a child article) action.
+ # - `show_actions` whether to show the per-article kebab (favorite/FAQ/delete) menu.
+ # - `add_margin`   extra bottom margin on the row (used by the favorites list).
+ # - `favorite_state` null | 'active' | 'pending' (used by the favorites list; see
+ #   `data-glpi-kb-favorite-current` consumers in AsideController.js).
+ #}
+{% macro render_article(article, can_create = false, show_actions = false, add_margin = false, favorite_state = null) %}
+    {% import _self as macros %}
+    {% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
+    {% set is_node = article.hasChildren or can_create %}
+    <li
+        data-glpi-kb-article-id="{{ article.id }}"
+        {% if is_node %}
+            data-glpi-kb-aside-category
+            {{ article.collapsed ? 'data-glpi-kb-aside-category-collapsed' : '' }}
+            role="group"
+            aria-label="{{ article.title }}"
+        {% endif %}
+        {% if favorite_state is not null %}
+            data-glpi-kb-favorite-current="{{ favorite_state }}"
+        {% endif %}
+        {% if article.is_current %}
+            data-glpi-kb-article-current
+            aria-current="page"
+        {% endif %}
+        class="article {{ is_node ? 'node' : '' }} {{ add_margin ? 'mb-2' : '' }}"
+    >
+        <div class="article-line d-flex align-items-center {{ is_node ? 'mb-2' : '' }}" {{ is_node ? 'data-glpi-kb-aside-category-header' : '' }}>
+            {% if article.hasChildren %}
+                <button
+                    type="button"
+                    class="d-flex align-items-center p-0 border-0 bg-transparent"
+                    data-glpi-kb-aside-category-toggle
+                    aria-label="{{ article.title }}"
+                    aria-expanded="{{ article.collapsed ? 'false' : 'true' }}"
+                >
+                    <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
+                </button>
+            {% endif %}
+            <a class="text-dark text-hover-link text-truncate flex-grow-1" href="{{ article.link }}">
+                <span data-glpi-kb-article-illustration data-testid="kb-illustration">
+                    {% if article.illustration %}
+                        {{ render_illustration(article.illustration, 20) }}
+                    {% endif %}
+                </span>
+                <span data-glpi-kb-article-title>{{ article.title }}</span>
+            </a>
+            {% if can_create %}
+                <button
+                    type="button"
+                    class="d-flex align-items-center ms-2 p-1 text-secondary border-0 bg-transparent"
+                    data-glpi-kb-aside-category-add="{{ article.id }}"
+                    aria-label="{{ __('Create an article under %s')|format(article.title) }}"
+                    title="{{ __('Create a child article under %s')|format(article.title) }}"
+                >
+                    <i class="ti ti-plus" aria-hidden="true"></i>
+                </button>
+            {% endif %}
+            {% if show_actions %}
+                {{ actions_menu.render_actions_menu_lazy() }}
+            {% endif %}
+        </div>
+        {% if is_node %}
+            <ul>
+                {% for child in article.getChildren %}
+                    {{ macros.render_article(child, can_create, show_actions) }}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+{#
+ # Renders a list of articles as a tree, as rendered by the aside and by the
+ # search endpoint (which returns the matching branches to swap in).
+ #}
+{% macro render_tree(articles, can_create = false, show_actions = false) %}
+    {% import _self as macros %}
+    <ul class="kb-tree ps-0">
+        {% for article in articles %}
+            {{ macros.render_article(article, can_create, show_actions) }}
+        {% endfor %}
+    </ul>
+{% endmacro %}

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -30,82 +30,7 @@
  # ---------------------------------------------------------------------
  #}
 
-{#
- # Renders a single article, recursing into its children.
- #
- # - `can_create`   whether to show the "+" (create a child article) action.
- # - `show_actions` whether to show the per-article kebab (favorite/FAQ/delete) menu.
- # - `add_margin`   extra bottom margin on the row (used by the favorites list).
- # - `favorite_state` null | 'active' | 'pending' (used by the favorites list; see
- #   `data-glpi-kb-favorite-current` consumers in AsideController.js).
- #}
-{% macro render_article(article, can_create = false, show_actions = false, add_margin = false, favorite_state = null) %}
-    {% import _self as macros %}
-    {% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
-    {% set is_node = article.hasChildren or can_create %}
-    <li
-        data-glpi-kb-article-id="{{ article.id }}"
-        {% if is_node %}
-            data-glpi-kb-aside-category
-            {{ article.collapsed ? 'data-glpi-kb-aside-category-collapsed' : '' }}
-            role="group"
-            aria-label="{{ article.title }}"
-        {% endif %}
-        {% if favorite_state is not null %}
-            data-glpi-kb-favorite-current="{{ favorite_state }}"
-        {% endif %}
-        {% if article.is_current %}
-            data-glpi-kb-article-current
-            aria-current="page"
-        {% endif %}
-        class="article {{ is_node ? 'node' : '' }} {{ add_margin ? 'mb-2' : '' }}"
-    >
-        <div class="article-line d-flex align-items-center {{ is_node ? 'mb-2' : '' }}" {{ is_node ? 'data-glpi-kb-aside-category-header' : '' }}>
-            {% if article.hasChildren %}
-                <button
-                    type="button"
-                    class="d-flex align-items-center p-0 border-0 bg-transparent"
-                    data-glpi-kb-aside-category-toggle
-                    aria-label="{{ article.title }}"
-                    aria-expanded="{{ article.collapsed ? 'false' : 'true' }}"
-                >
-                    <i class="ti ti-chevron-down me-1 fs-4" aria-hidden="true"></i>
-                </button>
-            {% endif %}
-            <a class="text-dark text-hover-link text-truncate flex-grow-1" href="{{ article.link }}">
-                <span data-glpi-kb-article-illustration data-testid="kb-illustration">
-                    {% if article.illustration %}
-                        {{ render_illustration(article.illustration, 20) }}
-                    {% endif %}
-                </span>
-                <span data-glpi-kb-article-title>{{ article.title }}</span>
-            </a>
-            {% if can_create %}
-                <button
-                    type="button"
-                    class="d-flex align-items-center ms-2 p-1 text-secondary border-0 bg-transparent"
-                    data-glpi-kb-aside-category-add="{{ article.id }}"
-                    aria-label="{{ __('Create an article under %s')|format(article.title) }}"
-                    title="{{ __('Create a child article under %s')|format(article.title) }}"
-                >
-                    <i class="ti ti-plus" aria-hidden="true"></i>
-                </button>
-            {% endif %}
-            {% if show_actions %}
-                {{ actions_menu.render_actions_menu_lazy() }}
-            {% endif %}
-        </div>
-        {% if is_node %}
-            <ul>
-                {% for child in article.getChildren %}
-                    {{ macros.render_article(child, can_create, show_actions) }}
-                {% endfor %}
-            </ul>
-        {% endif %}
-    </li>
-{% endmacro %}
-
-{% import _self as macros %}
+{% import "pages/tools/kb/_article_row.html.twig" as macros %}
 {% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
 
 {% set hide_favorites = not has_other_favorites and not current_is_favorite %}
@@ -213,11 +138,7 @@
     data-glpi-kb-aside-tree
     data-testid="aside-tree"
 >
-    <ul class="kb-tree ps-0">
-        {% for article in tree.getArticles %}
-            {{ macros.render_article(article, can_create, show_actions) }}
-        {% endfor %}
-    </ul>
+    {{ include('pages/tools/kb/aside_tree.html.twig') }}
     <p class="text-muted" data-glpi-kb-aside-no-results hidden>
         {{ __("No articles found.") }}
     </p>

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -106,8 +106,13 @@
 {% endmacro %}
 
 {% import _self as macros %}
+{% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
 
 {% set hide_favorites = not has_other_favorites and not current_is_favorite %}
+
+{% if show_actions %}
+    {{ actions_menu.render_actions_menu_placeholder() }}
+{% endif %}
 
 {# Apply the persisted collapsed state before first paint to avoid a flash of the open aside. #}
 <script>

--- a/templates/pages/tools/kb/aside_children.html.twig
+++ b/templates/pages/tools/kb/aside_children.html.twig
@@ -1,0 +1,38 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{#
+ # The children of one aside article, fetched by `AsideArticleChildrenController`
+ # when the reader unfolds it.
+ #}
+{% import "pages/tools/kb/_article_row.html.twig" as macros %}
+{{ macros.render_rows(children, can_create, show_actions) }}

--- a/templates/pages/tools/kb/aside_tree.html.twig
+++ b/templates/pages/tools/kb/aside_tree.html.twig
@@ -1,0 +1,38 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{#
+ # The aside tree body. Rendered inside the aside on page load, and on its
+ # own by `AsideSearchController` to replace the tree with search results.
+ #}
+{% import "pages/tools/kb/_article_row.html.twig" as macros %}
+{{ macros.render_tree(tree.getArticles, can_create, show_actions) }}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -520,6 +520,19 @@ export class KnowbaseItemPage extends GlpiPage
     }
 
     /**
+     * Unfold an article of the aside tree, unless it already is unfolded. The
+     * tree is folded by default, so a nested row has to be revealed before it
+     * can be interacted with.
+     */
+    public async doExpandAsideCategory(title: string): Promise<void>
+    {
+        const toggle = this.getAsideCategoryToggle(title);
+        if (await toggle.getAttribute('aria-expanded') === 'false') {
+            await toggle.click();
+        }
+    }
+
+    /**
      * Toggle an article and wait for its fold state to be persisted server-side.
      * Persistence is a fire-and-forget POST, so callers that reload right after
      * toggling must wait for it, otherwise the reload can abort the in-flight

--- a/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
+++ b/tests/e2e/specs/Knowbase/aside-create-article.spec.ts
@@ -220,3 +220,68 @@ test('the "+" on a folded article expands it, so the inline input is usable', as
     await expect(kb.getAsideTreeArticleRow(new_id)).toBeVisible();
     await expect(parent_toggle).toHaveAttribute('aria-expanded', 'true');
 });
+
+// Regression test that make sure we can create a child into a folded article.
+test('the inline input survives the lazy load of a folded article\'s children', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const unique = randomUUID().slice(0, 8);
+    const read_name = `E2E Lazy Read ${unique}`;
+    const parent_name = `E2E Lazy Parent ${unique}`;
+    const child_name = `E2E Lazy Child ${unique}`;
+    const article_title = `E2E Lazy New ${unique}`;
+
+    // The article being read is unrelated to the parent below, so that parent
+    // renders folded: its children are then not in the DOM at all, and
+    // unfolding it has to fetch them.
+    const read_id = await api.createItem('KnowbaseItem', {
+        name: read_name,
+        answer: 'Read content',
+        entities_id: getWorkerEntityId(),
+    });
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        answer: 'Parent content',
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItem', {
+        name: child_name,
+        answer: 'Child content',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    // Slow the children endpoint down, to widen the window in which its
+    // response can land on top of the inline input.
+    await page.route('**/Knowbase/Aside/Article/*/Children*', async (route) => {
+        const response = await route.fetch();
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await route.fulfill({ response });
+    });
+
+    await kb.goto(read_id);
+    await kb.waitForAsideReady();
+
+    const parent_toggle = kb.getAsideCategoryToggle(parent_name);
+    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'false');
+
+    const add_button = kb.getAsideCategoryAddButton(parent_name);
+    await kb.getAsideArticleTitleLink(parent_name).hover();
+    await add_button.click();
+
+    const inline_input = kb.getAsideCategoryCreateInput(parent_name);
+    await inline_input.fill(article_title);
+
+    // The fetched children fill the very list the input was inserted into.
+    // Once they are here, the input and what was typed into it must have
+    // survived.
+    await expect(kb.getAsideCategoryArticle(parent_name, child_name)).toBeVisible();
+    await expect(inline_input).toHaveValue(article_title);
+    await expect(inline_input).toBeFocused();
+
+    // And it still creates.
+    await inline_input.press('Enter');
+    await expect(page).toHaveURL(/knowbaseitem\.form\.php\?id=\d+/);
+    await expect(page.getByTestId('subject')).toHaveText(article_title);
+});

--- a/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-actions.spec.ts
@@ -99,10 +99,13 @@ test('A nested article dots menu acts on that article, not on its parent', async
     await kb.goto(viewed_id);
     await kb.waitForAsideReady();
 
-    // Load parent menu actions.
+    // Load parent menu actions. Revealing the child under its parent (the tree
+    // is folded by default) already interacts with the parent row, which
+    // prefetches them, so the waiter has to be armed before that.
     const parent_actions = page.waitForResponse(
         (response) => response.url().includes(`/Knowbase/${parent_id}/AsideActions`),
     );
+    await kb.doExpandAsideCategory(parent_name);
     await kb.getAsideArticleTitleLink(parent_name).hover();
     await parent_actions;
 

--- a/tests/e2e/specs/Knowbase/kb-aside-category-fold.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-category-fold.spec.ts
@@ -81,7 +81,62 @@ test('Article fold state is remembered across reloads', async ({ page, profile, 
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    // Arrange: a parent article with a child so we have something to fold.
+    // Arrange: the article being read, plus an unrelated parent with a child so
+    // we have a branch to fold that is not the one leading to what we read.
+    const unique = randomUUID().slice(0, 8);
+    const read_name = `E2E Read ${unique}`;
+    const parent_name = `E2E Parent ${unique}`;
+    const child_name = `E2E Child ${unique}`;
+
+    const read_id = await api.createItem('KnowbaseItem', {
+        name: read_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+    });
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: parent_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+    });
+    await api.createItem('KnowbaseItem', {
+        name: child_name,
+        answer: 'Test content',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    await kb.goto(read_id);
+    await kb.waitForAsideReady();
+
+    const parent_toggle = kb.getAsideCategoryToggle(parent_name);
+    const child_link = kb.getAsideCategoryArticle(parent_name, child_name);
+
+    // The knowledge base is folded by default.
+    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(child_link).toBeHidden();
+
+    // Unfold the parent, then reload: the unfolded state must be restored.
+    await kb.doToggleAsideCategoryAndWaitForPersist(parent_name);
+    await expect(child_link).toBeVisible();
+
+    await page.reload();
+    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(child_link).toBeVisible();
+
+    // Fold it again and reload: it must be folded once more.
+    await kb.waitForAsideReady();
+    await kb.doToggleAsideCategoryAndWaitForPersist(parent_name);
+    await expect(child_link).toBeHidden();
+
+    await page.reload();
+    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(child_link).toBeHidden();
+});
+
+test('Reading an article always reveals the branch leading to it', async ({ page, profile, api }) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
     const unique = randomUUID().slice(0, 8);
     const parent_name = `E2E Parent ${unique}`;
     const child_name = `E2E Child ${unique}`;
@@ -104,18 +159,14 @@ test('Article fold state is remembered across reloads', async ({ page, profile, 
     const parent_toggle = kb.getAsideCategoryToggle(parent_name);
     const child_link = kb.getAsideCategoryArticle(parent_name, child_name);
 
-    // Fold the parent, then reload: the folded state must be restored.
-    await kb.doToggleAsideCategoryAndWaitForPersist(parent_name);
-    await expect(child_link).toBeHidden();
-
-    await page.reload();
-    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'false');
-    await expect(child_link).toBeHidden();
-
-    // Unfold and reload again: the expanded state must likewise be restored.
-    await kb.waitForAsideReady();
-    await kb.doToggleAsideCategoryAndWaitForPersist(parent_name);
+    // The parent is folded by default, but it leads to the article being read.
+    await expect(parent_toggle).toHaveAttribute('aria-expanded', 'true');
     await expect(child_link).toBeVisible();
+
+    // Folding it hides the child, but reading the child reveals it again: the
+    // reader always gets to see where they are.
+    await kb.doToggleAsideCategoryAndWaitForPersist(parent_name);
+    await expect(child_link).toBeHidden();
 
     await page.reload();
     await expect(parent_toggle).toHaveAttribute('aria-expanded', 'true');

--- a/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
@@ -254,6 +254,88 @@ final class BuilderTest extends DbTestCase
         $this->fail('The root article is missing from the tree');
     }
 
+    public function testArticlesAreFoldedByDefaultExceptTheRoot(): void
+    {
+        $this->login();
+
+        $animals = $this->makeArticle('Animals');
+        $this->makeArticle('Cat article', $animals->getID());
+
+        $tree = (new Builder())->buildTree();
+
+        // The root is the entry point of the knowledge base, it is never folded.
+        $root = $tree->getArticles()[0];
+        $this->assertFalse($root->collapsed);
+
+        // Everything below it starts folded, so a large knowledge base does not
+        // open with every branch expanded.
+        $this->assertTrue($this->getTopLevelArticles($tree)['Animals']->collapsed);
+    }
+
+    public function testBranchLeadingToTheCurrentArticleIsUnfolded(): void
+    {
+        $this->login();
+
+        $animals = $this->makeArticle('Animals');
+        $birds   = $this->makeArticle('Birds', $animals->getID());
+        $eagle   = $this->makeArticle('Eagle article', $birds->getID());
+        $this->makeArticle('Plants');
+
+        $tree = (new Builder($eagle->getID()))->buildTree();
+        $by_title = $this->getTopLevelArticles($tree);
+
+        // Both ancestors of the read article are unfolded, so it is visible.
+        $animals_node = $by_title['Animals'];
+        $this->assertFalse($animals_node->collapsed);
+        $birds_node = array_column($animals_node->getChildren(), null, 'title')['Birds'];
+        $this->assertFalse($birds_node->collapsed);
+
+        // A branch that does not lead to it keeps the default.
+        $this->assertTrue($by_title['Plants']->collapsed);
+    }
+
+    public function testArticlesUnfoldedByTheUserAreRestored(): void
+    {
+        $this->login();
+
+        $plants = $this->makeArticle('Plants');
+        $this->makeArticle('Rose article', $plants->getID());
+        $animals = $this->makeArticle('Animals');
+        $this->makeArticle('Cat article', $animals->getID());
+
+        KnowbaseItem::setUnfoldedForCurrentUser($plants->getID(), true);
+
+        $by_title = $this->getTopLevelArticles((new Builder())->buildTree());
+        $this->assertFalse($by_title['Plants']->collapsed);
+        $this->assertTrue($by_title['Animals']->collapsed);
+
+        // Folding it again drops it from the stored ids.
+        KnowbaseItem::setUnfoldedForCurrentUser($plants->getID(), false);
+
+        $by_title = $this->getTopLevelArticles((new Builder())->buildTree());
+        $this->assertTrue($by_title['Plants']->collapsed);
+    }
+
+    public function testReadingAnArticleUnfoldsItsBranchWithoutStoringIt(): void
+    {
+        $this->login();
+
+        $animals = $this->makeArticle('Animals');
+        $birds   = $this->makeArticle('Birds', $animals->getID());
+        $eagle   = $this->makeArticle('Eagle article', $birds->getID());
+
+        // Reading an article reveals the branch leading to it even though the
+        // user never unfolded it, and reading it does not open that branch for
+        // good either.
+        $tree = (new Builder($eagle->getID()))->buildTree();
+        $this->assertFalse($this->getTopLevelArticles($tree)['Animals']->collapsed);
+        $this->assertSame([], KnowbaseItem::getUnfoldedIdsForCurrentUser());
+
+        // Seen from anywhere else, the branch is folded again.
+        $tree = (new Builder())->buildTree();
+        $this->assertTrue($this->getTopLevelArticles($tree)['Animals']->collapsed);
+    }
+
     /**
      * @param int|int[] $parent_id
      */

--- a/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/BuilderTest.php
@@ -68,6 +68,13 @@ final class BuilderTest extends DbTestCase
         $this->makeArticle('Eagle article', $birds->getID());
         $this->makeArticle('Rose article', $plants->getID());
 
+        // A folded article renders without its children, so unfold the branches
+        // walked below: this test is about the shape of the tree, not about the
+        // fold defaults.
+        foreach ([$animals, $birds, $plants] as $article) {
+            KnowbaseItem::setUnfoldedForCurrentUser($article->getID(), true);
+        }
+
         $tree = (new Builder())->buildTree();
 
         // The tree has a single root, the installation's root article, and every
@@ -223,6 +230,9 @@ final class BuilderTest extends DbTestCase
         $parent2 = $this->makeArticle('Parent two ' . __FUNCTION__);
         $this->makeArticle('Shared child ' . __FUNCTION__, [$parent1->getID(), $parent2->getID()]);
 
+        KnowbaseItem::setUnfoldedForCurrentUser($parent1->getID(), true);
+        KnowbaseItem::setUnfoldedForCurrentUser($parent2->getID(), true);
+
         $tree = (new Builder())->buildTree();
         $by_title = $this->getTopLevelArticles($tree);
 
@@ -334,6 +344,61 @@ final class BuilderTest extends DbTestCase
         // Seen from anywhere else, the branch is folded again.
         $tree = (new Builder())->buildTree();
         $this->assertTrue($this->getTopLevelArticles($tree)['Animals']->collapsed);
+    }
+
+    public function testFoldedArticlesRenderWithoutTheirChildren(): void
+    {
+        $this->login();
+
+        $animals = $this->makeArticle('Animals');
+        $this->makeArticle('Cat article', $animals->getID());
+
+        $node = $this->getTopLevelArticles((new Builder())->buildTree())['Animals'];
+
+        // The row still announces that it can be unfolded, so the reader gets a
+        // toggle, but the children are left out of the render.
+        $this->assertTrue($node->collapsed);
+        $this->assertTrue($node->hasChildren());
+        $this->assertFalse($node->children_loaded);
+        $this->assertSame([], $node->getChildren());
+
+        // Unfolded, the same article renders them.
+        KnowbaseItem::setUnfoldedForCurrentUser($animals->getID(), true);
+        $node = $this->getTopLevelArticles((new Builder())->buildTree())['Animals'];
+        $this->assertFalse($node->collapsed);
+        $this->assertTrue($node->children_loaded);
+        $this->assertEquals(['Cat article'], array_column($node->getChildren(), 'title'));
+    }
+
+    public function testBuildChildrenReturnsTheChildrenOfOneArticle(): void
+    {
+        $this->login();
+
+        $animals = $this->makeArticle('Animals');
+        $birds   = $this->makeArticle('Birds', $animals->getID());
+        $this->makeArticle('Cat article', $animals->getID());
+        $this->makeArticle('Eagle article', $birds->getID());
+
+        $children = (new Builder())->buildChildren($animals->getID());
+        $this->assertEqualsCanonicalizing(
+            ['Birds', 'Cat article'],
+            array_column($children, 'title'),
+        );
+
+        // The children carry their own fold state, so the branch below them is
+        // fetched in turn rather than all at once.
+        $birds_node = array_column($children, null, 'title')['Birds'];
+        $this->assertTrue($birds_node->collapsed);
+        $this->assertTrue($birds_node->hasChildren());
+        $this->assertSame([], $birds_node->getChildren());
+    }
+
+    public function testBuildChildrenOfAnArticleThatIsNotVisible(): void
+    {
+        $this->login();
+
+        $this->assertSame([], (new Builder())->buildChildren(0));
+        $this->assertSame([], (new Builder())->buildChildren(99999999));
     }
 
     /**


### PR DESCRIPTION
Add lazy loading in two places:

1\) The "kebab/dots" menu for extra actions was already partially lazy loaded: the menu was always loaded but its inner content was lazy loaded on hover.
Now the menu container itself is also deferred, which help with huge data set since that is DOM that will be copied for every article. 
This is done in commit 1.

2\)  Folded articles are now only loaded when opened (commit 4)..
This help a lot with huge tree but necessitated two small refactors:
* The default state of the tree was "everything unfolded" which mean that this changes had no impact by default. I've inverted it so the tree is folded by default (commit 3).
* The search code had some client side computation that are no longer possible since the full data is not accessible on the client until the tree is fully opened up. This computation has been moved to the server instead (commit 2).

Others commits are small fixes for issues found by an AI review of this work.