### PR TITLE
Add opt-in history scopes to field searches

### DIFF
--- a/.phpstan-baseline.php
+++ b/.phpstan-baseline.php
@@ -10622,24 +10622,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getActionsFor\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string\\<CommonDBTM\\>\\|CommonDBTM given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Glpi\\\\Search\\\\SearchOption\\:\\:getOptionsForItemtype\\(\\) expects class\\-string\\<CommonDBTM\\>, class\\-string\\<CommonDBTM\\>\\|CommonDBTM given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Parameter \\#1 \\$itemtype of static method Toolbox\\:\\:getNormalizedItemtype\\(\\) expects string, class\\-string\\<CommonDBTM\\>\\|CommonDBTM given\\.$#',
-	'identifier' => 'argument.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Glpi/Search/Input/QueryBuilder.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$params of static method Glpi\\\\Search\\\\Input\\\\QueryBuilder\\:\\:cleanParams\\(\\) expects array, array\\|true given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -241,6 +241,10 @@ final class QueryBuilder implements SearchInputInterface
             'itemtype' => $request['itemtype'],
             'fieldname' => $fieldname,
             'searchtype' => $request['searchtype'],
+            'history_search_available' => !filter_var($request['from_meta'] ?? false, FILTER_VALIDATE_BOOLEAN)
+                && !filter_var($request['disable_history_search'] ?? false, FILTER_VALIDATE_BOOLEAN)
+                && SearchOption::canSearchHistory($request['itemtype'], $request['field']),
+            'scope' => $request['scope'] ?? 'current',
             'actions' => $actions,
             'searchopt' => $searchopt,
             'dropdownname' => $dropdownname,

--- a/src/Glpi/Search/Input/QueryBuilder.php
+++ b/src/Glpi/Search/Input/QueryBuilder.php
@@ -188,7 +188,7 @@ final class QueryBuilder implements SearchInputInterface
         $num    = (int) $request['num'];
         $prefix = isset($p['prefix_crit']) ? htmlescape($p['prefix_crit']) : '';
 
-        if (!is_subclass_of($request['itemtype'], 'CommonDBTM')) {
+        if (!is_string($request['itemtype']) || !is_subclass_of($request['itemtype'], 'CommonDBTM')) {
             throw new RuntimeException('Invalid itemtype provided!');
         }
 

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5513,6 +5513,7 @@ final class SQLProvider implements SearchProviderInterface
             // common search
             if (
                 !isset($criterion['field'])
+                || ($criterion['scope'] ?? 'current') !== 'current'
                 || ($criterion['field'] != "all"
                     && $criterion['field'] != "view")
             ) {
@@ -5554,6 +5555,15 @@ final class SQLProvider implements SearchProviderInterface
                 } elseif (!isset($criterion['field'])) {
                     // No field to filter on
                     continue;
+                } elseif (($criterion['scope'] ?? 'current') !== 'current') {
+                    if ($is_having) {
+                        continue;
+                    }
+                    $new_where = (new Where())
+                        ->setOperator($LINK)
+                        ->withCriteria(self::getHistoryWhereCriteria($itemtype, $criterion, $NOT, $meta));
+                    $sql .= ' ' . $new_where->getQuery();
+                    $values = array_merge($values, $new_where->getParams());
                 } elseif (
                     isset($meta_searchopt[$criterion['field']]["usehaving"])
                     || ($meta && "AND NOT" === $criterion['link'])
@@ -5681,6 +5691,52 @@ final class SQLProvider implements SearchProviderInterface
             ->setQuery($sql)
             ->setParams($values)
         ;
+    }
+
+    /**
+     * Search retained old/new values of one field, without multiplying result rows.
+     * Negation applies to the entire set of values, not individual log entries.
+     */
+    private static function getHistoryWhereCriteria(string $itemtype, array $criterion, bool $not, bool $meta): array
+    {
+        if (
+            $meta
+            || !in_array($criterion['scope'], ['history', 'current_and_history'], true)
+            || !in_array($criterion['searchtype'], ['contains', 'notcontains'], true)
+            || !SearchOption::canSearchHistory($itemtype, $criterion['field'])
+        ) {
+            // Fail closed for forged requests and saved searches whose permissions changed.
+            return [new QueryExpression('false')];
+        }
+
+        $table = $itemtype::getTable();
+        $history = [
+            "$table.id" => new QuerySubQuery([
+                'SELECT' => 'items_id',
+                'FROM' => 'glpi_logs',
+                'WHERE' => [
+                    'itemtype' => $itemtype,
+                    'id_search_option' => (int) $criterion['field'],
+                    'linked_action' => 0,
+                    'OR' => [
+                        self::getTextCriteria('old_value', $criterion['value'], false, Operator::NONE),
+                        self::getTextCriteria('new_value', $criterion['value'], false, Operator::NONE),
+                    ],
+                ],
+            ]),
+        ];
+        if ($criterion['searchtype'] === 'notcontains') {
+            $not = !$not;
+        }
+        $history = $not ? ['NOT' => $history] : $history;
+        if ($criterion['scope'] === 'current_and_history') {
+            return [$not ? 'AND' : 'OR' => [
+                self::getWhereCriteria($not, $itemtype, $criterion['field'], 'contains', $criterion['value']),
+                $history,
+            ]];
+        }
+
+        return $history;
     }
 
     /**

--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -5696,6 +5696,11 @@ final class SQLProvider implements SearchProviderInterface
     /**
      * Search retained old/new values of one field, without multiplying result rows.
      * Negation applies to the entire set of values, not individual log entries.
+     *
+     * @param class-string<CommonDBTM> $itemtype
+     * @param array<string, mixed> $criterion
+     *
+     * @return array<string, mixed>
      */
     private static function getHistoryWhereCriteria(string $itemtype, array $criterion, bool $not, bool $meta): array
     {
@@ -5706,7 +5711,7 @@ final class SQLProvider implements SearchProviderInterface
             || !SearchOption::canSearchHistory($itemtype, $criterion['field'])
         ) {
             // Fail closed for forged requests and saved searches whose permissions changed.
-            return [new QueryExpression('false')];
+            return ['AND' => [new QueryExpression('false')]];
         }
 
         $table = $itemtype::getTable();

--- a/src/Glpi/Search/SearchOption.php
+++ b/src/Glpi/Search/SearchOption.php
@@ -53,6 +53,7 @@ use Group_Item;
 use Infocom;
 use Link;
 use Location;
+use Log;
 use ManualLink;
 use Manufacturer;
 use NetworkPort;
@@ -142,6 +143,33 @@ final class SearchOption implements ArrayAccess
     public function isComputationGroupBy(): bool
     {
         return $this['computationgroupby'] ?? false;
+    }
+
+    /**
+     * Whether a field can be searched in the item's own textual history.
+     * Related objects and computed fields do not share this history mapping.
+     */
+    public static function canSearchHistory(string $itemtype, int|string $field): bool
+    {
+        if (!Log::canView() || !is_subclass_of($itemtype, CommonDBTM::class)) {
+            return false;
+        }
+
+        $item = getItemForItemtype($itemtype);
+        $option = self::getOptionsForItemtype($itemtype)[$field] ?? null;
+        if (!$item || !$item->dohistory || !is_array($option)) {
+            return false;
+        }
+
+        return ($option['table'] ?? null) === $itemtype::getTable()
+            && in_array($option['datatype'] ?? 'string', ['string', 'text', 'itemlink'], true)
+            && (($option['datatype'] ?? '') !== 'itemlink' || $option['field'] === 'name')
+            && $item->isField($option['field'])
+            && !in_array($option['field'], $item->getNonLoggedFields(), true)
+            && !isset($option['computation'])
+            && !isset($option['usehaving'])
+            && empty($option['joinparams'])
+            && empty($option['nosearch']);
     }
 
     /**

--- a/templates/components/search/query_builder/criteria.html.twig
+++ b/templates/components/search/query_builder/criteria.html.twig
@@ -98,6 +98,9 @@
                   _idor_token: idor_token(used_itemtype),
                   field: value,
                   searchtype: searchtype,
+                  scope: criteria['scope']|default('current'),
+                  from_meta: from_meta,
+                  disable_history_search: itemtype == 'AllAssets',
                   value: p_value,
                   num: num,
                   p: p,
@@ -113,6 +116,7 @@
                params|merge({
                   action: 'display_searchoption',
                   field: '__VALUE__',
+                  scope: 'current',
                })
             ]) %}
          </div>

--- a/templates/components/search/query_builder/search_option.html.twig
+++ b/templates/components/search/query_builder/search_option.html.twig
@@ -61,6 +61,39 @@
    {{ call('Glpi\\Search\\Input\\QueryBuilder::displaySearchoptionValue', [params]) }}
 </div>
 
+{% if history_search_available %}
+   {% set scope_name = fieldname ~ prefix ~ "[" ~ num ~ "][scope]" %}
+   {% set scope_enabled = searchtype in ['contains', 'notcontains'] %}
+   <div class="col-auto history-search-scope {{ scope_enabled ? '' : 'd-none' }}" id="history-scope-{{ rand }}">
+      {{ fields.dropdownArrayField(scope_name, scope_enabled ? scope : 'current', {
+         current: __('Current value'),
+         history: __('History'),
+         current_and_history: __('Current value and history'),
+      }, __('Search in'), {
+         rand: rand,
+         full_width: true,
+         input_class: 'col-12',
+         no_label: true,
+         mb: 'mb-0',
+         disabled: not scope_enabled,
+      }) }}
+   </div>
+   <script>
+      $(function() {
+         const operator = document.getElementById({{ call('Html::cleanId', ['dropdown_' ~ searchtype_name ~ rand])|json_encode|raw }});
+         const container = $('#history-scope-{{ rand }}');
+         $(operator).on('change', function() {
+            const enabled = ['contains', 'notcontains'].includes(this.value);
+            container.toggleClass('d-none', !enabled);
+            container.find('select').prop('disabled', !enabled);
+            if (!enabled) {
+               container.find('select').val('current').trigger('change');
+            }
+         });
+      });
+   </script>
+{% endif %}
+
 {% if actions|length > 0 %}
     {% do call('Ajax::updateItemOnSelectEvent', [
        ("dropdown_" ~ searchtype_name ~ rand),

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -52,6 +52,7 @@ use Glpi\DBAL\QueryExpression;
 use Glpi\Form\AnswersSet;
 use Glpi\Form\Destination\AnswersSet_FormDestinationItem;
 use Glpi\Form\Form;
+use Glpi\Search\Input\QueryBuilder;
 use Glpi\Search\SearchOption;
 use Glpi\Tests\DbTestCase;
 use Group;
@@ -61,6 +62,7 @@ use Location;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\LogLevel;
 use Session;
+use Symfony\Component\DomCrawler\Crawler;
 use TaskCategory;
 use Ticket;
 use User;
@@ -7712,6 +7714,168 @@ class SearchTest extends DbTestCase
             count($data['sql']['search']->getParams()),
             'placeholder/param count mismatch: ' . $query
         );
+    }
+
+    public static function historySearchProvider(): iterable
+    {
+        yield 'current default' => [null, 'contains', 'old', ['current']];
+        yield 'explicit current' => ['current', 'contains', 'old', ['current']];
+        yield 'old name' => ['history', 'contains', 'old', ['renamed']];
+        yield 'intermediate name' => ['history', 'contains', 'middle', ['renamed']];
+        yield 'new value in history' => ['history', 'contains', 'final', ['renamed']];
+        yield 'current and history' => ['current_and_history', 'contains', 'old', ['renamed', 'current']];
+        yield 'duplicate log matches' => ['history', 'contains', 'history-search-', ['renamed']];
+        yield 'no history match' => ['history', 'contains', 'missing', []];
+        yield 'negate history set' => ['history', 'notcontains', 'old', ['current', 'control', 'untouched']];
+        yield 'negate combined set' => ['current_and_history', 'notcontains', 'old', ['control', 'untouched']];
+        yield 'literal quote' => ['history', 'contains', "old' OR 1=1 --", []];
+        yield 'AND NOT history' => ['history', 'contains', 'old', ['current', 'control', 'untouched'], 'AND NOT'];
+        yield 'double negation' => ['history', 'notcontains', 'old', ['renamed'], 'AND NOT'];
+        yield 'exact old name' => ['history', 'contains', '^history-search-old$', ['renamed']];
+    }
+
+    #[DataProvider('historySearchProvider')]
+    public function testHistorySearch(?string $scope, string $operator, string $value, array $expected, string $link = 'AND'): void
+    {
+        $this->login();
+        $entity = $this->getTestRootEntity(true);
+        $prefix = 'history-search-';
+        $items = [];
+        foreach (['renamed' => 'old', 'current' => 'old', 'control' => 'control', 'untouched' => 'untouched'] as $key => $name) {
+            $items[$key] = $this->createItem(Computer::class, [
+                'name' => $prefix . $name,
+                'entities_id' => $entity,
+            ]);
+        }
+        $renamed = $items['renamed'];
+        foreach (['middle', 'final'] as $name) {
+            $this->assertTrue($renamed->update(['id' => $renamed->getID(), 'name' => $prefix . $name]));
+        }
+        // Matching text in another field, another item type, or an action must not match Name.
+        $control = $items['control'];
+        $this->assertTrue($control->update(['id' => $control->getID(), 'comment' => $prefix . 'old']));
+        \Log::history($control->getID(), \Monitor::class, [1, $prefix . 'old', $prefix . 'new']);
+        \Log::history($control->getID(), Computer::class, [1, $prefix . 'old', $prefix . 'new'], '', \Log::HISTORY_ADD_DEVICE);
+
+        $criterion = ['field' => 1, 'searchtype' => $operator, 'value' => $value, 'link' => $link];
+        if ($scope !== null) {
+            $criterion['scope'] = $scope;
+        }
+
+        $data = $this->doSearch(Computer::class, [
+            'criteria' => [
+                ['field' => 1, 'searchtype' => 'contains', 'value' => $prefix],
+                ['link' => 'AND', 'criteria' => [
+                    $criterion,
+                ]],
+            ],
+        ]);
+        $expected_ids = array_map(static fn($key) => $items[$key]->getID(), $expected);
+        $actual_ids = array_column(array_column($data['data']['rows'], 'raw'), 'id');
+        $this->assertEqualsCanonicalizing($expected_ids, $actual_ids);
+        $this->assertSame(count($expected_ids), $data['data']['totalcount']);
+    }
+
+    public function testHistorySearchPermissionsAndUnsupportedFields(): void
+    {
+        $this->login();
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'history-permission-old',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $this->assertTrue($computer->update(['id' => $computer->getID(), 'name' => 'history-permission-new']));
+        $criterion = ['field' => 1, 'searchtype' => 'contains', 'value' => 'history-permission-old', 'scope' => 'history'];
+        $this->assertSame(1, $this->doSearch(Computer::class, ['criteria' => [$criterion]])['data']['totalcount']);
+
+        foreach ([2, 19, 80] as $field) {
+            $this->assertFalse(SearchOption::canSearchHistory(Computer::class, $field));
+            $data = $this->doSearch(Computer::class, ['criteria' => [array_replace($criterion, ['field' => $field])]]);
+            $this->assertSame(0, $data['data']['totalcount']);
+        }
+        $this->assertFalse(SearchOption::canSearchHistory(Computer::class, 'all'));
+        foreach ([['scope' => 'invalid'], ['searchtype' => 'equals']] as $invalid) {
+            $data = $this->doSearch(Computer::class, ['criteria' => [array_replace($criterion, $invalid)]]);
+            $this->assertSame(0, $data['data']['totalcount']);
+        }
+
+        $rights = $_SESSION['glpiactiveprofile']['logs'];
+        try {
+            $_SESSION['glpiactiveprofile']['logs'] = 0;
+            $this->assertFalse(SearchOption::canSearchHistory(Computer::class, 1));
+            foreach (['history', 'current_and_history'] as $scope) {
+                $data = $this->doSearch(Computer::class, ['criteria' => [array_replace($criterion, ['scope' => $scope])]]);
+                $this->assertSame(0, $data['data']['totalcount']);
+            }
+        } finally {
+            $_SESSION['glpiactiveprofile']['logs'] = $rights;
+        }
+    }
+
+    public function testHistorySearchOtherFieldsAndEntities(): void
+    {
+        $this->login();
+        $root = $this->getTestRootEntity(true);
+        $child = $this->createItem(Entity::class, ['name' => 'history-search-child', 'entities_id' => $root]);
+        $computer = $this->createItem(Computer::class, [
+            'name' => 'history-search-fields',
+            'serial' => 'history-old-serial',
+            'comment' => 'history-old-comment',
+            'entities_id' => $child->getID(),
+        ]);
+        $this->assertTrue($computer->update([
+            'id' => $computer->getID(),
+            'serial' => 'history-new-serial',
+            'comment' => 'history-new-comment',
+        ]));
+        foreach ([5 => 'serial', 16 => 'comment'] as $field => $name) {
+            $this->assertTrue(SearchOption::canSearchHistory(Computer::class, $field));
+            $criteria = [['field' => $field, 'searchtype' => 'contains', 'value' => 'history-old-' . $name, 'scope' => 'history']];
+            $this->setEntity($root, true);
+            $this->assertSame(1, $this->doSearch(Computer::class, ['criteria' => $criteria])['data']['totalcount']);
+            $this->setEntity($root, false);
+            $this->assertSame(0, $this->doSearch(Computer::class, ['criteria' => $criteria])['data']['totalcount']);
+        }
+        $this->setEntity($root, true);
+        $this->assertTrue($computer->delete(['id' => $computer->getID()]));
+        $this->assertSame(0, $this->doSearch(Computer::class, ['criteria' => $criteria])['data']['totalcount']);
+        $this->assertSame(1, $this->doSearch(Computer::class, ['criteria' => $criteria, 'is_deleted' => 1])['data']['totalcount']);
+    }
+
+    public function testHistorySearchInput(): void
+    {
+        $this->login();
+        foreach ([
+            [[], true, true],
+            [['from_meta' => 'false', 'disable_history_search' => 'false'], true, true],
+            [['from_meta' => 'true'], false, false],
+            [['disable_history_search' => 'true'], false, false],
+            [['field' => 2], false, false],
+            [['searchtype' => 'equals'], true, false],
+        ] as [$override, $visible, $enabled]) {
+            ob_start();
+            try {
+                QueryBuilder::displaySearchoption($override + [
+                    'itemtype' => Computer::class,
+                    'field' => 1,
+                    'num' => 0,
+                    'p' => ['prefix_crit' => '[1][criteria]'],
+                    'searchtype' => 'contains',
+                    'value' => '',
+                    'scope' => 'history',
+                ]);
+            } finally {
+                $html = ob_get_clean();
+            }
+            $crawler = new Crawler($html);
+            $select = $crawler->filter('select[name="criteria[1][criteria][0][scope]"]');
+            $this->assertCount($visible ? 1 : 0, $select);
+            if ($visible) {
+                $this->assertSame(!$enabled, $select->attr('disabled') !== null);
+                $this->assertSame($enabled ? 'history' : 'current', $select->filter('option[selected]')->attr('value'));
+                $operator_id = $crawler->filter('select[name="criteria[1][criteria][0][searchtype]"]')->attr('id');
+                $this->assertStringContainsString('document.getElementById("' . $operator_id . '")', $html);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove the feature works.
- [x] This change requires a documentation update.

## Description

An asset may be renamed while its previous name remains in old tickets, inventory exports, or operational documentation. Searching its current Name field no longer finds that asset.

This PR adds an explicit search scope to eligible text-field criteria for GLPI 12: **Current value**, **History**, or **Current value and history**.

**Current value remains the default.** History is searched only when explicitly selected.

This is a draft for discussion, not a request for review. Core inclusion and the proposed scope still need agreement through a contribution request, as required by CONTRIBUTING.md; no prior maintainer approval is claimed.

## Use case

A computer is renamed twice:

`DEMO-OLD-PC` → `DEMO-MIDDLE-PC` → `DEMO-CURRENT-PC`

Later, `DEMO-OLD-PC` is assigned to a different computer. An operator investigating an old ticket needs to find the original computer without knowing its current name.

In **Assets > Computers**, select **Name**, **contains**, and enter `DEMO-OLD-PC`:

| Search scope | Result |
| --- | --- |
| Current value (default) | The computer currently named `DEMO-OLD-PC` |
| History | The renamed computer, displayed as `DEMO-CURRENT-PC` |
| Current value and history | Both computers, so the operator can compare their identities and serial numbers |

The operator can then open the renamed computer's existing History tab to inspect its name changes. The same workflow also works for eligible fields such as Serial number and Comments.

## Changes

- Add a scope selector for an item's own logged text fields, with `contains` and `does not contain` operators.
- Search retained old and new log values for the selected field and item type.
- Return each item once, even when multiple log entries match.
- Apply negation to the complete selected set of values, including nested criteria and `AND NOT`.
- Require permission to view logs and retain normal item/entity visibility and trash filtering.
- Preserve explicitly selected scopes in saved searches; reset to Current value when changing the field or switching to an unsupported operator.
- Reject unsupported history requests, including requests whose log permissions are no longer available.
- Extend the existing functional search tests, including query-builder rendering and AJAX parameters.

## Backward compatibility and limits

Existing criteria without a scope continue to search current values only. No database migration is required.

This first implementation excludes related-object/meta criteria, computed fields, and the Global asset list. History means the retained **old and new values**, so it may include a current value that was recorded by a change. Purged history and text omitted by log-value truncation cannot be recovered.

Performance on production-sized log tables has not been measured. User documentation and agreement on the contribution scope remain follow-up work before review.

## Testing

Validation used an isolated local Docker environment with PHP 8.4 and MariaDB 11.8, with separate demo and test databases.

- `vendor/bin/phpunit tests/functional/SearchTest.php --filter HistorySearch` — 17 tests, 1232 assertions.
- PHP-CS-Fixer check on all four changed PHP files — passed.
- TwigCS with the project's `GlpiTwigRuleset` on both changed templates — passed.
- `git diff --check` — passed.
- Browser verification of all three scopes using the same old name, serial-number history, operator/field changes, and saved-search reloads.

Coverage includes the default with no scope supplied, old/intermediate/new values, field and item-type isolation, duplicate changes, combined scopes, negation, nested criteria, quoting, entity access, deleted items, log permissions, invalid requests, and the scope control.

The full GLPI test suite has not been run locally.

## Screenshots

The screenshots use synthetic demo data. Images are stored in a separate branch of the fork and are not part of this PR's source diff.

### Scope selector

![Scope selector, with Current value selected](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/07-scope-selector.png)

<details>
<summary>Current value: only the computer with the current matching name</summary>

![Current value criterion](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/01-current-filter.png)

![Current value result](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/02-current-results.png)

</details>

<details>
<summary>History: find the renamed computer using its previous name</summary>

![History criterion](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/03-history-filter.png)

![History result showing DEMO-CURRENT-PC](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/04-history-results.png)

</details>

<details>
<summary>Current value and history: find both computers</summary>

![Combined scope criterion](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/05-combined-filter.png)

![Combined scope results](https://raw.githubusercontent.com/mykolaq/glpi/27207793edb4e0ba9a7877ab2087798ff5549519/docs/pr-assets/history-search/06-combined-results.png)

</details>

## AI disclosure

OpenAI Codex was used to assist with codebase exploration, implementation, code review, tests, local Docker and browser validation, screenshots, and preparation of this pull request description. The checks performed are listed above; this remains a draft pending maintainer discussion and contributor review before requesting a formal review.
