### PR TITLE
A11Y : complete heading levels on item and reservation pages

### DIFF
--- a/css/legacy/includes/_styles.scss
+++ b/css/legacy/includes/_styles.scss
@@ -273,6 +273,14 @@
       padding: 10px 5px;
    }
 
+   /* Row headers carry structure only, they must render like the data cells. */
+   .tab_cadre_fixe th[scope="row"] {
+      background-color: transparent;
+      font-weight: inherit;
+      font-size: inherit;
+      padding: 5px;
+   }
+
    .tab_cadre_fixehov th {
       background-color: #F8F8F8;
       color: #2E2E2E;

--- a/js/src/vue/FullCalendar/useScheduler.js
+++ b/js/src/vue/FullCalendar/useScheduler.js
@@ -66,6 +66,8 @@ export default function useScheduler() {
     return {
         getListFullView,
         getResourceWeekView,
+        // Index of the day row in getResourceWeekView()'s slotLabelFormat, above weeks and below hours.
+        resourceWeekDayLevel: 1,
         defaultHeaderToolbar: {
             start: 'prev,next today',
             center: 'title',

--- a/js/src/vue/Reservations/ReservationScheduler.vue
+++ b/js/src/vue/Reservations/ReservationScheduler.vue
@@ -11,7 +11,7 @@
     import timeGridPlugin from "@fullcalendar/timegrid";
     import resourceTimelinePlugin from "@fullcalendar/resource-timeline";
     import BaseFullCalendar from "../FullCalendar/BaseFullCalendar.vue";
-    import {nextTick, onMounted, ref, useTemplateRef, watch} from "vue";
+    import {onMounted, ref, useTemplateRef, watch} from "vue";
     import ReservationEvent from "./ReservationEvent.vue";
     import useScheduler from "../FullCalendar/useScheduler.js";
 
@@ -83,8 +83,15 @@
             }
             return [];
         },
-        datesSet: () => nextTick(markDayHeadings),
-        eventsSet: () => nextTick(markDayHeadings),
+        dayCellDidMount: (arg) => markDayHeading(arg.el.querySelector('.fc-daygrid-day-number')),
+        dayHeaderDidMount: (arg) => {
+            // Month view column headers are weekday names, not days: they carry no date.
+            if (arg.el.dataset.date === undefined) {
+                return;
+            }
+
+            markDayHeading(arg.el.querySelector('.fc-col-header-cell-cushion, .fc-list-day-text'));
+        },
         selectable: props.can_reserve,
         select: (info) => {
             if (props.can_reserve) {
@@ -132,7 +139,6 @@
 
     onMounted(() => {
         calendar_api = calendar.value.getApi();
-        markDayHeadings();
     });
 
     function editEvent(info) {
@@ -168,19 +174,15 @@
             date1.getDate() === date2.getDate();
     }
 
-    // FullCalendar has no content hook for list day rows, mark both views after render.
-    function markDayHeadings() {
-        const root = calendar_api?.el;
-        if (!root) {
+    // Mark the node FullCalendar already renders, to keep the grid and table semantics.
+    function markDayHeading(day) {
+        // Disabled cells render an empty placeholder number, which must not become a heading.
+        if (!day || day.textContent.trim() === '') {
             return;
         }
 
-        root
-            .querySelectorAll('.fc-daygrid-day-number, .fc-list-day-text')
-            .forEach((day) => {
-                day.setAttribute('role', 'heading');
-                day.setAttribute('aria-level', '3');
-            });
+        day.setAttribute('role', 'heading');
+        day.setAttribute('aria-level', '3');
     }
 
     watch(current_view, (new_view) => {

--- a/js/src/vue/Reservations/ReservationScheduler.vue
+++ b/js/src/vue/Reservations/ReservationScheduler.vue
@@ -11,7 +11,7 @@
     import timeGridPlugin from "@fullcalendar/timegrid";
     import resourceTimelinePlugin from "@fullcalendar/resource-timeline";
     import BaseFullCalendar from "../FullCalendar/BaseFullCalendar.vue";
-    import {onMounted, ref, useTemplateRef, watch} from "vue";
+    import {nextTick, onMounted, ref, useTemplateRef, watch} from "vue";
     import ReservationEvent from "./ReservationEvent.vue";
     import useScheduler from "../FullCalendar/useScheduler.js";
 
@@ -83,6 +83,8 @@
             }
             return [];
         },
+        datesSet: () => nextTick(markDayHeadings),
+        eventsSet: () => nextTick(markDayHeadings),
         selectable: props.can_reserve,
         select: (info) => {
             if (props.can_reserve) {
@@ -130,6 +132,7 @@
 
     onMounted(() => {
         calendar_api = calendar.value.getApi();
+        markDayHeadings();
     });
 
     function editEvent(info) {
@@ -163,6 +166,21 @@
         return date1.getFullYear() === date2.getFullYear() &&
             date1.getMonth() === date2.getMonth() &&
             date1.getDate() === date2.getDate();
+    }
+
+    // FullCalendar has no content hook for list day rows, mark both views after render.
+    function markDayHeadings() {
+        const root = calendar_api?.el;
+        if (!root) {
+            return;
+        }
+
+        root
+            .querySelectorAll('.fc-daygrid-day-number, .fc-list-day-text')
+            .forEach((day) => {
+                day.setAttribute('role', 'heading');
+                day.setAttribute('aria-level', '3');
+            });
     }
 
     watch(current_view, (new_view) => {

--- a/js/src/vue/Reservations/ReservationScheduler.vue
+++ b/js/src/vue/Reservations/ReservationScheduler.vue
@@ -37,7 +37,7 @@
         },
     });
 
-    const { getListFullView, getResourceWeekView } = useScheduler();
+    const { getListFullView, getResourceWeekView, resourceWeekDayLevel } = useScheduler();
     const id = Number(props.id);
     const default_date = new Date(props.default_date);
     const calendar = useTemplateRef('calendar');
@@ -91,6 +91,14 @@
             }
 
             markDayHeading(arg.el.querySelector('.fc-col-header-cell-cushion, .fc-list-day-text'));
+        },
+        slotLabelDidMount: (arg) => {
+            // Timeline rows are week, day then hour. timeGrid time axis labels are always level 0.
+            if (arg.level !== resourceWeekDayLevel) {
+                return;
+            }
+
+            markDayHeading(arg.el.querySelector('.fc-timeline-slot-cushion'));
         },
         selectable: props.can_reserve,
         select: (info) => {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5655,7 +5655,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     public function showStatsDates()
     {
         $rand = mt_rand();
-        echo "<h2 class='header' id='stats_dates_$rand'>" . _sn('Date', 'Dates', Session::getPluralNumber()) . "</h2>";
+        echo "<h2 class='header lh-base' id='stats_dates_$rand'>" . _sn('Date', 'Dates', Session::getPluralNumber()) . "</h2>";
         echo "<table class='tab_cadre_fixe' aria-labelledby='stats_dates_$rand'>";
 
         echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Opening date') . "</th>";
@@ -5683,7 +5683,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     {
         echo "<div class='dates_timelines'>";
         $rand = mt_rand();
-        echo "<h2 class='header' id='stats_times_$rand'>" . _sn('Time', 'Times', Session::getPluralNumber()) . "</h2>";
+        echo "<h2 class='header lh-base' id='stats_times_$rand'>" . _sn('Time', 'Times', Session::getPluralNumber()) . "</h2>";
         echo "<table class='tab_cadre_fixe' aria-labelledby='stats_times_$rand'>";
 
         if (isset($this->fields['takeintoaccount_delay_stat'])) {

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5654,22 +5654,23 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function showStatsDates()
     {
-        echo "<table class='tab_cadre_fixe'>";
-        echo "<tr><th colspan='2'>" . _sn('Date', 'Dates', Session::getPluralNumber()) . "</th></tr>";
+        $rand = mt_rand();
+        echo "<h2 class='header' id='stats_dates_$rand'>" . _sn('Date', 'Dates', Session::getPluralNumber()) . "</h2>";
+        echo "<table class='tab_cadre_fixe' aria-labelledby='stats_dates_$rand'>";
 
-        echo "<tr class='tab_bg_2'><td>" . __s('Opening date') . "</td>";
+        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Opening date') . "</th>";
         echo "<td>" . htmlescape(Html::convDateTime($this->fields['date'])) . "</td></tr>";
 
-        echo "<tr class='tab_bg_2'><td>" . __s('Time to resolve') . "</td>";
+        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Time to resolve') . "</th>";
         echo "<td>" . htmlescape(Html::convDateTime($this->fields['time_to_resolve'])) . "</td></tr>";
 
         if (!$this->isNotSolved()) {
-            echo "<tr class='tab_bg_2'><td>" . __s('Resolution date') . "</td>";
+            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Resolution date') . "</th>";
             echo "<td>" . htmlescape(Html::convDateTime($this->fields['solvedate'])) . "</td></tr>";
         }
 
         if (in_array($this->fields['status'], static::getClosedStatusArray())) {
-            echo "<tr class='tab_bg_2'><td>" . __s('Closing date') . "</td>";
+            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Closing date') . "</th>";
             echo "<td>" . htmlescape(Html::convDateTime($this->fields['closedate'])) . "</td></tr>";
         }
         echo "</table>";
@@ -5681,11 +5682,12 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
     public function showStatsTimes()
     {
         echo "<div class='dates_timelines'>";
-        echo "<table class='tab_cadre_fixe'>";
-        echo "<tr><th colspan='2'>" . _sn('Time', 'Times', Session::getPluralNumber()) . "</th></tr>";
+        $rand = mt_rand();
+        echo "<h2 class='header' id='stats_times_$rand'>" . _sn('Time', 'Times', Session::getPluralNumber()) . "</h2>";
+        echo "<table class='tab_cadre_fixe' aria-labelledby='stats_times_$rand'>";
 
         if (isset($this->fields['takeintoaccount_delay_stat'])) {
-            echo "<tr class='tab_bg_2'><td>" . __s('Take into account') . "</td><td>";
+            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Take into account') . "</th><td>";
             if ($this->fields['takeintoaccount_delay_stat'] > 0) {
                 echo htmlescape(Html::timestampToString($this->fields['takeintoaccount_delay_stat'], false, false));
             } else {
@@ -5695,7 +5697,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         if (!$this->isNotSolved()) {
-            echo "<tr class='tab_bg_2'><td>" . __s('Resolution') . "</td><td>";
+            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Resolution') . "</th><td>";
 
             if ($this->fields['solve_delay_stat'] > 0) {
                 echo htmlescape(Html::timestampToString($this->fields['solve_delay_stat'], false, false));
@@ -5706,7 +5708,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
         }
 
         if (in_array($this->fields['status'], static::getClosedStatusArray())) {
-            echo "<tr class='tab_bg_2'><td>" . __s('Closure') . "</td><td>";
+            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Closure') . "</th><td>";
             if ($this->fields['close_delay_stat'] > 0) {
                 echo htmlescape(Html::timestampToString($this->fields['close_delay_stat'], true, false));
             } else {
@@ -5715,7 +5717,7 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
             echo "</td></tr>";
         }
 
-        echo "<tr class='tab_bg_2'><td>" . __s('Pending') . "</td><td>";
+        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Pending') . "</th><td>";
         if ($this->fields['waiting_duration'] > 0) {
             echo htmlescape(Html::timestampToString($this->fields['waiting_duration'], false, false));
         } else {

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -210,7 +210,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Item_DeviceSimcard::getTypeName(Session::getPluralNumber()),
-                'level' => 3,
+                'level' => 2,
             ],
             'columns' => [
                 'name' => __('Name'),
@@ -254,7 +254,7 @@ class Item_Line extends CommonDBRelation
                     'used'        => $used,
                 ],
                 'form_label' => __('Add an item'),
-                'form_label_level' => 3,
+                'form_label_level' => 2,
             ]);
         }
 
@@ -278,7 +278,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => _n('Item', 'Items', Session::getPluralNumber()),
-                'level' => 3,
+                'level' => 2,
             ],
             'columns' => [
                 'name' => __('Name'),

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -210,6 +210,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Item_DeviceSimcard::getTypeName(Session::getPluralNumber()),
+                'level' => 3,
             ],
             'columns' => [
                 'name' => __('Name'),
@@ -253,6 +254,7 @@ class Item_Line extends CommonDBRelation
                     'used'        => $used,
                 ],
                 'form_label' => __('Add an item'),
+                'form_label_level' => 3,
             ]);
         }
 
@@ -276,6 +278,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => _n('Item', 'Items', Session::getPluralNumber()),
+                'level' => 3,
             ],
             'columns' => [
                 'name' => __('Name'),
@@ -354,6 +357,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Item_DeviceSimcard::getTypeName(Session::getPluralNumber()),
+                'level' => 3,
             ],
             'columns' => [
                 'name' => __('Name'),
@@ -397,6 +401,7 @@ class Item_Line extends CommonDBRelation
                     'used'        => $used,
                 ],
                 'form_label' => __('Add a phone line'),
+                'form_label_level' => 3,
             ]);
         }
 
@@ -417,6 +422,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Line::getTypeName(Session::getPluralNumber()),
+                'level' => 3,
             ],
             'columns' => [
                 'name' => __('Name'),

--- a/src/Item_Line.php
+++ b/src/Item_Line.php
@@ -357,7 +357,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Item_DeviceSimcard::getTypeName(Session::getPluralNumber()),
-                'level' => 3,
+                'level' => 2,
             ],
             'columns' => [
                 'name' => __('Name'),
@@ -401,7 +401,7 @@ class Item_Line extends CommonDBRelation
                     'used'        => $used,
                 ],
                 'form_label' => __('Add a phone line'),
-                'form_label_level' => 3,
+                'form_label_level' => 2,
             ]);
         }
 
@@ -422,7 +422,7 @@ class Item_Line extends CommonDBRelation
             'nosort' => true,
             'super_header' => [
                 'label' => Line::getTypeName(Session::getPluralNumber()),
-                'level' => 3,
+                'level' => 2,
             ],
             'columns' => [
                 'name' => __('Name'),

--- a/src/Reservation.php
+++ b/src/Reservation.php
@@ -1018,7 +1018,8 @@ HTML;
         $ID     = $ri->getID();
 
         echo "<br>";
-        echo "<h1>" . __s('Reservations for this item') . "</h1>";
+        // Level 2: the page already carries the item h1. The h1 class keeps the rendering unchanged.
+        echo "<h2 class='h1'>" . __s('Reservations for this item') . "</h2>";
         echo "<div id='reservations_planning_$rand' class='reservations-planning tabbed'></div>";
 
         $default_date = date('Y-m-d');

--- a/templates/components/datatable.html.twig
+++ b/templates/components/datatable.html.twig
@@ -58,7 +58,8 @@
  * - footer_class: Additional CSS classes applied to the table footer element.
  * - no_header: Hide all column headers when set to true. Defaults to false.
  * - super_header: Optional header row spanning all columns. Can be a string or an
- *   array with 'label' (string) and optional 'is_raw' (boolean) keys.
+ *   array with 'label' (string) and optional 'is_raw' (boolean) and 'level' (int) keys.
+ *   'level' exposes the label as a heading of that level, for pages that need it.
  *
  * - nosort: Disable sorting on all columns. Defaults to false.
  * - sort: The currently sorted column key.
@@ -110,9 +111,12 @@
             {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
             {% if super_header_label is not empty %}
                 {% set super_header_raw = super_header is array ? (super_header['is_raw'] ?? false) : false %}
+                {% set super_header_level = super_header is array ? (super_header['level'] ?? null) : null %}
                 <tr>
                     <th colspan="1">
+                        {% if super_header_level and super_header_raw is not same as 'th_elements' %}<span role="heading" aria-level="{{ super_header_level }}">{% endif %}
                         {{ super_header_raw ? super_header_label|raw : super_header_label }}
+                        {% if super_header_level and super_header_raw is not same as 'th_elements' %}</span>{% endif %}
                     </th>
                 </tr>
             {% endif %}
@@ -148,9 +152,12 @@
                 {% if super_header is defined and super_header is not empty %}
                     {% set super_header_label = super_header is array ? super_header['label'] : super_header %}
                     {% set super_header_raw = super_header is array ? (super_header['is_raw'] ?? false) : false %}
+                    {% set super_header_level = super_header is array ? (super_header['level'] ?? null) : null %}
                     <tr>
                         {% if super_header_raw is not same as 'th_elements' %}<th colspan="{{ total_cols }}">{% endif %}
+                            {% if super_header_level and super_header_raw is not same as 'th_elements' %}<span role="heading" aria-level="{{ super_header_level }}">{% endif %}
                             {{ super_header_raw ? super_header_label|raw : super_header_label }}
+                            {% if super_header_level and super_header_raw is not same as 'th_elements' %}</span>{% endif %}
                         {% if super_header_raw is not same as 'th_elements' %}</th>{% endif %}
                     </tr>
                 {% endif %}

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -30,12 +30,63 @@
  # ---------------------------------------------------------------------
  #}
 
+{#
+/**
+ * This component renders the small "link an existing item, or create a new one" form
+ * displayed at the top of many relation tabs.
+ *
+ * Available variables:
+ *
+ * - link_itemtype: Itemtype of the relation class handling the submission. Used to build
+ *   the form id, name and action path.
+ * - source_itemtype: Itemtype of the item the relation starts from.
+ * - source_items_id: ID of that source item.
+ * - source_suffix: Optional string appended to the source field names, to allow several
+ *   instances of the form in the same page.
+ *
+ * - form_label: Optional label displayed above the fields. Rendered as plain text unless
+ *   'form_label_level' is given.
+ * - form_label_level: Optional heading level (int). When set and the label is not empty,
+ *   the label is exposed as a heading of that level, visually unchanged. Opt in only:
+ *   without it the label keeps its plain text rendering.
+ *
+ * - generic_target: Render an itemtype plus items_id dropdown pair instead of a single
+ *   dropdown. Defaults to false.
+ * - target_itemtype: Itemtype proposed in the dropdown, when 'generic_target' is false.
+ * - target_suffix: Optional string appended to the target field names.
+ * - generic_source: Post the source as 'itemtype' and 'items_id' hidden fields instead of
+ *   the source foreign key. Defaults to false.
+ *
+ * - link_types: When 'generic_target' is true, the list of selectable itemtypes. Otherwise,
+ *   an optional 'colkey' => 'label' list rendered as an extra 'link' dropdown of relation
+ *   types.
+ * - used: Optional array of already linked ids to exclude from the dropdown.
+ * - dropdown_options: Options merged into the dropdown. Its 'itemtype' key, when present,
+ *   overrides 'target_itemtype'.
+ * - ajax_dropdown: Optional array wiring a dependent dropdown. Must include 'toobserve',
+ *   'url', 'params' and a 'toupdate' array with 'id', 'itemtype' and 'params' keys.
+ *
+ * - add_button_label: Label of the submit button. Defaults to the generic "Add".
+ * - add_button_icon: Icon class of the submit button. Defaults to 'ti ti-link'.
+ * - create_link: When truthy, displays a second button linking to the creation form of the
+ *   target itemtype. Its optional 'url' key overrides the computed target form path.
+ * - button_label: Label of that creation link.
+ *
+ * - rand: Optional unique suffix for the generated ids. Defaults to a random value.
+ */
+#}
+
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% set rand = rand|default(random()) %}
 <div class="mb-3">
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
-      {{ form_label }}
+      {% if form_label_level is defined and form_label is not empty %}
+         {# Structure only: fs-4 is the body text size here, the label must not look different. #}
+         <h{{ form_label_level }} class="fw-normal mb-0 fs-4">{{ form_label }}</h{{ form_label_level }}>
+      {% else %}
+         {{ form_label }}
+      {% endif %}
       {% if generic_source ?? false %}
           {{ fields.hiddenField('itemtype' ~ (source_suffix ?? ''), source_itemtype) }}
           {{ fields.hiddenField('items_id' ~ (source_suffix ?? ''), source_items_id) }}

--- a/templates/components/form/link_existing_or_new.html.twig
+++ b/templates/components/form/link_existing_or_new.html.twig
@@ -82,8 +82,8 @@
 <div class="mb-3">
    <form id="{{ link_itemtype|lower ~ "_form" ~ rand }}" name="{{ link_itemtype|lower ~ "_form" ~ rand }}" method="post" action="{{ link_itemtype|itemtype_form_path }}">
       {% if form_label_level is defined and form_label is not empty %}
-         {# Structure only: fs-4 is the body text size here, the label must not look different. #}
-         <h{{ form_label_level }} class="fw-normal mb-0 fs-4">{{ form_label }}</h{{ form_label_level }}>
+         {# Structure only: fs-4 and lh-base restore the surrounding body text metrics. #}
+         <h{{ form_label_level }} class="fw-normal mb-0 fs-4 lh-base">{{ form_label }}</h{{ form_label_level }}>
       {% else %}
          {{ form_label }}
       {% endif %}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/406
- Here is a brief description of what this PR does : 

Fixes the three heading level defects reported by the Access42 audit under RGAA criterion 9.1: the `Add a phone line` label, the `Hours` block of the ITIL statistics tab, and each day of the reservation planning.

Since the first two come from templates shared by 15 and 25 call sites, the heading is opt in through a new documented parameter, so only the audited screens change.

Calendar days are marked with `role` and `aria-level` on the nodes FullCalendar already renders, which survives redraws and preserves the grid and table semantics.

Nothing changes visually, every semantic tag added is neutralised in CSS.

Two deliberate departures from the letter of the audit, both to keep the outline coherent: 

`Hours` is a level 2 heading so it stays a sibling of `Dates` rather than its subsection, and `Add a phone line` is level 3 because the three blocks of the tab are rendered side by side, not nested.




