### PR TITLE
Fix / Existing statuses missing from the Agent cleanup configuration

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2991,9 +2991,8 @@ HTML;
                         $ljoin = array_merge($ljoin, $value['LEFT JOIN']);
                     }
                     if (is_array($value) && isset($value['WHERE'])) {
-                        // Combine with OR instead of merging: sub-conditions share identical
-                        // keys (e.g. same table/column), so merging would let each one
-                        // silently overwrite the previous.
+                        // Combine with OR: sub-conditions target different types but must match any one of them,
+                        // and array_merge would silently produce AND instead of the required OR.
                         $or_where[] = $value['WHERE'];
                     } elseif (!is_numeric($key) && !in_array($key, ['AND', 'OR', 'NOT']) && !str_contains($key, '.')) {
                         // Ensure condition contains table name to prevent ambiguity with fields from `glpi_entities` table

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -2985,12 +2985,16 @@ HTML;
             if (isset($condition['WHERE'])) {
                 $where = array_merge($where, $condition['WHERE']);
             } else {
+                $or_where = [];
                 foreach ($condition as $key => $value) {
                     if (is_array($value) && isset($value['LEFT JOIN'])) {
-                        $ljoin = $value['LEFT JOIN'];
+                        $ljoin = array_merge($ljoin, $value['LEFT JOIN']);
                     }
                     if (is_array($value) && isset($value['WHERE'])) {
-                        $where = array_merge($where, $value['WHERE']);
+                        // Combine with OR instead of merging: sub-conditions share identical
+                        // keys (e.g. same table/column), so merging would let each one
+                        // silently overwrite the previous.
+                        $or_where[] = $value['WHERE'];
                     } elseif (!is_numeric($key) && !in_array($key, ['AND', 'OR', 'NOT']) && !str_contains($key, '.')) {
                         // Ensure condition contains table name to prevent ambiguity with fields from `glpi_entities` table
                         $where["$table.$key"] = $value;
@@ -3002,6 +3006,9 @@ HTML;
                         // e.g. to override the default `is_template` / `is_deleted` filtering.
                         $where[$key] = $value;
                     }
+                }
+                if (!empty($or_where)) {
+                    $where[] = ['OR' => $or_where];
                 }
             }
         }

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -3007,7 +3007,7 @@ HTML;
                         $where[$key] = $value;
                     }
                 }
-                if (!empty($or_where)) {
+                if ($or_where !== []) {
                     $where[] = ['OR' => $or_where];
                 }
             }

--- a/tests/functional/StateTest.php
+++ b/tests/functional/StateTest.php
@@ -36,12 +36,14 @@ namespace tests\units;
 
 use CommonDBTM;
 use Computer;
+use Dropdown;
 use DropdownVisibility;
 use Glpi\Features\StateInterface;
 use Glpi\Tests\DbTestCase;
 use Phone;
 use Printer;
 use ReflectionClass;
+use Session;
 
 class StateTest extends DbTestCase
 {
@@ -350,5 +352,54 @@ class StateTest extends DbTestCase
             ['itemtype' => \State::getType(), 'items_id' => $state->getID(), 'visible_itemtype' => $custom_asset->getAssetClassName()],
         ));
 
+    }
+
+    public function testDropdownGetDropdownValueCombinesMultipleVisibilityCriteriaWithOr(): void
+    {
+        // getDropdownValue() used to collapse a list of per-itemtype OR'd conditions
+        // (see Glpi\Inventory\Conf::showConfigForm()) into just the last one via array_merge().
+        $this->login();
+
+        $entities_id = $this->getTestRootEntity(true);
+
+        $state_computer_only = $this->createItem(\State::class, [
+            'name' => __FUNCTION__ . ' computer only',
+            'entities_id' => $entities_id,
+            'is_visible_computer' => 1,
+            'is_visible_phone' => 0,
+        ]);
+        $state_phone_only = $this->createItem(\State::class, [
+            'name' => __FUNCTION__ . ' phone only',
+            'entities_id' => $entities_id,
+            'is_visible_computer' => 0,
+            'is_visible_phone' => 1,
+        ]);
+        $state_neither = $this->createItem(\State::class, [
+            'name' => __FUNCTION__ . ' neither',
+            'entities_id' => $entities_id,
+            'is_visible_computer' => 0,
+            'is_visible_phone' => 0,
+        ]);
+
+        // Mirrors the exact pattern used in Glpi\Inventory\Conf::showConfigForm().
+        $condition = [
+            (new Computer())->getStateVisibilityCriteria(),
+            (new Phone())->getStateVisibilityCriteria(),
+        ];
+        $condition_key = Dropdown::addNewCondition($condition);
+
+        $results = Dropdown::getDropdownValue([
+            'itemtype'            => \State::getType(),
+            'display_emptychoice' => 0,
+            'condition'           => $condition_key,
+            '_idor_token'         => Session::getNewIDORToken(\State::getType(), ['condition' => $condition_key]),
+        ], false)['results'];
+
+        // Results are grouped by entity (single optgroup here, since all test states
+        // belong to the same entity).
+        $names = array_column($results[0]['children'] ?? [], 'text');
+        $this->assertContains($state_computer_only->fields['name'], $names);
+        $this->assertContains($state_phone_only->fields['name'], $names);
+        $this->assertNotContains($state_neither->fields['name'], $names);
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45966
- Old statuses were missing from the "Status to apply" / "If the asset status is" dropdowns in the Agent cleanup cron config — only statuses explicitly configured for one specific asset type showed up, hiding all the others, because of a faulty array_merge() that silently dropped every condition but the last one.
Fixed the underlying logic so a status shows up as soon as it's visible for at least one of the relevant asset types, as intended.

Added a regression test.

## Screenshots :

<img width="1914" height="417" alt="Capture d’écran du 2026-08-26 14-11-39" src="https://github.com/user-attachments/assets/5863827d-ee70-414f-bb52-d086bc4a8c22" />
<img width="566" height="268" alt="Capture d’écran du 2026-08-26 14-11-05" src="https://github.com/user-attachments/assets/e385ae58-3f14-43a0-8d16-95156b4708c0" />




