### PR TITLE
Check more files permissions in requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The present file will list all changes made to the project; according to the
 ## [11.0.9] unreleased
 
 ### Added
+- System requirements now check that the security key files (`glpicrypt.key`, `oauth.pem` and `oauth.pub`) can be read, or created when missing.
 
 ### Changed
 - Fixed searching values with multiple concurrent spaces.

--- a/src/Glpi/System/Requirement/SecurityKeysAccess.php
+++ b/src/Glpi/System/Requirement/SecurityKeysAccess.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace Glpi\System\Requirement;
+
+/**
+ * Check that the security key files stored in the configuration directory can
+ * be used, i.e. existing ones can be read, and missing ones can be generated.
+ */
+class SecurityKeysAccess extends AbstractRequirement
+{
+    /**
+     * Security key files names, relative to the configuration directory.
+     *
+     * @var string[]
+     */
+    private const KEY_FILES = [
+        'glpicrypt.key', // see \GLPIKey class
+        'oauth.pem',     // see \Glpi\OAuth\Server class
+        'oauth.pub',     // see \Glpi\OAuth\Server class
+    ];
+
+    /**
+     * Configuration directory path.
+     *
+     * @var string
+     */
+    private $config_dir;
+
+    /**
+     * @param string $config_dir Configuration directory path.
+     */
+    public function __construct(string $config_dir = GLPI_CONFIG_DIR)
+    {
+        parent::__construct(
+            __('Permissions for security keys files')
+        );
+
+        $this->config_dir = $config_dir;
+    }
+
+    protected function check()
+    {
+        $this->validated = true;
+
+        // Missing keys are generated during the installation/update process.
+        $is_dir_writable = is_writable($this->config_dir);
+
+        foreach (self::KEY_FILES as $filename) {
+            $file_path = $this->config_dir . '/' . $filename;
+
+            if (!file_exists($file_path)) {
+                if (!$is_dir_writable) {
+                    $this->validated = false;
+                    $this->validation_messages[] = sprintf(__('The security key file %s could not be created.'), $file_path);
+                }
+            } elseif (!is_readable($file_path)) {
+                $this->validated = false;
+                $this->validation_messages[] = sprintf(__('The security key file %s is not readable.'), $file_path);
+            }
+        }
+
+        if ($this->validated) {
+            $this->validation_messages[] = __('Security key files are accessibles.');
+        }
+    }
+}

--- a/src/Glpi/System/RequirementsManager.php
+++ b/src/Glpi/System/RequirementsManager.php
@@ -48,6 +48,7 @@ use Glpi\System\Requirement\LogsWriteAccess;
 use Glpi\System\Requirement\MemoryLimit;
 use Glpi\System\Requirement\PhpSupportedVersion;
 use Glpi\System\Requirement\PhpVersion;
+use Glpi\System\Requirement\SecurityKeysAccess;
 use Glpi\System\Requirement\SeLinux;
 use Glpi\System\Requirement\SessionsConfiguration;
 use Glpi\System\Requirement\SessionsSecurityConfiguration;
@@ -154,6 +155,8 @@ class RequirementsManager
                 }
             )
         );
+
+        $requirements[] = new SecurityKeysAccess();
 
         $requirements[] = new SeLinux();
 

--- a/tests/functional/Glpi/System/Requirement/SecurityKeysAccessTest.php
+++ b/tests/functional/Glpi/System/Requirement/SecurityKeysAccessTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ *
+ * http://glpi-project.org
+ *
+ * @copyright 2015-2026 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace tests\units\Glpi\System\Requirement;
+
+use Glpi\System\Requirement\SecurityKeysAccess;
+use Glpi\Tests\GLPITestCase;
+use org\bovigo\vfs\vfsStream;
+
+class SecurityKeysAccessTest extends GLPITestCase
+{
+    public function testCheckOnReadableKeys()
+    {
+        vfsStream::setup('config', 0o555, [
+            'glpicrypt.key' => 'key',
+            'oauth.pem'     => 'private',
+            'oauth.pub'     => 'public',
+        ]);
+
+        $instance = new SecurityKeysAccess(vfsStream::url('config'));
+        $this->assertTrue($instance->isValidated());
+        $this->assertEquals(
+            ['Security key files are accessibles.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckOnUnreadableKeys()
+    {
+        $structure = vfsStream::setup('config', 0o555, [
+            'glpicrypt.key' => 'key',
+            'oauth.pem'     => 'private',
+            'oauth.pub'     => 'public',
+        ]);
+        $structure->getChild('oauth.pem')->chmod(0o000);
+
+        $instance = new SecurityKeysAccess(vfsStream::url('config'));
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            ['The security key file ' . vfsStream::url('config/oauth.pem') . ' is not readable.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckOnMissingKeysInWritableDir()
+    {
+        vfsStream::setup('config', 0o777, []);
+
+        $instance = new SecurityKeysAccess(vfsStream::url('config'));
+        $this->assertTrue($instance->isValidated());
+        $this->assertEquals(
+            ['Security key files are accessibles.'],
+            $instance->getValidationMessages()
+        );
+    }
+
+    public function testCheckOnMissingKeysInProtectedDir()
+    {
+        vfsStream::setup('config', 0o555, ['glpicrypt.key' => 'key']);
+
+        $instance = new SecurityKeysAccess(vfsStream::url('config'));
+        $this->assertFalse($instance->isValidated());
+        $this->assertEquals(
+            [
+                'The security key file ' . vfsStream::url('config/oauth.pem') . ' could not be created.',
+                'The security key file ' . vfsStream::url('config/oauth.pub') . ' could not be created.',
+            ],
+            $instance->getValidationMessages()
+        );
+    }
+}


### PR DESCRIPTION
When updating an existing instance, if ACLs on `config/oauth.*` are incorrect; an clear error is thrown - but it happens during the update.

PR adds requirements checks for those ones, to prevent update attempts with missing or unreadable files.