### PR TITLE
Feat(Marketplace): allow marketplace to expose unstable plugins versi…

### DIFF
--- a/src/Glpi/Application/SystemConfigurator.php
+++ b/src/Glpi/Application/SystemConfigurator.php
@@ -150,7 +150,7 @@ final class SystemConfigurator
                 'GLPI_NETWORK_REGISTRATION_API_URL' => '{GLPI_NETWORK_API_URL}/registration/',
                 'GLPI_MARKETPLACE_ENABLE'           => 3, // 0 = Completely disabled, 1 = CLI only, 2 = Web only, 3 = CLI and Web
                 'GLPI_MARKETPLACE_PLUGINS_API_URI'  => '{GLPI_NETWORK_API_URL}/marketplace/',
-                'GLPI_MARKETPLACE_PRERELEASES'      => preg_match('/-(dev|alpha\d*|beta\d*|rc\d*)$/', GLPI_VERSION) === 1, // allow marketplace to expose unstable plugins versions
+                'GLPI_MARKETPLACE_PRERELEASES'      => 1, // allow marketplace to expose unstable plugins versions by default
                 'GLPI_MARKETPLACE_ALLOW_OVERRIDE'   => true, // allow marketplace to override a plugin found outside GLPI_MARKETPLACE_DIR
                 'GLPI_MARKETPLACE_MANUAL_DOWNLOADS' => true, // propose manual download link of plugins which cannot be installed/updated by marketplace
                 'GLPI_USER_AGENT_EXTRA_COMMENTS'    => '', // Extra comment to add to GLPI User-Agent


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have read the CONTRIBUTING document.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

As discussed with @orthagh , going through a prerelease phase (alpha, RC, etc.) for plugins makes the plugin update and release preparation process unnecessarily cumbersome, especially when preparing plugins for the next major GLPI version.

Currently, in order to make prerelease plugins available, GLPI itself must also be running a prerelease version (alpha, RC, dev, etc.). This creates an unnecessary dependency between the GLPI release status and the plugin release status.

I propose simplifying this process by allowing prerelease plugins to be available independently of the GLPI version's release status.

The existing constant could still be kept as-is for partners and integrators, allowing them to restrict the Marketplace view to officially released plugins only.


## Screenshots (if appropriate):


