### PR TITLE
Fix "tester" plugin fixture being loaded too late

### DIFF
--- a/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/BootPlugins.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Kernel\Listener\PostBootListener;
 
-use Glpi\Application\Environment;
 use Glpi\Debug\Profiler;
 use Glpi\Kernel\KernelListenerTrait;
 use Glpi\Kernel\ListenersPriority;
@@ -66,10 +65,6 @@ final readonly class BootPlugins implements EventSubscriberInterface
 
         Profiler::getInstance()->start('BootPlugins::execute', Profiler::CATEGORY_BOOT);
 
-        if (Environment::get()->shouldSetupTesterPlugin()) {
-            $this->setupTesterPlugin();
-        }
-
         $plugin = new Plugin();
 
         if (!$plugin->isPluginsExecutionSuspended()) {
@@ -77,16 +72,5 @@ final readonly class BootPlugins implements EventSubscriberInterface
         }
 
         Profiler::getInstance()->stop('BootPlugins::execute');
-    }
-
-    private function setupTesterPlugin(): void
-    {
-        global $DB;
-        $DB->updateOrInsert(table: Plugin::getTable(), params: [
-            'directory' => 'tester',
-            'name'      => 'tester',
-            'state'     => 1,
-            'version'   => '1.0.0',
-        ], where: ['directory' => 'tester']);
     }
 }

--- a/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
+++ b/src/Glpi/Kernel/Listener/PostBootListener/CheckPluginsStates.php
@@ -36,6 +36,7 @@ namespace Glpi\Kernel\Listener\PostBootListener;
 
 use Config;
 use DBConnection;
+use Glpi\Application\Environment;
 use Glpi\Debug\Profiler;
 use Glpi\Kernel\ListenersPriority;
 use Glpi\Kernel\PostBootEvent;
@@ -64,8 +65,25 @@ final readonly class CheckPluginsStates implements EventSubscriberInterface
 
         Profiler::getInstance()->start('CheckPluginsStates::execute', Profiler::CATEGORY_BOOT);
 
+        // Must be done before checking the plugins states, as the state check is responsible for loading
+        // the plugin `setup.php` file, which declares the plugin hooks (`plugin_tester_boot()`, ...).
+        if (Environment::get()->shouldSetupTesterPlugin()) {
+            $this->setupTesterPlugin();
+        }
+
         (new Plugin())->checkStates();
 
         Profiler::getInstance()->stop('CheckPluginsStates::execute');
+    }
+
+    private function setupTesterPlugin(): void
+    {
+        global $DB;
+        $DB->updateOrInsert(table: Plugin::getTable(), params: [
+            'directory' => 'tester',
+            'name'      => 'tester',
+            'state'     => 1,
+            'version'   => '1.0.0',
+        ], where: ['directory' => 'tester']);
     }
 }


### PR DESCRIPTION
Some tests always fail locally when executed right after a test database install:

<img width="1211" height="1239" alt="image" src="https://github.com/user-attachments/assets/cb870aab-78c4-4f15-b6f5-bdb0a8b8429c" />

Then it work for the next run, indicating an issue with the tester plugin not being taken into account during the first run.

After these changes, I no longer have issues:

<img width="1048" height="814" alt="image" src="https://github.com/user-attachments/assets/fb8671f4-04b5-484b-a31a-01005e782ebf" />
