### PR TITLE
Feat: register plugins for rector static analysis

### DIFF
--- a/PluginsRector.php
+++ b/PluginsRector.php
@@ -39,6 +39,29 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRect
 use RectorGlpi\Set\GlpiSetList;
 
 /**
+ * Marks the plugin as loaded so `Plugin*` classes resolve through the legacy autoloader during
+ * static analysis, without a full framework bootstrap (DB, session, plugin init logic).
+ *
+ * @param string[] $paths
+ */
+function registerPluginAutoloading(array $paths): void
+{
+    $plugin_root = \dirname($paths[0] ?? __DIR__);
+    $plugin_key  = \strtolower(\basename($plugin_root));
+
+    if (!\defined('GLPI_PLUGINS_DIRECTORIES')) {
+        \define('GLPI_PLUGINS_DIRECTORIES', [\dirname($plugin_root)]);
+    }
+
+    $loaded_plugins_property = new ReflectionProperty(Plugin::class, 'loaded_plugins');
+    $loaded_plugins          = $loaded_plugins_property->getValue();
+
+    if (!\in_array($plugin_key, $loaded_plugins, true)) {
+        $loaded_plugins_property->setValue(null, [...$loaded_plugins, $plugin_key]);
+    }
+}
+
+/**
  * Shared rector baseline for GLPI plugins.
  *
  * Plugins usage:
@@ -51,7 +74,10 @@ use RectorGlpi\Set\GlpiSetList;
  *
  * @param string[] $paths
  */
-return static fn(array $paths): RectorConfigBuilder => RectorConfig::configure()
+return static function (array $paths): RectorConfigBuilder {
+    registerPluginAutoloading($paths);
+
+    return RectorConfig::configure()
     ->withPaths($paths)
     ->withRootFiles()
     ->withSets([
@@ -76,4 +102,5 @@ return static fn(array $paths): RectorConfigBuilder => RectorConfig::configure()
         // `strict_types=1` turns scalar coercion that return runtime TypeErrors.
         SafeDeclareStrictTypesRector::class,
     ])
-;
+    ;
+};


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- fixes #N/A
- Plugin rightname rector rules need to reflect on real `Plugin*` classes (via `is_a()` with autoload) to validate a match.
Outside a full GLPI bootstrap, `Plugin::isPluginLoaded()` always returns false, so the legacy autoloader refuses to load these classes and the rules never fire.
This change marks the plugin being analyzed as loaded in `Plugin::$loaded_plugins` before running rector, without executing the plugin's own init logic or requiring a database connection.
No automated test covers this file directly, the behavior is validated end to end by the `rector-glpi` rule tests that depend on plugin class resolution.

Need: 
- https://github.com/glpi-project/glpi/pull/25294
- https://github.com/glpi-project/rector-glpi/pull/15

## Screenshots (if appropriate):


