### PR TITLE
Lazy load IllustrationManager

### DIFF
--- a/src/Glpi/UI/IllustrationManager.php
+++ b/src/Glpi/UI/IllustrationManager.php
@@ -88,11 +88,7 @@ final class IllustrationManager
             ?? '/lib/glpi-project/illustrations/glpi-illustrations-scenes-gradient.svg'
         ;
 
-        $this->checkIconFile($this->icons_definition_file);
-        $this->checkIconFile(GLPI_ROOT . "/public/$this->scenes_gradient_sprites_path");
-        $this->checkIconFile(GLPI_ROOT . "/public/$this->icons_sprites_path");
-        $this->validateOrInitCustomContentDir(self::CUSTOM_ILLUSTRATION_DIR);
-        $this->validateOrInitCustomContentDir(self::CUSTOM_SCENES_DIR);
+        // Nothing else to do here: files and custom content are checked lazily
     }
 
     public function getCustomIconIdFromPrefixedString(string $prefixed_id): string
@@ -261,6 +257,8 @@ final class IllustrationManager
 
     public function saveCustomIllustration(string $id, string $path): void
     {
+        $this->validateOrInitCustomContentDir(self::CUSTOM_ILLUSTRATION_DIR);
+
         $dest = self::CUSTOM_ILLUSTRATION_DIR . "/$id";
         $real_dest = realpath(dirname($dest)) . DIRECTORY_SEPARATOR . basename($dest);
         if (!str_starts_with($real_dest, realpath(self::CUSTOM_ILLUSTRATION_DIR) . DIRECTORY_SEPARATOR)) {
@@ -271,6 +269,8 @@ final class IllustrationManager
 
     public function saveCustomScene(string $id, string $path): void
     {
+        $this->validateOrInitCustomContentDir(self::CUSTOM_SCENES_DIR);
+
         $dest = self::CUSTOM_SCENES_DIR . "/$id";
         $real_dest = realpath(dirname($dest)) . DIRECTORY_SEPARATOR . basename($dest);
         if (!str_starts_with($real_dest, realpath(self::CUSTOM_SCENES_DIR) . DIRECTORY_SEPARATOR)) {
@@ -281,6 +281,8 @@ final class IllustrationManager
 
     public function getCustomIllustrationFile(string $id): ?string
     {
+        $this->validateOrInitCustomContentDir(self::CUSTOM_ILLUSTRATION_DIR);
+
         try {
             $file_path = realpath(self::CUSTOM_ILLUSTRATION_DIR . "/$id");
         } catch (FilesystemException) {
@@ -310,6 +312,8 @@ final class IllustrationManager
 
     public function getCustomSceneFile(string $id): ?string
     {
+        $this->validateOrInitCustomContentDir(self::CUSTOM_SCENES_DIR);
+
         $file_path = realpath(self::CUSTOM_SCENES_DIR . "/$id");
         $custom_dir_path = realpath(self::CUSTOM_SCENES_DIR);
 
@@ -342,6 +346,8 @@ final class IllustrationManager
 
     private function renderNativeIcon(string $icon_id, ?int $size = null): string
     {
+        $this->checkIconFile(GLPI_ROOT . "/public/$this->icons_sprites_path");
+
         $size = $this->computeSize($size);
 
         $twig = TemplateRenderer::getInstance();
@@ -371,6 +377,8 @@ final class IllustrationManager
         ?int $height = null,
         ?int $width = null,
     ): string {
+        $this->checkIconFile(GLPI_ROOT . "/public/$this->scenes_gradient_sprites_path");
+
         $twig = TemplateRenderer::getInstance();
         return $twig->render('components/illustration/icon.svg.twig', [
             'file_path' => $this->scenes_gradient_sprites_path,
@@ -397,6 +405,7 @@ final class IllustrationManager
     private function getIconsDefinitions(): array
     {
         if ($this->icons_definitions === null) {
+            $this->checkIconFile($this->icons_definition_file);
             $json = file_get_contents($this->icons_definition_file);
             $this->icons_definitions = json_decode($json, associative: true, flags: JSON_THROW_ON_ERROR);
         }

--- a/tests/functional/AuthTest.php
+++ b/tests/functional/AuthTest.php
@@ -336,6 +336,9 @@ class AuthTest extends DbTestCase
         // Restore the first cookie value to ensure it is still valid
         $_COOKIE[$cookie_name] = $first_cookie_value;
         $this->assertTrue((new Auth())->login('', ''));
+
+        //Clean cookie
+        unset($_COOKIE[$cookie_name]);
     }
 
     /**

--- a/tests/functional/Glpi/UI/IllustrationManagerTest.php
+++ b/tests/functional/Glpi/UI/IllustrationManagerTest.php
@@ -37,6 +37,7 @@ namespace tests\units\Glpi\UI;
 use Glpi\Tests\GLPITestCase;
 use Glpi\UI\IllustrationManager;
 use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
 
 final class IllustrationManagerTest extends GLPITestCase
 {
@@ -106,6 +107,39 @@ final class IllustrationManagerTest extends GLPITestCase
         // Act: get icons matching the requester filter.
         $manager = new IllustrationManager();
         $ids = $manager->searchIcons(page: $page, page_size: $page_size);
+    }
+
+    public function testInstantiationDoesNotRequireIllustrationFiles(): void
+    {
+        // Arrange / Act: instantiate the manager with paths that do not exist.
+        // The illustration files are provided by an npm package, that may not
+        // be installed (e.g. in a lint-only CI job), and instantiating the
+        // manager happens on every kernel boot.
+        $manager = new IllustrationManager(
+            icons_definition_file: '/does/not/exist/icons.json',
+            icons_sprites_path: '/lib/does-not-exist/icons.svg',
+            scenes_gradient_sprites_path: '/lib/does-not-exist/scenes.svg',
+        );
+
+        // Assert: no exception has been thrown.
+        $this->assertInstanceOf(IllustrationManager::class, $manager);
+    }
+
+    public function testRenderIconFailsWhenSpritesFileIsMissing(): void
+    {
+        // Arrange: a manager pointing to a missing sprites file.
+        // The sprites path is relative to the `public` directory.
+        $sprites_path = '/lib/does-not-exist/icons.svg';
+        $manager = new IllustrationManager(icons_sprites_path: $sprites_path);
+
+        // Assert: rendering an icon is where the missing file is reported.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Failed to read file: ' . GLPI_ROOT . '/public/' . $sprites_path
+        );
+
+        // Act
+        $manager->renderIcon('report-issue');
     }
 
     public function testRenderIconReturnsEmptyStringForEmptyValue(): void


### PR DESCRIPTION
IllustrationManager requires files to be present at it instanciation; which assumes node deps have been installed.
For the CI of a plugin, I install GLPI and composer deps only, to run check headers command:

```
Run cd glpi && php bin/console tools:licence_headers_check --plugin glpiinventory

RuntimeException {#7520
  #message: "Failed to read file: /home/runner/work/glpi-inventory-plugin/glpi-inventory-plugin/glpi/public/lib/glpi-project/illustrations/icons.json"
  #code: 0
  #file: "./src/Glpi/UI/IllustrationManager.php"
  #line: 419
  [...]
```

Of course I could just install npm deps plugin side, but that's not required, and that would take more time jusst for a lint job.
It seems also better this error not to happen in the constructor.

PR also fix a test that failed several times during my tests.