### PR TITLE
Uninstalling a plugin with lots of cron task logs will take minutes

### DIFF
--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -124,8 +124,9 @@ class CronTask extends CommonDBTM
     {
         global $DB;
 
-        // Delete related CronTaskLog.
-        // It cannot be done with `deleteChildrenAndRelationsFromDb` because `CronTaskLog` does not extend CommonDBConnexity.
+        // Bulk delete (not deleteByCriteria()): a frequent task can accumulate huge log volumes,
+        // and CronTaskLog has no children/history/delete() so skipping per-row lifecycle event.
+        // `CronTaskLog::cleanOld()` do the same.
         $DB->delete(CronTaskLog::getTable(), ['crontasks_id' => $this->fields['id']]);
     }
 

--- a/src/CronTask.php
+++ b/src/CronTask.php
@@ -122,10 +122,11 @@ class CronTask extends CommonDBTM
 
     public function cleanDBonPurge()
     {
+        global $DB;
+
         // Delete related CronTaskLog.
         // It cannot be done with `deleteChildrenAndRelationsFromDb` because `CronTaskLog` does not extend CommonDBConnexity.
-        $ctl = new CronTaskLog();
-        $ctl->deleteByCriteria(['crontasks_id' => $this->fields['id']]);
+        $DB->delete(CronTaskLog::getTable(), ['crontasks_id' => $this->fields['id']]);
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description
When uninstalling a plugin with lot of cronTaskLog the uninstall process could takes minutes.

For example in my case it had 30k cron task logs lines.

Fix do what `CronTaskLog::cleanOld` was doing with direct $DB call.

## Screenshots (if appropriate):
<img width="552" height="282" alt="Screenshot From 2026-08-26 13-59-18" src="https://github.com/user-attachments/assets/2eec9df5-3293-488f-a7a1-6ae1099edfaf" />

### After
I took a few second to type `yes`  so now it's instant
<img width="561" height="206" alt="image" src="https://github.com/user-attachments/assets/503297e8-ba9e-443f-8745-c9afc0a6dfd3" />