### PR TITLE
FIX / Restore the "include sub-groups' members" toggle

### DIFF
--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -740,8 +740,9 @@ TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
         if ($item instanceof Group) {
             $members = [];
             $ids = [];
-            $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
-            self::getDataForGroup($item, $members, $ids, '', $tree, false);
+            // Always count direct members only: the tab badge cannot reflect
+            // the "tree" toggle live (reloadTab() never refreshes it).
+            self::getDataForGroup($item, $members, $ids, '', 0, false);
 
             // We will also count implicits members from parents groups
             $members = array_merge(

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -413,14 +413,36 @@ class Group_User extends CommonDBRelation
         $used    = [];
         $ids     = [];
 
-        self::getDataForGroup($group, $used, $ids, $_GET['filters'] ?? [], true, false);
+        // Whether to also include members of this group's sub-groups.
+        // Persisted per-session, like other saved list options.
+        $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
+
+        if ($group->haveChildren()) {
+            // Carry over any active column filter: reloadTab() doesn't merge
+            // query strings across calls, so we must resend them ourselves.
+            $filters_qs = http_build_query(['filters' => $_GET['filters'] ?? []]);
+            $reload_suffix = $filters_qs !== '' ? ('&' . $filters_qs) : '';
+
+            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                {% import 'components/form/fields_macros.html.twig' as fields %}
+                <div class="d-flex justify-content-center mb-2">
+                    {{ fields.dropdownYesNo('tree', tree, __('Include members of sub-groups'), {
+                        on_change: 'reloadTab("start=0&tree="+this.value+"' ~ reload_suffix ~ '")'
+                    }) }}
+                </div>
+TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
+        } else {
+            $tree = 0;
+        }
+
+        self::getDataForGroup($group, $used, $ids, $_GET['filters'] ?? [], $tree, false);
         $all_groups = count($used);
         $used    = [];
         $ids     = [];
 
         // Retrieve member list
         // TODO: migrate to use CommonDBRelation::getListForItem()
-        $entityrestrict = self::getDataForGroup($group, $used, $ids, $_GET['filters'] ?? [], true, true);
+        $entityrestrict = self::getDataForGroup($group, $used, $ids, $_GET['filters'] ?? [], $tree, true);
 
         // We will load implicits members from parents groups and display
         // them after all the "direct" members
@@ -718,7 +740,8 @@ class Group_User extends CommonDBRelation
         if ($item instanceof Group) {
             $members = [];
             $ids = [];
-            self::getDataForGroup($item, $members, $ids, '', true, false);
+            $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
+            self::getDataForGroup($item, $members, $ids, '', $tree, false);
 
             // We will also count implicits members from parents groups
             $members = array_merge(

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -415,25 +415,8 @@ class Group_User extends CommonDBRelation
 
         // Whether to also include members of this group's sub-groups.
         // Persisted per-session, like other saved list options.
-        $tree = (int) Session::getSavedOption(self::class, 'tree', 0);
-
-        if ($group->haveChildren()) {
-            // Carry over any active column filter: reloadTab() doesn't merge
-            // query strings across calls, so we must resend them ourselves.
-            $filters_qs = http_build_query(['filters' => $_GET['filters'] ?? []]);
-            $reload_suffix = $filters_qs !== '' ? ('&' . $filters_qs) : '';
-
-            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
-                {% import 'components/form/fields_macros.html.twig' as fields %}
-                <div class="d-flex justify-content-center mb-2">
-                    {{ fields.dropdownYesNo('tree', tree, __('Include members of sub-groups'), {
-                        on_change: 'reloadTab("start=0&tree="+this.value+"' ~ reload_suffix ~ '")'
-                    }) }}
-                </div>
-TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
-        } else {
-            $tree = 0;
-        }
+        $has_children = $group->haveChildren();
+        $tree = $has_children ? (int) Session::getSavedOption(self::class, 'tree', 0) : 0;
 
         self::getDataForGroup($group, $used, $ids, $_GET['filters'] ?? [], $tree, false);
         $all_groups = count($used);
@@ -465,6 +448,24 @@ TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
 
         if ($canedit) {
             self::showAddUserForm($group, $ids, $entityrestrict);
+        }
+
+        if ($has_children) {
+            // Carry over any active column filter: reloadTab() doesn't merge
+            // query strings across calls, so we must resend them ourselves.
+            $filters_qs = http_build_query(['filters' => $_GET['filters'] ?? []]);
+            $reload_suffix = $filters_qs !== '' ? ('&' . $filters_qs) : '';
+
+            echo TemplateRenderer::getInstance()->renderFromStringTemplate(<<<TWIG
+                {% import 'components/form/fields_macros.html.twig' as fields %}
+                <hr class="my-3">
+                <div class="d-flex justify-content-end">
+                    {{ fields.dropdownYesNo('tree', tree, __('Include members of sub-groups'), {
+                        field_class: 'col-12 col-sm-8 col-md-5 col-xxl-4 mb-2',
+                        on_change: 'reloadTab("start=0&tree="+this.value+"' ~ reload_suffix ~ '")'
+                    }) }}
+                </div>
+TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
         }
 
         $number = count($used);

--- a/src/Group_User.php
+++ b/src/Group_User.php
@@ -460,12 +460,12 @@ class Group_User extends CommonDBRelation
                 {% import 'components/form/fields_macros.html.twig' as fields %}
                 <hr class="my-3">
                 <div class="d-flex justify-content-end">
-                    {{ fields.dropdownYesNo('tree', tree, __('Include members of sub-groups'), {
+                    {{ fields.dropdownYesNo('tree', tree, label, {
                         field_class: 'col-12 col-sm-8 col-md-5 col-xxl-4 mb-2',
                         on_change: 'reloadTab("start=0&tree="+this.value+"' ~ reload_suffix ~ '")'
                     }) }}
                 </div>
-TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix]);
+TWIG, ['tree' => $tree, 'reload_suffix' => $reload_suffix, 'label' => __('Include members of sub-groups')]);
         }
 
         $number = count($used);

--- a/tests/functional/Group_UserTest.php
+++ b/tests/functional/Group_UserTest.php
@@ -267,7 +267,7 @@ class Group_UserTest extends DbTestCase
         $this->assertNotContains($non_manager_in_child, $listed_ids);
     }
 
-    public function testCountForItemRespectsTreeSessionOption()
+    public function testCountForItemAlwaysCountsDirectMembersOnly()
     {
         $this->login();
 
@@ -280,15 +280,12 @@ class Group_UserTest extends DbTestCase
         $group_user->add(['groups_id' => $child_id, 'users_id' => $uid]);
 
         $this->assertTrue($group->getFromDB($parent_id));
-
-        // Make sure no leftover request param interferes with the saved option.
         unset($_REQUEST['tree']);
 
-        $_SESSION['glpi_saved'][\Group_User::class]['tree'] = 0;
-        $this->assertSame(0, $group_user->countForItem($group));
-
+        // The tab badge cannot reflect the "tree" toggle live, so it must
+        // always reflect direct membership only, regardless of its value.
         $_SESSION['glpi_saved'][\Group_User::class]['tree'] = 1;
-        $this->assertSame(1, $group_user->countForItem($group));
+        $this->assertSame(0, $group_user->countForItem($group));
 
         unset($_SESSION['glpi_saved'][\Group_User::class]['tree']);
     }

--- a/tests/functional/Group_UserTest.php
+++ b/tests/functional/Group_UserTest.php
@@ -192,6 +192,175 @@ class Group_UserTest extends DbTestCase
         $this->assertSame(1, $group_user->countForItem($group));
     }
 
+    public function testGetDataForGroupTreeParameter()
+    {
+        $this->login();
+
+        $group = new \Group();
+        $parent_id = (int) $group->add([
+            'name' => 'Parent group',
+        ]);
+        $this->assertGreaterThan(0, $parent_id);
+
+        $child_id = (int) $group->add([
+            'name'      => 'Child group',
+            'groups_id' => $parent_id,
+        ]);
+        $this->assertGreaterThan(0, $child_id);
+
+        $user_child_only = getItemByTypeName('User', 'normal', true);
+
+        $group_user = new \Group_User();
+        $this->assertGreaterThan(
+            0,
+            (int) $group_user->add(['groups_id' => $child_id, 'users_id' => $user_child_only])
+        );
+
+        $this->assertTrue($group->getFromDB($parent_id));
+
+        // Default / tree = 0: the parent only sees its own direct members,
+        // a member of the child group is not listed here.
+        $members = [];
+        $ids = [];
+        \Group_User::getDataForGroup($group, $members, $ids, '', 0, false);
+        $this->assertNotContains($user_child_only, array_column($members, 'id'));
+
+        // tree = 1 (explicit opt-in): the parent's list also includes
+        // members of its sub-groups.
+        $members = [];
+        $ids = [];
+        \Group_User::getDataForGroup($group, $members, $ids, '', 1, false);
+        $this->assertContains($user_child_only, array_column($members, 'id'));
+    }
+
+    public function testGetDataForGroupTreeAndManagerFilterCombined()
+    {
+        $this->login();
+
+        $group = new \Group();
+        $parent_id = (int) $group->add(['name' => 'Parent group']);
+        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id]);
+
+        $manager_in_child     = getItemByTypeName('User', 'normal', true);
+        $non_manager_in_child = getItemByTypeName('User', 'post-only', true);
+
+        $group_user = new \Group_User();
+        $group_user->add(['groups_id' => $child_id, 'users_id' => $manager_in_child, 'is_manager' => 1]);
+        $group_user->add(['groups_id' => $child_id, 'users_id' => $non_manager_in_child, 'is_manager' => 0]);
+
+        $this->assertTrue($group->getFromDB($parent_id));
+
+        // tree = 0: the "Manager" filter has nothing to work on, since
+        // sub-group members are not part of the parent's list at all.
+        $members = [];
+        $ids = [];
+        \Group_User::getDataForGroup($group, $members, $ids, ['manager' => '1'], 0, false);
+        $this->assertCount(0, $members);
+
+        // tree = 1: the "Manager" filter must correctly keep only the
+        // sub-group member who actually is a manager of that sub-group.
+        $members = [];
+        $ids = [];
+        \Group_User::getDataForGroup($group, $members, $ids, ['manager' => '1'], 1, false);
+        $listed_ids = array_column($members, 'id');
+        $this->assertContains($manager_in_child, $listed_ids);
+        $this->assertNotContains($non_manager_in_child, $listed_ids);
+    }
+
+    public function testCountForItemRespectsTreeSessionOption()
+    {
+        $this->login();
+
+        $group = new \Group();
+        $parent_id = (int) $group->add(['name' => 'Parent group']);
+        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id]);
+
+        $uid = getItemByTypeName('User', 'normal', true);
+        $group_user = new \Group_User();
+        $group_user->add(['groups_id' => $child_id, 'users_id' => $uid]);
+
+        $this->assertTrue($group->getFromDB($parent_id));
+
+        // Make sure no leftover request param interferes with the saved option.
+        unset($_REQUEST['tree']);
+
+        $_SESSION['glpi_saved'][\Group_User::class]['tree'] = 0;
+        $this->assertSame(0, $group_user->countForItem($group));
+
+        $_SESSION['glpi_saved'][\Group_User::class]['tree'] = 1;
+        $this->assertSame(1, $group_user->countForItem($group));
+
+        unset($_SESSION['glpi_saved'][\Group_User::class]['tree']);
+    }
+
+    public function testShowForGroupRendersTreeToggle()
+    {
+        $this->login();
+
+        $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        $group = new \Group();
+        $parent_id = (int) $group->add(['name' => 'Parent group', 'entities_id' => $entities_id]);
+        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id, 'entities_id' => $entities_id]);
+
+        $uid = getItemByTypeName('User', 'normal', true);
+        $group_user = new \Group_User();
+        $group_user->add(['groups_id' => $child_id, 'users_id' => $uid]);
+
+        $this->assertTrue($group->getFromDB($parent_id));
+
+        unset($_REQUEST['tree'], $_SESSION['glpi_saved'][\Group_User::class]['tree']);
+
+        ob_start();
+        \Group_User::showForGroup($group);
+        $output = ob_get_clean();
+
+        // The "include sub-groups" toggle must be rendered since the group
+        // has a child.
+        $this->assertStringContainsString("name='tree'", $output);
+
+        // A group with no children must not display the toggle at all.
+        $leaf_id = (int) $group->add(['name' => 'Leaf group', 'entities_id' => $entities_id]);
+        $this->assertTrue($group->getFromDB($leaf_id));
+        ob_start();
+        \Group_User::showForGroup($group);
+        $output = ob_get_clean();
+        $this->assertStringNotContainsString("name='tree'", $output);
+    }
+
+    public function testTreeToggleReloadPreservesActiveFilters()
+    {
+        $this->login();
+
+        $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $group = new \Group();
+        $parent_id = (int) $group->add(['name' => 'PF Parent', 'entities_id' => $entities_id]);
+        $child_id  = (int) $group->add(['name' => 'PF Child', 'groups_id' => $parent_id, 'entities_id' => $entities_id]);
+        $this->assertTrue($group->getFromDB($parent_id));
+
+        unset($_REQUEST['tree'], $_SESSION['glpi_saved'][\Group_User::class]['tree']);
+
+        // No active filter: the toggle's reload must not append a stray '&'.
+        $_GET['filters'] = [];
+        ob_start();
+        \Group_User::showForGroup($group);
+        $output = ob_get_clean();
+        $this->assertMatchesRegularExpression(
+            '/reloadTab\(&quot;start=0&amp;tree=&quot;\+this\.value\+&quot;&quot;\)/',
+            $output
+        );
+
+        // An active "Manager" filter must be carried over into the toggle's
+        // reload string, otherwise switching the toggle would silently reset it.
+        $_GET['filters'] = ['manager' => '1'];
+        ob_start();
+        \Group_User::showForGroup($group);
+        $output = ob_get_clean();
+        $this->assertStringContainsString('filters%5Bmanager%5D=1', $output);
+
+        unset($_GET['filters']);
+    }
+
     public function testIsUserInGroup()
     {
         $group = new \Group();

--- a/tests/functional/Group_UserTest.php
+++ b/tests/functional/Group_UserTest.php
@@ -196,40 +196,24 @@ class Group_UserTest extends DbTestCase
     {
         $this->login();
 
-        $group = new \Group();
-        $parent_id = (int) $group->add([
-            'name' => 'Parent group',
-        ]);
-        $this->assertGreaterThan(0, $parent_id);
-
-        $child_id = (int) $group->add([
-            'name'      => 'Child group',
-            'groups_id' => $parent_id,
-        ]);
-        $this->assertGreaterThan(0, $child_id);
-
+        $parent = $this->createItem(\Group::class, ['name' => 'Parent group']);
+        $child  = $this->createItem(\Group::class, ['name' => 'Child group', 'groups_id' => $parent->getID()]);
         $user_child_only = getItemByTypeName('User', 'normal', true);
 
-        $group_user = new \Group_User();
-        $this->assertGreaterThan(
-            0,
-            (int) $group_user->add(['groups_id' => $child_id, 'users_id' => $user_child_only])
-        );
-
-        $this->assertTrue($group->getFromDB($parent_id));
+        $this->createItem(\Group_User::class, ['groups_id' => $child->getID(), 'users_id' => $user_child_only]);
 
         // Default / tree = 0: the parent only sees its own direct members,
         // a member of the child group is not listed here.
         $members = [];
         $ids = [];
-        \Group_User::getDataForGroup($group, $members, $ids, '', 0, false);
+        \Group_User::getDataForGroup($parent, $members, $ids, '', 0, false);
         $this->assertNotContains($user_child_only, array_column($members, 'id'));
 
         // tree = 1 (explicit opt-in): the parent's list also includes
         // members of its sub-groups.
         $members = [];
         $ids = [];
-        \Group_User::getDataForGroup($group, $members, $ids, '', 1, false);
+        \Group_User::getDataForGroup($parent, $members, $ids, '', 1, false);
         $this->assertContains($user_child_only, array_column($members, 'id'));
     }
 
@@ -237,31 +221,26 @@ class Group_UserTest extends DbTestCase
     {
         $this->login();
 
-        $group = new \Group();
-        $parent_id = (int) $group->add(['name' => 'Parent group']);
-        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id]);
-
+        $parent = $this->createItem(\Group::class, ['name' => 'Parent group']);
+        $child  = $this->createItem(\Group::class, ['name' => 'Child group', 'groups_id' => $parent->getID()]);
         $manager_in_child     = getItemByTypeName('User', 'normal', true);
         $non_manager_in_child = getItemByTypeName('User', 'post-only', true);
 
-        $group_user = new \Group_User();
-        $group_user->add(['groups_id' => $child_id, 'users_id' => $manager_in_child, 'is_manager' => 1]);
-        $group_user->add(['groups_id' => $child_id, 'users_id' => $non_manager_in_child, 'is_manager' => 0]);
-
-        $this->assertTrue($group->getFromDB($parent_id));
+        $this->createItem(\Group_User::class, ['groups_id' => $child->getID(), 'users_id' => $manager_in_child, 'is_manager' => 1]);
+        $this->createItem(\Group_User::class, ['groups_id' => $child->getID(), 'users_id' => $non_manager_in_child, 'is_manager' => 0]);
 
         // tree = 0: the "Manager" filter has nothing to work on, since
         // sub-group members are not part of the parent's list at all.
         $members = [];
         $ids = [];
-        \Group_User::getDataForGroup($group, $members, $ids, ['manager' => '1'], 0, false);
+        \Group_User::getDataForGroup($parent, $members, $ids, ['manager' => '1'], 0, false);
         $this->assertCount(0, $members);
 
         // tree = 1: the "Manager" filter must correctly keep only the
         // sub-group member who actually is a manager of that sub-group.
         $members = [];
         $ids = [];
-        \Group_User::getDataForGroup($group, $members, $ids, ['manager' => '1'], 1, false);
+        \Group_User::getDataForGroup($parent, $members, $ids, ['manager' => '1'], 1, false);
         $listed_ids = array_column($members, 'id');
         $this->assertContains($manager_in_child, $listed_ids);
         $this->assertNotContains($non_manager_in_child, $listed_ids);
@@ -271,21 +250,17 @@ class Group_UserTest extends DbTestCase
     {
         $this->login();
 
-        $group = new \Group();
-        $parent_id = (int) $group->add(['name' => 'Parent group']);
-        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id]);
-
+        $parent = $this->createItem(\Group::class, ['name' => 'Parent group']);
+        $child  = $this->createItem(\Group::class, ['name' => 'Child group', 'groups_id' => $parent->getID()]);
         $uid = getItemByTypeName('User', 'normal', true);
-        $group_user = new \Group_User();
-        $group_user->add(['groups_id' => $child_id, 'users_id' => $uid]);
+        $group_user = $this->createItem(\Group_User::class, ['groups_id' => $child->getID(), 'users_id' => $uid]);
 
-        $this->assertTrue($group->getFromDB($parent_id));
         unset($_REQUEST['tree']);
 
         // The tab badge cannot reflect the "tree" toggle live, so it must
         // always reflect direct membership only, regardless of its value.
         $_SESSION['glpi_saved'][\Group_User::class]['tree'] = 1;
-        $this->assertSame(0, $group_user->countForItem($group));
+        $this->assertSame(0, $group_user->countForItem($parent));
 
         unset($_SESSION['glpi_saved'][\Group_User::class]['tree']);
     }
@@ -296,20 +271,16 @@ class Group_UserTest extends DbTestCase
 
         $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
 
-        $group = new \Group();
-        $parent_id = (int) $group->add(['name' => 'Parent group', 'entities_id' => $entities_id]);
-        $child_id  = (int) $group->add(['name' => 'Child group', 'groups_id' => $parent_id, 'entities_id' => $entities_id]);
+        $parent = $this->createItem(\Group::class, ['name' => 'Parent group', 'entities_id' => $entities_id]);
+        $child  = $this->createItem(\Group::class, ['name' => 'Child group', 'groups_id' => $parent->getID(), 'entities_id' => $entities_id]);
 
         $uid = getItemByTypeName('User', 'normal', true);
-        $group_user = new \Group_User();
-        $group_user->add(['groups_id' => $child_id, 'users_id' => $uid]);
-
-        $this->assertTrue($group->getFromDB($parent_id));
+        $this->createItem(\Group_User::class, ['groups_id' => $child->getID(), 'users_id' => $uid]);
 
         unset($_REQUEST['tree'], $_SESSION['glpi_saved'][\Group_User::class]['tree']);
 
         ob_start();
-        \Group_User::showForGroup($group);
+        \Group_User::showForGroup($parent);
         $output = ob_get_clean();
 
         // The "include sub-groups" toggle must be rendered since the group
@@ -317,10 +288,9 @@ class Group_UserTest extends DbTestCase
         $this->assertStringContainsString("name='tree'", $output);
 
         // A group with no children must not display the toggle at all.
-        $leaf_id = (int) $group->add(['name' => 'Leaf group', 'entities_id' => $entities_id]);
-        $this->assertTrue($group->getFromDB($leaf_id));
+        $leaf = $this->createItem(\Group::class, ['name' => 'Leaf group', 'entities_id' => $entities_id]);
         ob_start();
-        \Group_User::showForGroup($group);
+        \Group_User::showForGroup($leaf);
         $output = ob_get_clean();
         $this->assertStringNotContainsString("name='tree'", $output);
     }
@@ -330,17 +300,15 @@ class Group_UserTest extends DbTestCase
         $this->login();
 
         $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
-        $group = new \Group();
-        $parent_id = (int) $group->add(['name' => 'PF Parent', 'entities_id' => $entities_id]);
-        $child_id  = (int) $group->add(['name' => 'PF Child', 'groups_id' => $parent_id, 'entities_id' => $entities_id]);
-        $this->assertTrue($group->getFromDB($parent_id));
+        $parent = $this->createItem(\Group::class, ['name' => 'PF Parent', 'entities_id' => $entities_id]);
+        $this->createItem(\Group::class, ['name' => 'PF Child', 'groups_id' => $parent->getID(), 'entities_id' => $entities_id]);
 
         unset($_REQUEST['tree'], $_SESSION['glpi_saved'][\Group_User::class]['tree']);
 
         // No active filter: the toggle's reload must not append a stray '&'.
         $_GET['filters'] = [];
         ob_start();
-        \Group_User::showForGroup($group);
+        \Group_User::showForGroup($parent);
         $output = ob_get_clean();
         $this->assertMatchesRegularExpression(
             '/reloadTab\(&quot;start=0&amp;tree=&quot;\+this\.value\+&quot;&quot;\)/',
@@ -351,7 +319,7 @@ class Group_UserTest extends DbTestCase
         // reload string, otherwise switching the toggle would silently reset it.
         $_GET['filters'] = ['manager' => '1'];
         ob_start();
-        \Group_User::showForGroup($group);
+        \Group_User::showForGroup($parent);
         $output = ob_get_clean();
         $this->assertStringContainsString('filters%5Bmanager%5D=1', $output);
 


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45960
- When a user belongs to both a group and its sub-group, that user is shown twice (once per real membership). This is intentional, per the PR #16721 review discussion itself: each row is a genuine, distinct `glpi_groups_users` record, labelled by its own "Group" column. This PR does not change that behavior — `clearDuplicatedGroupData()` stays disabled, as decided at the time.
However, for the sake of clarity on the end-user side, it was decided to restore a Yes/No toggle so admins can choose for themselves whether they want that aggregated, sub-groups-included view at all, rather than always having it forced on them. Care was taken to preserve any active column filter (Manager, Dynamic, Delegatee).

## Screenshots :
<img width="1383" height="613" alt="Capture d’écran du 2026-08-27 14-09-36" src="https://github.com/user-attachments/assets/22602a29-7f8f-49e4-9726-7d916cccf2d9" />

<img width="1383" height="613" alt="Capture d’écran du 2026-08-27 14-09-47" src="https://github.com/user-attachments/assets/9dddf433-4f60-4e2b-af47-01ce904bab79" />

<img width="1383" height="613" alt="Capture d’écran du 2026-08-27 14-10-15" src="https://github.com/user-attachments/assets/4d375f2c-054b-4898-a6e8-54d0f4480f91" />

