### PR TITLE
Approval created without email notification is just a warning

### DIFF
--- a/src/CommonITILValidation.php
+++ b/src/CommonITILValidation.php
@@ -475,7 +475,7 @@ abstract class CommonITILValidation extends CommonDBChild
                             $user->getName()
                         )),
                         false,
-                        ERROR
+                        WARNING
                     );
                 }
             } elseif (is_a($this->fields["itemtype_target"], CommonDBTM::class, true)) {


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

The message that shows after asking for an approval from a user without an email address should be a warning, not an error. The approval is created successfully and the lack of an email only represents a degraded experience rather than blocking the approver from interacting with the request.

