### PR TITLE
Fix(Search): use session clock for SLA progress bar computation

### DIFF
--- a/src/Glpi/Search/Provider/SQLProvider.php
+++ b/src/Glpi/Search/Provider/SQLProvider.php
@@ -6194,7 +6194,7 @@ final class SQLProvider implements SearchProviderInterface
                             ));
                             $currenttime = $sla->getActiveTimeBetween(
                                 $item->fields['date'],
-                                date('Y-m-d H:i:s')
+                                $_SESSION['glpi_currenttime']
                             );
                             $totaltime   = $sla->getActiveTimeBetween(
                                 $item->fields['date'],
@@ -6212,14 +6212,14 @@ final class SQLProvider implements SearchProviderInterface
                             if ($calendars_id > 0 && $calendar->getFromDB($calendars_id)) { // Ticket entity have calendar
                                 $currenttime = $calendar->getActiveTimeBetween(
                                     $item->fields['date'],
-                                    date('Y-m-d H:i:s')
+                                    $_SESSION['glpi_currenttime']
                                 );
                                 $totaltime   = $calendar->getActiveTimeBetween(
                                     $item->fields['date'],
                                     $data[$ID][0]['name']
                                 );
                             } else { // No calendar
-                                $currenttime = strtotime(date('Y-m-d H:i:s'))
+                                $currenttime = strtotime($_SESSION['glpi_currenttime'])
                                     - strtotime($item->fields['date']);
                                 $totaltime   = strtotime($data[$ID][0]['name'])
                                     - strtotime($item->fields['date']);

--- a/tests/functional/SlaProgressBarTest.php
+++ b/tests/functional/SlaProgressBarTest.php
@@ -43,7 +43,6 @@ use SLA;
 use SLM;
 use Ticket;
 
-use function Safe\date;
 use function Safe\preg_match;
 use function Safe\strtotime;
 
@@ -58,6 +57,10 @@ class SlaProgressBarTest extends DbTestCase
     public function testProgressBarUsesEntityCalendarWhenSlaUsesTicketCalendar()
     {
         $this->login();
+
+        // Freeze "now" so the scenario is deterministic whatever day the suite runs on.
+        // 2026-08-17 is a Monday; the ticket below opens exactly 7 days earlier (also a Monday).
+        $this->setCurrentTime('2026-08-17 10:00:00');
 
         $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
 
@@ -103,9 +106,9 @@ class SlaProgressBarTest extends DbTestCase
             'definition_time' => 'hour',
         ], SLM::TTR, $slm)['sla'];
 
-        // Exactly 7 days ago: always one of each weekday, so elapsed time is deterministic
-        // (50 business hours calendar-aware vs 168h naive), whatever day the test runs on.
-        $ticket_date = date('Y-m-d H:i:s', strtotime('-7 days'));
+        // Exactly 7 days before the frozen "now": one of each weekday, so elapsed time is
+        // deterministic (50 business hours calendar-aware vs 168h naive).
+        $ticket_date = '2026-08-10 10:00:00';
 
         $ticket = $this->createItem(Ticket::class, [
             'name'        => 'SlaProgressBarTest ticket',
@@ -128,7 +131,7 @@ class SlaProgressBarTest extends DbTestCase
 
         $displayed_percentage = $this->getDisplayedTimeToResolveProgress($ticket);
 
-        // Delta absorbs the few seconds between this "now" and the one used by the search.
+        // Small delta to absorb rounding; the frozen clock makes both sides use the same "now".
         $this->assertEqualsWithDelta($expected_percentage, $displayed_percentage, 2);
     }
 
@@ -138,7 +141,7 @@ class SlaProgressBarTest extends DbTestCase
         $this->assertTrue($sla->getFromDB($ticket->fields['slas_id_ttr']));
         $sla->setTicketCalendar($calendar->getID());
 
-        $currenttime = $sla->getActiveTimeBetween($ticket->fields['date'], date('Y-m-d H:i:s'));
+        $currenttime = $sla->getActiveTimeBetween($ticket->fields['date'], $_SESSION['glpi_currenttime']);
         $totaltime   = $sla->getActiveTimeBetween($ticket->fields['date'], $ticket->fields['time_to_resolve']);
         $waitingtime = $ticket->fields['sla_waiting_duration'];
 
@@ -147,7 +150,7 @@ class SlaProgressBarTest extends DbTestCase
 
     private function computeNaive24_7Progress(Ticket $ticket): float
     {
-        $currenttime = strtotime(date('Y-m-d H:i:s')) - strtotime($ticket->fields['date']);
+        $currenttime = strtotime($_SESSION['glpi_currenttime']) - strtotime($ticket->fields['date']);
         $totaltime   = strtotime($ticket->fields['time_to_resolve']) - strtotime($ticket->fields['date']);
         $waitingtime = $ticket->fields['sla_waiting_duration'];
 


### PR DESCRIPTION
## Bug

Fixes #25266

`SlaProgressBarTest::testProgressBarUsesEntityCalendarWhenSlaUsesTicketCalendar` (added in #24863) is flaky, it fails intermittently depending on the day the suite runs.

## Cause

The progress-bar computation in `SQLProvider::giveItem()` (search options  151/158/181/186) reads "now" from real wall-clock time via `date('Y-m-d H:i:s')`, whereas the rest of that same `switch` case, and `Ticket::getSpecificValueToDisplay()` `_virtual_age` use `$_SESSION['glpi_currenttime']`.

Because "now" could not be frozen, the test anchored the ticket to `-7 days` from a moving reference. The naive 24/7 denominator (`time_to_resolve - date` in raw seconds) depends on how many weekends fall inside `date + 70 business hours`, which shifts with the start weekday. On 2026-08-25 the calendar-aware vs naive gap collapsed to 3 points (71 vs 74) and the `assertGreaterThan(5, ...)` sanity check failed.

## Fix

- `SQLProvider.php`: use `$_SESSION['glpi_currenttime']` for the three   "current time" reads in the progress computation. No functional change
  in production (the session value is real now there), it just makes the code consistent and mockable.
- `SlaProgressBarTest.php`: freeze the clock with the existing `setCurrentTime()` helper and use an absolute ticket date, making the scenario fully deterministic (expected 71 vs naive 78, gap 7).

## Tests

- `vendor/bin/phpunit tests/functional/SlaProgressBarTest.php`
- `vendor/bin/phpunit tests/functional/SLMTest.php`