### PR TITLE
Fix - Use dropdown translation in generated ticket content

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -43,6 +43,7 @@ use ConsumableItem;
 use Datacenter;
 use DbUtils;
 use Dropdown;
+use DropdownTranslation;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Category;
@@ -412,9 +413,17 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return $item->getFriendlyName();
         }
 
-        $name = $item instanceof CommonTreeDropdown
-            ? $item->fields['completename']
-            : $item->getFriendlyName();
+        $field = $item instanceof CommonTreeDropdown ? 'completename' : 'name';
+        $name  = $item->fields[$field];
+
+        // GLPI issue #25249: apply the dropdown translation so the generated
+        // ticket content and title follow the requester language.
+        $name = DropdownTranslation::getTranslatedValue(
+            $item->getID(),
+            $item::class,
+            $field,
+            value: $name
+        );
 
         // Append additional fields to match what is displayed in renderEndUserTemplate.
         $itemtype = $answer['itemtype'];

--- a/src/Glpi/Form/QuestionType/QuestionTypeItem.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeItem.php
@@ -38,6 +38,7 @@ namespace Glpi\Form\QuestionType;
 use CartridgeItem;
 use Cluster;
 use CommonDBTM;
+use CommonDropdown;
 use CommonTreeDropdown;
 use ConsumableItem;
 use Datacenter;
@@ -413,17 +414,21 @@ class QuestionTypeItem extends AbstractQuestionType implements
             return $item->getFriendlyName();
         }
 
-        $field = $item instanceof CommonTreeDropdown ? 'completename' : 'name';
-        $name  = $item->fields[$field];
+        $name = $item instanceof CommonTreeDropdown
+            ? $item->fields['completename']
+            : $item->getFriendlyName();
 
-        // GLPI issue #25249: apply the dropdown translation so the generated
-        // ticket content and title follow the requester language.
-        $name = DropdownTranslation::getTranslatedValue(
-            $item->getID(),
-            $item::class,
-            $field,
-            value: $name
-        );
+        // The ticket content is frozen at submission time, so the value must be
+        // resolved in the requester language here. Conditions are deliberately
+        // left untranslated: they must compare against the source value.
+        if ($item instanceof CommonDropdown) {
+            $name = DropdownTranslation::getTranslatedValue(
+                $item->getID(),
+                $item::class,
+                $item instanceof CommonTreeDropdown ? 'completename' : 'name',
+                value: $name
+            );
+        }
 
         // Append additional fields to match what is displayed in renderEndUserTemplate.
         $itemtype = $answer['itemtype'];

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -477,16 +477,26 @@ final class QuestionTypeItemTest extends DbTestCase
             'entities_id'  => $this->getTestRootEntity(true),
         ]);
 
+        // Only `name` is translated on purpose: GLPI derives the `completename`
+        // translation from the ancestors' translated names, and overwrites any
+        // `completename` row that is written directly.
+        $this->createItem(DropdownTranslation::class, [
+            'items_id' => $parent->getID(),
+            'itemtype' => Location::class,
+            'language' => 'fr_FR',
+            'field'    => 'name',
+            'value'    => 'Siège social',
+        ]);
         $this->createItem(DropdownTranslation::class, [
             'items_id' => $child->getID(),
             'itemtype' => Location::class,
             'language' => 'fr_FR',
-            'field'    => 'completename',
-            'value'    => 'Siège social > Salle de réunion',
+            'field'    => 'name',
+            'value'    => 'Salle de réunion',
         ]);
 
         // The translation cache is built at login, so the user must be logged
-        // in after the translation exists.
+        // in after the translations exist.
         $this->createItem(User::class, [
             'name'         => 'fr_FR',
             'language'     => 'fr_FR',

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeItemTest.php
@@ -36,6 +36,7 @@ namespace tests\units\Glpi\Form\QuestionType;
 
 use Computer;
 use Contact;
+use DropdownTranslation;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeItem;
 use Glpi\Form\QuestionType\QuestionTypeItemDefaultValueConfig;
@@ -452,5 +453,56 @@ final class QuestionTypeItemTest extends DbTestCase
         $result = (new QuestionTypeItem())->formatRawAnswer($case['answer'], new Question());
 
         $this->assertEquals($case['expected'], $result);
+    }
+
+    /**
+     * Non-regression test for #25249.
+     *
+     * The generated ticket content is frozen at submission time, so the item
+     * name has to be resolved in the requester language at that moment. Before
+     * the fix, formatRawAnswer() read the raw completename column and the
+     * answer was stored in the source language whatever the requester used.
+     */
+    public function testFormatRawAnswerUsesDropdownTranslation(): void
+    {
+        $this->login();
+
+        $parent = $this->createItem(Location::class, [
+            'name'        => 'Head office',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $child = $this->createItem(Location::class, [
+            'name'         => 'Meeting room',
+            'locations_id' => $parent->getID(),
+            'entities_id'  => $this->getTestRootEntity(true),
+        ]);
+
+        $this->createItem(DropdownTranslation::class, [
+            'items_id' => $child->getID(),
+            'itemtype' => Location::class,
+            'language' => 'fr_FR',
+            'field'    => 'completename',
+            'value'    => 'Siège social > Salle de réunion',
+        ]);
+
+        // The translation cache is built at login, so the user must be logged
+        // in after the translation exists.
+        $this->createItem(User::class, [
+            'name'         => 'fr_FR',
+            'language'     => 'fr_FR',
+            '_entities_id' => $this->getTestRootEntity(true),
+            '_profiles_id' => 1,
+        ]);
+        $this->login('fr_FR');
+
+        $result = (new QuestionTypeItem())->formatRawAnswer(
+            [
+                'itemtype' => Location::class,
+                'items_id' => $child->getID(),
+            ],
+            new Question()
+        );
+
+        $this->assertEquals('Siège social > Salle de réunion', $result);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes #25249

`QuestionTypeItem::formatRawAnswer()` reads the raw `completename` / friendly name
of the answered item, so the value frozen into the generated ticket content and
title is always in the source language, even when a `DropdownTranslation` exists
for the requester's language.

The ticket content is built once at submission time and stored in
`glpi_tickets.content`, so the value has to be resolved at that moment — there is
no later render that could apply the translation.

The other `fields['completename']` read in this file, in
`transformConditionValueForComparisons()`, is deliberately left alone: conditions
must compare against the source value, otherwise form logic would depend on the
viewer's language.

The breadcrumb half of the issue is already fixed on `11.0/bugfixes` by #24678,
so it is not included here.

Added `testFormatRawAnswerUsesDropdownTranslation` as a non-regression test: it
builds a `Location` tree, adds an `fr_FR` translation, logs in as a French user
and asserts the translated value is returned.

Reproduced and verified on a production instance running 11.0.8, `pt_PT` install
with `en_GB` users, applied via a bind-mount over the container file.

