### PR TITLE
fix: allow multiple file selection for File question type in Forms

### DIFF
--- a/src/Glpi/Form/QuestionType/QuestionTypeFile.php
+++ b/src/Glpi/Form/QuestionType/QuestionTypeFile.php
@@ -78,6 +78,7 @@ final class QuestionTypeFile extends AbstractQuestionType implements FormQuestio
                     'no_label'       : true,
                     'full_width'     : true,
                     'mb'             : '',
+                    'multiple'       : true,
                 }
             ) }}
 TWIG;
@@ -109,6 +110,7 @@ TWIG;
                     'no_label'             : true,
                     'full_width'           : true,
                     'mb'                   : '',
+                    'multiple'             : true,
                 }
             ) }}
 TWIG;

--- a/tests/functional/Glpi/Form/QuestionType/QuestionTypeFileTest.php
+++ b/tests/functional/Glpi/Form/QuestionType/QuestionTypeFileTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Form\QuestionType;
+
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Tests\DbTestCase;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class QuestionTypeFileTest extends DbTestCase
+{
+    use FormTesterTrait;
+
+    private function createFileQuestion(): Question
+    {
+        $builder = new FormBuilder();
+        $builder->addQuestion("File", QuestionTypeFile::class);
+        $form = $this->createForm($builder);
+
+        $questions = array_filter(
+            $form->getQuestions(),
+            fn($question) => $question->fields['name'] === "File"
+        );
+
+        $question = array_pop($questions);
+
+        $this->assertInstanceOf(Question::class, $question, 'File question must be created');
+
+        return $question;
+    }
+
+    public static function providerRenderMethod(): iterable
+    {
+        yield 'end user template' => ['renderEndUserTemplate'];
+        yield 'administration template' => ['renderAdministrationTemplate'];
+    }
+
+    #[DataProvider('providerRenderMethod')]
+    public function testTemplateRendersFileInputWithMultipleAttribute(string $render_method): void
+    {
+        $question = $this->createFileQuestion();
+
+        $html = (new QuestionTypeFile())->$render_method($question);
+
+        $this->assertStringContainsString("type='file'", $html, 'File input must be of type file');
+        $this->assertStringContainsString("multiple='multiple'", $html, 'File input must allow selecting multiple files via the native file picker');
+    }
+}

--- a/tests/functional/HtmlTest.php
+++ b/tests/functional/HtmlTest.php
@@ -1614,4 +1614,23 @@ SCSS,
 
         $this->assertStringContainsString('Selection too large, massive action disabled.', $output);
     }
+
+    public function testFileWithoutMultipleOptionDoesNotRenderMultipleAttribute(): void
+    {
+        $result = Html::file([
+            'display' => false,
+        ]);
+
+        $this->assertStringNotContainsString("multiple='multiple'", $result);
+    }
+
+    public function testFileWithMultipleOptionRendersMultipleAttribute(): void
+    {
+        $result = Html::file([
+            'display'  => false,
+            'multiple' => true,
+        ]);
+
+        $this->assertStringContainsString("multiple='multiple'", $result);
+    }
 }


### PR DESCRIPTION
## Description

Forms "File" question type only allowed selecting one file at a time via the browser's native file picker, even though drag and drop of multiple files already worked and the backend already supports it (`QuestionTypeFile::prepareEndUserAnswer()` loops over the answer array, creating one Document per file).

Root cause: the Twig templates in `QuestionTypeFile` never passed the `multiple` option down to `Html::file()`, so the `<input type="file">` never got the `multiple` attribute. `imageGalleryField` already relies on this same option via the same macro chain, so this brings `QuestionTypeFile` in line with existing, working behavior.

## Changes

- `src/Glpi/Form/QuestionType/QuestionTypeFile.php`: added `'multiple': true` in both `renderAdministrationTemplate()` and `renderEndUserTemplate()`
- Added `tests/functional/Glpi/Form/QuestionType/QuestionTypeFileTest.php`
- Added regression tests in `tests/functional/HtmlTest.php` proving  `Html::file()`'s default (no `multiple` option) is unaffected, so every other consumer of this shared function keeps single-file behavior.

## Test plan

- [x] `phpunit` on the new/modified test files
- [x] Manual: admin File question default value picker allows multi-select
- [x] Manual: end-user form submission with multiple files creates one Document per file

Fixes #25158