### PR TITLE
Fix helpdesk tile edit access check

### DIFF
--- a/src/Glpi/Controller/Config/Helpdesk/ShowEditTileFormController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/ShowEditTileFormController.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Controller\Config\Helpdesk;
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -53,9 +52,8 @@ final class ShowEditTileFormController extends AbstractTileController
             $request->query->getString('tile_itemtype'),
             $request->query->getInt('tile_id'),
         );
-        if (!$tile::canUpdate() || !$tile->canUpdateItem()) {
-            throw new AccessDeniedHttpException();
-        }
+        // Access is granted based on the linked item (entity/profile), not the tile itself.
+        $this->getAndValidateLinkedItemFromDatabase($tile);
 
         // Render form
         return $this->render('pages/admin/helpdesk_home_config_edit_tile_form.html.twig', [

--- a/src/Glpi/Controller/Config/Helpdesk/UpdateTileController.php
+++ b/src/Glpi/Controller/Config/Helpdesk/UpdateTileController.php
@@ -34,7 +34,6 @@
 
 namespace Glpi\Controller\Config\Helpdesk;
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -54,11 +53,8 @@ final class UpdateTileController extends AbstractTileController
             $request->request->getString('_itemtype'),
             $request->request->getInt('id'),
         );
-        if (!$tile::canUpdate() || !$tile->canUpdateItem()) {
-            throw new AccessDeniedHttpException();
-        }
 
-        // Validate linked item
+        // Validate linked item — access is granted based on the linked item (entity/profile), not the tile itself.
         $linked_item = $this->getAndValidateLinkedItemFromDatabase($tile);
 
         // Prepare input


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45863

A user with the entity > UPDATEHELPDESK permission can see the edit button on a helpdesk tile but receives an error when clicking it because the controller checks the config permission instead of the entity permission.

In TilesManager, showConfigFormForItem, the “Edit” button is displayed if item canUpdate is true (the entity).
But in ShowEditTileFormController, the check uses tile canUpdate, which verifies the “config” permission (defined by FormTile rightname = ‘config’).

ShowEditTileFormController: Removed the tile::canUpdate check and replaced it with getAndValidateLinkedItemFromDatabase($tile) which checks permissions on the linked item (entity/profile) making it consistent with what TilesManager showConfigFormForItem does to display the button
Removed the same check in UpdateTileController, as it is redundant.


