### PR TITLE
Fix RSQL lexer after it reaches a unary operator and escape handling

### DIFF
--- a/src/Glpi/Api/HL/RSQL/Lexer.php
+++ b/src/Glpi/Api/HL/RSQL/Lexer.php
@@ -78,6 +78,14 @@ final class Lexer
     public const CHAR_ESCAPE = '\\';
     public const CHARS_PROPERTY = '/[a-zA-Z0-9_.]/';
 
+    public const ESCAPEABLE_CHARS = [
+        self::CHAR_AND,
+        self::CHAR_OR,
+        self::CHAR_GROUP_OPEN,
+        self::CHAR_GROUP_CLOSE,
+        self::CHAR_ESCAPE,
+    ];
+
     private function __construct() {}
 
     /**
@@ -198,7 +206,7 @@ final class Lexer
 
                 while ($pos + 1 < $length) {
                     $char = mb_substr($query, ++$pos, 1, 'UTF-8');
-                    if ($char === self::CHAR_ESCAPE) {
+                    if (!$is_escaped && $char === self::CHAR_ESCAPE) {
                         $is_escaped = true;
                     } elseif (!$is_escaped && $expected_ending_char !== null && $char === $expected_ending_char) {
                         // If the current char is the expected ending char, then the value is complete.
@@ -217,6 +225,9 @@ final class Lexer
                         $pos--;
                         break;
                     } else {
+                        if ($is_escaped && !in_array($char, self::ESCAPEABLE_CHARS, true)) {
+                            $buffer .= self::CHAR_ESCAPE;
+                        }
                         $buffer .= $char;
                         $is_escaped = false;
                     }

--- a/src/Glpi/Api/HL/RSQL/Lexer.php
+++ b/src/Glpi/Api/HL/RSQL/Lexer.php
@@ -117,6 +117,7 @@ final class Lexer
         while ($pos < $length) {
             $char = mb_substr($query, $pos, 1, 'UTF-8');
             $prev_char = $pos - 1 >= 0 ? mb_substr($query, $pos - 1, 1, 'UTF-8') : null;
+            $in_unary_operator = false;
 
             if (!$in_value && $char === self::CHAR_GROUP_OPEN && $prev_char !== self::CHAR_ESCAPE) {
                 $tokens[] = [self::T_GROUP_OPEN, $char];
@@ -152,12 +153,22 @@ final class Lexer
                 if (empty($nextChar) || $nextChar !== '=') {
                     throw new RSQLException('', sprintf(__('RSQL query has an incomplete operator in filter for property "%1$s"'), $tokens[count($tokens) - 1][1]));
                 }
-                $tokens[] = [self::T_OPERATOR, $buffer . '='];
+                $buffer .= '=';
+                if (Parser::isOperatorUnary($buffer)) {
+                    $in_unary_operator = true;
+                }
+                $tokens[] = [self::T_OPERATOR, $buffer];
                 // Now the value is started
                 $buffer = '';
                 $pos += 2;
                 $fn_validate_pos();
+                if ($in_unary_operator) {
+                    $tokens[] = [self::T_UNSPECIFIED_VALUE, ''];
+                    $in_filter = false;
+                    continue;
+                }
                 $in_value = true;
+                $is_escaped = false;
                 $char = mb_substr($query, $pos, 1, 'UTF-8');
                 if ($char === '' || $char === self::CHAR_AND || $char === self::CHAR_OR) {
                     $tokens[] = [self::T_UNSPECIFIED_VALUE, ''];
@@ -174,18 +185,22 @@ final class Lexer
                 // When matching, we ignore escaped quotes and parenthesis.
                 $starting_char = $char;
                 $expected_ending_char = null;
-                $buffer = $char;
+                if ($char !== self::CHAR_ESCAPE) {
+                    $buffer = $char;
+                } else {
+                    $is_escaped = true;
+                }
                 if (in_array($starting_char, ['(', '"', '\''])) {
                     $expected_ending_char = $starting_char === '(' ? ')' : $starting_char;
                 } else {
                     // We have no starting quote or parenthesis, so the value continues until an unescaped comma, unescaped semicolon, unescaped close parenthesis, or end of string is found.
                 }
+
                 while ($pos + 1 < $length) {
                     $char = mb_substr($query, ++$pos, 1, 'UTF-8');
                     if ($char === self::CHAR_ESCAPE) {
-                        // If the current char is an escape character, then the next character is part of the value.
-                        $buffer .= $char;
-                    } elseif ($expected_ending_char !== null && $char === $expected_ending_char) {
+                        $is_escaped = true;
+                    } elseif (!$is_escaped && $expected_ending_char !== null && $char === $expected_ending_char) {
                         // If the current char is the expected ending char, then the value is complete.
                         $buffer .= $char;
                         $tokens[] = [self::T_VALUE, $buffer];
@@ -193,7 +208,7 @@ final class Lexer
                         $in_filter = false;
                         $in_value = false;
                         break;
-                    } elseif ($expected_ending_char === null && in_array($char, [self::CHAR_AND, self::CHAR_OR, self::CHAR_GROUP_CLOSE])) {
+                    } elseif (!$is_escaped && $expected_ending_char === null && in_array($char, [self::CHAR_AND, self::CHAR_OR, self::CHAR_GROUP_CLOSE])) {
                         // If the current char is a comma, semicolon, or close parenthesis, then the value is complete.
                         $tokens[] = [self::T_VALUE, $buffer];
                         $buffer = '';
@@ -203,6 +218,7 @@ final class Lexer
                         break;
                     } else {
                         $buffer .= $char;
+                        $is_escaped = false;
                     }
                 }
                 if ($buffer !== '') {

--- a/src/Glpi/Api/HL/RSQL/Parser.php
+++ b/src/Glpi/Api/HL/RSQL/Parser.php
@@ -252,6 +252,20 @@ final class Parser
     }
 
     /**
+     * @return bool True if the provided operator is unary (does not require a value. the only parameter for it is the property name), false otherwise.
+     */
+    public static function isOperatorUnary(string $operator): bool
+    {
+        $unary_operators = [
+            '=isnull=',
+            '=notnull=',
+            '=empty=',
+            '=notempty=',
+        ];
+        return in_array($operator, $unary_operators, true);
+    }
+
+    /**
      * @param array $tokens Tokens from the RSQL lexer.
      * @return Result RSQL query result
      * @throws RSQLException

--- a/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
+++ b/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
@@ -46,110 +46,170 @@ class LexerTest extends GLPITestCase
         return [
             [
                 'id==20',
-                [[5, 'id'], [6, '=='], [7, '20']],
+                [[Lexer::T_PROPERTY, 'id'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '20']],
             ],
             [
                 '((model.name=in=(A2696,A2757,A2777);name=like=*Staff*),(model.name=in=(A2602,A2604,A2603,A2605);name=like=*Student*)),name=in=(A2436,A2764,A2437,A2766)',
                 [
-                    [3, "("],[3, "("], [5,"model.name"], [6, "=in="], [7, "(A2696,A2757,A2777)"], [1, ";"],
-                    [5, "name"], [6, "=like="], [7, "*Staff*"], [4, ")"], [2, ","], [3, "("], [5, "model.name"],
-                    [6, "=in="], [7, "(A2602,A2604,A2603,A2605)"], [1, ";"], [5, "name"], [6, "=like="], [7, "*Student*"],
-                    [4, ")"], [4, ")"], [2, ","], [5, "name"],[6, "=in="], [7, "(A2436,A2764,A2437,A2766)"],
+                    [Lexer::T_GROUP_OPEN, "("],[Lexer::T_GROUP_OPEN, "("], [Lexer::T_PROPERTY,"model.name"], [Lexer::T_OPERATOR, "=in="], [Lexer::T_VALUE, "(A2696,A2757,A2777)"],
+                    [Lexer::T_AND, ";"], [Lexer::T_PROPERTY, "name"], [Lexer::T_OPERATOR, "=like="], [Lexer::T_VALUE, "*Staff*"],
+                    [Lexer::T_GROUP_CLOSE, ")"], [Lexer::T_OR, ","], [Lexer::T_GROUP_OPEN, "("],
+                    [Lexer::T_PROPERTY, "model.name"], [Lexer::T_OPERATOR, "=in="], [Lexer::T_VALUE, "(A2602,A2604,A2603,A2605)"],
+                    [Lexer::T_AND, ";"], [Lexer::T_PROPERTY, "name"], [Lexer::T_OPERATOR, "=like="], [Lexer::T_VALUE, "*Student*"],
+                    [Lexer::T_GROUP_CLOSE, ")"], [Lexer::T_GROUP_CLOSE, ")"], [Lexer::T_OR, ","],
+                    [Lexer::T_PROPERTY, "name"],[Lexer::T_OPERATOR, "=in="], [Lexer::T_VALUE, "(A2436,A2764,A2437,A2766)"],
                 ],
             ],
             [
                 'name==(test', // In this case, "(test" is a valid value
-                [[5, 'name'], [6, '=='], [7, '(test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '(test']],
             ],
             [
                 'name!=test', // Only operator that doesn't start with '='
-                [[5, 'name'], [6, '!='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '!='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=in=test',
-                [[5, 'name'], [6, '=in='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=in='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=out=test',
-                [[5, 'name'], [6, '=out='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=out='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=lt=test',
-                [[5, 'name'], [6, '=lt='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=lt='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=le=test',
-                [[5, 'name'], [6, '=le='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=le='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=gt=test',
-                [[5, 'name'], [6, '=gt='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=gt='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=ge=test',
-                [[5, 'name'], [6, '=ge='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=ge='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=like=test',
-                [[5, 'name'], [6, '=like='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=ilike=test',
-                [[5, 'name'], [6, '=ilike='], [7, 'test']],
-            ],
-            [
-                'name=isnull=test',
-                [[5, 'name'], [6, '=isnull='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=ilike='], [Lexer::T_VALUE, 'test']],
             ],
             [
                 'name=isnull=',
-                [[5, 'name'], [6, '=isnull='], [8, '']],
-            ],
-            [
-                'name=notnull=test',
-                [[5, 'name'], [6, '=notnull='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=isnull='], [Lexer::T_UNSPECIFIED_VALUE, '']],
             ],
             [
                 'name=notnull=',
-                [[5, 'name'], [6, '=notnull='], [8, '']],
-            ],
-            [
-                'name=empty=test',
-                [[5, 'name'], [6, '=empty='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notnull='], [Lexer::T_UNSPECIFIED_VALUE, '']],
             ],
             [
                 'name=empty=',
-                [[5, 'name'], [6, '=empty='], [8, '']],
-            ],
-            [
-                'name=notempty=test',
-                [[5, 'name'], [6, '=notempty='], [7, 'test']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=empty='], [Lexer::T_UNSPECIFIED_VALUE, '']],
             ],
             [
                 'name=notempty=',
-                [[5, 'name'], [6, '=notempty='], [8, '']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notempty='], [Lexer::T_UNSPECIFIED_VALUE, '']],
             ],
             [
                 // Multibyte test
                 'name==テスト',
-                [[5, 'name'], [6, '=='], [7, 'テスト']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, 'テスト']],
             ],
             [
                 'is_deleted==0',
-                [[5, 'is_deleted'], [6, '=='], [7, '0']],
+                [[Lexer::T_PROPERTY, 'is_deleted'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '0']],
             ],
             [
                 // No-value filter not at end of query
                 'name=empty=;id==10',
-                [[5, 'name'], [6, '=empty='], [8, ''], [1, ';'], [5, 'id'], [6, '=='], [7, '10']],
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=empty='], [Lexer::T_UNSPECIFIED_VALUE, ''], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'id'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '10']
+                ],
             ],
             [
                 'name=notlike=Test*',
-                [[5, 'name'], [6, '=notlike='], [7, 'Test*']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notlike='], [Lexer::T_VALUE, 'Test*']],
             ],
             [
                 'name=notilike=Test*',
-                [[5, 'name'], [6, '=notilike='], [7, 'Test*']],
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, 'Test*']],
+            ],
+            [
+                // Complex filter
+                //https://github.com/glpi-project/glpi/issues/23936
+                "is_deleted==False;(name=notilike='*(*',name=notilike='*)*',name=notilike='* *',name=notilike='.*',name=notilike='*.');location.id=out=(12,34);location.completename=notilike='Storage >*';name=ilike='*example.org';location.name=notnull=;location.name=notempty=",
+                [
+                    [Lexer::T_PROPERTY, 'is_deleted'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, 'False'], [Lexer::T_AND, ';'],
+                    [Lexer::T_GROUP_OPEN, '('],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*(*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*)*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'* *'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'.*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*.'"],
+                    [Lexer::T_GROUP_CLOSE, ')'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.id'], [Lexer::T_OPERATOR, '=out='], [Lexer::T_VALUE, '(12,34)'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.completename'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'Storage >*'"], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=ilike='], [Lexer::T_VALUE, "'*example.org'"], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.name'], [Lexer::T_OPERATOR, '=notnull='], [Lexer::T_UNSPECIFIED_VALUE, ''], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.name'], [Lexer::T_OPERATOR, '=notempty='], [Lexer::T_UNSPECIFIED_VALUE, ''],
+                ],
+            ],
+            [
+                // Complex filter with the no-value operators not at the end
+                //https://github.com/glpi-project/glpi/issues/23936
+                "is_deleted==False;location.name=notnull=;location.name=notempty=;(name=notilike='*(*',name=notilike='*)*',name=notilike='* *',name=notilike='.*',name=notilike='*.');location.id=out=(12,34);location.completename=notilike='Storage >*';name=ilike='*example.org'",
+                [
+                    [Lexer::T_PROPERTY, 'is_deleted'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, 'False'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.name'], [Lexer::T_OPERATOR, '=notnull='], [Lexer::T_UNSPECIFIED_VALUE, ''], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.name'], [Lexer::T_OPERATOR, '=notempty='], [Lexer::T_UNSPECIFIED_VALUE, ''], [Lexer::T_AND, ';'],
+                    [Lexer::T_GROUP_OPEN, '('],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*(*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*)*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'* *'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'.*'"], [Lexer::T_OR, ','],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'*.'"],
+                    [Lexer::T_GROUP_CLOSE, ')'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.id'], [Lexer::T_OPERATOR, '=out='], [Lexer::T_VALUE, '(12,34)'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'location.completename'], [Lexer::T_OPERATOR, '=notilike='], [Lexer::T_VALUE, "'Storage >*'"], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=ilike='], [Lexer::T_VALUE, "'*example.org'"],
+                ],
+            ],
+            [
+                'itemtype==Computer;items_id=in=(1,2,3);name=like=*Test*',
+                [
+                    [Lexer::T_PROPERTY, 'itemtype'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, 'Computer'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'items_id'], [Lexer::T_OPERATOR, '=in='], [Lexer::T_VALUE, '(1,2,3)'], [Lexer::T_AND, ';'],
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, '*Test*'],
+                ],
+            ],
+            [
+                // Filter with T_AND character as value
+                'name=like=\;*',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, ';*'],
+                ],
+            ],
+            [
+                'name=like=\(*',
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, '(*'],],
+            ],
+            [
+                'name=like=\)*',
+                [[Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, ')*'],],
+            ],
+            [
+                // Filter with T_AND character as value and quoted
+                'name=like=";*"',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, '";*"'],
+                ],
             ],
         ];
     }
@@ -198,5 +258,12 @@ class LexerTest extends GLPITestCase
         $this->expectException(RSQLException::class);
         $this->expectExceptionMessage('RSQL query has one or more unclosed groups');
         Lexer::tokenize($query);
+    }
+
+    public function testValueAfterUnaryOperator(): void
+    {
+        $this->expectException(RSQLException::class);
+        $this->expectExceptionMessage('RSQL query is missing an operator in filter for property "test"');
+        Lexer::tokenize('name=notnull=test');
     }
 }

--- a/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
+++ b/tests/functional/Glpi/Api/HL/RSQL/LexerTest.php
@@ -130,7 +130,7 @@ class LexerTest extends GLPITestCase
                 'name=empty=;id==10',
                 [
                     [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=empty='], [Lexer::T_UNSPECIFIED_VALUE, ''], [Lexer::T_AND, ';'],
-                    [Lexer::T_PROPERTY, 'id'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '10']
+                    [Lexer::T_PROPERTY, 'id'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '10'],
                 ],
             ],
             [
@@ -209,6 +209,30 @@ class LexerTest extends GLPITestCase
                 'name=like=";*"',
                 [
                     [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=like='], [Lexer::T_VALUE, '";*"'],
+                ],
+            ],
+            [
+                'name==\\Test',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '\Test'],
+                ],
+            ],
+            [
+                'name==\\\Test',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '\Test'],
+                ],
+            ],
+            [
+                'name==\\\\Test',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '\\Test'],
+                ],
+            ],
+            [
+                'name==\\\\\\\\Test',
+                [
+                    [Lexer::T_PROPERTY, 'name'], [Lexer::T_OPERATOR, '=='], [Lexer::T_VALUE, '\\\\Test'],
                 ],
             ],
         ];


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.


## Description

fixes #23936
- When the RSQL lexer reached a unary operator, it was not properly considering the start of another filter.
- When the lexer hit an escape character, it was improperly adding that character to the value and then if the next character was a control character like `T_AND`, it was adding the `T_AND` token instead of considering it part of the value.