### PR TITLE
Fix uncaught IconvException on unusable declared charset

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -2495,9 +2495,9 @@ class MailCollector extends CommonDBTM
 
         $charset = $content_type->getParameter('charset');
 
-        // If charset is not specified, and not UTF-8, force fallback default encoding
+        // If charset is not specified, fallback on detected encoding
         if ($charset === null) {
-            $charset = mb_check_encoding($contents, 'UTF-8') ? 'UTF-8' : 'ISO-8859-1';
+            $charset = $this->detectCharset($contents);
         }
 
         if (strtoupper($charset) != 'UTF-8') {
@@ -2525,16 +2525,43 @@ class MailCollector extends CommonDBTM
 
                 // Try to convert using iconv with TRANSLIT, then with IGNORE.
                 // TRANSLIT may result in failure depending on system iconv implementation.
-                try {
-                    $converted = @iconv($charset, 'UTF-8//TRANSLIT', $contents);
-                } catch (IconvException $e) {
-                    $converted = iconv($charset, 'UTF-8//IGNORE', $contents);
+                $converted = null;
+                foreach (['UTF-8//TRANSLIT', 'UTF-8//IGNORE'] as $target_charset) {
+                    try {
+                        $converted = @iconv($charset, $target_charset, $contents);
+                        break;
+                    } catch (IconvException $e) {
+                        // Conversion failed, try the next target charset, or fallback below.
+                    }
                 }
+
+                if ($converted === null) {
+                    // The declared charset is not supported by iconv either. It may not even be a
+                    // charset name at all (e.g. `Content-Type: text/html; charset="text/html"`).
+                    // Fallback on detected encoding, as if no charset was declared.
+                    $converted = mb_convert_encoding($contents, 'UTF-8', $this->detectCharset($contents));
+                }
+
                 $contents = $converted;
             }
         }
 
         return $contents;
+    }
+
+    /**
+     * Detect the charset of the given contents.
+     *
+     * Used when the message part declares no charset, or declares one that cannot be used
+     * for conversion.
+     *
+     * @param string $contents
+     *
+     * @return string
+     */
+    private function detectCharset(string $contents): string
+    {
+        return mb_check_encoding($contents, 'UTF-8') ? 'UTF-8' : 'ISO-8859-1';
     }
 
 

--- a/tests/emails-tests/54-invalid-charset.eml
+++ b/tests/emails-tests/54-invalid-charset.eml
@@ -1,0 +1,14 @@
+Date: Mon, 18 Aug 2026 12:45:00 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <invalid-charset@glpi-project.org>
+Subject: 54 - Invalid charset
+MIME-Version: 1.0
+Content-Type: text/html; charset="text/html"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p>This message declares an invalid charset: caf=E9 and pi=E8ces jointes.</p>
+</body>
+</html>

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -916,6 +916,7 @@ class MailCollectorTest extends DbTestCase
                     '47 - Missing charset parameter',
                     '49 - Message with invalid CC email address',
                     '53 - Large HTML Email Test',
+                    '54 - Invalid charset',
                     $long_subject_expected,
                 ],
             ],
@@ -1050,6 +1051,11 @@ PLAINTEXT,
 <span lang="HE" style="font-family:&quot;Arial&quot;,sans-serif">בדיקה של מייל עם עברית ואנגלית</span></p>
 </div>
 PLAINTEXT,
+            // Email declaring an invalid charset (54-invalid-charset.eml).
+            // The declared charset is not a charset name at all, contents encoding has to be detected.
+            '54 - Invalid charset' => <<<HTML
+<p>This message declares an invalid charset: café and pièces jointes.</p>
+HTML,
         ];
 
         foreach ($actors_specs as $actor_specs) {
@@ -1721,5 +1727,55 @@ PLAINTEXT,
             $extracted_content,
             'Extracted EML attachment must use CRLF line endings as required by RFC 2822'
         );
+    }
+
+    public static function decodedContentProvider(): iterable
+    {
+        // Charset handled by mbstring.
+        yield 'mbstring charset' => [
+            'charset'  => 'iso-8859-1',
+            'contents' => "Caf\xE9",
+            'expected' => 'Café',
+        ];
+
+        // Charset only handled by iconv.
+        yield 'iconv charset' => [
+            'charset'  => 'iso-8859-8-i',
+            'contents' => "\xE1\xE3\xE9\xF7\xE4",
+            'expected' => 'בדיקה',
+        ];
+
+        // Charset that is not a valid charset name at all, contents encoding has to be detected.
+        // See https://github.com/glpi-project/glpi/issues/25190
+        yield 'invalid charset with ISO-8859-1 contents' => [
+            'charset'  => 'text/html',
+            'contents' => "Caf\xE9",
+            'expected' => 'Café',
+        ];
+        yield 'invalid charset with UTF-8 contents' => [
+            'charset'  => 'text/html',
+            'contents' => 'Café',
+            'expected' => 'Café',
+        ];
+    }
+
+    #[DataProvider('decodedContentProvider')]
+    public function testGetDecodedContent(string $charset, string $contents, string $expected): void
+    {
+        $raw = implode("\r\n", [
+            'From: sender@example.com',
+            'To: receiver@glpi-project.org',
+            'Subject: Charset handling',
+            'MIME-Version: 1.0',
+            sprintf('Content-Type: text/plain; charset="%s"', $charset),
+            'Content-Transfer-Encoding: 8bit',
+            '',
+            $contents,
+            '',
+        ]);
+
+        $collector = new \MailCollector();
+
+        $this->assertSame($expected, trim($collector->getDecodedContent(new Message(['raw' => $raw]))));
     }
 }


### PR DESCRIPTION
Some senders put a value that is not a charset name at all in the `charset` parameter of the `Content-Type` header (e.g. `Content-Type: text/html; charset="text/html"`).

In that case, both the `UTF-8//TRANSLIT` and the `UTF-8//IGNORE` conversions fail, and the exception raised by the second one was not caught, aborting the whole mail collection: no ticket was created and the message stayed in the mailbox.

Encoding detection is extracted into `detectCharset()`, and is now also used when the declared charset cannot be used for conversion.

Fixes #25190