### PR TITLE
Rework prepared statements in debug bar

### DIFF
--- a/js/src/vue/Debug/Toolbar.vue
+++ b/js/src/vue/Debug/Toolbar.vue
@@ -2,7 +2,7 @@
     /**
      * @typedef {{ id: string, parent_id: string|null, category: string, name: string, start: number, end: number }} ProfilerSection
      * @typedef {{ execution_time: number, memory_usage: number, memory_peak: number, memory_limit: number }} ServerPerformanceMetrics
-     * @typedef {{ total_requests: number, total_duration: number, queries: { request_id: string, num: number, query: string, time: number, rows: number, warnings: string[], errors: string[] } }} SQLMetrics
+     * @typedef {{ total_requests: number, total_duration: number, queries: { request_id: string, num: number, query: string, raw_query: string, params: Array|Object|null, time: number, rows: number, warnings: string, errors: string } }} SQLMetrics
      * @typedef {{ id: string, parent_id: string, server_performance: ServerPerformanceMetrics, sql: SQLMetrics, globals: Object.<string, string>, [profiler]: ProfilerSection[] }} Profile
      * @typedef {{ id: string, data: Object.<string, string>, url: string, server_global: Object.<string, string>, type: string, start: Date, time: number, status: number, status_type: string, profile: Profile|null }} AJAXRequestData
      * @typedef {{ x: number, y: number, width: number, height: number }} ClientTimingBounds

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -267,7 +267,7 @@
                         </div>
                         <template v-if="query.has_params">
                             <button type="button" class="toggle-sql-params btn btn-sm btn-ghost-secondary px-1 py-0 mt-1"
-                                    :aria-expanded="isExpanded(query) ? 'true' : 'false'" aria-label="Toggle prepared statement and parameters"
+                                    :aria-expanded="isExpanded(query)" aria-label="Toggle prepared statement and parameters"
                                     @click="toggleParams(query)">
                                 <i :class="isExpanded(query) ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" aria-hidden="true"></i>
                                 <span class="ms-1">Prepared statement</span>

--- a/js/src/vue/Debug/Widget/SQLRequests.vue
+++ b/js/src/vue/Debug/Widget/SQLRequests.vue
@@ -49,6 +49,48 @@
         return sql_data;
     }
 
+    // Longest bound value shown as-is; the copy button always yields the full value.
+    const MAX_PARAM_LENGTH = 512;
+
+    function formatParamValue(value) {
+        if (value === null || value === undefined) {
+            return {type: 'NULL', display: 'NULL'};
+        }
+        if (typeof value === 'boolean') {
+            return {type: 'bool', display: value ? 'true' : 'false'};
+        }
+        if (typeof value === 'number') {
+            return {type: 'number', display: String(value)};
+        }
+        if (typeof value === 'object') {
+            // Should not happen, but never render "[object Object]"
+            return {type: 'object', display: JSON.stringify(value)};
+        }
+
+        const full = String(value);
+        // Neutralize control chars so a binary payload cannot wreck the layout
+        // eslint-disable-next-line no-control-regex -- matching control chars is the point here
+        let display = full.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '\uFFFD');
+        let suffix = '';
+        if (display.length > MAX_PARAM_LENGTH) {
+            display = display.substring(0, MAX_PARAM_LENGTH);
+            suffix = ` … (${full.length} chars)`;
+        }
+        return {type: 'string', display: `'${display}'${suffix}`};
+    }
+
+    function buildParamsList(params) {
+        if (params === null || params === undefined) {
+            return [];
+        }
+        // Params are positional, but PHP may serialize them as an object if they have string keys
+        const entries = Array.isArray(params)
+            ? params.map((value, i) => [String(i + 1), value])
+            : Object.entries(params);
+
+        return entries.map(([label, value]) => ({label: label, raw: value, ...formatParamValue(value)}));
+    }
+
     const sorted_col = ref(is_global_mode.value ? 'request_id' : 'num');
     const sort_dir = ref('asc');
     const sorted_queries_data = computed(() => {
@@ -57,11 +99,20 @@
         const sql_data = getCombinedSQLData();
         $.each(sql_data.queries, (request_id, data) => {
             data.forEach((query) => {
+                // Profiles recorded before prepared statements (or by plugins) have no raw_query
+                const raw_query = query['raw_query'] !== undefined && query['raw_query'] !== null
+                    ? query['raw_query']
+                    : query['query'];
+                const params_list = buildParamsList(query['params']);
                 sorted.push({
                     request_id: request_id,
                     num: query['num'],
                     time: query['time'],
                     query: query['query'],
+                    raw_query: raw_query,
+                    params_list: params_list,
+                    has_params: params_list.length > 0,
+                    has_raw_query: raw_query !== query['query'],
                     rows: query['rows'],
                     warnings: _.escape(query['warnings']),
                     errors: _.escape(query['errors']),
@@ -108,12 +159,9 @@
             sort_dir.value = 'asc';
         }
     }
-    function copyToClipboard(e) {
-        // copy content of code block in clipboard
-        const code =  $(e.currentTarget).parent().find('code');
+    function copyToClipboard(e, text, normalize_whitespace = true) {
         // Normalize whitespace as spaces and trim
-        const code_clean = code.text().replace(/\s+/g, ' ').trim();
-        copyTextToClipboard(code_clean);
+        copyTextToClipboard(normalize_whitespace ? text.replace(/\s+/g, ' ').trim() : text);
 
         // change temporary the button icon to a check then after a while return to the original icon
         const icon = $(e.currentTarget).find('i');
@@ -137,17 +185,52 @@
     }
 
     const colorized_queries = reactive(new Map());
+    const expanded_rows = reactive(new Set());
+
+    function rowKey(query) {
+        return `${query.request_id}-${query.num}`;
+    }
+
+    // Both the interpolated and the prepared query may be colorized, hence the field suffix
+    function codeKey(query, field) {
+        return `${rowKey(query)}-${field}`;
+    }
+
+    function ensureColorized(key, sql) {
+        if (colorized_queries.has(key)) {
+            return;
+        }
+        // Show uncolored query until the colorized version is ready
+        colorized_queries.set(key, _.escape(sql));
+        cleanSQLQuery(sql).then((html) => {
+            colorized_queries.set(key, html);
+        });
+    }
+
+    function isExpanded(query) {
+        return expanded_rows.has(rowKey(query));
+    }
+
+    function toggleParams(query) {
+        const key = rowKey(query);
+        if (expanded_rows.has(key)) {
+            expanded_rows.delete(key);
+            return;
+        }
+        expanded_rows.add(key);
+        // Only colorize the prepared query for rows the user actually opens
+        if (query.has_raw_query) {
+            ensureColorized(codeKey(query, 'raw_query'), query.raw_query);
+        }
+    }
+
+    function copyParams(e, query) {
+        copyToClipboard(e, JSON.stringify(query.params_list.map((param) => param.raw), null, 2), false);
+    }
 
     watch(() => sorted_queries_data.value, () => {
         sorted_queries_data.value.forEach((query) => {
-            const key = query.request_id + '-' + query.num;
-            if (!colorized_queries.has(key)) {
-                // Show uncolored query until the colorized version is ready
-                colorized_queries.set(key, query.query);
-                cleanSQLQuery(query.query).then((html) => {
-                    colorized_queries.set(key, html);
-                });
-            }
+            ensureColorized(codeKey(query, 'query'), query.query);
         });
     }, {
         immediate: true,
@@ -176,12 +259,43 @@
                     <td>
                         <div class="d-flex align-items-start" style="max-width: 50vw;">
                             <div style="max-width: 50vw; white-space: break-spaces;" class="w-100">
-                                <code class="d-block cm-s-default border-0" v-html="colorized_queries.get(query.request_id + '-' + query.num)"></code>
+                                <code class="d-block cm-s-default border-0" v-html="colorized_queries.get(codeKey(query, 'query'))"></code>
                             </div>
-                            <button type="button" @click="copyToClipboard($event)" class="ms-1 copy-code btn btn-sm btn-ghost-secondary" title="Copy query to clipboard">
+                            <button type="button" @click="copyToClipboard($event, query.query)" class="ms-1 copy-code btn btn-sm btn-ghost-secondary" title="Copy query to clipboard">
                                 <i class="ti ti-clipboard-copy" aria-hidden="true"></i>
                             </button>
                         </div>
+                        <template v-if="query.has_params">
+                            <button type="button" class="toggle-sql-params btn btn-sm btn-ghost-secondary px-1 py-0 mt-1"
+                                    :aria-expanded="isExpanded(query) ? 'true' : 'false'" aria-label="Toggle prepared statement and parameters"
+                                    @click="toggleParams(query)">
+                                <i :class="isExpanded(query) ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" aria-hidden="true"></i>
+                                <span class="ms-1">Prepared statement</span>
+                                <span class="badge bg-secondary text-secondary-fg ms-1">{{ query.params_list.length }}</span>
+                            </button>
+                            <div v-if="isExpanded(query)" class="sql-params-panel border rounded p-2 mt-1">
+                                <div v-if="query.has_raw_query" class="d-flex align-items-start">
+                                    <div style="white-space: break-spaces;" class="w-100">
+                                        <code class="d-block cm-s-default border-0" v-html="colorized_queries.get(codeKey(query, 'raw_query'))"></code>
+                                    </div>
+                                    <button type="button" @click="copyToClipboard($event, query.raw_query)" class="ms-1 copy-raw-query btn btn-sm btn-ghost-secondary" title="Copy prepared query to clipboard">
+                                        <i class="ti ti-clipboard-copy" aria-hidden="true"></i>
+                                    </button>
+                                </div>
+                                <div class="d-flex align-items-start mt-2">
+                                    <ul class="sql-params-list list-unstyled mb-0 w-100">
+                                        <li v-for="param in query.params_list" :key="param.label" class="d-flex">
+                                            <span class="param-index text-muted me-2">{{ param.label }}</span>
+                                            <span class="param-type text-muted me-2">{{ param.type }}</span>
+                                            <span class="param-value font-monospace">{{ param.display }}</span>
+                                        </li>
+                                    </ul>
+                                    <button type="button" @click="copyParams($event, query)" class="ms-1 copy-params btn btn-sm btn-ghost-secondary" title="Copy parameters to clipboard">
+                                        <i class="ti ti-clipboard-copy" aria-hidden="true"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </template>
                     </td>
                     <td>{{ query.time.toFixed(1) }}&nbsp;ms</td>
                     <td>{{ query.rows }}</td>
@@ -209,5 +323,20 @@
     }
     #debug-sql-request-table code {
         color: var(--tblr-body-color);
+    }
+    #debug-sql-request-table .sql-params-panel {
+        max-height: 40vh;
+        overflow: auto;
+    }
+    #debug-sql-request-table .param-index {
+        min-width: 2rem;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+    #debug-sql-request-table .param-type {
+        min-width: 4rem;
+    }
+    #debug-sql-request-table .param-value {
+        word-break: break-word;
     }
 </style>

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -2185,8 +2185,12 @@ class DBmysql
      *
      * The result is never executed; it just rebuilds the final query the debug bar
      * used to show before queries were turned into prepared statements. Placeholders
-     * are replaced left-to-right, mirroring how self::bindStatementParams() coerces
-     * values.
+     * are filled left-to-right; keys are ignored, just like self::bindStatementParams()
+     * does. This is only an approximation of what the server executed: values are
+     * rendered the way they read best, not the way mysqli coerces them.
+     *
+     * Values are appended to an output buffer instead of being substituted in place, so
+     * a `?` inside a value can never be mistaken for the next placeholder.
      *
      * @param string $query  Query string with `?` placeholders
      * @param ?array<int|string, mixed> $params Parameters bound to the query
@@ -2198,7 +2202,14 @@ class DBmysql
         if (empty($params)) {
             return $query;
         }
+        $result = '';
+        $offset = 0;
         foreach ($params as $param) {
+            $pos = strpos($query, '?', $offset);
+            if ($pos === false) {
+                //more parameters than placeholders
+                break;
+            }
             if ($param === null) {
                 $value = 'NULL';
             } elseif (is_bool($param)) {
@@ -2206,9 +2217,10 @@ class DBmysql
             } else {
                 $value = $this->quote($param);
             }
-            $query = preg_replace('/\?/', $value, $query, 1);
+            $result .= substr($query, $offset, $pos - $offset) . $value;
+            $offset = $pos + 1;
         }
-        return $query;
+        return $result . substr($query, $offset);
     }
 
     /**

--- a/src/Glpi/Debug/Profile.php
+++ b/src/Glpi/Debug/Profile.php
@@ -46,6 +46,11 @@ use function Safe\json_encode;
 
 final class Profile
 {
+    /**
+     * Maximum length, in bytes, of a bound value kept for debug display.
+     */
+    private const MAX_PARAM_LENGTH = 2048;
+
     private string $id;
 
     private ?string $parent_id;
@@ -155,6 +160,33 @@ final class Profile
     }
 
     /**
+     * Make a bound value safe to JSON encode.
+     *
+     * The whole debug info is JSON encoded, and a single value that is not valid UTF-8 makes
+     * that encoding fail: the AJAX endpoint throws, and the toolbar bootstrap in the page
+     * emits broken JavaScript. Since the client cannot recover from a failed encoding, binary
+     * and oversized values are replaced here, before they are stored.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function sanitizeBoundValue(mixed $value): mixed
+    {
+        if (!is_string($value)) {
+            return $value;
+        }
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            return sprintf('<binary: %d bytes>', strlen($value));
+        }
+        if (strlen($value) > self::MAX_PARAM_LENGTH) {
+            return mb_strcut($value, 0, self::MAX_PARAM_LENGTH)
+                . sprintf('… <truncated, %d bytes>', strlen($value));
+        }
+        return $value;
+    }
+
+    /**
      * @param string $query
      * @param ?array<int|string, mixed> $params
      * @param float $time
@@ -176,6 +208,13 @@ final class Profile
                 'queries' => [],
             ];
         }
+
+        //interpolate from the sanitized values, so that a binary value cannot make the whole
+        //debug info unencodable while still leaving the query readable
+        if ($params !== null) {
+            $params = array_map($this->sanitizeBoundValue(...), $params);
+        }
+
         $next_num = count($this->additional_info['sql']['queries'] ?? []);
         $this->additional_info['sql']['queries'][] = [
             'num' => $next_num,

--- a/tests/functional/DBTest.php
+++ b/tests/functional/DBTest.php
@@ -141,6 +141,75 @@ class DBTest extends GLPITestCase
         $this->assertSame($expected, \DBmysql::quoteValue($raw));
     }
 
+    public static function dataInterpolateParams(): iterable
+    {
+        yield ['SELECT * FROM `glpi_computers`', null, 'SELECT * FROM `glpi_computers`'];
+        yield ['SELECT * FROM `glpi_computers`', [], 'SELECT * FROM `glpi_computers`'];
+
+        // nominal case, several placeholders
+        yield [
+            'SELECT * FROM `glpi_computers` WHERE `name` = ? AND `id` = ?',
+            ['foo', 42],
+            'SELECT * FROM `glpi_computers` WHERE `name` = \'foo\' AND `id` = \'42\'',
+        ];
+
+        // special values
+        yield ['SELECT * FROM `t` WHERE `a` = ?', [null], 'SELECT * FROM `t` WHERE `a` = NULL'];
+        yield ['SELECT * FROM `t` WHERE `a` = ?', [true], 'SELECT * FROM `t` WHERE `a` = 1'];
+        yield ['SELECT * FROM `t` WHERE `a` = ?', [false], 'SELECT * FROM `t` WHERE `a` = 0'];
+
+        // a value used to be handled as a regex replacement string: `$1` was expanded as a
+        // (non existing) capturing group, and silently dropped from the displayed query
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ?',
+            ['$1 and ${2}'],
+            'SELECT * FROM `t` WHERE `a` = \'$1 and ${2}\'',
+        ];
+
+        // a `?` contained in a value used to be picked as the next placeholder, shifting
+        // every remaining parameter
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ? AND `b` = ?',
+            ['what?', 'z'],
+            'SELECT * FROM `t` WHERE `a` = \'what?\' AND `b` = \'z\'',
+        ];
+
+        // quoting is left untouched
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ?',
+            ["O'Brien"],
+            'SELECT * FROM `t` WHERE `a` = \'O\\\'Brien\'',
+        ];
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ?',
+            ['back\\slash'],
+            'SELECT * FROM `t` WHERE `a` = \'back\\\\slash\'',
+        ];
+
+        // keys are ignored, just like when binding
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ? AND `b` = ?',
+            ['a' => 'foo', 'b' => 'bar'],
+            'SELECT * FROM `t` WHERE `a` = \'foo\' AND `b` = \'bar\'',
+        ];
+
+        // more parameters than placeholders
+        yield ['SELECT * FROM `t` WHERE `a` = ?', ['foo', 'bar'], 'SELECT * FROM `t` WHERE `a` = \'foo\''];
+        // more placeholders than parameters
+        yield [
+            'SELECT * FROM `t` WHERE `a` = ? AND `b` = ?',
+            ['foo'],
+            'SELECT * FROM `t` WHERE `a` = \'foo\' AND `b` = ?',
+        ];
+    }
+
+    #[DataProvider('dataInterpolateParams')]
+    public function testInterpolateParams(string $query, ?array $params, string $expected)
+    {
+        $instance = new \DB();
+        $this->assertSame($expected, $instance->interpolateParams($query, $params));
+    }
+
 
     public static function dataInsert()
     {

--- a/tests/js/vue/Debug/Toolbar.spec.js
+++ b/tests/js/vue/Debug/Toolbar.spec.js
@@ -114,7 +114,7 @@ describe("Debug Bar", () => {
         window.AjaxMock.end();
     });
 
-    async function mountToolbar() {
+    async function mountToolbar(initial_request_overrides = {}) {
         const Toolbar = await import("/js/src/vue/Debug/Toolbar.vue").then(module => module.default);
 
         // import all widgets at once, assigning each to variable for use in the mount options later, and then await all to reduce test time
@@ -145,54 +145,56 @@ describe("Debug Bar", () => {
             import('/js/src/vue/Debug/Widget/ThemeSwitcher.vue').then(module => module.default),
         ]);
 
+        const base_initial_request = {
+            "id":"0f9fde97e889ed3f",
+            "parent_id":null,
+            "server_performance":{"execution_time":200,"memory_usage":5176272,"memory_peak":5346088,"memory_limit":268435456},
+            "sql":{"queries":[{"num":0,"query":"SELECT * FROM `glpi_assets_assetdefinitions`","time":0.3948211669921875,"rows":2,"errors":"","warnings":""}]},
+            "globals": {
+                "get": [],
+                "post": [],
+                "session": {
+                    "glpicookietest": "testcookie",
+                    "valid_id": "fce7f1b423db04cbd32aa7eab70c13d3",
+                    "glpi_currenttime": "2026-06-16 18:09:42",
+                    "glpi_use_mode": 2,
+                    "glpiID": 2,
+                },
+                "server": {
+                    "USER": "www-data",
+                    "HOME": "/var/www",
+                    "SCRIPT_NAME": "/index.php",
+                    "REQUEST_URI": "/front/entity.php"
+                },
+            },
+            "profiler":[
+                {
+                    "id":"3c961f88-a87f-486f-b853-20cb5e72baac",
+                    "parent_id":null,
+                    "category":"core",
+                    "name": "php_request",
+                    "start":1781647782350,
+                    "end":1781647782380,
+                    "duration":30,
+                    "auto_ended":false
+                },
+                {
+                    "id":"1954516f-d3fc-4260-8eea-6f9ad526f1a7",
+                    "parent_id":"3c961f88-a87f-486f-b853-20cb5e72baac",
+                    "category":"boot",
+                    "name":"InitializeDbConnection::execute",
+                    "start":1781647782351,
+                    "end":1781647782362,
+                    "duration":11,
+                    "auto_ended":false
+                }
+            ],
+        };
+
         const wrapper = mount(Toolbar, {
             attachTo: document.body,
             props: {
-                initial_request: {
-                    "id":"0f9fde97e889ed3f",
-                    "parent_id":null,
-                    "server_performance":{"execution_time":200,"memory_usage":5176272,"memory_peak":5346088,"memory_limit":268435456},
-                    "sql":{"queries":[{"num":0,"query":"SELECT * FROM `glpi_assets_assetdefinitions`","time":0.3948211669921875,"rows":2,"errors":"","warnings":""}]},
-                    "globals": {
-                        "get": [],
-                        "post": [],
-                        "session": {
-                            "glpicookietest": "testcookie",
-                            "valid_id": "fce7f1b423db04cbd32aa7eab70c13d3",
-                            "glpi_currenttime": "2026-06-16 18:09:42",
-                            "glpi_use_mode": 2,
-                            "glpiID": 2,
-                        },
-                        "server": {
-                            "USER": "www-data",
-                            "HOME": "/var/www",
-                            "SCRIPT_NAME": "/index.php",
-                            "REQUEST_URI": "/front/entity.php"
-                        },
-                    },
-                    "profiler":[
-                        {
-                            "id":"3c961f88-a87f-486f-b853-20cb5e72baac",
-                            "parent_id":null,
-                            "category":"core",
-                            "name": "php_request",
-                            "start":1781647782350,
-                            "end":1781647782380,
-                            "duration":30,
-                            "auto_ended":false
-                        },
-                        {
-                            "id":"1954516f-d3fc-4260-8eea-6f9ad526f1a7",
-                            "parent_id":"3c961f88-a87f-486f-b853-20cb5e72baac",
-                            "category":"boot",
-                            "name":"InitializeDbConnection::execute",
-                            "start":1781647782351,
-                            "end":1781647782362,
-                            "duration":11,
-                            "auto_ended":false
-                        }
-                    ],
-                }
+                initial_request: {...base_initial_request, ...initial_request_overrides}
             },
             global: {
                 components: {
@@ -280,8 +282,77 @@ describe("Debug Bar", () => {
         expect(firstRowCells[2].text()).toContain('`glpi_assets_assetdefinitions`'); // query
         expect(firstRowCells[3].text()).toMatch(/^\d+\.\d+\sms$/); // time
         expect(firstRowCells[4].text()).toMatch(/^\d+$/); // rows
-        expect(firstRowCells[5].text()).toBe(''); // errors
-        expect(firstRowCells[6].text()).toBe(''); // warnings
+        expect(firstRowCells[5].text()).toBe(''); // warnings
+        expect(firstRowCells[6].text()).toBe(''); // errors
+
+        // this fixture has neither raw_query nor params: nothing to disclose
+        expect(expandedContent.find('.toggle-sql-params').exists()).toBe(false);
+    });
+
+    it('SQL requests with prepared statement parameters', async () => {
+        window.copyTextToClipboard = vi.fn();
+
+        const raw_query = 'SELECT * FROM `glpi_computers` WHERE `name` = ? AND `id` = ?';
+        const wrapper = await mountToolbar({
+            "sql": {
+                "queries": [
+                    {
+                        "num": 0,
+                        "query": "SELECT * FROM `glpi_computers` WHERE `name` = 'what?' AND `id` = '42'",
+                        "raw_query": raw_query,
+                        "params": ['what?', 42],
+                        "time": 0.5,
+                        "rows": 1,
+                        "errors": "",
+                        "warnings": ""
+                    }
+                ]
+            }
+        });
+
+        await wrapper.find('.debug-toolbar-widget[data-glpi-debug-widget-id="sql"]').trigger('click');
+        const expandedContent = wrapper.find('#debug-toolbar-expanded-content');
+        await flushPromises();
+
+        // collapsed by default, the interpolated query is what is shown
+        expect(expandedContent.findAll('#debug-sql-request-table > tbody > tr').length).toBe(1);
+        expect(expandedContent.find('#debug-sql-request-table > tbody > tr td:nth-of-type(3) code').text())
+            .toContain("`name` = 'what?'");
+        expect(expandedContent.find('.sql-params-panel').exists()).toBe(false);
+
+        const toggle = expandedContent.find('.toggle-sql-params');
+        expect(toggle.exists()).toBe(true);
+        expect(toggle.attributes('aria-expanded')).toBe('false');
+        expect(toggle.find('.badge').text()).toBe('2');
+
+        // expanded: the prepared query and its parameters
+        await toggle.trigger('click');
+        await flushPromises();
+        expect(expandedContent.findAll('#debug-sql-request-table > tbody > tr').length).toBe(1);
+        expect(expandedContent.find('.toggle-sql-params').attributes('aria-expanded')).toBe('true');
+
+        const panel = expandedContent.find('.sql-params-panel');
+        expect(panel.exists()).toBe(true);
+        expect(panel.find('code').text()).toContain('`name` = ? AND `id` = ?');
+
+        const params = panel.findAll('.sql-params-list li');
+        expect(params.length).toBe(2);
+        expect(params[0].find('.param-index').text()).toBe('1');
+        expect(params[0].find('.param-type').text()).toBe('string');
+        expect(params[0].find('.param-value').text()).toBe("'what?'");
+        expect(params[1].find('.param-index').text()).toBe('2');
+        expect(params[1].find('.param-type').text()).toBe('number');
+        expect(params[1].find('.param-value').text()).toBe('42');
+
+        // each block copies its own content
+        await panel.find('.copy-raw-query').trigger('click');
+        expect(window.copyTextToClipboard).toHaveBeenLastCalledWith(raw_query);
+        await panel.find('.copy-params').trigger('click');
+        expect(window.copyTextToClipboard).toHaveBeenLastCalledWith(JSON.stringify(['what?', 42], null, 2));
+
+        // and it collapses back
+        await expandedContent.find('.toggle-sql-params').trigger('click');
+        expect(expandedContent.find('.sql-params-panel').exists()).toBe(false);
     });
 
     it('HTTP requests', async () => {
@@ -360,8 +431,8 @@ describe("Debug Bar", () => {
         expect(firstRowCells[1].text()).toContain('`glpi_assets_assetdefinitions`'); // query
         expect(firstRowCells[2].text()).toMatch(/^\d+\.\d+\sms$/); // time
         expect(firstRowCells[3].text()).toMatch(/^\d+$/); // rows
-        expect(firstRowCells[4].text()).toBe(''); // errors
-        expect(firstRowCells[5].text()).toBe(''); // warnings
+        expect(firstRowCells[4].text()).toBe(''); // warnings
+        expect(firstRowCells[5].text()).toBe(''); // errors
     });
 
     it('Client performance', async () => {


### PR DESCRIPTION
First commit fix an issue on interpolating parameters in query for default display.

Second commit improves display:
<img width="1517" height="296" alt="image" src="https://github.com/user-attachments/assets/e9e0bf43-6c08-45eb-9242-08f17d06293d" />