### PR TITLE
fix(mailcollector): prevent a faulty email from blocking the mailgate task

### DIFF
--- a/src/MailCollector.php
+++ b/src/MailCollector.php
@@ -763,6 +763,9 @@ class MailCollector extends CommonDBTM
                         );
                         $rejinput['reason'] = NotImportedEmail::FAILED_OPERATION;
                         $rejected->add($rejinput);
+                        // Move the message out of the inbox, otherwise it would be fetched again,
+                        // and would fail again, on every collect.
+                        $delete[$uid] = self::REFUSED_FOLDER;
                         continue;
                     }
 
@@ -814,12 +817,15 @@ class MailCollector extends CommonDBTM
                             $refused++;
                             $rejinput['reason'] = NotImportedEmail::NOT_ENOUGH_RIGHTS;
                             $rejected->add($rejinput);
-                        } elseif ($ticket->add($tkt)) {
+                        } elseif ($this->addItemFromMessage($ticket, $tkt)) {
                             $delete[$uid] =  self::ACCEPTED_FOLDER;
                         } else {
                             $error++;
                             $rejinput['reason'] = NotImportedEmail::FAILED_OPERATION;
                             $rejected->add($rejinput);
+                            // Move the message out of the inbox, otherwise it would be fetched again,
+                            // and would fail again, on every collect.
+                            $delete[$uid] = self::REFUSED_FOLDER;
                         }
                     } elseif (
                         isset($tkt['tickets_id'])
@@ -865,6 +871,9 @@ class MailCollector extends CommonDBTM
                             $error++;
                             $rejinput['reason'] = NotImportedEmail::FAILED_OPERATION;
                             $rejected->add($rejinput);
+                            // Move the message out of the inbox, otherwise it would be fetched again,
+                            // and would fail again, on every collect.
+                            $delete[$uid] = self::REFUSED_FOLDER;
                         } elseif (
                             !$CFG_GLPI['use_anonymous_followups']
                              && !$ticket->canUserAddFollowups($tkt['_users_id_requester'])
@@ -874,12 +883,15 @@ class MailCollector extends CommonDBTM
                             $refused++;
                             $rejinput['reason'] = NotImportedEmail::NOT_ENOUGH_RIGHTS;
                             $rejected->add($rejinput);
-                        } elseif ($fup->add($fup_input)) {
+                        } elseif ($this->addItemFromMessage($fup, $fup_input)) {
                             $delete[$uid] =  self::ACCEPTED_FOLDER;
                         } else {
                             $error++;
                             $rejinput['reason'] = NotImportedEmail::FAILED_OPERATION;
                             $rejected->add($rejinput);
+                            // Move the message out of the inbox, otherwise it would be fetched again,
+                            // and would fail again, on every collect.
+                            $delete[$uid] = self::REFUSED_FOLDER;
                         }
                     } else {
                         if ($is_user_anonymous && !$CFG_GLPI["use_anonymous_helpdesk"]) {
@@ -939,6 +951,38 @@ class MailCollector extends CommonDBTM
             } else {
                 return $msg;
             }
+        }
+    }
+
+
+    /**
+     * Add the item (ticket or followup) corresponding to a collected message.
+     *
+     * Errors are caught here to prevent a single faulty message (e.g. containing a value that is
+     * rejected by the DB server) to stop the whole collect process, and therefore the whole
+     * mailgate crontask.
+     *
+     * @param CommonDBTM $item   Item to add
+     * @param array<string, mixed> $input  Item fields
+     *
+     * @return bool
+     */
+    private function addItemFromMessage(CommonDBTM $item, array $input): bool
+    {
+        try {
+            return (bool) $item->add($input);
+        } catch (Throwable $e) {
+            ErrorHandler::logCaughtException($e);
+            ErrorHandler::displayCaughtExceptionMessage($e);
+            Toolbox::logInFile(
+                'mailgate',
+                sprintf(
+                    __('Error during message import (%s). Check in "%s" for more details') . "\n",
+                    $e->getMessage(),
+                    GLPI_LOG_DIR . '/php-errors.log'
+                )
+            );
+            return false;
         }
     }
 
@@ -1292,6 +1336,13 @@ class MailCollector extends CommonDBTM
     public function cleanSubject($text)
     {
         $text = str_replace("=20", "\n", $text);
+
+        if (!mb_check_encoding($text, 'UTF-8')) {
+            // Subject may contain invalid UTF-8 sequences, that would be rejected by the DB server.
+            // See https://github.com/glpi-project/glpi/issues/25325
+            $text = iconv($this->detectCharset($text), 'UTF-8', $text);
+        }
+
         return mb_substr($text, 0, 255, 'UTF-8');
     }
 
@@ -1913,7 +1964,25 @@ class MailCollector extends CommonDBTM
                 $mc->maxfetch_emails = $max;
 
                 $task->log("Collect mails from " . $data["name"] . " (" . $data["host"] . ")\n");
-                $message = $mc->collect($data["id"]);
+                try {
+                    $message = $mc->collect($data["id"]);
+                } catch (Throwable $e) {
+                    ErrorHandler::logCaughtException($e);
+
+                    // Update last collect date even if an error occurs.
+                    // This will prevent collectors that are constantly errored to be stuck at the begin of the
+                    // crontask process queue, and therefore to prevent other collectors to be processed.
+                    $mc->update([
+                        'id'                => $data['id'],
+                        'last_collect_date' => $_SESSION["glpi_currenttime"],
+                    ]);
+
+                    $message = sprintf(
+                        __('Error during mails collect (%s). Check in "%s" for more details'),
+                        $e->getMessage(),
+                        GLPI_LOG_DIR . '/php-errors.log'
+                    );
+                }
 
                 $task->addVolume($mc->fetch_emails);
                 $task->log("$message\n");
@@ -2497,6 +2566,14 @@ class MailCollector extends CommonDBTM
 
         // If charset is not specified, fallback on detected encoding
         if ($charset === null) {
+            $charset = $this->detectCharset($contents);
+        }
+
+        if (strtoupper($charset) === 'UTF-8' && !mb_check_encoding($contents, 'UTF-8')) {
+            // The sender declared the `UTF-8` charset, but did not honor it.
+            // Invalid UTF-8 sequences would be rejected by the DB server, so contents encoding
+            // has to be detected, to be able to convert them.
+            // See https://github.com/glpi-project/glpi/issues/25325
             $charset = $this->detectCharset($contents);
         }
 

--- a/tests/emails-tests/55-invalid-utf8-body.eml
+++ b/tests/emails-tests/55-invalid-utf8-body.eml
@@ -1,0 +1,14 @@
+Date: Tue, 01 Sep 2026 09:12:00 +0200 (CEST)
+From: Normal User <normal@glpi-project.org>
+To: GLPI debug <unittests@glpi-project.org>
+Message-ID: <invalid-utf8-body@glpi-project.org>
+Subject: 55 - Invalid UTF-8 body
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+<html>
+<body>
+<p>This message declares the UTF-8 charset but contains invalid bytes: café and pièces jointes.</p>
+</body>
+</html>

--- a/tests/imap/MailCollectorTest.php
+++ b/tests/imap/MailCollectorTest.php
@@ -105,6 +105,11 @@ class MailCollectorTest extends DbTestCase
             ], [
                 'raw'       => str_repeat('A', 300),
                 'expected'  => str_repeat('A', 255),
+            ], [
+                // Subject containing invalid UTF-8 sequences, that would be rejected by the DB server.
+                // See https://github.com/glpi-project/glpi/issues/25325
+                'raw'       => "Probl\xE8me sur l'imprimante",
+                'expected'  => "Problème sur l'imprimante",
             ],
         ];
     }
@@ -805,6 +810,12 @@ class MailCollectorTest extends DbTestCase
             $msg
         );
 
+        // No message should be left in the mailbox: even the messages that cannot be imported have
+        // to be moved out of the inbox, otherwise they would be fetched again on every collect, and
+        // would prevent other collectors to be processed.
+        // See https://github.com/glpi-project/glpi/issues/25325
+        $this->assertSame(0, $this->collector->getTotalMails());
+
         // Check not imported emails
         $not_imported_specs = [
             [
@@ -917,6 +928,7 @@ class MailCollectorTest extends DbTestCase
                     '49 - Message with invalid CC email address',
                     '53 - Large HTML Email Test',
                     '54 - Invalid charset',
+                    '55 - Invalid UTF-8 body',
                     $long_subject_expected,
                 ],
             ],
@@ -1055,6 +1067,15 @@ PLAINTEXT,
             // The declared charset is not a charset name at all, contents encoding has to be detected.
             '54 - Invalid charset' => <<<HTML
 <p>This message declares an invalid charset: café and pièces jointes.</p>
+HTML,
+            // Email declaring the UTF-8 charset but containing invalid UTF-8 sequences
+            // (55-invalid-utf8-body.eml).
+            // Contents encoding has to be detected, otherwise the ticket creation would fail on
+            // DB servers that reject invalid UTF-8 sequences, and the message would stay in the
+            // mailbox, blocking the whole mailgate crontask on every run.
+            // See https://github.com/glpi-project/glpi/issues/25325
+            '55 - Invalid UTF-8 body' => <<<HTML
+<p>This message declares the UTF-8 charset but contains invalid bytes: café and pièces jointes.</p>
 HTML,
         ];
 
@@ -1755,6 +1776,15 @@ HTML,
         yield 'invalid charset with UTF-8 contents' => [
             'charset'  => 'text/html',
             'contents' => 'Café',
+            'expected' => 'Café',
+        ];
+
+        // Charset declared as UTF-8, but contents are not encoded in UTF-8.
+        // Invalid sequences would be rejected by the DB server, contents encoding has to be detected.
+        // See https://github.com/glpi-project/glpi/issues/25325
+        yield 'UTF-8 charset with invalid UTF-8 contents' => [
+            'charset'  => 'utf-8',
+            'contents' => "Caf\xE9",
             'expected' => 'Café',
         ];
     }


### PR DESCRIPTION
Emails declaring the `utf-8` charset while containing invalid UTF-8 byte sequences were rejected.
Message was then kept, and since last collect date was not updated, it keeps running first and failing each time.

- ensure that decoded contents and subject are valid UTF-8, whatever charset is declared by the sender;
- catch errors occurring during the ticket/followup creation;
- move messages that cannot be imported out of the inbox, so they are not fetched again on every collect;
- catch errors occurring during a collect, and update the collector `last_collect_date`, so an errored collector cannot prevent other collectors to be processed.

Fixes #25325