### PR TITLE
(Notification) preview css isolation

### DIFF
--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -78,7 +78,12 @@
                 </tr>
                 <tr>
                     <td>{{ data['content_text']|nl2br }}</td>
-                    <td>{{ data['content_html']|raw }}</td>
+                    <td>
+                        <iframe srcdoc="{{ data['content_html']|e('html_attr') }}"
+                                style="width: 100%; border: none; min-height: 200px;"
+                                onload="this.style.height = (this.contentDocument.body ? this.contentDocument.body.scrollHeight + 30 : 200) + 'px';"
+                                sandbox="allow-same-origin"></iframe>
+                    </td>
                 </tr>
             </tbody>
         </table>

--- a/templates/pages/setup/notification/translation_debug.html.twig
+++ b/templates/pages/setup/notification/translation_debug.html.twig
@@ -80,6 +80,7 @@
                     <td>{{ data['content_text']|nl2br }}</td>
                     <td>
                         <iframe srcdoc="{{ data['content_html']|e('html_attr') }}"
+                                title="{{ __('Email HTML body preview') }}"
                                 style="width: 100%; border: none; min-height: 200px;"
                                 onload="this.style.height = (this.contentDocument.body ? this.contentDocument.body.scrollHeight + 30 : 200) + 'px';"
                                 sandbox="allow-same-origin"></iframe>


### PR DESCRIPTION
<!--

Dear GLPI developer.

BEFORE SUBMITTING YOUR PULL REQUEST, please make sure to read and follow these steps:

* We don't support community plugins. Contact directly their authors, or use the community forum : http://forum.glpi-project.org.
* For feature requests or enhancements, use the suggest dedicated site (http://suggest.glpi-project.org). We check it very often.
* We prefer to keep this tracker in ENGLISH. If you want support in your language, the community forum (http://forum.glpi-project.org) is the best place.
* Evolutions and features should target the `main` branch and should be discussed in an issue before submitting a PR.
* Bug fixes should target the latest stable release branch (usually the default branch).
* Please use the below template.

For more information, please check contributing guide:
https://github.com/glpi-project/glpi/blob/main/CONTRIBUTING.md

The GLPI team.
-->

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !46039
- The CSS from the notification template spills over onto the entire page during preview. 


