### PR TITLE
Hotfix video attachments

### DIFF
--- a/templates/components/itilobject/timeline/sub_documents.html.twig
+++ b/templates/components/itilobject/timeline/sub_documents.html.twig
@@ -71,6 +71,7 @@
             {% set imgs = imgs|merge([{
                'title': '',
                '_video': true,
+               'type': 'html',
                'src': docpath,
                'html': video_html,
                'img_class': 'shadow',

--- a/tests/e2e/specs/Ticket/ticket_video_download.spec.ts
+++ b/tests/e2e/specs/Ticket/ticket_video_download.spec.ts
@@ -54,6 +54,8 @@ test('Can attach a video to a ticket and download it', async ({ profile, page })
     await page.locator('.sub-documents .pswp-trigger').click();
     // eslint-disable-next-line playwright/no-raw-locators -- PhotoSwipe has no accessible roles
     const download_button = page.locator('.pswp a[download]');
+    // eslint-disable-next-line playwright/no-raw-locators -- PhotoSwipe has no accessible roles
+    await expect(page.locator('.pswp video')).toBeVisible();
 
     const download_promise = page.waitForEvent('download');
     await download_button.click();


### PR DESCRIPTION

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Description

I messed up and missed testing video playback while fixing #24997. This PR corrects that.

## Screenshots (if appropriate):

<img width="342" height="160" alt="image" src="https://github.com/user-attachments/assets/351738e7-0d2d-4ee8-9b51-d6e9182e0a8b" />

