### PR TITLE
Rework KB search results

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -1317,9 +1317,11 @@ body.in_modal .kb-editor-reserved {
         }
     }
 
-    // Current article: highlighted with primary color to identify it in the tree and favorites.
+    // Current article: highlighted with primary color to identify it in the
+    // tree, in the favorites and in the search results (`> a`).
     [data-glpi-kb-article-current] {
-        > .article-line > a {
+        > .article-line > a,
+        > a {
             color: color-mix(
                 in srgb,
                 transparent,
@@ -1343,9 +1345,15 @@ body.in_modal .kb-editor-reserved {
         border-bottom: 0;
     }
 
-    // Tree items hidden by the search filter.
+    // The tree and the favorites, kept in place while the search results stand
+    // in for them.
     [data-glpi-kb-search-hidden] {
         display: none;
+    }
+
+    // Header border, dropped for as long as the favorites are standing aside.
+    [data-glpi-kb-aside-header][data-glpi-kb-aside-header-search-no-border] {
+        border-bottom: 0;
     }
 
     // Clear button: interactive only when active (has text to clear).
@@ -1372,6 +1380,21 @@ body.in_modal .kb-editor-reserved {
         [data-glpi-kb-aside-category-add] {
             visibility: visible;
         }
+    }
+
+    // Favorites keep their natural height, but never at the expense of the
+    // list below them now that the aside is bounded.
+    [data-glpi-kb-aside-favorites] {
+        min-height: 0;
+        overflow-y: auto;
+    }
+
+    // The tree pane takes what the header leaves and scrolls as a whole, so the
+    // scrollbar sits on the card edge instead of inside whichever list is
+    // standing in it.
+    [data-glpi-kb-aside-tree] {
+        min-height: 0;
+        overflow-y: auto;
     }
 
     // KB aside tree hierarchy connector lines
@@ -1422,6 +1445,47 @@ body.in_modal .kb-editor-reserved {
                 }
             }
         }
+    }
+
+    // Search results: a flat list of rows replacing the tree, each one showing
+    // the beginning of the article's content.
+    .kb-search-results {
+        list-style: none;
+        margin: 0;
+
+        > .article > a {
+            display: block;
+            padding: 0.25rem 0.375rem;
+            border-radius: var(--tblr-border-radius);
+
+            &:hover,
+            &:focus-visible {
+                background-color: var(--tblr-bg-surface-secondary);
+            }
+        }
+
+        // Required so `text-truncate` shrinks the title below its content.
+        [data-glpi-kb-article-title] {
+            min-width: 0;
+        }
+
+        // Three lines of content, whatever the width of the aside.
+        [data-glpi-kb-search-result-excerpt] {
+            /* stylelint-disable-next-line value-no-vendor-prefix -- no equivalent without prefix, and exists in all browsers */
+            display: -webkit-box;
+            /* stylelint-disable-next-line property-no-vendor-prefix -- no equivalent without prefix, and exists in all browsers */
+            -webkit-line-clamp: 3;
+            /* stylelint-disable-next-line property-no-vendor-prefix -- no equivalent without prefix, and exists in all browsers */
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            overflow-wrap: anywhere;
+        }
+    }
+
+    // The next page is loaded as this row comes into view.
+    [data-glpi-kb-aside-search-load-more] {
+        list-style: none;
+        padding: 0.5rem 0.375rem;
     }
 }
 
@@ -1475,8 +1539,15 @@ body.in_modal .kb-editor-reserved {
         justify-content: flex-end;
     }
 
-    // Desktop collapse via max-width + overflow:hidden (zeroes the flex min so the column shrinks to the rail).
     @media (min-width: 992px) {
+        // Taken out of the flow so it follows the main article height, itself
+        // floored at the viewport by Tabler's .page/.page-body flex chain.
+        [data-glpi-kb-aside-body] {
+            position: absolute;
+            inset: 0;
+        }
+
+        // Collapse via max-width + overflow:hidden (zeroes the flex min so the column shrinks to the rail).
         &[data-glpi-kb-aside-collapsed] {
             max-width: 2.75rem;
             overflow: hidden;

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -526,6 +526,9 @@ export class GlpiKnowbaseArticleController
     }
 
     /**
+     * Mirror the favorite state in the aside; same visibility rule as the
+     * aside's own `#refreshFavoritesVisibility()`.
+     *
      * @param {boolean} is_favorited
      */
     #updateFavoritesAside(is_favorited)

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -58,19 +58,18 @@ export class GlpiKnowbaseAsideController
     #search_request_id = 0;
 
     /**
+     * Watches the "load more" marker at the end of the search results.
+     * @type {IntersectionObserver|null}
+     */
+    #search_load_more_observer = null;
+
+    /**
      * Children requests by article id, so a branch is only fetched once even if
      * the reader folds and unfolds it repeatedly.
      *
      * @type {Map<number, Promise<string>>}
      */
     #children_cache = new Map();
-
-    /**
-     * Whether the favorites section was hidden on initial server render.
-     * Used to restore the correct state after clearing the search.
-     * @type {boolean}
-     */
-    #favorites_originally_hidden = false;
 
     /**
      * In-flight/resolved dots menu content, keyed by article id. The tree
@@ -152,10 +151,9 @@ export class GlpiKnowbaseAsideController
     {
         const id = node.dataset.glpiKbArticleId;
 
-        // The same article can be rendered more than once: under each of its
-        // parents, and again in the search results while the rendered tree is
-        // kept hidden. They all share one fold state, so every copy gets the
-        // very same treatment.
+        // The same article can be rendered more than once, under each of its
+        // parents. They all share one fold state, so every copy gets the very
+        // same treatment.
         const nodes = id ? this.#aside.querySelectorAll(
             `[data-glpi-kb-aside-category][data-glpi-kb-article-id="${CSS.escape(id)}"]`,
         ) : [node];
@@ -205,7 +203,7 @@ export class GlpiKnowbaseAsideController
         if (!this.#children_cache.has(id)) {
             const current_id = this.#aside
                 .querySelector('[data-glpi-kb-aside-tree] [data-glpi-kb-article-current]')
-                ?.dataset.glpiKbArticleId ?? '';
+                ?.dataset.glpiKbArticleId ?? '0';
             this.#children_cache.set(
                 id,
                 get(
@@ -485,10 +483,6 @@ export class GlpiKnowbaseAsideController
         const search_input  = this.#aside.querySelector('[data-glpi-kb-aside-search-input]');
         const search_icon   = this.#aside.querySelector('[data-glpi-kb-aside-search-icon]');
         const clear_button  = this.#aside.querySelector('[data-glpi-kb-aside-search-clear]');
-        const favorites     = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
-
-        // Record the initial server-rendered state so we can restore it on clear.
-        this.#favorites_originally_hidden = favorites.hasAttribute('data-glpi-kb-aside-favorites-hidden');
 
         // Debounce the search method to avoid hitting the server with too many
         // requests.
@@ -529,33 +523,30 @@ export class GlpiKnowbaseAsideController
 
     async #performSearch(value)
     {
-        const tree      = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
-        const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
+        const tree = this.#aside.querySelector('[data-glpi-kb-aside-tree]');
 
         const request_id = ++this.#search_request_id;
 
         // Search criteria was removed, show all items again
         if (value.trim() === '') {
             this.#showAllTreeItems(tree);
-            this.#restoreFavorites(favorites);
+            this.#setFavoritesSearchHidden(false);
             return;
         }
 
         // Send request to backend
-        const current_id = this.#aside
-            .querySelector('[data-glpi-kb-article-current]')?.dataset.glpiKbArticleId ?? '';
         const response = await get(
             `Knowbase/Aside/Search?contains=${encodeURIComponent(value)}`
-            + `&current_id=${encodeURIComponent(current_id)}`,
+            + `&current_id=${encodeURIComponent(this.#currentArticleId())}`,
         );
-        const { ids, html } = await response.json();
+        const html = await response.text();
         if (request_id !== this.#search_request_id) {
             return;
         }
 
-        // Apply results
+        // Apply results.
         this.#showTreeResults(tree, html);
-        this.#filterFavorites(favorites, new Set(ids));
+        this.#setFavoritesSearchHidden(true);
     }
 
     /**
@@ -573,14 +564,114 @@ export class GlpiKnowbaseAsideController
 
         let results = tree.querySelector(':scope > [data-glpi-kb-aside-tree-results]');
         if (!results) {
-            results = document.createElement('div');
+            results = document.createElement('ul');
+            results.className = 'kb-search-results ps-0';
             results.setAttribute('data-glpi-kb-aside-tree-results', '');
+            results.dataset.testid = 'kb-search-results';
             rendered ? rendered.after(results) : tree.prepend(results);
         }
         results.innerHTML = html;
 
+        // Back to the first result
+        tree.scrollTop = 0;
+
+        this.#watchSearchLoadMore(results);
+
         const no_results = tree.querySelector('[data-glpi-kb-aside-no-results]');
         no_results.hidden = results.querySelector('[data-glpi-kb-article-id]') !== null;
+    }
+
+    /**
+     * The results are loaded 50 at a time. The server puts a marker after the
+     * last one, watched here to append the next page as it comes into view.
+     *
+     * @param {HTMLElement} list
+     */
+    #watchSearchLoadMore(list)
+    {
+        // The list is replaced on each search, so the observer is always reset.
+        this.#search_load_more_observer?.disconnect();
+        this.#search_load_more_observer = null;
+
+        const marker = list.querySelector('[data-glpi-kb-aside-search-load-more]');
+        if (!marker) {
+            return;
+        }
+
+        this.#search_load_more_observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        this.#loadNextSearchPage(entry.target);
+                    }
+                }
+            },
+            // The results scroll with the pane holding them, and the next page
+            // is loaded slightly before the marker is actually reached.
+            { root: list.closest('[data-glpi-kb-aside-tree]'), rootMargin: '200px' },
+        );
+        this.#search_load_more_observer.observe(marker);
+    }
+
+    /**
+     * @param {HTMLElement} marker
+     */
+    async #loadNextSearchPage(marker)
+    {
+        // Both the observer and a fast scroll may ask for the same page.
+        if (marker.dataset.glpiLoading !== undefined) {
+            return;
+        }
+        marker.dataset.glpiLoading = '';
+
+        // The marker is a live region: it says what is happening now, and the
+        // reader may come back to it after a failure.
+        const loading = marker.querySelector('[data-glpi-kb-aside-search-load-more-loading]');
+        const error = marker.querySelector('[data-glpi-kb-aside-search-load-more-error]');
+        loading.hidden = false;
+        error.hidden = true;
+
+        // The marker carries the search it belongs to.
+        const contains = marker.dataset.glpiKbAsideSearchContains;
+        const offset = marker.dataset.glpiKbAsideSearchNextOffset;
+
+        let page;
+        try {
+            const response = await get(
+                `Knowbase/Aside/Search?contains=${encodeURIComponent(contains)}`
+                + `&offset=${encodeURIComponent(offset)}`
+                + `&current_id=${encodeURIComponent(this.#currentArticleId())}`,
+            );
+            page = await response.text();
+        } catch {
+            // The marker stays watched, so scrolling it out of view and back
+            // in asks for the page again.
+            delete marker.dataset.glpiLoading;
+            loading.hidden = true;
+            error.hidden = false;
+            return;
+        }
+
+        // The marker left the document: its search is over.
+        if (!marker.isConnected) {
+            return;
+        }
+
+        // The page ends with the marker of the following one, if any.
+        const list = marker.parentElement;
+        marker.insertAdjacentHTML('beforebegin', page);
+        marker.remove();
+
+        this.#watchSearchLoadMore(list);
+    }
+
+    /**
+     * @returns {string} `0` when no article is being read
+     */
+    #currentArticleId()
+    {
+        return this.#aside.querySelector('[data-glpi-kb-article-current]')
+            ?.dataset.glpiKbArticleId ?? '0';
     }
 
     /**
@@ -590,6 +681,9 @@ export class GlpiKnowbaseAsideController
      */
     #showAllTreeItems(tree)
     {
+        this.#search_load_more_observer?.disconnect();
+        this.#search_load_more_observer = null;
+
         tree.querySelector(':scope > [data-glpi-kb-aside-tree-results]')?.remove();
 
         for (const el of tree.querySelectorAll('[data-glpi-kb-search-hidden]')) {
@@ -601,69 +695,24 @@ export class GlpiKnowbaseAsideController
     }
 
     /**
-     * Restore the favorites section to its original server-rendered state.
+     * Hide the favorites section (and the header border going with it) for as
+     * long as the results stand in for the tree. This is a reason of its own,
+     * kept apart from the "no favorites to show" state the section owns.
      *
-     * @param {HTMLElement} favorites_el
+     * @param {boolean} hidden
      */
-    #restoreFavorites(favorites_el)
+    #setFavoritesSearchHidden(hidden)
     {
-        for (const el of favorites_el.querySelectorAll('[data-glpi-kb-search-hidden]')) {
-            el.removeAttribute('data-glpi-kb-search-hidden');
-        }
-
-        this.#setFavoritesVisible(favorites_el, !this.#favorites_originally_hidden);
-    }
-
-    /**
-     * Filter the favorites section to only show articles whose IDs are in matching_ids.
-     * Hides the entire section (and the header border) when nothing matches.
-     *
-     * @param {HTMLElement} favorites_el
-     * @param {Set<number>} matching_ids
-     */
-    #filterFavorites(favorites_el, matching_ids)
-    {
-        if (this.#favorites_originally_hidden) {
-            return;
-        }
-
-        let any_visible = false;
-
-        for (const article of favorites_el.querySelectorAll('[data-glpi-kb-article-id]')) {
-            // Skip pending entries — they are already hidden by CSS and should not
-            // count as visible regardless of whether they match the search.
-            if (article.dataset.glpiKbFavoriteCurrent === 'pending') {
-                continue;
-            }
-
-            const id = parseInt(article.dataset.glpiKbArticleId);
-            if (matching_ids.has(id)) {
-                article.removeAttribute('data-glpi-kb-search-hidden');
-                any_visible = true;
-            } else {
-                article.setAttribute('data-glpi-kb-search-hidden', '');
-            }
-        }
-
-        this.#setFavoritesVisible(favorites_el, any_visible);
-    }
-
-    /**
-     * Toggle the favorites section visibility and the matching header border.
-     *
-     * @param {HTMLElement} favorites_el
-     * @param {boolean}     visible
-     */
-    #setFavoritesVisible(favorites_el, visible)
-    {
+        const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
         const header = this.#aside.querySelector('[data-glpi-kb-aside-header]');
 
-        if (visible) {
-            favorites_el.removeAttribute('data-glpi-kb-aside-favorites-hidden');
-            header.removeAttribute('data-glpi-kb-aside-header-no-border');
+        // The header holds the search input, so it only loses its border.
+        if (hidden) {
+            favorites.setAttribute('data-glpi-kb-search-hidden', '');
+            header.setAttribute('data-glpi-kb-aside-header-search-no-border', '');
         } else {
-            favorites_el.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
-            header.setAttribute('data-glpi-kb-aside-header-no-border', '');
+            favorites.removeAttribute('data-glpi-kb-search-hidden');
+            header.removeAttribute('data-glpi-kb-aside-header-search-no-border');
         }
     }
 
@@ -988,13 +1037,14 @@ export class GlpiKnowbaseAsideController
         if (is_favorited) {
             const already_listed = list.querySelector(`:scope > [data-glpi-kb-article-id="${CSS.escape(id)}"]`);
             if (!already_listed) {
+                // Scoped to the tree list: the search results hold rows of
+                // the same articles, in a shape of their own.
                 const source = this.#aside.querySelector(
-                    `[data-glpi-kb-aside-tree] [data-glpi-kb-article-id="${CSS.escape(id)}"]`
+                    `[data-glpi-kb-aside-tree] > ul.kb-tree [data-glpi-kb-article-id="${CSS.escape(id)}"]`
                 );
                 if (source) {
                     const clone = source.cloneNode(true);
                     clone.classList.add('mb-2');
-                    clone.removeAttribute('data-glpi-kb-search-hidden');
                     this.#flattenClonedFavorite(clone);
                     // The source row's dots menu is still open (the user just
                     // clicked a toggle inside it); close it in the clone.
@@ -1071,6 +1121,9 @@ export class GlpiKnowbaseAsideController
      * Show or hide the favorites section (and matching header border) depending
      * on whether it still holds any visible entry.
      *
+     * `ArticleController.#updateFavoritesAside()` applies the same rule from the
+     * article side.
+     *
      * @param {HTMLElement} favorites_el
      */
     #refreshFavoritesVisibility(favorites_el)
@@ -1087,8 +1140,5 @@ export class GlpiKnowbaseAsideController
             favorites_el.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
             header?.setAttribute('data-glpi-kb-aside-header-no-border', '');
         }
-
-        // Keep the "restore after search" baseline in sync with the live state.
-        this.#favorites_originally_hidden = !has_visible;
     }
 }

--- a/src/Glpi/Controller/Knowbase/AsideSearchController.php
+++ b/src/Glpi/Controller/Knowbase/AsideSearchController.php
@@ -34,16 +34,19 @@
 
 namespace Glpi\Controller\Knowbase;
 
-use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Knowbase\Aside\Builder;
+use Glpi\Knowbase\Aside\SearchResultsBuilder;
 use KnowbaseItem;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * Render one page of the aside search results, which replace the article tree
+ * for as long as the reader is searching.
+ */
 final class AsideSearchController extends AbstractController
 {
     #[Route(
@@ -51,10 +54,8 @@ final class AsideSearchController extends AbstractController
         name: "knowbase_aside_search",
         methods: 'GET',
     )]
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(Request $request): Response
     {
-        global $DB;
-
         // If we can't see the knowbase, it make no sense to search inside it
         if (!KnowbaseItem::canView()) {
             throw new AccessDeniedHttpException();
@@ -67,33 +68,17 @@ final class AsideSearchController extends AbstractController
             throw new BadRequestHttpException();
         }
 
-        // Get article IDs that match this filter
-        $criteria = KnowbaseItem::getListRequest(['contains' => $contains], 'search');
-
-        // Only the matching ids are needed here
-        $criteria['SELECT'] = [KnowbaseItem::getTableField('id')];
-        unset($criteria['ORDERBY']);
-
-        $ids = [];
-        foreach ($DB->request($criteria) as $data) {
-            $ids[] = (int) $data['id'];
+        // Validate offset
+        $offset = $request->query->getInt('offset');
+        if ($offset < 0 || $offset % SearchResultsBuilder::PAGE_SIZE !== 0) {
+            throw new BadRequestHttpException();
         }
 
-        // Render the filtered tree
-        $tree = (new Builder($request->query->getInt('current_id')))->buildSearchTree($ids);
+        $builder = new SearchResultsBuilder($request->query->getInt('current_id'));
 
-        return new JsonResponse([
-            // Consumed by the favorites section, which filters the rows it
-            // already holds.
-            'ids'  => $ids,
-            'html' => TemplateRenderer::getInstance()->render(
-                'pages/tools/kb/aside_tree.html.twig',
-                [
-                    'tree'         => $tree,
-                    'can_create'   => KnowbaseItem::canCreate(),
-                    'show_actions' => KnowbaseItem::canShowAsideActions(),
-                ]
-            ),
+        return $this->render('pages/tools/kb/aside_search_results.html.twig', [
+            'results'  => $builder->build($contains, $offset),
+            'contains' => $contains,
         ]);
     }
 }

--- a/src/Glpi/Knowbase/Aside/Builder.php
+++ b/src/Glpi/Knowbase/Aside/Builder.php
@@ -79,14 +79,6 @@ final class Builder
      */
     private array $folded_ids_lookup_map = [];
 
-    /**
-     * Articles to render, when the tree is restricted to a subset (search).
-     * Null renders the whole tree.
-     *
-     * @var array<int, true>|null
-     */
-    private ?array $rendered_ids = null;
-
     private bool $hierarchy_loaded = false;
 
     public function __construct(private readonly int $current_id = 0) {}
@@ -94,42 +86,11 @@ final class Builder
     public function buildTree(): Tree
     {
         $this->loadHierarchy();
-        $this->rendered_ids = null;
         $this->folded_ids_lookup_map = $this->computeFoldedIds();
 
         $tree = new Tree();
         foreach (array_keys($this->roots) as $id) {
             $tree->addArticle($this->buildArticle($id, []));
-        }
-
-        return $tree;
-    }
-
-    /**
-     * Tree restricted to the given articles and to the branches leading to
-     * them, as used by the aside search.
-     *
-     * Ancestors are included so a match is never orphaned, and nothing is
-     * folded: a match has to be visible without the reader unfolding its
-     * ancestors first. Descendants of a match are left out unless they match
-     * too, which is what the search filter it replaces did.
-     *
-     * @param int[] $matching_ids
-     */
-    public function buildSearchTree(array $matching_ids): Tree
-    {
-        $this->loadHierarchy();
-        $this->rendered_ids = $this->withAncestors(array_intersect_key(
-            array_fill_keys(array_map('intval', $matching_ids), true),
-            $this->data
-        ));
-        $this->folded_ids_lookup_map = [];
-
-        $tree = new Tree();
-        foreach (array_keys($this->roots) as $id) {
-            if ($this->isRendered($id)) {
-                $tree->addArticle($this->buildArticle($id, []));
-            }
         }
 
         return $tree;
@@ -147,7 +108,6 @@ final class Builder
         if (!isset($this->data[$parent_id])) {
             return [];
         }
-        $this->rendered_ids = null;
         $this->folded_ids_lookup_map = $this->computeFoldedIds();
 
         $children = [];
@@ -208,12 +168,12 @@ final class Builder
     private function buildArticle(int $id, array $ancestors): Article
     {
         $row = $this->data[$id];
-        $folded = $this->rendered_ids === null && isset($this->folded_ids_lookup_map[$id]);
+        $folded = isset($this->folded_ids_lookup_map[$id]);
 
         $ancestors[$id] = true;
         $children = [];
         foreach ($this->children_of[$id] ?? [] as $child_id) {
-            if (isset($ancestors[$child_id]) || !$this->isRendered($child_id)) {
+            if (isset($ancestors[$child_id])) {
                 continue; // cycles are forbidden by writes; guard defensively
             }
             $children[] = $child_id;
@@ -267,14 +227,8 @@ final class Builder
         return $folded;
     }
 
-    private function isRendered(int $id): bool
-    {
-        return $this->rendered_ids === null || isset($this->rendered_ids[$id]);
-    }
-
     /**
-     * The given articles plus every ancestor leading to them, so a restricted
-     * tree stays attached to its roots.
+     * The given articles plus every ancestor leading to them.
      *
      * @param array<int, true> $ids
      *

--- a/src/Glpi/Knowbase/Aside/SearchResult.php
+++ b/src/Glpi/Knowbase/Aside/SearchResult.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Knowbase\Aside;
+
+/**
+ * A single article matched by the aside search, as one row of the results list.
+ */
+final class SearchResult
+{
+    /**
+     * @param string $excerpt Plain text preview of the article's content, see
+     *                        `SearchResultsBuilder::buildExcerpt()`.
+     */
+    public function __construct(
+        public readonly int $id,
+        public readonly string $title,
+        public readonly string $illustration,
+        public readonly string $link,
+        public readonly string $excerpt,
+        public readonly bool $is_current = false,
+    ) {}
+}

--- a/src/Glpi/Knowbase/Aside/SearchResults.php
+++ b/src/Glpi/Knowbase/Aside/SearchResults.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Knowbase\Aside;
+
+/**
+ * One page of the aside search results.
+ */
+final class SearchResults
+{
+    /**
+     * @param SearchResult[] $results
+     * @param int|null       $next_offset Offset to request the next page with,
+     *                                    null when this is the last one.
+     */
+    public function __construct(
+        private readonly array $results,
+        private readonly ?int $next_offset = null,
+    ) {}
+
+    /** @return SearchResult[] */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    public function getNextOffset(): ?int
+    {
+        return $this->next_offset;
+    }
+}

--- a/src/Glpi/Knowbase/Aside/SearchResultsBuilder.php
+++ b/src/Glpi/Knowbase/Aside/SearchResultsBuilder.php
@@ -1,0 +1,340 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\Knowbase\Aside;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Glpi\RichText\RichText;
+use KnowbaseItem;
+use KnowbaseItemTranslation;
+
+use function Safe\preg_match;
+use function Safe\preg_replace;
+
+/**
+ * Builds one page of the aside search results.
+ *
+ * Unlike `Builder`, which loads the whole article hierarchy to render the
+ * aside tree, the search results are a flat list ordered by relevance.
+ */
+final class SearchResultsBuilder
+{
+    /**
+     * Results per page.
+     */
+    public const int PAGE_SIZE = 50;
+
+    /**
+     * Excerpts are cut at this many characters.
+     */
+    private const int EXCERPT_MAX_CHARS = 300;
+
+    /**
+     * Article columns a result row needs.
+     */
+    private const array SELECTED_COLUMNS = [
+        'glpi_knowbaseitems.id',
+        'glpi_knowbaseitems.name',
+        'glpi_knowbaseitems.answer',
+        'glpi_knowbaseitems.illustration',
+    ];
+
+    /**
+     * Elements dropped from an excerpt.
+     */
+    private const array EMBEDDED_TAGS = [
+        'img',
+        'table',
+        'hr',
+        'figure',
+        'iframe',
+        'video',
+        'audio',
+        'svg',
+        'object',
+        'embed',
+    ];
+
+    /**
+     * Video placeholders, written by the editor as an empty div.
+     */
+    private const string VIDEO_PLACEHOLDER_ATTRIBUTE = 'data-video-provider';
+
+    public function __construct(private readonly int $current_id = 0) {}
+
+    /**
+     * @param string $contains Search terms, as typed by the reader.
+     * @param int    $offset   Rank of the first result to return.
+     */
+    public function build(string $contains, int $offset = 0): SearchResults
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        $criteria = KnowbaseItem::getListRequest(['contains' => $contains], 'search');
+        $criteria['SELECT'] = $this->narrowSelect($criteria['SELECT']);
+
+        // Add fallback to ID for sorting out tied content.
+        $criteria['ORDERBY'] = array_merge(
+            (array) ($criteria['ORDERBY'] ?? []),
+            [KnowbaseItem::getTableField('id') . ' DESC'],
+        );
+
+        // Offset/limit
+        $criteria['LIMIT'] = self::PAGE_SIZE + 1;
+        $criteria['START'] = $offset;
+
+        $ids = [];
+        foreach ($DB->request($criteria) as $row) {
+            $ids[] = (int) $row['id'];
+        }
+        $has_next_page = count($ids) > self::PAGE_SIZE;
+
+        $results = [];
+        foreach ($this->loadRows(array_slice($ids, 0, self::PAGE_SIZE), $criteria) as $row) {
+            $results[] = $this->buildResult($row);
+        }
+
+        return new SearchResults(
+            $results,
+            $has_next_page ? $offset + self::PAGE_SIZE : null,
+        );
+    }
+
+    /**
+     * Reduce the select `getListRequest()` builds to what ranking the matches
+     * needs: the id, and the computed columns the `ORDERBY` and `HAVING` use.
+     *
+     * The `GROUP BY` makes MySQL sort the whole result set in a temporary table
+     * before the `LIMIT` applies, so every column left here is carried for each
+     * match instead of for the page. The article columns a row displays are
+     * loaded by `loadRows()` once the page is known.
+     *
+     * @param array<int, mixed> $select
+     *
+     * @return array<int, mixed>
+     */
+    private function narrowSelect(array $select): array
+    {
+        $narrowed = [];
+        foreach ($select as $column) {
+            if (is_string($column)) {
+                // Article and translation columns, `loadRows()` handles them.
+                continue;
+            }
+            // `visibility_count` and the `SCORE` the ORDERBY sorts on.
+            $narrowed[] = $column;
+        }
+        array_unshift($narrowed, KnowbaseItem::getTableField('id'));
+
+        return $narrowed;
+    }
+
+    /**
+     * Article columns a result row needs, for one page worth of ids.
+     *
+     * @param int[]                $ids      Page ids, in the order they rank.
+     * @param array<string, mixed> $criteria Criteria the page was ranked with.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadRows(array $ids, array $criteria): array
+    {
+        /** @var \DBmysql $DB */
+        global $DB;
+
+        if ($ids === []) {
+            return [];
+        }
+
+        $row_criteria = [
+            'SELECT' => self::SELECTED_COLUMNS,
+            'FROM'   => KnowbaseItem::getTable(),
+            'WHERE'  => [KnowbaseItem::getTableField('id') => $ids],
+        ];
+
+        // `getListRequest()` joins the translations only when there are some,
+        // and a result must show the translation the reader searched through.
+        $translations_table = KnowbaseItemTranslation::getTable();
+        if (isset($criteria['LEFT JOIN'][$translations_table])) {
+            $row_criteria['LEFT JOIN'] = [
+                $translations_table => $criteria['LEFT JOIN'][$translations_table],
+            ];
+            $row_criteria['SELECT'][] = KnowbaseItemTranslation::getTableField('name') . ' AS transname';
+            $row_criteria['SELECT'][] = KnowbaseItemTranslation::getTableField('answer') . ' AS transanswer';
+        }
+
+        $rows = [];
+        foreach ($DB->request($row_criteria) as $row) {
+            $rows[(int) $row['id']] = $row;
+        }
+
+        // `IN` returns the rows in whatever order it likes, restore the ranking.
+        $ordered = [];
+        foreach ($ids as $id) {
+            if (isset($rows[$id])) {
+                $ordered[] = $rows[$id];
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function buildResult(array $row): SearchResult
+    {
+        $id = (int) $row['id'];
+
+        // The search matches the translated columns too, so a result must show
+        // the reader the translation they searched through, when there is one.
+        $title  = ($row['transname'] ?? '') !== '' ? (string) $row['transname'] : (string) $row['name'];
+        $answer = ($row['transanswer'] ?? '') !== '' ? (string) $row['transanswer'] : (string) $row['answer'];
+
+        return new SearchResult(
+            id: $id,
+            title: $title,
+            illustration: (string) ($row['illustration'] ?? ''),
+            link: KnowbaseItem::getFormURLWithID($id),
+            excerpt: $this->buildExcerpt($answer),
+            is_current: $this->current_id > 0 && $id === $this->current_id,
+        );
+    }
+
+    /**
+     * Plain text preview of an article's content, capped at
+     * `EXCERPT_MAX_CHARS`.
+     */
+    private function buildExcerpt(string $answer): string
+    {
+        if (trim($answer) === '') {
+            return '';
+        }
+
+        $answer = $this->stripEmbeddedContent($answer);
+
+        // Get raw text
+        $text = RichText::getTextFromHtml(
+            $answer,
+            compact: true,       // an excerpt has no room for the URL of a link
+            preserve_case: true, // headings would come out shouting otherwise
+        );
+
+        // Format list items and quotes
+        $text = preg_replace('/^\h*(?:\*\h+|>+\h*)/mu', '', $text);
+
+        // Remove spacing
+        $text = trim(preg_replace('/\s+/u', ' ', $text));
+
+        return $this->cap($text);
+    }
+
+    /**
+     * Drop what an excerpt cannot carry: an image comes out as its alt text, a
+     * video as the URL of its player, a table as its cells one after the other.
+     */
+    private function stripEmbeddedContent(string $html): string
+    {
+        // Parsing the answer is the most expensive thing here, 50 times a page.
+        $tags = implode('|', self::EMBEDDED_TAGS);
+        $pattern = '/<(' . $tags . ')[\s>\/]|' . self::VIDEO_PLACEHOLDER_ATTRIBUTE . '/i';
+        if (preg_match($pattern, $html) !== 1) {
+            return $html;
+        }
+
+        $document = new DOMDocument();
+
+        // Wrapped: the parser guesses the encoding wrong without a document.
+        $previous_state = libxml_use_internal_errors(true);
+        $loaded = $document->loadHTML(
+            '<html><head><meta charset="utf-8"></head><body>' . $html . '</body></html>',
+        );
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous_state);
+
+        $body = $document->getElementsByTagName('body')->item(0);
+        if (!$loaded || $body === null) {
+            // Unparseable markup: a noisy excerpt beats no excerpt.
+            return $html;
+        }
+
+        $xpath = new DOMXPath($document);
+        $query = '//' . implode(' | //', self::EMBEDDED_TAGS)
+            . ' | //*[@' . self::VIDEO_PLACEHOLDER_ATTRIBUTE . ']';
+        $nodes = $xpath->query($query);
+        if ($nodes === false) {
+            return $html;
+        }
+
+        // A query result is a snapshot, so removing nested nodes is safe.
+        foreach ($nodes as $node) {
+            if ($node instanceof DOMElement) {
+                $node->parentNode?->removeChild($node);
+            }
+        }
+
+        // Only the article's own content: not the wrapper added above.
+        $stripped = '';
+        foreach ($body->childNodes as $child) {
+            $stripped .= $document->saveHTML($child);
+        }
+
+        return $stripped;
+    }
+
+    /**
+     * Cut the excerpt down to `EXCERPT_MAX_CHARS`, on a word boundary.
+     */
+    private function cap(string $text): string
+    {
+        if (mb_strlen($text) <= self::EXCERPT_MAX_CHARS) {
+            return $text;
+        }
+
+        $cut = mb_substr($text, 0, self::EXCERPT_MAX_CHARS);
+
+        // An unbroken run longer than the cap (a URL) has no boundary to use.
+        $boundary = mb_strrpos($cut, ' ');
+        if ($boundary !== false && $boundary >= (int) (self::EXCERPT_MAX_CHARS / 2)) {
+            $cut = mb_substr($cut, 0, $boundary);
+        }
+
+        // The rows mark their own cut when the excerpt overflows them; this one
+        // is for the excerpt that fits.
+        return rtrim($cut) . '…';
+    }
+}

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -2139,6 +2139,21 @@ TWIG, $twig_params);
                 break;
 
             case 'search':
+                // Publication window
+                $criteria['WHERE'][] = [
+                    [
+                        'OR'  => [
+                            ['glpi_knowbaseitems.begin_date'  => null],
+                            ['glpi_knowbaseitems.begin_date'  => ['<', QueryFunction::now()]],
+                        ],
+                    ], [
+                        'OR'  => [
+                            ['glpi_knowbaseitems.end_date'    => null],
+                            ['glpi_knowbaseitems.end_date'    => ['>', QueryFunction::now()]],
+                        ],
+                    ],
+                ];
+
                 if (((string) $params["contains"]) !== '') {
                     $search = $params["contains"];
                     $search_wilcard = self::computeBooleanFullTextSearch($search);
@@ -2191,22 +2206,6 @@ TWIG, $twig_params);
 
                     $search_where[] = ['OR' => $ors];
 
-                    // Add visibility date
-                    $visibility_crit = [
-                        [
-                            'OR'  => [
-                                ['glpi_knowbaseitems.begin_date'  => null],
-                                ['glpi_knowbaseitems.begin_date'  => ['<', QueryFunction::now()]],
-                            ],
-                        ], [
-                            'OR'  => [
-                                ['glpi_knowbaseitems.end_date'    => null],
-                                ['glpi_knowbaseitems.end_date'    => ['>', QueryFunction::now()]],
-                            ],
-                        ],
-                    ];
-                    $search_where[] = $visibility_crit;
-
                     $criteria['ORDERBY'] = ['SCORE DESC'];
 
                     // preliminar query to allow alternate search if no result with fulltext
@@ -2240,8 +2239,6 @@ TWIG, $twig_params);
                             $ors[] = ["glpi_knowbaseitemtranslations.answer" => ['LIKE', Search::makeTextSearchValue($contains)]];
                         }
                         $criteria['WHERE'][] = ['OR' => $ors];
-                        // Add visibility date
-                        $criteria['WHERE'][] = $visibility_crit;
                     } else {
                         $criteria['WHERE'] = $search_where;
                     }

--- a/templates/pages/tools/kb/_article_row.html.twig
+++ b/templates/pages/tools/kb/_article_row.html.twig
@@ -106,12 +106,11 @@
 {% endmacro %}
 
 {#
- # Renders a list of articles as a tree, as rendered by the aside and by the
- # search endpoint (which returns the matching branches to swap in).
+ # Renders a list of articles as a tree, as rendered by the aside.
  #}
 {% macro render_tree(articles, can_create = false, show_actions = false) %}
     {% import _self as macros %}
-    <ul class="kb-tree ps-0">
+    <ul class="kb-tree ps-0" data-testid="kb-aside-tree-list">
         {{ macros.render_rows(articles, can_create, show_actions) }}
     </ul>
 {% endmacro %}

--- a/templates/pages/tools/kb/aside_search_results.html.twig
+++ b/templates/pages/tools/kb/aside_search_results.html.twig
@@ -1,0 +1,100 @@
+{#
+ # ---------------------------------------------------------------------
+ #
+ # GLPI - Gestionnaire Libre de Parc Informatique
+ #
+ # http://glpi-project.org
+ #
+ # @copyright 2015-2026 Teclib' and contributors.
+ # @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ #
+ # ---------------------------------------------------------------------
+ #
+ # LICENSE
+ #
+ # This file is part of GLPI.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ #
+ # ---------------------------------------------------------------------
+ #}
+
+{#
+ # One page of the aside search results. Rendered by `AsideSearchController`,
+ # both when a search is run and when the aside asks for the next page as the
+ # reader scrolls through the results.
+ #}
+
+{% for result in results.getResults %}
+    <li
+        data-glpi-kb-article-id="{{ result.id }}"
+        data-testid="kb-search-result-{{ result.id }}"
+        {% if result.is_current %}
+            data-glpi-kb-article-current
+            aria-current="page"
+        {% endif %}
+        class="article"
+    >
+        <a class="d-block text-dark text-hover-link" href="{{ result.link }}">
+            <span class="d-flex align-items-center">
+                <span
+                    class="{{ result.illustration ? 'me-1' : '' }}"
+                    data-glpi-kb-article-illustration
+                    data-testid="kb-illustration"
+                >
+                    {% if result.illustration %}
+                        {{ render_illustration(result.illustration, 20) }}
+                    {% endif %}
+                </span>
+                <span class="text-truncate" data-glpi-kb-article-title>{{ result.title }}</span>
+            </span>
+            {# No `d-block`: its `!important` would beat the `-webkit-box` the
+             # three line clamp needs. #}
+            {% if result.excerpt %}
+                <span
+                    class="text-muted small"
+                    data-glpi-kb-search-result-excerpt
+                    data-testid="kb-search-result-excerpt"
+                >
+                    {{ result.excerpt }}
+                </span>
+            {% endif %}
+        </a>
+    </li>
+{% endfor %}
+
+{% if results.getNextOffset is not null %}
+    {# Watched by the aside, which swaps it for the next page when it comes
+     # into view. It carries the search it belongs to, so a page arriving after
+     # the reader has typed something else can be discarded. #}
+    <li
+        class="text-secondary small"
+        role="status"
+        data-testid="kb-search-load-more"
+        data-glpi-kb-aside-search-load-more
+        data-glpi-kb-aside-search-next-offset="{{ results.getNextOffset }}"
+        data-glpi-kb-aside-search-contains="{{ contains }}"
+    >
+        {# The marker ships with the page before it, and a live region
+         # announces whatever it holds: both states stay hidden until the aside
+         # says which one applies. #}
+        <span data-glpi-kb-aside-search-load-more-loading hidden>
+            <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+            {{ __("Loading...") }}
+        </span>
+        <span data-glpi-kb-aside-search-load-more-error hidden>
+            {{ __("The next results could not be loaded.") }}
+        </span>
+    </li>
+{% endif %}

--- a/templates/pages/tools/kb/aside_tree.html.twig
+++ b/templates/pages/tools/kb/aside_tree.html.twig
@@ -31,8 +31,7 @@
  #}
 
 {#
- # The aside tree body. Rendered inside the aside on page load, and on its
- # own by `AsideSearchController` to replace the tree with search results.
+ # The aside tree body, rendered inside the aside on page load.
  #}
 {% import "pages/tools/kb/_article_row.html.twig" as macros %}
 {{ macros.render_tree(tree.getArticles, can_create, show_actions) }}

--- a/tests/e2e/pages/KnowbaseItemPage.ts
+++ b/tests/e2e/pages/KnowbaseItemPage.ts
@@ -805,6 +805,85 @@ export class KnowbaseItemPage extends GlpiPage
     }
 
     /**
+     * The search results list, which stands in for the tree while a search is
+     * active.
+     */
+    public get asideSearchResults(): Locator
+    {
+        return this.aside.getByTestId('kb-search-results');
+    }
+
+    /**
+     * Every result row. The "load more" marker closing a page is a status
+     * message, not an item of the list, so it is not one of these.
+     */
+    public get asideSearchResultRows(): Locator
+    {
+        return this.asideSearchResults.getByRole('listitem');
+    }
+
+    public getAsideSearchResultRow(id: number): Locator
+    {
+        return this.asideSearchResults.getByTestId(`kb-search-result-${id}`);
+    }
+
+    public getAsideSearchResultExcerpt(id: number): Locator
+    {
+        return this.getAsideSearchResultRow(id).getByTestId('kb-search-result-excerpt');
+    }
+
+    /**
+     * The marker closing a page of results, swapped for the next page as it
+     * comes into view.
+     */
+    public get asideSearchLoadMore(): Locator
+    {
+        return this.page.getByTestId('kb-search-load-more');
+    }
+
+    /**
+     * The marker's "loading" state, shown only while a page is on its way.
+     */
+    public get asideSearchLoadMoreLoading(): Locator
+    {
+        return this.asideSearchLoadMore.getByText('Loading...');
+    }
+
+    /**
+     * The marker's error state, shown when a page could not be loaded.
+     */
+    public get asideSearchLoadMoreError(): Locator
+    {
+        return this.asideSearchLoadMore.getByText('The next results could not be loaded.');
+    }
+
+    /**
+     * The rendered tree, kept in place (hidden) while the search results stand
+     * in for it.
+     */
+    public get asideRenderedTree(): Locator
+    {
+        return this.asideTree.getByTestId('kb-aside-tree-list');
+    }
+
+    /**
+     * Scroll the results to their end, which is what asks for the next page.
+     */
+    public async doScrollAsideSearchResultsToEnd(): Promise<void>
+    {
+        await this.asideTree.evaluate((el) => el.scrollTo(0, el.scrollHeight));
+    }
+
+    /**
+     * Scroll the results back to their start, which takes the marker closing
+     * the page out of view.
+     */
+    public async doScrollAsideSearchResultsToStart(): Promise<void>
+    {
+        await this.asideTree.evaluate((el) => el.scrollTo(0, 0));
+    }
+
+    /**
      * Open the header "Share" popover and wait for its lazily-loaded content
      * to be ready.
      */

--- a/tests/e2e/specs/Knowbase/kb-aside-search.spec.ts
+++ b/tests/e2e/specs/Knowbase/kb-aside-search.spec.ts
@@ -33,10 +33,36 @@
 import { randomUUID } from 'crypto';
 import { expect, test } from '../../fixtures/glpi_fixture';
 import { KnowbaseItemPage } from '../../pages/KnowbaseItemPage';
+import { Api } from '../../utils/Api';
 import { Profiles } from '../../utils/Profiles';
 import { getWorkerEntityId } from '../../utils/WorkerEntities';
 
-test('Matching articles are shown and non-matching are hidden across parent articles', async ({
+/**
+ * A token no other article can hold, so a search for it returns exactly what
+ * the test created.
+ */
+function uniqueToken(): string
+{
+    return randomUUID().slice(0, 8);
+}
+
+/**
+ * Articles matching `token`, created in parallel: a page of results is 50, so
+ * the pagination test needs more articles than the rest of this file put
+ * together.
+ */
+async function createMatchingArticles(api: Api, token: string, count: number): Promise<number[]>
+{
+    return await Promise.all(
+        Array.from({ length: count }, (_, i) => api.createItem('KnowbaseItem', {
+            name: `E2E Result ${i} ${token}`,
+            answer: '<p>Filler content</p>',
+            entities_id: getWorkerEntityId(),
+        })),
+    );
+}
+
+test('The results replace the tree, listing every match on its own row', async ({
     page,
     profile,
     api,
@@ -44,32 +70,28 @@ test('Matching articles are shown and non-matching are hidden across parent arti
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    // Use distinct tokens so searching for one cannot match the other
-    const token_a = randomUUID().slice(0, 8);
-    const token_b = randomUUID().slice(0, 8);
-    const parent_a  = `E2E Parent A ${token_a}`;
-    const parent_b  = `E2E Parent B ${token_b}`;
-    const article_a  = `E2E Article A ${token_a}`;
-    const article_b  = `E2E Article B ${token_b}`;
+    // Distinct tokens, so searching for one cannot match the other.
+    const token_a = uniqueToken();
+    const token_b = uniqueToken();
 
     const parent_a_id = await api.createItem('KnowbaseItem', {
-        name: parent_a,
+        name: `E2E Parent A ${token_a}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
     });
     const parent_b_id = await api.createItem('KnowbaseItem', {
-        name: parent_b,
+        name: `E2E Parent B ${token_b}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
     });
     const article_a_id = await api.createItem('KnowbaseItem', {
-        name: article_a,
+        name: `E2E Article A ${token_a}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
         _parents: [parent_a_id],
     });
-    await api.createItem('KnowbaseItem', {
-        name: article_b,
+    const article_b_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Article B ${token_b}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
         _parents: [parent_b_id],
@@ -78,17 +100,22 @@ test('Matching articles are shown and non-matching are hidden across parent arti
     await kb.goto(article_a_id);
     await kb.doSearchAside(token_a);
 
-    // Parent A and its child article must be visible
-    await expect(kb.getAsideCategory(parent_a)).toBeVisible();
-    await expect(kb.getAsideCategoryArticle(parent_a, article_a)).toBeVisible();
+    // The tree gives way to the results.
+    await expect(kb.asideSearchResults).toBeVisible();
+    await expect(kb.asideRenderedTree).toBeHidden();
 
-    // Parent B and its child article must be hidden
-    await expect(kb.getAsideCategory(parent_b)).toBeHidden();
-    await expect(kb.getAsideCategoryArticle(parent_b, article_b)).toBeHidden();
+    // Both matches are listed, and a match is a row of its own: the nesting of
+    // the tree is gone, so the child does not hang under its parent.
+    await expect(kb.asideSearchResultRows).toHaveCount(2);
+    await expect(kb.getAsideSearchResultRow(parent_a_id)).toBeVisible();
+    await expect(kb.getAsideSearchResultRow(article_a_id)).toBeVisible();
+
+    // Nothing that does not match is listed.
+    await expect(kb.getAsideSearchResultRow(parent_b_id)).toHaveCount(0);
+    await expect(kb.getAsideSearchResultRow(article_b_id)).toHaveCount(0);
 });
 
-
-test('Parent articles with at least one matching child remain visible', async ({
+test('A result shows the title of the article and the beginning of its content', async ({
     page,
     profile,
     api,
@@ -96,78 +123,28 @@ test('Parent articles with at least one matching child remain visible', async ({
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    const matching_token     = randomUUID().slice(0, 8);
-    const non_matching_token = randomUUID().slice(0, 8);
-    const parent_name        = `E2E Parent ${matching_token}`;
-    const matching_article   = `E2E Article ${matching_token}`;
-    const other_article      = `E2E Article ${non_matching_token}`;
+    const token = uniqueToken();
+    const title = `E2E Reset a password ${token}`;
 
-    const parent_id = await api.createItem('KnowbaseItem', {
-        name: parent_name,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-    });
-    const matching_id = await api.createItem('KnowbaseItem', {
-        name: matching_article,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-        _parents: [parent_id],
-    });
-    await api.createItem('KnowbaseItem', {
-        name: other_article,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-        _parents: [parent_id],
-    });
-
-    await kb.goto(matching_id);
-    await kb.doSearchAside(matching_token);
-
-    // The parent must stay visible because it has one matching child
-    await expect(kb.getAsideCategory(parent_name)).toBeVisible();
-    await expect(kb.getAsideCategoryArticle(parent_name, matching_article)).toBeVisible();
-
-    // The non-matching sibling article must be hidden
-    await expect(kb.getAsideCategoryArticle(parent_name, other_article)).toBeHidden();
-});
-
-test('Clearing the search restores the full tree', async ({
-    page,
-    profile,
-    api,
-}) => {
-    await profile.set(Profiles.SuperAdmin);
-    const kb = new KnowbaseItemPage(page);
-
-    const token           = randomUUID().slice(0, 8);
-    const no_match_token  = randomUUID().slice(0, 8);
-    const parent_name     = `E2E Parent ${token}`;
-    const article_name    = `E2E Article ${token}`;
-
-    const parent_id = await api.createItem('KnowbaseItem', {
-        name: parent_name,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-    });
     const article_id = await api.createItem('KnowbaseItem', {
-        name: article_name,
-        answer: 'Test content',
+        name: title,
+        answer: '<p>Open the user form.</p><p>Then use the reset action.</p>',
         entities_id: getWorkerEntityId(),
-        _parents: [parent_id],
     });
 
     await kb.goto(article_id);
+    await kb.doSearchAside(token);
 
-    // Filter the tree so the article is hidden
-    await kb.doSearchAside(no_match_token);
-    await expect(kb.getAsideCategoryArticle(parent_name, article_name)).toBeHidden();
+    const row = kb.getAsideSearchResultRow(article_id);
+    await expect(row).toContainText(title);
 
-    // Clear the search manually, the tree must be fully restored
-    await kb.doClearAsideSearch();
-    await expect(kb.getAsideCategoryArticle(parent_name, article_name)).toBeVisible();
+    // The content of the article, as flowing text: the paragraphs of the
+    // article are not run together, and its markup is nowhere to be seen.
+    await expect(kb.getAsideSearchResultExcerpt(article_id))
+        .toHaveText('Open the user form. Then use the reset action.');
 });
 
-test('Only matching favorites remain visible', async ({
+test('The article being read is marked in the results', async ({
     page,
     profile,
     api,
@@ -175,35 +152,17 @@ test('Only matching favorites remain visible', async ({
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    const token_a   = randomUUID().slice(0, 8);
-    const token_b   = randomUUID().slice(0, 8);
-    const article_a = `E2E Favorite A ${token_a}`;
-    const article_b = `E2E Favorite B ${token_b}`;
+    const token = uniqueToken();
+    const [other_id, current_id] = await createMatchingArticles(api, token, 2);
 
-    const article_a_id = await api.createItem('KnowbaseItem', {
-        name: article_a,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-    });
-    const article_b_id = await api.createItem('KnowbaseItem', {
-        name: article_b,
-        answer: 'Test content',
-        entities_id: getWorkerEntityId(),
-    });
+    await kb.goto(current_id);
+    await kb.doSearchAside(token);
 
-    await api.knowbase.addFavorite(article_a_id);
-    await api.knowbase.addFavorite(article_b_id);
-
-    await kb.goto(article_b_id);
-
-    // Search for token_a, the article_a must stay visible in favorites, article_b must be hidden
-    await kb.doSearchAside(token_a);
-    await expect(kb.getFavoriteArticle(article_a)).toBeVisible();
-    await expect(kb.getFavoriteArticle(article_b)).toBeHidden();
-    await expect(kb.favoritesSection).toBeVisible();
+    await expect(kb.getAsideSearchResultRow(current_id)).toHaveAttribute('aria-current', 'page');
+    await expect(kb.getAsideSearchResultRow(other_id)).not.toHaveAttribute('aria-current', 'page');
 });
 
-test('Favorites section is hidden when no favorites match the search, and restored on clear', async ({
+test('Results are cut into pages, the next one loading as the reader scrolls', async ({
     page,
     profile,
     api,
@@ -211,32 +170,176 @@ test('Favorites section is hidden when no favorites match the search, and restor
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    const token          = randomUUID().slice(0, 8);
-    const no_match_token = randomUUID().slice(0, 8);
-    const article_name   = `E2E Favorite ${token}`;
+    // One more than a page, so there is a second page holding a single result.
+    const page_size = 50;
+    const token = uniqueToken();
+    const ids = await createMatchingArticles(api, token, page_size + 1);
 
-    const article_id = await api.createItem('KnowbaseItem', {
-        name: article_name,
+    await kb.goto(ids[0]);
+    await kb.doSearchAside(token);
+
+    // A page of results, closed by the marker asking for the next one.
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size);
+    await expect(kb.asideSearchLoadMore).toHaveCount(1);
+
+    // The marker is a live region, and nothing is loading until it is reached.
+    await expect(kb.asideSearchLoadMoreLoading).toBeHidden();
+
+    await kb.doScrollAsideSearchResultsToEnd();
+
+    // The last page arrives, and nothing is left to ask for.
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size + 1);
+    await expect(kb.asideSearchLoadMore).toHaveCount(0);
+
+    // Every article is listed exactly once: no page overlaps or skips another.
+    const listed = await kb.asideSearchResultRows.evaluateAll(
+        (rows) => rows.map((row) => Number((row as HTMLElement).dataset.glpiKbArticleId)),
+    );
+    expect([...listed].sort()).toEqual([...ids].sort());
+});
+
+test('A failed page request does not put an end to the results', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const page_size = 50;
+    const token = uniqueToken();
+    const ids = await createMatchingArticles(api, token, page_size + 1);
+
+    // Fail the second page once, the way a dropped connection would.
+    let fail_next_page = true;
+    await page.route(
+        (url) => url.pathname.endsWith('/Knowbase/Aside/Search')
+            && url.searchParams.get('offset') === String(page_size),
+        async (route) => {
+            if (!fail_next_page) {
+                await route.continue();
+                return;
+            }
+            fail_next_page = false;
+            await route.fulfill({ status: 500, body: '' });
+        },
+    );
+
+    await kb.goto(ids[0]);
+    await kb.doSearchAside(token);
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size);
+
+    await kb.doScrollAsideSearchResultsToEnd();
+    await expect(kb.asideSearchLoadMoreError).toBeVisible();
+
+    // Taking the marker out of view and back in asks for the page again.
+    await kb.doScrollAsideSearchResultsToStart();
+    await expect(kb.asideSearchLoadMore).not.toBeInViewport();
+    await kb.doScrollAsideSearchResultsToEnd();
+
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size + 1);
+    await expect(kb.asideSearchLoadMore).toHaveCount(0);
+});
+
+test('A new search starts back at the first page', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const page_size = 50;
+    const token = uniqueToken();
+    const ids = await createMatchingArticles(api, token, page_size + 1);
+
+    // An article of its own, to search for once scrolled to the end.
+    const lone_token = uniqueToken();
+    const lone_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Lone article ${lone_token}`,
+        answer: '<p>Lone content</p>',
+        entities_id: getWorkerEntityId(),
+    });
+
+    await kb.goto(ids[0]);
+    await kb.doSearchAside(token);
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size);
+    await kb.doScrollAsideSearchResultsToEnd();
+    await expect(kb.asideSearchResultRows).toHaveCount(page_size + 1);
+
+    // Searching again from the end of the previous results must not carry the
+    // scroll over, which would ask for every page of the new search at once.
+    await kb.doSearchAside(lone_token);
+    await expect(kb.asideSearchResultRows).toHaveCount(1);
+    await expect(kb.getAsideSearchResultRow(lone_id)).toBeVisible();
+});
+
+test('The aside works on an article that has not been saved yet', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = uniqueToken();
+    const parent_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Unsaved parent ${token}`,
+        answer: '<p>Parent content</p>',
+        entities_id: getWorkerEntityId(),
+    });
+    const child_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Unsaved child ${token}`,
+        answer: '<p>Child content</p>',
+        entities_id: getWorkerEntityId(),
+        _parents: [parent_id],
+    });
+
+    // The creation form: no article is being read, so the aside has no current
+    // article to name in the requests it sends.
+    await page.goto('/front/knowbaseitem.form.php', { waitUntil: 'domcontentloaded' });
+    await kb.waitForAsideReady();
+
+    // Unfolding a category still loads its children.
+    await kb.doExpandAsideCategory(`E2E Unsaved parent ${token}`);
+    await expect(kb.getAsideTreeArticleRow(child_id)).toBeVisible();
+
+    await kb.doSearchAside(token);
+    await expect(kb.getAsideSearchResultRow(parent_id)).toBeVisible();
+    await expect(kb.getAsideSearchResultRow(child_id)).toBeVisible();
+});
+
+test('Favorites are hidden while a search is active, and restored when it is cleared', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = uniqueToken();
+    const favorite_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Favorite ${token}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
     });
 
-    await api.knowbase.addFavorite(article_id);
-    await kb.goto(article_id);
-
+    await api.knowbase.addFavorite(favorite_id);
+    await kb.goto(favorite_id);
     await expect(kb.favoritesSection).toBeVisible();
 
-    // Search for something that matches no favorite, the entire section must disappear
-    await kb.doSearchAside(no_match_token);
+    // The results stand in for the whole tree view, favorites included, even
+    // when a favorite is itself a match.
+    await kb.doSearchAside(token);
+    await expect(kb.getAsideSearchResultRow(favorite_id)).toBeVisible();
     await expect(kb.favoritesSection).toBeHidden();
 
-    // Clearing the search must restore the section and the article inside it
     await kb.doClearAsideSearch();
     await expect(kb.favoritesSection).toBeVisible();
-    await expect(kb.getFavoriteArticle(article_name)).toBeVisible();
+    await expect(kb.getFavoriteArticleRow(favorite_id)).toBeVisible();
 });
 
-test('"No articles found" message is shown when nothing matches and hidden when results exist', async ({
+test('Clearing the search restores the tree', async ({
     page,
     profile,
     api,
@@ -244,32 +347,33 @@ test('"No articles found" message is shown when nothing matches and hidden when 
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    const token          = randomUUID().slice(0, 8);
-    const no_match_token = randomUUID().slice(0, 8);
-    const parent_name    = `E2E Parent ${token}`;
-    const article_name   = `E2E Article ${token}`;
-
+    const token = uniqueToken();
     const parent_id = await api.createItem('KnowbaseItem', {
-        name: parent_name,
+        name: `E2E Parent ${token}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
     });
     const article_id = await api.createItem('KnowbaseItem', {
-        name: article_name,
+        name: `E2E Article ${token}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
         _parents: [parent_id],
     });
 
     await kb.goto(article_id);
+    await kb.doSearchAside(uniqueToken());
 
-    // Search for something that matches nothing, message must appear
-    await kb.doSearchAside(no_match_token);
-    await expect(kb.asideNoResultsMessage).toBeVisible();
+    // The row count alone is met before the search is even sent, and clearing
+    // would then just restart the debounce with an empty value.
+    await expect(kb.asideRenderedTree).toBeHidden();
+    await expect(kb.asideSearchResultRows).toHaveCount(0);
 
-    // Search for the actual article, message must disappear
-    await kb.doSearchAside(token);
-    await expect(kb.asideNoResultsMessage).toBeHidden();
+    await kb.doClearAsideSearch();
+
+    // The results are gone and the tree is back, without a round trip.
+    await expect(kb.asideSearchResults).toHaveCount(0);
+    await expect(kb.asideRenderedTree).toBeVisible();
+    await expect(kb.getAsideTreeArticleRow(article_id)).toBeVisible();
 });
 
 test('Clear button appears when typing and clicking it restores the tree', async ({
@@ -280,35 +384,50 @@ test('Clear button appears when typing and clicking it restores the tree', async
     await profile.set(Profiles.SuperAdmin);
     const kb = new KnowbaseItemPage(page);
 
-    const token         = randomUUID().slice(0, 8);
-    const no_match_token = randomUUID().slice(0, 8);
-    const parent_name   = `E2E Parent ${token}`;
-    const article_name  = `E2E Article ${token}`;
-
-    const parent_id = await api.createItem('KnowbaseItem', {
-        name: parent_name,
+    const token = uniqueToken();
+    const article_id = await api.createItem('KnowbaseItem', {
+        name: `E2E Article ${token}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
     });
+
+    await kb.goto(article_id);
+    await kb.waitForAsideReady();
+
+    // Not interactive until there is something to clear.
+    await expect(kb.asideSearchClearButton).toBeDisabled();
+
+    await kb.doSearchAside(uniqueToken());
+    await expect(kb.asideSearchClearButton).toBeEnabled();
+    await expect(kb.asideRenderedTree).toBeHidden();
+
+    await kb.doClickAsideSearchClear();
+    await expect(kb.asideSearchClearButton).toBeDisabled();
+    await expect(kb.asideRenderedTree).toBeVisible();
+    await expect(kb.getAsideTreeArticleRow(article_id)).toBeVisible();
+});
+
+test('"No articles found" is shown when nothing matches and hidden when results exist', async ({
+    page,
+    profile,
+    api,
+}) => {
+    await profile.set(Profiles.SuperAdmin);
+    const kb = new KnowbaseItemPage(page);
+
+    const token = uniqueToken();
     const article_id = await api.createItem('KnowbaseItem', {
-        name: article_name,
+        name: `E2E Article ${token}`,
         answer: 'Test content',
         entities_id: getWorkerEntityId(),
-        _parents: [parent_id],
     });
 
     await kb.goto(article_id);
 
-    // Clear button must not be interactive before typing
-    await expect(kb.asideSearchClearButton).toBeDisabled();
+    await kb.doSearchAside(uniqueToken());
+    await expect(kb.asideNoResultsMessage).toBeVisible();
 
-    // Type a non-matching term, clear button must become interactive and article must be hidden
-    await kb.doSearchAside(no_match_token);
-    await expect(kb.asideSearchClearButton).toBeEnabled();
-    await expect(kb.getAsideCategoryArticle(parent_name, article_name)).toBeHidden();
-
-    // Click the clear button, article must be restored
-    await kb.doClickAsideSearchClear();
-    await expect(kb.asideSearchClearButton).toBeDisabled();
-    await expect(kb.getAsideCategoryArticle(parent_name, article_name)).toBeVisible();
+    await kb.doSearchAside(token);
+    await expect(kb.asideNoResultsMessage).toBeHidden();
+    await expect(kb.getAsideSearchResultRow(article_id)).toBeVisible();
 });

--- a/tests/functional/Glpi/Controller/Knowbase/AsideSearchControllerTest.php
+++ b/tests/functional/Glpi/Controller/Knowbase/AsideSearchControllerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\Controller\Knowbase;
+
+use Glpi\Controller\Knowbase\AsideSearchController;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Knowbase\Aside\SearchResultsBuilder;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+use Symfony\Component\HttpFoundation\Request;
+
+class AsideSearchControllerTest extends DbTestCase
+{
+    /**
+     * @param array<string, string|int> $query
+     */
+    private function callController(array $query): string
+    {
+        $controller = new AsideSearchController();
+        return $controller->__invoke(new Request($query))->getContent();
+    }
+
+    public function testRendersOneRowPerMatchingArticle(): void
+    {
+        $this->login();
+
+        $id = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Reset a password zqxjctrlone',
+            'answer' => '<p>Open the user form</p>',
+        ])->getID();
+        $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Unrelated article',
+            'answer' => '<p>Content</p>',
+        ]);
+
+        $html = $this->callController(['contains' => 'zqxjctrlone']);
+
+        $this->assertStringContainsString('data-glpi-kb-article-id="' . $id . '"', $html);
+        $this->assertStringContainsString('Reset a password zqxjctrlone', $html);
+        $this->assertStringContainsString('Open the user form', $html);
+        $this->assertStringNotContainsString('Unrelated article', $html);
+
+        // A single page of results: nothing left for the reader to scroll to.
+        $this->assertStringNotContainsString('data-glpi-kb-aside-search-load-more', $html);
+    }
+
+    public function testFullPageOfResultsIsFollowedByTheNextOne(): void
+    {
+        $this->login();
+
+        for ($i = 0; $i <= SearchResultsBuilder::PAGE_SIZE; $i++) {
+            $this->createItem(KnowbaseItem::class, [
+                'name'   => "Article $i zqxjctrltwo",
+                'answer' => '<p>Content</p>',
+            ]);
+        }
+
+        $html = $this->callController(['contains' => 'zqxjctrltwo']);
+
+        $this->assertStringContainsString('data-glpi-kb-aside-search-load-more', $html);
+        $this->assertStringContainsString(
+            'data-glpi-kb-aside-search-next-offset="' . SearchResultsBuilder::PAGE_SIZE . '"',
+            $html,
+        );
+        // The marker carries the search it belongs to, so a page arriving late
+        // can be told apart from the search the reader is now running.
+        $this->assertStringContainsString('data-glpi-kb-aside-search-contains="zqxjctrltwo"', $html);
+
+        // Asking for that next page returns the last result and stops there.
+        $next = $this->callController([
+            'contains' => 'zqxjctrltwo',
+            'offset'   => SearchResultsBuilder::PAGE_SIZE,
+        ]);
+        $this->assertSame(1, substr_count($next, 'data-glpi-kb-article-id='));
+        $this->assertStringNotContainsString('data-glpi-kb-aside-search-load-more', $next);
+    }
+
+    public function testEmptySearchIsRejected(): void
+    {
+        $this->login();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController(['contains' => '   ']);
+    }
+
+    /**
+     * Only the offsets this controller hands out are valid: any other one would
+     * return results overlapping the page the reader already has.
+     */
+    public function testOffsetOutsideOfThePageBoundariesIsRejected(): void
+    {
+        $this->login();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController(['contains' => 'anything', 'offset' => 7]);
+    }
+
+    public function testNegativeOffsetIsRejected(): void
+    {
+        $this->login();
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->callController(['contains' => 'anything', 'offset' => -50]);
+    }
+}

--- a/tests/functional/Glpi/Knowbase/Aside/SearchResultsBuilderTest.php
+++ b/tests/functional/Glpi/Knowbase/Aside/SearchResultsBuilderTest.php
@@ -1,0 +1,395 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\unit\Glpi\Knowbase\Aside;
+
+use Glpi\Knowbase\Aside\SearchResult;
+use Glpi\Knowbase\Aside\SearchResultsBuilder;
+use Glpi\Tests\DbTestCase;
+use KnowbaseItem;
+use KnowbaseItem_User;
+use KnowbaseItemTranslation;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class SearchResultsBuilderTest extends DbTestCase
+{
+    public function testResultCarriesWhatARowShows(): void
+    {
+        $this->login();
+
+        $article = $this->createItem(KnowbaseItem::class, [
+            'name'         => 'Reset a password zqxjtokenone',
+            'answer'       => '<p>Open the user form</p><p>Then click reset</p>',
+            'illustration' => 'antivirus',
+        ]);
+
+        $results = (new SearchResultsBuilder())->build('zqxjtokenone')->getResults();
+
+        $this->assertCount(1, $results);
+        $result = $results[0];
+        $this->assertInstanceOf(SearchResult::class, $result);
+        $this->assertSame($article->getID(), $result->id);
+        $this->assertSame('Reset a password zqxjtokenone', $result->title);
+        $this->assertSame('antivirus', $result->illustration);
+        $this->assertSame(KnowbaseItem::getFormURLWithID($article->getID()), $result->link);
+        $this->assertSame('Open the user form Then click reset', $result->excerpt);
+        $this->assertFalse($result->is_current);
+    }
+
+    public function testSearchWithoutMatchReturnsNothing(): void
+    {
+        $this->login();
+
+        $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Reset a password zqxjtokentwo',
+            'answer' => '<p>Content</p>',
+        ]);
+
+        $page = (new SearchResultsBuilder())->build('zqxjtokennomatch');
+
+        $this->assertSame([], $page->getResults());
+        $this->assertNull($page->getNextOffset());
+    }
+
+    /**
+     * An excerpt is plain text: the markup of the answer never reaches the
+     * browser, and neither does the part of it a row cannot show.
+     */
+    public function testExcerptIsPlainTextAndCapped(): void
+    {
+        $this->login();
+
+        $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Long article zqxjtokenthree',
+            'answer' => '<p>' . str_repeat('word ', 200) . '</p>',
+        ]);
+
+        $excerpt = (new SearchResultsBuilder())->build('zqxjtokenthree')->getResults()[0]->excerpt;
+
+        $this->assertStringNotContainsString('<', $excerpt);
+        $this->assertStringStartsWith('word word', $excerpt);
+
+        // Cut short of the cap, on a word boundary, and marked as cut.
+        $this->assertLessThanOrEqual(301, mb_strlen($excerpt));
+        $this->assertStringEndsWith('word…', $excerpt);
+    }
+
+    /**
+     * A word longer than the cap has no boundary to cut on, and must not be
+     * thrown away down to the end of the previous one.
+     */
+    public function testExcerptOfAnUnbrokenRunOfCharactersIsCutInIt(): void
+    {
+        $this->login();
+
+        $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Long article zqxjtokeneight',
+            'answer' => '<p>' . str_repeat('x', 400) . '</p>',
+        ]);
+
+        $excerpt = (new SearchResultsBuilder())->build('zqxjtokeneight')->getResults()[0]->excerpt;
+
+        $this->assertSame(str_repeat('x', 300) . '…', $excerpt);
+    }
+
+    public static function embeddedContentProvider(): iterable
+    {
+        yield 'an image, as its alt text' => [
+            '<p>Before</p><p><img src="picture.png" alt="A screenshot"></p><p>After</p>',
+            'Before After',
+        ];
+        yield 'a table, as its cells one after the other' => [
+            '<p>Intro</p><table><tr><td>A1</td><td>B1</td></tr></table><p>Outro</p>',
+            'Intro Outro',
+        ];
+        yield 'a table nested in another one' => [
+            '<p>Intro</p><table><tr><td><table><tr><td>Inner</td></tr></table></td></tr></table><p>Outro</p>',
+            'Intro Outro',
+        ];
+        yield 'a video, as the URL of its player' => [
+            '<p>Watch</p><div data-video-provider="youtube" data-video-id="dQw4w9WgXcQ"></div><p>End</p>',
+            'Watch End',
+        ];
+        yield 'a figure, with its caption' => [
+            '<p>Before</p><figure class="image"><img src="picture.png" alt="Alt">'
+                . '<figcaption>The caption</figcaption></figure><p>After</p>',
+            'Before After',
+        ];
+        yield 'an iframe' => [
+            '<p>Before</p><iframe src="https://example.org/embed"></iframe><p>After</p>',
+            'Before After',
+        ];
+        yield 'a horizontal rule, as a row of dashes' => [
+            '<p>Before</p><hr><p>After</p>',
+            'Before After',
+        ];
+    }
+
+    /**
+     * Content an excerpt cannot show is left out of it, rather than padding it
+     * with what a text renderer makes of it.
+     */
+    #[DataProvider('embeddedContentProvider')]
+    public function testExcerptLeavesOutEmbeddedContent(string $answer, string $expected): void
+    {
+        $this->login();
+
+        $this->createItem(
+            KnowbaseItem::class,
+            [
+                'name'   => 'Article zqxjtokennine',
+                'answer' => $answer,
+            ],
+            skip_fields: ['answer'],
+        );
+
+        $results = (new SearchResultsBuilder())->build('zqxjtokennine')->getResults();
+
+        $this->assertCount(1, $results);
+        $this->assertSame($expected, $results[0]->excerpt);
+    }
+
+    public static function proseProvider(): iterable
+    {
+        yield 'paragraphs are kept apart' => [
+            '<p>First line</p><p>Second line</p>',
+            'First line Second line',
+        ];
+        yield 'a heading is not shouted' => [
+            '<h1>Title</h1><p>Body text</p>',
+            'Title Body text',
+        ];
+        yield 'a list loses its bullets' => [
+            '<p>Steps</p><ul><li>One</li><li>Two</li></ul>',
+            'Steps One Two',
+        ];
+        yield 'a quote loses its marker' => [
+            '<blockquote><p>Quoted</p></blockquote><p>Body</p>',
+            'Quoted Body',
+        ];
+        yield 'a link keeps its text and drops its URL' => [
+            '<p>See <a href="https://example.org/a/long/url">this page</a> now</p>',
+            'See this page now',
+        ];
+        yield 'entities are decoded' => [
+            '<p>Caf&eacute; &amp; croissant</p>',
+            'Café & croissant',
+        ];
+    }
+
+    /**
+     * What the article actually says survives as a running sentence.
+     */
+    #[DataProvider('proseProvider')]
+    public function testExcerptReadsAsFlowingText(string $answer, string $expected): void
+    {
+        $this->login();
+
+        $this->createItem(
+            KnowbaseItem::class,
+            [
+                'name'   => 'Article zqxjtokenten',
+                'answer' => $answer,
+            ],
+            skip_fields: ['answer'],
+        );
+
+        $results = (new SearchResultsBuilder())->build('zqxjtokenten')->getResults();
+
+        $this->assertCount(1, $results);
+        $this->assertSame($expected, $results[0]->excerpt);
+    }
+
+    public function testArticleWithoutContentHasNoExcerpt(): void
+    {
+        $this->login();
+
+        $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Empty article zqxjtokenfour',
+            'answer' => '',
+        ]);
+
+        $results = (new SearchResultsBuilder())->build('zqxjtokenfour')->getResults();
+
+        $this->assertCount(1, $results);
+        $this->assertSame('', $results[0]->excerpt);
+    }
+
+    /**
+     * The results are cut into pages, and every match is on exactly one of
+     * them: a reader scrolling through the pages must not be shown the same
+     * article twice, nor miss one.
+     */
+    public function testResultsAreCutIntoPages(): void
+    {
+        $this->login();
+
+        $page_size = SearchResultsBuilder::PAGE_SIZE;
+        $extra     = 3;
+
+        $expected_ids = [];
+        for ($i = 0; $i < $page_size + $extra; $i++) {
+            $expected_ids[] = $this->createItem(KnowbaseItem::class, [
+                'name'   => "Article $i zqxjtokenfive",
+                'answer' => '<p>Content</p>',
+            ])->getID();
+        }
+
+        $builder = new SearchResultsBuilder();
+
+        $first = $builder->build('zqxjtokenfive');
+        $this->assertCount($page_size, $first->getResults());
+        $this->assertSame($page_size, $first->getNextOffset());
+
+        $second = $builder->build('zqxjtokenfive', $first->getNextOffset());
+        $this->assertCount($extra, $second->getResults());
+        $this->assertNull($second->getNextOffset());
+
+        $returned_ids = array_merge(
+            array_column($first->getResults(), 'id'),
+            array_column($second->getResults(), 'id'),
+        );
+        $this->assertSameSize($returned_ids, array_unique($returned_ids));
+        $this->assertEqualsCanonicalizing($expected_ids, $returned_ids);
+    }
+
+    /**
+     * The results are loaded in two queries: the ranking one, then the columns
+     * a row displays. The second must not lose the order of the first.
+     */
+    public function testResultsKeepTheirRelevanceOrder(): void
+    {
+        $this->login();
+
+        // Identical content: the scores tie, so the order is the `id DESC`
+        // fallback and is known ahead of time.
+        $ids = [];
+        for ($i = 0; $i < 3; $i++) {
+            $ids[] = $this->createItem(KnowbaseItem::class, [
+                'name'   => 'Tied article zqxjtokenten',
+                'answer' => '<p>Content</p>',
+            ])->getID();
+        }
+        rsort($ids);
+
+        $results = (new SearchResultsBuilder())->build('zqxjtokenten')->getResults();
+
+        $this->assertSame($ids, array_column($results, 'id'));
+    }
+
+    public function testResultShowsTheTranslationTheReaderSearchedThrough(): void
+    {
+        $this->login();
+
+        $article = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Original title zqxjtokeneleven',
+            'answer' => '<p>Original content</p>',
+        ]);
+        $this->createItem(KnowbaseItemTranslation::class, [
+            'knowbaseitems_id' => $article->getID(),
+            'language'         => $_SESSION['glpilanguage'],
+            'name'             => 'Translated title zqxjtokentwelve',
+            'answer'           => '<p>Translated content</p>',
+        ]);
+
+        // The token only exists in the translation, so a result proves the
+        // translated columns are both searched and read back.
+        $results = (new SearchResultsBuilder())->build('zqxjtokentwelve')->getResults();
+
+        $this->assertCount(1, $results);
+        $this->assertSame($article->getID(), $results[0]->id);
+        $this->assertSame('Translated title zqxjtokentwelve', $results[0]->title);
+        $this->assertSame('Translated content', $results[0]->excerpt);
+    }
+
+    public function testCurrentIdMarksMatchingResult(): void
+    {
+        $this->login();
+
+        $other = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Other article zqxjtokensix',
+            'answer' => '<p>Content</p>',
+        ]);
+        $current = $this->createItem(KnowbaseItem::class, [
+            'name'   => 'Current article zqxjtokensix',
+            'answer' => '<p>Content</p>',
+        ]);
+
+        $results = (new SearchResultsBuilder($current->getID()))
+            ->build('zqxjtokensix')
+            ->getResults();
+
+        $by_id = array_column($results, null, 'id');
+        $this->assertTrue($by_id[$current->getID()]->is_current);
+        $this->assertFalse($by_id[$other->getID()]->is_current);
+    }
+
+    /**
+     * The search sees exactly what the reader is allowed to see.
+     */
+    public function testResultsRespectVisibility(): void
+    {
+        // Authored by another user, so the "author" visibility bypass never
+        // makes the article visible to the restricted user below.
+        $glpi_user = getItemByTypeName('User', 'glpi', true);
+        $this->login();
+
+        $article = $this->createItem(KnowbaseItem::class, [
+            'name'     => 'Restricted article zqxjtokenseven',
+            'answer'   => '<p>Content</p>',
+            'users_id' => $glpi_user,
+        ]);
+
+        // Without any visibility grant, the article is not searchable.
+        $this->login('normal', 'normal');
+        $this->assertSame(
+            [],
+            (new SearchResultsBuilder())->build('zqxjtokenseven')->getResults(),
+        );
+
+        // Granted, the very same search returns it.
+        $this->login();
+        $this->createItem(KnowbaseItem_User::class, [
+            'knowbaseitems_id' => $article->getID(),
+            'users_id'         => getItemByTypeName('User', 'normal', true),
+        ]);
+
+        $this->login('normal', 'normal');
+        $results = (new SearchResultsBuilder())->build('zqxjtokenseven')->getResults();
+        $this->assertSame(
+            [$article->getID()],
+            array_column($results, 'id'),
+        );
+    }
+}

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -805,6 +805,51 @@ HTML,
         }
     }
 
+    public function testGetListRequestHidesArticlesOutsideTheirValidityWindowOnWildcardSearch(): void
+    {
+        global $DB;
+
+        // A search made only of operators result in `*`, which matches the whole
+        // knowledge base. Make sure the publication window is still applied.
+        $glpi_user = getItemByTypeName("User", "glpi", true);
+        $this->login();
+        $entity = $this->getTestRootEntity(only_id: true);
+
+        $articles = [];
+        // Relative dates: `begin_date` is a timestamp column, capped at 2038 on MySQL.
+        foreach (
+            [
+                'valid'   => ['begin_date' => null, 'end_date' => null],
+                'expired' => ['begin_date' => null, 'end_date' => date('Y-m-d H:i:s', strtotime('-1 year'))],
+                'future'  => ['begin_date' => date('Y-m-d H:i:s', strtotime('+1 year')), 'end_date' => null],
+            ] as $key => $dates
+        ) {
+            $articles[$key] = $this->createItem(KnowbaseItem::class, [
+                'name'        => __FUNCTION__ . '_' . $key,
+                'answer'      => __FUNCTION__ . '_' . $key,
+                'is_faq'      => 1,
+                'users_id'    => $glpi_user,
+                'entities_id' => $entity,
+                'begin_date'  => $dates['begin_date'],
+                'end_date'    => $dates['end_date'],
+            ]);
+            $this->createItem(\Entity_KnowbaseItem::class, [
+                'knowbaseitems_id' => $articles[$key]->getID(),
+                'entities_id'      => $entity,
+                'is_recursive'     => 1,
+            ]);
+        }
+
+        $this->login('post-only', 'postonly');
+
+        $criteria = KnowbaseItem::getListRequest(['contains' => '*'], 'search');
+        $names = array_column(iterator_to_array($DB->request($criteria)), 'name');
+
+        $this->assertContains($articles['valid']->fields['name'], $names);
+        $this->assertNotContains($articles['expired']->fields['name'], $names);
+        $this->assertNotContains($articles['future']->fields['name'], $names);
+    }
+
     public function testGetAnswerAnchors(): void
     {
         // Create test KB with multiple headers


### PR DESCRIPTION
The search feature on the new KB was only applied as a filter of the aside tree.
This is bad for two reasons:
* You can't really paginate a tree so it fails with high volume
* You lose the article ranking as a tree can't order results from different branches too

To fix this, I've replaced the search result by a flat list that solves both of these issues:
<img width="313" height="469" alt="image" src="https://github.com/user-attachments/assets/2b7b7511-ef25-4e64-8335-b1d05b037c28" />
