### PR TITLE
Remove six statements that assign a value to itself

### DIFF
--- a/src/CommonDBTM.php
+++ b/src/CommonDBTM.php
@@ -2025,10 +2025,7 @@ class CommonDBTM extends CommonGLPI
         }
 
         if ($addMessAfterRedirect) {
-            // Do not display quotes
-            if (isset($this->fields['name'])) {
-                $this->fields['name'] = $this->fields['name'];
-            } else {
+            if (!isset($this->fields['name'])) {
                 //TRANS: %1$s is the itemtype, %2$d is the id of the item
                 $this->fields['name'] = sprintf(
                     __('%1$s - ID %2$d'),

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -602,8 +602,6 @@ class Domain extends CommonDBTM implements AssignableItemInterface
                     foreach (array_keys($ids) as $key) {
                         $item->getFromDB($key);
                         unset($item->fields["id"]);
-                        $item->fields["name"]    = $item->fields["name"];
-                        $item->fields["comment"] = $item->fields["comment"];
                         $item->fields["entities_id"] = $input['entities_id'];
                         if ($item->add($item->fields)) {
                             $ma->itemDone($item->getType(), $key, MassiveAction::ACTION_OK);

--- a/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
+++ b/src/Glpi/Console/Diagnostic/CheckHtmlEncodingCommand.php
@@ -269,7 +269,6 @@ final class CheckHtmlEncodingCommand extends AbstractCommand
         $update = [];
         foreach ($fields as $field) {
             $update[$field] = $this->fixOneField($item, $field);
-            $update[$field] = $update[$field];
         }
 
         $success = $DB->update(

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -5935,7 +5935,6 @@ JAVASCRIPT;
                         foreach ($tomerge as $fup2) {
                             $fup2['items_id'] = $merge_target_id;
                             $fup2['sourceitems_id'] = $id;
-                            $fup2['content'] = $fup2['content'];
                             $fup2['_disablenotif'] = true;
                             unset($fup2['id']);
                             if (!$fup->add($fup2)) {
@@ -5956,7 +5955,6 @@ JAVASCRIPT;
                         foreach ($tomerge as $task2) {
                             $task2['tickets_id'] = $merge_target_id;
                             $task2['sourceitems_id'] = $id;
-                            $task2['content'] = $task2['content'];
                             $task2['_disablenotif'] = true;
                             unset($task2['id']);
                             unset($task2['uuid']);


### PR DESCRIPTION
Six statements assign a value to itself and do nothing. `CommonDBTM::post_updateItem` has one under a `// Do not display quotes` comment, so whatever used to strip them is gone and the comment now describes nothing, which is what sent me looking at the rest. `Domain` has two in the duplicate massive action, `Ticket` has one in each of the followup and task merge loops, and `CheckHtmlEncodingCommand` has one immediately after the line that actually computes the value.

In `CommonDBTM` the dead line was the whole body of the `if`, so I inverted the condition and dropped the comment with it. The others are plain deletions and the surrounding assignments are untouched.

If any of these once carried a call that got lost rather than being pure leftovers, say which and I will restore it instead.

AI tools: found with a small textual scanner I wrote for self-assignments and duplicate keys in PHP, and Claude Code helped draft this description. Every one of the six was read in context by hand before touching it.
