### PR TITLE
Refactor : Migrate CommonITILObject statistics tab HTML to Twig templates

### DIFF
--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5654,26 +5654,15 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function showStatsDates()
     {
-        $rand = mt_rand();
-        echo "<h2 class='header lh-base' id='stats_dates_$rand'>" . _sn('Date', 'Dates', Session::getPluralNumber()) . "</h2>";
-        echo "<table class='tab_cadre_fixe' aria-labelledby='stats_dates_$rand'>";
-
-        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Opening date') . "</th>";
-        echo "<td>" . htmlescape(Html::convDateTime($this->fields['date'])) . "</td></tr>";
-
-        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Time to resolve') . "</th>";
-        echo "<td>" . htmlescape(Html::convDateTime($this->fields['time_to_resolve'])) . "</td></tr>";
-
-        if (!$this->isNotSolved()) {
-            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Resolution date') . "</th>";
-            echo "<td>" . htmlescape(Html::convDateTime($this->fields['solvedate'])) . "</td></tr>";
-        }
-
-        if (in_array($this->fields['status'], static::getClosedStatusArray())) {
-            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Closing date') . "</th>";
-            echo "<td>" . htmlescape(Html::convDateTime($this->fields['closedate'])) . "</td></tr>";
-        }
-        echo "</table>";
+        // Row presence depends on the status; its value may be empty.
+        TemplateRenderer::getInstance()->display('components/itilobject/stats_dates.html.twig', [
+            'opening_date'    => Html::convDateTime($this->fields['date']),
+            'time_to_resolve' => Html::convDateTime($this->fields['time_to_resolve']),
+            'is_solved'       => !$this->isNotSolved(),
+            'solve_date'      => Html::convDateTime($this->fields['solvedate']),
+            'is_closed'       => in_array($this->fields['status'], static::getClosedStatusArray()),
+            'close_date'      => Html::convDateTime($this->fields['closedate']),
+        ]);
     }
 
     /**
@@ -5681,52 +5670,27 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function showStatsTimes()
     {
-        echo "<div class='dates_timelines'>";
-        $rand = mt_rand();
-        echo "<h2 class='header lh-base' id='stats_times_$rand'>" . _sn('Time', 'Times', Session::getPluralNumber()) . "</h2>";
-        echo "<table class='tab_cadre_fixe' aria-labelledby='stats_times_$rand'>";
+        $has_takeintoaccount = isset($this->fields['takeintoaccount_delay_stat']);
+        $is_solved           = !$this->isNotSolved();
+        $is_closed           = in_array($this->fields['status'], static::getClosedStatusArray());
 
-        if (isset($this->fields['takeintoaccount_delay_stat'])) {
-            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Take into account') . "</th><td>";
-            if ($this->fields['takeintoaccount_delay_stat'] > 0) {
-                echo htmlescape(Html::timestampToString($this->fields['takeintoaccount_delay_stat'], false, false));
-            } else {
-                echo '&nbsp;';
-            }
-            echo "</td></tr>";
-        }
-
-        if (!$this->isNotSolved()) {
-            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Resolution') . "</th><td>";
-
-            if ($this->fields['solve_delay_stat'] > 0) {
-                echo htmlescape(Html::timestampToString($this->fields['solve_delay_stat'], false, false));
-            } else {
-                echo '&nbsp;';
-            }
-            echo "</td></tr>";
-        }
-
-        if (in_array($this->fields['status'], static::getClosedStatusArray())) {
-            echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Closure') . "</th><td>";
-            if ($this->fields['close_delay_stat'] > 0) {
-                echo htmlescape(Html::timestampToString($this->fields['close_delay_stat'], true, false));
-            } else {
-                echo '&nbsp;';
-            }
-            echo "</td></tr>";
-        }
-
-        echo "<tr class='tab_bg_2'><th scope='row'>" . __s('Pending') . "</th><td>";
-        if ($this->fields['waiting_duration'] > 0) {
-            echo htmlescape(Html::timestampToString($this->fields['waiting_duration'], false, false));
-        } else {
-            echo '&nbsp;';
-        }
-        echo "</td></tr>";
-
-        echo "</table>";
-        echo "</div>";
+        TemplateRenderer::getInstance()->display('components/itilobject/stats_times.html.twig', [
+            'has_takeintoaccount' => $has_takeintoaccount,
+            'takeintoaccount'     => $has_takeintoaccount && $this->fields['takeintoaccount_delay_stat'] > 0
+                ? Html::timestampToString($this->fields['takeintoaccount_delay_stat'], false, false)
+                : null,
+            'is_solved'           => $is_solved,
+            'resolution'          => $is_solved && $this->fields['solve_delay_stat'] > 0
+                ? Html::timestampToString($this->fields['solve_delay_stat'], false, false)
+                : null,
+            'is_closed'           => $is_closed,
+            'closure'             => $is_closed && $this->fields['close_delay_stat'] > 0
+                ? Html::timestampToString($this->fields['close_delay_stat'], true, false)
+                : null,
+            'pending'             => $this->fields['waiting_duration'] > 0
+                ? Html::timestampToString($this->fields['waiting_duration'], false, false)
+                : null,
+        ]);
     }
 
 

--- a/src/CommonITILObject.php
+++ b/src/CommonITILObject.php
@@ -5654,14 +5654,17 @@ abstract class CommonITILObject extends CommonDBTM implements KanbanInterface, T
      */
     public function showStatsDates()
     {
+        $is_solved = !$this->isNotSolved();
+        $is_closed = in_array($this->fields['status'], static::getClosedStatusArray());
+
         // Row presence depends on the status; its value may be empty.
         TemplateRenderer::getInstance()->display('components/itilobject/stats_dates.html.twig', [
             'opening_date'    => Html::convDateTime($this->fields['date']),
             'time_to_resolve' => Html::convDateTime($this->fields['time_to_resolve']),
-            'is_solved'       => !$this->isNotSolved(),
-            'solve_date'      => Html::convDateTime($this->fields['solvedate']),
-            'is_closed'       => in_array($this->fields['status'], static::getClosedStatusArray()),
-            'close_date'      => Html::convDateTime($this->fields['closedate']),
+            'is_solved'       => $is_solved,
+            'solve_date'      => $is_solved ? Html::convDateTime($this->fields['solvedate']) : null,
+            'is_closed'       => $is_closed,
+            'close_date'      => $is_closed ? Html::convDateTime($this->fields['closedate']) : null,
         ]);
     }
 

--- a/templates/components/itilobject/stats_dates.html.twig
+++ b/templates/components/itilobject/stats_dates.html.twig
@@ -1,0 +1,43 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+{% set rand = random() %}
+<h2 class="header lh-base" id="stats_dates_{{ rand }}">{{ _n('Date', 'Dates', get_plural_number()) }}</h2>
+<table class="tab_cadre_fixe" aria-labelledby="stats_dates_{{ rand }}">
+    <tr class="tab_bg_2"><th scope="row">{{ __('Opening date') }}</th><td>{{ opening_date }}</td></tr>
+    <tr class="tab_bg_2"><th scope="row">{{ __('Time to resolve') }}</th><td>{{ time_to_resolve }}</td></tr>
+    {% if is_solved %}
+        <tr class="tab_bg_2"><th scope="row">{{ __('Resolution date') }}</th><td>{{ solve_date }}</td></tr>
+    {% endif %}
+    {% if is_closed %}
+        <tr class="tab_bg_2"><th scope="row">{{ __('Closing date') }}</th><td>{{ close_date }}</td></tr>
+    {% endif %}
+</table>

--- a/templates/components/itilobject/stats_times.html.twig
+++ b/templates/components/itilobject/stats_times.html.twig
@@ -1,0 +1,55 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+<div class="dates_timelines">
+    {% set rand = random() %}
+    <h2 class="header lh-base" id="stats_times_{{ rand }}">{{ _n('Time', 'Times', get_plural_number()) }}</h2>
+    <table class="tab_cadre_fixe" aria-labelledby="stats_times_{{ rand }}">
+        {% if has_takeintoaccount %}
+            <tr class="tab_bg_2"><th scope="row">{{ __('Take into account') }}</th><td>
+                {%- if takeintoaccount is not null %}{{ takeintoaccount }}{% else %}&nbsp;{% endif -%}
+            </td></tr>
+        {% endif %}
+        {% if is_solved %}
+            <tr class="tab_bg_2"><th scope="row">{{ __('Resolution') }}</th><td>
+                {%- if resolution is not null %}{{ resolution }}{% else %}&nbsp;{% endif -%}
+            </td></tr>
+        {% endif %}
+        {% if is_closed %}
+            <tr class="tab_bg_2"><th scope="row">{{ __('Closure') }}</th><td>
+                {%- if closure is not null %}{{ closure }}{% else %}&nbsp;{% endif -%}
+            </td></tr>
+        {% endif %}
+        <tr class="tab_bg_2"><th scope="row">{{ __('Pending') }}</th><td>
+            {%- if pending is not null %}{{ pending }}{% else %}&nbsp;{% endif -%}
+        </td></tr>
+    </table>
+</div>

--- a/tests/e2e/specs/Itil/stats_tab_rendering.spec.ts
+++ b/tests/e2e/specs/Itil/stats_tab_rendering.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { expect, test } from '../../fixtures/glpi_fixture';
+import { GlpiPage } from '../../pages/GlpiPage';
+import { Profiles } from '../../utils/Profiles';
+import { getWorkerEntityId } from '../../utils/WorkerEntities';
+
+test.describe('Problem statistics tab', () => {
+    let glpi_page: GlpiPage;
+    let problem_id: number;
+
+    test.beforeEach(async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        glpi_page = new GlpiPage(page);
+
+        problem_id = await api.createItem('Problem', {
+            name: `Stats tab problem - ${randomUUID()}`,
+            content: 'Problem used to check the statistics tab rendering',
+            entities_id: getWorkerEntityId(),
+        });
+    });
+
+    test('Statistics tab renders both dates and times tables', async ({ page }) => {
+        await page.goto(`/front/problem.form.php?id=${problem_id}`);
+        // A real click exercises the AJAX tab load, unlike a forcetab URL.
+        await glpi_page.doGoToTab('Statistics');
+
+        // Dates table (stats_dates.html.twig).
+        await expect(page.getByRole('heading', { name: 'Dates', level: 2, exact: true })).toBeVisible();
+        await expect(page.getByRole('rowheader', { name: 'Opening date', exact: true })).toBeVisible();
+        await expect(page.getByRole('rowheader', { name: 'Time to resolve', exact: true })).toBeVisible();
+
+        // Times table (stats_times.html.twig).
+        await expect(page.getByRole('heading', { name: 'Times', level: 2, exact: true })).toBeVisible();
+        await expect(page.getByRole('rowheader', { name: 'Pending', exact: true })).toBeVisible();
+    });
+});

--- a/tests/functional/CommonITILObjectStatsTest.php
+++ b/tests/functional/CommonITILObjectStatsTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Change;
+use CommonITILObject;
+use Glpi\Tests\DbTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Problem;
+use Ticket;
+
+class CommonITILObjectStatsTest extends DbTestCase
+{
+    /**
+     * Collapses whitespace between tags and uniformises attribute quotes, so a
+     * single-line `echo` can be compared to an indented template. The heading
+     * ids are random (mt_rand()/random()), so they are normalized too.
+     */
+    private function normalizeHtml(string $html): string
+    {
+        $html = preg_replace('/(\s[a-zA-Z-]+)=\'([^\']*)\'/', '$1="$2"', $html);
+        $html = preg_replace('/>\s+</', '><', $html);
+        $html = preg_replace('/(stats_dates_|stats_times_)\d+/', '$1RAND', $html);
+
+        return trim($html);
+    }
+
+    // Ticket overrides showStatsDates() (src/Ticket.php:5406) and does not exercise this code.
+    public static function statsDatesProvider(): iterable
+    {
+        $fields = [
+            'date'            => '2026-01-15 09:30:00',
+            'time_to_resolve' => '2026-01-20 17:00:00',
+            'solvedate'       => null,
+            'closedate'       => null,
+            'solve_delay_stat' => 0,
+            'close_delay_stat' => 0,
+            'waiting_duration' => 0,
+        ];
+
+        foreach ([Change::class, Problem::class] as $itemtype) {
+            yield "$itemtype / nouveau, prise en compte absente" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + ['status' => CommonITILObject::INCOMING],
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr></table>',
+            ];
+
+            yield "$itemtype / nouveau, prise en compte nulle" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + [
+                    'status' => CommonITILObject::INCOMING,
+                    'takeintoaccount_delay_stat' => 0,
+                ],
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr></table>',
+            ];
+
+            yield "$itemtype / pris en compte" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + [
+                    'status' => CommonITILObject::ASSIGNED,
+                    'takeintoaccount_delay_stat' => 300,
+                ],
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr></table>',
+            ];
+
+            yield "$itemtype / resolu" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::SOLVED,
+                    'solvedate' => '2026-01-16 11:00:00',
+                    'takeintoaccount_delay_stat' => 300,
+                    'solve_delay_stat' => 3600,
+                ]),
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr><tr class="tab_bg_2"><th scope="row">Resolution date</th><td>2026-01-16 11:00</td></tr></table>',
+            ];
+
+            yield "$itemtype / cloture apres attente" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::CLOSED,
+                    'solvedate' => '2026-01-16 11:00:00',
+                    'closedate' => '2026-01-17 08:15:00',
+                    'takeintoaccount_delay_stat' => 300,
+                    'solve_delay_stat' => 3600,
+                    'close_delay_stat' => 7200,
+                    'waiting_duration' => 60,
+                ]),
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr><tr class="tab_bg_2"><th scope="row">Resolution date</th><td>2026-01-16 11:00</td></tr><tr class="tab_bg_2"><th scope="row">Closing date</th><td>2026-01-17 08:15</td></tr></table>',
+            ];
+
+            // Closed status but 'NULL' dates: the row is still emitted, with an empty cell.
+            yield "$itemtype / cloture avec dates a NULL" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::CLOSED,
+                    'solvedate' => 'NULL',
+                    'closedate' => 'NULL',
+                    'takeintoaccount_delay_stat' => 300,
+                ]),
+                'expected' => '<h2 class="header lh-base" id="stats_dates_RAND">Dates</h2><table class="tab_cadre_fixe" aria-labelledby="stats_dates_RAND"><tr class="tab_bg_2"><th scope="row">Opening date</th><td>2026-01-15 09:30</td></tr><tr class="tab_bg_2"><th scope="row">Time to resolve</th><td>2026-01-20 17:00</td></tr><tr class="tab_bg_2"><th scope="row">Resolution date</th><td></td></tr><tr class="tab_bg_2"><th scope="row">Closing date</th><td></td></tr></table>',
+            ];
+        }
+    }
+
+    // showStatsTimes() is overridden nowhere (single implementation): all three itemtypes stay covered.
+    public static function statsTimesProvider(): iterable
+    {
+        $fields = [
+            'date'            => '2026-01-15 09:30:00',
+            'time_to_resolve' => '2026-01-20 17:00:00',
+            'solvedate'       => null,
+            'closedate'       => null,
+            'solve_delay_stat' => 0,
+            'close_delay_stat' => 0,
+            'waiting_duration' => 0,
+        ];
+
+        foreach ([Ticket::class, Change::class, Problem::class] as $itemtype) {
+            // Field absent: the 'Take into account' row is not emitted at all.
+            yield "$itemtype / nouveau, prise en compte absente" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + ['status' => CommonITILObject::INCOMING],
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Pending</th><td>&nbsp;</td></tr></table></div>',
+            ];
+
+            // Field present but zero: the row is emitted with &nbsp;.
+            yield "$itemtype / nouveau, prise en compte nulle" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + [
+                    'status' => CommonITILObject::INCOMING,
+                    'takeintoaccount_delay_stat' => 0,
+                ],
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Take into account</th><td>&nbsp;</td></tr><tr class="tab_bg_2"><th scope="row">Pending</th><td>&nbsp;</td></tr></table></div>',
+            ];
+
+            yield "$itemtype / pris en compte" => [
+                'itemtype' => $itemtype,
+                'fields'   => $fields + [
+                    'status' => CommonITILObject::ASSIGNED,
+                    'takeintoaccount_delay_stat' => 300,
+                ],
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Take into account</th><td>5 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Pending</th><td>&nbsp;</td></tr></table></div>',
+            ];
+
+            yield "$itemtype / resolu" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::SOLVED,
+                    'solvedate' => '2026-01-16 11:00:00',
+                    'takeintoaccount_delay_stat' => 300,
+                    'solve_delay_stat' => 3600,
+                ]),
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Take into account</th><td>5 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Resolution</th><td>1 hours 0 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Pending</th><td>&nbsp;</td></tr></table></div>',
+            ];
+
+            yield "$itemtype / cloture apres attente" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::CLOSED,
+                    'solvedate' => '2026-01-16 11:00:00',
+                    'closedate' => '2026-01-17 08:15:00',
+                    'takeintoaccount_delay_stat' => 300,
+                    'solve_delay_stat' => 3600,
+                    'close_delay_stat' => 7200,
+                    'waiting_duration' => 60,
+                ]),
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Take into account</th><td>5 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Resolution</th><td>1 hours 0 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Closure</th><td>2 hours 0 minutes 0 seconds</td></tr><tr class="tab_bg_2"><th scope="row">Pending</th><td>1 minute</td></tr></table></div>',
+            ];
+
+            // Resolution and Closure at zero: both rows emit &nbsp; (else branches not covered elsewhere).
+            yield "$itemtype / cloture sans duree" => [
+                'itemtype' => $itemtype,
+                'fields'   => array_merge($fields, [
+                    'status'    => CommonITILObject::CLOSED,
+                    'solvedate' => '2026-01-16 11:00:00',
+                    'closedate' => '2026-01-17 08:15:00',
+                    'takeintoaccount_delay_stat' => 300,
+                    'solve_delay_stat' => 0,
+                    'close_delay_stat' => 0,
+                ]),
+                'expected' => '<div class="dates_timelines"><h2 class="header lh-base" id="stats_times_RAND">Times</h2><table class="tab_cadre_fixe" aria-labelledby="stats_times_RAND"><tr class="tab_bg_2"><th scope="row">Take into account</th><td>5 minutes</td></tr><tr class="tab_bg_2"><th scope="row">Resolution</th><td>&nbsp;</td></tr><tr class="tab_bg_2"><th scope="row">Closure</th><td>&nbsp;</td></tr><tr class="tab_bg_2"><th scope="row">Pending</th><td>&nbsp;</td></tr></table></div>',
+            ];
+        }
+    }
+
+    /**
+     * Creates an item and overwrites its fields in memory (the only way to get a
+     * deterministic output and to reach the "field absent" branch), then captures $method.
+     */
+    private function captureStats(string $itemtype, array $fields, string $method): string
+    {
+        $this->login();
+
+        // Pin date format and plural number, otherwise the reference depends on local config.
+        $_SESSION['glpidate_format']  = 0;
+        $_SESSION['glpipluralnumber'] = 2;
+
+        $item = $this->createItem($itemtype, [
+            'name'        => 'Stats reference item',
+            'content'     => 'Stats reference content',
+            'entities_id' => $this->getTestRootEntity(only_id: true),
+        ]);
+        $this->assertInstanceOf(CommonITILObject::class, $item);
+
+        $item->fields = array_merge($item->fields, $fields);
+        foreach (['takeintoaccount_delay_stat'] as $optional) {
+            if (!array_key_exists($optional, $fields)) {
+                unset($item->fields[$optional]);
+            }
+        }
+
+        ob_start();
+        $item->$method();
+        $html = ob_get_clean();
+
+        return $this->normalizeHtml($html);
+    }
+
+    #[DataProvider('statsDatesProvider')]
+    public function testShowStatsDatesOutputIsStable(string $itemtype, array $fields, string $expected): void
+    {
+        $this->assertSame($expected, $this->captureStats($itemtype, $fields, 'showStatsDates'));
+    }
+
+    #[DataProvider('statsTimesProvider')]
+    public function testShowStatsTimesOutputIsStable(string $itemtype, array $fields, string $expected): void
+    {
+        $this->assertSame($expected, $this->captureStats($itemtype, $fields, 'showStatsTimes'));
+    }
+}

--- a/tests/functional/CommonITILObjectStatsTest.php
+++ b/tests/functional/CommonITILObjectStatsTest.php
@@ -241,9 +241,13 @@ class CommonITILObjectStatsTest extends DbTestCase
             }
         }
 
+        // finally: a template error must surface as itself, not as a leaked buffer.
         ob_start();
-        $item->$method();
-        $html = ob_get_clean();
+        try {
+            $item->$method();
+        } finally {
+            $html = ob_get_clean();
+        }
 
         return $this->normalizeHtml($html);
     }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes https://github.com/glpi-project/glpi/issues/25257
- Here is a brief description of what this PR does : Take the echoed HTML from the class to a Twig template, and provide test for it.

Tested live with same dataset on Tickets / Changes / Problems from two separate instance (one with the migration to Twig the other no), with no noticeable issue. Best maintenability on the future for this tab.

