### PR TITLE
Remove 'single-thread' phpunit group

### DIFF
--- a/.github/actions/init_clone-databases.sh
+++ b/.github/actions/init_clone-databases.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e -u -x -o pipefail
+
+# Clone the tests database to be able to run the tests in parallel.
+# The first paratest worker uses the `glpi` database, the following ones use `glpi_<worker number>`.
+# The number of databases to create must match the number of paratest workers (see `test_tests-functional.sh`).
+
+docker compose exec -T db bash -c '
+  set -e -u -o pipefail
+  if command -v mariadb &> /dev/null; then
+    DB_CLIENT="mariadb"
+    DB_DUMP="mariadb-dump"
+  else
+    DB_CLIENT="mysql"
+    DB_DUMP="mysqldump --set-gtid-purged=OFF"
+  fi
+  for i in 2 3 4; do
+    $DB_CLIENT -u root -e "DROP DATABASE IF EXISTS glpi_$i;"
+    $DB_CLIENT -u root -e "CREATE DATABASE glpi_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+    $DB_DUMP -u root --single-transaction glpi | $DB_CLIENT -u root glpi_$i
+    echo "Database glpi_$i created and populated"
+  done
+'

--- a/.github/actions/test_tests-functional.sh
+++ b/.github/actions/test_tests-functional.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e -u -x -o pipefail
 
-vendor/bin/phpunit --group "single-thread" $@
+# The number of workers must match the number of test databases (see `init_clone-databases.sh`)
+vendor/bin/paratest -p 4 $@

--- a/.github/actions/test_tests-functional_parallel.sh
+++ b/.github/actions/test_tests-functional_parallel.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e -u -x -o pipefail
-
-vendor/bin/paratest --exclude-group "single-thread" $@

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,32 +203,14 @@ jobs:
         run: |
           .github/actions/init_initialize-9.5-db.sh
           docker compose exec -T app .github/actions/test_update-from-9.5.sh
-      - name: "Functional tests (phpunit)"
-        if: "${{ success() || failure() }}"
-        run: |
-          docker compose exec -T app .github/actions/test_tests-functional.sh
       - name: "Clone databases"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T db bash -c '
-            set -e -u -o pipefail
-            if command -v mariadb &> /dev/null; then
-              DB_CLIENT="mariadb"
-              DB_DUMP="mariadb-dump"
-            else
-              DB_CLIENT="mysql"
-              DB_DUMP="mysqldump --set-gtid-purged=OFF"
-            fi
-            for i in 2 3 4; do
-              $DB_CLIENT -u root -e "CREATE DATABASE glpi_$i CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-              $DB_DUMP -u root --single-transaction glpi | $DB_CLIENT -u root glpi_$i
-              echo "Database glpi_$i created and populated"
-            done
-          '
-      - name: "Functional tests (paratest)"
+          .github/actions/init_clone-databases.sh
+      - name: "Functional tests"
         if: "${{ success() || failure() }}"
         run: |
-          docker compose exec -T app .github/actions/test_tests-functional_parallel.sh
+          docker compose exec -T app .github/actions/test_tests-functional.sh
       - name: "Cache tests"
         if: "${{ success() || failure() }}"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ phpunit: ## Run phpunits tests, example: make phpunit c='tests/functional/Glpi/M
 paratest: ## Run paratest, example: make paratest p=8
 	@$(eval p ?= 4)
 	@$(eval c ?=)
-	$(PHP) php vendor/bin/paratest -p $(p) --exclude-group "single-thread" $(c)
+	$(PHP) php vendor/bin/paratest -p $(p) $(c)
 .PHONY: paratest
 
 phpstan: ## Run phpstan

--- a/src/Glpi/OAuth/Server.php
+++ b/src/Glpi/OAuth/Server.php
@@ -61,8 +61,11 @@ use function Safe\unlink;
 
 final class Server
 {
-    private const PRIVATE_KEY_PATH = GLPI_CONFIG_DIR . '/oauth.pem';
-    private const PUBLIC_KEY_PATH  = GLPI_CONFIG_DIR . '/oauth.pub';
+    private const PRIVATE_KEY_FILENAME = 'oauth.pem';
+    private const PUBLIC_KEY_FILENAME  = 'oauth.pub';
+
+    private const PRIVATE_KEY_PATH = GLPI_CONFIG_DIR . '/' . self::PRIVATE_KEY_FILENAME;
+    private const PUBLIC_KEY_PATH  = GLPI_CONFIG_DIR . '/' . self::PUBLIC_KEY_FILENAME;
 
     /**
      * @var ClientRepository
@@ -210,15 +213,18 @@ final class Server
         ];
     }
 
-    public static function checkKeys(): bool
+    public static function checkKeys(string $config_dir = GLPI_CONFIG_DIR): bool
     {
+        $private_key_path = $config_dir . '/' . self::PRIVATE_KEY_FILENAME;
+        $public_key_path  = $config_dir . '/' . self::PUBLIC_KEY_FILENAME;
+
         if (
-            file_exists(self::PRIVATE_KEY_PATH)
-            && file_exists(self::PUBLIC_KEY_PATH)
+            file_exists($private_key_path)
+            && file_exists($public_key_path)
         ) {
             // Keys are already generated
 
-            if (is_readable(self::PRIVATE_KEY_PATH) && is_readable(self::PUBLIC_KEY_PATH)) {
+            if (is_readable($private_key_path) && is_readable($public_key_path)) {
                 return true;
             } else {
                 throw new OAuth2KeyException('Either private or public OAuth keys cannot be read. Please check file system permissions');

--- a/tests/functional/Glpi/OAuth/ServerTest.php
+++ b/tests/functional/Glpi/OAuth/ServerTest.php
@@ -37,15 +37,35 @@ namespace tests\units\Glpi\Migration;
 use Glpi\Exception\OAuth2KeyException;
 use Glpi\OAuth\Server;
 use Glpi\Tests\DbTestCase;
-use PHPUnit\Framework\Attributes\Group;
+
+use function Safe\chmod;
+use function Safe\copy;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
 
 class ServerTest extends DbTestCase
 {
+    /**
+     * Directory holding a disposable copy of the OAuth keys, if any.
+     */
+    private ?string $keys_directory = null;
+
     public function tearDown(): void
     {
-        //reset correct chmod
-        \Safe\chmod(GLPI_CONFIG_DIR . '/oauth.pem', 0o600);
-        \Safe\chmod(GLPI_CONFIG_DIR . '/oauth.pub', 0o600);
+        if ($this->keys_directory !== null) {
+            foreach (['oauth.pem', 'oauth.pub'] as $key_filename) {
+                if (!file_exists($this->keys_directory . '/' . $key_filename)) {
+                    continue; //the copy may have failed
+                }
+                //reset correct chmod to be able to delete the file
+                chmod($this->keys_directory . '/' . $key_filename, 0o600);
+                unlink($this->keys_directory . '/' . $key_filename);
+            }
+            rmdir($this->keys_directory);
+            $this->keys_directory = null;
+        }
+
         parent::tearDown();
     }
 
@@ -55,29 +75,54 @@ class ServerTest extends DbTestCase
         $this->assertTrue(Server::checkKeys());
     }
 
-    #[Group('single-thread')] // Modifing permission on the oauth file
     public function testPrivateKeyNotReadable()
     {
-        //by default, keys must be present and readable.
-        $this->assertTrue(Server::checkKeys());
+        //operate on a copy of the keys, as making the real ones unreadable would impact any other test running concurrently.
+        $config_dir = $this->getKeysCopyDirectory();
+
+        //keys must be present and readable.
+        $this->assertTrue(Server::checkKeys($config_dir));
 
         //change ACLs on private key to make it unreadable
-        \Safe\chmod(GLPI_CONFIG_DIR . '/oauth.pem', 0o000);
+        chmod($config_dir . '/oauth.pem', 0o000);
         $this->expectException(OAuth2KeyException::class);
         $this->expectExceptionMessage('Either private or public OAuth keys cannot be read. Please check file system permissions');
-        $this->assertTrue(Server::checkKeys());
+        $this->assertTrue(Server::checkKeys($config_dir));
     }
 
-    #[Group('single-thread')] // Modifing permission on the oauth file
     public function testPublicKeyNotReadable()
     {
-        //by default, keys must be present and readable.
-        $this->assertTrue(Server::checkKeys());
+        //operate on a copy of the keys, as making the real ones unreadable would impact any other test running concurrently.
+        $config_dir = $this->getKeysCopyDirectory();
+
+        //keys must be present and readable.
+        $this->assertTrue(Server::checkKeys($config_dir));
 
         //change ACLs on public key to make it unreadable
-        \Safe\chmod(GLPI_CONFIG_DIR . '/oauth.pub', 0o000);
+        chmod($config_dir . '/oauth.pub', 0o000);
         $this->expectException(OAuth2KeyException::class);
         $this->expectExceptionMessage('Either private or public OAuth keys cannot be read. Please check file system permissions');
-        $this->assertTrue(Server::checkKeys());
+        $this->assertTrue(Server::checkKeys($config_dir));
+    }
+
+    /**
+     * Copy the OAuth keys into a dedicated directory, removed during the teardown.
+     *
+     * @return string Path of the directory containing the copied keys.
+     */
+    private function getKeysCopyDirectory(): string
+    {
+        $directory = sys_get_temp_dir() . '/glpi_test_oauth_keys_' . uniqid();
+        mkdir($directory);
+        $this->keys_directory = $directory;
+
+        foreach (['oauth.pem', 'oauth.pub'] as $key_filename) {
+            copy(
+                GLPI_CONFIG_DIR . '/' . $key_filename,
+                $directory . '/' . $key_filename
+            );
+        }
+
+        return $directory;
     }
 }

--- a/tests/functional/SessionTest.php
+++ b/tests/functional/SessionTest.php
@@ -35,20 +35,57 @@
 namespace tests\units;
 
 use Computer;
-use Glpi\Cache\CacheManager;
 use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\SessionExpiredException;
 use Glpi\Tests\DbTestCase;
+use Laminas\I18n\Translator\Translator;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use Profile;
 use Profile_User;
 use ProfileRight;
 use ReflectionClass;
 use User;
 
+use function Safe\copy;
+use function Safe\file_put_contents;
+use function Safe\glob;
+use function Safe\mkdir;
+use function Safe\rmdir;
+use function Safe\unlink;
+
 class SessionTest extends DbTestCase
 {
+    /**
+     * Language used to test the local i18n files.
+     * It must be a language that is not used by any other test, as the local
+     * i18n overrides would be visible by the tests running concurrently.
+     */
+    private const LOCAL_I18N_LANGUAGE = 'mn_MN';
+
+    /**
+     * Directory holding the local i18n files used by the tests, if any.
+     */
+    private ?string $local_i18n_directory = null;
+
+    public function tearDown(): void
+    {
+        if ($this->local_i18n_directory !== null) {
+            /** @var Translator $TRANSLATE */
+            global $TRANSLATE;
+
+            foreach (glob($this->local_i18n_directory . '/*') as $local_file) {
+                unlink($local_file);
+            }
+            rmdir($this->local_i18n_directory);
+            $this->local_i18n_directory = null;
+
+            // Drop the translations loaded from the local files.
+            $TRANSLATE->clearCache('glpi', self::LOCAL_I18N_LANGUAGE);
+        }
+
+        parent::tearDown();
+    }
+
     public function testAddMessageAfterRedirect()
     {
         $err_msg = 'Something is broken. Weird.';
@@ -217,47 +254,50 @@ class SessionTest extends DbTestCase
         }
     }
 
-    #[Group('single-thread')] // Changing locale files
     public function testLocalI18n()
     {
-        $manager = new CacheManager();
-        $cache = $manager->getTranslationsCacheInstance();
-        $cache->clear();
+        /** @var Translator $TRANSLATE */
+        global $TRANSLATE;
+
+        $language = self::LOCAL_I18N_LANGUAGE;
+        $mofile = $language . '.mo';
+        $phpfile = $language . '.php';
+
+        //create a dedicated directory for local i18n ("core_*" directories are loaded like the "core" one)
+        $directory = GLPI_LOCAL_I18N_DIR . '/core_test_' . uniqid();
+        mkdir($directory, 0o755, true);
+        $this->local_i18n_directory = $directory;
 
         //load locales
-        \Session::loadLanguage('en_GB');
-        $this->assertEquals('Login', __('Login'));
+        \Session::loadLanguage($language);
+        $default_login = __('Login');
+        $default_password = __('Password');
 
-        //create directory for local i18n
-        if (!file_exists(GLPI_LOCAL_I18N_DIR . '/core')) {
-            mkdir(GLPI_LOCAL_I18N_DIR . '/core');
-        }
+        //make sure the language catalog was actually loaded (`loadLanguage()` silently falls back to en_GB)
+        $this->assertNotEquals('Login', $default_login);
 
         //write local MO file with i18n override
         copy(
             __DIR__ . '/../local_en_GB.mo',
-            GLPI_LOCAL_I18N_DIR . '/core/en_GB.mo'
+            $directory . '/' . $mofile
         );
-        $cache->clear();
-        \Session::loadLanguage('en_GB');
+        $TRANSLATE->clearCache('glpi', $language);
+        \Session::loadLanguage($language);
 
         $this->assertEquals('Login from local gettext', __('Login'));
-        $this->assertEquals('Password', __('Password'));
+        $this->assertEquals($default_password, __('Password'));
 
         //write local PHP file with i18n override
         file_put_contents(
-            GLPI_LOCAL_I18N_DIR . '/core/en_GB.php',
+            $directory . '/' . $phpfile,
             "<?php\n\$lang['Login'] = 'Login from local PHP';\n\$lang['Password'] = 'Password from local PHP';\nreturn \$lang;"
         );
-        $cache->clear();
-        \Session::loadLanguage('en_GB');
+        $TRANSLATE->clearCache('glpi', $language);
+        \Session::loadLanguage($language);
 
+        //MO file takes precedence over the PHP one
         $this->assertEquals('Login from local gettext', __('Login'));
         $this->assertEquals('Password from local PHP', __('Password'));
-
-        //cleanup -- keep at the end
-        unlink(GLPI_LOCAL_I18N_DIR . '/core/en_GB.php');
-        unlink(GLPI_LOCAL_I18N_DIR . '/core/en_GB.mo');
     }
 
     public static function mustChangePasswordProvider()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -283,7 +283,8 @@ run_single_test () {
       || LAST_EXIT_CODE=$?
       ;;
     "functional")
-         docker compose exec -T app .github/actions/test_tests-functional.sh $TEST_ARGS \
+         $APPLICATION_ROOT/.github/actions/init_clone-databases.sh \
+      && docker compose exec -T app .github/actions/test_tests-functional.sh $TEST_ARGS \
       || LAST_EXIT_CODE=$?
       ;;
     "cache")


### PR DESCRIPTION
3 tests used the `#[Group('single-thread')]` annotation that required a specific CI step:
<img width="774" height="541" alt="image" src="https://github.com/user-attachments/assets/b4ed1b11-87f1-4336-92d5-ca52fb45cc89" />

I've adapted them to make sure they can now run alongside other tests and simplified the CI config as a result.

For the Oauth tests, they were changing permissions on a file that might be used by others tests workers.
I've fixed it by making it work on a copy of the file instead. This required adding a parameter to a method so the target folder can be specified.

For the locales tests, it was a combinaison of using a specific folder too and targeting a language that is not used by any others tests so the shared cache don't cause issues.
Not perfect but difficult to do better here without rewriting a lot of code. I'd rather do something simple for now, especially on a bugfix branch.

We are now back to one single step:
<img width="463" height="236" alt="image" src="https://github.com/user-attachments/assets/daf253fa-683f-48cb-a150-bdc72457d88f" />

