### PR TITLE
[HLAPI] Add is_favorite to KBArticle schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The present file will list all changes made to the project; according to the
 - Knowledge base articles can be moved in the aside tree by dragging them: onto an article to become its child, or onto the top or bottom edge of an article to become its sibling. Dragging is mouse-only for now, and reorders nothing: only the parent changes.
 - Knowledge base articles can also be moved from the "Move" entry of an article's menu in the aside tree, which opens a searchable list of parent articles.
 - High-Level API version 3.0.0.
+- `=istruthy=` and `=isnottruthy=` RSQL operators.
 
 ### Changed
 - "Computer" search option (ID 12) for Databases has been replaced by "Associated item type" (ID 14) and "Associated item" (ID 12) options. These are not searchable but can be displayed.
@@ -34,6 +35,7 @@ The present file will list all changes made to the project; according to the
 - New `errored` property for the cronttask (automatic actions) service in the status checker to indicate the names of the errored actions requiring manual intervention.
 - "Logs purge" tab moved from `Setup > General` to `Setup > Data and Privacy` and renamed to "Historical logs".
 - Knowledge base article visibility now inherits down the tree: a user who can access an article, or any of its ancestors, can view it. **On upgrade, existing categories become invisible until access is granted to them** (which then cascades to their contents). The root article is an exception: it is readable by anyone who can read the knowledge base, and it never grants access to its descendants.
+- Using `==` and `!=` RSQL operators with boolean fields are coerced to `=istruthy=` and `=isnottruthy=`. There should be no noticeable change in behavior with any existing queries, but this was done to fix behavior with a field added with HLAPI v3.
 
 ### Deprecated
 

--- a/src/Glpi/Api/HL/Controller/KnowbaseController.php
+++ b/src/Glpi/Api/HL/Controller/KnowbaseController.php
@@ -238,7 +238,7 @@ class KnowbaseController extends AbstractController
                             'table' => KnowbaseItem_Favorite::getTable(),
                             'fkey' => 'id',
                             'field' => KnowbaseItem::getForeignKeyField(),
-                            'condition' => ['users_id' => Session::getLoginUserID()],
+                            'condition' => static fn() => ['users_id' => Session::getLoginUserID()],
                         ],
                     ],
                 ],

--- a/src/Glpi/Api/HL/Controller/KnowbaseController.php
+++ b/src/Glpi/Api/HL/Controller/KnowbaseController.php
@@ -48,6 +48,7 @@ use Group;
 use Group_KnowbaseItem;
 use KnowbaseItem;
 use KnowbaseItem_Comment;
+use KnowbaseItem_Favorite;
 use KnowbaseItem_Item;
 use KnowbaseItem_KnowbaseItem;
 use KnowbaseItem_Profile;
@@ -55,6 +56,7 @@ use KnowbaseItem_Revision;
 use KnowbaseItem_User;
 use KnowbaseItemTranslation;
 use Profile;
+use Session;
 use User;
 
 #[Route(path: '/Knowledgebase', requirements: [
@@ -225,6 +227,18 @@ class KnowbaseController extends AbstractController
                                 ],
                                 'name' => ['type' => Doc\Schema::TYPE_STRING],
                             ],
+                        ],
+                    ],
+                    'is_favorite' => [
+                        'type' => Doc\Schema::TYPE_BOOLEAN,
+                        'x-version-introduced' => '3.0.0',
+                        'description' => 'Whether the article is marked as favorite by the current user.',
+                        'x-field' => 'id',
+                        'x-join' => [
+                            'table' => KnowbaseItem_Favorite::getTable(),
+                            'fkey' => 'id',
+                            'field' => KnowbaseItem::getForeignKeyField(),
+                            'condition' => ['users_id' => Session::getLoginUserID()],
                         ],
                     ],
                 ],

--- a/src/Glpi/Api/HL/Doc/Schema.php
+++ b/src/Glpi/Api/HL/Doc/Schema.php
@@ -42,6 +42,7 @@ use Glpi\Toolbox\ArrayPathAccessor;
 use Safe\Exceptions\DatetimeException;
 
 use function Safe\preg_match;
+use function Safe\preg_replace;
 use function Safe\strtotime;
 
 /**
@@ -503,7 +504,7 @@ class Schema implements ArrayAccess
             self::TYPE_STRING => (string) $value,
             self::TYPE_INTEGER => (int) $value,
             self::TYPE_NUMBER => (float) $value,
-            self::TYPE_BOOLEAN => (bool) $value,
+            self::TYPE_BOOLEAN => (bool) (is_string($value) ? trim(preg_replace('/[[:cntrl:]]/', '', $value)) : $value),
             default => $value
         };
 

--- a/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
+++ b/src/Glpi/Api/HL/GraphQL/DefaultResolvers.php
@@ -37,6 +37,7 @@ namespace Glpi\Api\HL\GraphQL;
 use CommonDBTM;
 use DBConnection;
 use Glpi\Api\HL\APIException;
+use Glpi\Api\HL\Doc\Schema;
 use Glpi\Api\HL\RightConditionNotMetException;
 use Glpi\Api\HL\RSQL\RSQLException;
 use Glpi\Api\HL\Schemas;
@@ -52,6 +53,7 @@ use GraphQL\Type\Definition\ResolveInfo;
 use stdClass;
 
 use function Safe\json_decode;
+use function Safe\preg_replace;
 
 /**
  * Default GraphQL field resolvers that use the OpenAPI schema to fetch data from the database.
@@ -321,6 +323,10 @@ class DefaultResolvers
         if (!array_key_exists($field_name, $source) || $source[$field_name] === null) {
             // no action needed on null values
             return null;
+        }
+
+        if ($parent_schema['properties'][$field_name]['type'] === Schema::TYPE_BOOLEAN) {
+            return (bool) (is_string($source[$field_name]) ? trim(preg_replace('/[[:cntrl:]]/', '', $source[$field_name])) : $source[$field_name]);
         }
 
         // other formats already handled by GraphQL type system

--- a/src/Glpi/Api/HL/RSQL/Parser.php
+++ b/src/Glpi/Api/HL/RSQL/Parser.php
@@ -246,6 +246,22 @@ final class Parser
                         ];
                     },
                 ],
+                [
+                    'operator' => '=istruthy=',
+                    'description' => 'is truthy',
+                    'value_expected' => false,
+                    'sql_where_callable' => fn($a, $b) => [
+                        [new QueryExpression($this->db::quoteName($a) . ' IS TRUE')],
+                    ],
+                ],
+                [
+                    'operator' => '=isnottruthy=',
+                    'description' => 'is not truthy',
+                    'value_expected' => false,
+                    'sql_where_callable' => fn($a, $b) => [
+                        [new QueryExpression($this->db::quoteName($a) . ' IS NOT TRUE')],
+                    ],
+                ]
             ];
         }
         return $operators;
@@ -320,11 +336,16 @@ final class Parser
                         $value = substr($value, 1, -1);
                     }
                     if (isset($flat_props[$buffer['property']])) {
-                        $value = match ($flat_props[$buffer['property']]['type']) {
+                        if ($flat_props[$buffer['property']]['type'] === Doc\Schema::TYPE_BOOLEAN) {
                             // Boolean values are stored as 0 or 1 in the database, but the user may try using "true" or "false" in the RSQL query
-                            Doc\Schema::TYPE_BOOLEAN => filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 1 : 0,
-                            default => $value,
-                        };
+                            $value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+                            // If using == or != operator, switch with equivalent operator for boolean values based on the original operator and the value
+                            if ($buffer['operator'] === $operators['==']['sql_where_callable']) {
+                                $buffer['operator'] = $value ? $operators['=istruthy=']['sql_where_callable'] : $operators['=isnottruthy=']['sql_where_callable'];
+                            } elseif ($buffer['operator'] === $operators['!=']['sql_where_callable']) {
+                                $buffer['operator'] = $value ? $operators['=isnottruthy=']['sql_where_callable'] : $operators['=istruthy=']['sql_where_callable'];
+                            }
+                        }
                     }
                     $criteria_array = $buffer['operator']($buffer['field'], $value);
                     $it = new DBmysqlIterator($this->db);

--- a/src/Glpi/Api/HL/RSQL/Parser.php
+++ b/src/Glpi/Api/HL/RSQL/Parser.php
@@ -261,7 +261,7 @@ final class Parser
                     'sql_where_callable' => fn($a, $b) => [
                         [new QueryExpression($this->db::quoteName($a) . ' IS NOT TRUE')],
                     ],
-                ]
+                ],
             ];
         }
         return $operators;

--- a/src/Glpi/Api/HL/Search.php
+++ b/src/Glpi/Api/HL/Search.php
@@ -312,6 +312,9 @@ final class Search
                 // recursively inject the join alias into the condition keys in the cases where they don't contain a '.'
                 $fn_update_keys = static function ($condition) use (&$fn_update_keys, $join_alias) {
                     $new_condition = [];
+                    if (is_callable($condition)) {
+                        $condition = $condition();
+                    }
                     foreach ($condition as $key => $value) {
                         if (is_array($value)) {
                             $value = $fn_update_keys($value);

--- a/src/KnowbaseItem.php
+++ b/src/KnowbaseItem.php
@@ -912,14 +912,14 @@ class KnowbaseItem extends CommonDBVisible implements ExtraVisibilityCriteria, S
     {
         // Specific case for anonymous users + multi entities
         if (!Session::getLoginUserID()) {
-            $where = ['is_faq' => 1];
+            $where = [self::getTable() . '.is_faq' => 1];
             if (Session::isMultiEntitiesMode()) {
                 $where[Entity_KnowbaseItem::getTableField('entities_id')] = 0;
                 $where[Entity_KnowbaseItem::getTableField('is_recursive')] = 1;
             }
         } else {
             $where = self::getVisibilityCriteriaKB();
-            $where['is_faq'] = 1;
+            $where[self::getTable() . '.is_faq'] = 1;
         }
 
         return $where;

--- a/tests/fixtures/hlapi/snapshots/3.0.0/components.json
+++ b/tests/fixtures/hlapi/snapshots/3.0.0/components.json
@@ -10577,6 +10577,9 @@
                             }
                         }
                     }
+                },
+                "is_favorite": {
+                    "type": "boolean"
                 }
             }
         },

--- a/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
@@ -210,6 +210,20 @@ class KnowbaseControllerTest extends HLAPITestCase
             'users_id' => getItemByTypeName(User::class, 'post-only', true),
         ]);
 
+        $DB->insert(KnowbaseItem::getTable(), [
+            'name' => '_knowbaseitem_notfavorite_test',
+            'answer' => 'Not favorite test content',
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_faq' => 1,
+        ]);
+        $article_id2 = $DB->insertId();
+
+        $DB->insert(Entity_KnowbaseItem::getTable(), [
+            'knowbaseitems_id' => $article_id2,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1,
+        ]);
+
         // The `is_favorite` property is a scalar join (a scalar value pulled from another table) which reflects if the article is marked as favorite by the current user.
         $this->login();
 
@@ -230,6 +244,38 @@ class KnowbaseControllerTest extends HLAPITestCase
                 ->jsonContent(function ($content) {
                     $this->assertArrayHasKey('is_favorite', $content);
                     $this->assertTrue($content['is_favorite']);
+                });
+        });
+
+        // Test is_favorite as RSQL filter
+        $this->api->call(new Request('GET', '/Knowledgebase/Article'), function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertCount(2, $content);
+                    $this->assertEquals('_knowbaseitem_favorite_test', $content[0]['name']);
+                    $this->assertEquals('_knowbaseitem_notfavorite_test', $content[1]['name']);
+                });
+        });
+
+        $request = new Request('GET', '/Knowledgebase/Article');
+        $request->setParameter('filter', 'is_favorite==1');
+        $this->api->call($request, function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertCount(1, $content);
+                    $this->assertEquals('_knowbaseitem_favorite_test', $content[0]['name']);
+                });
+        });
+        $request = new Request('GET', '/Knowledgebase/Article');
+        $request->setParameter('filter', 'is_favorite==0');
+        $this->api->call($request, function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertCount(1, $content);
+                    $this->assertEquals('_knowbaseitem_notfavorite_test', $content[0]['name']);
                 });
         });
     }

--- a/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
+++ b/tests/functional/Glpi/Api/HL/Controller/KnowbaseControllerTest.php
@@ -35,12 +35,15 @@
 namespace tests\units\Glpi\Api\HL\Controller;
 
 use Budget;
+use Entity_KnowbaseItem;
 use Glpi\Http\Request;
 use Glpi\Tests\HLAPITestCase;
 use KnowbaseItem;
+use KnowbaseItem_Favorite;
 use KnowbaseItemTranslation;
 use Project;
 use Ticket;
+use User;
 
 class KnowbaseControllerTest extends HLAPITestCase
 {
@@ -182,5 +185,52 @@ class KnowbaseControllerTest extends HLAPITestCase
         ], [
             'date_creation' => '2026-03-01T10:00:00+00:00',
         ]);
+    }
+
+    public function testIsFavoriteProperty(): void
+    {
+        global $DB;
+
+        $DB->insert(KnowbaseItem::getTable(), [
+            'name' => '_knowbaseitem_favorite_test',
+            'answer' => 'Favorite test content',
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_faq' => 1,
+        ]);
+        $article_id = $DB->insertId();
+
+        $DB->insert(Entity_KnowbaseItem::getTable(), [
+            'knowbaseitems_id' => $article_id,
+            'entities_id' => $this->getTestRootEntity(true),
+            'is_recursive' => 1,
+        ]);
+
+        $DB->insert(KnowbaseItem_Favorite::getTable(), [
+            'knowbaseitems_id' => $article_id,
+            'users_id' => getItemByTypeName(User::class, 'post-only', true),
+        ]);
+
+        // The `is_favorite` property is a scalar join (a scalar value pulled from another table) which reflects if the article is marked as favorite by the current user.
+        $this->login();
+
+        $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $article_id), function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertArrayHasKey('is_favorite', $content);
+                    $this->assertFalse($content['is_favorite']);
+                });
+        });
+
+        $this->login('post-only', 'postonly');
+
+        $this->api->call(new Request('GET', '/Knowledgebase/Article/' . $article_id), function ($call) {
+            $call->response
+                ->isOK()
+                ->jsonContent(function ($content) {
+                    $this->assertArrayHasKey('is_favorite', $content);
+                    $this->assertTrue($content['is_favorite']);
+                });
+        });
     }
 }

--- a/tests/functional/Glpi/Api/HL/RSQL/ParserTest.php
+++ b/tests/functional/Glpi/Api/HL/RSQL/ParserTest.php
@@ -79,6 +79,7 @@ class ParserTest extends GLPITestCase
                         ],
                     ],
                 ],
+                'is_favorite' => ['type' => 'boolean'],
             ],
         ];
         $search_class = new \ReflectionClass(Search::class);
@@ -117,23 +118,23 @@ class ParserTest extends GLPITestCase
             ],
             [
                 [[5, 'scalar_join'], [6, '=='], [7, '1']],
-                "(`scalar_join`.`external_prop` = ?)", // While the property is 'scalar_join', that is also the join name. The field it points to is 'external_prop', so the resolved SQL is `scalar_join`.`external_prop`.
-                ['1'],
+                "(`scalar_join`.`external_prop` IS TRUE)", // While the property is 'scalar_join', that is also the join name. The field it points to is 'external_prop', so the resolved SQL is `scalar_join`.`external_prop`.
+                [],
             ],
             [
                 [[5, 'scalar_join'], [6, '=='], [7, 'true']],
-                "(`scalar_join`.`external_prop` = ?)",
-                ['1'],
+                "(`scalar_join`.`external_prop` IS TRUE)",
+                [],
             ],
             [
                 [[5, 'scalar_join'], [6, '=='], [7, '0']],
-                "(`scalar_join`.`external_prop` = ?)",
-                ['0'],
+                "(`scalar_join`.`external_prop` IS NOT TRUE)",
+                [],
             ],
             [
                 [[5, 'scalar_join'], [6, '=='], [7, 'false']],
-                "(`scalar_join`.`external_prop` = ?)",
-                ['0'],
+                "(`scalar_join`.`external_prop` IS NOT TRUE)",
+                [],
             ],
             [
                 [[5, 'extra_fields.extra1'], [6, '=='], [7, 'test']],
@@ -229,6 +230,16 @@ class ParserTest extends GLPITestCase
                 [[5, 'name'], [6, '=notilike='], [7, 'test']],
                 "(`_`.`name` NOT LIKE ?)",
                 ['test'],
+            ],
+            [
+                [[5, 'is_favorite'], [6, '=istruthy='], [8, '']],
+                "(`_`.`is_favorite` IS TRUE)",
+                [],
+            ],
+            [
+                [[5, 'is_favorite'], [6, '=isnottruthy='], [8, '']],
+                "(`_`.`is_favorite` IS NOT TRUE)",
+                [],
             ],
         ];
     }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have read the CONTRIBUTING document.
- [x] I have performed a self-review of my code.

## Description

- Adds an `is_favorite` scalar property on the `KBArticle` to indicate if it a favorite of the current user.
- Fixes casting done to boolean values that are scalar joins where the value would be an " " when missing but still cast as `true`. Strings being cast to boolean now get trimmed first.
- Fixes `is_faq` column in KB FAQ criteria which was missing a table name and was causing a SQL error from HLAPI because it was ambiguous.
- Adds `=istruthy=` and `=isnottruthy=` RSQL operators. Use of `==` and `!=` with boolean fields will now be coerced to truthiness operators instead. Should not have a noticeable effect with existing queries, but was required for the unique `is_favorite` case.