### PR TITLE
KB aside UX improvements

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -1350,8 +1350,9 @@ body.in_modal .kb-editor-reserved {
         display: none;
     }
 
-    // Favorites section hidden when there are no favorites to display (set server-side or by JS).
-    [data-glpi-kb-aside-favorites][data-glpi-kb-aside-favorites-hidden] {
+    // Favorites section hidden when there are no favorites to display
+    // Either there are no .article childrens or the only .article also has data-glpi-kb-favorite-current="pending" (the current article is not yet a favorite).
+    [data-glpi-kb-aside-favorites]:not(:has(.article:not([data-glpi-kb-favorite-current="pending"]))) {
         display: none;
     }
 

--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -1403,6 +1403,7 @@ body.in_modal .kb-editor-reserved {
     [data-glpi-kb-aside-favorites] {
         min-height: 0;
         overflow-y: auto;
+        max-height: min(200px, 25%);
     }
 
     // The tree pane takes what the header leaves and scrolls as a whole, so the

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -549,18 +549,10 @@ export class GlpiKnowbaseArticleController
             return;
         }
 
-        const has_other_favorites = favorites_section.querySelector('li:not([data-glpi-kb-favorite-current])') !== null;
-
         if (is_favorited) {
             current_entry.setAttribute('data-glpi-kb-favorite-current', 'active');
-            favorites_section.removeAttribute('data-glpi-kb-aside-favorites-hidden');
-            header.removeAttribute('data-glpi-kb-aside-header-no-border');
         } else {
             current_entry.setAttribute('data-glpi-kb-favorite-current', 'pending');
-            if (!has_other_favorites) {
-                favorites_section.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
-                header.setAttribute('data-glpi-kb-aside-header-no-border', '');
-            }
         }
     }
 

--- a/js/modules/Knowbase/AsideController.js
+++ b/js/modules/Knowbase/AsideController.js
@@ -1060,11 +1060,6 @@ export class GlpiKnowbaseAsideController
             }
             entry.remove();
         }
-
-        const favorites = this.#aside.querySelector('[data-glpi-kb-aside-favorites]');
-        if (favorites) {
-            this.#refreshFavoritesVisibility(favorites);
-        }
     }
 
     /**
@@ -1090,7 +1085,6 @@ export class GlpiKnowbaseAsideController
         const current = favorites.querySelector('[data-glpi-kb-favorite-current]');
         if (current && parseInt(current.dataset.glpiKbArticleId) === id) {
             current.setAttribute('data-glpi-kb-favorite-current', is_favorited ? 'active' : 'pending');
-            this.#refreshFavoritesVisibility(favorites);
             return;
         }
 
@@ -1125,8 +1119,6 @@ export class GlpiKnowbaseAsideController
                 }
             }
         }
-
-        this.#refreshFavoritesVisibility(favorites);
     }
 
     /**
@@ -1180,31 +1172,6 @@ export class GlpiKnowbaseAsideController
         if (menu) {
             // Drop any inline positioning Popper may have applied while open.
             menu.removeAttribute('style');
-        }
-    }
-
-    /**
-     * Show or hide the favorites section (and matching header border) depending
-     * on whether it still holds any visible entry.
-     *
-     * `ArticleController.#updateFavoritesAside()` applies the same rule from the
-     * article side.
-     *
-     * @param {HTMLElement} favorites_el
-     */
-    #refreshFavoritesVisibility(favorites_el)
-    {
-        const header = this.#aside.querySelector('[data-glpi-kb-aside-header]');
-        const has_visible = favorites_el.querySelector(
-            '[data-glpi-kb-article-id]:not([data-glpi-kb-favorite-current="pending"])'
-        ) !== null;
-
-        if (has_visible) {
-            favorites_el.removeAttribute('data-glpi-kb-aside-favorites-hidden');
-            header?.removeAttribute('data-glpi-kb-aside-header-no-border');
-        } else {
-            favorites_el.setAttribute('data-glpi-kb-aside-favorites-hidden', '');
-            header?.setAttribute('data-glpi-kb-aside-header-no-border', '');
         }
     }
 }

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -3497,7 +3497,6 @@ TWIG, $twig_params);
         $favorites = $this->getCurrentArticleAndFavorites($current_id);
 
         $current_is_favorite = KnowbaseItem_Favorite::isFavoriteForCurrentUser($current_id);
-        $has_other_favorites = array_filter($favorites, fn(Article $a) => !$a->is_current) !== [];
 
         // Don't render the aside if we don't have any article.
         $tree = (new Builder($current_id))->buildTree();
@@ -3511,7 +3510,6 @@ TWIG, $twig_params);
                 'tree'                => $tree,
                 'favorites'           => $favorites,
                 'current_is_favorite' => $current_is_favorite,
-                'has_other_favorites' => $has_other_favorites,
                 'can_create'          => self::canCreate(),
                 'can_update'          => self::canUpdate(),
                 'show_actions'        => self::canShowAsideActions(),

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -33,8 +33,6 @@
 {% import "pages/tools/kb/_article_row.html.twig" as macros %}
 {% import "pages/tools/kb/_actions_menu.html.twig" as actions_menu %}
 
-{% set hide_favorites = not has_other_favorites and not current_is_favorite %}
-
 {% if show_actions %}
     {{ actions_menu.render_actions_menu_placeholder() }}
 {% endif %}
@@ -68,7 +66,7 @@
 
 <div id="kb-aside-body" data-glpi-kb-aside-body>
 
-<div class="card-header flex-column align-items-start" data-glpi-kb-aside-header {{ hide_favorites ? 'data-glpi-kb-aside-header-no-border' : '' }}>
+<div class="card-header flex-column align-items-start" data-glpi-kb-aside-header>
     <div class="d-flex align-items-center w-100 mb-3">
         <h3 class="card-title fw-bold mb-0 flex-grow-1">{{ __("Articles") }}</h3>
         <button
@@ -110,7 +108,6 @@
     class="card-body flex-grow-0"
     data-glpi-kb-aside-favorites
     data-testid="kb-aside-favorites"
-    {{ hide_favorites ? 'data-glpi-kb-aside-favorites-hidden' : '' }}
 >
     <h4 class="card-title fw-bold fs-4">
         <i class="ti ti-star-filled me-1 fs-5 text-yellow" aria-hidden="true"></i>

--- a/templates/pages/tools/kb/aside.html.twig
+++ b/templates/pages/tools/kb/aside.html.twig
@@ -105,7 +105,7 @@
 </div>
 
 <div
-    class="card-body flex-grow-0"
+    class="card-body flex-grow-0 flex-shrink-0"
     data-glpi-kb-aside-favorites
     data-testid="kb-aside-favorites"
 >


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

I was re-testing the KB and found a few remaining UX issues with the article list aside.

1. KB favorites list was too small when there are a lot of articles to show in the list.
<img width="315" height="262" alt="Selection_769" src="https://github.com/user-attachments/assets/3f826e9d-e58d-4d8b-9628-527d3560006c" />

2. KB aside folded state did not seem correct. I had KB article with ID 4 that contained a child with ID 5 and my current article was Article 1. Article 4 was calculated to not be folded, but Article 5 was and Article 5 had no children.

To address these:
1. I converted the aside from using multiple card bodies, flex and overflow to an accordion UI. I added an "All articles" header for the main articles tree.
2. I simplified the showing/hiding of the favorites. There was no need to control it with JS adding style tokens when it was possible with pure CSS (unless I missed a case).
3. I removed the root article consideration when skipping the folding of articles.

<img width="309" height="414" alt="Selection_770" src="https://github.com/user-attachments/assets/55ff6803-19db-4d19-acf0-d04d1cd0a363" />
