### PR TITLE
FIX / Fix misaligned Heading column in knowledge base article attachments table

### DIFF
--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -1066,7 +1066,7 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
                 $attachments[] = [
                     'row_class' => $data['is_deleted'] ? 'table-danger' : '',
                     'filename' => $downloadlink,
-                    'heading' => $heading_names[$data["documentcategories_id"]],
+                    'headings' => $heading_names[$data["documentcategories_id"]],
                     'assocdate' => $data["assocdate"],
                 ];
             }

--- a/tests/functional/KnowbaseItemTest.php
+++ b/tests/functional/KnowbaseItemTest.php
@@ -335,6 +335,52 @@ HTML,
         $this->assertEquals(2, $count);
     }
 
+    /**
+     * The attached documents table must render the Heading cell for each row.
+     */
+    public function testShowFullAttachmentsColumnsAlignment(): void
+    {
+        $this->login();
+        $entity_id = (int) getItemByTypeName('Entity', '_test_root_entity', true);
+        $this->setEntity('_test_root_entity', true);
+
+        $category = $this->createItem(\DocumentCategory::class, [
+            'name' => __FUNCTION__ . ' heading',
+        ]);
+
+        $kbitem = $this->createItem(\KnowbaseItem::class, [
+            'name'   => __FUNCTION__,
+            'answer' => __FUNCTION__,
+        ]);
+        $this->createItem(\Entity_KnowbaseItem::class, [
+            'knowbaseitems_id' => $kbitem->getID(),
+            'entities_id'      => $entity_id,
+            'is_recursive'     => 1,
+        ]);
+
+        $document = $this->createItem(\Document::class, [
+            'name'                  => __FUNCTION__ . ' document',
+            'entities_id'           => $entity_id,
+            'documentcategories_id' => $category->getID(),
+        ]);
+        $this->createItem(\Document_Item::class, [
+            'documents_id' => $document->getID(),
+            'itemtype'     => \KnowbaseItem::class,
+            'items_id'     => $kbitem->getID(),
+        ]);
+
+        $this->assertTrue($kbitem->getFromDB($kbitem->getID()));
+        $html = $kbitem->showFull(['display' => false]);
+
+        $this->assertSame(
+            1,
+            preg_match_all(
+                '#<td[^>]*>(?:(?!</td>).)*?' . preg_quote(__FUNCTION__ . ' heading', '#') . '(?:(?!</td>).)*?</td>#s',
+                $html
+            )
+        );
+    }
+
     public function testGetForCategory()
     {
         global $DB;


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !45977
- In the full knowledge base article view, the attached documents table ("Contenu" section) rendered its rows shifted by one column: the association date appeared under the **Heading** column and the **Date** column stayed empty.
The table column is named `headings`, but `KnowbaseItem::showFull()` filled each row with a `heading` key. Since the datatable template only outputs a cell when the key matches the column, the Heading cell was never rendered
and every column after it shifted left by one.

## Screenshots :

<img width="1383" height="613" alt="Capture d’écran du 2026-08-28 15-04-32" src="https://github.com/user-attachments/assets/2173c7cc-ddbe-4cb3-9a01-e72f425cc6b9" />
<img width="1383" height="613" alt="Capture d’écran du 2026-08-28 16-15-24" src="https://github.com/user-attachments/assets/bfe619c0-8f40-4f59-9146-9498e26337fd" />

After the fix: 
<img width="1383" height="613" alt="Capture d’écran du 2026-08-28 16-39-42" src="https://github.com/user-attachments/assets/51fc8708-7555-45bc-aec0-ca6d362b6caf" />

