### PR TITLE
fix(search): order default lists by first visible column again

### DIFF
--- a/src/Glpi/Search/SearchEngine.php
+++ b/src/Glpi/Search/SearchEngine.php
@@ -430,8 +430,15 @@ final class SearchEngine
         $data['search']['no_search']   = true;
 
         $data['toview'] = SearchOption::getDefaultToView($itemtype, $params);
-        if ($p['sort'] === [0]) {
+        if (
+            $p['sort'] === [0]
+            && !($data['search']['disable_order_by_fallback'] ?? false)
+        ) {
             $p['sort'] = [array_values($data['toview'])[0]];
+            // Sync the resolved default sort back into the search params snapshot.
+            // Otherwise SQLProvider still reads the initial `[0]` (which never matches
+            // any search option id) and silently falls back to `ORDER BY id`.
+            $data['search']['sort'] = $p['sort'];
         }
         $data['meta_toview'] = [];
         if (!$forcetoview) {

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3095,7 +3095,7 @@ class SearchTest extends DbTestCase
         // GROUP_CONCAT(... ORDER BY ...) which are part of the SELECT, not the sort).
         // See glpi-project/glpi#25208: the no-ORDER-BY optimization for default asset
         // lists must be preserved (commit 3dad2e1cab).
-        $this->assertStringNotMatchesRegularExpression('/ORDER BY .* (ASC|DESC) LIMIT/', $sql);
+        $this->assertDoesNotMatchRegularExpression('/ORDER BY .* (ASC|DESC) LIMIT/', $sql);
     }
 
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3091,7 +3091,11 @@ class SearchTest extends DbTestCase
         ]);
 
         $sql = $this->cleanSQL($data['sql']['search']);
-        $this->assertStringNotContainsString('ORDER BY', $sql);
+        // Assert there is no top-level ORDER BY clause (only the internal ones of
+        // GROUP_CONCAT(... ORDER BY ...) which are part of the SELECT, not the sort).
+        // See glpi-project/glpi#25208: the no-ORDER-BY optimization for default asset
+        // lists must be preserved (commit 3dad2e1cab).
+        $this->assertStringNotMatchesRegularExpression('/ORDER BY .* (ASC|DESC) LIMIT/', $sql);
     }
 
 

--- a/tests/functional/SearchTest.php
+++ b/tests/functional/SearchTest.php
@@ -3046,11 +3046,54 @@ class SearchTest extends DbTestCase
             "`glpi_computers`.`id` AS `ITEM_SearchTest\Computer_1_id`",
             $data['sql']['search']
         );
+        // Default search without an explicit sort must end up ordering by the first
+        // visible column (name, search option 1), not by the hidden `id` column.
+        // See glpi-project/glpi#25208.
         $this->assertStringContainsString(
+            "ITEM_SearchTest\Computer_1` ASC",
+            $data['sql']['search']
+        );
+        $this->assertStringNotContainsString(
             "ORDER BY `id`",
             $data['sql']['search']
         );
     }
+    public function testDefaultSortUsesFirstVisibleColumnForNonAssets()
+    {
+        // Regression test for glpi-project/glpi#25208 and #25221
+        // Non-asset default search (no explicit sort) must ORDER BY the first visible column,
+        // not by the hidden `id` column.
+        $data = $this->doSearch('User', [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+        ]);
+
+        $sql = $this->cleanSQL($data['sql']['search']);
+        $this->assertStringNotContainsString('ORDER BY `id`', $sql);
+        // User search option 1 is the "login" field (glpi_users.name)
+        $this->assertStringContainsString(
+            'ORDER BY `glpi_users`.`name` ASC',
+            $sql
+        );
+    }
+
+    public function testDefaultSortKeepsNoOrderByForAssets()
+    {
+        // Regression test for glpi-project/glpi#25208 and #25221
+        // Asset default search must keep the no-ORDER-BY optimization (perf concern
+        // from commit 3dad2e1cab): restoring the sort must not silently reintroduce
+        // an ORDER BY clause on default asset lists.
+        $data = $this->doSearch('Computer', [
+            'is_deleted' => 0,
+            'start'      => 0,
+            'search'     => 'Search',
+        ]);
+
+        $sql = $this->cleanSQL($data['sql']['search']);
+        $this->assertStringNotContainsString('ORDER BY', $sql);
+    }
+
 
     public function testGroupParamAfterMeta()
     {


### PR DESCRIPTION
## Fix default sorting: order non-asset lists by first visible column again

Fixes #25208 (replaces closed PR #25221)

### Problem

Since GLPI 11, default list views (Users, Groups, Entities, Locations, …) are silently sorted by the **hidden `id` column** instead of the first visible column when the user has not explicitly chosen a sort.

This is a **regression introduced by #17376** (`7ae0f4aaef`, "Fix default sort search option", 2024): it changed the non-asset default from `sort = 1` to `sort = 0` with the comment *"Search engine will automatically determine the best sorting column (ID or the first displayed column)"* — but the engine's substitution was never wired back, so it silently falls back to `id`.

### Root cause

In `SearchEngine::prepareDataForSearch()`:

```php
$data['search'] = $p;                                  // snapshot — sort is [0] here
...
$data['toview'] = SearchOption::getDefaultToView($itemtype, $params);
if ($p['sort'] === [0]) {
    $p['sort'] = [array_values($data['toview'])[0]];   // only $p is updated
}
```

`$data['search']` was copied before the default-sort substitution. `SQLProvider::constructSQL()` reads `$data['search']['sort']` (still `[0]`), which never matches any search option id in the ORDER BY loop, so the `ORDER BY id` fallback is always used.

### Change

1. Sync the resolved default sort back into `$data['search']` (the actual fix).
2. **Skip the substitution when `disable_order_by_fallback` is set** — i.e. for asset default searches, where `3dad2e1cab` deliberately disables sorting for performance. Restoring the v10 sort must not silently reintroduce an `ORDER BY` on default asset lists.

```php
if (
    $p['sort'] === [0]
    && !($data['search']['disable_order_by_fallback'] ?? false)
) {
    $p['sort'] = [array_values($data['toview'])[0]];
    $data['search']['sort'] = $p['sort'];
}
```

### Tests

- Updated `testSearchWithNamespacedItem`: now expects `ORDER BY ITEM_SearchTest\Computer_1 ASC` (first visible column) instead of `ORDER BY id`.
- Added `testDefaultSortUsesFirstVisibleColumnForNonAssets`: User default search → `ORDER BY glpi_users.name ASC`.
- Added `testDefaultSortKeepsNoOrderByForAssets`: Computer default search → **no** `ORDER BY` clause (perf optimization preserved).
- Updated the `#25221` analysis: the previous one-line PR (#25221) failed CI because it applied the substitution unconditionally, which would have broken the asset no-ORDER-BY behavior AND the existing `testSearchWithNamespacedItem`.

### Affected behavior

| Itemtype | Before | After |
|---|---|---|
| Non-asset (User, Group, …) default list | `ORDER BY id` (invisible column) | `ORDER BY first visible column` (as in GLPI 10) |
| Asset (Computer, …) default list | no `ORDER BY` (perf) | **unchanged** — no `ORDER BY` |
