### PR TITLE
Fix(CommonITILObject): distinguish itemtype when detecting duplicate ITIL links (#25161)

### DIFF
--- a/src/CommonITILObject_CommonITILObject.php
+++ b/src/CommonITILObject_CommonITILObject.php
@@ -74,8 +74,12 @@ abstract class CommonITILObject_CommonITILObject extends CommonDBRelation
         $links = static::getLinkedTo(static::$itemtype_1, $input[static::$items_id_1]);
         if (count($links)) {
             foreach ($links as $link) {
-                // Allow reclassifying LINK_TO as DUPLICATE_WITH, but otherwise, no duplicates allowed
-                if ($link['items_id'] === $input[static::$items_id_1] || $link['items_id'] === $input[static::$items_id_2]) {
+                // Allow reclassifying LINK_TO as DUPLICATE_WITH, but otherwise, no duplicates allowed.
+                // Compare both itemtype and items_id so that different itemtypes sharing the same id are not seen as duplicates.
+                if (
+                    ($link['itemtype'] === static::$itemtype_1 && $link['items_id'] === $input[static::$items_id_1])
+                    || ($link['itemtype'] === static::$itemtype_2 && $link['items_id'] === $input[static::$items_id_2])
+                ) {
                     if ((int) $link['link'] === self::LINK_TO && (int) $input['link'] === self::DUPLICATE_WITH) {
                         $link_item = getItemForItemtype($link['link_class']);
                         $link_item->delete(['id' => $link['id']]);

--- a/tests/functional/CommonITILObject_CommonITILObjectTest.php
+++ b/tests/functional/CommonITILObject_CommonITILObjectTest.php
@@ -597,59 +597,59 @@ class CommonITILObject_CommonITILObjectTest extends DbTestCase
      */
     public function testSameIdWithDifferentItemtypesIsNotConsideredDuplicate(): void
     {
+        global $DB;
+
         $this->login();
 
         $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
 
-        // Create a Change.
-        $change = new \Change();
-        $changes_id = $change->add([
-            'name'        => 'Change with shared id',
+        $changes_id = $this->createItem(\Change::class, [
+            'name'        => 'Change #25161',
             'content'     => 'test',
             'status'      => \Change::INCOMING,
             'entities_id' => $entities_id,
-        ]);
-        $this->assertGreaterThan(0, $changes_id);
+        ])->getID();
 
-        // Create a Ticket with the same ID as the Change.
-        $ticket = new \Ticket();
-        $shared_id_ticket_id = $ticket->add([
-            'id'          => $changes_id,
-            'name'        => 'Ticket sharing the change id',
+        // Create two tickets with consecutive ids so at least one is guaranteed to
+        // differ from the Change id, without forcing an auto-increment value.
+        $ticket_a = $this->createItem(\Ticket::class, [
+            'name'        => 'Ticket A #25161',
             'content'     => 'test',
             'status'      => \Ticket::INCOMING,
             'entities_id' => $entities_id,
-        ]);
-        $this->assertSame($changes_id, $shared_id_ticket_id);
+        ])->getID();
 
-        // Create another Ticket with a different ID.
-        $other_ticket_id = $ticket->add([
-            'name'        => 'Other ticket',
+        $ticket_b = $this->createItem(\Ticket::class, [
+            'name'        => 'Ticket B #25161',
             'content'     => 'test',
             'status'      => \Ticket::INCOMING,
             'entities_id' => $entities_id,
-        ]);
-        $this->assertGreaterThan(0, $other_ticket_id);
+        ])->getID();
+
+        $other_ticket_id = $ticket_a === $changes_id ? $ticket_b : $ticket_a;
+
+        $this->assertNotSame($changes_id, $other_ticket_id);
+
+        // Reproduce the existing link returned by `getLinkedTo()` for the regression:
+        // a Ticket relation with the same numeric id as the Change.
+        // The linked Ticket does not need to exist for this test.
+        $this->assertNotFalse($DB->insert('glpi_changes_tickets', [
+            'changes_id' => $changes_id,
+            'tickets_id' => $changes_id,
+            'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
+        ]));
 
         $change_ticket = new \Change_Ticket();
 
-        // Create the initial link: Change #1 <-> Ticket #1.
-        $link_id = $change_ticket->add([
+        // A genuine duplicate of that exact pair is still rejected.
+        $this->assertFalse($change_ticket->add([
             'changes_id' => $changes_id,
-            'tickets_id' => $shared_id_ticket_id,
+            'tickets_id' => $changes_id,
             'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
-        ]);
-        $this->assertGreaterThan(0, $link_id);
+        ]));
 
-        // The exact same link must still be rejected as a duplicate.
-        $duplicate_link_id = $change_ticket->add([
-            'changes_id' => $changes_id,
-            'tickets_id' => $shared_id_ticket_id,
-            'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
-        ]);
-        $this->assertFalse($duplicate_link_id);
-
-        // The existing Ticket #1 must not prevent linking another Ticket to Change #1.
+        // A different Ticket must not be considered a duplicate just because
+        // its ID is compared with the Change ID from the existing relation.
         $allowed_link_id = $change_ticket->add([
             'changes_id' => $changes_id,
             'tickets_id' => $other_ticket_id,

--- a/tests/functional/CommonITILObject_CommonITILObjectTest.php
+++ b/tests/functional/CommonITILObject_CommonITILObjectTest.php
@@ -590,4 +590,71 @@ class CommonITILObject_CommonITILObjectTest extends DbTestCase
         ]);
         $this->assertFalse($result);
     }
+
+    /**
+     * Duplicate detection must distinguish linked objects using both `itemtype`
+     * and `items_id`, not `items_id` alone (see GLPI issue #25161).
+     */
+    public function testSameIdWithDifferentItemtypesIsNotConsideredDuplicate(): void
+    {
+        $this->login();
+
+        $entities_id = getItemByTypeName('Entity', '_test_root_entity', true);
+
+        // Create a Change.
+        $change = new \Change();
+        $changes_id = $change->add([
+            'name'        => 'Change with shared id',
+            'content'     => 'test',
+            'status'      => \Change::INCOMING,
+            'entities_id' => $entities_id,
+        ]);
+        $this->assertGreaterThan(0, $changes_id);
+
+        // Create a Ticket with the same ID as the Change.
+        $ticket = new \Ticket();
+        $shared_id_ticket_id = $ticket->add([
+            'id'          => $changes_id,
+            'name'        => 'Ticket sharing the change id',
+            'content'     => 'test',
+            'status'      => \Ticket::INCOMING,
+            'entities_id' => $entities_id,
+        ]);
+        $this->assertSame($changes_id, $shared_id_ticket_id);
+
+        // Create another Ticket with a different ID.
+        $other_ticket_id = $ticket->add([
+            'name'        => 'Other ticket',
+            'content'     => 'test',
+            'status'      => \Ticket::INCOMING,
+            'entities_id' => $entities_id,
+        ]);
+        $this->assertGreaterThan(0, $other_ticket_id);
+
+        $change_ticket = new \Change_Ticket();
+
+        // Create the initial link: Change #1 <-> Ticket #1.
+        $link_id = $change_ticket->add([
+            'changes_id' => $changes_id,
+            'tickets_id' => $shared_id_ticket_id,
+            'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
+        ]);
+        $this->assertGreaterThan(0, $link_id);
+
+        // The exact same link must still be rejected as a duplicate.
+        $duplicate_link_id = $change_ticket->add([
+            'changes_id' => $changes_id,
+            'tickets_id' => $shared_id_ticket_id,
+            'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
+        ]);
+        $this->assertFalse($duplicate_link_id);
+
+        // The existing Ticket #1 must not prevent linking another Ticket to Change #1.
+        $allowed_link_id = $change_ticket->add([
+            'changes_id' => $changes_id,
+            'tickets_id' => $other_ticket_id,
+            'link'       => \CommonITILObject_CommonITILObject::LINK_TO,
+        ]);
+        $this->assertGreaterThan(0, $allowed_link_id);
+    }
 }


### PR DESCRIPTION
## Description

`CommonITILObject_CommonITILObject::prepareInputForAdd()` refused to create an ITIL object-to-object link whenever an already-linked object shared the same numeric id as one of the objects being linked, even though the two objects were of different itemtypes.

Example: `Change #1` linked to `Ticket #1`. Linking `Change #1` to any other ticket then failed with *"Unknown ITIL Object"*, because the duplicate check compared the linked `items_id` against the new `items_id` without looking at the itemtype.

## Fix

The "no multiple links" check now compares **itemtype + items_id** on each side of the relation instead of `items_id` alone, so a coincidental id match between different itemtypes is no longer treated as a duplicate. Genuine duplicates (same itemtype + same id, both orientations) and self-links are still rejected, and the `LINK_TO` → `DUPLICATE_WITH` reclassification path is unchanged.

Single-file production change in `src/CommonITILObject_CommonITILObject.php`.

## Tests

Added `testSameIdWithDifferentItemtypesIsNotConsideredDuplicate()` to `tests/functional/CommonITILObject_CommonITILObjectTest.php`:

- a genuine duplicate link is still rejected
- an existing link no longer blocks linking a different object that happens to share the same numeric id.

The new test fails on the previous implementation and passes with this change.

Fixes #25161