### PR TITLE
kb fix modifying child aside data instead of just current article

### DIFF
--- a/css/includes/components/_kb.scss
+++ b/css/includes/components/_kb.scss
@@ -1478,7 +1478,7 @@ body.in_modal .kb-editor-reserved {
         list-style: none;
         margin: 0;
 
-        > .article > a {
+        > .article > .article-line > a {
             display: block;
             padding: 0.25rem 0.375rem;
             border-radius: var(--tblr-border-radius);

--- a/js/modules/Knowbase/ArticleController.js
+++ b/js/modules/Knowbase/ArticleController.js
@@ -579,7 +579,7 @@ export class GlpiKnowbaseArticleController
 
         const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
         const entries = aside.querySelectorAll(
-            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-title]`
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] > .article-line [data-glpi-kb-article-title]`
         );
         for (const entry of entries) {
             entry.textContent = title;
@@ -598,7 +598,7 @@ export class GlpiKnowbaseArticleController
 
         const aside = document.querySelector('[data-main-page-aside="knowbaseitem"]');
         const containers = aside.querySelectorAll(
-            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] [data-glpi-kb-article-illustration]`
+            `[data-glpi-kb-article-id="${CSS.escape(String(this.#item_id))}"] > .article-line [data-glpi-kb-article-illustration]`
         );
 
         // The illustration picker preview already holds a freshly rendered node

--- a/templates/pages/tools/kb/aside_search_results.html.twig
+++ b/templates/pages/tools/kb/aside_search_results.html.twig
@@ -46,7 +46,8 @@
         {% endif %}
         class="article"
     >
-        <a class="d-block text-body text-hover-link" href="{{ result.link }}">
+        <div class="article-line">
+            <a class="d-block text-body text-hover-link" href="{{ result.link }}">
             <span class="d-flex align-items-center">
                 <span
                     class="{{ result.illustration ? 'me-1' : '' }}"
@@ -71,6 +72,7 @@
                 </span>
             {% endif %}
         </a>
+        </div>
     </li>
 {% endfor %}
 


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

Child articles are placed under the parent's `li[data-glpi-kb-article-id]` element so selectors targeting it would apply to child articles as well unless specifically only looking under the direct `.article-line` child.