### PR TITLE
[DEV] Add podman rootless configuration explaination

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -7,6 +7,23 @@ from the GLPI root directory.
 
 You can customize the docker services by creating a `docker-compose.override.yaml` file in the GLPI root directory.
 
+### Podman (rootless)
+
+If you use rootless [Podman](https://podman.io/) instead of Docker, you will likely hit two issues:
+
+- Apache fails to bind to port 80 in the container (`Permission denied: AH00072: make_sock`)
+- Files written by the container (sessions, logs, plugin caches, etc.) fail with `Permission denied` on the host
+
+Both can be fixed by adding `userns_mode: "keep-id"` to the `app` service in your `docker-compose.override.yaml`, which tells Podman to map the container's uid/gid to your real host uid/gid instead of a subordinate range.
+
+```yaml
+services:
+  app:
+    userns_mode: "keep-id"
+```
+
+> **Note:** `userns_mode: keep-id` is a Podman-specific value and is not understood by Docker. Only set it in your local, untracked `docker-compose.override.yaml`.
+
 ### HTTP server
 
 By default, the HTTP port is published to on the `8080` port on the host machine.


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

For developer using podman, the provided docker-compose must be overridden with a small specificity to avoid write and port permission error.

`userns_mode: "keep-id"` is a podman only directive so we can't make it natively inside the docker-compose.

## Related PR
- Docker image : https://github.com/glpi-project/docker-images/pull/312
  - Match the prod image dep and avoid also adding in the docker compose override
   ```yaml
   sysctls:
      - net.ipv4.ip_unprivileged_port_start=0
   ```