### PR TITLE
KB : Fix comment highlight hover on passages split by markup

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -53,8 +53,9 @@
     text-underline-offset: 3px;
     cursor: pointer;
 
+    // Hover is JS-driven: a passage is one element per text node it crosses.
     // A focused thread points at its passage the same way hovering does.
-    &:hover,
+    &.kb-comment-highlight--hovered,
     &.kb-comment-highlight--focused {
         text-decoration-thickness: 3px;
         background-color: var(--tblr-warning-bg-subtle);

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -61,7 +61,7 @@
         background-color: var(--tblr-warning-bg-subtle);
     }
 
-    // Distinct from the :hover wash, so selecting text stays tellable from
+    // Distinct from the --hovered wash, so selecting text stays tellable from
     // merely hovering it.
     &::selection {
         background-color: rgb(var(--tblr-warning-rgb), 0.4);

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -1099,7 +1099,7 @@ export class GlpiKnowbaseArticleController
         // CSS :hover would reach only the fragment under the cursor.
         content_el.addEventListener('mouseover', (e) => {
             const mark = e.target.closest('.kb-comment-highlight');
-            this.#setHoveredComment(mark ? mark.dataset.commentId : null);
+            this.#setHoveredComment(mark?.dataset.commentId ?? null);
         });
 
         content_el.addEventListener('mouseleave', () => {
@@ -1330,6 +1330,8 @@ export class GlpiKnowbaseArticleController
                     this.#syncAnchorQuotes();
                 },
             });
+            // The pointer may already sit on a passage, edit mode being keyboard-reachable.
+            this.#applyHoveredComment();
         } else {
             this.#editor.setEditable(true);
         }

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -119,6 +119,9 @@ export class GlpiKnowbaseArticleController
     /** @type {Array<{id: string, text: string}>} */
     #resolved_anchors = [];
 
+    /** @type {string|null} */
+    #hovered_comment_id = null;
+
     #handleTitleKeydown = (e) => {
         if (e.key === 'Enter') {
             e.preventDefault();
@@ -1092,6 +1095,16 @@ export class GlpiKnowbaseArticleController
             e.preventDefault();
             this.#onHighlightClick(mark.dataset.commentId);
         });
+
+        // CSS :hover would reach only the fragment under the cursor.
+        content_el.addEventListener('mouseover', (e) => {
+            const mark = e.target.closest('.kb-comment-highlight');
+            this.#setHoveredComment(mark ? mark.dataset.commentId : null);
+        });
+
+        content_el.addEventListener('mouseleave', () => {
+            this.#setHoveredComment(null);
+        });
     }
 
     /**
@@ -1136,6 +1149,8 @@ export class GlpiKnowbaseArticleController
             this.#resolved_anchors = content_el
                 ? highlightComments(content_el, this.#comment_anchors)
                 : [];
+            // Marks are rebuilt from scratch, losing the hovered tag.
+            this.#applyHoveredComment();
         }
 
         this.#syncAnchorQuotes();
@@ -1187,6 +1202,36 @@ export class GlpiKnowbaseArticleController
                 .querySelector(`.kb-comment-highlight[data-comment-id="${CSS.escape(comment_id)}"]`)
                 ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
+    }
+
+    /**
+     * @param {string|null} comment_id
+     */
+    #setHoveredComment(comment_id)
+    {
+        if (this.#hovered_comment_id === comment_id) {
+            return;
+        }
+
+        this.#hovered_comment_id = comment_id;
+        this.#applyHoveredComment();
+    }
+
+    #applyHoveredComment()
+    {
+        // Edit-mode decorations would wipe a hand-set class on the next redraw.
+        if (this.#editor) {
+            this.#editor.setCommentHighlightHover(this.#hovered_comment_id);
+            return;
+        }
+
+        const content_el = this.#container.querySelector('[data-glpi-kb-content]');
+        content_el?.querySelectorAll('.kb-comment-highlight').forEach((mark) => {
+            mark.classList.toggle(
+                'kb-comment-highlight--hovered',
+                mark.dataset.commentId === this.#hovered_comment_id
+            );
+        });
     }
 
     #initScheduleVisibilityDialog(modal)

--- a/js/modules/KnowbaseEditor.js
+++ b/js/modules/KnowbaseEditor.js
@@ -457,6 +457,14 @@ class KnowbaseEditor {
     }
 
     /**
+     * Mark `comment_id`'s passage as hovered across all its fragments, or clear it with null.
+     * @param {string|null} comment_id
+     */
+    setCommentHighlightHover(comment_id) {
+        this.#editor?.commands.setCommentHighlightHover(comment_id);
+    }
+
+    /**
      * Anchors whose quoted text is still present in the document.
      * @returns {Array<{id: string, text: string}>}
      */

--- a/js/modules/TipTap/CommentHighlightExtension.js
+++ b/js/modules/TipTap/CommentHighlightExtension.js
@@ -42,6 +42,22 @@ const { Decoration, DecorationSet } = TiptapPMView;
 const comment_highlight_key = new PluginKey('commentHighlight');
 
 /**
+ * Attrs of one decoration; a passage's hovered state is carried by every fragment.
+ * @param {string} comment_id
+ * @param {boolean} is_hovered
+ * @returns {object}
+ */
+function decorationAttrs(comment_id, is_hovered) {
+    return {
+        class: `kb-comment-highlight${is_hovered ? ' kb-comment-highlight--hovered' : ''}`,
+        'data-comment-id': comment_id,
+        role: 'button',
+        tabindex: '0',
+        'aria-label': __('View comment'),
+    };
+}
+
+/**
  * Anchors whose quoted text is still present in the document.
  * @param {object} state - ProseMirror editor state.
  * @returns {Array<{id: string, text: string}>} The text actually located, which can
@@ -111,7 +127,7 @@ const CommentHighlight = Extension.create({
 
     addProseMirrorPlugins() {
         /** Locate one anchor by text search, as done on load and when recovering a lost range. */
-        const locate = (index, anchor) => {
+        const locate = (index, anchor, hovered_id) => {
             const located = locateAnchor(index.text, anchor);
             if (!located) {
                 return null;
@@ -122,21 +138,20 @@ const CommentHighlight = Extension.create({
             for (const { segment, start: seg_start, end: seg_end } of overlaps(index.segments, start, end)) {
                 const from = segment.pos + (seg_start - segment.start);
                 const to = segment.pos + (seg_end - segment.start);
-                decorations.push(Decoration.inline(from, to, {
-                    class: 'kb-comment-highlight',
-                    'data-comment-id': id,
-                    role: 'button',
-                    tabindex: '0',
-                    'aria-label': __('View comment'),
-                }, { comment_id: id }));
+                decorations.push(Decoration.inline(
+                    from,
+                    to,
+                    decorationAttrs(id, id === hovered_id),
+                    { comment_id: id },
+                ));
             }
             return { decorations, resolved: { id, text: index.text.slice(start, end) } };
         };
 
-        const build = (doc) => {
+        const build = (doc, hovered_id) => {
             const anchors = this.storage.anchors;
             if (!anchors || anchors.length === 0) {
-                return { set: DecorationSet.empty, resolved: [] };
+                return { set: DecorationSet.empty, resolved: [], hovered_id };
             }
 
             const index = buildPmTextIndex(doc);
@@ -144,7 +159,7 @@ const CommentHighlight = Extension.create({
             const resolved = [];
 
             for (const anchor of anchors) {
-                const found = locate(index, anchor);
+                const found = locate(index, anchor, hovered_id);
                 if (found === null) {
                     continue;
                 }
@@ -152,7 +167,7 @@ const CommentHighlight = Extension.create({
                 resolved.push(found.resolved);
             }
 
-            return { set: DecorationSet.create(doc, decorations), resolved };
+            return { set: DecorationSet.create(doc, decorations), resolved, hovered_id };
         };
 
         /**
@@ -161,7 +176,7 @@ const CommentHighlight = Extension.create({
         const remap = (old, tr) => {
             const anchors = this.storage.anchors;
             if (!anchors || anchors.length === 0) {
-                return { set: DecorationSet.empty, resolved: [] };
+                return { set: DecorationSet.empty, resolved: [], hovered_id: old.hovered_id };
             }
 
             const surviving = new Map();
@@ -187,24 +202,40 @@ const CommentHighlight = Extension.create({
                     continue;
                 }
                 index ??= buildPmTextIndex(tr.doc);
-                const found = locate(index, anchor);
+                const found = locate(index, anchor, old.hovered_id);
                 if (found !== null) {
                     decorations.push(...found.decorations);
                     resolved.push(found.resolved);
                 }
             }
 
-            return { set: DecorationSet.create(tr.doc, decorations), resolved };
+            return { set: DecorationSet.create(tr.doc, decorations), resolved, hovered_id: old.hovered_id };
+        };
+
+        /** Decoration attrs are immutable, so a hover change recreates them in place. */
+        const rehover = (old, doc, hovered_id) => {
+            const decorations = old.set.find().map((deco) => Decoration.inline(
+                deco.from,
+                deco.to,
+                decorationAttrs(deco.spec.comment_id, deco.spec.comment_id === hovered_id),
+                deco.spec,
+            ));
+            return { set: DecorationSet.create(doc, decorations), resolved: old.resolved, hovered_id };
         };
 
         return [
             new Plugin({
                 key: comment_highlight_key,
                 state: {
-                    init: (_config, state) => build(state.doc),
+                    init: (_config, state) => build(state.doc, null),
                     apply: (tr, old) => {
                         if (tr.getMeta('commentHighlightRefresh')) {
-                            return build(tr.doc);
+                            return build(tr.doc, old.hovered_id);
+                        }
+                        // Distinguish a null hover (nothing hovered) from no meta at all.
+                        const hovered_id = tr.getMeta('commentHighlightHover');
+                        if (hovered_id !== undefined) {
+                            return rehover(old, tr.doc, hovered_id);
                         }
                         if (!tr.docChanged) {
                             return old;
@@ -229,6 +260,13 @@ const CommentHighlight = Extension.create({
                 }
                 if (dispatch) {
                     dispatch(tr.setMeta('commentHighlightRefresh', true));
+                }
+                return true;
+            },
+
+            setCommentHighlightHover: (comment_id) => ({ tr, dispatch }) => {
+                if (dispatch) {
+                    dispatch(tr.setMeta('commentHighlightHover', comment_id));
                 }
                 return true;
             },

--- a/js/modules/TipTap/CommentHighlightExtension.js
+++ b/js/modules/TipTap/CommentHighlightExtension.js
@@ -235,7 +235,8 @@ const CommentHighlight = Extension.create({
                         // Distinguish a null hover (nothing hovered) from no meta at all.
                         const hovered_id = tr.getMeta('commentHighlightHover');
                         if (hovered_id !== undefined) {
-                            return rehover(old, tr.doc, hovered_id);
+                            // A chained command can carry both: map positions before retagging.
+                            return rehover(tr.docChanged ? remap(old, tr) : old, tr.doc, hovered_id);
                         }
                         if (!tr.docChanged) {
                             return old;

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -497,6 +497,16 @@ export class KnowbaseItemPage extends GlpiPage
     }
 
     /**
+     * Computed underline thickness of every highlight fragment, in document order.
+     */
+    public async getCommentHighlightThicknesses(): Promise<string[]>
+    {
+        return this.getCommentHighlights().evaluateAll(
+            (els) => els.map((el) => getComputedStyle(el).textDecorationThickness)
+        );
+    }
+
+    /**
      * Anchor quotes currently displayed on comment threads in the side panel.
      */
     public getCommentAnchorQuotes(): Locator

--- a/tests/e2e/specs/Knowbase/Comments/comment-on-selection.spec.ts
+++ b/tests/e2e/specs/Knowbase/Comments/comment-on-selection.spec.ts
@@ -771,12 +771,12 @@ test.describe('Knowledge Base - Comment on a text selection', () => {
             .poll(() => kb.getCommentHighlightThicknesses())
             .toEqual(['3px', '3px']);
 
-        // And symmetrically, from the heading fragment.
         await page.getByText('Untouched trailing text').hover();
         await expect
             .poll(() => kb.getCommentHighlightThicknesses())
             .toEqual(['2px', '2px']);
 
+        // And symmetrically, from the heading fragment.
         await kb.getCommentHighlights().nth(0).hover();
         await expect
             .poll(() => kb.getCommentHighlightThicknesses())

--- a/tests/e2e/specs/Knowbase/Comments/comment-on-selection.spec.ts
+++ b/tests/e2e/specs/Knowbase/Comments/comment-on-selection.spec.ts
@@ -739,4 +739,114 @@ test.describe('Knowledge Base - Comment on a text selection', () => {
         await page.getByText('Plain body text with nothing anchored').click();
         await expect(neighbour).toHaveCSS('opacity', '1');
     });
+
+    test('Hovering one fragment of a passage spanning two blocks emphasises all of them', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Test hover across blocks',
+            entities_id: getWorkerEntityId(),
+            answer: '<h3>Section title</h3><p>Body sentence here</p><p>Untouched trailing text</p>',
+        });
+        // Across the heading/paragraph boundary: the indexed text has no separator.
+        await api.createItem('KnowbaseItem_Comment', {
+            knowbaseitems_id: id,
+            comment: 'Comment on a two-block passage',
+            anchor_prefix: 'Section ',
+            anchor_exact: 'titleBody sentence',
+            anchor_suffix: ' here',
+            anchor_occurrence: 0,
+        });
+
+        await kb.goto(id);
+        await kb.waitForArticleReady();
+
+        // One element per text node crossed.
+        await expect(kb.getCommentHighlights()).toHaveCount(2);
+        expect(await kb.getCommentHighlightThicknesses()).toEqual(['2px', '2px']);
+
+        await kb.getCommentHighlights().nth(1).hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['3px', '3px']);
+
+        // And symmetrically, from the heading fragment.
+        await page.getByText('Untouched trailing text').hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['2px', '2px']);
+
+        await kb.getCommentHighlights().nth(0).hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['3px', '3px']);
+    });
+
+    test('Hovering a passage split by inline markup emphasises all of it', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Test hover across inline markup',
+            entities_id: getWorkerEntityId(),
+            answer: '<p>Hello <strong>brave</strong> new world</p>',
+        });
+        // A <strong> inside a single paragraph splits the passage just like a block boundary.
+        await api.createItem('KnowbaseItem_Comment', {
+            knowbaseitems_id: id,
+            comment: 'Comment on a bold-split passage',
+            anchor_prefix: 'Hello ',
+            anchor_exact: 'brave new',
+            anchor_suffix: ' world',
+            anchor_occurrence: 0,
+        });
+
+        await kb.goto(id);
+        await kb.waitForArticleReady();
+
+        await expect(kb.getCommentHighlights()).toHaveCount(2);
+
+        await kb.getCommentHighlights().nth(0).hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['3px', '3px']);
+    });
+
+    test('Hovering one fragment emphasises the whole passage in edit mode too', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const kb = new KnowbaseItemPage(page);
+
+        const id = await api.createItem('KnowbaseItem', {
+            name: 'Test hover across blocks while editing',
+            entities_id: getWorkerEntityId(),
+            answer: '<h3>Section title</h3><p>Body sentence here</p><p>Untouched trailing text</p>',
+        });
+        await api.createItem('KnowbaseItem_Comment', {
+            knowbaseitems_id: id,
+            comment: 'Comment on a two-block passage',
+            anchor_prefix: 'Section ',
+            anchor_exact: 'titleBody sentence',
+            anchor_suffix: ' here',
+            anchor_occurrence: 0,
+        });
+
+        await kb.goto(id);
+        await kb.waitForArticleReady();
+        // Highlights become ProseMirror decorations, still one per text node.
+        await kb.editor.enterEditMode();
+
+        await expect(kb.getCommentHighlights()).toHaveCount(2);
+        expect(await kb.getCommentHighlightThicknesses()).toEqual(['2px', '2px']);
+
+        await kb.getCommentHighlights().nth(1).hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['3px', '3px']);
+
+        await page.getByText('Untouched trailing text').hover();
+        await expect
+            .poll(() => kb.getCommentHighlightThicknesses())
+            .toEqual(['2px', '2px']);
+    });
 });


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.


## Description

- It fixes https://github.com/glpi-project/roadmap/issues/472
- Here is a brief description of what this PR does : 

A commented passage is rendered as several pieces whenever it crosses a markup boundary, such as a heading followed by a paragraph or a bold word. Hovering relied on a local CSS effect, so only the piece under the cursor was emphasised.

Hovering is now a shared state owned by the passage: the article view tracks which comment is hovered and broadcasts it to every piece, in read and edit mode alike. A passage lights up and fades out as a whole.


## Screenshots (if appropriate):

<img width="770" height="236" alt="image" src="https://github.com/user-attachments/assets/1e515c38-43f9-4a0a-813c-37e83729981e" />

