### PR TITLE
Fix: cache custom illustrations and prevent id collisions

### DIFF
--- a/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
+++ b/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
@@ -45,6 +45,8 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class CustomIllustrationController extends AbstractController
 {
+    private const CACHE_MAX_AGE = 60 * 60 * 24 * 365;
+
     public function __construct(
         private IllustrationManager $illustration_manager
     ) {}
@@ -62,7 +64,21 @@ final class CustomIllustrationController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        // Read parameters
-        return new BinaryFileResponse($file);
+        // Clear the no-cache headers sent by the session cache limiter, Symfony only appends its own.
+        header_remove('Cache-Control');
+        header_remove('Expires');
+        header_remove('Pragma');
+
+        // Id is immutable per upload (see UploadController), safe to cache long-term.
+        $response = new BinaryFileResponse($file);
+        $response->setAutoEtag();
+        $response->setAutoLastModified();
+        $response->setCache([
+            'private' => true,
+            'immutable' => true,
+            'max_age' => self::CACHE_MAX_AGE,
+        ]);
+
+        return $response;
     }
 }

--- a/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
+++ b/src/Glpi/Controller/UI/Illustration/CustomIllustrationController.php
@@ -40,6 +40,7 @@ use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Glpi\UI\IllustrationManager;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -57,7 +58,7 @@ final class CustomIllustrationController extends AbstractController
         name: "glpi_ui_illustration_custom_illustration",
         methods: "GET",
     )]
-    public function __invoke(string $id): Response
+    public function __invoke(string $id, Request $request): Response
     {
         $file = $this->illustration_manager->getCustomIllustrationFile($id);
         if (!$file) {
@@ -78,6 +79,9 @@ final class CustomIllustrationController extends AbstractController
             'immutable' => true,
             'max_age' => self::CACHE_MAX_AGE,
         ]);
+
+        // Turns the response into a 304 when the client's cached ETag/Last-Modified still matches.
+        $response->isNotModified($request);
 
         return $response;
     }

--- a/src/Glpi/Controller/UI/Illustration/UploadController.php
+++ b/src/Glpi/Controller/UI/Illustration/UploadController.php
@@ -71,7 +71,11 @@ final class UploadController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        $this->illustration_manager->saveCustomIllustration($file_name, $file_path);
-        return new JsonResponse(['file' => $file_name]);
+        // Never reuse the client-supplied filename as id: it would let a same-named re-upload overwrite this one at the same cached URL.
+        $extension = pathinfo($file_name, PATHINFO_EXTENSION);
+        $illustration_id = uniqid('', true) . ($extension !== '' ? ".$extension" : '');
+
+        $this->illustration_manager->saveCustomIllustration($illustration_id, $file_path);
+        return new JsonResponse(['file' => $illustration_id]);
     }
 }

--- a/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
+++ b/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
@@ -38,6 +38,7 @@ use Glpi\Controller\UI\Illustration\CustomIllustrationController;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Tests\DbTestCase;
 use Glpi\UI\IllustrationManager;
+use Symfony\Component\HttpFoundation\Request;
 
 final class CustomIllustrationControllerTest extends DbTestCase
 {
@@ -54,7 +55,7 @@ final class CustomIllustrationControllerTest extends DbTestCase
         $this->saveFixtureIllustration('foo.png', $id);
 
         $controller = new CustomIllustrationController(new IllustrationManager());
-        $response = $controller->__invoke($id);
+        $response = $controller->__invoke($id, new Request());
 
         // private: route is authenticated, must not be cached by shared/proxy caches
         $this->assertTrue($response->headers->hasCacheControlDirective('private'));
@@ -72,6 +73,6 @@ final class CustomIllustrationControllerTest extends DbTestCase
         $this->expectException(BadRequestHttpException::class);
 
         $controller = new CustomIllustrationController(new IllustrationManager());
-        $controller->__invoke('unknown-illustration-id.png');
+        $controller->__invoke('unknown-illustration-id.png', new Request());
     }
 }

--- a/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
+++ b/tests/functional/Glpi/Controller/UI/Illustration/CustomIllustrationControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\UI\Illustration;
+
+use Glpi\Controller\UI\Illustration\CustomIllustrationController;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Tests\DbTestCase;
+use Glpi\UI\IllustrationManager;
+
+final class CustomIllustrationControllerTest extends DbTestCase
+{
+    private function saveFixtureIllustration(string $fixture, string $id): void
+    {
+        $tmp_path = GLPI_TMP_DIR . "/$id";
+        copy(GLPI_ROOT . "/tests/fixtures/uploads/$fixture", $tmp_path);
+        (new IllustrationManager())->saveCustomIllustration($id, $tmp_path);
+    }
+
+    public function testResponseIsCacheableForOneYear(): void
+    {
+        $id = 'custom-illustration-controller-test.png';
+        $this->saveFixtureIllustration('foo.png', $id);
+
+        $controller = new CustomIllustrationController(new IllustrationManager());
+        $response = $controller->__invoke($id);
+
+        // private: route is authenticated, must not be cached by shared/proxy caches
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('immutable'));
+        $this->assertEquals(
+            60 * 60 * 24 * 365,
+            (int) $response->headers->getCacheControlDirective('max-age')
+        );
+        $this->assertNotEmpty($response->getEtag());
+        $this->assertNotNull($response->getLastModified());
+    }
+
+    public function testUnknownIdThrowsBadRequest(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+
+        $controller = new CustomIllustrationController(new IllustrationManager());
+        $controller->__invoke('unknown-illustration-id.png');
+    }
+}

--- a/tests/functional/Glpi/Controller/UI/Illustration/UploadControllerTest.php
+++ b/tests/functional/Glpi/Controller/UI/Illustration/UploadControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\UI\Illustration;
+
+use Glpi\Controller\UI\Illustration\UploadController;
+use Glpi\Tests\DbTestCase;
+use Glpi\UI\IllustrationManager;
+use Symfony\Component\HttpFoundation\Request;
+
+final class UploadControllerTest extends DbTestCase
+{
+    private function copyFixtureToTmpDir(string $fixture, string $tmp_name): string
+    {
+        $tmp_path = GLPI_TMP_DIR . "/$tmp_name";
+        copy(GLPI_ROOT . "/tests/fixtures/uploads/$fixture", $tmp_path);
+        return $tmp_path;
+    }
+
+    public function testUploadedIdDoesNotReuseClientSuppliedFilename(): void
+    {
+        $this->copyFixtureToTmpDir('foo.png', 'logo.png');
+
+        $controller = new UploadController(new IllustrationManager());
+        $request = Request::create('/UI/Illustration/Upload', 'POST', ['filename' => 'logo.png']);
+        $response = $controller->__invoke($request);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertArrayHasKey('file', $data);
+        $this->assertNotEquals('logo.png', $data['file']);
+        $this->assertStringEndsWith('.png', $data['file']);
+    }
+
+    public function testUploadingSameOriginalFilenameTwiceDoesNotOverwritePreviousIllustration(): void
+    {
+        $this->copyFixtureToTmpDir('foo.png', 'logo.png');
+        $controller = new UploadController(new IllustrationManager());
+        $first_response = $controller->__invoke(
+            Request::create('/UI/Illustration/Upload', 'POST', ['filename' => 'logo.png'])
+        );
+        $first_id = json_decode($first_response->getContent(), true)['file'];
+
+        $this->copyFixtureToTmpDir('bar.png', 'logo.png');
+        $second_response = $controller->__invoke(
+            Request::create('/UI/Illustration/Upload', 'POST', ['filename' => 'logo.png'])
+        );
+        $second_id = json_decode($second_response->getContent(), true)['file'];
+
+        $manager = new IllustrationManager();
+        $this->assertNotEquals($first_id, $second_id);
+        $this->assertEquals(
+            md5_file(GLPI_ROOT . '/tests/fixtures/uploads/foo.png'),
+            md5_file($manager->getCustomIllustrationFile($first_id))
+        );
+        $this->assertEquals(
+            md5_file(GLPI_ROOT . '/tests/fixtures/uploads/bar.png'),
+            md5_file($manager->getCustomIllustrationFile($second_id))
+        );
+    }
+}


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
- It fixes:
  - !45968
  - #25102
  - #25203

Custom illustration uploads reused the client-supplied filename as the storage id, so a same-named re-upload could silently overwrite a different illustration at the same cached URL.
The illustration endpoint also sent no caching headers, forcing browsers to reload it on every page.
Uploads now get a unique, content-immutable id, and the endpoint returns long-lived private/immutable Cache-Control headers with an ETag and Last-Modified.

## Screenshots (if appropriate):


