### PR TITLE
Fix (Forms) - Entity of the requester form destination strategy

### DIFF
--- a/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
+++ b/src/Glpi/Form/Destination/CommonITILField/EntityFieldStrategy.php
@@ -172,11 +172,19 @@ enum EntityFieldStrategy: string
         if (count($it) === 0) {
             return null;
         }
-        $profile = $it->current();
+        $entities = array_map('intval', array_column(iterator_to_array($it), 'entities_id'));
 
         // If only one profile, use its entity
-        if (count($it) === 1) {
-            return $profile['entities_id'];
+        if (count($entities) === 1) {
+            return $entities[0];
+        }
+
+        // Prefer the requester's own configured default entity (Preferences >
+        // Default entity), if they are actually assigned to it. This mirrors
+        // the entity GLPI itself would activate for that user on login.
+        $default_entity = $requester->fields['entities_id'];
+        if ($default_entity !== null && in_array((int) $default_entity, $entities, true)) {
+            return (int) $default_entity;
         }
 
         $default_profiles = $DB->request([
@@ -219,6 +227,6 @@ enum EntityFieldStrategy: string
         }
 
         // Fallback to first profile
-        return $profile['entities_id'];
+        return $entities[0];
     }
 }

--- a/tests/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
+++ b/tests/functional/Glpi/Form/Destination/CommonITILField/EntityFieldTest.php
@@ -490,6 +490,65 @@ final class EntityFieldTest extends AbstractDestinationFieldTest
         );
     }
 
+    public function testEntityFromRequesterUsesConfiguredDefaultEntity(): void
+    {
+        // Arrange: create a form with an actor question used as the requester
+        $builder = new FormBuilder();
+        $builder->addQuestion("Requester", QuestionTypeRequester::class);
+        $form = $this->createForm($builder);
+
+        $requester_config = new RequesterFieldConfig(
+            strategies: [ITILActorFieldStrategy::SPECIFIC_ANSWERS],
+            specific_question_ids: [$this->getQuestionId($form, "Requester")]
+        );
+        $this->setDestinationFieldConfig(
+            form: $form,
+            key: RequesterField::getKey(),
+            config: $requester_config,
+        );
+
+        $form = Form::getById($form->getId());
+        $this->setDestinationFieldConfig(
+            form: $form,
+            key: EntityField::getKey(),
+            config: new EntityFieldConfig(strategy: EntityFieldStrategy::REQUESTER_ENTITY),
+        );
+
+        $admin_profile        = getItemByTypeName(Profile::class, "Super-Admin", true);
+        $selfservice_profile  = getItemByTypeName(Profile::class, "Self-Service", true);
+        $child_2 = getItemByTypeName(Entity::class, "_test_child_2", true);
+        $child_3 = getItemByTypeName(Entity::class, "_test_child_3", true);
+
+        // The user is assigned to two entities. Without a configured default
+        // entity, the "Self-Service" profile (GLPI's default profile) would
+        // win and the ticket would be created in $child_2 instead.
+        $user = $this->createItem(User::class, [
+            'name'          => 'My_user_with_default_entity',
+            '_profiles_id'  => $admin_profile,
+            '_entities_id'  => $child_3,
+            '_is_recursive' => true,
+        ]);
+        $this->createItem(Profile_User::class, [
+            'users_id'     => $user->getID(),
+            'profiles_id'  => $selfservice_profile,
+            'entities_id'  => $child_2,
+            'is_recursive' => true,
+        ]);
+
+        // The user explicitly configured their default entity (Preferences >
+        // Default entity) to be $child_3.
+        $this->updateItem(User::class, $user->getID(), ['entities_id' => $child_3]);
+
+        // Act: submit an answer to the form
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Requester" => "users_id-{$user->getID()}",
+        ]);
+
+        // Assert: the requester's configured default entity takes priority
+        // over the profile-based heuristics.
+        $this->assertEquals($child_3, $ticket->fields['entities_id']);
+    }
+
     private function sendFormAndAssertTicketEntity(
         Form $form,
         EntityFieldConfig $config,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !46066
- Here is a brief description of what this PR does

When a form destination's entity strategy is set to "**Entity of the requester**" and the requester has access to multiple entities, the ticket could end up in the wrong entity (root, or another entity than expected) even when the requester has a "**Default entity**" explicitly configured in their preferences.

The previous logic never looked at the requester's own default entity. It only guessed the entity from profile-based heuristics (GLPI's globally configured default profile, then any helpdesk-interface profile, then an arbitrary first match).

### Fix
`EntityFieldStrategy::getEntityIdFromRequester()` now checks the requester's configured default entity (`User.entities_id`, the same field GLPI itself uses to pick the active entity on login) first, and uses it whenever the requester is actually assigned to it. The previous heuristics are kept as a fallback for requesters without a valid default entity among their assignments.