### PR TITLE
fix(forms): discard unknown actor or associated items strategies in destination config

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -8006,12 +8006,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Condition/Engine.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\$strategies of class Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\AssigneeFieldConfig constructor expects array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\>, array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\|null\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/AssigneeFieldConfig.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getFromDB\\(\\) on CommonDBTM\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -8022,12 +8016,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsField.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\$strategies of class Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\AssociatedItemsFieldConfig constructor expects array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\AssociatedItemsFieldStrategy\\>, array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\AssociatedItemsFieldStrategy\\|null\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Cannot call method getEntityID\\(\\) on Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\EntityFieldStrategy\\|false\\.$#',
@@ -8114,12 +8102,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/LocationField.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\$strategies of class Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ObserverFieldConfig constructor expects array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\>, array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\|null\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/ObserverFieldConfig.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Cannot call method getRequestSource\\(\\) on Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\RequestSourceFieldStrategy\\|false\\.$#',
 	'identifier' => 'method.nonObject',
 	'count' => 1,
@@ -8130,12 +8112,6 @@ $ignoreErrors[] = [
 	'identifier' => 'method.nonObject',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/RequestTypeField.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\$strategies of class Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\RequesterFieldConfig constructor expects array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\>, array\\<Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\ITILActorFieldStrategy\\|null\\> given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Form/Destination/CommonITILField/RequesterFieldConfig.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method Glpi\\\\Form\\\\Destination\\\\CommonITILField\\\\SLATTRField\\:\\:getTimeDefinitionFromLegacy\\(\\) should return string but returns string\\|false\\.$#',

--- a/src/Glpi/Form/Destination/CommonITILField/AssigneeFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssigneeFieldConfig.php
@@ -43,16 +43,8 @@ final class AssigneeFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategies = array_map(
-            fn(string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
-            $data[self::STRATEGIES] ?? []
-        );
-        if ($strategies === []) {
-            $strategies = [ITILActorFieldStrategy::FROM_TEMPLATE];
-        }
-
         return new self(
-            strategies: $strategies,
+            strategies: self::deserializeStrategies($data, ITILActorFieldStrategy::FROM_TEMPLATE),
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
@@ -37,6 +37,7 @@ namespace Glpi\Form\Destination\CommonITILField;
 use CommonITILObject;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
+use Glpi\Form\Destination\DeserializeStrategiesTrait;
 use Glpi\Form\Destination\HasFieldWithQuestionId;
 use Override;
 
@@ -45,6 +46,8 @@ final class AssociatedItemsFieldConfig implements
     JsonFieldInterface,
     ConfigFieldWithStrategiesInterface
 {
+    use DeserializeStrategiesTrait;
+
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGIES = 'strategies';
     public const SPECIFIC_QUESTION_IDS = 'specific_question_ids';
@@ -64,15 +67,11 @@ final class AssociatedItemsFieldConfig implements
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategies = array_values(array_filter(array_map(
-            fn($strategy) => is_scalar($strategy)
-                ? AssociatedItemsFieldStrategy::tryFrom((string) $strategy)
-                : null,
-            $data[self::STRATEGIES] ?? []
-        )));
-
         return new self(
-            strategies: $strategies ?: [AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS],
+            strategies: self::deserializeStrategies(
+                $data,
+                AssociatedItemsFieldStrategy::LAST_VALID_ANSWER
+            ),
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
             specific_associated_items: $data[self::SPECIFIC_ASSOCIATED_ITEMS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldConfig.php
@@ -64,16 +64,15 @@ final class AssociatedItemsFieldConfig implements
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategies = array_map(
-            fn(string $strategy) => AssociatedItemsFieldStrategy::tryFrom($strategy),
+        $strategies = array_values(array_filter(array_map(
+            fn($strategy) => is_scalar($strategy)
+                ? AssociatedItemsFieldStrategy::tryFrom((string) $strategy)
+                : null,
             $data[self::STRATEGIES] ?? []
-        );
-        if ($strategies === []) {
-            $strategies = [AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS];
-        }
+        )));
 
         return new self(
-            strategies: $strategies,
+            strategies: $strategies ?: [AssociatedItemsFieldStrategy::ALL_VALID_ANSWERS],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
             specific_associated_items: $data[self::SPECIFIC_ASSOCIATED_ITEMS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
@@ -37,12 +37,15 @@ namespace Glpi\Form\Destination\CommonITILField;
 
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
+use Glpi\Form\Destination\DeserializeStrategiesTrait;
 use Override;
 
 abstract class ITILActorFieldConfig implements
     JsonFieldInterface,
     ConfigFieldWithStrategiesInterface
 {
+    use DeserializeStrategiesTrait;
+
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGIES              = 'strategies';
     public const SPECIFIC_ITILACTORS_IDS = 'specific_itilactors_ids';
@@ -58,25 +61,6 @@ abstract class ITILActorFieldConfig implements
         private array $specific_itilactors_ids = [],
         private array $specific_question_ids = [],
     ) {}
-
-    /**
-     * @param array<string, mixed> $data
-     *
-     * @return non-empty-array<ITILActorFieldStrategy>
-     */
-    protected static function deserializeStrategies(
-        array $data,
-        ITILActorFieldStrategy $default
-    ): array {
-        $strategies = array_values(array_filter(array_map(
-            fn($strategy) => is_scalar($strategy)
-                ? ITILActorFieldStrategy::tryFrom((string) $strategy)
-                : null,
-            $data[self::STRATEGIES] ?? []
-        )));
-
-        return $strategies ?: [$default];
-    }
 
     #[Override]
     public function jsonSerialize(): array

--- a/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ITILActorFieldConfig.php
@@ -59,6 +59,25 @@ abstract class ITILActorFieldConfig implements
         private array $specific_question_ids = [],
     ) {}
 
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return non-empty-array<ITILActorFieldStrategy>
+     */
+    protected static function deserializeStrategies(
+        array $data,
+        ITILActorFieldStrategy $default
+    ): array {
+        $strategies = array_values(array_filter(array_map(
+            fn($strategy) => is_scalar($strategy)
+                ? ITILActorFieldStrategy::tryFrom((string) $strategy)
+                : null,
+            $data[self::STRATEGIES] ?? []
+        )));
+
+        return $strategies ?: [$default];
+    }
+
     #[Override]
     public function jsonSerialize(): array
     {

--- a/src/Glpi/Form/Destination/CommonITILField/ObserverFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/ObserverFieldConfig.php
@@ -43,16 +43,8 @@ final class ObserverFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategies = array_map(
-            fn(string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
-            $data[self::STRATEGIES] ?? []
-        );
-        if ($strategies === []) {
-            $strategies = [ITILActorFieldStrategy::FROM_TEMPLATE];
-        }
-
         return new self(
-            strategies: $strategies,
+            strategies: self::deserializeStrategies($data, ITILActorFieldStrategy::FROM_TEMPLATE),
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/CommonITILField/RequesterFieldConfig.php
+++ b/src/Glpi/Form/Destination/CommonITILField/RequesterFieldConfig.php
@@ -43,16 +43,8 @@ final class RequesterFieldConfig extends ITILActorFieldConfig
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
-        $strategies = array_map(
-            fn(string $strategy) => ITILActorFieldStrategy::tryFrom($strategy),
-            $data[self::STRATEGIES] ?? []
-        );
-        if ($strategies === []) {
-            $strategies = [ITILActorFieldStrategy::FORM_FILLER];
-        }
-
         return new self(
-            strategies: $strategies,
+            strategies: self::deserializeStrategies($data, ITILActorFieldStrategy::FORM_FILLER),
             specific_itilactors_ids: $data[self::SPECIFIC_ITILACTORS_IDS] ?? [],
             specific_question_ids: $data[self::SPECIFIC_QUESTION_IDS] ?? [],
         );

--- a/src/Glpi/Form/Destination/DeserializeStrategiesTrait.php
+++ b/src/Glpi/Form/Destination/DeserializeStrategiesTrait.php
@@ -43,6 +43,8 @@ use BackedEnum;
 trait DeserializeStrategiesTrait
 {
     /**
+     * @template T of BackedEnum
+     *
      * @param array<string, mixed> $data
      * @param T                    $default
      *

--- a/src/Glpi/Form/Destination/DeserializeStrategiesTrait.php
+++ b/src/Glpi/Form/Destination/DeserializeStrategiesTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @copyright 2003-2014 by the INDEPNET Development Team.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Form\Destination;
+
+use BackedEnum;
+
+/**
+ * Shared strategies deserialization for configs that hold multiple strategies.
+ */
+trait DeserializeStrategiesTrait
+{
+    /**
+     * @param array<string, mixed> $data
+     * @param T                    $default
+     *
+     * @return non-empty-array<T>
+     */
+    protected static function deserializeStrategies(array $data, BackedEnum $default): array
+    {
+        $strategy_class = $default::class;
+        $strategies = array_values(array_filter(array_map(
+            fn($strategy) => is_scalar($strategy)
+                ? $strategy_class::tryFrom((string) $strategy)
+                : null,
+            $data[static::getStrategiesInputName()] ?? []
+        )));
+
+        return $strategies ?: [$default];
+    }
+}

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
@@ -53,6 +53,15 @@ final class AssociatedItemsFieldTest extends AbstractDestinationFieldTest
 {
     use FormTesterTrait;
 
+    public function testDeserializedFallbackMatchesTheFieldDefaultStrategy(): void
+    {
+        $this->assertEquals(
+            (new AssociatedItemsField())->getDefaultConfig($this->createForm(new FormBuilder()))
+                ->getStrategies(),
+            AssociatedItemsFieldConfig::jsonDeserialize([])->getStrategies(),
+        );
+    }
+
     public function testEmptyStrategyValueIsIgnoredWhenDeserializingConfig(): void
     {
         // "0" is the empty value of the strategy dropdown. It may have been

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/AssociatedItemsFieldTest.php
@@ -53,6 +53,22 @@ final class AssociatedItemsFieldTest extends AbstractDestinationFieldTest
 {
     use FormTesterTrait;
 
+    public function testEmptyStrategyValueIsIgnoredWhenDeserializingConfig(): void
+    {
+        // "0" is the empty value of the strategy dropdown. It may have been
+        // stored by a configuration form saved without picking any strategy.
+        $config = AssociatedItemsFieldConfig::jsonDeserialize([
+            AssociatedItemsFieldConfig::STRATEGIES => ['0'],
+        ]);
+
+        // An unknown strategy must be discarded, so the field falls back on its
+        // default strategy instead of exposing a `null` strategy.
+        $this->assertEquals(
+            AssociatedItemsFieldConfig::jsonDeserialize([])->getStrategies(),
+            $config->getStrategies(),
+        );
+    }
+
     public function testAssociatedItemsFromSpecificItems(): void
     {
         $this->login();

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/RequesterFieldTest.php
@@ -630,6 +630,55 @@ final class RequesterFieldTest extends AbstractActorFieldTest
         );
     }
 
+    public function testTicketIsCreatedWhenStoredStrategyIsUnknown(): void
+    {
+        // Login is required to assign actors
+        $this->login();
+
+        $form = $this->createAndGetFormWithMultipleActorsQuestions();
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+
+        // Simulate a destination whose requester strategy was stored as the
+        // empty value of the strategy dropdown. The update is done directly in
+        // database to bypass `prepareInput`, which now rejects such a value.
+        global $DB;
+        $this->assertTrue($DB->update(
+            $destination::getTable(),
+            [
+                'config' => json_encode([
+                    RequesterField::getKey() => [
+                        ITILActorFieldConfig::STRATEGIES => ['0'],
+                        ITILActorFieldConfig::SPECIFIC_ITILACTORS_IDS => null,
+                        ITILActorFieldConfig::SPECIFIC_QUESTION_IDS => null,
+                    ],
+                ]),
+            ],
+            ['id' => $destination->getID()]
+        ));
+
+        // Submit form
+        $answers_handler = AnswersHandler::getInstance();
+        $answers_set = $answers_handler->saveAnswers(
+            $form,
+            [],
+            getItemByTypeName(User::class, TU_USER, true)
+        );
+
+        // The ticket must still be created, with the form filler as requester.
+        $created_items = $answers_set->getCreatedItems();
+        $this->assertCount(1, $created_items);
+        /** @var Ticket $ticket */
+        $ticket = current($created_items);
+        $actors = $ticket->getActorsForType(CommonITILActor::REQUESTER);
+        $this->assertCount(1, $actors);
+        $this->assertEquals(
+            getItemByTypeName(User::class, TU_USER, true),
+            $actors[0]['items_id']
+        );
+    }
+
     #[Override]
     public static function provideConvertFieldConfigFromFormCreator(): iterable
     {

--- a/tests/src/AbstractActorFieldTest.php
+++ b/tests/src/AbstractActorFieldTest.php
@@ -507,6 +507,41 @@ abstract class AbstractActorFieldTest extends AbstractDestinationFieldTest
         );
     }
 
+    public function testEmptyStrategyValueIsIgnoredWhenDeserializingConfig(): void
+    {
+        $config_class = (new ($this->getFieldClass())())->getConfigClass();
+
+        // "0" is the empty value of the strategy dropdown. It may have been
+        // stored by a configuration form saved without picking any strategy.
+        $config = $config_class::jsonDeserialize([
+            ITILActorFieldConfig::STRATEGIES => ['0'],
+        ]);
+
+        // An unknown strategy must be discarded, so the field falls back on its
+        // default strategy instead of exposing a `null` strategy.
+        $this->assertEquals(
+            $config_class::jsonDeserialize([])->getStrategies(),
+            $config->getStrategies(),
+        );
+    }
+
+    public function testEmptyStrategyValueIsDiscardedFromDeserializedStrategies(): void
+    {
+        $config_class = (new ($this->getFieldClass())())->getConfigClass();
+
+        $config = $config_class::jsonDeserialize([
+            ITILActorFieldConfig::STRATEGIES => [
+                '0',
+                ITILActorFieldStrategy::FORM_FILLER->value,
+            ],
+        ]);
+
+        $this->assertEquals(
+            [ITILActorFieldStrategy::FORM_FILLER],
+            $config->getStrategies(),
+        );
+    }
+
     private function createAndGetFormWithItemQuestions(): Form
     {
         $builder = new FormBuilder();


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have read the CONTRIBUTING document.
- [X] I have performed a self-review of my code.
- [X] I have added tests that prove my fix is effective or that my feature works.

## Description

- It fixes !46001

The strategy dropdown submits its empty value (`0`) when a strategy is added through "Combine with another option" without picking one, and nothing rejected it before storage.