### PR TITLE
Fix array unions on $CFG_GPI inventory values

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -1312,7 +1312,7 @@ TWIG);
 
         if (
             Session::haveRight($itemtype::$rightname, UPDATE)
-            && in_array($itemtype, $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'], true)
+            && in_array($itemtype, array_merge($CFG_GLPI['inventory_types'], $CFG_GLPI['inventory_lockable_objects']), true)
         ) {
             $actions[$action_unlock_component] = __s('Unlock components');
             $actions[$action_unlock_fields] = __s('Unlock fields');

--- a/src/Lockedfield.php
+++ b/src/Lockedfield.php
@@ -477,7 +477,10 @@ class Lockedfield extends CommonDBTM
             'uuid',
             'comment',
         ];
-        $itemtypes = $CFG_GLPI['inventory_types'] + $CFG_GLPI['inventory_lockable_objects'];
+        $itemtypes = array_values(array_unique(array_merge(
+            $CFG_GLPI['inventory_types'],
+            $CFG_GLPI['inventory_lockable_objects']
+        )));
 
         if ($specific_itemtype !== null && in_array($specific_itemtype, $itemtypes)) {
             $itemtypes = [$specific_itemtype];


### PR DESCRIPTION
Array union on array with numeric keys results in lost values.

Example:
<img width="497" height="237" alt="image" src="https://github.com/user-attachments/assets/ff54b78e-9b24-4ce6-9568-576a473230a7" />

`$CFG_GLPI['inventory_types']` and `$CFG_GLPI['inventory_lockable_objects']` both have numeric keys and thus should never be merged with the union operation.

<img width="1235" height="337" alt="image" src="https://github.com/user-attachments/assets/f0e7b44d-7e72-4603-b1e0-f98d131c194b" />
