### PR TITLE
Fix: enable core rector rules for plugins

### DIFF
--- a/PluginsRector.php
+++ b/PluginsRector.php
@@ -36,6 +36,7 @@ use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
 use Rector\Configuration\RectorConfigBuilder;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
+use RectorGlpi\Set\GlpiSetList;
 
 /**
  * Shared rector baseline for GLPI plugins.
@@ -53,6 +54,9 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRect
 return static fn(array $paths): RectorConfigBuilder => RectorConfig::configure()
     ->withPaths($paths)
     ->withRootFiles()
+    ->withSets([
+        GlpiSetList::GLPI_DEFAULT_SET,
+    ])
     ->withCache(
         cacheDirectory: 'var/rector',
         cacheClass: FileCacheStorage::class,


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- `PluginsRector.php` now includes `GlpiSetList::GLPI_DEFAULT_SET`, so plugins get the same automated rector fixes as GLPI core.
- Concretely, this is what caught the `forbidHardCodedRightName` phpstan errors in the Centreon plugin (e.g. `Session::checkRight('computer', ...)`): running `make rector` on a plugin now rewrites these hardcoded right name strings to their `Class::$rightname` equivalent automatically, and rewrites legacy `getType()` calls to `::class`, instead of requiring a manual fix per occurrence.

## Screenshots (if appropriate):


