### PR TITLE
fix(domainrecord): enforce update rights on manageable domain records

### DIFF
--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -237,7 +237,7 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
         if (!CommonDBTM::canCreateItem()) {
             return false;
         }
-        
+
         return $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
             || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true);
     }

--- a/src/DomainRecord.php
+++ b/src/DomainRecord.php
@@ -209,9 +209,6 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
 
     public static function canUpdate(): bool
     {
-        if (!self::canUpdateAssignableItem()) {
-            return false;
-        }
         if (count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes'])) {
             return true;
         }
@@ -236,37 +233,46 @@ class DomainRecord extends CommonDBChild implements AssignableItemInterface
 
     public function canCreateItem(): bool
     {
-        return count($_SESSION['glpiactiveprofile']['managed_domainrecordtypes']) > 0;
+        // Skip CommonDBChild checks since authorization is enforced by the parent Domain.
+        if (!CommonDBTM::canCreateItem()) {
+            return false;
+        }
+        
+        return $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
+            || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true);
     }
 
     public function canUpdateItem(): bool
     {
-        if (!$this->canUpdateItemAssignableItem()) {
+        // Skip CommonDBChild checks since authorization is enforced by the parent Domain.
+        if (!CommonDBTM::canUpdateItem()) {
             return false;
         }
-        return parent::canUpdateItem()
-         && (
-             $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
-         || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true)
-         );
+
+        return $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
+            || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true);
     }
 
     public function canDeleteItem(): bool
     {
-        return parent::canDeleteItem()
-         && (
-             $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
-         || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true)
-         );
+        // Skip CommonDBChild checks since authorization is enforced by the parent Domain.
+        if (!CommonDBTM::canDeleteItem()) {
+            return false;
+        }
+
+        return $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
+            || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true);
     }
 
     public function canPurgeItem(): bool
     {
-        return parent::canPurgeItem()
-         && (
-             $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
-         || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true)
-         );
+        // Skip CommonDBChild checks since authorization is enforced by the parent Domain.
+        if (!CommonDBTM::canPurgeItem()) {
+            return false;
+        }
+
+        return $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'] === [-1]
+            || in_array($this->fields['domainrecordtypes_id'], $_SESSION['glpiactiveprofile']['managed_domainrecordtypes'], true);
     }
 
     public function defineTabs($options = [])

--- a/tests/functional/DomainRecordTest.php
+++ b/tests/functional/DomainRecordTest.php
@@ -115,7 +115,8 @@ class DomainRecordTest extends DbTestCase
         $this->assertSame('www', DomainRecord::getDisplayName($domain, 'www.Test'));
     }
 
-    public static function testDomainRecordCRUDRightsProvider() {
+    public static function testDomainRecordCRUDRightsProvider()
+    {
 
         $empty_manageable_records = [];
         $all_manageable_records_id = [-1];
@@ -138,7 +139,7 @@ class DomainRecordTest extends DbTestCase
                     'canUpdate' => false,
                     'canDelete' => false,
                     'canPurge' => false,
-                ]
+                ],
             ];
 
             yield [
@@ -155,7 +156,7 @@ class DomainRecordTest extends DbTestCase
                     'canUpdate' => true,
                     'canDelete' => true,
                     'canPurge' => true,
-                ]
+                ],
             ];
 
             yield [
@@ -172,12 +173,13 @@ class DomainRecordTest extends DbTestCase
                     'canUpdate' => false,
                     'canDelete' => false,
                     'canPurge' => false,
-                ]
+                ],
             ];
         }
     }
 
-    public function testDomainRecordCRUDRights() {
+    public function testDomainRecordCRUDRights()
+    {
         $this->login();
 
         $profile = $this->createItem(\Profile::class, [
@@ -192,12 +194,12 @@ class DomainRecordTest extends DbTestCase
             '_entities_id' => $this->getTestRootEntity(true),
         ], ['password', 'password2', '_profiles_id', '_entities_id']);
 
-        $profile_rights = new \ProfileRight();
+        $profile_rights = new ProfileRight();
         $profile_rights->getFromDBByCrit([
             'profiles_id' => $profile->getID(),
             'name' => 'domain',
         ]);
-        $domain = $this->createItem(\Domain::class, [
+        $domain = $this->createItem(Domain::class, [
             "name" => "DomainTest",
             "entities_id" => $this->getTestRootEntity(true),
         ]);
@@ -205,7 +207,7 @@ class DomainRecordTest extends DbTestCase
         $a_domain_record_type = getItemByTypeName(DomainRecordType::class, 'A');
         $aaaa_domain_record_type = getItemByTypeName(DomainRecordType::class, 'AAAA');
 
-        [$a_domain_record, $aaaa_domain_record] = $this->createItems(\DomainRecord::class, [
+        [$a_domain_record, $aaaa_domain_record] = $this->createItems(DomainRecord::class, [
             [
                 'domains_id' => $domain->getID(),
                 'domainrecordtypes_id' => $a_domain_record_type->getID(),
@@ -220,7 +222,7 @@ class DomainRecordTest extends DbTestCase
 
         foreach (self::testDomainRecordCRUDRightsProvider() as $i => $data) {
             $this->login();
-            $this->updateItem(\ProfileRight::class, $profile_rights->getID(), [
+            $this->updateItem(ProfileRight::class, $profile_rights->getID(), [
                 'rights' => $data['rights'],
             ]);
             $this->updateItem(\Profile::class, $profile->getID(), [

--- a/tests/functional/DomainRecordTest.php
+++ b/tests/functional/DomainRecordTest.php
@@ -36,7 +36,9 @@ namespace tests\units;
 
 use Domain;
 use DomainRecord;
+use DomainRecordType;
 use Glpi\Tests\DbTestCase;
+use ProfileRight;
 
 /* Test for inc/software.class.php */
 
@@ -111,5 +113,171 @@ class DomainRecordTest extends DbTestCase
 
         // Record name is a genuine FQDN suffixed by the domain name.
         $this->assertSame('www', DomainRecord::getDisplayName($domain, 'www.Test'));
+    }
+
+    public static function testDomainRecordCRUDRightsProvider() {
+
+        $empty_manageable_records = [];
+        $all_manageable_records_id = [-1];
+        $a_mangeable_record_id = [getItemByTypeName(DomainRecordType::class, 'A', true)];
+
+        $rights = [0, CREATE, UPDATE, DELETE, PURGE];
+
+        foreach ($rights as $right) {
+            yield [
+                'rights' => $right,
+                'manageable_records' => $empty_manageable_records,
+                'A_record_type_rights' => [
+                    'canCreate' => false,
+                    'canUpdate' => false,
+                    'canDelete' => false,
+                    'canPurge' => false,
+                ],
+                'AAAA_record_type_rights' => [
+                    'canCreate' => false,
+                    'canUpdate' => false,
+                    'canDelete' => false,
+                    'canPurge' => false,
+                ]
+            ];
+
+            yield [
+                'rights' => $right,
+                'manageable_records' => $all_manageable_records_id,
+                'A_record_type_rights' => [
+                    'canCreate' => true,
+                    'canUpdate' => true,
+                    'canDelete' => true,
+                    'canPurge' => true,
+                ],
+                'AAAA_record_type_rights' => [
+                    'canCreate' => true,
+                    'canUpdate' => true,
+                    'canDelete' => true,
+                    'canPurge' => true,
+                ]
+            ];
+
+            yield [
+                'rights' => $right,
+                'manageable_records' => $a_mangeable_record_id,
+                'A_record_type_rights' => [
+                    'canCreate' => true,
+                    'canUpdate' => true,
+                    'canDelete' => true,
+                    'canPurge' => true,
+                ],
+                'AAAA_record_type_rights' => [
+                    'canCreate' => false,
+                    'canUpdate' => false,
+                    'canDelete' => false,
+                    'canPurge' => false,
+                ]
+            ];
+        }
+    }
+
+    public function testDomainRecordCRUDRights() {
+        $this->login();
+
+        $profile = $this->createItem(\Profile::class, [
+            "name" => 'testDomainRecordCRUDRightsProfile',
+            "interface" => "central",
+        ]);
+        $this->createItem(\User::class, [
+            'name' => 'testDomainRecordCRUDRights',
+            'password' => 'testDomainRecordCRUDRights',
+            'password2' => 'testDomainRecordCRUDRights',
+            '_profiles_id' => $profile->getID(),
+            '_entities_id' => $this->getTestRootEntity(true),
+        ], ['password', 'password2', '_profiles_id', '_entities_id']);
+
+        $profile_rights = new \ProfileRight();
+        $profile_rights->getFromDBByCrit([
+            'profiles_id' => $profile->getID(),
+            'name' => 'domain',
+        ]);
+        $domain = $this->createItem(\Domain::class, [
+            "name" => "DomainTest",
+            "entities_id" => $this->getTestRootEntity(true),
+        ]);
+
+        $a_domain_record_type = getItemByTypeName(DomainRecordType::class, 'A');
+        $aaaa_domain_record_type = getItemByTypeName(DomainRecordType::class, 'AAAA');
+
+        [$a_domain_record, $aaaa_domain_record] = $this->createItems(\DomainRecord::class, [
+            [
+                'domains_id' => $domain->getID(),
+                'domainrecordtypes_id' => $a_domain_record_type->getID(),
+                'name' => 'a_domain_record',
+            ],
+            [
+                'domains_id' => $domain->getID(),
+                'domainrecordtypes_id' => $aaaa_domain_record_type->getID(),
+                'name' => 'aaaa_domain_record',
+            ],
+        ]);
+
+        foreach (self::testDomainRecordCRUDRightsProvider() as $i => $data) {
+            $this->login();
+            $this->updateItem(\ProfileRight::class, $profile_rights->getID(), [
+                'rights' => $data['rights'],
+            ]);
+            $this->updateItem(\Profile::class, $profile->getID(), [
+                'managed_domainrecordtypes' => $data['manageable_records'],
+            ], ['managed_domainrecordtypes']);
+
+            $this->login('testDomainRecordCRUDRights', 'testDomainRecordCRUDRights');
+
+            // Test CREATE
+            $new_a_record = new DomainRecord();
+            $a_create_input = [
+                'domains_id' => $domain->getID(),
+                'domainrecordtypes_id' => $a_domain_record_type->getID(),
+            ];
+            $this->assertSame(
+                $data['A_record_type_rights']['canCreate'],
+                $new_a_record->can(-1, CREATE, $a_create_input),
+            );
+            $new_aaaa_record = new DomainRecord();
+            $aaaa_create_input = [
+                'domains_id' => $domain->getID(),
+                'domainrecordtypes_id' => $aaaa_domain_record_type->getID(),
+            ];
+            $this->assertSame(
+                $data['AAAA_record_type_rights']['canCreate'],
+                $new_aaaa_record->can(-1, CREATE, $aaaa_create_input),
+            );
+
+            // Test UPDATE
+            $this->assertSame(
+                $data['A_record_type_rights']['canUpdate'],
+                $a_domain_record->can($a_domain_record->getID(), UPDATE),
+            );
+            $this->assertSame(
+                $data['AAAA_record_type_rights']['canUpdate'],
+                $aaaa_domain_record->can($aaaa_domain_record->getID(), UPDATE),
+            );
+
+            // Test DELETE
+            $this->assertSame(
+                $data['A_record_type_rights']['canDelete'],
+                $a_domain_record->can($a_domain_record->getID(), DELETE),
+            );
+            $this->assertSame(
+                $data['AAAA_record_type_rights']['canDelete'],
+                $aaaa_domain_record->can($aaaa_domain_record->getID(), DELETE),
+            );
+
+            // Test PURGE
+            $this->assertSame(
+                $data['A_record_type_rights']['canPurge'],
+                $a_domain_record->can($a_domain_record->getID(), PURGE),
+            );
+            $this->assertSame(
+                $data['AAAA_record_type_rights']['canPurge'],
+                $aaaa_domain_record->can($aaaa_domain_record->getID(), PURGE),
+            );
+        }
     }
 }


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45963
- In GLPI 10, profiles authorized to manage certain types of domain records could modify the records corresponding to those types, even if they did not have rights to modify or delete the domains. This PR restores the original behavior.


## Screenshots (if appropriate):

Configuration of allowed domain records in the profile:
<img width="629" height="71" alt="image" src="https://github.com/user-attachments/assets/e8f4211d-746d-406e-b742-4fb13016dcab" />
<img width="676" height="68" alt="image" src="https://github.com/user-attachments/assets/f72494dc-1e2f-4c95-85a6-1362bf433deb" />

An “A” record authorized by the profile can be modified and deleted
<img width="1232" height="453" alt="image" src="https://github.com/user-attachments/assets/dc89a0ea-6ed3-4929-ad1c-29820bc32613" />

A “AAAA” domain record that is not authorized by the profile cannot be modified or deleted.
<img width="1228" height="379" alt="image" src="https://github.com/user-attachments/assets/b1ef1a82-8189-4a9f-bb2f-b81672cc9baf" />





