### PR TITLE
Avoid saving sessions in hlapi requests

### DIFF
--- a/src/Glpi/Api/HL/Router.php
+++ b/src/Glpi/Api/HL/Router.php
@@ -817,7 +817,7 @@ EOT;
         $auth->auth_succeded = true;
         $auth->user = new User();
         $auth->user->getFromDB($this->current_client['user_id']);
-        Session::init($auth);
+        Session::init($auth, true);
         if ($request->getHeaderLine('Accept-Language')) {
             // Make sure language header is set in SERVER superglobal so that Session::getPreferredLanguage() works
             $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $request->getHeaderLine('Accept-Language');

--- a/src/Session.php
+++ b/src/Session.php
@@ -118,10 +118,11 @@ class Session
      * Init user session
      *
      * @param Auth $auth Auth object to init session
+     * @param bool $temporary If true, the session will not be persisted. Useful for stateless cases like the HLAPI.
      *
      * @return void
      **/
-    public static function init(Auth $auth)
+    public static function init(Auth $auth, bool $temporary = false)
     {
         global $CFG_GLPI;
 
@@ -140,11 +141,16 @@ class Session
                 $save[$t] = $_SESSION[$t];
             }
         }
-        self::destroy();
-        if (!defined('TU_USER')) { //FIXME: no idea why this fails with phpunit... :(
+        if (!$temporary) {
+            self::destroy();
+        } else {
+            // Just clear the superglobal to avoid regenerating the session ID and triggering a session being saved
+            $_SESSION = [];
+        }
+        if (!$temporary && !defined('TU_USER')) { //FIXME: no idea why this fails with phpunit... :(
             session_regenerate_id();
         }
-        self::start();
+        self::start($temporary);
         $_SESSION = $save;
         $_SESSION['valid_id'] = session_id();
         // Define default time :
@@ -244,11 +250,13 @@ class Session
                     return;
                 }
 
-                $session_recorded = SessionTracker::recordNewSession($auth);
-                if (!$session_recorded) {
-                    self::destroy();
-                    $auth->auth_succeded = false;
-                    $auth->addToError(__("An error occurred while creating your session. Please try again."));
+                if (!$temporary) {
+                    $session_recorded = SessionTracker::recordNewSession($auth);
+                    if (!$session_recorded) {
+                        self::destroy();
+                        $auth->auth_succeded = false;
+                        $auth->addToError(__("An error occurred while creating your session. Please try again."));
+                    }
                 }
             } else {
                 $auth->auth_succeded = false;
@@ -281,11 +289,13 @@ class Session
     /**
      * Start the GLPI php session
      *
+     * @param bool $temporary If true, the session will not be persisted. Useful for stateless cases like the HLAPI.
+     *
      * @return void
      **/
-    public static function start()
+    public static function start(bool $temporary = false)
     {
-        if (session_status() === PHP_SESSION_NONE) {
+        if (!$temporary && session_status() === PHP_SESSION_NONE) {
             session_start();
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

A bug fix, but probably too risky for 11.0.
fixes #25305

For every HLAPI request, 3 new sessions were being created even when it is supposed to be stateless.
A new parameter and logic were added to avoid calls to `session_start` and `session_regenerate_id`, which both cause sessions to be written, when the intention is to just initialize the session superglobal for the request so that existing GLPI logic still works.

Note that logging into GLPI on the web also creates two different session files, but that is beyond the scope of what I wanted to address here and since it only happens at login instead of every request, it is a lot less impactful.