### PR TITLE
fix(ui): replace obsolete 'ti-external-link-alt' with 'ti-external-link'

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3012,8 +3012,7 @@ class Plugin extends CommonDBTM
                 if (!empty($value)) {
                     $value = htmlescape($value);
                     return "<a href=\"" . $value . "\" target='_blank'>
-                     <i class='ti ti-external-link-alt fs-2x'></i><span class='sr-only'>$value</span>
-                  </a>";
+                     <i class='ti ti-external-link fs-2x'></i><span class='sr-only'>$value</span></a>";
                 }
                 return "&nbsp;";
             case 'name':

--- a/templates/install/accept_license.html.twig
+++ b/templates/install/accept_license.html.twig
@@ -37,7 +37,7 @@
 
     <p>
         <a class="btn btn-sm btn-info" target="_blank" href="https://www.gnu.org/licenses/translations.html">
-            <i class="ti ti-external-link-alt me-1"></i>
+            <i class="ti ti-external-link me-1"></i>
             {{ __("Unofficial translations are also available") }}
         </a>
     </p>


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

In GLPI 11 (after migrating to Tabler Icons), the class `ti-external-link-alt` was accidentally carried over from legacy FontAwesome (`fa-external-link-alt`).

Since Tabler Icons only defines `.ti-external-link` (without any `-alt` suffix), the `<i>` element matches no CSS rules, rendering an invisible `0px × 0px` element.

In the Plugins table (`front/plugin.php`), because the link text is also hidden via `<span class="sr-only">`, the plugin website link is completely invisible to users.

### Changes
- Replace `ti-external-link-alt` with `ti-external-link` in `src/Plugin.php` (plugin homepage column).
- Replace `ti-external-link-alt` with `ti-external-link` in `templates/install/accept_license.html.twig` (installer license link).
