### PR TITLE
fix kanban with translated columns

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -1567,7 +1567,7 @@ TWIG, $twig_params);
 
             $restrict = [];
             if (!empty($column_ids) && !$get_default) {
-                $restrict = ['id' => $column_ids];
+                $restrict = [ProjectState::getTable() . '.id' => $column_ids];
             }
 
             $addselect = [];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Fixes ambiguous column in query when some project state has a name translation.
fixes #24763