### PR TITLE
fix(project): fix TypeError in getFromDBForItemIDs request

### DIFF
--- a/src/ProjectTaskLink.php
+++ b/src/ProjectTaskLink.php
@@ -50,7 +50,7 @@ class ProjectTaskLink extends CommonDBRelation
     public static ?string $items_id_2 = 'projecttasks_id_target';
 
     /**
-     * @param array $projecttaskIds List of project task IDs
+     * @param int[] $projecttaskIds List of project task IDs
      * @return DBmysqlIterator
      * @used-by gantt plugin
      */

--- a/src/ProjectTaskLink.php
+++ b/src/ProjectTaskLink.php
@@ -50,18 +50,22 @@ class ProjectTaskLink extends CommonDBRelation
     public static ?string $items_id_2 = 'projecttasks_id_target';
 
     /**
-     * @param string $projecttaskIds Comma-separated list of project task IDs
+     * @param array $projecttaskIds List of project task IDs
      * @return DBmysqlIterator
      * @used-by gantt plugin
      */
-    public function getFromDBForItemIDs($projecttaskIds)
+    public function getFromDBForItemIDs(array $projecttaskIds)
     {
         global $DB;
 
         $iterator = $DB->request([
-            'SELECT' => ['glpi_projecttasklinks.*'],
-            'FROM' => 'glpi_projecttasklinks',
-            'WHERE' => "projecttasks_id_source IN (" . $projecttaskIds . ") AND projecttasks_id_target IN (" . $projecttaskIds . ")",
+            'FROM' => self::getTable(),
+            'WHERE' => [
+                'AND' => [
+                    'projecttasks_id_source' => $projecttaskIds,
+                    'projecttasks_id_target' => $projecttaskIds,
+                ],
+            ],
         ]);
 
         return $iterator;

--- a/tests/functional/ProjectTaskLinkTest.php
+++ b/tests/functional/ProjectTaskLinkTest.php
@@ -39,8 +39,6 @@ use Project;
 use ProjectTask;
 use ProjectTaskLink;
 
-/* Test for inc/projecttasklink.class.php */
-
 class ProjectTaskLinkTest extends DbTestCase
 {
     public function testGetFromDBForItemIDs()

--- a/tests/functional/ProjectTaskLinkTest.php
+++ b/tests/functional/ProjectTaskLinkTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units;
+
+use Glpi\Tests\DbTestCase;
+use Project;
+use ProjectTask;
+use ProjectTaskLink;
+
+/* Test for inc/projecttasklink.class.php */
+
+class ProjectTaskLinkTest extends DbTestCase
+{
+    public function testGetFromDBForItemIDs()
+    {
+        $this->login();
+
+        $project = $this->createItem(Project::class, ['name' => 'Test project for task links']);
+
+        $task_input = [
+            'projects_id'             => $project->getID(),
+            'plan_start_date'         => '2026-01-01 00:00:00',
+            'plan_end_date'           => '2026-01-10 00:00:00',
+            'projecttasktemplates_id' => 0,
+        ];
+        [$task_1, $task_2, $task_3] = $this->createItems(ProjectTask::class, [
+            ['name' => 'task 1'] + $task_input,
+            ['name' => 'task 2'] + $task_input,
+            ['name' => 'task 3'] + $task_input,
+        ]);
+
+        [$link_1_2, $link_2_3] = $this->createItems(ProjectTaskLink::class, [
+            [
+                'projecttasks_id_source' => $task_1->getID(),
+                'source_uuid'            => uniqid(),
+                'projecttasks_id_target' => $task_2->getID(),
+                'target_uuid'            => uniqid(),
+            ],
+            [
+                'projecttasks_id_source' => $task_2->getID(),
+                'source_uuid'            => uniqid(),
+                'projecttasks_id_target' => $task_3->getID(),
+                'target_uuid'            => uniqid(),
+            ],
+        ]);
+
+        $projecttasklink = new ProjectTaskLink();
+
+        // Only task_1 and task_2 requested. Only the link between them must be returned
+        $this->assertSame(
+            [$link_1_2->getID()],
+            $this->getLinkIds($projecttasklink, [$task_1->getID(), $task_2->getID()])
+        );
+
+        // All 3 tasks requested: both links must be returned
+        $expected = [$link_1_2->getID(), $link_2_3->getID()];
+        sort($expected);
+        $this->assertSame(
+            $expected,
+            $this->getLinkIds($projecttasklink, [$task_1->getID(), $task_2->getID(), $task_3->getID()])
+        );
+
+        // Only task_3 requested: no link has both ends in scope
+        $this->assertSame(
+            [],
+            $this->getLinkIds($projecttasklink, [$task_3->getID()])
+        );
+    }
+
+    private function getLinkIds(ProjectTaskLink $projecttasklink, array $ids): array
+    {
+        $found = [];
+        foreach ($projecttasklink->getFromDBForItemIDs($ids) as $data) {
+            $found[] = (int) $data['id'];
+        }
+        sort($found);
+
+        return $found;
+    }
+}


### PR DESCRIPTION
- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- Refactor the SQL query in the ProjectTaskLink::getFromDBForItemIDs() method to correct a type error

## Screenshots (if appropriate):

[2026-09-03 08:04:54] glpi.CRITICAL:   *** Uncaught PHP Exception TypeError: "DBmysqlIterator::analyseCrit(): Argument 1 ($crit) must be of type array, string given, called in ./src/DBmysqlIterator.php on line 349" at DBmysqlIterator.php line 575
  Backtrace :
  ./src/DBmysqlIterator.php:575                      
  ./src/DBmysqlIterator.php:349                      DBmysqlIterator->analyseCrit()
  ./src/DBmysqlIterator.php:148                      DBmysqlIterator->buildQuery()
  ./src/DBmysql.php:1065                             DBmysqlIterator->execute()
  ./src/ProjectTaskLink.php:61                       DBmysql->request()
  ./plugins/gantt/src/LinkDAO.php:45                 ProjectTaskLink->getFromDBForItemIDs()
  ./plugins/gantt/src/DataFactory.php:100            GlpiPlugin\Gantt\LinkDAO->getLinksForItemIDs()
  ./plugins/gantt/ajax/gantt.php:55                  GlpiPlugin\Gantt\DataFactory->getProjectTaskLinks()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:183    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:193        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./src/Glpi/Kernel/Kernel.php:214                   Symfony\Component\HttpKernel\Kernel->handle()
  ./public/index.php:78                              Glpi\Kernel\Kernel->handle()

