### PR TITLE
A11Y : Fix illustration picker keyboard accessibility

### DIFF
--- a/css/includes/components/_illustration-picker.scss
+++ b/css/includes/components/_illustration-picker.scss
@@ -46,3 +46,22 @@
 .illustration-selector-extra-margin {
     padding-bottom: 10px;
 }
+
+// Neutralize the user-agent styling of the <button> now used by the trigger and
+// the tiles; :where() keeps it at zero specificity so component classes win.
+// `width` included: a button shrinks to its content where the <div> filled its
+// container (`100%` would break the sizing of a shrink-to-fit parent).
+:where(.illustration-picker-btn, .illustration-picker-tile) {
+    width: -moz-available;
+    width: -webkit-fill-available;
+    width: stretch;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    text-align: inherit;
+}
+
+.illustration-picker-tile {
+    cursor: pointer;
+}

--- a/css/includes/components/_illustration-picker.scss
+++ b/css/includes/components/_illustration-picker.scss
@@ -47,21 +47,17 @@
     padding-bottom: 10px;
 }
 
-// Neutralize the user-agent styling of the <button> now used by the trigger and
-// the tiles; :where() keeps it at zero specificity so component classes win.
-// `width` included: a button shrinks to its content where the <div> filled its
-// container (`100%` would break the sizing of a shrink-to-fit parent).
-:where(.illustration-picker-btn, .illustration-picker-tile) {
+// Strip the UA button styling; :where() and the tag let component classes win.
+// `width`: a button shrinks to its content where the <div> filled its container.
+:where(button.illustration-picker-btn, button.illustration-picker-tile) {
     width: -moz-available;
     width: -webkit-fill-available;
     width: stretch;
+    align-items: normal;
     padding: 0;
     border: 0;
     background: none;
     color: inherit;
-    text-align: inherit;
-}
-
-.illustration-picker-tile {
     cursor: pointer;
+    text-align: inherit;
 }

--- a/css/includes/components/_illustration-picker.scss
+++ b/css/includes/components/_illustration-picker.scss
@@ -47,8 +47,6 @@
     padding-bottom: 10px;
 }
 
-// Strip the UA button styling; :where() and the tag let component classes win.
-// `width`: a button shrinks to its content where the <div> filled its container.
 :where(button.illustration-picker-btn, button.illustration-picker-tile) {
     width: -moz-available;
     width: -webkit-fill-available;

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -153,14 +153,12 @@
         border-color 0.2s ease,
         box-shadow 0.2s ease;
 
-    // Only add spacing in edit mode, where the preview becomes a real <button>
-    // that can be hovered to pick an illustration.
+    // Spacing only in edit mode, where the preview is a real <button>.
     // Offset the padding with a matching negative margin so surrounding
     // content keeps its position when switching between view and edit mode.
     &:is(button) {
         padding: 0.25rem;
         margin: -0.25rem;
-        cursor: pointer;
 
         &:hover {
             border-color: var(--tblr-border-color);

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -153,13 +153,14 @@
         border-color 0.2s ease,
         box-shadow 0.2s ease;
 
-    // Only add spacing in edit mode, where the preview becomes an interactive
-    // button (role="button") that can be hovered to pick an illustration.
+    // Only add spacing in edit mode, where the preview becomes a real <button>
+    // that can be hovered to pick an illustration.
     // Offset the padding with a matching negative margin so surrounding
     // content keeps its position when switching between view and edit mode.
-    &[role="button"] {
+    &:is(button) {
         padding: 0.25rem;
         margin: -0.25rem;
+        cursor: pointer;
 
         &:hover {
             border-color: var(--tblr-border-color);

--- a/js/modules/IllustrationPicker/Controller.js
+++ b/js/modules/IllustrationPicker/Controller.js
@@ -102,27 +102,52 @@ export class GlpiIllustrationPickerController
      */
     setEditable(editable)
     {
-        const preview = this.#getPreviewElement();
-        if (preview === null) {
+        if (this.#getPreviewElement() === null) {
             return;
         }
 
+        const preview = this.#morphPreview(editable ? 'button' : 'div');
+
         if (editable) {
-            preview.setAttribute('role', 'button');
+            preview.setAttribute('type', 'button');
             preview.setAttribute('aria-label', __('Select an illustration'));
             preview.setAttribute('data-bs-toggle', 'modal');
             preview.setAttribute('data-bs-target', `#${this.#modal_node.id}`);
             preview.removeAttribute('aria-disabled');
         } else {
-            preview.removeAttribute('role');
+            preview.removeAttribute('type');
             preview.removeAttribute('aria-label');
             preview.removeAttribute('data-bs-toggle');
             preview.removeAttribute('data-bs-target');
             preview.setAttribute('aria-disabled', 'true');
         }
 
-        // Re-apply now that the role changed.
+        // Re-apply now that the trigger changed.
         this.#setPreviewStatus(this.#selected_title);
+    }
+
+    /**
+     * Swaps the trigger between <button> (editable) and <div> (read-only),
+     * carrying over its attributes and children.
+     *
+     * @param {string} tag
+     * @return {HTMLElement}
+     */
+    #morphPreview(tag)
+    {
+        const current = this.#getPreviewElement();
+        if (current.localName === tag) {
+            return current;
+        }
+
+        const morphed = document.createElement(tag);
+        for (const { name, value } of current.attributes) {
+            morphed.setAttribute(name, value);
+        }
+        morphed.replaceChildren(...current.childNodes);
+        current.replaceWith(morphed);
+
+        return morphed;
     }
 
     /**
@@ -230,6 +255,14 @@ export class GlpiIllustrationPickerController
         this.#modal_node.addEventListener('shown.bs.modal', () => {
             this.#container.querySelector("[data-glpi-icon-picker-filter]").focus();
         });
+
+        // The picker is often injected after page load, where Bootstrap's tab
+        // data-api no longer runs: instantiate the active tab ourselves,
+        // otherwise arrow-key navigation and the roving tabindex are missing.
+        const active_tab = this.#container.querySelector('[data-bs-toggle="tab"].active');
+        if (active_tab !== null) {
+            bootstrap.Tab.getOrCreateInstance(active_tab);
+        }
     }
 
     #setNativeIllustration(illustration)
@@ -275,7 +308,7 @@ export class GlpiIllustrationPickerController
     /**
      * Names the currently selected illustration, as a sibling of the
      * trigger referenced via aria-describedby (a descendant would be
-     * pruned by the trigger's own role="button" name computation).
+     * pruned by the trigger button's own name computation).
      *
      * @param {?string} title
      */
@@ -286,7 +319,7 @@ export class GlpiIllustrationPickerController
         const preview = this.#getPreviewElement();
         let status = this.#container.querySelector('[data-glpi-icon-picker-value-preview-status]');
 
-        if (!title || preview.getAttribute('role') !== 'button') {
+        if (!title || preview.localName !== 'button') {
             status?.remove();
             preview.removeAttribute('aria-describedby');
             return;

--- a/js/modules/IllustrationPicker/Controller.js
+++ b/js/modules/IllustrationPicker/Controller.js
@@ -127,8 +127,7 @@ export class GlpiIllustrationPickerController
     }
 
     /**
-     * Swaps the trigger between <button> (editable) and <div> (read-only),
-     * carrying over its attributes and children.
+     * Swaps the trigger between <button> (editable) and <div> (read-only).
      *
      * @param {string} tag
      * @return {HTMLElement}
@@ -256,9 +255,7 @@ export class GlpiIllustrationPickerController
             this.#container.querySelector("[data-glpi-icon-picker-filter]").focus();
         });
 
-        // The picker is often injected after page load, where Bootstrap's tab
-        // data-api no longer runs: instantiate the active tab ourselves,
-        // otherwise arrow-key navigation and the roving tabindex are missing.
+        // The tab data-api skips pickers injected after load: no arrows, no roving tabindex.
         const active_tab = this.#container.querySelector('[data-bs-toggle="tab"].active');
         if (active_tab !== null) {
             bootstrap.Tab.getOrCreateInstance(active_tab);

--- a/templates/components/illustration/icon_picker.html.twig
+++ b/templates/components/illustration/icon_picker.html.twig
@@ -90,36 +90,37 @@
         data-glpi-icon-picker-value-preview-title="{{ selected_title }}"
         data-testid="illustration-picker"
     >
-        <div class="{{ preview_inner_css_classes }}">
+        {# <span>s only: a <button> trigger cannot hold block-level children. #}
+        <span class="d-block {{ preview_inner_css_classes }}">
             {# Placeholder: visible when no illustration is set. #}
-            <div
+            <span
                 class="d-flex align-items-center justify-content-center{% if not is_empty %} d-none{% endif %}"
                 data-glpi-icon-picker-value-preview-placeholder
                 style="width: {{ size }}px; height: {{ size }}px;"
             >
                 <i class="ti ti-photo-plus text-muted" style="font-size: {{ (size * 0.6)|round }}px;" aria-hidden="true"></i>
-            </div>
+            </span>
 
             {# Native illustration preview slot. #}
-            <div
-                class="{% if is_custom_file or is_empty %}d-none{% endif %}"
+            <span
+                class="d-block{% if is_custom_file or is_empty %} d-none{% endif %}"
                 data-glpi-icon-picker-value-preview-native
                 style="width: {{ size }}px; height: {{ size }}px;"
             >
                 {% if not is_custom_file and not is_empty %}
                     {{ render_illustration(value, size) }}
                 {% endif %}
-            </div>
+            </span>
 
             {# Custom illustration preview slot. #}
-            <div
-                class="{% if not is_custom_file %}d-none{% endif %}"
+            <span
+                class="d-block{% if not is_custom_file %} d-none{% endif %}"
                 data-glpi-icon-picker-value-preview-custom
                 data-testid="illustration-custom-preview"
             >
                 {{ render_illustration(is_custom_file ? value : custom_icon_prefix, size) }}
-            </div>
-        </div>
+            </span>
+        </span>
     </{{ preview_tag }}>
 
     {% if editable and selected_title is not empty %}

--- a/templates/components/illustration/icon_picker.html.twig
+++ b/templates/components/illustration/icon_picker.html.twig
@@ -41,10 +41,8 @@
  #   - preview_inner_css_classes: CSS classes for the inner preview wrapper
  #   - backdrop: whether the modal should have a backdrop (defaults to true)
  #   - editable: whether clicking the preview opens the modal (defaults to true).
- #     When false, the preview renders without role/aria-label/data-bs-toggle, so
- #     it is neither clickable nor exposed as a button to assistive tech.
- #     Consumers can flip this state at runtime via
- #     GlpiIllustrationPickerController.setEditable().
+ #     Renders a <button> when true, a plain <div> otherwise. Consumers can flip
+ #     this state at runtime via GlpiIllustrationPickerController.setEditable().
  #}
 
 {% set custom_icon_prefix = constant(
@@ -75,10 +73,11 @@
     {% set selected_title = (not is_empty and not is_custom_file) ? getIconTitle(value) : '' %}
     {% set status_id = container_id ~ "-status" %}
 
-    <div
-        class="{{ preview_css_classes }}"
+    {% set preview_tag = editable ? 'button' : 'div' %}
+    <{{ preview_tag }}
+        class="{{ preview_css_classes }} illustration-picker-btn"
         {% if editable %}
-            role="button"
+            type="button"
             aria-label="{{ __("Select an illustration") }}"
             {% if selected_title is not empty %}
                 aria-describedby="{{ status_id }}"
@@ -122,11 +121,11 @@
                 {{ render_illustration(is_custom_file ? value : custom_icon_prefix, size) }}
             </div>
         </div>
-    </div>
+    </{{ preview_tag }}>
 
     {% if editable and selected_title is not empty %}
         {# Named as the trigger's description, not a child: a descendant would be
-         # pruned by the trigger's own role="button" name computation. #}
+         # pruned by the trigger button's own name computation. #}
         <span
             id="{{ status_id }}"
             class="visually-hidden"

--- a/templates/components/illustration/icon_picker.html.twig
+++ b/templates/components/illustration/icon_picker.html.twig
@@ -41,8 +41,7 @@
  #   - preview_inner_css_classes: CSS classes for the inner preview wrapper
  #   - backdrop: whether the modal should have a backdrop (defaults to true)
  #   - editable: whether clicking the preview opens the modal (defaults to true).
- #     Renders a <button> when true, a plain <div> otherwise. Consumers can flip
- #     this state at runtime via GlpiIllustrationPickerController.setEditable().
+ #     Renders a <button> when true, a <div> otherwise (see setEditable()).
  #}
 
 {% set custom_icon_prefix = constant(

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -46,8 +46,7 @@
 >
     <div class="modal-dialog rounded">
         <div class="modal-content">
-            {# Tabs are <button> to be focusable, and the close button stays out
-             # of the tablist, which must only own the tabs. #}
+            {# <button> to be focusable; the tablist must own only the tabs. #}
             <div class="px-4 pt-2 d-flex">
                 <div class="nav nav-underline" role="tablist">
                     <div class="nav-item" role="presentation">

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -60,10 +60,10 @@
                             aria-controls="{{ pick_an_icon_pane_id }}"
                             aria-selected="true"
                         >
-                            <div class="d-flex align-items-center">
+                            <span class="d-flex align-items-center">
                                 <i class="ti ti-photo-scan fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Pick an illustration") }}
-                            </div>
+                            </span>
                         </button>
                     </div>
                     <div class="nav-item" role="presentation">
@@ -77,10 +77,10 @@
                             aria-controls="{{ upload_an_icon_pane_id }}"
                             aria-selected="false"
                         >
-                            <div class="d-flex align-items-center">
+                            <span class="d-flex align-items-center">
                                 <i class="ti ti-file-upload fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Upload your own illustration") }}
-                            </div>
+                            </span>
                         </button>
                     </div>
                 </div>

--- a/templates/components/illustration/icon_picker_modal.html.twig
+++ b/templates/components/illustration/icon_picker_modal.html.twig
@@ -46,10 +46,13 @@
 >
     <div class="modal-dialog rounded">
         <div class="modal-content">
-            <div class="px-4 pt-2" role="tablist">
-                <div class="nav nav-underline">
-                    <div class="nav-item">
-                        <a
+            {# Tabs are <button> to be focusable, and the close button stays out
+             # of the tablist, which must only own the tabs. #}
+            <div class="px-4 pt-2 d-flex">
+                <div class="nav nav-underline" role="tablist">
+                    <div class="nav-item" role="presentation">
+                        <button
+                            type="button"
                             class="nav-link pointer active"
                             role="tab"
                             id="pick-an-icon-{{ rand }}"
@@ -62,10 +65,11 @@
                                 <i class="ti ti-photo-scan fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Pick an illustration") }}
                             </div>
-                        </a>
+                        </button>
                     </div>
-                    <div class="nav-item">
-                        <a
+                    <div class="nav-item" role="presentation">
+                        <button
+                            type="button"
                             class="nav-link pointer"
                             role="tab"
                             id="upload-an-icon-{{ rand }}"
@@ -78,18 +82,18 @@
                                 <i class="ti ti-file-upload fa-lg me-2" aria-hidden="true"></i>
                                 {{ __("Upload your own illustration") }}
                             </div>
-                        </a>
+                        </button>
                     </div>
-                    <button
-                        type="button"
-                        class="btn-close ms-auto align-self-center"
-                        data-bs-dismiss="modal"
-                        aria-label="{{ __("Close") }}"
-                    ></button>
                 </div>
+                <button
+                    type="button"
+                    class="btn-close ms-auto align-self-center"
+                    data-bs-dismiss="modal"
+                    aria-label="{{ __("Close") }}"
+                ></button>
             </div>
             <div class="modal-body tab-content">
-                <div id="{{ pick_an_icon_pane_id }}" class="tab-pane fade active show" role="tabpanel">
+                <div id="{{ pick_an_icon_pane_id }}" class="tab-pane fade active show" role="tabpanel" aria-labelledby="pick-an-icon-{{ rand }}">
                     <div class="input-icon mb-3">
                         <span class="input-icon-addon">
                             <i
@@ -115,7 +119,7 @@
                         'page_size': 30,
                     }, with_context: false) }}
                 </div>
-                <div id="{{ upload_an_icon_pane_id }}" class="tab-pane fade" role="tabpanel">
+                <div id="{{ upload_an_icon_pane_id }}" class="tab-pane fade" role="tabpanel" aria-labelledby="upload-an-icon-{{ rand }}">
                     {% do call('Html::file', [
                         {
                             'name': 'custom_icon',

--- a/templates/components/illustration/icon_picker_search_results.html.twig
+++ b/templates/components/illustration/icon_picker_search_results.html.twig
@@ -43,9 +43,9 @@
         <div class="row g-3 mb-4 align-items-start" role="group" aria-label="{{ __('Illustrations') }}">
             {% if page == 1 and filter is empty %}
                 {# Tile to clear the selection — only shown on the first page with no filter. #}
-                <div
-                    class="col-4 col-sm-3 col-lg-2"
-                    role="button"
+                <button
+                    type="button"
+                    class="col-4 col-sm-3 col-lg-2 illustration-picker-tile"
                     aria-label="{{ __('No illustration') }}"
                     data-bs-dismiss="modal"
                     data-glpi-icon-picker-value=""
@@ -56,12 +56,12 @@
                             <span class="mt-2 small text-center">{{ __("No illustration") }}</span>
                         </div>
                     </div>
-                </div>
+                </button>
             {% endif %}
             {% for icon_id in icon_ids %}
-                <div
-                    class="col-4 col-sm-3 col-lg-2"
-                    role="button"
+                <button
+                    type="button"
+                    class="col-4 col-sm-3 col-lg-2 illustration-picker-tile"
                     aria-label="{{ getIconTitle(icon_id) }}"
                     data-bs-dismiss="modal"
                     data-glpi-icon-picker-value="{{ icon_id }}"
@@ -71,7 +71,7 @@
                             {{ render_illustration(icon_id) }}
                         </div>
                     </div>
-                </div>
+                </button>
             {% endfor %}
         </div>
 

--- a/templates/components/illustration/icon_picker_search_results.html.twig
+++ b/templates/components/illustration/icon_picker_search_results.html.twig
@@ -50,12 +50,12 @@
                     data-bs-dismiss="modal"
                     data-glpi-icon-picker-value=""
                 >
-                    <div class="card border-secondary-hover cursor-pointer rounded">
-                        <div class="card-body h-100 aspect-ratio-1 d-flex flex-column align-items-center justify-content-center text-secondary">
+                    <span class="card border-secondary-hover cursor-pointer rounded">
+                        <span class="card-body h-100 aspect-ratio-1 d-flex flex-column align-items-center justify-content-center text-secondary">
                             <i class="ti ti-photo-off fs-1" aria-hidden="true"></i>
                             <span class="mt-2 small text-center">{{ __("No illustration") }}</span>
-                        </div>
-                    </div>
+                        </span>
+                    </span>
                 </button>
             {% endif %}
             {% for icon_id in icon_ids %}
@@ -66,11 +66,11 @@
                     data-bs-dismiss="modal"
                     data-glpi-icon-picker-value="{{ icon_id }}"
                 >
-                    <div class="card border-secondary-hover cursor-pointer rounded">
-                        <div class="card-body h-100 aspect-ratio-1">
+                    <span class="card border-secondary-hover cursor-pointer rounded">
+                        <span class="card-body h-100 aspect-ratio-1">
                             {{ render_illustration(icon_id) }}
-                        </div>
-                    </div>
+                        </span>
+                    </span>
                 </button>
             {% endfor %}
         </div>

--- a/tests/e2e/specs/Illustration/illustration_picker.spec.ts
+++ b/tests/e2e/specs/Illustration/illustration_picker.spec.ts
@@ -67,6 +67,41 @@ test.describe('Illustration picker', () => {
         await expect(picker_page.getIllustration('Request a service')).not.toBeAttached();
     });
 
+    test('Can pick an image with the keyboard', async ({ profile, page }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const picker_page = new IllustrationPickerPage(page);
+        await picker_page.gotoFormServiceCatalogTab(form_id);
+
+        // The trigger must be focusable and driven by Enter.
+        await picker_page.select_illustration_button.press('Enter');
+        await expect(picker_page.picker_modal).toBeVisible();
+        await expect(picker_page.picker_modal).toHaveAttribute('data-cy-shown', 'true');
+
+        // The tabs must be focusable, so that the upload pane can be reached
+        // with the arrow keys.
+        const illustrations_tab = picker_page.picker_modal.getByRole('tab', {
+            name: 'Pick an illustration',
+        });
+        await illustrations_tab.focus();
+        await expect(illustrations_tab).toBeFocused();
+        await illustrations_tab.press('ArrowRight');
+        await expect(picker_page.picker_modal.getByRole('button', {
+            name: 'Use selected file',
+        })).toBeVisible();
+
+        // Back to the illustrations, then pick one with Enter.
+        await picker_page.picker_modal.getByRole('tab', {
+            name: 'Upload your own illustration',
+        }).press('ArrowLeft');
+        await picker_page.picker_modal.getByRole('button', {
+            name: 'Cartridge',
+            exact: true,
+        }).press('Enter');
+
+        await expect(picker_page.picker_modal).toHaveAttribute('data-cy-shown', 'false');
+        await expect(picker_page.getIllustration('Cartridge')).toBeVisible();
+    });
+
     test('Can use pagination', async ({ profile, page }) => {
         await profile.set(Profiles.SuperAdmin);
         const picker_page = new IllustrationPickerPage(page);

--- a/tests/e2e/specs/Illustration/illustration_picker.spec.ts
+++ b/tests/e2e/specs/Illustration/illustration_picker.spec.ts
@@ -72,13 +72,15 @@ test.describe('Illustration picker', () => {
         const picker_page = new IllustrationPickerPage(page);
         await picker_page.gotoFormServiceCatalogTab(form_id);
 
-        // The trigger must be focusable and driven by Enter.
+        // Trigger: focusable and driven by Enter.
         await picker_page.select_illustration_button.press('Enter');
         await expect(picker_page.picker_modal).toBeVisible();
         await expect(picker_page.picker_modal).toHaveAttribute('data-cy-shown', 'true');
 
-        // The tabs must be focusable, so that the upload pane can be reached
-        // with the arrow keys.
+        // Autofocus proves the controller ran, unlike `data-cy-shown`.
+        await expect(picker_page.search_input).toBeFocused();
+
+        // Tabs must be focusable for the arrows to reach the upload pane.
         const illustrations_tab = picker_page.picker_modal.getByRole('tab', {
             name: 'Pick an illustration',
         });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- It fixes https://github.com/glpi-project/roadmap/issues/469
- Here is a brief description of what this PR does : fix non accessible illustration picker (use of div instead of button).



