### PR TITLE
Fix missing height on service catalog header

### DIFF
--- a/templates/pages/self-service/service_catalog.html.twig
+++ b/templates/pages/self-service/service_catalog.html.twig
@@ -39,7 +39,7 @@
 {% set icons = sort_strategies|map((value) => value.getIcon()) %}
 
 {% block content_title %}
-    <div class="d-flex">
+    <div class="d-flex w-full">
         <ol
             data-breadcrumbs-container
             class="breadcrumb breadcrumb-alternate"


### PR DESCRIPTION
I've noticed that the service catalog header was not displayed correctly on main.

Before:
<img width="1356" height="371" alt="image" src="https://github.com/user-attachments/assets/e5263a99-d249-46b1-9bc7-ef8f8389f08b" />

After:
<img width="1327" height="276" alt="image" src="https://github.com/user-attachments/assets/b55022fe-f627-4f62-830b-69e9548141f8" />
